### PR TITLE
DO NOT REVIEW: [skip ci] tt-llk: Add Doxygen docstrings to Blackhole llk-api

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_binary_api.h
@@ -40,6 +40,22 @@ inline void llk_math_eltwise_binary_init(
         tensor_shape, acc_to_dest);
 }
 
+/**
+ * @brief Perform an elementwise binary operation where Output = SrcA [+, -, *] SrcB.
+ *
+ * Dispatches to the standard or dest-reuse implementation based on the binary_reuse_dest template
+ * parameter. This overload uses the default tile shape.
+ *
+ * @tparam eltwise_binary_type: Type of eltwise binary op, values = <ELWADD/ELWSUB/ELWMUL>
+ * @tparam src_b_bcast_type: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
+ * @tparam is_fp32_dest_acc_en: Enable FP32 mode in destination register
+ * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
+ * @tparam binary_reuse_dest: Reuse destination as source type, values = <NONE/DEST_TO_SRCA/DEST_TO_SRCB>
+ * @param dst_index: Tile index into the destination register.
+ * @param clear_fp32_dst_acc: Clears index in destination register when float32 mode is enabled.
+ * @note Call @ref llk_math_eltwise_binary_init with matching template args before this function.
+ * @note On the unpack thread, @ref llk_unpack_AB must feed the operand tiles into SrcA/SrcB.
+ */
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,
@@ -66,6 +82,24 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
         binary_reuse_dest>(ckernel::DEFAULT_TENSOR_SHAPE, dst_index, clear_fp32_dst_acc);
 }
 
+/**
+ * @brief Perform an elementwise binary operation where Output = SrcA [+, -, *] SrcB.
+ *
+ * Dispatches to the standard or dest-reuse implementation based on the binary_reuse_dest template
+ * parameter. Derives the tile shape from operand_A.
+ *
+ * @tparam eltwise_binary_type: Type of eltwise binary op, values = <ELWADD/ELWSUB/ELWMUL>
+ * @tparam src_b_bcast_type: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
+ * @tparam is_fp32_dest_acc_en: Enable FP32 mode in destination register
+ * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
+ * @tparam binary_reuse_dest: Reuse destination as source type, values = <NONE/DEST_TO_SRCA/DEST_TO_SRCB>
+ * @param operand_A: Logical dataflow buffer id for input A, used to derive the tile shape.
+ * @param operand_B: Unused.
+ * @param dst_index: Tile index into the destination register.
+ * @param clear_fp32_dst_acc: Clears index in destination register when float32 mode is enabled.
+ * @note Call @ref llk_math_eltwise_binary_init with matching template args before this function.
+ * @note On the unpack thread, @ref llk_unpack_AB must feed the operand tiles into SrcA/SrcB.
+ */
 template <
     EltwiseBinaryType eltwise_binary_type,
     BroadcastType src_b_bcast_type,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_common_api.h
@@ -19,6 +19,15 @@
 /*************************************************************************
  * LLK MATH COMMON
  *************************************************************************/
+/**
+ * @brief Configure the math (FPU) thread's ALU control registers for the given source operands.
+ *
+ * Derives the source A and B data formats from the operands' circular buffers.
+ *
+ * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
+ * @param srca_operand: Circular-buffer index of source A.
+ * @param srcb_operand: Circular-buffer index of source B.
+ */
 template <bool is_fp32_dest_acc_en>
 inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::uint32_t srcb_operand) {
     std::uint32_t srca_operand_id = get_operand_id(srca_operand);
@@ -27,38 +36,92 @@ inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::u
         unpack_dst_format[srca_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
+/**
+ * @brief Enable or disable FP32 accumulation in the destination register for both FPU and SFPU.
+ *
+ * @param enable: True to enable FP32 dest accumulation, false to disable.
+ */
 inline void llk_math_set_fp32_dest_acc(bool enable) { _llk_math_set_fp32_dest_acc_(enable); }
 
+/**
+ * @brief Enable or disable the destination read-address remap (stride-of-16) used by untilize mode.
+ *
+ * @param remap_enable: True to enable the stride-of-16 remap (untilize), false to restore linear addressing.
+ */
 inline void llk_math_reconfig_remap(const bool remap_enable) { _llk_math_reconfig_remap_(remap_enable); }
 
+/**
+ * @brief Block the math thread until the destination register is available for writing.
+ */
 inline void llk_math_wait_for_dest_available() {
     WAYPOINT("MWDW");
     _llk_math_wait_for_dest_available_<DST_SYNC_MODE>();
     WAYPOINT("MWDD");
 }
 
+/**
+ * @brief Signal completion of a destination section by setting the math semaphores, flipping banks in half-sync mode.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled.
+ */
 template <bool is_fp32_dest_acc_en>
 inline void llk_math_dest_section_done() {
     _llk_math_dest_section_done_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
+/**
+ * @brief Initialize the math/pack synchronization semaphore and reset the destination section base.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled.
+ */
 template <bool is_fp32_dest_acc_en>
 inline void llk_math_pack_sync_init() {
     _llk_math_pack_sync_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 }
 
+/**
+ * @brief Reconfigure the math thread for a new source A data format.
+ *
+ * Derives the new source A data format from the operand's circular buffer.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when
+ * to_from_int8 is set).
+ * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
+ * @param srca_new_operand: Circular-buffer index of the new source A operand.
+ */
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
     _llk_math_reconfig_data_format_srca_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srca_operand_id]);
 }
 
+/**
+ * @brief Reconfigure the math thread for a new source B data format.
+ *
+ * Derives the new source B data format from the operand's circular buffer.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when
+ * to_from_int8 is set).
+ * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
+ * @param srcb_new_operand: Circular-buffer index of the new source B operand.
+ */
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srcb_operand_id = get_operand_id(srcb_new_operand);
     _llk_math_reconfig_data_format_srcb_<is_fp32_dest_acc_en, to_from_int8>(unpack_dst_format[new_srcb_operand_id]);
 }
 
+/**
+ * @brief Reconfigure the math thread for new source A and source B data formats.
+ *
+ * Derives both source data formats from the operands' circular buffers.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when
+ * to_from_int8 is set).
+ * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
+ * @param srca_new_operand: Circular-buffer index of the new source A operand.
+ * @param srcb_new_operand: Circular-buffer index of the new source B operand.
+ */
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format(const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
     std::uint32_t new_srca_operand_id = get_operand_id(srca_new_operand);
@@ -68,6 +131,19 @@ inline void llk_math_reconfig_data_format(const std::uint32_t srca_new_operand, 
         unpack_dst_format[new_srca_operand_id], unpack_dst_format[new_srcb_operand_id]);
 }
 
+/**
+ * @brief Conditionally reconfigure the math thread for new source A and/or B operands.
+ *
+ * Reprograms only the sources whose data format differs between the old and new operands.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when
+ * to_from_int8 is set).
+ * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
+ * @param srca_old_operand: Currently configured source A operand (circular-buffer index).
+ * @param srca_new_operand: New source A operand (circular-buffer index).
+ * @param srcb_old_operand: Currently configured source B operand (circular-buffer index).
+ * @param srcb_new_operand: New source B operand (circular-buffer index).
+ */
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format(
     const std::uint32_t srca_old_operand,
@@ -89,6 +165,17 @@ inline void llk_math_reconfig_data_format(
     }
 }
 
+/**
+ * @brief Conditionally reconfigure the math thread for a new source A operand.
+ *
+ * Reprograms only when the new operand's data format differs from the old one's.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when
+ * to_from_int8 is set).
+ * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
+ * @param srca_old_operand: Currently configured source A operand (circular-buffer index).
+ * @param srca_new_operand: New source A operand (circular-buffer index).
+ */
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
@@ -100,6 +187,17 @@ inline void llk_math_reconfig_data_format_srca(
     }
 }
 
+/**
+ * @brief Conditionally reconfigure the math thread for a new source B operand.
+ *
+ * Reprograms only when the new operand's data format differs from the old one's.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether FP32 accumulation in the destination register is enabled (required when
+ * to_from_int8 is set).
+ * @tparam to_from_int8: Set when the reconfiguration switches to or from an Int8/Int32 format.
+ * @param srcb_old_operand: Currently configured source B operand (circular-buffer index).
+ * @param srcb_new_operand: New source B operand (circular-buffer index).
+ */
 template <bool is_fp32_dest_acc_en, bool to_from_int8 = false>
 inline void llk_math_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_matmul_api.h
@@ -10,6 +10,22 @@
  * LLK MATMUL
  *************************************************************************/
 
+/**
+ * @brief Configure the math (FPU/matrix engine) thread for a matmul: programs address mods and the MVMUL MOP.
+ *
+ * Derives the in0/in1 tile dimensions and partial-face flag from the operands' circular buffers.
+ *
+ * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
+ * @tparam THROTTLE_LEVEL: Compute-throughput throttle level; 0 disables throttling, valid throttled range is
+ * {1,2,3,4,5}.
+ * @param operandA: Circular-buffer index of operand A (in0).
+ * @param operandB: Circular-buffer index of operand B (in1).
+ * @param transpose: Non-zero to transpose in1 faces during the multiply.
+ * @param ct_dim: Number of column tiles in the output block.
+ * @param rt_dim: Number of row tiles in the output block.
+ * @note On the unpack thread, pair with @ref llk_unpack_AB_matmul_init which feeds SrcA/SrcB.
+ * @note @ref llk_math_matmul runs the configured matmul with matching template args.
+ */
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
 inline void llk_math_matmul_init(
     const std::uint32_t operandA,
@@ -31,6 +47,17 @@ inline void llk_math_matmul_init(
         in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face, transpose, ct_dim, rt_dim);
 }
 
