### PR TITLE
Prototype: collision-safe program cache via exact key comparison (option 1, #45821)

### DIFF
--- a/tt_metal/api/tt-metalium/program_cache.hpp
+++ b/tt_metal/api/tt-metalium/program_cache.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <string>
 #include <unordered_map>
 
 #include <tt-metalium/program.hpp>
@@ -103,15 +104,34 @@ struct CachedProgramFactory {
         cached_program{std::move(cached_workload)}, program_factory_index{program_factory_index} {}
 };
 
+// Program-cache key: the 64-bit hash PLUS an exact, collision-free canonical encoding of the key
+// material (see ttsl::hash::canonical_key). std::unordered_map uses the hash to pick a bucket and
+// operator== to confirm the match -- so a 64-bit hash collision lands two distinct keys in the
+// same bucket and is resolved by exact comparison instead of producing a wrong cache hit
+// (issue #45821). An empty `canonical` opts out (hash-only behavior) for ops whose custom
+// compute_program_hash we cannot faithfully mirror.
+struct ProgramCacheKey {
+    uint64_t hash = 0;
+    std::string canonical;
+
+    bool operator==(const ProgramCacheKey& other) const {
+        return hash == other.hash && canonical == other.canonical;
+    }
+};
+
+struct ProgramCacheKeyHasher {
+    std::size_t operator()(const ProgramCacheKey& key) const { return static_cast<std::size_t>(key.hash); }
+};
+
 // Generic Program Cache: This data structure is tied to a device handle and can store generic program types from
 // TT-Metal and TT-Eager using tt::stl::concepts::unique_any.
 struct ProgramCache {
-    bool contains(uint64_t program_hash) const { return this->cache_.contains(program_hash); }
+    bool contains(const ProgramCacheKey& program_key) const { return this->cache_.contains(program_key); }
 
-    CachedProgramFactory& get(uint64_t program_hash) { return this->cache_.at(program_hash); }
+    CachedProgramFactory& get(const ProgramCacheKey& program_key) { return this->cache_.at(program_key); }
 
-    void insert(uint64_t program_hash, CachedProgramFactory&& program) {
-        this->cache_.insert({program_hash, std::move(program)});
+    void insert(const ProgramCacheKey& program_key, CachedProgramFactory&& program) {
+        this->cache_.insert({program_key, std::move(program)});
     }
 
     void enable() { is_enabled_ = true; }
@@ -130,7 +150,7 @@ struct ProgramCache {
 private:
     bool is_enabled_ = true;
     bool allow_cache_misses_ = true;
-    std::unordered_map<uint64_t, CachedProgramFactory> cache_;
+    std::unordered_map<ProgramCacheKey, CachedProgramFactory, ProgramCacheKeyHasher> cache_;
 };
 
 }  // namespace tt::tt_metal::program_cache::detail

--- a/tt_stl/tests/test_hash.cpp
+++ b/tt_stl/tests/test_hash.cpp
@@ -7,7 +7,10 @@
 #include <tt_stl/span.hpp>
 
 #include <array>
+#include <chrono>
 #include <cstdint>
+#include <iostream>
+#include <string>
 #include <unordered_set>
 #include <vector>
 
@@ -167,6 +170,141 @@ TEST(HashCollisionTest, SmallKeysCoverAllOutputBits) {
     }
     EXPECT_EQ(or_all, ~hash_t{0}) << "some output bit is never set across small keys";
     EXPECT_EQ(and_all, hash_t{0}) << "some output bit is always set across small keys";
+}
+
+// =============================================================================================
+// canonical_key: the exact, collision-free companion used to resolve hash collisions (option 1).
+// =============================================================================================
+
+std::string canonical_shape(const std::vector<uint32_t>& dims) {
+    return canonical_key(ttsl::Span<const uint32_t>(dims.data(), dims.size()));
+}
+
+TEST(CanonicalKeyTest, DistinguishesShapes) {
+    // The shapes that collided under the old 64-bit hash (issue #45821) must be distinct as exact
+    // keys regardless of the hash, so a collision can always be resolved to a correct (rebuild) miss.
+    EXPECT_NE(canonical_shape({3, 17, 1, 1}), canonical_shape({1, 152, 1, 1}));
+    EXPECT_NE(canonical_shape({3, 17}), canonical_shape({1, 152}));
+}
+
+TEST(CanonicalKeyTest, EqualForEqualInputs) {
+    EXPECT_EQ(canonical_shape({3, 17, 1, 1}), canonical_shape({3, 17, 1, 1}));
+    EXPECT_EQ(canonical_key(uint32_t{42}, uint32_t{7}), canonical_key(uint32_t{42}, uint32_t{7}));
+}
+
+TEST(CanonicalKeyTest, OrderAndLengthSensitive) {
+    EXPECT_NE(canonical_shape({2, 3}), canonical_shape({3, 2}));
+    // Length-prefixing prevents [1,2],[3] from encoding the same as [1],[2,3] etc.
+    EXPECT_NE(canonical_shape({1, 2, 3}), canonical_shape({1, 2}));
+    EXPECT_NE(canonical_shape({1, 1}), canonical_shape({1}));
+}
+
+TEST(CanonicalKeyTest, DistinguishesScalarsEnumsOptionals) {
+    EXPECT_NE(canonical_key(uint32_t{1}, uint32_t{2}), canonical_key(uint32_t{2}, uint32_t{1}));
+    enum class E : int { A, B };
+    EXPECT_NE(canonical_key(E::A), canonical_key(E::B));
+    EXPECT_NE(canonical_key(std::optional<uint32_t>{}), canonical_key(std::optional<uint32_t>{0}));
+    EXPECT_NE(canonical_key(float{1.0f}), canonical_key(float{2.0f}));
+    EXPECT_NE(canonical_key(std::string{"ab"}), canonical_key(std::string{"ba"}));
+}
+
+// Coverage over the same adversarial set used for the hash: the exact key must be injective here
+// (it is by construction, but pin it so a future encoding change can't silently regress).
+TEST(CanonicalKeyTest, NoCollisionsOverSmall4DShapes) {
+    constexpr uint32_t kMax = 40;
+    std::unordered_set<std::string> seen;
+    size_t count = 0;
+    for (uint32_t a = 0; a < kMax; ++a) {
+        for (uint32_t b = 0; b < kMax; ++b) {
+            for (uint32_t c = 0; c < kMax; ++c) {
+                for (uint32_t d = 0; d < kMax; ++d) {
+                    seen.insert(canonical_shape({a, b, c, d}));
+                    ++count;
+                }
+            }
+        }
+    }
+    EXPECT_EQ(seen.size(), count) << "canonical key collision among small 4-D shapes";
+}
+
+// =============================================================================================
+// The cache contract: a 64-bit hash collision is resolved by exact comparison of the canonical
+// key, so two distinct keys with the same hash coexist and each retrieves its OWN entry -- the
+// std::unordered_map bucket-walk doing the work. This mirrors
+// tt::tt_metal::program_cache::detail::ProgramCacheKey, replicated here to keep the tt_stl test
+// free of tt_metal dependencies.
+// =============================================================================================
+
+TEST(ProgramCacheKeyTest, HashCollisionResolvedByCanonicalKey) {
+    struct Key {
+        uint64_t hash;
+        std::string canonical;
+        bool operator==(const Key& o) const { return hash == o.hash && canonical == o.canonical; }
+    };
+    struct KeyHash {
+        size_t operator()(const Key& k) const { return k.hash; }
+    };
+
+    std::unordered_map<Key, int, KeyHash> cache;
+
+    // Two DISTINCT shapes forced to the SAME 64-bit hash -- exactly the #45821 collision.
+    Key a{42, canonical_shape({3, 17, 1, 1})};
+    Key b{42, canonical_shape({1, 152, 1, 1})};
+    ASSERT_EQ(a.hash, b.hash);          // same bucket
+    ASSERT_NE(a.canonical, b.canonical);
+
+    cache[a] = 1;  // "program" for shape A
+    cache[b] = 2;  // "program" for shape B
+
+    EXPECT_EQ(cache.size(), 2u);  // both coexist in one bucket (native chaining)
+    EXPECT_EQ(cache.at(a), 1);    // A retrieves A's entry, NOT B's -> the wrong-hit bug is gone
+    EXPECT_EQ(cache.at(b), 2);
+    EXPECT_TRUE(cache.contains(a));
+    EXPECT_TRUE(cache.contains(b));
+
+    // An identical key (same hash + same canonical) is a real hit and collapses onto the entry.
+    Key a_again{42, canonical_shape({3, 17, 1, 1})};
+    EXPECT_EQ(cache.at(a_again), 1);
+    cache[a_again] = 9;
+    EXPECT_EQ(cache.size(), 2u);
+    EXPECT_EQ(cache.at(a), 9);
+}
+
+// Informational: the per-dispatch host cost of option 1 is one canonical_key build (a full key
+// traversal + a small string alloc) on top of the hash that already runs every dispatch. Print
+// both so the overhead is a number, not a guess. Loose sanity bound only (machine-dependent).
+struct CostAttrs {
+    uint32_t a, b, c;
+    int32_t e;
+    float f;
+    static constexpr auto attribute_names = std::forward_as_tuple("a", "b", "c", "e", "f");
+    auto attribute_values() const { return std::forward_as_tuple(a, b, c, e, f); }
+};
+
+TEST(CanonicalKeyTest, RelativeCostVsHash) {
+    const CostAttrs attrs{1, 2, 3, 4, 5.0f};
+    const std::vector<uint32_t> shape{1, 152, 24, 32};
+    constexpr int N = 1'000'000;
+
+    volatile uint64_t hsink = 0;
+    auto t0 = std::chrono::steady_clock::now();
+    for (int i = 0; i < N; ++i) {
+        hsink ^= hash_objects_with_default_seed(uint64_t{777}, attrs, shape);
+    }
+    auto t1 = std::chrono::steady_clock::now();
+    volatile size_t csink = 0;
+    for (int i = 0; i < N; ++i) {
+        csink += canonical_key(uint64_t{777}, attrs, shape).size();
+    }
+    auto t2 = std::chrono::steady_clock::now();
+
+    const double hash_ns = std::chrono::duration<double, std::nano>(t1 - t0).count() / N;
+    const double canon_ns = std::chrono::duration<double, std::nano>(t2 - t1).count() / N;
+    std::cout << "[ cost     ] hash_objects=" << hash_ns << " ns/op, canonical_key=" << canon_ns
+              << " ns/op, ratio=" << (canon_ns / hash_ns) << "x (key size=" << canonical_key(uint64_t{777}, attrs, shape).size()
+              << " bytes)\n";
+    EXPECT_GT(hash_ns, 0.0);
+    EXPECT_GT(canon_ns, 0.0);
 }
 
 }  // namespace

