### PR TITLE
[Bug fix] fix h2d device pull l1 and only apply tests to blackhole galaxy

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_h2d_stream_service.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_h2d_stream_service.py
@@ -8,17 +8,16 @@ import torch
 
 import ttnn
 
-from conftest import is_6u
-from models.common.utility_functions import is_blackhole, skip_for_slow_dispatch
+from models.common.utility_functions import skip_for_slow_dispatch
 
-# H2DStreamService claims FD dispatch-column service cores, which are only supported on
-# Blackhole or UBB Galaxy clusters and require fast dispatch. Skip the whole module on any
-# other configuration so unsupported runners skip cleanly instead of hitting the claim TT_FATAL.
+# H2DStreamService claims FD dispatch-column service cores and DMA-pins host memory; it is only
+# supported on Blackhole Galaxy and requires fast dispatch. Skip the whole module on any other
+# configuration so unsupported runners skip cleanly instead of hitting the claim TT_FATAL.
 pytestmark = [
     skip_for_slow_dispatch(),
     pytest.mark.skipif(
-        not (is_blackhole() or is_6u()),
-        reason="H2DStreamService service cores require Blackhole or UBB Galaxy",
+        ttnn.cluster.get_cluster_type() != ttnn.cluster.ClusterType.BLACKHOLE_GALAXY,
+        reason="H2DStreamService is only supported on Blackhole Galaxy",
     ),
 ]
 

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -136,12 +136,6 @@ void H2DSocket::init_config_buffer(const std::shared_ptr<MeshDevice>& mesh_devic
 }
 
 void H2DSocket::init_data_buffer(const std::shared_ptr<MeshDevice>& mesh_device, uint32_t pcie_alignment) {
-    if (h2d_mode_ != H2DMode::HOST_PUSH) {
-        // DEVICE_PULL: data FIFO lives in pinned host memory; no device-side L1 allocation needed.
-        write_ptr_ = 0;
-        return;
-    }
-
     auto& svc = tt::tt_metal::MetalContext::instance().get_service_core_manager();
     auto* recv_device = mesh_device->get_device(recv_core_.device_coord);
     if (svc.claimed_cores(recv_device->id()).contains(recv_core_.core_coord)) {


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

H2DStream tests should only be applied for Blackhole galaxy; it was previously being tested on other setups, which were failing tests. 

Additionally, PR #46144 added an early return in H2DSocket::init_data_buffer() for DEVICE_PULL mode, skipping the device-side L1 buffer allocation and leaving aligned_data_buf_start_ = 0. That zero became the socket  
      read_ptr, which the h2d_receiver kernel uses as the L1 destination address for NOC reads pulling pages from host pinned memory so data landed at L1 address 0 (reserved firmware region), corrupting the 
      stream and hanging the loopback. 
This PR fixes by remove that early return issue. 


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bzhang/fix-h2d-device-pull-l1-and-test-gating)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bzhang/fix-h2d-device-pull-l1-and-test-gating)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bzhang/fix-h2d-device-pull-l1-and-test-gating)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bzhang/fix-h2d-device-pull-l1-and-test-gating)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bzhang/fix-h2d-device-pull-l1-and-test-gating)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bzhang/fix-h2d-device-pull-l1-and-test-gating)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bzhang/fix-h2d-device-pull-l1-and-test-gating)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bzhang/fix-h2d-device-pull-l1-and-test-gating)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bzhang/fix-h2d-device-pull-l1-and-test-gating)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bzhang/fix-h2d-device-pull-l1-and-test-gating)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bzhang/fix-h2d-device-pull-l1-and-test-gating)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bzhang/fix-h2d-device-pull-l1-and-test-gating)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bzhang/fix-h2d-device-pull-l1-and-test-gating)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bzhang/fix-h2d-device-pull-l1-and-test-gating)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bzhang/fix-h2d-device-pull-l1-and-test-gating)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bzhang/fix-h2d-device-pull-l1-and-test-gating)