### PR TITLE
[Bug fix] Fix DeepSeek slot remap for device sampling

### DIFF
--- a/models/demos/deepseek_v3/tests/test_generator_vllm.py
+++ b/models/demos/deepseek_v3/tests/test_generator_vllm.py
@@ -59,15 +59,13 @@ def test_decode_forward_passes_slot_remap_to_device_sampling(monkeypatch: pytest
         def _validate_and_initialize_sampling(self, *args, **kwargs):
             captured["validate_sampling"] = (args, kwargs)
 
-        def _sampling_device_slot(self, user_id: int) -> int:
-            return 32 * (user_id // self.batch_size_per_row) + (user_id % self.batch_size_per_row)
-
-        def _sampling_device_slot_remap(self, slot_remap):
-            return generator_vllm_module.DeepseekGenerator._sampling_device_slot_remap(self, slot_remap)
-
         def _sample_tokens_device(self, logits, **kwargs):
             captured["sample_call"] = (logits, kwargs)
             return "sampled"
+
+        def sample_decode_on_device(self, logits, **kwargs):
+            captured["sample_decode_on_device"] = (logits, kwargs)
+            return self._sample_tokens_device(logits, **kwargs)
 
         def _tokens_from_device(self, tokens, mesh_device, batch_size_per_row):
             captured["tokens_from_device"] = (tokens, mesh_device, batch_size_per_row)
@@ -93,9 +91,6 @@ def test_decode_forward_passes_slot_remap_to_device_sampling(monkeypatch: pytest
     assert captured["super_decode_forward"]["sample_on_device"] is True
     assert captured["sample_call"][0] == "decode_logits"
     assert captured["sample_call"][1]["slot_remap"] == [7, 6, 5, 4]
-    assert fake_model._sampling_device_slot_remap(captured["sample_call"][1]["slot_remap"]) == [7, 6, 5, 4] + list(
-        range(8, 32)
-    ) + [39, 38, 37, 36] + list(range(40, 64))
     assert captured["sample_call"][1]["skip_precompile"] is True
     assert output == "host_tokens"
 

--- a/models/demos/deepseek_v3/tests/test_generator_vllm.py
+++ b/models/demos/deepseek_v3/tests/test_generator_vllm.py
@@ -44,6 +44,52 @@ def test_deepseek_generator_exposes_max_tokens_all_users_capability() -> None:
     assert generator_vllm_module.DeepseekGenerator.get_max_tokens_all_users() == FALLBACK_MAX_TOKENS_ALL_USERS
 
 
+def test_decode_forward_passes_slot_remap_to_device_sampling(monkeypatch: pytest.MonkeyPatch) -> None:
+    captured: dict[str, object] = {}
+
+    class _FakeModel:
+        model_run_config_decode = object()
+        mesh_device = object()
+        batch_size_per_row = 8
+
+        def set_kv_cache(self, kv_cache):
+            captured["kv_cache"] = kv_cache
+
+        def _validate_and_initialize_sampling(self, *args, **kwargs):
+            captured["validate_sampling"] = (args, kwargs)
+
+        def _sample_tokens_device(self, logits, **kwargs):
+            captured["sample_call"] = (logits, kwargs)
+            return "sampled"
+
+        def _tokens_from_device(self, tokens, mesh_device, batch_size_per_row):
+            captured["tokens_from_device"] = (tokens, mesh_device, batch_size_per_row)
+            return "host_tokens"
+
+    def fake_super_decode_forward(self, *args, **kwargs):
+        captured["super_decode_forward"] = kwargs
+        return "decode_logits"
+
+    monkeypatch.setattr(generator_vllm_module.DeepseekGenerator, "decode_forward", fake_super_decode_forward)
+
+    fake_model = _FakeModel()
+    output = generator_vllm_module.DeepseekV3ForCausalLM.decode_forward(
+        fake_model,
+        tokens=generator_vllm_module.torch.tensor([[11], [22]]),
+        start_pos=generator_vllm_module.torch.tensor([3, 4]),
+        sampling_params=object(),
+        slot_remap=[7, 6, 5, 4],
+        read_from_device=True,
+    )
+
+    assert captured["super_decode_forward"]["tokens"].tolist() == [11, 22]
+    assert captured["super_decode_forward"]["sample_on_device"] is True
+    assert captured["sample_call"][0] == "decode_logits"
+    assert captured["sample_call"][1]["slot_remap"] == [7, 6, 5, 4]
+    assert captured["sample_call"][1]["skip_precompile"] is True
+    assert output == "host_tokens"
+
+
 @pytest.mark.skip(reason="Disabled: see #45677")
 def test_get_max_tokens_all_users_overrides_deepseek_r1_on_wormhole(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(generator_vllm_module, "is_wormhole_b0", lambda: True)

--- a/models/demos/deepseek_v3/tests/test_generator_vllm.py
+++ b/models/demos/deepseek_v3/tests/test_generator_vllm.py
@@ -51,12 +51,19 @@ def test_decode_forward_passes_slot_remap_to_device_sampling(monkeypatch: pytest
         model_run_config_decode = object()
         mesh_device = object()
         batch_size_per_row = 8
+        batch_size = 16
 
         def set_kv_cache(self, kv_cache):
             captured["kv_cache"] = kv_cache
 
         def _validate_and_initialize_sampling(self, *args, **kwargs):
             captured["validate_sampling"] = (args, kwargs)
+
+        def _sampling_device_slot(self, user_id: int) -> int:
+            return 32 * (user_id // self.batch_size_per_row) + (user_id % self.batch_size_per_row)
+
+        def _sampling_device_slot_remap(self, slot_remap):
+            return generator_vllm_module.DeepseekGenerator._sampling_device_slot_remap(self, slot_remap)
 
         def _sample_tokens_device(self, logits, **kwargs):
             captured["sample_call"] = (logits, kwargs)
@@ -86,6 +93,9 @@ def test_decode_forward_passes_slot_remap_to_device_sampling(monkeypatch: pytest
     assert captured["super_decode_forward"]["sample_on_device"] is True
     assert captured["sample_call"][0] == "decode_logits"
     assert captured["sample_call"][1]["slot_remap"] == [7, 6, 5, 4]
+    assert fake_model._sampling_device_slot_remap(captured["sample_call"][1]["slot_remap"]) == [7, 6, 5, 4] + list(
+        range(8, 32)
+    ) + [39, 38, 37, 36] + list(range(40, 64))
     assert captured["sample_call"][1]["skip_precompile"] is True
     assert output == "host_tokens"
 

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -66,9 +66,13 @@ class _FakeSeedManager:
         self.max_batch_size = max_batch_size
         self.reset_calls = []
         self.new_value_calls = []
+        self.slot_remap_calls = []
 
     def reset_seed(self, seeds, user_ids):
         self.reset_calls.append((seeds, user_ids))
+
+    def apply_slot_remap(self, remap):
+        self.slot_remap_calls.append(remap)
 
     def get_new_values(self, user_slots):
         self.new_value_calls.append(user_slots)
@@ -90,10 +94,13 @@ def _fake_deepseek_generator(*, batch_size_per_row=8, sampling_dp=2):
         _sampling_device_slot = DeepseekGenerator._sampling_device_slot
         _sampling_device_slots = DeepseekGenerator._sampling_device_slots
         _sampling_device_seed_slots = DeepseekGenerator._sampling_device_seed_slots
+        _sample_tokens_device = DeepseekGenerator._sample_tokens_device
 
         def __init__(self):
             self.batch_size_per_row = batch_size_per_row
             self.sampling_generator = _FakeSamplingGenerator(padded_batch_size=32, sampling_dp=sampling_dp)
+            self._sampling_trace_logits_device = None
+            self._sampling_trace_logits_host = None
 
     return _FakeDeepseekGenerator()
 
@@ -155,6 +162,30 @@ def test_deepseek_sampling_seed_reset_uses_row_padded_device_slots():
     assert seeds[72:96] == [None] * 24
     assert seeds[96:104] == list(range(124, 132))
     assert seeds[104:] == [None] * 24
+
+
+def test_deepseek_sample_tokens_device_applies_slot_remap_before_seed_advance():
+    generator = _fake_deepseek_generator(batch_size_per_row=8, sampling_dp=2)
+    sampling_generator = generator.sampling_generator
+
+    class _FakeLogits:
+        shape = (1, 1, 32, 128)
+
+    sampling_generator.sample = lambda logits, **kwargs: logits
+    slot_remap = list(range(63, -1, -1))
+
+    DeepseekGenerator._sample_tokens_device(
+        generator,
+        _FakeLogits(),
+        slot_remap=slot_remap,
+        user_slots=[0, 8, 9],
+        skip_precompile=True,
+    )
+
+    [applied_remap] = sampling_generator.seed_manager.slot_remap_calls
+    assert applied_remap == slot_remap
+    [advanced_slots] = sampling_generator.seed_manager.new_value_calls
+    assert advanced_slots == [0, 32, 33]
 
 
 @torch.no_grad()

--- a/models/demos/deepseek_v3/tests/test_sampling.py
+++ b/models/demos/deepseek_v3/tests/test_sampling.py
@@ -94,10 +94,12 @@ def _fake_deepseek_generator(*, batch_size_per_row=8, sampling_dp=2):
         _sampling_device_slot = DeepseekGenerator._sampling_device_slot
         _sampling_device_slots = DeepseekGenerator._sampling_device_slots
         _sampling_device_seed_slots = DeepseekGenerator._sampling_device_seed_slots
+        _sampling_device_slot_remap = DeepseekGenerator._sampling_device_slot_remap
         _sample_tokens_device = DeepseekGenerator._sample_tokens_device
 
         def __init__(self):
             self.batch_size_per_row = batch_size_per_row
+            self.batch_size = self.batch_size_per_row * sampling_dp
             self.sampling_generator = _FakeSamplingGenerator(padded_batch_size=32, sampling_dp=sampling_dp)
             self._sampling_trace_logits_device = None
             self._sampling_trace_logits_host = None
@@ -164,7 +166,15 @@ def test_deepseek_sampling_seed_reset_uses_row_padded_device_slots():
     assert seeds[104:] == [None] * 24
 
 
-def test_deepseek_sample_tokens_device_applies_slot_remap_before_seed_advance():
+def test_deepseek_sampling_slot_remap_expands_to_row_padded_seed_slots():
+    generator = _fake_deepseek_generator(batch_size_per_row=8, sampling_dp=2)
+
+    expanded = DeepseekGenerator._sampling_device_slot_remap(generator, [7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12])
+
+    assert expanded == [7, 6, 5, 4, 3, 2, 1, 0] + list(range(8, 32)) + [39, 38, 37, 36] + list(range(36, 64))
+
+
+def test_deepseek_sample_tokens_device_applies_row_padded_slot_remap_before_seed_advance():
     generator = _fake_deepseek_generator(batch_size_per_row=8, sampling_dp=2)
     sampling_generator = generator.sampling_generator
 
@@ -172,7 +182,7 @@ def test_deepseek_sample_tokens_device_applies_slot_remap_before_seed_advance():
         shape = (1, 1, 32, 128)
 
     sampling_generator.sample = lambda logits, **kwargs: logits
-    slot_remap = list(range(63, -1, -1))
+    slot_remap = [7, 6, 5, 4, 3, 2, 1, 0, 15, 14, 13, 12]
 
     DeepseekGenerator._sample_tokens_device(
         generator,
@@ -183,7 +193,7 @@ def test_deepseek_sample_tokens_device_applies_slot_remap_before_seed_advance():
     )
 
     [applied_remap] = sampling_generator.seed_manager.slot_remap_calls
-    assert applied_remap == slot_remap
+    assert applied_remap == [7, 6, 5, 4, 3, 2, 1, 0] + list(range(8, 32)) + [39, 38, 37, 36] + list(range(36, 64))
     [advanced_slots] = sampling_generator.seed_manager.new_value_calls
     assert advanced_slots == [0, 32, 33]
 

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -990,6 +990,26 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
             seed_slots[self._sampling_device_slot(user_id)] = seeds[user_id]
         return seed_slots
 
+    def _sampling_device_slot_remap(self, slot_remap: list[int] | None) -> list[int] | None:
+        if slot_remap is None:
+            return None
+        if len(slot_remap) > self.batch_size:
+            raise ValueError(
+                f"slot_remap length {len(slot_remap)} exceeds DeepSeek batch size {self.batch_size}"
+            )
+
+        seed_slot_count = self.sampling_generator.seed_manager.max_batch_size
+        seed_slot_remap = list(range(seed_slot_count))
+        for new_user_slot, old_user_slot in enumerate(slot_remap):
+            old_user_slot = int(old_user_slot)
+            if old_user_slot < 0 or old_user_slot >= self.batch_size:
+                raise ValueError(
+                    f"slot_remap[{new_user_slot}]={old_user_slot} is outside the valid user-slot range "
+                    f"[0, {self.batch_size})"
+                )
+            seed_slot_remap[self._sampling_device_slot(new_user_slot)] = self._sampling_device_slot(old_user_slot)
+        return seed_slot_remap
+
     def _sample_tokens_device(
         self,
         logits: ttnn.Tensor,
@@ -1044,8 +1064,9 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
             else:
                 sampling_logits = padded_logits
 
-        if slot_remap is not None:
-            self.sampling_generator.seed_manager.apply_slot_remap(slot_remap)
+        seed_slot_remap = self._sampling_device_slot_remap(slot_remap)
+        if seed_slot_remap is not None:
+            self.sampling_generator.seed_manager.apply_slot_remap(seed_slot_remap)
         self.sampling_generator.seed_manager.get_new_values(self._sampling_device_slots(user_slots))
         try:
             tt_out = self.sampling_generator.sample(

--- a/models/demos/deepseek_v3/tt/generator.py
+++ b/models/demos/deepseek_v3/tt/generator.py
@@ -994,6 +994,7 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
         self,
         logits: ttnn.Tensor,
         enable_trace: bool = False,
+        slot_remap: list[int] | None = None,
         user_slots: list[int] | None = None,
         skip_precompile: bool = False,
     ) -> ttnn.Tensor:
@@ -1043,6 +1044,8 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
             else:
                 sampling_logits = padded_logits
 
+        if slot_remap is not None:
+            self.sampling_generator.seed_manager.apply_slot_remap(slot_remap)
         self.sampling_generator.seed_manager.get_new_values(self._sampling_device_slots(user_slots))
         try:
             tt_out = self.sampling_generator.sample(
@@ -1087,15 +1090,17 @@ class DeepseekGenerator(ModelCapabilitiesMixin, WarmupForwardMixin):
           param change — not unconditionally per step. Passing ``sampling_params``
           here refreshes that state (idempotent when unchanged); the vLLM bridge
           already initialises it before the forward, so it passes ``None``.
-        - ``prompt_tokens`` / ``output_tokens`` / ``slot_remap`` are not yet
-          threaded into deepseek's penalty/seed state (see
-          :meth:`_reset_sampling_state` TODO); accepted for signature
-          compatibility and currently ignored.
+        - ``prompt_tokens`` / ``output_tokens`` are not yet threaded into
+          deepseek's penalty state (see :meth:`_reset_sampling_state` TODO).
         """
         if sampling_params is not None:
             self._validate_and_initialize_sampling(sampling_params, sample_on_device=True, enable_trace=enable_trace)
         return self._sample_tokens_device(
-            tt_logits, enable_trace=enable_trace, user_slots=user_slots, skip_precompile=True
+            tt_logits,
+            enable_trace=enable_trace,
+            slot_remap=slot_remap,
+            user_slots=user_slots,
+            skip_precompile=True,
         )
 
     def _tokens_from_device(self, tt_out_tok, mesh_device, batch_size_per_row: int) -> torch.Tensor:

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -231,10 +231,9 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
         sampling_params = kwargs.get("sampling_params", None)
         sample_on_device = bool(sampling_params is not None)
         reset_batch = kwargs.get("reset_batch", False)
-        # NOTE: vLLM also passes `slot_remap` (the seed-slot reindex map from batch
-        # condense) in kwargs, but deepseek does not consume it — so per-request
-        # seeded determinism is not preserved across condense. Tracked by
-        # https://github.com/tenstorrent/tt-metal/issues/46350.
+        # vLLM passes `slot_remap` in compact user-slot space after batch condense.
+        # DeepSeek forwards it into device sampling, where generator.py expands it
+        # into the row-padded seed-manager slot layout before advancing seeds.
 
         # Set kv_cache if provided and all entries are valid
         if kv_cache is not None and not any(entry is None for entry in kv_cache):

--- a/models/demos/deepseek_v3/tt/generator_vllm.py
+++ b/models/demos/deepseek_v3/tt/generator_vllm.py
@@ -225,6 +225,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
 
         page_tables = kwargs.get("page_table", None)
         kv_cache = kwargs.get("kv_cache", None)
+        slot_remap = kwargs.get("slot_remap", None)
         enable_trace = kwargs.get("enable_trace", False)
         read_from_device = kwargs.get("read_from_device", True)
         sampling_params = kwargs.get("sampling_params", None)
@@ -258,6 +259,7 @@ class DeepseekV3ForCausalLM(DeepseekGenerator):
             decode_output = self.sample_decode_on_device(
                 decode_step_output,
                 enable_trace=enable_trace,
+                slot_remap=slot_remap,
             )
             if read_from_device:
                 decode_output = self._tokens_from_device(


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
1. Fix DeepSeek vLLM decode sampling so `slot_remap` is converted into the row-padded seed-slot layout used by DeepSeek device sampling before the next decode-step seed advance.
2. Apply that converted remap before `seed_manager.get_new_values(...)` so condensed vLLM batches keep slot-to-seed state aligned across sampling rows.
3. Add focused host-side regressions for both boundaries:
   - the DeepSeek vLLM wrapper still forwards `slot_remap`
   - the DeepSeek sampling path expands logical user-slot remaps into the expected row-padded seed-slot remap before advancing seeds

### Notes for reviewers
1. The functional change is limited to the DeepSeek vLLM sampling bridge:
   - `models/demos/deepseek_v3/tt/generator_vllm.py`
   - `models/demos/deepseek_v3/tt/generator.py`
2. The key contract detail is that DeepSeek sampling uses row-padded seed slots:
   - logical user slots are mapped through `_sampling_device_slot(...)`
   - `SeedManager.apply_slot_remap(...)` expects remaps in that seed-slot index space, not in compact logical-user space
3. This follows the same seed-manager ordering already used in:
   - `models/tt_transformers/tt/generator.py`
   - `models/demos/llama3_70b_galaxy/tt/generator.py`
4. The issue here is not cache or decode math. It is slot-to-seed state drift after vLLM condenses the active batch and DeepSeek advances seeds against the wrong slot layout.
5. I kept the regression coverage host-side and focused on the contract boundary instead of trying to prove this through a full hardware-backed decode run.

### Test plan
1. `python3 -m py_compile models/demos/deepseek_v3/tt/generator.py`
2. `python3 -m py_compile models/demos/deepseek_v3/tt/generator_vllm.py`
3. `python3 -m py_compile models/demos/deepseek_v3/tests/test_sampling.py`
4. `python3 -m py_compile models/demos/deepseek_v3/tests/test_generator_vllm.py`
5. `git diff --check`
6. `python3` AST parse probe for the touched files
7. host-side logic probe confirming `_sampling_device_slot_remap(...)` expands `[7,6,5,4,3,2,1,0,15,14,13,12]` into the expected row-padded seed-slot remap
8. I could not complete local pytest collection in this WSL environment because the available Python envs here do not include `pytest`, and the available Python envs for this lane do not provide a ready importable TTNN runtime test environment.