+/**
+ * @brief Perform a matmul block, accumulating in0 * in1 into the destination register.
+ *
+ * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
+ * @tparam THROTTLE_LEVEL: Compute-throughput throttle level; must match the value used at init.
+ * @param dst_index: Base tile index into the destination register for the output block.
+ * @param ct_dim: Number of column tiles in the output block.
+ * @param rt_dim: Number of row tiles in the output block.
+ * @note Call @ref llk_math_matmul_init with matching template args before this function.
+ * @note On the unpack thread, @ref llk_unpack_AB_matmul must feed the operand tiles into SrcA/SrcB.
+ */
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0, uint32_t num_faces = 4 /*not used*/>
 inline void llk_math_matmul(const uint dst_index, const std::uint32_t ct_dim = 1, const std::uint32_t rt_dim = 1) {
     static_assert(num_faces == 4, "num_faces other than 4 is not supported in llk_math_matmul");

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_reduce_api.h
@@ -10,6 +10,20 @@
  * LLK REDUCE
  *************************************************************************/
 
+/**
+ * @brief Perform a reduction on the math thread, pooling faces into the destination register.
+ *
+ * @tparam type: Pooling op, values = <SUM/AVG/MAX>
+ * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
+ * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
+ * @tparam is_int_fpu_en: Enable integer FPU datapath (casts int32 dest datums to int8 before moving to SrcB).
+ * @tparam enforce_fp32_accumulation: Force FP32 accumulation through the transpose (requires is_fp32_dest_acc_en).
+ * @param dst_index: Tile index into the destination register.
+ * @param tensor_shape: Tensor shape describing tile dimensions.
+ * @note Call @ref llk_math_reduce_init with matching template args before this function, and
+ *       @ref llk_math_reduce_uninit after it to restore modified state.
+ */
 template <
     PoolType type,
     ReduceDim dim,
@@ -23,6 +37,23 @@ inline void llk_math_reduce(const uint dst_index, const ckernel::TensorShape& te
         dst_index, tensor_shape);
 }
 
+/**
+ * @brief Perform a reduction on the math thread, pooling faces into the destination register.
+ *
+ * Derives the tile shape from operand A's circular buffer.
+ *
+ * @tparam type: Pooling op, values = <SUM/AVG/MAX>
+ * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
+ * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
+ * @tparam is_int_fpu_en: Enable integer FPU datapath (casts int32 dest datums to int8 before moving to SrcB).
+ * @tparam enforce_fp32_accumulation: Force FP32 accumulation through the transpose (requires is_fp32_dest_acc_en).
+ * @param operandA: Circular-buffer index of source operand A (used to derive the tile shape).
+ * @param operandB: Circular-buffer index of the scaler operand B.
+ * @param dst_index: Tile index into the destination register.
+ * @note Call @ref llk_math_reduce_init with matching template args before this function, and
+ *       @ref llk_math_reduce_uninit after it to restore modified state.
+ */
 template <
     PoolType type,
     ReduceDim dim,
@@ -40,6 +71,18 @@ inline void llk_math_reduce(const std::uint32_t operandA, const std::uint32_t op
         dst_index, tensor_shape);
 }
 
+/**
+ * @brief Configure the math (FPU) thread for a reduce operation.
+ *
+ * @tparam type: Pooling op, values = <SUM/AVG/MAX>
+ * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
+ * @tparam math_fidelity: Math fidelity for controlling precision, values = <LoFi/HiFi2/HiFi3/HiFi4>
+ * @tparam enforce_fp32_accumulation: Force FP32 accumulation (requires is_fp32_dest_acc_en).
+ * @note On the unpack thread, pair with @ref llk_unpack_reduce_init (single operand) or
+ *       @ref llk_unpack_AB_reduce_init (with scaler operand).
+ * @note @ref llk_math_reduce runs the configured reduction; call @ref llk_math_reduce_uninit after.
+ */
 template <
     PoolType type,
     ReduceDim dim,
@@ -50,6 +93,12 @@ inline void llk_math_reduce_init() {
     _llk_math_reduce_init_<type, dim, is_fp32_dest_acc_en, math_fidelity, enforce_fp32_accumulation>();
 }
 
+/**
+ * @brief Uninitialize after a reduce operation, undoing any init/execute-time workarounds.
+ *
+ * @tparam enforce_fp32_accumulation: Must match the value used at init.
+ * @note Reverses @ref llk_math_reduce_init.
+ */
 template <bool enforce_fp32_accumulation = false>
 inline void llk_math_reduce_uninit() {
     _llk_math_reduce_uninit_<enforce_fp32_accumulation>();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_transpose_dest_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_transpose_dest_api.h
@@ -7,6 +7,17 @@
 #include "llk_math_common_api.h"
 #include "llk_math_transpose_dest.h"
 
+/**
+ * @brief Transpose a tile in place within the destination register.
+ *
+ * @tparam transpose_of_faces: Also transpose the arrangement of faces, not just elements within a face.
+ * @tparam is_32bit: True for 32-bit datums (uses the format-switching transpose path).
+ * @param dst_index: Tile index into the destination register.
+ * @note Call @ref llk_math_transpose_dest_init with matching template args before this function.
+ * @note On the unpack thread, the tile must already be in dest (via @ref llk_unpack_A datacopy);
+ *       @ref llk_unpack_set_srcb_dummy_valid marks SrcB valid so the MOVB2D/MOVD2B sequence can run.
+ * @note <transpose_of_faces=false, is_32bit=false> is not supported.
+ */
 template <bool transpose_of_faces = true, bool is_32bit = false>
 inline void llk_math_transpose_dest(uint dst_index) {
     LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
@@ -14,6 +25,13 @@ inline void llk_math_transpose_dest(uint dst_index) {
     _llk_math_transpose_dest_<transpose_of_faces, is_32bit>(dst_index);
 }
 
+/**
+ * @brief Configure the math thread (address mods and MOP) for a destination-register transpose.
+ *
+ * @tparam transpose_of_faces: Also transpose the arrangement of faces, not just elements within a face.
+ * @tparam is_32bit: True for 32-bit datums (configures the format-switching transpose path).
+ * @note @ref llk_math_transpose_dest runs the configured transpose with matching template args.
+ */
 template <bool transpose_of_faces = true, bool is_32bit = false>
 inline void llk_math_transpose_dest_init() {
     _llk_math_transpose_dest_init_<transpose_of_faces, is_32bit>();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -11,6 +11,21 @@
  * LLK ELTWISE UNARY DATACOPY
  *************************************************************************/
 
+/**
+ * @brief Copy a tile into the destination register, optionally broadcasting source B.
+ *
+ * Derives the source and destination data formats from the operand's circular buffer.
+ *
+ * @tparam type: Datacopy direction, values = <A2D/B2D>
+ * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
+ * @tparam src_b_bcast_type: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
+ * @tparam unpack_to_dest: Unpack writes directly to dest (vs. via source registers).
+ * @param dst_index: Tile index into the destination register.
+ * @param operand: Circular-buffer index of the operand to copy.
+ * @note Call @ref llk_math_eltwise_unary_datacopy_init with matching template args before this function, and
+ *       @ref llk_math_eltwise_unary_datacopy_uninit after it to restore modified state.
+ * @note On the unpack thread, @ref llk_unpack_A must feed the tile into SrcA/SrcB (or dest for unpack-to-dest).
+ */
 template <
     DataCopyType type,
     bool is_fp32_dest_acc_en,
@@ -24,6 +39,22 @@ inline void llk_math_eltwise_unary_datacopy(uint dst_index, uint operand = 0) {
         dst_index, unpack_src_format[operand_id], unpack_dst_format[operand_id]);
 }
 
+/**
+ * @brief Copy a contiguous block of tiles into the destination register.
+ *
+ * Loops @ref llk_math_eltwise_unary_datacopy over @p ntiles destination tiles starting at
+ * @p start_dst_index, deriving the data formats from the operand's circular buffer.
+ *
+ * @tparam type: Datacopy direction, values = <A2D/B2D>
+ * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
+ * @tparam src_b_bcast_type: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
+ * @tparam unpack_to_dest: Unpack writes directly to dest (vs. via source registers).
+ * @param start_dst_index: First tile index into the destination register.
+ * @param ntiles: Number of consecutive tiles to copy.
+ * @param operand: Circular-buffer index of the operand to copy.
+ * @note Call @ref llk_math_eltwise_unary_datacopy_init with matching template args before this function, and
+ *       @ref llk_math_eltwise_unary_datacopy_uninit after it to restore modified state.
+ */
 template <
     DataCopyType type,
     bool is_fp32_dest_acc_en,
@@ -40,6 +71,21 @@ inline void llk_math_eltwise_unary_datacopy_block(uint start_dst_index, uint nti
     }
 }
 
+/**
+ * @brief Initialize the math thread (address mods and MOP) for an elementwise unary datacopy.
+ *
+ * Derives num_faces and the source/destination formats from the operand's circular buffer.
+ *
+ * @tparam type: Datacopy direction, values = <A2D/B2D>
+ * @tparam is_fp32_dest_acc_en: Enable FP32 accumulation in the destination register.
+ * @tparam src_b_bcast_type: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
+ * @tparam is_int_fpu_en: Enable integer FPU datapath.
+ * @tparam pack_mode: Packing layout, values = <Default/Tilize>
+ * @param operand: Circular-buffer index of the operand to copy.
+ * @note On the unpack thread, pair with @ref llk_unpack_A_init (copy/transpose),
+ *       @ref llk_unpack_tilize_init (tilize) or @ref llk_unpack_untilize_init.
+ * @note @ref llk_math_eltwise_unary_datacopy runs the configured op with matching template args.
+ */
 template <
     DataCopyType type,
     bool is_fp32_dest_acc_en,
@@ -62,6 +108,13 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0
         num_faces, dst_format, is_input_8bit_format);
 }
 
