### PR TITLE
DO NOT REVIEW: [skip ci] tt-llk: Add Doxygen docstrings to Quasar llk-api

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_binary_api.h
@@ -27,6 +27,10 @@
  * @param operand_B: Logical dataflow buffer id for input B
  * @param acc_to_dest: Flag to control if the result should be accumulated with the current dest
  *     (NONE broadcast path only).
+ *
+ * @note On the unpack thread (T0): for binary_reuse_dest == NONE pair with @ref llk_unpack_AB_init; for
+ *       DEST_TO_SRCA/DEST_TO_SRCB pair with @ref llk_unpack_A_init. On the pack thread, pair with @ref llk_pack_init.
+ * @ref llk_math_eltwise_binary is the matching execute call on this thread.
  */
 template <
     EltwiseBinaryType eltwise_binary_type,
@@ -73,6 +77,8 @@ inline void llk_math_eltwise_binary_init(
  * If dest reg in float16 mode -> values = [0 - 8] in double buffering mode, values = [0 - 16] in full mode
  * If dest reg in float32 mode -> values = [0 - 4] in double buffering mode, values = [0 - 8] in full mode
  * @param clear_fp32_dst_acc: Determines if FP32 clear should be used before dest-reuse.
+ *
+ * @note Call @ref llk_math_eltwise_binary_init with matching template args before this function.
  */
 template <
     EltwiseBinaryType eltwise_binary_type,
@@ -116,6 +122,8 @@ inline void llk_math_eltwise_binary(uint dst_index, const bool clear_fp32_dst_ac
  * If dest reg in float16 mode -> values = [0 - 8] in double buffering mode, values = [0 - 16] in full mode
  * If dest reg in float32 mode -> values = [0 - 4] in double buffering mode, values = [0 - 8] in full mode
  * @param clear_fp32_dst_acc: Determines if FP32 clear should be used before dest-reuse.
+ *
+ * @note Call @ref llk_math_eltwise_binary_init with matching template args before this function.
  */
 template <
     EltwiseBinaryType eltwise_binary_type,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_common_api.h
@@ -62,6 +62,9 @@ inline void llk_math_hw_configure(const std::uint32_t srca_operand, const std::u
     }
 }
 
+/**
+ * @brief No-op on Quasar; kept for API parity with arches that toggle the math remap path.
+ */
 inline void llk_math_reconfig_remap(const bool /*remap_enable*/) {}
 
 /**

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_matmul_api.h
@@ -25,6 +25,10 @@
 * Input 0 * Input 1 -> SrcB * SrcA
 * Input 0 dim = [rt_dim, 1], Input 1 dim = [1, ct_dim]
 * Output is a matrix block of dimension [rt_dim, ct_dim]
+*
+* @note On the unpack thread, pair with @ref llk_unpack_AB_matmul_init (T0); on the pack thread, pair with
+*       @ref llk_pack_init (T2).
+* @ref llk_math_matmul_tile or @ref llk_math_matmul_block runs the configured matmul on this thread.
 */
 template <ckernel::MathFidelity math_fidelity>
 inline void llk_math_matmul_init(
@@ -50,6 +54,8 @@ inline void llk_math_matmul_init(
  * This function performs the matrix multiply operation of Input 0 * Input 1 -> SrcB * SrcA,
  * Input 0 = 1 tile -> SrcB reg, Input 1 = 1 tile -> SrcA reg,
  * Output = 1 tile -> Dst reg at specified dst_index
+ *
+ * @note Call @ref llk_math_matmul_init with matching template args before this function.
  */
 inline void llk_math_matmul_tile(const std::uint32_t dst_index) { _llk_math_matmul_tile_(dst_index); }
 
@@ -68,6 +74,7 @@ inline void llk_math_matmul_tile(const std::uint32_t dst_index) { _llk_math_matm
  * This function does not iterate over kt_dim, must iterate over kt_dim externally to this function
  * Dest index is always assumed to start at 0 for this operation
  *
+ * @note Call @ref llk_math_matmul_init with matching template args before this function.
  */
 inline void llk_math_matmul_block(const std::uint32_t ct_dim, const std::uint32_t rt_dim) {
     _llk_math_matmul_block_(ct_dim, rt_dim);

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_reduce_api.h
@@ -22,6 +22,9 @@
  * @param operandA: The input operand Data Flow Buffer identifier
  * @param operandB: The scaler input operand Data Flow Buffer identifier
  *
+ * @note On the unpack thread, pair with @ref llk_unpack_AB_reduce_init (T0); on the pack thread, pair with
+ *       @ref llk_pack_reduce_mask_config (T2).
+ * @ref llk_math_reduce is the matching execute call on this thread.
  */
 template <PoolType pool_type, ReduceDim reduce_dim, const bool EN_32BIT_DEST, ckernel::MathFidelity math_fidelity>
 inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
@@ -39,5 +42,7 @@ inline void llk_math_reduce_init(const std::uint32_t operandA, const std::uint32
  * @brief Perform a reduce operation
  *
  * @param dst_index: Tile index into the destination register.
+ *
+ * @note Call @ref llk_math_reduce_init with matching template args before this function.
  */
 inline void llk_math_reduce(const std::uint32_t dst_index) { _llk_math_reduce_(dst_index); }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -13,6 +13,12 @@
  * LLK ELTWISE UNARY DATACOPY
  *************************************************************************/
 
+/**
+ * @brief Builds the TileShape for an operand from its circular buffer (used by the unary-broadcast math path).
+ *
+ * @param operand: Logical dataflow buffer id for the input operand
+ * @return TileShape with the operand's face count, face dims, and narrow-tile flag.
+ */
 inline TileShape llk_math_eltwise_unary_broadcast_tile_shape(const std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
     return TileShape{
@@ -32,6 +38,9 @@ inline TileShape llk_math_eltwise_unary_broadcast_tile_shape(const std::uint32_t
  * @tparam is_int_fpu_en Unused on Quasar.
  * @tparam tilize Unused on Quasar.
  * @param operand Logical dataflow buffer id for the input operand
+ *
+ * @note On the unpack thread, pair with @ref llk_unpack_A_init (T0); on the pack thread, pair with @ref llk_pack_init.
+ * @ref llk_math_eltwise_unary_datacopy is the matching execute call on this thread.
  */
 template <
     DataCopyType type,
@@ -68,6 +77,8 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand = 0
  * @tparam unpack_to_dest when true, unpack-to-dest path; plain datacopy otherwise
  * @param dst_index Tile index into the destination register.
  * @param operand Logical dataflow buffer id for the input operand (defaults to 0 for legacy call sites).
+ *
+ * @note Call @ref llk_math_eltwise_unary_datacopy_init with matching template args before this function.
  */
 template <
     DataCopyType type = DataCopyType::A2D,
@@ -94,6 +105,8 @@ inline void llk_math_eltwise_unary_datacopy(const std::uint32_t dst_index, const
  * @param start_dst_index Starting tile index in the destination register.
  * @param ntiles Number of tiles to copy to the destination register.
  * @param operand Logical dataflow buffer id for the input operand (defaults to 0 for legacy call sites).
+ *
+ * @note Loops the single-tile datacopy over ntiles. Call @ref llk_math_eltwise_unary_datacopy_init before this.
  */
 inline void llk_math_eltwise_unary_datacopy_block(
     const std::uint32_t start_dst_index, const std::uint32_t ntiles, const std::uint32_t operand = 0) {
@@ -107,6 +120,9 @@ inline void llk_math_eltwise_unary_datacopy_block(
     }
 }
 
+/**
+ * @brief No-op on Quasar; kept for API parity with arches that restore math state after datacopy.
+ */
 template <
     [[maybe_unused]] BroadcastType src_b_bcast_type = BroadcastType::NONE,
     [[maybe_unused]] bool unpack_to_dest = false>

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
@@ -62,7 +62,12 @@ inline bool should_reconfig_pack_in_data_format(const std::uint32_t old_output, 
 }
 
 /**
+ * @brief Reconfigure the packer input data format to that of a new output operand.
+ *
  * Reprograms packer THCON IN_DATA_FORMAT only (gasket); L1 format stays in buffer descriptors.
+ *
+ * @tparam EN_32BIT_DEST: Unused on Quasar; kept for API parity
+ * @param new_output: The new output DataFlow Buffer identifier whose formats are programmed
  */
 template <[[maybe_unused]] bool EN_32BIT_DEST>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
@@ -70,6 +75,15 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     _llk_pack_reconfig_data_format_<p_pacr::PACK0>(pack_src_format[output_id], pack_dst_format[output_id]);
 }
 
+/**
+ * @brief Reconfigure the packer input data format from an old output operand to a new one.
+ *
+ * Silent no-op when the old and new outputs already share both src and dst formats.
+ *
+ * @tparam EN_32BIT_DEST: Unused on Quasar; kept for API parity
+ * @param old_output: The currently programmed output DataFlow Buffer identifier
+ * @param new_output: The new output DataFlow Buffer identifier to switch to
+ */
 template <bool EN_32BIT_DEST>
 inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const std::uint32_t new_output) {
     if (!should_reconfig_pack_in_data_format(old_output, new_output)) {
@@ -123,6 +137,10 @@ TT_ALWAYS_INLINE void llk_pack_relu_config(const std::uint32_t config) {
     _llk_pack_relu_config_<p_pacr::PACK0, false /* EN_32B_DEST */>(ckernel::ReluConfig::from_packed(config));
 }
 
+/**
+ * @brief Configure packer ReLU at runtime from a ReluConfig.
+ * @param relu_config Packer ReLU configuration (type and threshold).
+ */
 TT_ALWAYS_INLINE void llk_pack_relu_config(const ckernel::ReluConfig& relu_config) {
     _llk_pack_relu_config_<p_pacr::PACK0, false /* EN_32B_DEST */>(relu_config);
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_reduce_api.h
@@ -17,6 +17,9 @@
  *
  * @tparam reduce_dim The reduce op dimension, values = [REDUCE_ROW, REDUCE_COL, REDUCE_SCALAR]
  * @tparam pack_mode Unused on Quasar
+ *
+ * @note On the unpack thread, pair with @ref llk_unpack_AB_reduce_init (T0); on the math thread, pair with
+ *       @ref llk_math_reduce_init (T1). Call @ref llk_pack_reduce_mask_clear afterwards to restore normal packing.
  */
 template <ReduceDim reduce_dim, [[maybe_unused]] PackMode pack_mode = PackMode::Default>
 inline void llk_pack_reduce_mask_config([[maybe_unused]] uint32_t ocb) {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_tile_api.h
@@ -17,6 +17,8 @@
  *
  * This function initializes packer0 to pack a single tile from the destination register to the output
  * DataFlow Buffer.
+ *
+ * @ref llk_pack is the matching execute call on this thread.
  */
 inline void llk_pack_init(const std::uint32_t pack_output) {
     const std::uint8_t output_id = static_cast<std::uint8_t>(get_output_id(pack_output));
@@ -70,6 +72,8 @@ inline std::uint32_t get_output_tile_index(std::uint8_t output_id, std::uint32_t
  * @param output_tile_index: The index in the output CB to write to
  *
  * This function packs tiles from the destination register to the output DataFlow Buffer, packer0 is used.
+ *
+ * @note Resolves the output tile's L1 address from the output buffer. Call @ref llk_pack_init before this.
  */
 template <bool out_of_order_output = false>
 inline void llk_pack(
@@ -89,6 +93,8 @@ inline void llk_pack(
  *
  * Packs ntiles tiles starting at start_tile_index from the destination register into the L1
  * output buffer identified by pack_output starting from output_tile_index
+ *
+ * @note Loops the single-tile pack over ntiles. Call @ref llk_pack_init before this.
  */
 // TODO: AM; Optimize block calls by using ntiles per pack, issue #40798
 inline void llk_pack_block(std::uint32_t start_tile_index, std::uint32_t pack_output, uint32_t ntiles) {

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_untilize_api.h
@@ -28,6 +28,8 @@
  * @tparam block_ct_dim  Width of a single block in tiles.
  * @tparam full_ct_dim   Total width of the tensor row in tiles (default = block_ct_dim).
  * @param pack_output    Output DataFlow Buffer identifier.
+ *
+ * @ref llk_pack_untilize is the matching execute call on this thread.
  */
 template <std::uint32_t block_ct_dim, std::uint32_t full_ct_dim = block_ct_dim>
 inline void llk_pack_untilize_init(std::uint32_t pack_output) {
@@ -54,6 +56,9 @@ inline void llk_pack_untilize_init(std::uint32_t pack_output) {
  * @param pack_output         Output DataFlow Buffer identifier.
  * @param block_c_index       Column-block index within the full row, used to offset the L1
  *                            write address when full_ct_dim > block_ct_dim (default 0).
+ * @param tile_dst_rt_offset  Per-row offset into the dst register for the pre-filled dst path (default 0).
+ *
+ * @note Call @ref llk_pack_untilize_init with matching template args before this function.
  */
 template <std::uint32_t block_ct_dim, std::uint32_t full_ct_dim = block_ct_dim>
 inline void llk_pack_untilize(

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_api.h
@@ -21,6 +21,8 @@
  * @param operandA: The input operand dataflow buffer for source A
  * @param operandB: The input operand dataflow buffer for source B
  * @param transpose: Unused param; only for API compatibility.
+ *
+ * @ref llk_unpack_AB is the matching execute call on this thread.
  */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(
@@ -36,6 +38,15 @@ inline void llk_unpack_AB_init(
     }
 }
 
+/**
+ * @brief Initialization for unpack of binary operations, uses SrcA & SrcB.
+ *
+ * Convenience overload that forwards to @ref llk_unpack_AB_init with Transpose::None.
+ *
+ * @tparam BType: Broadcast type for SrcB; one of {NONE, ROW, COL, SCALAR}.
+ * @param operandA: The input operand dataflow buffer for source A
+ * @param operandB: The input operand dataflow buffer for source B
+ */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB_init(const std::uint32_t operandA, const std::uint32_t operandB) {
     llk_unpack_AB_init<BType>(operandA, operandB, ckernel::Transpose::None);
@@ -50,6 +61,9 @@ inline void llk_unpack_AB_init(const std::uint32_t operandA, const std::uint32_t
  * @param tile_index_b: Tile index within the operandB dataflow buffer to read from
  * @param bcast_row_idx: Present for API compatibility with Blackhole binary `llk_unpack_AB` (ROW uses it there).
  *     Unused on Quasar; row selection within the B tile is not implemented in this wrapper.
+ *
+ * @note Resolves each tile's L1 address from its operand's circular buffer. Call @ref llk_unpack_AB_init
+ *       with matching template args before this function.
  */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_AB(

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -23,6 +23,8 @@
 *
 * This function initializes the unpacker to unpack operand 0 from the input0 operand circular buffer into SrcB
 * and operand 1 from the input1 operand circular buffer into SrcA. Matrix multiply FPU operation does SrcB * SrcA.
+*
+* @ref llk_unpack_AB_matmul is the matching execute call on this thread.
 */
 template <bool TRANSPOSE_EN = false>
 __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
@@ -58,6 +60,9 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
  * Output [rt_dim, ct_dim] = Input0 [rt_dim, kt_dim] x Input1 [kt_dim, ct_dim]
  * This unpacker only sets up Input0 [rt_dim, 1] x Input1 [1, ct_dim]
  * kt_dim is assumed to be iterated over outside this api call
+ *
+ * @note Resolves each tile's L1 address from its operand's circular buffer. Call @ref llk_unpack_AB_matmul_init
+ *       with matching template args before this function.
  */
 inline void llk_unpack_AB_matmul(
     const std::uint32_t operandA,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_reduce_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_AB_reduce_api.h
@@ -21,6 +21,9 @@
  * This function initializes the UNPACKER0 to unpack a single tile from the input DFB to srcA
  * and UNPACKER1 to unpack a single face from the input DFB to srcB, with specified reduce dimension.
  *
+ * @note On the math thread, pair with @ref llk_math_reduce_init (T1); on the pack thread, pair with
+ *       @ref llk_pack_reduce_mask_config (T2).
+ * @ref llk_unpack_AB_reduce is the matching execute call on this thread.
  */
 template <ReduceDim reduce_dim>
 inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::uint32_t operandB) {
@@ -43,6 +46,8 @@ inline void llk_unpack_AB_reduce_init(const std::uint32_t operandA, const std::u
  * This function performs unpacking for reduce kernels, the UNPACKER0 unpacks a single tile from the input DFB
  * to srcA and UNPACKER1 unpacks a single face from the input DFB to srcB.
  *
+ * @note Resolves each tile's L1 address from its operand's circular buffer. Call @ref llk_unpack_AB_reduce_init
+ *       with matching template args before this function.
  */
 inline void llk_unpack_AB_reduce(
     const std::uint32_t operandA,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -21,6 +21,9 @@
  *
  * This function initializes unpacker0 to unpack a single tile
  * from the input circular buffer to srcA/dest register.
+ *
+ * @note Resolves the operand's format and face dims from its circular buffer.
+ * @ref llk_unpack_A is the matching execute call on this thread.
  */
 template <bool TRANSPOSE_EN, bool IS_32b_DEST_EN>
 inline void llk_unpack_A_init(const std::uint32_t operand) {
@@ -45,6 +48,8 @@ inline void llk_unpack_A_init(const std::uint32_t operand) {
  * @param transpose_of_faces: Non-zero enables transpose of 16x16 faces (unary/broadcast NONE path only)
  * @param within_face_16x16_transpose: Unused on Quasar; kept for API parity with Blackhole / other arches
  * @param operand: The input operand logical dataflow buffer / CB id
+ *
+ * @ref llk_unpack_A is the matching execute call on this thread.
  */
 template <
     BroadcastType BType = BroadcastType::NONE,
@@ -101,6 +106,9 @@ inline void llk_unpack_A_init(
  * @tparam unpack_to_dest: Broadcast path only — when true, unpack targets dest (UNP_A); otherwise SrcB (UNP_B)
  * @param operand: The logical dataflow buffer id
  * @param tile_index: The index in the input CB to read from
+ *
+ * @note Resolves the tile's L1 address from the operand's circular buffer. Call @ref llk_unpack_A_init
+ *       with matching template args before this function.
  */
 template <
     BroadcastType BType = BroadcastType::NONE,
@@ -132,6 +140,9 @@ inline void llk_unpack_A(const std::uint32_t operand, const std::uint32_t tile_i
  * @param operand: The logical dataflow buffer id
  * @param start_tile_index: The starting tile index within the input buffer
  * @param ntiles: The number of consecutive tiles to unpack
+ *
+ * @note Loops the single-tile unpack over ntiles. Call @ref llk_unpack_A_init with matching template
+ *       args before this function.
  */
 // TODO: AM; Optimize block calls by using ntiles per unpack, issue #40798
 template <
@@ -156,5 +167,10 @@ inline void llk_unpack_A_block(
     }
 }
 
+/**
+ * @brief No-op on Quasar; kept for API parity with arches that restore unpacker state after @ref llk_unpack_A.
+ *
+ * @param operand: Unused; kept for API parity.
+ */
 template <BroadcastType BType = BroadcastType::NONE>
 inline void llk_unpack_A_uninit(const std::uint32_t operand) {}

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_common_api.h
@@ -23,8 +23,8 @@
 /**
  * @brief Programs l1 info & source register format for both UNP_A and UNP_B
  *
- * @param operandA: The input0 operand circular buffer
- * @param operandB: The input1 operand circular buffer
+ * @param unpA_operand: The input0 operand circular buffer (UNP_A)
+ * @param unpB_operand: The input1 operand circular buffer (UNP_B)
  */
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std::uint32_t unpB_operand) {
     const std::uint32_t unpA_operand_id = get_operand_id(unpA_operand);
@@ -66,7 +66,7 @@ inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand, const std:
 /**
  * @brief Programs l1 info & source register format for UNP_A
  *
- * @param operandA: The input operand circular buffer
+ * @param unpA_operand: The input operand circular buffer (UNP_A; also reused for UNP_B)
  */
 inline void llk_unpack_hw_configure(const std::uint32_t unpA_operand) {
     llk_unpack_hw_configure(unpA_operand, unpA_operand);
@@ -78,7 +78,14 @@ inline bool should_reconfig_src_reg_df(std::uint32_t old_operand, std::uint32_t 
 }
 
 /**
+ * @brief Reconfigure the SrcA unpacker data format to that of a new operand.
+ *
  * Reprograms unpacker THCON OUT_DATA_FORMAT only (gasket); L1 format stays in buffer descriptors.
+ *
+ * @tparam EN_32BIT_DEST: Set to true to use 32bit math dest in Float32 or Int32 format
+ * @tparam dim_stride_target: Must be p_dim_stride_target::IGNORE; stride/tile-dim changes are unsupported on Quasar
+ * @tparam to_from_int8: Unused on Quasar; kept for API parity
+ * @param srca_new_operand: The new SrcA operand circular buffer whose formats are programmed
  */
 template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, [[maybe_unused]] bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_operand) {
@@ -90,6 +97,16 @@ inline void llk_unpack_reconfig_data_format_srca(const std::uint32_t srca_new_op
         unpack_src_format[srca_operand_id], unpack_dst_format[srca_operand_id]);
 }
 
+/**
+ * @brief Reconfigure the SrcB unpacker data format to that of a new operand.
+ *
+ * Reprograms unpacker THCON OUT_DATA_FORMAT only (gasket); L1 format stays in buffer descriptors.
+ *
+ * @tparam EN_32BIT_DEST: Set to true to use 32bit math dest in Float32 or Int32 format
+ * @tparam dim_stride_target: Must be p_dim_stride_target::IGNORE; stride/tile-dim changes are unsupported on Quasar
+ * @tparam to_from_int8: Unused on Quasar; kept for API parity
+ * @param srcb_new_operand: The new SrcB operand circular buffer whose formats are programmed
+ */
 template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, [[maybe_unused]] bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_operand) {
     static_assert(
@@ -100,6 +117,17 @@ inline void llk_unpack_reconfig_data_format_srcb(const std::uint32_t srcb_new_op
         unpack_src_format[srcb_operand_id], unpack_dst_format[srcb_operand_id]);
 }
 
+/**
+ * @brief Reconfigure the SrcA unpacker data format from an old operand to a new one.
+ *
+ * Silent no-op when the old and new operands already share both src and dst formats.
+ *
+ * @tparam EN_32BIT_DEST: Set to true to use 32bit math dest in Float32 or Int32 format
+ * @tparam dim_stride_target: Must be p_dim_stride_target::IGNORE; stride/tile-dim changes are unsupported on Quasar
+ * @tparam to_from_int8: Unused on Quasar; kept for API parity
+ * @param srca_old_operand: The currently programmed SrcA operand circular buffer
+ * @param srca_new_operand: The new SrcA operand circular buffer to switch to
+ */
 template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srca(
     const std::uint32_t srca_old_operand, const std::uint32_t srca_new_operand) {
@@ -113,6 +141,17 @@ inline void llk_unpack_reconfig_data_format_srca(
     llk_unpack_reconfig_data_format_srca<EN_32BIT_DEST, dim_stride_target, to_from_int8>(srca_new_operand);
 }
 
+/**
+ * @brief Reconfigure the SrcB unpacker data format from an old operand to a new one.
+ *
+ * Silent no-op when the old and new operands already share both src and dst formats.
+ *
+ * @tparam EN_32BIT_DEST: Set to true to use 32bit math dest in Float32 or Int32 format
+ * @tparam dim_stride_target: Must be p_dim_stride_target::IGNORE; stride/tile-dim changes are unsupported on Quasar
+ * @tparam to_from_int8: Unused on Quasar; kept for API parity
+ * @param srcb_old_operand: The currently programmed SrcB operand circular buffer
+ * @param srcb_new_operand: The new SrcB operand circular buffer to switch to
+ */
 template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format_srcb(
     const std::uint32_t srcb_old_operand, const std::uint32_t srcb_new_operand) {
@@ -126,6 +165,15 @@ inline void llk_unpack_reconfig_data_format_srcb(
     llk_unpack_reconfig_data_format_srcb<EN_32BIT_DEST, dim_stride_target, to_from_int8>(srcb_new_operand);
 }
 
+/**
+ * @brief Reconfigure both SrcA and SrcB unpacker data formats to those of new operands.
+ *
+ * @tparam EN_32BIT_DEST: Set to true to use 32bit math dest in Float32 or Int32 format
+ * @tparam dim_stride_target: Must be p_dim_stride_target::IGNORE; stride/tile-dim changes are unsupported on Quasar
+ * @tparam to_from_int8: Unused on Quasar; kept for API parity
+ * @param srca_new_operand: The new SrcA operand circular buffer
+ * @param srcb_new_operand: The new SrcB operand circular buffer
+ */
 template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_new_operand, const std::uint32_t srcb_new_operand) {
@@ -136,6 +184,19 @@ inline void llk_unpack_reconfig_data_format(
     llk_unpack_reconfig_data_format_srcb<EN_32BIT_DEST, dim_stride_target, to_from_int8>(srcb_new_operand);
 }
 
+/**
+ * @brief Reconfigure both SrcA and SrcB unpacker data formats from old operands to new ones.
+ *
+ * Each side is a silent no-op when its old and new operands already share both src and dst formats.
+ *
+ * @tparam EN_32BIT_DEST: Set to true to use 32bit math dest in Float32 or Int32 format
+ * @tparam dim_stride_target: Must be p_dim_stride_target::IGNORE; stride/tile-dim changes are unsupported on Quasar
+ * @tparam to_from_int8: Unused on Quasar; kept for API parity
+ * @param srca_old_operand: The currently programmed SrcA operand circular buffer
+ * @param srca_new_operand: The new SrcA operand circular buffer to switch to
+ * @param srcb_old_operand: The currently programmed SrcB operand circular buffer
+ * @param srcb_new_operand: The new SrcB operand circular buffer to switch to
+ */
 template <bool EN_32BIT_DEST, p_dim_stride_target dim_stride_target, bool to_from_int8 = false>
 inline void llk_unpack_reconfig_data_format(
     const std::uint32_t srca_old_operand,

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_tilize_api.h
@@ -20,6 +20,8 @@
  * @param operand       The input dataflow buffer identifier.
  * @param full_ct_dim   Number of tiles in a full row of the input tensor.
  * @param block_ct_dim  Number of tiles per MOP invocation (defaults to 1).
+ *
+ * @ref llk_unpack_tilize_block is the matching execute call on this thread.
  */
 inline void llk_unpack_tilize_init(
     const std::uint32_t operand, const std::uint32_t full_ct_dim, const std::uint32_t block_ct_dim = 1) {
@@ -38,6 +40,8 @@ inline void llk_unpack_tilize_init(
  * @param operand          The input dataflow buffer identifier.
  * @param block_c_tiles    Number of tiles in one block row (must match BLOCK_CT_DIM from init).
  * @param input_tile_index Starting tile index (encodes row offset via block_c_tiles stride).
+ *
+ * @note Call @ref llk_unpack_tilize_init before this function.
  */
 inline void llk_unpack_tilize_block(
     const std::uint32_t operand, const std::uint32_t block_c_tiles, const std::uint32_t input_tile_index = 0) {


### PR DESCRIPTION
Adds Doxygen docstrings to the public `llk_*` wrappers in the Quasar llk-api layer.

Mostly copied straight from the llk-lib docstrings we just merged (#45842), with the param lists adapted to the wrapper signatures (operand / CB-index based instead of raw address/format). A handful of wrapper-only helpers (`*_block`, `hw_configure`, `reconfig_data_format`) got short fresh docstrings.

Comments only — no code changes.

Part of the llk-api docstring effort; the other two arches are in sibling PRs.