### PR TITLE
[CI] Disable test_h2d_stream_service_replicated_sweep large buffer on blackhole (blackhole-post-commit)

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_h2d_stream_service.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_h2d_stream_service.py
@@ -118,6 +118,8 @@ def test_h2d_stream_service_replicated_sweep(
     fifo_pages,
     input_path,
 ):
+    if shape_list == [1, 1, 1, 65536] and input_path == "tensor":
+        pytest.skip("Disabled: DMA buffer pin fails for large buffer on blackhole. See #46428")
     shape = ttnn.Shape(shape_list)
     per_row_bytes = shape_list[-1] * _DTYPE_SIZE
     global_spec = _make_global_spec(shape)


### PR DESCRIPTION
Disable deterministic failing test in `blackhole-post-commit.yaml` (`ttnn-unit-tests (P150b) / core ttnn unit test group [bh_p150b_civ2]` job).

Closes #46428

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| `tests/ttnn/unit_tests/base_functionality/test_h2d_stream_service.py::test_h2d_stream_service_replicated_sweep[silicon_arch_name=blackhole-input_path=tensor-shape_list=[1, 1, 1, 65536]-scratch_cb_pages=1-fifo_pages=1]` | https://github.com/tenstorrent/tt-metal/actions/runs/27165679180/job/80209617722 | [ec55847b](https://github.com/tenstorrent/tt-metal/commit/ec55847b2c28ab0d7cce5cedb28c9a1a88a47f5b) | 2026-06-08 20:41 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/blackhole-post-commit-h2d-stream-service-2026-06-09)