### PR TITLE
[Feature] Add debug-verbosity Tracy zones

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -177,6 +177,8 @@ tt_metal/tools/profiler/event_metadata.hpp @sohaibnadeemTT @tenstorrent/codeowne
 tt_metal/tools/profiler/fabric_event_profiler.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/tools/profiler/noc_event_profiler.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
 tt_metal/tools/profiler/noc_event_profiler_utils.hpp @sohaibnadeemTT @tenstorrent/codeowner-bypass
+tt_metal/tools/profiler/tracy_debug_categories.txt @mo-tenstorrent @akerteszTT @yusufbashiTT @tenstorrent/codeowner-bypass
+tt_metal/tools/profiler/tracy_debug_zones.hpp @mo-tenstorrent @akerteszTT @yusufbashiTT @tenstorrent/codeowner-bypass
 tt_metal/tools/precompile_fw/**/CMakeLists.txt @abhullar-tt @ruizhangTT @tenstorrent/metalium-developers-infra
 tt_metal/tools/jit_compile_server/**/CMakeLists.txt @abhullar-tt @ruizhangTT @tenstorrent/metalium-developers-infra
 tt_metal/tools/dispatch_telemetry_dump/**/CMakeLists.txt @anashTT @jbaumanTT @sidnadTT @tenstorrent/metalium-developers-infra

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -23,6 +23,7 @@ show_help() {
     echo "  -b, --build-type build_type      Set the build type. Default is Release."
     echo "  -t, --enable-time-trace          Enable build time trace (clang only)."
     echo "  --disable-profiler               Disable Tracy profiler (enabled by default)."
+    echo "  --build-perf-debug               Enable debug-verbosity Tracy profiling zones (disabled by default)."
     echo "  --install-prefix                 Where to install build artifacts."
     echo "  --build-dir                      Build directory."
     echo "  --build-tests                    Build All Testcases."
@@ -70,6 +71,7 @@ enable_ccache="OFF"
 enable_time_trace="OFF"
 build_type="Release"
 disable_profiler="OFF"
+build_perf_debug="OFF"
 build_dir=""
 build_tests="OFF"
 build_ttnn_tests="OFF"
@@ -108,6 +110,7 @@ enable-ccache
 enable-time-trace
 build-type:
 disable-profiler
+build-perf-debug
 install-prefix:
 build-dir:
 build-tests
@@ -170,6 +173,8 @@ while true; do
             build_type="$2";shift;;
         --disable-profiler)
             disable_profiler="ON";;
+        --build-perf-debug)
+            build_perf_debug="ON";;
         --install-prefix)
             install_prefix="$2";shift;;
         --build-tests)
@@ -241,6 +246,10 @@ fi
 tracy_enabled="ON"
 if [ "$disable_profiler" = "ON" ]; then
     tracy_enabled="OFF"
+    if [ "$build_perf_debug" = "ON" ]; then
+        echo "WARNING: --build-perf-debug has no effect with --disable-profiler; debug zones stay compiled out."
+        build_perf_debug="OFF"
+    fi
 fi
 
 # Validate the build_type
@@ -289,6 +298,7 @@ echo "INFO: Enable Light Metal Trace: $light_metal_trace"
 echo "INFO: Enable Distributed: $enable_distributed"
 echo "INFO: With python bindings: $with_python_bindings"
 echo "INFO: Enable Tracy: $tracy_enabled"
+echo "INFO: Tracy debug zones: $build_perf_debug"
 echo "INFO: Enable LTO: $enable_lto"
 echo "INFO: Warnings as errors: $warnings_as_errors"
 
@@ -322,6 +332,12 @@ fi
 
 if [ "$disable_profiler" = "ON" ]; then
     cmake_args+=("-DENABLE_TRACY=OFF")
+fi
+
+if [ "$build_perf_debug" = "ON" ]; then
+    cmake_args+=("-DENABLE_TRACY_DEBUG=ON")
+else
+    cmake_args+=("-DENABLE_TRACY_DEBUG=OFF")
 fi
 
 if [ "$export_compile_commands" = "ON" ]; then

--- a/build_metal.sh
+++ b/build_metal.sh
@@ -16,6 +16,10 @@ fi
 
 # Function to display help
 show_help() {
+    local valid_perf_categories
+    valid_perf_categories=$(grep -vE '^[[:space:]]*(#|$)' \
+        "$(dirname "$0")/tt_metal/tools/profiler/tracy_debug_categories.txt" 2>/dev/null \
+        | awk '{print $1}' | paste -sd, - | sed 's/,/, /g' || true)
     echo "Usage: $0 [options]..."
     echo "  -h, --help                       Show this help message."
     echo "  -e, --export-compile-commands    Enable CMAKE_EXPORT_COMPILE_COMMANDS."
@@ -23,7 +27,7 @@ show_help() {
     echo "  -b, --build-type build_type      Set the build type. Default is Release."
     echo "  -t, --enable-time-trace          Enable build time trace (clang only)."
     echo "  --disable-profiler               Disable Tracy profiler (enabled by default)."
-    echo "  --build-perf-debug               Enable debug-verbosity Tracy profiling zones (disabled by default)."
+    echo "  --build-perf-debug <categories>  Tracy debug-verbosity categories to compile in: off (default), all, or a comma-separated list of ${valid_perf_categories}."
     echo "  --install-prefix                 Where to install build artifacts."
     echo "  --build-dir                      Build directory."
     echo "  --build-tests                    Build All Testcases."
@@ -71,7 +75,7 @@ enable_ccache="OFF"
 enable_time_trace="OFF"
 build_type="Release"
 disable_profiler="OFF"
-build_perf_debug="OFF"
+perf_debug_categories=""
 build_dir=""
 build_tests="OFF"
 build_ttnn_tests="OFF"
@@ -110,7 +114,7 @@ enable-ccache
 enable-time-trace
 build-type:
 disable-profiler
-build-perf-debug
+build-perf-debug:
 install-prefix:
 build-dir:
 build-tests
@@ -174,7 +178,7 @@ while true; do
         --disable-profiler)
             disable_profiler="ON";;
         --build-perf-debug)
-            build_perf_debug="ON";;
+            perf_debug_categories="$2";shift;;
         --install-prefix)
             install_prefix="$2";shift;;
         --build-tests)
@@ -246,9 +250,9 @@ fi
 tracy_enabled="ON"
 if [ "$disable_profiler" = "ON" ]; then
     tracy_enabled="OFF"
-    if [ "$build_perf_debug" = "ON" ]; then
+    if [ -n "$perf_debug_categories" ] && [ "$perf_debug_categories" != "off" ]; then
         echo "WARNING: --build-perf-debug has no effect with --disable-profiler; debug zones stay compiled out."
-        build_perf_debug="OFF"
+        perf_debug_categories="off"
     fi
 fi
 
@@ -283,6 +287,18 @@ if [ -z "$PYTHON_ENV_DIR" ]; then
     PYTHON_ENV_DIR=$(pwd)/python_env
 fi
 
+# ENABLE_TRACY is sticky in the cache, so a prior --disable-profiler carries over.
+if [ "$disable_profiler" != "ON" ] && [ -f "$build_dir/CMakeCache.txt" ]; then
+    cached_enable_tracy=$(sed -n 's/^ENABLE_TRACY:[^=]*=//p' "$build_dir/CMakeCache.txt")
+    if [ "$cached_enable_tracy" = "OFF" ]; then
+        tracy_enabled="OFF"
+        if [ -n "$perf_debug_categories" ] && [ "$perf_debug_categories" != "off" ]; then
+            echo "WARNING: ENABLE_TRACY=OFF is cached from a prior --disable-profiler; --build-perf-debug has no effect until reconfigured."
+            perf_debug_categories="off"
+        fi
+    fi
+fi
+
 # Debug output to verify parsed options
 echo "INFO: Export compile commands: $export_compile_commands"
 echo "INFO: Enable ccache: $enable_ccache"
@@ -298,7 +314,17 @@ echo "INFO: Enable Light Metal Trace: $light_metal_trace"
 echo "INFO: Enable Distributed: $enable_distributed"
 echo "INFO: With python bindings: $with_python_bindings"
 echo "INFO: Enable Tracy: $tracy_enabled"
-echo "INFO: Tracy debug zones: $build_perf_debug"
+if [ "$tracy_enabled" != "ON" ]; then
+    perf_debug_categories_effective="off (Tracy disabled)"
+elif [ -n "$perf_debug_categories" ]; then
+    perf_debug_categories_effective="$perf_debug_categories"
+elif [ -f "$build_dir/CMakeCache.txt" ]; then
+    perf_debug_categories_effective=$(sed -n 's/^TRACY_DEBUG_CATEGORY:[^=]*=//p' "$build_dir/CMakeCache.txt")
+    perf_debug_categories_effective="${perf_debug_categories_effective:-off} (cached)"
+else
+    perf_debug_categories_effective="off"
+fi
+echo "INFO: Tracy debug-verbosity categories: $perf_debug_categories_effective"
 echo "INFO: Enable LTO: $enable_lto"
 echo "INFO: Warnings as errors: $warnings_as_errors"
 
@@ -334,10 +360,8 @@ if [ "$disable_profiler" = "ON" ]; then
     cmake_args+=("-DENABLE_TRACY=OFF")
 fi
 
