### PR TITLE
Support batch>1 in wan fused RMSNorm+ROPE post-all-gather op

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/transformers/test_distributed_fused_rmsnorm.py
+++ b/tests/ttnn/nightly/unit_tests/operations/transformers/test_distributed_fused_rmsnorm.py
@@ -225,6 +225,39 @@ def test_distributed_fused_rmsnorm_sweep_fusions(
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["BFLOAT16_in"])
 @pytest.mark.parametrize("stats_dtype", [ttnn.bfloat16], ids=["BFLOAT16_stats"])
+@pytest.mark.parametrize("batch", [2, 3, 4], ids=["batch2", "batch3", "batch4"])
+@pytest.mark.parametrize("seqlen", [256, 2048], ids=["seqlen256", "seqlen2048"])
+@pytest.mark.parametrize("hidden_dim", [2048, 5120], ids=["hidden_dim2048", "hidden_dim5120"])
+@pytest.mark.parametrize("num_heads_per_device", [1, 5], ids=["num_heads1", "num_heads5"])
+@pytest.mark.parametrize("use_weight", [True], ids=["has_weight"])
+@pytest.mark.parametrize("use_rope", [True, False], ids=["has_rope", "no_rope"])
+@pytest.mark.parametrize("num_simulated_devices", [8], ids=["num_simulated_devices8"])
+def test_distributed_fused_rmsnorm_batched(
+    device,
+    num_simulated_devices,
+    batch,
+    seqlen,
+    hidden_dim,
+    dtype,
+    stats_dtype,
+    num_heads_per_device,
+    use_weight,
+    use_rope,
+    reset_seeds,
+):
+    """Batch > 1: leading (batch) dims fold into the row dimension; ROPE cycles per
+    batch and the head-split output is written into each batch element's own slice.
+    Mirrors the wan2.x attention norm (40 heads / 8 devices -> 5 heads/device)."""
+    num_heads = num_heads_per_device * num_simulated_devices
+    check_hidden_dim_divisible_by_num_heads(hidden_dim, num_heads)
+    inp_shape = (batch, 1, seqlen, hidden_dim)
+    run_distributed_fused_rmsnorm(
+        device, num_simulated_devices, inp_shape, dtype, stats_dtype, num_heads_per_device, use_weight, use_rope
+    )
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["BFLOAT16_in"])
+@pytest.mark.parametrize("stats_dtype", [ttnn.bfloat16], ids=["BFLOAT16_stats"])
 @pytest.mark.parametrize(
     "seqlen",
     [128, 256, 8192],

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_post_all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_post_all_gather_device_operation.cpp
@@ -76,9 +76,11 @@ void FusedRMSNormPostAllGatherDeviceOperation::validate_on_program_cache_miss(
         a.padded_shape()[-1]);
 
     TT_FATAL(a.logical_shape().rank() == 4, "Input must have rank 4, got: {}", a.logical_shape().rank());
-    // Expected input shape: [batch, 1, sequence_length, hidden_dim]
+    // Expected input shape: [batch, 1, sequence_length, hidden_dim]. Dim 1 is the
+    // "head slot" that the op expands into num_heads on output, so it must be 1.
+    // The batch dim (dim 0) may be >1: leading dims are folded into the row dimension
+    // (rows are laid out row-major), and ROPE cycles every sequence_length rows.
     TT_FATAL(a.logical_shape()[1] == 1, "Input dim 1 must be 1, got: {}", a.logical_shape()[1]);
-    TT_FATAL(a.logical_shape()[0] == 1, "Expecting input batch dimension to be 1, got: {}", a.logical_shape()[0]);
 
     if (weight_opt.has_value()) {
         // Gamma is given

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_post_all_gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/fused_rmsnorm_post_all_gather_program_factory.cpp
@@ -38,10 +38,16 @@ tt::tt_metal::ProgramDescriptor FusedRMSNormPostAllGatherProgramFactory::create_
 
     const auto& input_shape = input_tensor.padded_shape();
     const uint32_t W = input_shape[-1];
-    const uint32_t H = input_shape[-2];
+    const uint32_t seq_H = input_shape[-2];
+    // Leading dims (batch) are folded into the row dimension (tiles are laid out
+    // row-major), so the op processes batch * seq_H rows. ROPE and the head-split
+    // output stride cycle every seq_H rows (rows_per_batch_tiles) so each batch
+    // element reuses the same per-position rope and writes to its own output slice.
+    const uint32_t folded_H = input_tensor.physical_volume() / W;
 
     const uint32_t num_tile_cols = W / TILE_WIDTH;
-    const uint32_t num_tile_rows = H / TILE_HEIGHT;
+    const uint32_t num_tile_rows = folded_H / TILE_HEIGHT;
+    const uint32_t rows_per_batch_tiles = seq_H / TILE_HEIGHT;
     const uint32_t head_dim_tiles = num_tile_cols / num_heads;
 
     const uint32_t stats_tiles_cols = stats_tensor.padded_shape()[-1] / TILE_WIDTH;
@@ -50,7 +56,9 @@ tt::tt_metal::ProgramDescriptor FusedRMSNormPostAllGatherProgramFactory::create_
     TT_FATAL(num_devices > 0, "Number of devices must be greater than 0");
 
     log_debug(tt::LogOp, "W: {}", W);
-    log_debug(tt::LogOp, "H: {}", H);
+    log_debug(tt::LogOp, "seq_H: {}", seq_H);
+    log_debug(tt::LogOp, "folded_H: {}", folded_H);
+    log_debug(tt::LogOp, "rows_per_batch_tiles: {}", rows_per_batch_tiles);
     log_debug(tt::LogOp, "num_tile_rows: {}", num_tile_rows);
     log_debug(tt::LogOp, "num_tile_cols: {}", num_tile_cols);
     log_debug(tt::LogOp, "stats_tiles_cols: {}", stats_tiles_cols);
@@ -213,7 +221,7 @@ tt::tt_metal::ProgramDescriptor FusedRMSNormPostAllGatherProgramFactory::create_
         dst_reg_count,
         head_dim_tiles,
         num_heads,
-        num_tile_rows,
+        rows_per_batch_tiles,
     };
     tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_compile_time_args);
 
