### PR TITLE
[skip ci] Disable sdxl test_demo with device_encoders+trace on wormhole_b0 (single-card-demo-tests)

### DIFF
--- a/models/demos/stable_diffusion_xl_base/demo/demo.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo.py
@@ -11,7 +11,7 @@ from diffusers import DiffusionPipeline
 from loguru import logger
 from transformers import CLIPTextModel, CLIPTextModelWithProjection
 
-from models.common.utility_functions import is_blackhole, profiler
+from models.common.utility_functions import is_blackhole, is_wormhole_b0, profiler
 from models.demos.stable_diffusion_xl_base.conftest import is_galaxy
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     CONCATENATED_TEXT_EMBEDINGS_SIZE,
@@ -310,6 +310,9 @@ def test_demo(
 ):
     if image_resolution == (512, 512) and is_blackhole():
         pytest.skip("512x512 not supported on Blackhole")
+
+    if encoders_on_device and capture_trace and not use_cfg_parallel and is_wormhole_b0():
+        pytest.skip("Disabled on wormhole_b0: see #46424")
 
     prepare_device(mesh_device, use_cfg_parallel)
     return run_demo_inference(

--- a/models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
@@ -10,7 +10,7 @@ import torch
 from diffusers import DiffusionPipeline, StableDiffusionXLImg2ImgPipeline
 from loguru import logger
 
-from models.common.utility_functions import is_blackhole, profiler
+from models.common.utility_functions import is_blackhole, is_wormhole_b0, profiler
 from models.demos.stable_diffusion_xl_base.conftest import is_galaxy
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     SDXL_FABRIC_CONFIG,
@@ -323,6 +323,8 @@ def test_demo_base_and_refiner(
     timesteps,
     sigmas,
 ):
+    if encoders_on_device and capture_trace and not use_cfg_parallel and is_wormhole_b0():
+        pytest.skip("Disabled on wormhole_b0: see #46424")
     prepare_device(mesh_device, use_cfg_parallel)
     return run_demo_inference(
         mesh_device,
@@ -353,3 +355,4 @@ def test_demo_base_and_refiner(
         timesteps,
         sigmas,
     )
+


### PR DESCRIPTION
Disable deterministic failing tests in `single-card-demo-tests.yaml` (`sdxl-N150-func` job).

Tracks #46424

**Failure:** `TypeError: CLIPEncoder.forward() takes 2 positional arguments but 3 were given`

| Disabled test | Most recent failing run (job link) | Commit | Run completed at |
|---|---|---|---|
| `models/demos/stable_diffusion_xl_base/demo/demo.py::test_demo[wormhole_b0-default_additional_parameters-with_trace-device_encoders-device_vae-5.0-50-negative_prompt0-An astronaut riding a green horse-False-no_cfg_parallel-1024x1024]` | https://github.com/tenstorrent/tt-metal/actions/runs/27159995928/job/80178667801 | [7097398f](https://github.com/tenstorrent/tt-metal/commit/7097398fbced3b6f1cbf0a9a5e23e7f56f2e0fc0) | 2026-06-08 18:56 UTC |
| `models/demos/stable_diffusion_xl_base/demo/demo.py::test_demo[wormhole_b0-default_additional_parameters-with_trace-device_encoders-device_vae-5.0-50-negative_prompt0-An astronaut riding a green horse-False-no_cfg_parallel-512x512]` | https://github.com/tenstorrent/tt-metal/actions/runs/27159995928/job/80178667801 | [7097398f](https://github.com/tenstorrent/tt-metal/commit/7097398fbced3b6f1cbf0a9a5e23e7f56f2e0fc0) | 2026-06-08 18:56 UTC |
| `models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py::test_demo_base_and_refiner[wormhole_b0-default_additional_parameters-default_refiner_params-0.8-True-with_trace-device_encoders-device_vae-5.0-50-None-An astronaut riding a green horse-False-no_cfg_parallel-1024x1024]` | https://github.com/tenstorrent/tt-metal/actions/runs/27175683021/job/80224803046 | [3965f285](https://github.com/tenstorrent/tt-metal/commit/3965f285330173df91ac6dac0c72bd801d87c47e) | 2026-06-09 00:55 UTC |
| `models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py::test_demo_base_and_refiner[wormhole_b0-default_additional_parameters-default_refiner_params-0.8-True-with_trace-device_encoders-device_vae-5.0-50-None-An astronaut riding a green horse-False-no_cfg_parallel-512x512]` | https://github.com/tenstorrent/tt-metal/actions/runs/27175683021/job/80224803046 | [3965f285](https://github.com/tenstorrent/tt-metal/commit/3965f285330173df91ac6dac0c72bd801d87c47e) | 2026-06-09 00:55 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/single-card-demo-tests-sdxl-wormhole-2026-06-09)