+/**
+ * @brief Uninitialize after an elementwise unary datacopy, undoing init-time workarounds.
+ *
+ * @tparam src_b_bcast_type: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
+ * @tparam unpack_to_dest: Whether unpack wrote directly to dest.
+ * @note Reverses @ref llk_math_eltwise_unary_datacopy_init.
+ */
 template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
 inline void llk_math_eltwise_unary_datacopy_uninit() {
     _llk_math_eltwise_unary_datacopy_uninit_<src_b_bcast_type, unpack_to_dest>();

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
@@ -15,21 +15,20 @@
  *************************************************************************/
 
 /**
- * Enable or disable FP32 accumulation in the packer destination register.
+ * @brief Enable or disable reading the destination register as 32-bit (FP32) data for the packer.
  *
- * @param enable When true, the packer treats the destination register as FP32 accumulated.
+ * @param enable: True to read dest as 32-bit (FP32) data, false otherwise.
  */
 inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_acc_(enable); }
 
 /**
- * Configure the packer hardware for the given output operand.
+ * @brief One-time hardware configuration of the packer for the given output operand.
  *
- * Face geometry (face_r_dim, num_faces), tile column dimension, partial-face flag and tile
- * size are derived from the output CB metadata associated with the operand id. Relu is left
- * disabled here.
+ * Face geometry (face_r_dim, num_faces), tile column dimension, partial-face flag and tile size are
+ * derived from the output CB metadata associated with the operand id. Relu is left disabled here.
  *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @param  pack_output         Output circular buffer / operand index.
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @param pack_output: Output circular buffer / operand index.
  */
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_hw_configure(std::uint32_t pack_output) {
@@ -53,17 +52,17 @@ inline void llk_pack_hw_configure(std::uint32_t pack_output) {
 }
 
 /**
- * Compute the L1 write address for a packer output tile.
+ * @brief Compute the L1 write address for a packer output tile.
  *
  * For out-of-order output, the address is derived from the explicit tile index. For in-order
  * output, the running fifo write-tile pointer is used and then advanced by one page. Only
  * PackMode::Default and PackMode::Untilize are accepted; pack-untilize must use the dedicated
  * llk_pack_untilize APIs.
  *
- * @tparam out_of_order_output When true, address by output_tile_index; otherwise use the running fifo pointer.
- * @tparam pack_addr_mode      Packer addressing mode (Default or Untilize).
- * @param  output_id           Resolved output operand id.
- * @param  output_tile_index   Tile index within the output (used only for out-of-order output).
+ * @tparam out_of_order_output: When true, address by output_tile_index; otherwise use the running fifo pointer.
+ * @tparam pack_addr_mode: Packer addressing mode (Default or Untilize).
+ * @param output_id: Resolved output operand id.
+ * @param output_tile_index: Tile index within the output (used only for out-of-order output).
  * @return L1 write address for the requested output tile.
  */
 template <bool out_of_order_output, PackMode pack_addr_mode = PackMode::Default>
@@ -89,15 +88,17 @@ inline std::uint32_t get_output_tile_address(std::uint8_t output_id, std::uint32
 }
 
 /**
- * Block the packer until the math thread signals that the destination register is ready to pack.
+ * @brief Stall the packer until the math thread has produced data to pack.
  */
 inline void llk_packer_wait_for_math_done() { _llk_packer_wait_for_math_done_(); }
 
 /**
- * Signal that the packer has finished its current destination-register section, releasing it
- * back to the math thread.
+ * @brief Finish a destination-register section: wait for pack, clear dest, and release math.
  *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
+ * Signals that the packer has finished its current destination-register section, releasing it back
+ * to the math thread.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
  */
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_dest_section_done() {
@@ -105,11 +106,11 @@ inline void llk_pack_dest_section_done() {
 }
 
 /**
- * Initialize the packer destination-offset registers for the given pack mode.
+ * @brief Initialize the packer destination-offset registers and select the dest registers.
  *
- * @tparam pack_mode   Packer program mode (Default or Untilize; Tilize is not used on this path).
- * @tparam diagonal    Diagonal packing flag (unused on Blackhole).
- * @param  pack_output Output circular buffer / operand index (defaults to 16).
+ * @tparam pack_mode: Packer program mode (Default or Untilize; Tilize is not used on this path).
+ * @tparam diagonal: Diagonal packing flag (unused on Blackhole).
+ * @param pack_output: Output circular buffer / operand index (defaults to 16).
  */
 template <PackMode pack_mode = PackMode::Default, bool diagonal = false>
 inline void llk_init_packer_dest_offset_registers([[maybe_unused]] const std::uint32_t pack_output = 16) {
@@ -121,11 +122,11 @@ inline void llk_init_packer_dest_offset_registers([[maybe_unused]] const std::ui
 }
 
 /**
- * Initialize the packer destination register for the given pack mode.
+ * @brief Initialize packer destination state at the start of a kernel.
  *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @tparam pack_mode           Packer program mode (Default or Untilize; Tilize is not used on this path).
- * @param  pack_output         Output circular buffer / operand index (defaults to 16).
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @tparam pack_mode: Packer program mode (Default or Untilize; Tilize is not used on this path).
+ * @param pack_output: Output circular buffer / operand index (defaults to 16).
  */
 template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
 inline void llk_pack_dest_init([[maybe_unused]] const std::uint32_t pack_output = 16) {
@@ -136,13 +137,13 @@ inline void llk_pack_dest_init([[maybe_unused]] const std::uint32_t pack_output 
 }
 
 /**
- * Reconfigure the packer for a new output operand's data format.
+ * @brief Reconfigure the packer for a new output operand's data format.
  *
- * Face geometry (face_r_dim, num_faces), tile column dimension and tile size are derived from
- * the new output's CB metadata.
+ * Face geometry (face_r_dim, num_faces), tile column dimension and tile size are derived from the
+ * new output's CB metadata.
  *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @param  new_output          New output circular buffer / operand index to configure for.
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @param new_output: New output circular buffer / operand index to configure for.
  */
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
@@ -188,12 +189,14 @@ llk_pack_reconfig_data_format_disaggregated(
 }
 
 /**
- * Conditionally reconfigure the packer when switching output operands: only reprograms the data
- * format when the new output's destination format differs from the old one and neither is Invalid.
+ * @brief Conditionally reconfigure the packer when switching output operands.
  *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @param  old_output          Currently configured output operand index.
- * @param  new_output          New output operand index to switch to.
+ * Only reprograms the data format when the new output's destination format differs from the old one
+ * and neither is Invalid.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @param old_output: Currently configured output operand index.
+ * @param new_output: New output operand index to switch to.
  */
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en>
@@ -209,17 +212,17 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const 
 }
 
 /**
- * Program the packer relu configuration register.
+ * @brief Configure the packer relu mode and threshold.
  *
- * @param relu_config Relu mode/threshold configuration.
+ * @param relu_config: Relu configuration supplying the hardware mode and threshold to apply.
  */
 TT_ALWAYS_INLINE void llk_pack_relu_config(const ckernel::ReluConfig& relu_config) {
     _llk_pack_relu_config_(relu_config);
 }
 
 /**
- * Enable or disable packer L1 accumulation.
+ * @brief Enable or disable packer L1 accumulation.
  *
- * @param enable Non-zero to enable L1 accumulation, zero to disable.
+ * @param enable: Non-zero to accumulate packed output into existing L1 data, zero to overwrite.
  */
 inline void llk_pack_reconfig_l1_acc(const std::uint32_t enable) { _llk_pack_reconfig_l1_acc_(enable); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_reduce_api.h
@@ -9,12 +9,27 @@
  * LLK PACK REDUCE
  *************************************************************************/
 
-// Use the runtime face_r_dim of the output CB. Required for narrow tiles
-// (e.g. tile_dimensions=[1,32]) where face_r_dim differs from FACE_R_DIM.
+/**
+ * @brief Configure the packer edge-offset masks and tile-row-set mapping for a reduce output.
+ *
+ * Uses the runtime face_r_dim of the output CB, required for narrow tiles (e.g. [1,32]) where
+ * face_r_dim differs from FACE_R_DIM.
+ *
+ * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @tparam pack_mode: Packing layout, values = <Default/Untilize>
+ * @param ocb: Output circular-buffer index whose face geometry the masks are sized to.
+ * @note Pairs with @ref llk_math_reduce on the math thread, whose reduced output these masks gate.
+ * @note Call @ref llk_pack_reduce_mask_clear to restore the default pass-through masks.
+ */
 template <ReduceDim dim, PackMode pack_mode = PackMode::Default>
 inline void llk_pack_reduce_mask_config(uint32_t ocb) {
     const std::uint32_t output_id = get_output_id(ocb);
     _llk_pack_reduce_mask_config_<dim, pack_mode>(get_output_face_r_dim(output_id));
 }
 
+/**
+ * @brief Restore the default packer edge masks and tile-row-set mapping after a reduce.
+ *
+ * @note Pairs with @ref llk_pack_reduce_mask_config.
+ */
 inline void llk_pack_reduce_mask_clear() { _llk_pack_reduce_mask_clear_(); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
@@ -9,6 +9,22 @@
  * LLK PACK
  *************************************************************************/
 
+/**
+ * @brief Initialize the packer (addrmod + MOP + strides) for a pack op.
+ *
+ * Derives the source format and face geometry from the output's circular buffer. When packing
+ * tilized 8-bit datums the Blackhole row-unswizzle workaround is skipped (the issue does not
+ * affect 8-bit datums).
+ *
+ * @tparam pack_mode: Packing layout, values = <Default/Tilize/Untilize>
+ * @tparam zero_output: When true, packer emits zeros instead of dest data.
+ * @tparam skip_addrmod_config: When true, leave ADDR_MOD slots untouched (assume already programmed).
+ * @tparam skip_packer_strides: When true, do not re-program the packer strides.
+ * @param pack_output: Output circular-buffer index to configure the packer for.
+ * @param num_tiles: Number of tiles processed per MOP run.
+ * @param input_operand: Input operand circular-buffer index, used to detect 8-bit source datums.
+ * @note Call @ref llk_pack with matching template args after this.
+ */
 template <
     PackMode pack_mode = PackMode::Default,
     bool zero_output = false,
@@ -34,6 +50,19 @@ inline void llk_pack_init(
         pack_src_format[output_id], face_r_dim, tile_c_dim, num_faces, num_tiles, is_input_8bit_format);
 }
 
+/**
+ * @brief Pack one tile from the destination register to L1.
+ *
+ * Resolves the output tile's L1 write address from its circular buffer and runs the packer MOP.
+ *
+ * @tparam is_fp32_dest_acc_en: True if the destination register accumulates in FP32.
+ * @tparam out_of_order_output: When true, address by output_tile_index; otherwise use the running fifo pointer.
+ * @tparam pack_mode: Packing layout, values = <Default/Untilize> (Tilize not supported here)
+ * @param tile_index: Index of the source tile in the destination register.
+ * @param output: Output circular-buffer index to write to.
+ * @param output_tile_index: Tile index within the output (used only for out-of-order output).
+ * @note Call @ref llk_pack_init with matching template/runtime args before this function.
+ */
 template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, PackMode pack_mode = PackMode::Default>
 inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32_t output_tile_index = 0) {
     std::uint8_t output_id = get_output_id(output);
@@ -52,6 +81,21 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
     _llk_pack_<DST_SYNC_MODE, is_fp32_dest_acc_en, pack_mode>(tile_index, pack_tile_addr);
 }
 
+/**
+ * @brief Pack a contiguous block of tiles from the destination register to L1 (matmul output path).
+ *
+ * Loops the packer MOP over @p ntiles destination tiles, resolving each output tile's L1 write
+ * address from its circular buffer.
+ *
+ * @tparam is_fp32_dest_acc_en: True if the destination register accumulates in FP32.
+ * @tparam out_of_order_output: When true, address by output_tile_index; otherwise use the running fifo pointer.
+ * @tparam pack_mode: Packing layout, values = <Default/Untilize> (Tilize not supported here)
+ * @param start_tile_index: First source tile index in the destination register.
+ * @param output: Output circular-buffer index to write to.
+ * @param ntiles: Number of consecutive tiles to pack.
+ * @param output_tile_index: Tile index within the output (used only for out-of-order output).
+ * @note Call @ref llk_pack_init with matching template/runtime args before this function.
+ */
 template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, PackMode pack_mode = PackMode::Default>
 inline void llk_matmul_pack(
     std::uint32_t start_tile_index, std::uint32_t output, uint32_t ntiles, std::uint32_t output_tile_index = 0) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
@@ -12,17 +12,16 @@
  *************************************************************************/
 
 /**
- * Configure the packer hardware for an untilize output operand.
+ * @brief One-time hardware configuration of the packer for an untilize output operand.
  *
- * Face geometry (face_r_dim, num_faces), tile column dimension, partial-face flag
- * and tile size are all derived from the output CB metadata associated with the
- * operand id. Callers no longer thread face geometry through the API, since per-CB
- * face geometry is recorded in the CB descriptor at program creation time. The relu
- * configuration is taken from the supplied pack params.
+ * Face geometry (face_r_dim, num_faces), tile column dimension, partial-face flag and tile size are
+ * all derived from the output CB metadata associated with the operand id, so callers no longer
+ * thread face geometry through the API. The relu configuration is taken from the supplied pack
+ * params.
  *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @tparam pack_mode           Packer program mode (e.g. Default, Untilize).
- * @param  pack_params         Pack parameters carrying the output operand and relu config.
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @tparam pack_mode: Packing layout, values = <Default/Untilize>
+ * @param pack_params: Pack parameters carrying the output operand and relu config.
  */
 template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
 inline void llk_pack_untilize_hw_configure(const llk_pack_params_t* pack_params) {
@@ -116,19 +115,21 @@ llk_pack_untilize_hw_configure_disaggregated(
 }
 
 /**
- * Initialize the packer for an untilize operation on the given output operand.
+ * @brief Initialize the packer for an untilize pack op on the given output operand.
  *
- * Face geometry (face_r_dim, num_faces) is derived from the output CB metadata. In
- * debug builds, validates that the packers are configured correctly for the resolved
- * face row dimension before programming the untilize init sequence.
+ * Face geometry (face_r_dim, num_faces) is derived from the output CB metadata. In debug builds,
+ * validates that the packers are configured correctly for the resolved face row dimension before
+ * programming the untilize init sequence.
  *
- * @tparam block_ct_dim   Width of a single block in tiles.
- * @tparam full_ct_dim    Width of the full input in tiles (defaults to block_ct_dim).
- * @tparam diagonal       Diagonal packing flag (unused on Blackhole; must be false).
- * @tparam narrow_row     Whether the input rows are narrow.
- * @tparam row_num_datums Number of datums per row.
- * @tparam dense          Pack two 2-face tiles into a single 4-face region.
- * @param  output         Output circular buffer / operand index.
+ * @tparam block_ct_dim: Number of input tiles per block.
+ * @tparam full_ct_dim: Total number of input tiles across all blocks (defaults to block_ct_dim).
+ * @tparam diagonal: Diagonal packing flag (unused on Blackhole; must be false).
+ * @tparam narrow_row: True when packing fewer than TILE_C_DIM datums per row.
+ * @tparam row_num_datums: Number of datums per output row when narrow_row is set.
+ * @tparam dense: Pack two 2-face tiles into a single 4-face region.
+ * @param output: Output circular buffer / operand index.
+ * @note Call @ref llk_pack_untilize to execute and @ref llk_pack_untilize_uninit afterwards to
+ *       restore the modified packer state.
  */
 template <
     std::uint32_t block_ct_dim = 8,
@@ -185,10 +186,13 @@ llk_pack_untilize_init(std::uint32_t output, const std::uint32_t face_r_dim, con
 }
 
 /**
- * Tear down the packer untilize configuration so a subsequent operation can
- * reprogram the packer. The source format is read from the output CB metadata.
+ * @brief Restore the packer Z stride after an untilize pack op.
  *
- * @param output Output circular buffer / operand index.
+ * Tears down the packer untilize configuration so a subsequent operation can reprogram the packer.
+ * The source format is read from the output CB metadata.
+ *
+ * @param output: Output circular buffer / operand index.
+ * @note Call @ref llk_pack_untilize_init before this function.
  */
 inline void llk_pack_untilize_uninit(std::uint32_t output) {
     const std::uint32_t output_id = get_output_id(output);
@@ -196,23 +200,24 @@ inline void llk_pack_untilize_uninit(std::uint32_t output) {
 }
 
 /**
- * Pack an untilized block of tiles from the destination register into the output CB.
+ * @brief Untilize-pack a block of tiles from the destination register into the output CB.
  *
- * Iterates over block_rt_dim tile rows, computing the packer write address from the
- * output CB fifo state for each row. Face geometry (face_r_dim, num_faces) is derived
- * from the output CB metadata.
+ * Iterates over block_rt_dim tile rows, computing the packer write address from the output CB fifo
+ * state for each row. Face geometry (face_r_dim, num_faces) is derived from the output CB metadata.
  *
- * @tparam block_ct_dim       Width of a single block in tiles.
- * @tparam full_ct_dim        Width of the full input in tiles (defaults to block_ct_dim).
- * @tparam diagonal           Diagonal packing flag (unused on Blackhole; must be false).
- * @tparam narrow_row         Whether the input rows are narrow.
- * @tparam row_num_datums     Number of datums per row (unused on Blackhole).
- * @tparam tile_dst_ct_offset Compile-time column offset of the tile in the destination register.
- * @tparam dense              Pack two 2-face tiles into a single 4-face region.
- * @param  block_rt_dim       Height of the block in tiles (number of rows to pack).
- * @param  output             Output circular buffer / operand index.
- * @param  block_c_index      Block column index (used when full_ct_dim > block_ct_dim).
- * @param  tile_dst_rt_offset Runtime row offset of the tile in the destination register.
+ * @tparam block_ct_dim: Number of input tiles per block.
+ * @tparam full_ct_dim: Total number of input tiles across all blocks (defaults to block_ct_dim).
+ * @tparam diagonal: Diagonal packing flag (unused on Blackhole; must be false).
+ * @tparam narrow_row: True when packing fewer than TILE_C_DIM datums per row.
+ * @tparam row_num_datums: Number of datums per row (unused on Blackhole).
+ * @tparam tile_dst_ct_offset: Compile-time column-tile offset into the destination register.
+ * @tparam dense: Pack two 2-face tiles into a single 4-face region.
+ * @param block_rt_dim: Height of the block in tiles (number of rows to pack).
+ * @param output: Output circular buffer / operand index.
+ * @param block_c_index: Block column index (used when full_ct_dim > block_ct_dim).
+ * @param tile_dst_rt_offset: Runtime row offset of the tile in the destination register.
+ * @note Call @ref llk_pack_untilize_init before this function and @ref llk_pack_untilize_uninit
+ *       after the untilize sequence completes.
  */
 template <
     std::uint32_t block_ct_dim = 8,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_api.h
@@ -10,6 +10,21 @@
  * LLK UNPACK AB
  *************************************************************************/
 
+/**
+ * @brief Initialize unpacker to unpack two source operands A and B into SrcA and SrcB registers.
+ *
+ * Configures the unpacker hardware for dual-operand unpacking with support for various
+ * broadcast modes and optional transpose. Derives the tile geometry from operand A's
+ * circular buffer.
+ *
+ * @tparam BType: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
+ * @param operandA: Circular-buffer index of source operand A.
+ * @param operandB: Circular-buffer index of source operand B.
+ * @param transpose: Transpose mode for SrcA face order and/or within-face transpose, values =
+ * <None/IntraFace/InterFace/Both>
+ * @note Call @ref llk_unpack_AB with matching template args after this.
+ * @ref llk_math_eltwise_binary_init is the matching init on the math thread (consumes SrcA/SrcB).
+ */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
     const std::uint32_t operandA, const std::uint32_t operandB, const ckernel::Transpose transpose) {
@@ -29,11 +44,36 @@ inline void llk_unpack_AB_init(
     _llk_unpack_AB_init_<BType>(tensor_shape, transpose);
 }
 
+/**
+ * @brief Initialize unpacker to unpack operands A and B with no transpose.
+ *
+ * Convenience overload that forwards to the transpose-aware init with @ref ckernel::Transpose::None.
+ *
+ * @tparam BType: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
+ * @param operandA: Circular-buffer index of source operand A.
+ * @param operandB: Circular-buffer index of source operand B.
+ * @note Call @ref llk_unpack_AB with matching template args after this.
+ */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(const std::uint32_t operandA, const std::uint32_t operandB) {
     llk_unpack_AB_init<BType>(operandA, operandB, ckernel::Transpose::None);
 }
 
+/**
+ * @brief Unpack two tiles from L1 memory into SrcA and SrcB registers.
+ *
+ * Resolves each tile's L1 address from its operand's circular buffer and runs the configured
+ * MOP, handling context switching and synchronization with the unpacker.
+ *
+ * @tparam BType: Broadcast type for source B, values = <NONE/COL/ROW/SCALAR>
+ * @param operandA: Circular-buffer index of source operand A.
+ * @param operandB: Circular-buffer index of source operand B.
+ * @param tile_index_a: Index of the tile to unpack within operand A's buffer.
+ * @param tile_index_b: Index of the tile to unpack within operand B's buffer.
+ * @param bcast_row_idx: Row index within source B tile for ROW broadcast.
+ * @note Call @ref llk_unpack_AB_init with matching template args before this function.
+ * @ref llk_math_eltwise_binary on the math thread consumes the SrcA/SrcB tiles unpacked here.
+ */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB(
     const std::uint32_t operandA,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -10,6 +10,23 @@
  * LLK UNPACK AB MATMUL
  *************************************************************************/
 
+/**
+ * @brief Initialize the unpacker for a matmul (A x B) operation.
+ *
+ * Programs per-unpacker datum counts (full-tile or face-by-face for partial faces), stashes
+ * kt_dim for tile-size scaling, and programs the matmul MOP. Operand A maps to SrcB and
+ * operand B to SrcA; partial-face and face/datum geometry are derived from the operands'
+ * circular buffers.
+ *
+ * @param operandA: Circular-buffer index of source operand A (mapped to SrcB).
+ * @param operandB: Circular-buffer index of source operand B (mapped to SrcA).
+ * @param transpose: Nonzero to enable within-face (16x16) transpose for SrcA.
+ * @param ct_dim: Number of column tiles in the output block.
+ * @param rt_dim: Number of row tiles in the output block.
+ * @param kt_dim: Number of tiles along the contraction (K) dimension.
+ * @note Call @ref llk_unpack_AB_matmul with matching template args after this.
+ * @ref llk_math_matmul_init is the matching init on the math thread (consumes SrcA/SrcB).
+ */
 __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const std::uint32_t operandA,
     const std::uint32_t operandB,
@@ -55,6 +72,23 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
         partial_face_b);
 }
 
+/**
+ * @brief Unpack the operand tiles for a matmul (A x B) into SrcA and SrcB.
+ *
+ * Iterates over the reused dimension, computing per-tile L1 addresses from the operands'
+ * circular buffers (with kt_dim striding), and unpacks operand A to SrcB / operand B to SrcA
+ * for each step while synchronizing through the unpack semaphore.
+ *
+ * @param operandA: Circular-buffer index of source operand A (mapped to SrcB).
+ * @param operandB: Circular-buffer index of source operand B (mapped to SrcA).
+ * @param tile_index_a: Starting tile index into operand A's buffer.
+ * @param tile_index_b: Starting tile index into operand B's buffer.
+ * @param ct_dim: Number of column tiles in the output block.
+ * @param rt_dim: Number of row tiles in the output block.
+ * @param kt_dim: Number of tiles along the contraction (K) dimension.
+ * @note Call @ref llk_unpack_AB_matmul_init before this function.
+ * @ref llk_math_matmul on the math thread consumes the SrcA/SrcB tiles unpacked here.
+ */
 inline void llk_unpack_AB_matmul(
     const std::uint32_t operandA,
     const std::uint32_t operandB,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -10,6 +10,22 @@
  * LLK UNPACK AB REDUCE
  *************************************************************************/
 
+/**
+ * @brief Initialize the unpacker for reduce operations.
+ *
+ * Configures the unpacker hardware registers and MOP for reduction, including haloize mode for
+ * row reductions and the unpacker X-dimension endpoints. Derives the tile geometry from
+ * operand A's circular buffer.
+ *
+ * @tparam pool_type: Type of pooling operation, values = <SUM/AVG/MAX>
+ * @tparam reduce_dim: Dimension along which to reduce, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @tparam enforce_fp32_accumulation: Configure the ALU for FP32 accumulation (MOVB2D hi16/lo16 path).
+ * @param operandA: Circular-buffer index of source operand A.
+ * @param operandB: Circular-buffer index of the scaler operand B.
+ * @note For REDUCE_ROW operations, the face is transposed using haloize mode.
+ * @note Call @ref llk_unpack_AB_reduce with matching template args after this.
+ * @ref llk_math_reduce_init is the matching init on the math thread (this is the scaler-operand unpack pairing).
+ */
 template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulation = false>
 inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
     const std::uint32_t operandA_id = get_operand_id(operandA);
@@ -23,6 +39,20 @@ inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::u
     _llk_unpack_AB_reduce_init_<pool_type, reduce_dim, enforce_fp32_accumulation>(tensor_shape);
 }
 
+/**
+ * @brief Execute the unpacker for reduction operations.
+ *
+ * Resolves each tile's L1 address from its operand's circular buffer, programs the source A and
+ * B base addresses, synchronizes with Trisc via semaphores, and runs the configured MOP.
+ *
+ * @tparam pool_type: Type of pooling operation, values = <SUM/AVG/MAX>
+ * @tparam reduce_dim: Dimension along which to reduce, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @param operandA: Circular-buffer index of source operand A.
+ * @param operandB: Circular-buffer index of the scaler operand B.
+ * @param tile_index_a: Index of the tile to unpack within operand A's buffer.
+ * @param tile_index_b: Index of the tile to unpack within operand B's buffer.
+ * @note Call @ref llk_unpack_AB_reduce_init with matching template args before this function.
+ */
 template <PoolType pool_type, ReduceDim reduce_dim>
 inline void llk_unpack_AB_reduce(
     const std::uint32_t operandA,

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -10,6 +10,24 @@
  * LLK UNPACK A
  *************************************************************************/
 
+/**
+ * @brief Initialize the unpacker for a single-operand (A) unpack.
+ *
+ * Configures the within-face transpose register and per-unpacker datum count, then programs
+ * the MOP for the requested broadcast/dest-reuse/unpack-to-dest mode. Derives format,
+ * face_r_dim and num_faces from the operand's circular buffer.
+ *
+ * @tparam BType: Broadcast type, values = <NONE/COL/ROW/SCALAR>
+ * @tparam acc_to_dest: Accumulate the operand into the dest register rather than overwriting it.
+ * @tparam binary_reuse_dest: Reuse dest as a source operand, values = <NONE/DEST_TO_SRCA/DEST_TO_SRCB>
+ * @tparam unpack_to_dest: Unpack directly into the dest register (32-bit datums).
+ * @param transpose_of_faces: Nonzero to reorder (transpose) faces during the unpack.
+ * @param within_face_16x16_transpose: Nonzero to enable the 16x16 within-face transpose (haloize mode).
+ * @param operand: Circular-buffer index of the operand to unpack.
+ * @note Call @ref llk_unpack_A with matching template args after this, and
+ *       @ref llk_unpack_A_uninit afterwards to restore the modified datum-count state.
+ * @ref llk_math_eltwise_unary_datacopy_init is the matching init on the math thread (datacopy/transpose consumer).
+ */
 template <
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
@@ -44,6 +62,23 @@ inline void llk_unpack_A_init(
         operand_unpack_dst_format);
 }
 
+/**
+ * @brief Unpack a single tile (operand A) from L1 into the SrcA/SrcB or dest register.
+ *
+ * Resolves the tile's L1 address from the operand's circular buffer, synchronizes with the
+ * unpacker via semaphores, and runs the configured MOP. When unpacking 32-bit datums to dest,
+ * also manages the dest write address and completion handshake.
+ *
+ * @tparam BType: Broadcast type, values = <NONE/COL/ROW/SCALAR>
+ * @tparam acc_to_dest: Accumulate the operand into the dest register rather than overwriting it.
+ * @tparam binary_reuse_dest: Reuse dest as a source operand, values = <NONE/DEST_TO_SRCA/DEST_TO_SRCB>
+ * @tparam unpack_to_dest: Unpack directly into the dest register (32-bit datums).
+ * @param operand: Circular-buffer index of the operand to unpack.
+ * @param tile_index: Index of the tile to unpack within the operand's buffer.
+ * @note Call @ref llk_unpack_A_init with matching template args before this function, and
+ *       @ref llk_unpack_A_uninit after it to restore modified state.
+ * @ref llk_math_eltwise_unary_datacopy on the math thread consumes the tile unpacked here.
+ */
 template <
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
@@ -71,6 +106,22 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
     WAYPOINT("UPAD");
 }
 
+/**
+ * @brief Unpack a contiguous block of tiles (operand A) from L1.
+ *
+ * Loops @ref llk_unpack_A over @p ntiles consecutive tiles starting at @p start_tile_index,
+ * resolving each tile's L1 address from the operand's circular buffer.
+ *
+ * @tparam BType: Broadcast type, values = <NONE/COL/ROW/SCALAR>
+ * @tparam acc_to_dest: Accumulate the operand into the dest register rather than overwriting it.
+ * @tparam binary_reuse_dest: Reuse dest as a source operand, values = <NONE/DEST_TO_SRCA/DEST_TO_SRCB>
+ * @tparam unpack_to_dest: Unpack directly into the dest register (32-bit datums).
+ * @param operand: Circular-buffer index of the operand to unpack.
+ * @param start_tile_index: Index of the first tile to unpack within the operand's buffer.
+ * @param ntiles: Number of consecutive tiles to unpack.
+ * @note Call @ref llk_unpack_A_init with matching template args before this function, and
+ *       @ref llk_unpack_A_uninit after it to restore modified state.
+ */
 template <
     BroadcastType BType = BroadcastType::NONE,
     bool acc_to_dest = false,
@@ -94,6 +145,16 @@ inline void llk_unpack_A_block(
     }
 }
 
+/**
+ * @brief Restore unpacker datum-count state after single-operand (A) unpacking.
+ *
+ * Resets the X-dimension address counter for the unpacker used by this broadcast mode back to
+ * a full face worth of datums. Derives face_r_dim from the operand's circular buffer.
+ *
+ * @tparam BType: Broadcast type, values = <NONE/COL/ROW/SCALAR>
+ * @param operand: Circular-buffer index of the operand that was unpacked.
+ * @note Call @ref llk_unpack_A_init with matching template args before this function.
+ */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_A_uninit(const std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_common_api.h
@@ -21,18 +21,16 @@
  *************************************************************************/
 
 /**
- * Configure the unpacker hardware for operands A and B.
+ * @brief Configure the unpacker hardware for both operands A and B.
  *
- * Face geometry (face_r_dim, num_faces) and tile size for both operands are
- * derived from the CB metadata associated with each operand id. This is the
- * primary entry point: callers no longer need to thread face geometry through
- * the API, since per-CB face geometry is recorded in the CB descriptor at
- * program creation time.
+ * Face geometry (face_r_dim, num_faces) and tile size for both operands are derived from the CB
+ * metadata associated with each operand id, so callers no longer thread face geometry through the
+ * API.
  *
- * @tparam is_fp32_dest_acc_en   Enable FP32 accumulation in the destination register.
- * @tparam disable_src_zero_flag When true, disables the source-zero optimisation flag.
- * @param  unpA_operand          Operand index for unpack source A (In0).
- * @param  unpB_operand          Operand index for unpack source B (In1).
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @tparam disable_src_zero_flag: Disable the source zero-substitution flag.
+ * @param unpA_operand: Operand index for unpack source A (In0).
+ * @param unpB_operand: Operand index for unpack source B (In1).
  */
 template <bool is_fp32_dest_acc_en, bool disable_src_zero_flag = false>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std::uint32_t unpB_operand) {
@@ -114,13 +112,14 @@ llk_unpack_hw_configure(
 }
 
 /**
- * Single-operand convenience overload that configures both unpack sources from
- * the same operand id. Equivalent to calling the two-operand overload with
- * unpA_operand == unpB_operand.
+ * @brief Configure the unpacker hardware using a single operand for both sources.
  *
- * @tparam is_fp32_dest_acc_en   Enable FP32 accumulation in the destination register.
- * @tparam disable_src_zero_flag When true, disables the source-zero optimisation flag.
- * @param  unpA_operand          Operand index used for both unpack source A and B.
+ * Convenience overload equivalent to calling the two-operand overload with unpA_operand ==
+ * unpB_operand.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @tparam disable_src_zero_flag: Disable the source zero-substitution flag.
+ * @param unpA_operand: Operand index used for both unpack source A and B.
  */
 template <bool is_fp32_dest_acc_en, bool disable_src_zero_flag = false>
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
@@ -141,14 +140,14 @@ inline bool should_reconfigure_cbs(std::uint32_t old_operand, std::uint32_t new_
 }
 
 /**
- * Reconfigure the srcA unpacker for a new operand's data format.
+ * @brief Reconfigure the operand A (srcA) unpacker for a new operand's data format.
  *
  * Face geometry (face_r_dim, num_faces) and tile size are derived from the new operand's CB metadata.
  *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
- * @param  srca_new_operand    New operand id to configure srcA for.
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
+ * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @param srca_new_operand: New operand index to configure srcA for.
  */
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
@@ -165,14 +164,14 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
 }
 
 /**
- * Reconfigure the srcB unpacker for a new operand's data format.
+ * @brief Reconfigure the operand B (srcB) unpacker for a new operand's data format.
  *
  * Face geometry (face_r_dim, num_faces) and tile size are derived from the new operand's CB metadata.
  *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
- * @param  srcb_new_operand    New operand id to configure srcB for.
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
+ * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @param srcb_new_operand: New operand index to configure srcB for.
  */
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
@@ -189,15 +188,16 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
 }
 
 /**
- * Conditionally reconfigure the srcA unpacker when switching operands. Reprograms only when the CBs
- * differ, an explicit dim/stride target is requested, or the face geometry changed between the old
- * and new operands.
+ * @brief Conditionally reconfigure the srcA unpacker when switching operands.
  *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
- * @param  srca_old_operand    Currently configured srcA operand id.
- * @param  srca_new_operand    New srcA operand id to switch to.
+ * Reprograms only when the CBs differ, an explicit dim/stride target is requested, or the face
+ * geometry changed between the old and new operands.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
+ * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @param srca_old_operand: Currently configured srcA operand index.
+ * @param srca_new_operand: New srcA operand index to switch to.
  */
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
@@ -219,15 +219,16 @@ inline void llk_unpack_reconfig_data_format_srca(
 }
 
 /**
- * Conditionally reconfigure the srcB unpacker when switching operands. Reprograms only when the CBs
- * differ, an explicit dim/stride target is requested, or the face geometry changed between the old
- * and new operands.
+ * @brief Conditionally reconfigure the srcB unpacker when switching operands.
  *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
- * @param  srcb_old_operand    Currently configured srcB operand id.
- * @param  srcb_new_operand    New srcB operand id to switch to.
+ * Reprograms only when the CBs differ, an explicit dim/stride target is requested, or the face
+ * geometry changed between the old and new operands.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
+ * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @param srcb_old_operand: Currently configured srcB operand index.
+ * @param srcb_new_operand: New srcB operand index to switch to.
  */
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
@@ -249,13 +250,13 @@ inline void llk_unpack_reconfig_data_format_srcb(
 }
 
 /**
- * Reconfigure both srcA and srcB unpackers for new operands and refresh the zero-source flag.
+ * @brief Reconfigure both srcA and srcB unpackers for new operands and refresh the zero-source flag.
  *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
- * @param  srca_new_operand    New srcA operand id.
- * @param  srcb_new_operand    New srcB operand id.
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
+ * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @param srca_new_operand: New srcA operand index.
+ * @param srcb_new_operand: New srcB operand index.
  */
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
@@ -268,16 +269,18 @@ inline void llk_unpack_reconfig_data_format(
 }
 
 /**
- * Conditionally reconfigure both srcA and srcB unpackers when switching operands (using the old
- * operands to decide whether reprogramming is needed) and refresh the zero-source flag.
+ * @brief Conditionally reconfigure both srcA and srcB unpackers when switching operands.
  *
- * @tparam is_fp32_dest_acc_en Enable FP32 accumulation in the destination register.
- * @tparam dim_stride_target   Dimension/stride programming target for the unpacker.
- * @tparam to_from_int8        Whether the reconfiguration crosses an int8 format boundary.
- * @param  srca_old_operand    Currently configured srcA operand id.
- * @param  srca_new_operand    New srcA operand id.
- * @param  srcb_old_operand    Currently configured srcB operand id.
- * @param  srcb_new_operand    New srcB operand id.
+ * Uses the old operands to decide whether reprogramming is needed, then refreshes the zero-source
+ * flag.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether the dest register accumulates in FP32.
+ * @tparam dim_stride_target: Whether to reprogram dim/stride, values = <IGNORE/FACE_ROW_MAJOR>
+ * @tparam to_from_int8: Reconfiguring to/from an Int8 format (requires FP32 dest mode).
+ * @param srca_old_operand: Currently configured srcA operand index.
+ * @param srca_new_operand: New srcA operand index.
+ * @param srcb_old_operand: Currently configured srcB operand index.
+ * @param srcb_new_operand: New srcB operand index.
  */
 // TODO NC: Clean up as the part of tt-metal#34499
 template <bool is_fp32_dest_acc_en, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
@@ -295,12 +298,16 @@ inline void llk_unpack_reconfig_data_format(
 }
 
 /**
- * Disable unpacker debug features.
+ * @brief Set the unpacker debug feature-disable bit as a hardware bug workaround.
+ *
+ * @note Writes bit 11 of RISCV_DEBUG_REG_DBG_FEATURE_DISABLE (workaround for tt-metal#46219).
  */
 // TODO NC: Remove as a part of tt-metal#36411
 inline void llk_unpack_dbg_feature_disable() { _llk_unpack_dbg_feature_disable_(); }
 
 /**
- * Mark srcB as holding dummy-valid data so the math thread can proceed without a real srcB unpack.
+ * @brief Mark srcB as data-valid without unpacking real data.
+ *
+ * Lets the math thread proceed when srcB is not actually fed from L1.
  */
 inline void llk_unpack_set_srcb_dummy_valid() { _llk_unpack_set_srcb_dummy_valid_(); }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_reduce_api.h
@@ -10,6 +10,18 @@
  * LLK UNPACK REDUCE
  *************************************************************************/
 
+/**
+ * @brief Initialize the unpacker for a reduce-with-scaler operation.
+ *
+ * Programs the unpacker MOP for reduction, deriving the scaler operand's (SrcB) format from
+ * the first operand's destination format.
+ *
+ * @tparam type: Reduction pooling op, values = <SUM/AVG/MAX>
+ * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @param within_face_16x16_transpose: Nonzero to enable the 16x16 within-face transpose.
+ * @note Call @ref llk_unpack_reduce with matching template args after this.
+ * @ref llk_math_reduce_init is the matching init on the math thread (single-operand unpack pairing).
+ */
 template <PoolType type, ReduceDim dim>
 inline void llk_unpack_reduce_init(const std::uint32_t within_face_16x16_transpose = 0) {
     constexpr std::uint32_t unpA_operand_id = 0;
@@ -25,6 +37,17 @@ inline void llk_unpack_reduce_init(const std::uint32_t within_face_16x16_transpo
     _llk_unpack_reduce_init_<type, dim>(unpB_src_format, unpB_dst_format, within_face_16x16_transpose);
 }
 
+/**
+ * @brief Unpack a tile for a reduce-with-scaler operation.
+ *
+ * Resolves the tile's L1 address from the operand's circular buffer and runs the configured MOP.
+ *
+ * @tparam type: Reduction pooling op, values = <SUM/AVG/MAX>
+ * @tparam dim: Reduction dimension, values = <REDUCE_ROW/REDUCE_COL/REDUCE_SCALAR>
+ * @param operand: Circular-buffer index of the operand to unpack.
+ * @param tile_index: Index of the tile to unpack within the operand's buffer.
+ * @note Call @ref llk_unpack_reduce_init with matching template args before this function.
+ */
 template <PoolType type, ReduceDim dim>
 inline void llk_unpack_reduce(const std::uint32_t operand, const std::uint32_t tile_index) {
     std::uint32_t operand_id = get_operand_id(operand);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_tilize_api.h
@@ -11,12 +11,14 @@
  *************************************************************************/
 
 /**
- * Initialize the unpacker for a single-operand tilize operation.
+ * @brief Initialize the unpacker for a tilize operation.
  *
  * Face row dimension, narrow-tile flag and face count are derived from the operand's CB metadata.
  *
- * @param operand Input circular buffer / operand index.
- * @param ct_dim  Number of tiles along the column (tilize block width).
+ * @param operand: Input circular buffer / operand index.
+ * @param ct_dim: Number of column tiles in the block (tilize block width).
+ * @note Call @ref llk_unpack_tilize to execute and @ref llk_unpack_tilize_uninit afterwards to
+ *       restore the modified unpacker state.
  */
 inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint32_t ct_dim) {
     const std::uint32_t operand_id = get_operand_id(operand);
@@ -28,10 +30,13 @@ inline void llk_unpack_tilize_init(const std::uint32_t operand, const std::uint3
 }
 
 /**
- * Tear down the tilize unpacker configuration so a subsequent operation can reprogram the unpacker.
+ * @brief Restore unpacker state after a tilize operation.
  *
- * @param operand    Input circular buffer / operand index.
- * @param face_r_dim Face row dimension to restore (defaults to FACE_R_DIM).
+ * Tears down the tilize configuration so a subsequent operation can reprogram the unpacker.
+ *
+ * @param operand: Input circular buffer / operand index.
+ * @param face_r_dim: Face row dimension to restore (defaults to FACE_R_DIM).
+ * @note Call @ref llk_unpack_tilize_init before this function.
  */
 inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
     std::uint32_t operand_id = get_operand_id(operand);
@@ -40,13 +45,15 @@ inline void llk_unpack_tilize_uninit(const std::uint32_t operand, const std::uin
 }
 
 /**
- * Unpack and tilize a single tile from the operand's circular buffer into srcA.
+ * @brief Unpack and tilize a single tile from the operand's circular buffer into srcA.
  *
  * Face geometry and narrow-tile flag are derived from the operand's CB metadata; the source base
  * address is read from the CB fifo state.
  *
- * @param operand    Input circular buffer / operand index.
- * @param tile_index Tile index within the input to tilize.
+ * @param operand: Input circular buffer / operand index.
+ * @param tile_index: Tile index within the input to tilize.
+ * @note Call @ref llk_unpack_tilize_init before this function and @ref llk_unpack_tilize_uninit
+ *       after the tilize sequence completes.
  */
 inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index) {
     std::uint32_t operand_id = get_operand_id(operand);
@@ -70,11 +77,13 @@ inline void llk_unpack_tilize(std::uint32_t operand, std::uint32_t tile_index) {
 }
 
 /**
- * Unpack and tilize a contiguous block of tiles by repeatedly calling llk_unpack_tilize.
+ * @brief Unpack and tilize a contiguous block of tiles.
  *
- * @param operand          Input circular buffer / operand index.
- * @param block_c_tiles    Number of column tiles in the block.
- * @param input_tile_index Starting tile index within the input (defaults to 0).
+ * Repeatedly calls @ref llk_unpack_tilize over the column tiles of the block.
+ *
+ * @param operand: Input circular buffer / operand index.
+ * @param block_c_tiles: Number of column tiles in the block.
+ * @param input_tile_index: Starting tile index within the input (defaults to 0).
  */
 inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c_tiles, std::uint32_t input_tile_index = 0) {
     // Not sure if input_tile_index can be arbitrary but it works for moving across rows of files,
@@ -90,13 +99,13 @@ inline void llk_unpack_tilize_block(std::uint32_t operand, std::uint32_t block_c
  *************************************************************************/
 
 /**
- * Program the unpacker MOP (macro-op) configuration for the combined tilize-A / unpack-B operation.
+ * @brief Program the unpacker MOP/replay buffer for tilize-A-with-unpack-B.
  *
- * @tparam neginf_srcA      Initialize srcA padding with negative infinity (for reduce-max).
- * @tparam reload_srcB      Whether srcB is reloaded each iteration.
- * @tparam zero_srcA        Zero out srcA.
- * @tparam zero_srcA_reduce Zero out srcA for the reduce path.
- * @param  num_faces        Number of faces per tile (defaults to 4).
+ * @tparam neginf_srcA: Clear srcA to negative infinity before unpacking (e.g. for max-reduce).
+ * @tparam reload_srcB: Reload srcB once rather than incrementing its face each step.
+ * @tparam zero_srcA: Clear srcA to zero before unpacking.
+ * @tparam zero_srcA_reduce: Clear srcA to zero before unpacking for a reduce fused with tilize.
+ * @param num_faces: Number of faces per tile (defaults to 4).
  */
 // TODO: add support for all the template parameters
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
@@ -105,19 +114,21 @@ inline void llk_unpack_tilizeA_B_mop_config(const std::uint32_t num_faces = 4) {
 }
 
 /**
- * Initialize the unpacker for the combined tilize-A / unpack-B operation.
+ * @brief Initialize the unpacker to tilize operand A while unpacking operand B.
  *
  * Operand A and B face geometry (face_r_dim, num_faces) is derived from circular-buffer unpack
- * metadata (see set_unpack_face_geometry). In debug builds, validates that both unpackers are
- * configured consistently before programming the init sequence.
+ * metadata. In debug builds, validates that both unpackers are configured consistently before
+ * programming the init sequence.
  *
- * @tparam neginf_srcA      Initialize srcA padding with negative infinity (for reduce-max).
- * @tparam reload_srcB      Whether srcB is reloaded each iteration.
- * @tparam zero_srcA        Zero out srcA.
- * @tparam zero_srcA_reduce Zero out srcA for the reduce path.
- * @param  operandA         Input operand index for tilize source A.
- * @param  operandB         Input operand index for unpack source B.
- * @param  ct_dim           Number of tiles along the column (tilize block width).
+ * @tparam neginf_srcA: Clear srcA to negative infinity before unpacking (e.g. for max-reduce).
+ * @tparam reload_srcB: Reload srcB once rather than incrementing its face each step.
+ * @tparam zero_srcA: Clear srcA to zero before unpacking.
+ * @tparam zero_srcA_reduce: Clear srcA to zero before unpacking for a reduce fused with tilize.
+ * @param operandA: Input operand index for tilize source A.
+ * @param operandB: Input operand index for unpack source B.
+ * @param ct_dim: Number of column tiles in the block (tilize block width).
+ * @note Call @ref llk_unpack_tilizeA_B to execute and @ref llk_unpack_tilizeA_B_uninit afterwards to
+ *       restore the modified unpacker state.
  */
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
 inline void llk_unpack_tilizeA_B_init(
@@ -194,20 +205,22 @@ llk_unpack_tilizeA_B_init(
 }
 
 /**
- * Unpack and tilize one srcA tile while unpacking the corresponding srcB tile.
+ * @brief Tilize operand A and unpack operand B for one srcA tile.
  *
  * Operand A face geometry and narrow-tile flag are derived from CB unpack metadata; source base
  * addresses are read from the CB fifo state.
  *
- * @tparam neginf_srcA      Initialize srcA padding with negative infinity (for reduce-max).
- * @tparam reload_srcB      Whether srcB is reloaded each iteration.
- * @tparam zero_srcA        Zero out srcA.
- * @tparam zero_srcA_reduce Zero out srcA for the reduce path.
- * @param  operandA     Input operand index for tilize source A.
- * @param  operandB     Input operand index for unpack source B.
- * @param  tile_index_a Tile index within operand A.
- * @param  tile_index_b Tile index within operand B.
- * @param  block_ct_dim Number of column tiles in the block.
+ * @tparam neginf_srcA: Clear srcA to negative infinity before unpacking (e.g. for max-reduce).
+ * @tparam reload_srcB: Reload srcB once rather than incrementing its face each step.
+ * @tparam zero_srcA: Clear srcA to zero before unpacking.
+ * @tparam zero_srcA_reduce: Clear srcA to zero before unpacking for a reduce fused with tilize.
+ * @param operandA: Input operand index for tilize source A.
+ * @param operandB: Input operand index for unpack source B.
+ * @param tile_index_a: Tile index within operand A.
+ * @param tile_index_b: Tile index within operand B.
+ * @param block_ct_dim: Number of column tiles in the block.
+ * @note Call @ref llk_unpack_tilizeA_B_init before this function and @ref llk_unpack_tilizeA_B_uninit
+ *       after the tilize sequence completes.
  */
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
 inline void llk_unpack_tilizeA_B(
@@ -320,17 +333,18 @@ llk_unpack_tilizeA_B(
 }
 
 /**
- * Unpack and tilize a block of srcA column tiles against srcB by repeatedly calling
- * llk_unpack_tilizeA_B.
+ * @brief Tilize a block of srcA column tiles against srcB.
  *
- * @tparam neginf_srcA      Initialize srcA padding with negative infinity (for reduce-max).
- * @tparam reload_srcB      Whether srcB is reloaded each iteration.
- * @tparam zero_srcA        Zero out srcA.
- * @tparam zero_srcA_reduce Zero out srcA for the reduce path.
- * @param  operandA        Input operand index for tilize source A.
- * @param  operandB        Input operand index for unpack source B.
- * @param  block_c_tiles_a Number of column tiles in operand A's block.
- * @param  tile_idx_b      Tile index within operand B.
+ * Repeatedly calls @ref llk_unpack_tilizeA_B over the column tiles of operand A's block.
+ *
+ * @tparam neginf_srcA: Clear srcA to negative infinity before unpacking (e.g. for max-reduce).
+ * @tparam reload_srcB: Reload srcB once rather than incrementing its face each step.
+ * @tparam zero_srcA: Clear srcA to zero before unpacking.
+ * @tparam zero_srcA_reduce: Clear srcA to zero before unpacking for a reduce fused with tilize.
+ * @param operandA: Input operand index for tilize source A.
+ * @param operandB: Input operand index for unpack source B.
+ * @param block_c_tiles_a: Number of column tiles in operand A's block.
+ * @param tile_idx_b: Tile index within operand B.
  */
 template <bool neginf_srcA = false, std::uint32_t reload_srcB = false, bool zero_srcA = false, bool zero_srcA_reduce = false>
 inline void llk_unpack_tilizeA_B_block(
@@ -385,10 +399,13 @@ llk_unpack_tilizeA_B_block(
 }
 
 /**
- * Tear down the combined tilize-A / unpack-B configuration so a subsequent operation can reprogram
+ * @brief Restore unpacker state after a tilize-A-with-unpack-B operation.
+ *
+ * Tears down the combined tilize-A / unpack-B configuration so a subsequent operation can reprogram
  * the unpacker.
  *
- * @param operand Input circular buffer / operand index.
+ * @param operand: Input circular buffer / operand index.
+ * @note Call @ref llk_unpack_tilizeA_B_init before this function.
  */
 inline void llk_unpack_tilizeA_B_uninit(const std::uint32_t operand) {
     std::uint32_t operand_id = get_operand_id(operand);

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_untilize_api.h
@@ -10,6 +10,16 @@
  * LLK UNPACK UNTILIZE
  *************************************************************************/
 
+/**
+ * @brief Initialize the unpacker for an untilize operation.
+ *
+ * Programs the unpacker for untilize, deriving the destination format and tile size from the
+ * operand's circular buffer.
+ *
+ * @param operand: Circular-buffer index of the operand to untilize.
+ * @note Call @ref llk_unpack_untilize_uninit to restore the default unpacker config.
+ * @ref llk_math_eltwise_unary_datacopy_init (A2D) is the matching init on the math thread.
+ */
 inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t face_r_dim = 1;
@@ -18,6 +28,15 @@ inline void llk_unpack_untilize_init(std::uint32_t operand = 0) {
         unpack_dst_format[operand_id], get_local_cb_interface(operand_id).fifo_page_size, face_r_dim);
 }
 
+/**
+ * @brief Restore unpacker state after an untilize operation.
+ *
+ * Derives the destination format from the operand's circular buffer.
+ *
+ * @param operand: Circular-buffer index of the operand that was untilized.
+ * @param face_r_dim: Rows per face, used to compute the restored datum count and Y stride.
+ * @note Call @ref llk_unpack_untilize_init before this function.
+ */
 inline void llk_unpack_untilize_uninit(const std::uint32_t operand, const std::uint32_t face_r_dim = FACE_R_DIM) {
     std::uint32_t operand_id = get_operand_id(operand);
     WAYPOINT("UPUW");
@@ -25,6 +44,17 @@ inline void llk_unpack_untilize_uninit(const std::uint32_t operand, const std::u
     WAYPOINT("UPUD");
 }
 
+/**
+ * @brief Run one untilize pass (top or bottom faces) over a row of tiles.
+ *
+ * Resolves the tile-row base address from the operand's circular buffer.
+ *
+ * @tparam first_pass: Select the top faces (true) or bottom faces (false) of each tile.
+ * @param operand: Circular-buffer index of the operand to untilize.
+ * @param block_tile_cols: Number of tile columns in the block row.
+ * @note Call @ref llk_unpack_untilize_init before this function, and
+ *       @ref llk_unpack_untilize_uninit after the final pass to restore modified state.
+ */
 template <bool first_pass = true>
 inline void llk_unpack_untilize_pass(std::uint32_t operand, std::uint32_t block_tile_cols) {
     const std::uint32_t operand_id = get_operand_id(operand);
@@ -33,6 +63,16 @@ inline void llk_unpack_untilize_pass(std::uint32_t operand, std::uint32_t block_
     _llk_unpack_untilize_pass_<first_pass>(base_address, block_tile_cols);
 }
 
+/**
+ * @brief Untilize a row of tiles by running both unpack passes.
+ *
+ * Runs @ref llk_unpack_untilize_pass for the top faces then the bottom faces of the row.
+ *
+ * @param operand: Circular-buffer index of the operand to untilize.
+ * @param block_c_tiles: Number of tile columns in the block row.
+ * @note Call @ref llk_unpack_untilize_init before this function, and
+ *       @ref llk_unpack_untilize_uninit after to restore modified state.
+ */
 inline void llk_unpack_untilize(std::uint32_t operand, std::uint32_t block_c_tiles) {
     WAYPOINT("UPUW");
     llk_unpack_untilize_pass<true>(operand, block_c_tiles);


### PR DESCRIPTION
Adds Doxygen docstrings to the public `llk_*` wrappers in the Blackhole llk-api layer.

Mostly copied straight from the llk-lib docstrings we just merged (#45825), with the param lists adapted to the wrapper signatures (operand / CB-index based instead of raw address/format). A handful of wrapper-only helpers (`*_block`, `hw_configure`, `reconfig_data_format`) got short fresh docstrings.

Comments only — no code changes.

Part of the llk-api docstring effort; the other two arches are in sibling PRs.