-if [ "$build_perf_debug" = "ON" ]; then
-    cmake_args+=("-DENABLE_TRACY_DEBUG=ON")
-else
-    cmake_args+=("-DENABLE_TRACY_DEBUG=OFF")
+if [ -n "$perf_debug_categories" ]; then
+    cmake_args+=("-DTRACY_DEBUG_CATEGORY=$perf_debug_categories")
 fi
 
 if [ "$export_compile_commands" = "ON" ]; then

--- a/cmake/project_options.cmake
+++ b/cmake/project_options.cmake
@@ -5,6 +5,7 @@
 option(WITH_PYTHON_BINDINGS "Enables build of python bindings" ON)
 option(ENABLE_CODE_TIMERS "Enable code timers" OFF)
 option(ENABLE_TRACY "Enable Tracy Profiling" ON)
+option(ENABLE_TRACY_DEBUG "Enable debug-verbosity Tracy profiling zones" OFF)
 option(ENABLE_LIBCXX "Enable using libc++" OFF)
 option(ENABLE_BUILD_TIME_TRACE "Enable build time trace (Clang only -ftime-trace)" OFF)
 option(BUILD_SHARED_LIBS "Create shared libraries" ON)

--- a/cmake/project_options.cmake
+++ b/cmake/project_options.cmake
@@ -5,7 +5,11 @@
 option(WITH_PYTHON_BINDINGS "Enables build of python bindings" ON)
 option(ENABLE_CODE_TIMERS "Enable code timers" OFF)
 option(ENABLE_TRACY "Enable Tracy Profiling" ON)
-option(ENABLE_TRACY_DEBUG "Enable debug-verbosity Tracy profiling zones" OFF)
+set(TRACY_DEBUG_CATEGORY
+    "off"
+    CACHE STRING
+    "Tracy debug-verbosity categories to compile in: off, or a comma-separated list from tt_metal/tools/profiler/tracy_debug_categories.txt."
+)
 option(ENABLE_LIBCXX "Enable using libc++" OFF)
 option(ENABLE_BUILD_TIME_TRACE "Enable build time trace (Clang only -ftime-trace)" OFF)
 option(BUILD_SHARED_LIBS "Create shared libraries" ON)

--- a/docs/source/tt-metalium/tools/tracy_profiler.rst
+++ b/docs/source/tt-metalium/tools/tracy_profiler.rst
@@ -32,6 +32,22 @@ Tracy profiling support is **enabled by default** when building Metalium. Simply
     ninja
     ninja install
 
+Debug-verbosity Tracy zones are disabled by default. To build host-side
+``TTZone*D`` zones, keep Tracy enabled and opt in explicitly:
+
+..  code-block:: bash
+
+    # Via build script
+    ./build_metal.sh --build-perf-debug
+
+    # Or via CMake flags
+    cmake . -DENABLE_TRACY=ON -DENABLE_TRACY_DEBUG=ON
+    ninja
+    ninja install
+
+The ``TTZone*D`` macros, such as ``TTZoneScopedD`` and ``TTZoneTextD``, compile
+out otherwise.
+
 GUI
 ---
 

--- a/docs/source/tt-metalium/tools/tracy_profiler.rst
+++ b/docs/source/tt-metalium/tools/tracy_profiler.rst
@@ -11,7 +11,7 @@ Profiling is an essential part of software development that helps developers gai
 Overview
 --------
 
-`Tracy <https://github.com/wolfpld/tracy>`_ is an opens-source C++ profiling tool with sampling and code instrumentation profiling capabilities. Metalium uses a fork for Tracy adapted to the the Tensix Processors as it's primary profiling tool.
+`Tracy <https://github.com/wolfpld/tracy>`_ is an open-source C++ profiling tool with sampling and code-instrumentation capabilities. Metalium uses a fork for Tracy adapted to the Tensix processors as its primary profiling tool.
 
 Detailed documentation about Tracy itself can be found here: https://github.com/wolfpld/tracy/releases/latest/download/tracy.pdf. Reading the ``Quick-start guide`` section can help with the rest of this documentation.
 
@@ -32,21 +32,27 @@ Tracy profiling support is **enabled by default** when building Metalium. Simply
     ninja
     ninja install
 
-Debug-verbosity Tracy zones are disabled by default. To build host-side
-``TTZone*D`` zones, keep Tracy enabled and opt in explicitly:
+Debug-verbosity zones are off by default and gated behind opt-in *categories*.
+Build with one or more (comma-separated), or ``all`` for every zone; see
+``./build_metal.sh --help`` for the list:
 
 ..  code-block:: bash
 
     # Via build script
-    ./build_metal.sh --build-perf-debug
+    ./build_metal.sh --build-perf-debug dispatch,program
 
     # Or via CMake flags
-    cmake . -DENABLE_TRACY=ON -DENABLE_TRACY_DEBUG=ON
-    ninja
-    ninja install
+    cmake -B build -DENABLE_TRACY=ON -DTRACY_DEBUG_CATEGORY=dispatch,program
+    ninja -C build
+    ninja -C build install
 
-The ``TTZone*D`` macros, such as ``TTZoneScopedD`` and ``TTZoneTextD``, compile
-out otherwise.
+The selection is cached and persists across builds until changed;
+``--build-perf-debug off`` disables it.
+
+To instrument code, tag a zone with a ``TTZone*D`` macro whose first argument is
+the category as an upper-snake token (``rt-profiler`` -> ``RT_PROFILER``), e.g.
+``TTZoneScopedD(DISPATCH)`` or ``TTZoneScopedDN(RT_PROFILER, "name")``. A zone
+whose category is not selected compiles out.
 
 GUI
 ---

--- a/tt_metal/common/work_split.cpp
+++ b/tt_metal/common/work_split.cpp
@@ -14,7 +14,7 @@
 #include <utility>
 #include <vector>
 