--- a/tt_stl/tt_stl/reflection.hpp
+++ b/tt_stl/tt_stl/reflection.hpp
@@ -1451,6 +1451,111 @@ inline hash_t hash_objects(hash_t seed, const Types&... args) noexcept {
     return seed;
 }
 
+// ---------------------------------------------------------------------------------------------
+// Canonical key encoding (collision-free companion to hash_objects).
+//
+// hash_objects folds a key down to 64 bits, which can collide (issue #45821). For a cache that
+// must NEVER return a wrong entry, the 64-bit hash selects a bucket and an EXACT comparison of
+// the key resolves collisions -- the textbook hash-map contract. append_canonical builds that
+// exact key: a byte string whose traversal mirrors hash_object branch-for-branch, so it
+// distinguishes precisely the inputs the hash combines (same coverage => no spurious misses, no
+// missed collisions) and contains no volatile data (addresses, buffers) -- only the structural
+// values, just like the hash.
+//
+// Encoding is exact for every type on the op-key path: integers, enums, floating point,
+// std::string, the compile-time-attribute / reflect aggregates, and the standard containers
+// (length-prefixed; unordered_map sorted by key to stay order-invariant, mirroring hash_object).
+// The one lossy leaf is a type exposing ONLY to_hash(): its 8 hash bytes are appended, so for
+// such a type equality degrades to hash equality -- no worse than today, and none occur on the
+// tensor/shape path (TensorSpec is walked structurally down to the shape integers).
+inline void append_bytes(std::string& out, const void* p, std::size_t n) {
+    out.append(static_cast<const char*>(p), n);
+}
+
+template <typename T>
+inline void append_canonical(std::string& out, const T& object);
+
+template <typename... Types>
+inline void append_canonical_all(std::string& out, const Types&... args) {
+    (append_canonical(out, args), ...);
+}
+
+template <typename T>
+inline void append_canonical(std::string& out, const T& object) {
+    out.push_back('\x1f');  // unit separator: disambiguates adjacent leaves/fields
+    if constexpr (std::numeric_limits<T>::is_integer) {
+        append_bytes(out, &object, sizeof(object));
+    } else if constexpr (std::is_enum_v<T>) {
+        const auto v = static_cast<std::underlying_type_t<T>>(object);
+        append_bytes(out, &v, sizeof(v));
+    } else if constexpr (std::is_floating_point_v<T>) {
+        append_bytes(out, &object, sizeof(object));
+    } else if constexpr (std::is_same_v<T, std::string>) {
+        const std::uint64_t n = object.size();
+        append_bytes(out, &n, sizeof(n));
+        append_bytes(out, object.data(), object.size());
+    } else if constexpr (ttsl::reflection::detail::supports_compile_time_attributes_v<T>) {
+        std::apply([&out](const auto&... a) { (append_canonical(out, a), ...); }, object.attribute_values());
+    } else if constexpr (is_specialization_v<T, std::tuple>) {
+        std::apply([&out](const auto&... a) { (append_canonical(out, a), ...); }, object);
+    } else if constexpr (is_specialization_v<T, std::pair>) {
+        append_canonical(out, object.first);
+        append_canonical(out, object.second);
+    } else if constexpr (is_specialization_v<T, std::optional>) {
+        const char has = object.has_value() ? 1 : 0;
+        out.push_back(has);
+        if (object.has_value()) {
+            append_canonical(out, object.value());
+        }
+    } else if constexpr (is_specialization_v<T, std::variant>) {
+        const std::uint64_t index = object.index();
+        append_bytes(out, &index, sizeof(index));
+        std::visit([&out](const auto& value) { append_canonical(out, value); }, object);
+    } else if constexpr (is_specialization_v<T, std::reference_wrapper>) {
+        append_canonical(out, object.get());
+    } else if constexpr (
+        is_specialization_v<T, std::vector> || is_specialization_v<T, std::set> || is_span_v<T>) {
+        const std::uint64_t n = object.size();
+        append_bytes(out, &n, sizeof(n));
+        for (const auto& element : object) {
+            append_canonical(out, element);
+        }
+    } else if constexpr (is_specialization_v<T, std::map>) {
+        const std::uint64_t n = object.size();
+        append_bytes(out, &n, sizeof(n));
+        for (const auto& [key, value] : object) {
+            append_canonical(out, key);
+            append_canonical(out, value);
+        }
+    } else if constexpr (is_specialization_v<T, std::unordered_map>) {
+        // Sort by key so the encoding is order-invariant, mirroring hash_object.
+        std::vector<typename T::const_iterator> iterators;
+        iterators.reserve(object.size());
+        for (auto it = object.begin(); it != object.end(); ++it) {
+            iterators.push_back(it);
+        }
+        std::sort(iterators.begin(), iterators.end(), [](const auto& a, const auto& b) {
+            return a->first < b->first;
+        });
+        const std::uint64_t n = object.size();
+        append_bytes(out, &n, sizeof(n));
+        for (const auto& it : iterators) {
+            append_canonical(out, it->first);
+            append_canonical(out, it->second);
+        }
+    } else if constexpr (ttsl::concepts::Reflectable<T>) {
+        reflect::for_each([&out, &object](auto I) { append_canonical(out, reflect::get<I>(object)); }, object);
+    } else if constexpr (ttsl::reflection::detail::supports_to_hash_v<T>) {
+        const hash_t h = object.to_hash();  // lossy leaf (see note above)
+        append_bytes(out, &h, sizeof(h));
+    } else if constexpr (detail::is_std_hashable_v<T>) {
+        const std::size_t h = std::hash<T>{}(object);  // lossy fallback
+        append_bytes(out, &h, sizeof(h));
+    } else {
+        static_assert(ttsl::concepts::always_false_v<T>, "Type doesn't support ttsl::hash::canonical_key");
+    }
+}
+
 }  // namespace detail
 
 template <typename... Types>
