### PR TITLE
Add tracy option to dump device profiler data after each ttnn op

### DIFF
--- a/tools/tracy/__main__.py
+++ b/tools/tracy/__main__.py
@@ -113,6 +113,13 @@ def main():
         default=False,
     )
     parser.add_option(
+        "--dump-per-op",
+        dest="dump_per_op",
+        action="store_true",
+        help="Dump collected device data to files and push after each TTNN operation",
+        default=False,
+    )
+    parser.add_option(
         "--disable-device-data-dump-to-files",
         dest="disable_device_data_dump_to_files",
         action="store_true",
@@ -217,6 +224,9 @@ def main():
 
     if options.mid_run_device_data:
         os.environ["TT_METAL_PROFILER_MID_RUN_DUMP"] = "1"
+
+    if options.dump_per_op:
+        os.environ["TTNN_PROFILER_PER_OP_DUMP"] = "1"
 
     if options.disable_device_data_dump_to_files:
         os.environ["TT_METAL_PROFILER_DISABLE_DUMP_TO_FILES"] = "1"

--- a/ttnn/api/tools/profiler/op_profiler_serialize.hpp
+++ b/ttnn/api/tools/profiler/op_profiler_serialize.hpp
@@ -139,6 +139,7 @@ private:
 inline thread_safe_cached_ops_map cached_ops{};
 inline thread_safe_call_stack call_stack;
 inline bool op_profiler_is_enabled = false;
+inline bool per_op_dump_is_enabled = false;
 
 #endif  // TRACY_ENABLE
 
@@ -269,6 +270,14 @@ inline bool is_op_profiler_env_var_set() {
         op_profiler_is_enabled = true;
     }
     return op_profiler_is_enabled;
+}
+
+inline bool is_per_op_dump_env_var_set() {
+    const char* per_op_dump_enable_str = std::getenv("TTNN_PROFILER_PER_OP_DUMP");
+    if (per_op_dump_enable_str != nullptr && per_op_dump_enable_str[0] == '1') {
+        per_op_dump_is_enabled = true;
+    }
+    return per_op_dump_is_enabled;
 }
 
 // ---------------------------------------------------------------------------

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -227,6 +227,11 @@ void enqueue_mesh_workload(
         tensor_args,
         tensor_return_value,
         program_cache_hit);
+
+    // Dump device profiler data
+    if (tt::tt_metal::op_profiler::is_per_op_dump_env_var_set()) {
+        tt::tt_metal::ReadMeshDeviceProfilerResults(*mesh_device);
+    }
 }
 
 // Dispatches `fn` to `program_factory` through either the `MeshWorkloadFactoryConcept` directly, or through the adapted

--- a/ttnn/cpp/ttnn/operations/trace.cpp
+++ b/ttnn/cpp/ttnn/operations/trace.cpp
@@ -13,23 +13,45 @@
 
 namespace ttnn::operations::trace {
 
+inline bool trace_capture_disabled = false;
+
+inline bool is_trace_capture_disabled_env_var_set() {
+    const char* trace_capture_disable_str = std::getenv("TTNN_DISABLE_TRACE_CAPTURE");
+    if (trace_capture_disable_str != nullptr && trace_capture_disable_str[0] == '1') {
+        trace_capture_disabled = true;
+    }
+    return trace_capture_disabled;
+}
+
 MeshTraceId begin_trace_capture(MeshDevice* device, std::optional<QueueId> cq_id) {
     ZoneScoped;
     QueueId cq_id_value = cq_id.value_or(get_current_command_queue_id_for_thread());
+    if (is_trace_capture_disabled_env_var_set()) {
+        return MeshTraceId(0);
+    }
     return device->begin_mesh_trace(cq_id_value.get());
 }
 void end_trace_capture(MeshDevice* device, MeshTraceId trace_id, std::optional<QueueId> cq_id) {
     ZoneScoped;
     QueueId cq_id_value = cq_id.value_or(get_current_command_queue_id_for_thread());
+    if (is_trace_capture_disabled_env_var_set()) {
+        return;
+    }
     device->end_mesh_trace(cq_id_value.get(), trace_id);
 }
 void execute_trace(MeshDevice* device, MeshTraceId trace_id, std::optional<QueueId> cq_id, bool blocking) {
     ZoneScoped;
     QueueId cq_id_value = cq_id.value_or(get_current_command_queue_id_for_thread());
+    if (is_trace_capture_disabled_env_var_set()) {
+        return;
+    }
     device->replay_mesh_trace(cq_id_value.get(), trace_id, blocking);
 }
 void release_trace(MeshDevice* device, MeshTraceId trace_id) {
     ZoneScoped;
+    if (is_trace_capture_disabled_env_var_set()) {
+        return;
+    }
     device->release_mesh_trace(trace_id);
 }
 


### PR DESCRIPTION
This is meant to alleviate profiler buffer limitations when running large workloads (i.e. models).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadeem/profiler_per_op_dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadeem/profiler_per_op_dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadeem/profiler_per_op_dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadeem/profiler_per_op_dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadeem/profiler_per_op_dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadeem/profiler_per_op_dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadeem/profiler_per_op_dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadeem/profiler_per_op_dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadeem/profiler_per_op_dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadeem/profiler_per_op_dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadeem/profiler_per_op_dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadeem/profiler_per_op_dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadeem/profiler_per_op_dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadeem/profiler_per_op_dump)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadeem/profiler_per_op_dump)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadeem/profiler_per_op_dump)