-#include "tracy/Tracy.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 #include <umd/device/types/xy_pair.hpp>
 
 namespace tt::tt_metal {
@@ -152,6 +152,7 @@ CoreRangeSet num_cores_to_corerangeset_in_subcoregrids(
     const uint32_t target_num_cores,
     const CoreRangeSet& sub_core_grids,
     const bool row_wise = false) {
+    TTZoneScopedD(MISC);
     TT_FATAL(target_num_cores > 0, "Target number of cores must be greater than 0");
     TT_FATAL(
         target_num_cores <= sub_core_grids.num_cores(),
@@ -313,6 +314,7 @@ CoreRangeSet num_cores_to_corerangeset_in_subcoregrids(
 
 std::tuple<std::vector<uint32_t>, CoreRangeSet> split_work_to_cores_even_multiples(
     const CoreCoord& core_grid, const uint32_t units_to_divide, const uint32_t multiple, const bool row_wise) {
+    TTZoneScopedD(MISC);
     const uint32_t batches_to_divide = std::ceil(units_to_divide / multiple), max_num_cores = core_grid.x * core_grid.y;
     const uint32_t target_num_cores = (batches_to_divide >= max_num_cores) ? max_num_cores : batches_to_divide;
 
@@ -336,6 +338,7 @@ std::tuple<std::vector<uint32_t>, CoreRangeSet> split_work_to_cores_even_multipl
 
 std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> split_work_to_cores(
     const CoreCoord grid_size, const uint32_t units_to_divide, const bool row_wise) {
+    TTZoneScopedD(MISC);
     if (units_to_divide == 0) {
         return std::make_tuple(0, CoreRangeSet(), CoreRangeSet(), CoreRangeSet(), 0, 0);
     }

--- a/tt_metal/distributed/fd_mesh_command_queue.cpp
+++ b/tt_metal/distributed/fd_mesh_command_queue.cpp
@@ -524,7 +524,7 @@ void FDMeshCommandQueue::enqueue_write_shard_to_core(
     uint32_t size_bytes,
     bool blocking,
     ttsl::Span<const SubDeviceId> sub_device_ids) {
-    ZoneScoped;
+    TTZoneScopedD(DISPATCH);
 
     auto lock = lock_api_function_();
     if (!mesh_device_->impl().is_local(address.device_coord)) {
@@ -559,7 +559,7 @@ void FDMeshCommandQueue::enqueue_write_dram_core_counter(
     uint32_t value,
     bool blocking,
     ttsl::Span<const SubDeviceId> sub_device_ids) {
-    ZoneScoped;
+    TTZoneScopedD(DISPATCH);
 
     // No lock_api_function_() here: the caller (TensorPrefetcherManager) already holds
     // the MeshDevice api lock across the counter bump + WAIT_CQ enqueue, and that lock is
@@ -606,7 +606,7 @@ void FDMeshCommandQueue::enqueue_read_shard_from_core(
     uint32_t size_bytes,
     bool blocking,
     ttsl::Span<const SubDeviceId> sub_device_ids) {
-    ZoneScoped;
+    TTZoneScopedD(DISPATCH);
     auto lock = lock_api_function_();
 
     if (this->get_target_device_type() == tt::TargetDevice::Mock ||
@@ -692,7 +692,7 @@ void FDMeshCommandQueue::finish(ttsl::Span<const SubDeviceId> sub_device_ids) {
     this->finish_nolock(sub_device_ids);
 
     {
-        ZoneScopedN("RealtimeProfilerSyncCheck");
+        TTZoneScopedDN(RT_PROFILER, "RealtimeProfilerSyncCheck");
         mesh_device_->impl().trigger_realtime_profiler_sync_check();
     }
 

--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -884,7 +884,7 @@ bool MeshDeviceImpl::close() {
 }
 
 bool MeshDeviceImpl::close_impl(MeshDevice* pimpl_wrapper) {
-    ZoneScoped;
+    TTZoneScopedD(MISC);
 
     log_trace(tt::LogMetal, "Closing mesh device {}", this->id());
 
@@ -1348,7 +1348,7 @@ void MeshDeviceImpl::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) 
 }
 
 void MeshDeviceImpl::replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking) {
-    ZoneScoped;
+    TTZoneScopedD(DISPATCH);
     TracyTTMetalReplayMeshTrace(this->get_device_ids(), *trace_id);
     auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
     const auto& trace_buffer = active_sub_device_manager->get_trace(trace_id);

--- a/tt_metal/distributed/realtime_profiler_manager.cpp
+++ b/tt_metal/distributed/realtime_profiler_manager.cpp
@@ -768,9 +768,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 return false;
             }
 
-            // TODO: Uncomment this and apply a debug verbosity level when
-            // https://github.com/tenstorrent/tt-metal/issues/30615 is done.
-            // ZoneScopedN("ProcessPage");
+            TTZoneScopedDN(RT_PROFILER, "ProcessPage");
             dev_state.socket->read(page_buf.data(), 1);
             uint32_t* read_ptr = page_buf.data();
 
@@ -800,9 +798,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             // Skip records with id==0 (non-GO dispatch commands like SET_NUM_WORKER_SEMS):
             // they have no valid program and may carry stale end timestamps.
             if (start_id != 0) {
-                // TODO: Uncomment this and apply a debug verbosity level when
-                // https://github.com/tenstorrent/tt-metal/issues/30615 is done.
-                // ZoneScopedN("InvokeCallbacks");
+                TTZoneScopedDN(RT_PROFILER, "InvokeCallbacks");
                 tt::ProgramRealtimeRecord record{
                     .runtime_id = start_id,
                     .chip_id = dev_state.chip_id,
@@ -828,9 +824,7 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
                 continue;
             }
 
-            // TODO: Uncomment this and apply a debug verbosity level when
-            // https://github.com/tenstorrent/tt-metal/issues/30615 is done.
-            // ZoneScopedN("PollLoop");
+            TTZoneScopedDN(RT_PROFILER, "PollLoop");
             bool any_data = false;
 
             for (auto& dev_state : devices_) {
@@ -848,18 +842,14 @@ RealtimeProfilerManager::RealtimeProfilerManager(const std::shared_ptr<MeshDevic
             }
 
             if (!any_data) {
-                // TODO: Uncomment this and apply a debug verbosity level when
-                // https://github.com/tenstorrent/tt-metal/issues/30615 is done.
-                // ZoneScopedN("Idle");
+                TTZoneScopedDN(RT_PROFILER, "Idle");
                 std::this_thread::sleep_for(std::chrono::milliseconds(10));
             }
         }
 
         // Drain in-flight PCIe pages until all sockets stay empty for several rounds.
         {
-            // TODO: Uncomment this and apply a debug verbosity level when
-            // https://github.com/tenstorrent/tt-metal/issues/30615 is done.
-            // ZoneScopedN("DrainShutdown");
+            TTZoneScopedDN(RT_PROFILER, "DrainShutdown");
             constexpr uint32_t kDrainQuietRounds = 10;
             uint64_t drain_pages = 0;
             uint32_t quiet_rounds = 0;

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -32,7 +32,7 @@
 #include "tt_metal/impl/event/dispatch.hpp"
 #include "tt_metal/impl/device/dispatch.hpp"
 #include <tt-metalium/graph_tracking.hpp>
-#include <tracy/Tracy.hpp>
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 #include <tt_stl/overloaded.hpp>
 #include "tt_metal/api/tt-metalium/experimental/pinned_memory.hpp"
 #include <umd/device/types/core_coordinates.hpp>
@@ -683,7 +683,7 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
     const BufferCorePageMapping& core_page_mapping,
     const CoreCoord& core,
     ttsl::Span<const SubDeviceId> sub_device_ids) {
-    ZoneScoped;
+    TTZoneScopedD(DISPATCH);
     ContextId context_id = tt::tt_metal::extract_context_id(buffer.device());
     const auto& hal = tt::tt_metal::MetalContext::instance(context_id).hal();
     const uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
@@ -932,6 +932,7 @@ void issue_buffer_dispatch_command_sequence(
     T& dispatch_params,
     ttsl::Span<const SubDeviceId> sub_device_ids,
     CoreType /*dispatch_core_type*/) {
+    TTZoneScopedD(DISPATCH);
     uint32_t num_worker_counters = sub_device_ids.size();
     bool use_pinned_memory = dispatch_params.use_pinned_transfer;
     uint32_t num_pages_to_write =
@@ -1040,6 +1041,7 @@ void write_interleaved_buffer_to_device(
     const BufferDispatchConstants& buf_dispatch_constants,
     ttsl::Span<const SubDeviceId> sub_device_ids,
     CoreType dispatch_core_type) {
+    TTZoneScopedD(DISPATCH);
     bool use_pinned_memory = dispatch_params.use_pinned_transfer;
 
     // data appended after CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PAGED
@@ -1089,6 +1091,7 @@ void write_sharded_buffer_to_core(
     ttsl::Span<const SubDeviceId> sub_device_ids,
     const CoreCoord core,
     CoreType dispatch_core_type) {
+    TTZoneScopedD(DISPATCH);
     // Skip writing the padded pages along the bottom
     // Currently since writing sharded tensors uses write_linear, we write the padded pages on width
     // Alternative write each page row into separate commands, or have a strided linear write
@@ -1140,6 +1143,7 @@ bool write_to_device_buffer(
     ttsl::Span<const SubDeviceId> sub_device_ids,
     const std::shared_ptr<experimental::PinnedMemory>& pinned_memory,
     const CoreRangeSet* logical_core_filter) {
+    TTZoneScopedD(DISPATCH);
     SystemMemoryManager& sysmem_manager = buffer.device()->sysmem_manager();
     ContextId context_id = tt::tt_metal::extract_context_id(buffer.device());
     const auto& hal = tt::tt_metal::MetalContext::instance(context_id).hal();
@@ -1638,6 +1642,7 @@ void copy_completion_queue_data_into_user_space(
     uint32_t cq_id,
     SystemMemoryManager& sysmem_manager,
     std::atomic<bool>& exit_condition) {
+    TTZoneScopedD(DISPATCH);
     const auto& [page_size, padded_page_size, buffer_page_mapping, core_page_mapping, dst, dst_offset, num_pages_read] =
         read_buffer_descriptor;
     const DeviceAddr padded_num_bytes = ((DeviceAddr)num_pages_read * padded_page_size) + sizeof(CQDispatchCmd);

--- a/tt_metal/impl/data_format/bfloat16.cpp
+++ b/tt_metal/impl/data_format/bfloat16.cpp
@@ -11,7 +11,7 @@
 #include <vector>
 
 #include <tt_stl/assert.hpp>
-#include "tracy/Tracy.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 
 #include "impl/data_format/bfloat16_utils.hpp"
 
@@ -156,7 +156,7 @@ std::vector<bfloat16> create_identity_matrix(int rows, int cols, int num_ones) {
 }
 
 std::vector<uint32_t> pack_bfloat16_vec_into_uint32_vec(const std::vector<bfloat16>& data) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     TT_ASSERT(data.size() % 2 == 0);
     std::vector<uint32_t> result(data.size() / 2);
     std::memcpy(result.data(), data.data(), result.size() * sizeof(uint32_t));

--- a/tt_metal/impl/data_format/bfloat2.cpp
+++ b/tt_metal/impl/data_format/bfloat2.cpp
@@ -16,7 +16,7 @@
 #include "impl/context/metal_context.hpp"
 #include "math.hpp"
 #include "tile.hpp"
-#include "tracy/Tracy.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 #include "tt_backend_api_types.hpp"
 
 template <typename T>
@@ -61,7 +61,7 @@ std::vector<float> unpack_bfp2_tiles_into_float_vec(
     bool row_major_output,
     bool is_exp_a,
     const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
 
     uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
 

--- a/tt_metal/impl/data_format/bfloat4.cpp
+++ b/tt_metal/impl/data_format/bfloat4.cpp
@@ -18,7 +18,7 @@
 #include "impl/context/metal_context.hpp"
 #include "math.hpp"
 #include "tile.hpp"
-#include "tracy/Tracy.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 #include "tt_backend_api_types.hpp"
 
 template <typename T>
@@ -63,7 +63,7 @@ std::vector<float> unpack_bfp4_tiles_into_float_vec(
     bool row_major_output,
     bool is_exp_a,
     const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
 
     uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
 

--- a/tt_metal/impl/data_format/bfloat8.cpp
+++ b/tt_metal/impl/data_format/bfloat8.cpp
@@ -17,7 +17,7 @@
 #include "impl/context/metal_context.hpp"
 #include "math.hpp"
 #include "tile.hpp"
-#include "tracy/Tracy.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 #include "tt_backend_api_types.hpp"
 
 template <typename T>
@@ -62,7 +62,7 @@ std::vector<float> unpack_bfp8_tiles_into_float_vec(
     bool row_major_output,
     bool is_exp_a,
     const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
 
     uint32_t l1_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(tt::tt_metal::HalMemType::L1);
 

--- a/tt_metal/impl/data_format/blockfloat_common.cpp
+++ b/tt_metal/impl/data_format/blockfloat_common.cpp
@@ -14,7 +14,7 @@
 #include "impl/context/metal_context.hpp"
 #include "math.hpp"
 #include "tile.hpp"
-#include "tracy/Tracy.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 #include "tt_backend_api_types.hpp"
 
 namespace {
@@ -343,7 +343,7 @@ std::vector<uint32_t> pack_as_bfp_tiles(
     bool row_major_input,
     bool is_exp_a,
     const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
 
     TT_ASSERT(
         BfpFormat == tt::DataFormat::Bfp2 || BfpFormat == tt::DataFormat::Bfp4 || BfpFormat == tt::DataFormat::Bfp8 ||

--- a/tt_metal/impl/data_format/mxfp4.cpp
+++ b/tt_metal/impl/data_format/mxfp4.cpp
@@ -10,7 +10,7 @@
 #include <tt_stl/span.hpp>
 
 #include <tt-metalium/tile.hpp>
-#include "tracy/Tracy.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 
 #include "mx_tile_pack.hpp"
 
@@ -42,7 +42,7 @@ constexpr tt::tt_metal::mx::FormatParams kMxFp4Params = {
 template <typename T>
 std::vector<uint32_t> pack_as_mxfp4_tiles(
     ttsl::Span<const T> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::pack_as_mx_tiles_impl(data, row_major_input, tile, kMxFp4Params);
 }
 
@@ -52,6 +52,6 @@ template std::vector<uint32_t> pack_as_mxfp4_tiles<float>(
 
 std::vector<float> unpack_mxfp4_tiles_into_float_vec(
     ttsl::Span<const uint32_t> mxfp4_tiles, bool row_major_output, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::unpack_mx_tiles_into_float_vec_impl(mxfp4_tiles, row_major_output, tile, kMxFp4Params);
 }

--- a/tt_metal/impl/data_format/mxfp6.cpp
+++ b/tt_metal/impl/data_format/mxfp6.cpp
@@ -10,7 +10,7 @@
 #include <tt_stl/span.hpp>
 
 #include <tt-metalium/tile.hpp>
-#include "tracy/Tracy.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 
 #include "mx_tile_pack.hpp"
 
@@ -63,14 +63,14 @@ constexpr tt::tt_metal::mx::FormatParams kMxFp6PParams = {
 template <typename T>
 std::vector<uint32_t> pack_as_mxfp6r_tiles(
     ttsl::Span<const T> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::pack_as_mx_tiles_impl(data, row_major_input, tile, kMxFp6RParams);
 }
 
 template <typename T>
 std::vector<uint32_t> pack_as_mxfp6p_tiles(
     ttsl::Span<const T> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::pack_as_mx_tiles_impl(data, row_major_input, tile, kMxFp6PParams);
 }
 
@@ -82,12 +82,12 @@ template std::vector<uint32_t> pack_as_mxfp6p_tiles<float>(
 
 std::vector<float> unpack_mxfp6r_tiles_into_float_vec(
     ttsl::Span<const uint32_t> mxfp6_tiles, bool row_major_output, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::unpack_mx_tiles_into_float_vec_impl(mxfp6_tiles, row_major_output, tile, kMxFp6RParams);
 }
 
 std::vector<float> unpack_mxfp6p_tiles_into_float_vec(
     ttsl::Span<const uint32_t> mxfp6_tiles, bool row_major_output, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::unpack_mx_tiles_into_float_vec_impl(mxfp6_tiles, row_major_output, tile, kMxFp6PParams);
 }

--- a/tt_metal/impl/data_format/mxfp8.cpp
+++ b/tt_metal/impl/data_format/mxfp8.cpp
@@ -10,7 +10,7 @@
 #include <tt_stl/span.hpp>
 
 #include <tt-metalium/tile.hpp>
-#include "tracy/Tracy.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 
 #include "mx_tile_pack.hpp"
 
@@ -66,14 +66,14 @@ constexpr tt::tt_metal::mx::FormatParams kMxFp8E4M3Params = {
 template <typename T>
 std::vector<uint32_t> pack_as_mxfp8_e5m2_tiles(
     ttsl::Span<const T> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::pack_as_mx_tiles_impl(data, row_major_input, tile, kMxFp8E5M2Params);
 }
 
 template <typename T>
 std::vector<uint32_t> pack_as_mxfp8_e4m3_tiles(
     ttsl::Span<const T> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::pack_as_mx_tiles_impl(data, row_major_input, tile, kMxFp8E4M3Params);
 }
 
@@ -85,12 +85,12 @@ template std::vector<uint32_t> pack_as_mxfp8_e4m3_tiles<float>(
 
 std::vector<float> unpack_mxfp8_e5m2_tiles_into_float_vec(
     ttsl::Span<const uint32_t> mxfp8_tiles, bool row_major_output, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::unpack_mx_tiles_into_float_vec_impl(mxfp8_tiles, row_major_output, tile, kMxFp8E5M2Params);
 }
 
 std::vector<float> unpack_mxfp8_e4m3_tiles_into_float_vec(
     ttsl::Span<const uint32_t> mxfp8_tiles, bool row_major_output, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::unpack_mx_tiles_into_float_vec_impl(mxfp8_tiles, row_major_output, tile, kMxFp8E4M3Params);
 }

--- a/tt_metal/impl/data_format/mxint.cpp
+++ b/tt_metal/impl/data_format/mxint.cpp
@@ -10,7 +10,7 @@
 #include <tt_stl/span.hpp>
 
 #include <tt-metalium/tile.hpp>
-#include "tracy/Tracy.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 
 #include "mx_tile_pack.hpp"
 
@@ -65,21 +65,21 @@ constexpr tt::tt_metal::mx::FormatParams kMxInt2Params = {
 template <typename T>
 std::vector<uint32_t> pack_as_mxint8_tiles(
     ttsl::Span<const T> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::pack_as_mx_tiles_impl(data, row_major_input, tile, kMxInt8Params);
 }
 
 template <typename T>
 std::vector<uint32_t> pack_as_mxint4_tiles(
     ttsl::Span<const T> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::pack_as_mx_tiles_impl(data, row_major_input, tile, kMxInt4Params);
 }
 
 template <typename T>
 std::vector<uint32_t> pack_as_mxint2_tiles(
     ttsl::Span<const T> data, bool row_major_input, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::pack_as_mx_tiles_impl(data, row_major_input, tile, kMxInt2Params);
 }
 
@@ -93,18 +93,18 @@ template std::vector<uint32_t> pack_as_mxint2_tiles<float>(
 
 std::vector<float> unpack_mxint8_tiles_into_float_vec(
     ttsl::Span<const uint32_t> mxint_tiles, bool row_major_output, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::unpack_mx_tiles_into_float_vec_impl(mxint_tiles, row_major_output, tile, kMxInt8Params);
 }
 
 std::vector<float> unpack_mxint4_tiles_into_float_vec(
     ttsl::Span<const uint32_t> mxint_tiles, bool row_major_output, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::unpack_mx_tiles_into_float_vec_impl(mxint_tiles, row_major_output, tile, kMxInt4Params);
 }
 
 std::vector<float> unpack_mxint2_tiles_into_float_vec(
     ttsl::Span<const uint32_t> mxint_tiles, bool row_major_output, const std::optional<tt::tt_metal::Tile>& tile) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     return tt::tt_metal::mx::unpack_mx_tiles_into_float_vec_impl(mxint_tiles, row_major_output, tile, kMxInt2Params);
 }

--- a/tt_metal/impl/data_format/tilize_utils.cpp
+++ b/tt_metal/impl/data_format/tilize_utils.cpp
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <tracy/Tracy.hpp>
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/tilize_utils.hpp>
 #include <cstddef>
@@ -45,7 +45,7 @@ std::uint32_t round_up_to_tile(int val, int tile_val) { return (val + tile_val -
 template <typename T>
 std::vector<T> to_tile_major_layout_swizzled(
     ttsl::Span<const T> in_row_major, const PhysicalSize& shape, std::optional<PhysicalSize> tile_shape) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     std::vector<T> tilized_result;
     if (in_row_major.size() == 0) {
         return tilized_result;
@@ -82,7 +82,7 @@ std::vector<T> to_tile_major_layout_swizzled(
 template <typename T>
 std::vector<T> convert_layout_tile_swizzled_to_row_major(
     ttsl::Span<const T> in_tile_swizzled, const PhysicalSize& shape, std::optional<PhysicalSize> tile_shape) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     std::vector<T> result;
     if (in_tile_swizzled.size() == 0) {
         return result;
@@ -123,7 +123,7 @@ std::vector<T> convert_layout_tile_swizzled_to_tile_nfaces(
     std::optional<PhysicalSize> face_shape,
     const bool transpose_face,
     bool transpose_face_order) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     std::vector<T> result;
     if (in_tile_swizzled.size() == 0) {
         return result;
@@ -187,7 +187,7 @@ std::vector<T> convert_layout_tile_nfaces_to_tile_swizzled(
     std::optional<PhysicalSize> face_shape,
     const bool transpose_face,
     bool transpose_face_order) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
     std::vector<T> result(in_tile_nfaces.size());
     if (in_tile_nfaces.size() == 0) {
         return result;
@@ -260,7 +260,7 @@ std::vector<T> to_tile_major_layout_nfaces(
     std::optional<PhysicalSize> face_shape,
     const bool transpose_face,
     const bool transpose_face_order) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
 
     size_t H = shape[0];
     size_t W = shape[1];
@@ -342,7 +342,7 @@ std::vector<T> convert_layout_tile_nfaces_to_row_major(
     std::optional<PhysicalSize> face_shape,
     const bool transpose_face,
     bool transpose_face_order) {
-    ZoneScoped;
+    TTZoneScopedD(DATA_FORMAT);
 
     size_t H = shape[0];
     size_t W = shape[1];
@@ -434,6 +434,7 @@ std::vector<T> convert_layout(
     std::optional<PhysicalSize> face_shape,
     const bool transpose_within_face,
     const bool transpose_of_faces) {
+    TTZoneScopedD(DATA_FORMAT);
     if (inp.size() == 0) {
         return std::vector<T>();
     }
@@ -485,6 +486,7 @@ std::vector<T> convert_layout(
     std::optional<PhysicalSize> face_shape,
     const bool transpose_within_face,
     const bool transpose_of_faces) {
+    TTZoneScopedD(DATA_FORMAT);
     TT_ASSERT(shape.size() >= 2, "Shape size {} must be at least rank 2!", shape.size());
     uint32_t H = shape[shape.size() - 2];
     uint32_t W = shape[shape.size() - 1];

--- a/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
+++ b/tt_metal/impl/dataflow_buffer/dataflow_buffer.cpp
@@ -17,6 +17,7 @@
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 #include "tt_metal/impl/program/program_impl.hpp"
 #include "tt_metal/impl/kernels/kernel.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 
 namespace tt::tt_metal::experimental::dfb {
 
@@ -1759,7 +1760,7 @@ std::vector<CoreRange> ProgramImpl::dataflow_buffers_unique_coreranges() const {
 }
 
 void ProgramImpl::set_dfb_data_fmt_and_tile(const std::vector<CoreRange>& crs, JitBuildOptions& build_options) const {
-    // ZoneScoped;
+    TTZoneScopedD(PROGRAM);
     // Match detail::ProgramImpl::set_cb_data_fmt_and_tile: DFB logical ids map to CBIndex slots for HLK unpack/pack.
     for (const auto& logical_cr : crs) {
         const auto& dfbs_on_core = this->dataflow_buffers_on_corerange(logical_cr);

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -10,7 +10,7 @@
 #include "impl/context/metal_context.hpp"
 #include "system_memory_manager.hpp"
 #include "program/dispatch.hpp"
-#include <tracy/Tracy.hpp>
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/xy_pair.hpp>
@@ -27,7 +27,7 @@ namespace tt::tt_metal {
 
 HWCommandQueue::HWCommandQueue(Device* device, uint32_t id, NOC /*noc_index*/) :
     id_(id), manager_(device->sysmem_manager()), device_(device) {
-    ZoneScopedN("CommandQueue_constructor");
+    TTZoneScopedDN(DISPATCH, "CommandQueue_constructor");
 
     uint16_t channel =
         tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(device_->id());
@@ -71,7 +71,7 @@ const CoreCoord& HWCommandQueue::virtual_enqueue_program_dispatch_core() const {
 }
 
 void HWCommandQueue::terminate() {
-    ZoneScopedN("HWCommandQueue_terminate");
+    TTZoneScopedDN(DISPATCH, "HWCommandQueue_terminate");
     TT_FATAL(!this->manager_.get_bypass_mode(), "Terminate cannot be used with tracing");
     log_debug(tt::LogDispatch, "Terminating dispatch kernels for command queue {}", this->id_);
     // CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_TERMINATE

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -28,7 +28,7 @@
 #include <tt-logger/tt-logger.hpp>
 #include <umd/device/types/cluster_descriptor_types.hpp>
 #include <umd/device/types/xy_pair.hpp>
-#include <tracy/Tracy.hpp>
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
 #include "impl/dispatch/kernels/cq_prefetch.hpp"
@@ -689,7 +689,7 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
         if (this->prefetch_q_dev_ptrs[cq_id] != this->prefetch_q_dev_fences[cq_id]) {
             return;
         }
-        ZoneScopedN("wait_for_fetch_q_space");
+        TTZoneScopedDN(DISPATCH, "wait_for_fetch_q_space");
 
         // Body of the operation
         auto fetch_operation_body = [&]() {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -10,7 +10,7 @@
 #include <cstring>
 #include <span>
 #include <sub_device_types.hpp>
-#include <tracy/Tracy.hpp>
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/mesh_command_queue.hpp>
@@ -2644,7 +2644,7 @@ void update_traced_program_dispatch_commands(
     ProgramBinaryStatus program_binary_status,
     std::pair<bool, int> unicast_go_signal_update) {
     uint32_t i = 0;
-    ZoneScopedN("program_loaded_on_device");
+    TTZoneScopedDN(DISPATCH, "program_loaded_on_device");
     const auto& hal = MetalContext::instance().hal();
     const ProgramImpl& program = *trace_node.program;
     const TraceDispatchMetadata& dispatch_md = trace_node.dispatch_metadata;

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -87,6 +87,7 @@
 #include "impl/allocator/allocator.hpp"
 #include <internal/service/service_core_manager.hpp>
 #include "impl/internal/service/service_core_manager_impl.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 
 namespace tt {
 enum CBIndex : std::uint8_t;
@@ -1336,7 +1337,7 @@ void detail::ProgramImpl::allocate_scratchpads(const IDevice* device) {
 }
 
 void detail::ProgramImpl::allocate_circular_buffers(const IDevice* device) {
-    // ZoneScoped;
+    TTZoneScopedD(PROGRAM);
 
     // If device is a MeshDevice, we need to track all its sub-devices
     std::vector<const IDevice*> devices_to_track;
@@ -1504,7 +1505,7 @@ void detail::ProgramImpl::deallocate_circular_buffers() {
 }
 
 void detail::ProgramImpl::validate_circular_buffer_region(const IDevice* device) {
-    // ZoneScoped;
+    TTZoneScopedD(PROGRAM);
 
     // TODO: Circular buffer allocation and validation could be better optimized by determining usage per sub-device
     std::optional<DeviceAddr> lowest_address =
@@ -1808,7 +1809,7 @@ void detail::ProgramImpl::set_remote_circular_buffer_init(const std::shared_ptr<
 
 void detail::ProgramImpl::set_cb_data_fmt_and_tile(
     const std::vector<CoreRange>& crs, JitBuildOptions& build_options) const {
-    // ZoneScoped;
+    TTZoneScopedD(PROGRAM);
     for (const auto& logical_cr : crs) {
         const auto& cbs_on_core = this->circular_buffers_on_corerange(logical_cr);
         for (const auto& circular_buffer : cbs_on_core) {
@@ -2158,7 +2159,7 @@ void ProgramImpl::generate_trace_dispatch_commands(distributed::MeshDevice* mesh
 }
 
 void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
-    // ZoneScoped;
+    TTZoneScopedD(PROGRAM);
     const auto& build_env =
         BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id());
 

--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -46,6 +46,7 @@
 #include "profiler_paths.hpp"
 #include "tt_metal/llrt/tt_elffile.hpp"
 #include <umd/device/types/arch.hpp>
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 
 namespace fs = std::filesystem;
 
@@ -513,7 +514,7 @@ void JitBuildState::write_build_state_hash(const string& out_dir) const {
 }
 
 void JitBuildState::compile_one(const string& out_dir, const JitBuildSettings* settings, size_t src_index) const {
-    // ZoneScoped;
+    TTZoneScopedD(JIT);
 
     string cmd{"cd " + out_dir + " && " + env_.gpp_};
     string defines = this->defines_;
@@ -602,7 +603,7 @@ bool JitBuildState::need_compile(const string& out_dir, const string& obj) const
 
 std::bitset<JitBuildState::kMaxBuildBitset> JitBuildState::compile(
     const string& out_dir, const JitBuildSettings* settings, bool state_changed) const {
-    // ZoneScoped;
+    TTZoneScopedD(JIT);
     TT_FATAL(
         this->srcs_.size() <= kMaxBuildBitset,
         "Number of source files ({}) exceeds kMaxBuildBitset ({})",
@@ -690,7 +691,7 @@ void JitBuildState::link(const string& out_dir, const JitBuildSettings* settings
 // same name don't result in duplicate symbols but B can reference A's symbols. Force the fw_export symbols to remain
 // strong so to propagate link addresses
 void JitBuildState::weaken(const string& out_dir) const {
-    // ZoneScoped;
+    TTZoneScopedD(JIT);
 
     std::string pathname_in = out_dir + target_name_ + ".elf";
     jit_build::utils::FileRenamer out_file(this->weakened_firmware_name_);
@@ -710,7 +711,7 @@ void JitBuildState::weaken(const string& out_dir) const {
 }
 
 void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const {
-    // ZoneScoped;
+    TTZoneScopedD(JIT);
     static std::atomic<bool> new_log = true;
     // Mutex to serialize concurrent writes to the shared zone src locations log file.
     // Multiple kernels are compiled in parallel; without serialization their grep outputs
@@ -733,7 +734,7 @@ void JitBuildState::extract_zone_src_locations(const std::string& out_dir) const
 }
 
 void JitBuildState::build(const JitBuildSettings* settings, std::span<const JitBuildState* const> link_targets) const {
-    // ZoneScoped;
+    TTZoneScopedD(JIT);
     auto t0_build = std::chrono::steady_clock::now();
     auto kernel_name = settings ? std::string_view{settings->get_full_kernel_name()} : "";
     std::string out_dir = fmt::format("{}{}{}/", this->out_path_, kernel_name, this->target_name_);
@@ -886,7 +887,7 @@ tt::jit_build::TargetRecipe JitBuildState::export_target_recipe(const JitBuildSe
 }
 
 void jit_build(const JitBuildState& build, const JitBuildSettings* settings) {
-    // ZoneScoped;
+    TTZoneScopedD(JIT);
     auto t0 = std::chrono::steady_clock::now();
     build.build(settings);
     auto elapsed_ms = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -38,6 +38,7 @@
 #include "jit_build_settings.hpp"
 #include <tt-logger/tt-logger.hpp>
 #include "impl/kernels/kernel_source.hpp"
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 
 namespace tt::tt_metal {
 enum class UnpackToDestMode : uint8_t;
@@ -835,9 +836,8 @@ void generate_all_descriptors(const JitBuildEnv& env, const JitBuildOptions& opt
 
 // clang-format off
 void jit_build_genfiles_descriptors(const JitBuildEnv& env, const JitBuildOptions& options) {
-    //ZoneScoped;
-    //const std::string tracyPrefix = "generate_descriptors_";
-    //ZoneName((tracyPrefix + options.name).c_str(), options.name.length() + tracyPrefix.length());
+    TTZoneScopedDN(JIT, "generate_descriptors");
+    TTZoneTextD(JIT, options.name.c_str(), options.name.length());
     fs::create_directories(options.path);
     generate_all_descriptors(env, options);
 }

--- a/tt_metal/jit_build/jit_build_utils.cpp
+++ b/tt_metal/jit_build/jit_build_utils.cpp
@@ -26,11 +26,13 @@
 
 #include <tt-logger/tt-logger.hpp>
 
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
+
 namespace tt::jit_build::utils {
 
 bool run_command(const std::string& cmd, const std::string& log_file, bool verbose) {
-    // ZoneScoped;
-    // ZoneText( cmd.c_str(), cmd.length());
+    TTZoneScopedD(JIT);
+    TTZoneTextD(JIT, cmd.c_str(), cmd.length());
     int ret;
     static std::mutex io_mutex;
 

--- a/tt_metal/jit_build/kernel_signature_parser.cpp
+++ b/tt_metal/jit_build/kernel_signature_parser.cpp
@@ -12,7 +12,7 @@
 #include <string_view>
 #include <vector>
 
-#include <tracy/Tracy.hpp>
+#include "tt_metal/tools/profiler/tracy_debug_zones.hpp"
 
 namespace tt::tt_metal {
 
@@ -255,9 +255,7 @@ std::string read_identifier(const std::string& s, size_t& pos) {
 }  // namespace
 
 std::optional<KernelMainSignature> parse_kernel_main_signature(const std::string& source) {
-    // Profiler zone: measures the TT_KERNEL signature-parse overhead added to the JIT pipeline.
-    // Captured under Tracy when TRACY_ENABLE is on; a no-op otherwise.
-    ZoneScopedN("parse_kernel_main_signature");
+    TTZoneScopedD(JIT);
 
     const std::string text = strip_noise(source);
     const size_t n = text.size();

--- a/tt_metal/third_party/CMakeLists.txt
+++ b/tt_metal/third_party/CMakeLists.txt
@@ -54,6 +54,9 @@ install(
 )
 
 if(NOT ENABLE_TRACY)
+    if(ENABLE_TRACY_DEBUG)
+        message(WARNING "ENABLE_TRACY_DEBUG=ON has no effect with ENABLE_TRACY=OFF; debug zones are compiled out.")
+    endif()
     return()
 endif()
 
@@ -64,6 +67,10 @@ target_compile_options(TracyClient PUBLIC -fno-omit-frame-pointer)
 target_compile_options(TracyClient PRIVATE -Wno-unused-variable)
 # Their executable exports symbols (-rdynamic) → Tracy can map addresses to names.
 target_link_options(TracyClient PUBLIC -rdynamic)
+
+if(ENABLE_TRACY_DEBUG)
+    target_compile_definitions(TracyClient PUBLIC TT_TRACY_DEBUG)
+endif()
 
 # TracyClient is a PUBLIC dependency of TT::Metalium, so its interface exports
 # $<INSTALL_INTERFACE:include/tracy>. Tracy's own header install rules are

--- a/tt_metal/third_party/CMakeLists.txt
+++ b/tt_metal/third_party/CMakeLists.txt
@@ -54,9 +54,6 @@ install(
 )
 
 if(NOT ENABLE_TRACY)
-    if(ENABLE_TRACY_DEBUG)
-        message(WARNING "ENABLE_TRACY_DEBUG=ON has no effect with ENABLE_TRACY=OFF; debug zones are compiled out.")
-    endif()
     return()
 endif()
 
@@ -67,10 +64,6 @@ target_compile_options(TracyClient PUBLIC -fno-omit-frame-pointer)
 target_compile_options(TracyClient PRIVATE -Wno-unused-variable)
 # Their executable exports symbols (-rdynamic) → Tracy can map addresses to names.
 target_link_options(TracyClient PUBLIC -rdynamic)
-
-if(ENABLE_TRACY_DEBUG)
-    target_compile_definitions(TracyClient PUBLIC TT_TRACY_DEBUG)
-endif()
 
 # TracyClient is a PUBLIC dependency of TT::Metalium, so its interface exports
 # $<INSTALL_INTERFACE:include/tracy>. Tracy's own header install rules are
@@ -217,3 +210,86 @@ ExternalProject_Add(
     INSTALL_COMMAND
         "" # Suppress default cmake --install: artifacts stay in BINARY_DIR for CI packaging to pick up.
 )
+
+set(_tt_tracy_categories_file "${CMAKE_CURRENT_SOURCE_DIR}/../tools/profiler/tracy_debug_categories.txt")
+set_property(
+    DIRECTORY
+    APPEND
+    PROPERTY
+        CMAKE_CONFIGURE_DEPENDS
+            "${_tt_tracy_categories_file}"
+)
+file(STRINGS "${_tt_tracy_categories_file}" _tt_tracy_categories_raw)
+set(_tt_tracy_categories "")
+foreach(_line IN LISTS _tt_tracy_categories_raw)
+    string(STRIP "${_line}" _line)
+    if(NOT _line STREQUAL "" AND NOT _line MATCHES "^#")
+        list(APPEND _tt_tracy_categories "${_line}")
+    endif()
+endforeach()
+
+set(_tt_tracy_valid
+    ${_tt_tracy_categories}
+    all
+)
+string(REPLACE ";" ", " _tt_tracy_valid_pretty "${_tt_tracy_valid}")
+set_property(
+    CACHE
+        TRACY_DEBUG_CATEGORY
+    PROPERTY
+        STRINGS
+            off
+            ${_tt_tracy_valid}
+)
+
+set(_tt_tracy_selected "")
+if(NOT TRACY_DEBUG_CATEGORY STREQUAL "off")
+    string(REPLACE "," ";" _tt_tracy_selected_raw "${TRACY_DEBUG_CATEGORY}")
+    foreach(_sel IN LISTS _tt_tracy_selected_raw)
+        string(STRIP "${_sel}" _sel)
+        if(NOT _sel IN_LIST _tt_tracy_valid)
+            message(
+                FATAL_ERROR
+                "Invalid TRACY_DEBUG_CATEGORY entry '${_sel}'; expected off, or a comma-separated list of: ${_tt_tracy_valid_pretty}."
+            )
+        endif()
+        list(APPEND _tt_tracy_selected "${_sel}")
+    endforeach()
+endif()
+
+# We emit the defines into a generated header, not onto TracyClient's PUBLIC (tree-wide) compile line, so
+# changing TRACY_DEBUG_CATEGORY recompiles only TUs including tracy_debug_zones.hpp, not all of TT::Metalium.
+set(_tt_tracy_defs "#pragma once\n")
+set(_idx 0)
+foreach(_cat IN LISTS _tt_tracy_categories)
+    set(_on 0)
+    if("all" IN_LIST _tt_tracy_selected OR "${_cat}" IN_LIST _tt_tracy_selected)
+        set(_on 1)
+    endif()
+    string(TOUPPER "${_cat}" _tok)
+    string(REPLACE "-" "_" _tok "${_tok}")
+    string(APPEND _tt_tracy_defs "#define TT_TRACY_CATEGORY_${_tok} ${_on}\n")
+    string(APPEND _tt_tracy_defs "#define TT_TRACY_CATEGORY_INDEX_${_tok} ${_idx}\n")
+    math(EXPR _idx "${_idx} + 1")
+endforeach()
+
+set(_tt_tracy_generated_dir "${PROJECT_BINARY_DIR}/generated/profiler")
+file(CONFIGURE OUTPUT "${_tt_tracy_generated_dir}/tracy_debug_categories_generated.hpp" CONTENT "${_tt_tracy_defs}")
+# Build-time header; deliberately not exported to the installed SDK.
+target_include_directories(TracyClient PUBLIC "$<BUILD_INTERFACE:${_tt_tracy_generated_dir}>")
+
+unset(_tt_tracy_categories_file)
+unset(_tt_tracy_categories_raw)
+unset(_tt_tracy_categories)
+unset(_tt_tracy_valid)
+unset(_tt_tracy_valid_pretty)
+unset(_tt_tracy_selected)
+unset(_tt_tracy_selected_raw)
+unset(_line)
+unset(_sel)
+unset(_cat)
+unset(_on)
+unset(_tok)
+unset(_idx)
+unset(_tt_tracy_defs)
+unset(_tt_tracy_generated_dir)

--- a/tt_metal/third_party/CMakeLists.txt
+++ b/tt_metal/third_party/CMakeLists.txt
@@ -247,6 +247,7 @@ if(NOT TRACY_DEBUG_CATEGORY STREQUAL "off")
     string(REPLACE "," ";" _tt_tracy_selected_raw "${TRACY_DEBUG_CATEGORY}")
     foreach(_sel IN LISTS _tt_tracy_selected_raw)
         string(STRIP "${_sel}" _sel)
+        string(TOLOWER "${_sel}" _sel)
         if(NOT _sel IN_LIST _tt_tracy_valid)
             message(
                 FATAL_ERROR

--- a/tt_metal/tools/profiler/tracy_debug_categories.txt
+++ b/tt_metal/tools/profiler/tracy_debug_categories.txt
@@ -1,0 +1,12 @@
+# --build-perf-debug categories: one per line, lower-case-hyphenated; '#' and blank lines ignored.
+#
+#   !! The call-site token is the UPPER_SNAKE form of the category:
+#          rt-profiler  ->  TTZoneScopedD(RT_PROFILER)
+#
+# 'misc' is a catch-all for zones that fit no specific category.
+dispatch
+program
+data-format
+rt-profiler
+jit
+misc

--- a/tt_metal/tools/profiler/tracy_debug_zones.hpp
+++ b/tt_metal/tools/profiler/tracy_debug_zones.hpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <tracy/Tracy.hpp>
+
+// Tracy zones and their zone annotations, compiled in only with the --build-perf-debug build flag.
+#if defined(TT_TRACY_DEBUG)
+#define TTZoneScopedD ZoneScoped
+#define TTZoneScopedND(name) ZoneScopedN(name)
+#define TTZoneScopedCD(color) ZoneScopedC(color)
+#define TTZoneScopedNCD(name, color) ZoneScopedNC(name, color)
+#define TTZoneScopedSD(depth) ZoneScopedS(depth)
+#define TTZoneScopedNSD(name, depth) ZoneScopedNS(name, depth)
+#define TTZoneScopedCSD(color, depth) ZoneScopedCS(color, depth)
+#define TTZoneScopedNCSD(name, color, depth) ZoneScopedNCS(name, color, depth)
+#define TTZoneTextD(txt, size) ZoneText(txt, size)
+#define TTZoneNameD(txt, size) ZoneName(txt, size)
+#define TTZoneColorD(color) ZoneColor(color)
+#define TTZoneValueD(value) ZoneValue(value)
+#define TTZoneIsActiveD ZoneIsActive
+#else
+#define TTZoneScopedD
+#define TTZoneScopedND(name)
+#define TTZoneScopedCD(color)
+#define TTZoneScopedNCD(name, color)
+#define TTZoneScopedSD(depth)
+#define TTZoneScopedNSD(name, depth)
+#define TTZoneScopedCSD(color, depth)
+#define TTZoneScopedNCSD(name, color, depth)
+#define TTZoneTextD(txt, size)
+#define TTZoneNameD(txt, size)
+#define TTZoneColorD(color)
+#define TTZoneValueD(value)
+#define TTZoneIsActiveD false
+#endif

--- a/tt_metal/tools/profiler/tracy_debug_zones.hpp
+++ b/tt_metal/tools/profiler/tracy_debug_zones.hpp
@@ -46,16 +46,23 @@ constexpr uint32_t category_color(std::size_t index) { return kCategoryColors[in
 constexpr bool zone_name_valid(const char* name) { return name != nullptr; }
 }  // namespace tt::tracy_debug
 
-// TT_TRACY_EMIT(category, disabled, enabled...) expands to `enabled...` when the category is selected, else to
-// `disabled`. It pastes the category's 1/0 define onto TT_TRACY_EMIT_ to pick the branch; the two-step CONCAT
-// is what forces that define to expand before the paste.
+// TT_TRACY_EMIT(category, disabled, enabled...) selects `enabled...` when the category is selected, `disabled`
+// when it is not, and the undeclared identifier TT_TRACY_ERROR_unknown_tracy_debug_category (a readable compile
+// error at the call site) when the category token has no entry in tracy_debug_categories.txt. The category's define
+// resolves to 1/0, or stays an unexpanded token when unknown; PROBE/SELECT then map 1/0/other onto the
+// enabled/disabled/error branch. The two-step CONCAT forces the category define to expand before it is pasted.
 #define TT_TRACY_CONCAT_(a, b) a##b
 #define TT_TRACY_CONCAT(a, b) TT_TRACY_CONCAT_(a, b)
 #define TT_TRACY_EMIT_1(disabled, ...) __VA_ARGS__
 #define TT_TRACY_EMIT_0(disabled, ...) disabled
+#define TT_TRACY_EMIT_BAD(disabled, ...) TT_TRACY_ERROR_unknown_tracy_debug_category
+#define TT_TRACY_PROBE_0 ~, TT_TRACY_EMIT_0
+#define TT_TRACY_PROBE_1 ~, TT_TRACY_EMIT_1
+#define TT_TRACY_SECOND(_1, _2, ...) _2
+#define TT_TRACY_SELECT(...) TT_TRACY_SECOND(__VA_ARGS__, TT_TRACY_EMIT_BAD, ~)
+#define TT_TRACY_BRANCH_FOR(value) TT_TRACY_SELECT(TT_TRACY_CONCAT(TT_TRACY_PROBE_, value))
 #if defined(TRACY_ENABLE)
-#define TT_TRACY_EMIT(category, disabled, ...) \
-    TT_TRACY_CONCAT(TT_TRACY_EMIT_, TT_TRACY_CATEGORY_##category)(disabled, __VA_ARGS__)
+#define TT_TRACY_EMIT(category, disabled, ...) TT_TRACY_BRANCH_FOR(TT_TRACY_CATEGORY_##category)(disabled, __VA_ARGS__)
 #else
 #define TT_TRACY_EMIT(category, disabled, ...) disabled
 #endif

--- a/tt_metal/tools/profiler/tracy_debug_zones.hpp
+++ b/tt_metal/tools/profiler/tracy_debug_zones.hpp
@@ -3,35 +3,129 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include <array>
+#include <cstddef>
+#include <cstdint>
 #include <tracy/Tracy.hpp>
+#include <type_traits>
 
-// Tracy zones and their zone annotations, compiled in only with the --build-perf-debug build flag.
-#if defined(TT_TRACY_DEBUG)
-#define TTZoneScopedD ZoneScoped
-#define TTZoneScopedND(name) ZoneScopedN(name)
-#define TTZoneScopedCD(color) ZoneScopedC(color)
-#define TTZoneScopedNCD(name, color) ZoneScopedNC(name, color)
-#define TTZoneScopedSD(depth) ZoneScopedS(depth)
-#define TTZoneScopedNSD(name, depth) ZoneScopedNS(name, depth)
-#define TTZoneScopedCSD(color, depth) ZoneScopedCS(color, depth)
-#define TTZoneScopedNCSD(name, color, depth) ZoneScopedNCS(name, color, depth)
-#define TTZoneTextD(txt, size) ZoneText(txt, size)
-#define TTZoneNameD(txt, size) ZoneName(txt, size)
-#define TTZoneColorD(color) ZoneColor(color)
-#define TTZoneValueD(value) ZoneValue(value)
-#define TTZoneIsActiveD ZoneIsActive
-#else
-#define TTZoneScopedD
-#define TTZoneScopedND(name)
-#define TTZoneScopedCD(color)
-#define TTZoneScopedNCD(name, color)
-#define TTZoneScopedSD(depth)
-#define TTZoneScopedNSD(name, depth)
-#define TTZoneScopedCSD(color, depth)
-#define TTZoneScopedNCSD(name, color, depth)
-#define TTZoneTextD(txt, size)
-#define TTZoneNameD(txt, size)
-#define TTZoneColorD(color)
-#define TTZoneValueD(value)
-#define TTZoneIsActiveD false
+// Opt-in Tracy macros (zones, messages, plots) for debug-verbosity profiling. A TTZone*D / TTMessage*D /
+// TTPlotD macro's first argument is a category token (DISPATCH, RT_PROFILER, ...); it is compiled in only when
+// that category is selected at build time via --build-perf-debug ('all' selects every category), and compiles
+// to nothing otherwise. Categories are defined once in tt_metal/tools/profiler/tracy_debug_categories.txt; from
+// it the build generates, per category, TT_TRACY_CATEGORY_<TOKEN> (1 if selected, 0 if not) and
+// TT_TRACY_CATEGORY_INDEX_<TOKEN> (declaration order, used to auto-assign a color) into the header included here.
+#if defined(TRACY_ENABLE)
+#include <tracy_debug_categories_generated.hpp>
 #endif
+
+namespace tt::tracy_debug {
+inline constexpr std::array<uint32_t, 20> kCategoryColors{
+    0xE6194B,  // Red
+    0x3CB44B,  // Green
+    0xFFE119,  // Yellow
+    0x4363D8,  // Blue
+    0xF58231,  // Orange
+    0x911EB4,  // Purple
+    0x42D4F4,  // Cyan
+    0xF032E6,  // Magenta
+    0xBFEF45,  // Lime
+    0xFABED4,  // Pink
+    0x469990,  // Teal
+    0xDCBEFF,  // Lavender
+    0x9A6324,  // Brown
+    0xFFFAC8,  // Beige
+    0x800000,  // Maroon
+    0xAAFFC3,  // Mint
+    0x808000,  // Olive
+    0xFFD8B1,  // Apricot
+    0x000075,  // Navy
+    0xA9A9A9,  // Grey
+};
+constexpr uint32_t category_color(std::size_t index) { return kCategoryColors[index % kCategoryColors.size()]; }
+constexpr bool zone_name_valid(const char* name) { return name != nullptr; }
+}  // namespace tt::tracy_debug
+
+// TT_TRACY_EMIT(category, disabled, enabled...) expands to `enabled...` when the category is selected, else to
+// `disabled`. It pastes the category's 1/0 define onto TT_TRACY_EMIT_ to pick the branch; the two-step CONCAT
+// is what forces that define to expand before the paste.
+#define TT_TRACY_CONCAT_(a, b) a##b
+#define TT_TRACY_CONCAT(a, b) TT_TRACY_CONCAT_(a, b)
+#define TT_TRACY_EMIT_1(disabled, ...) __VA_ARGS__
+#define TT_TRACY_EMIT_0(disabled, ...) disabled
+#if defined(TRACY_ENABLE)
+#define TT_TRACY_EMIT(category, disabled, ...) \
+    TT_TRACY_CONCAT(TT_TRACY_EMIT_, TT_TRACY_CATEGORY_##category)(disabled, __VA_ARGS__)
+#else
+#define TT_TRACY_EMIT(category, disabled, ...) disabled
+#endif
+
+#define TT_TRACY_CATEGORY_COLOR(category) (::tt::tracy_debug::category_color(TT_TRACY_CATEGORY_INDEX_##category))
+
+#define TT_TRACY_CONSTEXPR_STR(s) sizeof(::std::integral_constant<bool, ::tt::tracy_debug::zone_name_valid(s)>)
+#define TT_TRACY_CONSTEXPR_COLOR(v) sizeof(::std::integral_constant<uint32_t, (v)>)
+
+// A Tracy-only arg type (tracy::PlotFormatType) can't be checked under --disable-profiler.
+#if defined(TRACY_ENABLE)
+#define TT_TRACY_SIZEOF_IF_ENABLED(x) sizeof(x)
+#else
+#define TT_TRACY_SIZEOF_IF_ENABLED(x) 0u
+#endif
+
+// Category-gated Tracy macros; the first argument is a category token
+// from tt_metal/tools/profiler/tracy_debug_categories.txt.
+#define TTZoneScopedD(category) TT_TRACY_EMIT(category, , ZoneScopedC(TT_TRACY_CATEGORY_COLOR(category)))
+#define TTZoneScopedDN(category, name) \
+    TT_TRACY_EMIT(category, (void(TT_TRACY_CONSTEXPR_STR(name))), ZoneScopedNC(name, TT_TRACY_CATEGORY_COLOR(category)))
+#define TTZoneScopedDC(category, color) \
+    TT_TRACY_EMIT(category, (void(TT_TRACY_CONSTEXPR_COLOR(color))), ZoneScopedC(color))
+#define TTZoneScopedDNC(category, name, color) \
+    TT_TRACY_EMIT(                             \
+        category, (void(TT_TRACY_CONSTEXPR_STR(name) + TT_TRACY_CONSTEXPR_COLOR(color))), ZoneScopedNC(name, color))
+#define TTZoneScopedDS(category, depth) \
+    TT_TRACY_EMIT(category, (void(sizeof(depth))), ZoneScopedCS(TT_TRACY_CATEGORY_COLOR(category), depth))
+#define TTZoneScopedDNS(category, name, depth)                \
+    TT_TRACY_EMIT(                                            \
+        category,                                             \
+        (void(TT_TRACY_CONSTEXPR_STR(name) + sizeof(depth))), \
+        ZoneScopedNCS(name, TT_TRACY_CATEGORY_COLOR(category), depth))
+#define TTZoneScopedDCS(category, color, depth) \
+    TT_TRACY_EMIT(category, (void(TT_TRACY_CONSTEXPR_COLOR(color) + sizeof(depth))), ZoneScopedCS(color, depth))
+#define TTZoneScopedDNCS(category, name, color, depth)                                          \
+    TT_TRACY_EMIT(                                                                              \
+        category,                                                                               \
+        (void(TT_TRACY_CONSTEXPR_STR(name) + TT_TRACY_CONSTEXPR_COLOR(color) + sizeof(depth))), \
+        ZoneScopedNCS(name, color, depth))
+#define TTZoneTextD(category, txt, size) \
+    TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(size))), ZoneText(txt, size))
+#define TTZoneNameD(category, txt, size) \
+    TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(size))), ZoneName(txt, size))
+#define TTZoneColorD(category, color) TT_TRACY_EMIT(category, (void(sizeof(color))), ZoneColor(color))
+#define TTZoneValueD(category, value) TT_TRACY_EMIT(category, (void(sizeof(value))), ZoneValue(value))
+#define TTZoneIsActiveD(category) TT_TRACY_EMIT(category, false, ZoneIsActive)
+
+#define TTMessageD(category, txt, size) \
+    TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(size))), TracyMessage(txt, size))
+#define TTMessageDL(category, txt) TT_TRACY_EMIT(category, (void(sizeof(txt))), TracyMessageL(txt))
+#define TTMessageDC(category, txt, size, color) \
+    TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(size) + sizeof(color))), TracyMessageC(txt, size, color))
+#define TTMessageDLC(category, txt, color) \
+    TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(color))), TracyMessageLC(txt, color))
+#define TTMessageDS(category, txt, size, depth) \
+    TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(size) + sizeof(depth))), TracyMessageS(txt, size, depth))
+#define TTMessageDLS(category, txt, depth) \
+    TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(depth))), TracyMessageLS(txt, depth))
+#define TTMessageDCS(category, txt, size, color, depth)                     \
+    TT_TRACY_EMIT(                                                          \
+        category,                                                           \
+        (void(sizeof(txt) + sizeof(size) + sizeof(color) + sizeof(depth))), \
+        TracyMessageCS(txt, size, color, depth))
+#define TTMessageDLCS(category, txt, color, depth) \
+    TT_TRACY_EMIT(category, (void(sizeof(txt) + sizeof(color) + sizeof(depth))), TracyMessageLCS(txt, color, depth))
+
+#define TTPlotD(category, name, val) TT_TRACY_EMIT(category, (void(sizeof(name) + sizeof(val))), TracyPlot(name, val))
+#define TTPlotConfigD(category, name, type, step, fill, color)                                                 \
+    TT_TRACY_EMIT(                                                                                             \
+        category,                                                                                              \
+        (void(sizeof(name) + TT_TRACY_SIZEOF_IF_ENABLED(type) + sizeof(step) + sizeof(fill) + sizeof(color))), \
+        TracyPlotConfig(name, type, step, fill, color))

--- a/tt_metal/tools/profiler/tt_metal_tracy.hpp
+++ b/tt_metal/tools/profiler/tt_metal_tracy.hpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
+#include "tracy_debug_zones.hpp"
 #include <tt_metal_profiler.hpp>
 #include "impl/context/metal_context.hpp"
 #include "distributed/mesh_device_impl.hpp"


### PR DESCRIPTION
### PR Category
Feature

### Summary
Adds an opt-in Tracy debug-verbosity tier that gates host-side zones behind named categories, compiled in only on request. New `TTZone*D` macros take a category token (e.g. `DISPATCH`, `DATA_FORMAT`) and expand to a real Tracy zone only when that category is selected at build time via `--build-perf-debug`; otherwise they compile to nothing. The flag accepts `off` (default), `all`, or a comma-separated list of categories.

Categories are defined once in `tt_metal/tools/profiler/tracy_debug_categories.txt` (currently `dispatch, program, data-format, rt-profiler, jit, misc`), each auto-assigned a distinct Tracy color by declaration order.

Moves several previously always-on host zones into this tier (tagged by category) and restores zones that were removed in #28825 pending a verbosity mechanism.

Closes #30615.

### Notes for reviewers
- `tracy_debug_zones.hpp` mirrors Tracy's zone macros 1:1 with a `D` marker. So far only `TTZoneScopedD`, `TTZoneScopedDN`, and `TTZoneTextD` are used; the remaining variants are there for completeness.
- Zone macros check their arguments for well-formedness even when the category is disabled and the zone compiles out.
- `--build-perf-debug` is a persistent CMake cache variable: a selection stays in effect across rebuilds until changed; passing `off` clears it.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yusuf/tracy-verbosity-levels)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yusuf/tracy-verbosity-levels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yusuf/tracy-verbosity-levels)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yusuf/tracy-verbosity-levels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=yusuf/tracy-verbosity-levels)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:yusuf/tracy-verbosity-levels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yusuf/tracy-verbosity-levels)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yusuf/tracy-verbosity-levels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yusuf/tracy-verbosity-levels)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yusuf/tracy-verbosity-levels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yusuf/tracy-verbosity-levels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yusuf/tracy-verbosity-levels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yusuf/tracy-verbosity-levels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yusuf/tracy-verbosity-levels)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yusuf/tracy-verbosity-levels)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yusuf/tracy-verbosity-levels)