@@ -305,7 +313,8 @@ tt::tt_metal::ProgramDescriptor FusedRMSNormPostAllGatherProgramFactory::create_
              rope_cos_buffer,
              rope_sin_buffer,
              tile_row_start,
-             tile_row_end});
+             tile_row_end,
+             rows_per_batch_tiles});
 
         compute_kernel_desc.emplace_runtime_args(core, {num_tile_rows_to_process});
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_post_allgather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_post_allgather_reader.cpp
@@ -46,6 +46,9 @@ void kernel_main() {
     const uint32_t rope_sin_addr = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t tile_row_start = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t tile_row_end = get_arg_val<uint32_t>(arg_idx++);
+    // Number of row-tiles per batch element (= sequence_length / TILE_HEIGHT). Leading
+    // (batch) dims are folded into tile_row, so ROPE must cycle every rows_per_batch_tiles.
+    const uint32_t rows_per_batch_tiles = get_arg_val<uint32_t>(arg_idx++);
 
     // ublocks size defined in tiles
     const uint32_t input_tile_bytes = get_tile_size(input_cb);
@@ -136,7 +139,9 @@ void kernel_main() {
                     /**
                      * When processing the first column of a specific row, read the sin/cos inputs for rope.
                      */
-                    uint32_t rope_tile_start_idx = tile_row * head_dim_tiles;
+                    // Cycle rope per batch: each batch element reuses the same
+                    // per-position rope tiles (rope buffer holds only seq_len positions).
+                    uint32_t rope_tile_start_idx = (tile_row % rows_per_batch_tiles) * head_dim_tiles;
                     cb_reserve_back(rope_cos_cb, head_dim_tiles);
                     uint32_t rope_cos_wr_ptr = get_write_ptr(rope_cos_cb);
                     for (uint32_t i = 0; i < head_dim_tiles; i++) {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_post_allgather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_post_allgather_writer.cpp
@@ -14,7 +14,9 @@ void kernel_main() {
     constexpr uint32_t block_size = get_compile_time_arg_val(2);
     constexpr uint32_t head_dim_tiles = get_compile_time_arg_val(3);
     constexpr uint32_t num_heads = get_compile_time_arg_val(4);
-    constexpr uint32_t num_tile_rows = get_compile_time_arg_val(5);
+    // Row-tiles per batch element (= sequence_length / TILE_HEIGHT). The output is
+    // [batch, num_heads, seq, head_dim]; leading (batch) dims are folded into tile_row.
+    constexpr uint32_t rows_per_batch = get_compile_time_arg_val(5);
 
     constexpr auto output_args = TensorAccessorArgs<6>();
     const uint32_t tile_bytes = get_tile_size(output_cb);
@@ -25,13 +27,21 @@ void kernel_main() {
 
     const auto output_accessor = TensorAccessor(output_args, output_addr);
 
-    constexpr uint32_t head_stride = num_tile_rows * head_dim_tiles;
+    // Stride between heads (within one batch element) and between batch elements.
+    constexpr uint32_t head_stride = rows_per_batch * head_dim_tiles;
+    constexpr uint32_t batch_stride = num_heads * head_stride;
 
     for (uint32_t tile_row = tile_row_start; tile_row < tile_row_end; tile_row++) {
         uint32_t head_idx = 0;
         uint32_t tile_idx_in_head = 0;
 
-        uint32_t tile_id = tile_row * head_dim_tiles;
+        // Decompose the folded row index into (batch element, seq row-tile) so each
+        // batch element writes into its own [num_heads, seq, head_dim] output slice.
+        const uint32_t batch_idx = tile_row / rows_per_batch;
+        const uint32_t seq_tile = tile_row % rows_per_batch;
+        const uint32_t batch_base = batch_idx * batch_stride;
+
+        uint32_t tile_id = batch_base + seq_tile * head_dim_tiles;
 
         for (uint32_t col_tile = 0; col_tile < num_tile_cols; col_tile += block_size) {
             cb_wait_front(output_cb, block_size);
@@ -44,7 +54,7 @@ void kernel_main() {
                 if (tile_idx_in_head == head_dim_tiles) {
                     tile_idx_in_head = 0;
                     head_idx++;
-                    tile_id = head_idx * head_stride + tile_row * head_dim_tiles;
+                    tile_id = batch_base + head_idx * head_stride + seq_tile * head_dim_tiles;
                 }
             }
             noc_async_writes_flushed();


### PR DESCRIPTION
The fused distributed RMSNorm post-all-gather op (used for wan2.x attention norm_q/norm_k, which fuse RMSNorm + ROPE + head-split) asserted both leading dims == 1, so it only accepted [1, 1, seq, hidden] and produced [1, num_heads, seq, head_dim]. This blocked batched (B>1) Wan inference: the model's attention feeds [B, 1, seq, hidden] and expects [B, num_heads, seq, head_dim].

Tiles are laid out row-major, so the leading batch dim folds naturally into the row dimension (the pre-all-gather op already does exactly this via physical_volume()/W). Make the post op match:

- device op validate: drop the dim0 (batch) == 1 assert; keep dim1 == 1 (the head slot the op expands into num_heads). compute_output_specs already yields [B, num_heads, seq, head_dim] since it only rewrites dims 1 and 3.
- program factory: derive total rows from physical_volume()/W (folded over batch) instead of shape[-2]; compute rows_per_batch_tiles = seq/TILE_HEIGHT and pass it to the reader (rope) and writer (output stride).
- reader kernel: cycle the ROPE tile index modulo rows_per_batch_tiles so each batch element reuses the same per-position rope (the rope buffer holds only seq positions).
- writer kernel: decompose the folded row index into (batch, seq_tile) and offset into each batch element's own [num_heads, seq, head_dim] output slice (head_stride is now per-batch; add a batch_stride).

All changes are no-ops for B=1, so existing single-batch behavior is unchanged. Adds test_distributed_fused_rmsnorm_batched (batch 2/3/4, rope on/off, wan-like 40-head config); batched sweep passes (PCC ~0.99999) and the batch=1 regression is unchanged.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=cglagovich/wan_rmsnorm_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:cglagovich/wan_rmsnorm_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=cglagovich/wan_rmsnorm_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:cglagovich/wan_rmsnorm_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=cglagovich/wan_rmsnorm_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:cglagovich/wan_rmsnorm_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=cglagovich/wan_rmsnorm_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:cglagovich/wan_rmsnorm_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=cglagovich/wan_rmsnorm_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:cglagovich/wan_rmsnorm_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=cglagovich/wan_rmsnorm_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:cglagovich/wan_rmsnorm_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=cglagovich/wan_rmsnorm_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:cglagovich/wan_rmsnorm_batch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=cglagovich/wan_rmsnorm_batch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:cglagovich/wan_rmsnorm_batch)