@@ -1461,6 +1566,16 @@ inline hash_t hash_objects(hash_t seed, const Types&... args) noexcept {
 template <typename... Types>
 inline hash_t hash_objects_with_default_seed(const Types&... args) noexcept {
     return detail::hash_objects(DEFAULT_SEED, args...);
+}
+
+// Exact, collision-free encoding of `args` for use as a program-cache key alongside the 64-bit
+// hash: two argument packs produce the same string iff the hash traversal cannot distinguish
+// them. See detail::append_canonical.
+template <typename... Types>
+inline std::string canonical_key(const Types&... args) {
+    std::string out;
+    detail::append_canonical_all(out, args...);
+    return out;
 }
 
 // Ripped out of boost for std::size_t so as to not pull in bulky boost dependencies

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -46,6 +46,7 @@ using CachedMeshWorkload = tt::tt_metal::program_cache::detail::CachedMeshWorklo
 namespace detail {
 
 using ::tt::tt_metal::program_cache::detail::CachedProgramFactory;
+using ::tt::tt_metal::program_cache::detail::ProgramCacheKey;
 
 template <typename... Ts>
 [[nodiscard]] std::variant<Ts...> map_index_to_variant(std::size_t i, std::variant<Ts...>) {
@@ -263,14 +264,14 @@ void handle_mesh_adapter_cache_hit(
     typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
-    ttsl::hash::hash_t program_hash) {
+    const ProgramCacheKey& program_key) {
     if constexpr (HasValidateOnProgramCacheHit<mesh_device_operation_t>) {
         mesh_device_operation_t::validate_on_program_cache_hit(operation_attributes, tensor_args);
     } else {
         mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
     }
 
-    auto& cached_program_factory = program_cache.get(program_hash);
+    auto& cached_program_factory = program_cache.get(program_key);
     auto program_factory_index = cached_program_factory.program_factory_index;
     auto program_factory = map_index_to_variant(
         program_factory_index, mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args));
@@ -302,7 +303,7 @@ void create_and_cache_mesh_workload(
     typename mesh_device_operation_t::tensor_return_value_t& tensor_return_value,
     ttnn::MeshDevice* mesh_device,
     tt::tt_metal::program_cache::detail::ProgramCache& program_cache,
-    ttsl::hash::hash_t program_hash) {
+    const ProgramCacheKey& program_key) {
     mesh_device_operation_t::validate_on_program_cache_miss(operation_attributes, tensor_args);
 
     auto program_factory = mesh_device_operation_t::select_program_factory(operation_attributes, tensor_args);
@@ -346,8 +347,8 @@ void create_and_cache_mesh_workload(
             bool should_cache = program_cache.is_enabled() && !hook_blocks;
             if (should_cache) {
                 program_cache.insert(
-                    program_hash, CachedProgramFactory{std::move(cached_workload), program_factory_index});
-                auto& cached_program_factory = program_cache.get(program_hash);
+                    program_key, CachedProgramFactory{std::move(cached_workload), program_factory_index});
+                auto& cached_program_factory = program_cache.get(program_key);
                 auto& workload = cached_program_factory.cached_program.template get<cached_mesh_workload_t>().workload;
                 enqueue_mesh_workload<mesh_device_operation_t>(
                     operation_attributes,
@@ -381,15 +382,19 @@ void launch_operation_with_adapter(
     }
 
     auto& program_cache = mesh_device->get_program_cache();
-    auto program_hash = 0;
+    // The cache key is the 64-bit hash plus an exact canonical encoding; a hash collision is
+    // resolved by std::unordered_map's own operator== on the canonical part (issue #45821).
+    ProgramCacheKey program_key;
     bool program_cache_hit = false;
 
     auto is_program_cache_enabled = program_cache.is_enabled();
     if (is_program_cache_enabled) {
         // Use device_operation's compute_program_hash if available
-        program_hash =
+        program_key.hash =
             mesh_device_operation_t::compute_mesh_workload_hash(mesh_device, operation_attributes, tensor_args);
-        program_cache_hit = program_cache.contains(program_hash);
+        program_key.canonical =
+            mesh_device_operation_t::compute_mesh_workload_canonical_key(mesh_device, operation_attributes, tensor_args);
+        program_cache_hit = program_cache.contains(program_key);
         if (!program_cache_hit && !program_cache.cache_misses_allowed()) {
             auto op_name = get_operation_name<mesh_device_operation_t>(operation_attributes);
             TT_THROW("Device operation \"{}\": program cache miss occurred, but cache misses are forbidden", op_name);
@@ -397,16 +402,16 @@ void launch_operation_with_adapter(
     }
 
     log_operation<mesh_device_operation_t>(
-        mesh_device->id(), operation_attributes, tensor_args, program_hash, program_cache_hit);
+        mesh_device->id(), operation_attributes, tensor_args, program_key.hash, program_cache_hit);
 
     ttsl::reflection::visit_object_of_type<Tensor>(CheckDeviceBufferIsAllocated{}, tensor_args);
 
     if (program_cache_hit) {
         handle_mesh_adapter_cache_hit<mesh_device_operation_t>(
-            operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
+            operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_key);
     } else {
         create_and_cache_mesh_workload<mesh_device_operation_t>(
-            operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_hash);
+            operation_attributes, tensor_args, tensor_return_value, mesh_device, program_cache, program_key);
     }
 }
 

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -736,6 +736,35 @@ public:
         return hash;
     }
 
+    // Exact, collision-free companion to compute_mesh_workload_hash: the cache compares this on a
+    // hash hit so a 64-bit collision is resolved to a correct (rebuild) miss instead of a wrong
+    // hit (issue #45821). It must mirror the SAME inputs the hash combines.
+    //
+    // For ops with a custom compute_program_hash we can't infer which fields it keyed on (it may
+    // deliberately exclude some, e.g. an RNG seed), so we return an empty string -- opting that op
+    // out of collision resolution (hash-only, today's behavior) unless it provides a
+    // compute_program_canonical_key hook. The default reflection-hash path is mirrored exactly.
+    static std::string compute_mesh_workload_canonical_key(
+        tt::tt_metal::distributed::MeshDevice* mesh_device,
+        const operation_attributes_t& attrs,
+        const tensor_args_t& tensor_args) {
+        std::string key;
+        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
+            if constexpr (requires { DeviceOperation::compute_program_canonical_key(attrs, tensor_args); }) {
+                key = DeviceOperation::compute_program_canonical_key(attrs, tensor_args);
+            } else {
+                return {};  // custom hash, no canonical hook -> opt out of collision resolution
+            }
+        } else {
+            key = ttsl::hash::canonical_key(ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
+        }
+
+        for (const auto& coord : mesh_device_operation_utils::extract_tensor_coordinates(tensor_args, mesh_device)) {
+            key += ttsl::hash::canonical_key(coord);
+        }
+        return key;
+    }
+
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& attributes,
         const tensor_args_t& tensor_args,


### PR DESCRIPTION
> **Draft / prototype for discussion.** Stacked on #46385 (base = `dgomez/fix-hash-collision-45821`), so this diff is *only* the option-1 work. Re-targets to `main` once #46385 merges.

### Why

#46385 makes a program-cache hash collision *improbable* (~10⁻¹³ at realistic cache sizes). This prototype makes it *impossible to observe as a wrong result*, which is what @borys… asked for (option 1): store the key and compare it, the textbook hash-map contract the cache had opted out of by keying on the bare `uint64`.

Closes the correctness gap behind #45821 structurally rather than probabilistically.

### Design

**`ProgramCacheKey{ uint64_t hash; std::string canonical }`** — the cache map (`program_cache.hpp`) now keys on this. `std::unordered_map` uses `hash` to pick the bucket and `operator==` on `canonical` to confirm the match, so two distinct keys with the same 64-bit hash **coexist in the bucket and each retrieves its own entry** (native chaining). No bespoke verification logic — the container does it.

**`ttsl::hash::canonical_key(...)`** (`reflection.hpp`) — an exact, collision-free serialization that mirrors `hash_object` branch-for-branch (integers, enums, floats, strings, compile-time-attribute / reflect aggregates, `std::variant`, `optional`, `reference_wrapper`, all containers). Same traversal as the hash ⇒ same coverage, and no volatile fields (no addresses/buffers) ⇒ no spurious misses. One intentionally-lossy leaf: a `to_hash`-only type (documented).

**Wiring** — `compute_mesh_workload_canonical_key` parallels `compute_mesh_workload_hash` and is threaded through the 4 cache sites in `device_operation.hpp`.

### Custom-`compute_program_hash` ops are NOT touched

This is the key scoping decision. For an op with a custom hash, the framework only has its opaque 64-bit output — it can't recover the key material, and building a canonical from the full attributes would *break* these ops (e.g. `rand` deliberately excludes the seed so different seeds share a program; an exact full-attr key would rebuild every call).

So custom-hash ops return an **empty canonical and opt out automatically** — zero edits, behavior identical to today, riding #46385's strong hash at ~10⁻¹³. The default reflection-hash path (including `Permute`, the op that actually broke) gets the hard guarantee for free.

If a specific custom-hash op ever needs the absolute guarantee, it can opt in via a `compute_program_canonical_key` hook (present but unused). The clean long-term form would be flipping that op's contract to return a hashable+comparable key the framework derives both from — opt-in, per-op, not required here.

### Tests

`tt_stl/tests/test_hash.cpp`:
- `CanonicalKeyTest` — the #45821 shapes get distinct canonical keys; injective over the 2.56M-shape sweep; order/length/enum/optional/variant sensitivity.
- **`ProgramCacheKeyTest.HashCollisionResolvedByCanonicalKey`** — forces the two #45821 shapes to the *same* 64-bit hash and proves both coexist and each retrieves its own entry. Deterministic proof of the mechanism, no hardware.
- `RelativeCostVsHash` — microbenchmark (below).

`unit_tests_stl`: **124/124**. Full ttnn rebuild: clean. On-device `batch_norm` repro (the #45821 shapes, program cache on): **PASS, PCC ~0.9999**.

### Cost

`canonical_key` ≈ **66 ns/op** vs `hash_objects` ≈ **17 ns/op** (~3.8×), 64-byte key for a representative op key → **~49 ns extra per dispatch (~0.3% of a ~16 µs dispatch)**, plus a per-hit string compare and ~64 B stored per cache entry.

### Open questions
1. Keep the `compute_program_canonical_key` opt-in hook, or drop it so there's zero invitation to touch custom hashes?
2. Serialized canonical key (this PR: uniform, no buffer-lifetime issues, 64 B/entry) vs a reflection-derived structural `operator==` (no stored string, needs type-erasure)?

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/45821-equality-fallback-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/45821-equality-fallback-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/45821-equality-fallback-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/45821-equality-fallback-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/45821-equality-fallback-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/45821-equality-fallback-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/45821-equality-fallback-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/45821-equality-fallback-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/45821-equality-fallback-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/45821-equality-fallback-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/45821-equality-fallback-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/45821-equality-fallback-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/45821-equality-fallback-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/45821-equality-fallback-prototype)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/45821-equality-fallback-prototype)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/45821-equality-fallback-prototype)