### PR TITLE
[skip ci] Disable sdxl test_demo with device_encoders+trace on blackhole (blackhole-demo-tests)

### DIFF
--- a/models/demos/stable_diffusion_xl_base/demo/demo.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo.py
@@ -311,6 +311,9 @@ def test_demo(
     if image_resolution == (512, 512) and is_blackhole():
         pytest.skip("512x512 not supported on Blackhole")
 
+    if encoders_on_device and capture_trace and not use_cfg_parallel and is_blackhole():
+        pytest.skip("Disabled on blackhole: see #46426")
+
     prepare_device(mesh_device, use_cfg_parallel)
     return run_demo_inference(
         mesh_device,

--- a/models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py
@@ -323,6 +323,8 @@ def test_demo_base_and_refiner(
     timesteps,
     sigmas,
 ):
+    if encoders_on_device and capture_trace and not use_cfg_parallel and is_blackhole():
+        pytest.skip("Disabled on blackhole: see #46426")
     prepare_device(mesh_device, use_cfg_parallel)
     return run_demo_inference(
         mesh_device,
@@ -353,3 +355,4 @@ def test_demo_base_and_refiner(
         timesteps,
         sigmas,
     )
+


### PR DESCRIPTION
Disable deterministic failing tests in `blackhole-demo-tests.yaml` (`stable_diffusion_xl / stable_diffusion_xl demos [bh_p150b_civ2]` job).

Tracks #46426

**Failure:** `TypeError: CLIPEncoder.forward() takes 2 positional arguments but 3 were given`

| Disabled test | Most recent failing run (job link) | Commit | Run completed at |
|---|---|---|---|
| `models/demos/stable_diffusion_xl_base/demo/demo.py::test_demo[blackhole-default_additional_parameters-with_trace-device_encoders-device_vae-5.0-50-negative_prompt0-An astronaut riding a green horse-False-no_cfg_parallel-1024x1024]` | https://github.com/tenstorrent/tt-metal/actions/runs/27185553601/job/80254318066 | [f4a3533f](https://github.com/tenstorrent/tt-metal/commit/f4a3533fb2ba7c8f303eaccc3f32dbc9b950291d) | 2026-06-09 05:42 UTC |
| `models/demos/stable_diffusion_xl_base/demo/demo_base_and_refiner.py::test_demo_base_and_refiner[blackhole-default_additional_parameters-default_refiner_params-0.8-True-with_trace-device_encoders-device_vae-5.0-50-None-An astronaut riding a green horse-False-no_cfg_parallel-1024x1024]` | https://github.com/tenstorrent/tt-metal/actions/runs/27175756052/job/80225004065 | [3965f285](https://github.com/tenstorrent/tt-metal/commit/3965f285330173df91ac6dac0c72bd801d87c47e) | 2026-06-09 01:10 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/blackhole-demo-tests-sdxl-blackhole-2026-06-09)
