### PR TITLE
[Feature] Support non pow of 2 socket page sizes

### DIFF
--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -346,7 +346,13 @@ void D2HSocket::set_page_size(uint32_t page_size) {
     TT_FATAL(page_size % pcie_alignment_ == 0, "Page size must be PCIE-aligned.");
     TT_FATAL(page_size <= fifo_size_, "Page size must be less than or equal to the FIFO size.");
 
-    uint32_t next_fifo_rd_ptr = align(read_ptr_, page_size);
+    // tt::align() uses a bitwise-OR formula that only produces correct
+    // results when alignment is a power of two. Socket page sizes can be
+    // non-power-of-two (e.g. 2560 = 5×512 for some shard sizes), where
+    // tt::align(5120, 2560) returns 7168 instead of 5120. Use modular
+    // arithmetic so this works for any positive alignment.
+    uint32_t next_fifo_rd_ptr =
+        ((read_ptr_ + page_size - 1) / page_size) * page_size;
     uint32_t fifo_page_aligned_size = fifo_size_ - (fifo_size_ % page_size);
 
     if (next_fifo_rd_ptr >= fifo_page_aligned_size) {

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -493,7 +493,13 @@ void H2DSocket::set_page_size(uint32_t page_size) {
     TT_FATAL(page_size % pcie_alignment_ == 0, "Page size must be PCIE-aligned.");
     TT_FATAL(page_size <= fifo_size_, "Page size must be less than or equal to the FIFO size.");
 
-    uint32_t next_fifo_wr_ptr = align(write_ptr_, page_size);
+    // tt::align() uses a bitwise-OR formula that only produces correct
+    // results when alignment is a power of two. Socket page sizes can be
+    // non-power-of-two (e.g. 2560 = 5×512 for some shard sizes), where
+    // tt::align(5120, 2560) returns 7168 instead of 5120. Use modular
+    // arithmetic so this works for any positive alignment.
+    uint32_t next_fifo_wr_ptr =
+        ((write_ptr_ + page_size - 1) / page_size) * page_size;
     uint32_t fifo_page_aligned_size = fifo_size_ - (fifo_size_ % page_size);
 
     if (next_fifo_wr_ptr >= fifo_page_aligned_size) {


### PR DESCRIPTION
### Summary
Support non pow of 2 socket page sizes via basic modular arithmetic.
```
// tt::align() uses a bitwise-OR formula that only produces correct
    // results when alignment is a power of two. Socket page sizes can be
    // non-power-of-two (e.g. 2560 = 5×512 for some shard sizes), where
    // tt::align(5120, 2560) returns 7168 instead of 5120. Use modular
    // arithmetic so this works for any positive alignment.
```

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bzhang/support-non-pow-2-socket-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bzhang/support-non-pow-2-socket-page-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bzhang/support-non-pow-2-socket-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bzhang/support-non-pow-2-socket-page-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bzhang/support-non-pow-2-socket-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bzhang/support-non-pow-2-socket-page-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bzhang/support-non-pow-2-socket-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bzhang/support-non-pow-2-socket-page-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bzhang/support-non-pow-2-socket-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bzhang/support-non-pow-2-socket-page-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bzhang/support-non-pow-2-socket-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bzhang/support-non-pow-2-socket-page-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bzhang/support-non-pow-2-socket-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bzhang/support-non-pow-2-socket-page-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bzhang/support-non-pow-2-socket-page-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bzhang/support-non-pow-2-socket-page-size)