### PR TITLE
[Bug fix] Support offset (non-`(0,0)`) shard grids in sharded GroupNorm

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -322,22 +322,37 @@ def test_group_norm_with_block_sharded_v2_8x4_grid(device, N, C, H, W, num_group
     )
 
 
+OFFSET_SHARD_GRID_SHAPE_CASES = [
+    # (N, C, H, W, num_groups), (core_grid_x, core_grid_y)
+    ((1, 1280, 16, 16, 32), (4, 4)),
+    ((1, 960, 1, 1024, 32), (8, 4)),
+]
+OFFSET_SHARD_GRID_OFFSETS = [
+    ttnn.CoreCoord(0, 0),
+    ttnn.CoreCoord(2, 0),
+    ttnn.CoreCoord(0, 2),
+    ttnn.CoreCoord(1, 1),
+    ttnn.CoreCoord(4, 4),
+]
+OFFSET_SHARD_GRID_ORIENTATIONS = [ttnn.ShardOrientation.COL_MAJOR, ttnn.ShardOrientation.ROW_MAJOR]
+
+
+def _offset_grid_fits_device(device, core_grid, offset):
+    dev = device.compute_with_storage_grid_size()
+    return offset.x + core_grid[0] <= dev.x and offset.y + core_grid[1] <= dev.y
+
+
 @pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
-@pytest.mark.parametrize("N, C, H, W, num_groups", [(1, 1280, 16, 16, 32)])
+@pytest.mark.parametrize("shape, core_grid", OFFSET_SHARD_GRID_SHAPE_CASES)
+@pytest.mark.parametrize("grid_offset", OFFSET_SHARD_GRID_OFFSETS)
+@pytest.mark.parametrize("orientation", OFFSET_SHARD_GRID_ORIENTATIONS)
 @pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
-@pytest.mark.parametrize(
-    "core_grid, grid_offset, orientation",
-    [
-        ((4, 4), ttnn.CoreCoord(2, 0), ttnn.ShardOrientation.COL_MAJOR),
-        ((4, 4), ttnn.CoreCoord(0, 2), ttnn.ShardOrientation.COL_MAJOR),
-        ((4, 4), ttnn.CoreCoord(2, 0), ttnn.ShardOrientation.ROW_MAJOR),
-        ((4, 4), ttnn.CoreCoord(0, 2), ttnn.ShardOrientation.ROW_MAJOR),
-    ],
-)
-def test_group_norm_with_offset_shard_grid(
-    device, N, C, H, W, num_groups, use_welford, core_grid, grid_offset, orientation
-):
+def test_group_norm_with_offset_shard_grid(device, shape, core_grid, grid_offset, orientation, use_welford):
     """Sharded groupnorm must work when the shard grid does not start at core (0, 0), for both orientations."""
+    if not _offset_grid_fits_device(device, core_grid, grid_offset):
+        pytest.skip(f"core grid {core_grid} at offset ({grid_offset.x}, {grid_offset.y}) does not fit on this device")
+
+    N, C, H, W, num_groups = shape
     torch.manual_seed(0)
 
     grid_size = ttnn.CoreGrid(y=core_grid[1], x=core_grid[0])
@@ -413,23 +428,13 @@ def test_group_norm_with_offset_shard_grid(
     output_tensor = ttnn.from_device(output_tensor)
     output_tensor = ttnn.to_torch(output_tensor)
 
-    if use_welford:
-        pcc_threshold = 0.99975
-        rtol = 0.14
-        atol = 0.085
-        frobenius_threshold = 0.02
-    else:
-        pcc_threshold = 0.9999
-        rtol = 0.065
-        atol = 0.065
-        frobenius_threshold = 0.015
     assert_numeric_metrics(
         torch_output_tensor,
         output_tensor,
-        pcc_threshold=pcc_threshold,
-        rtol=rtol,
-        atol=atol,
-        frobenius_threshold=frobenius_threshold,
+        pcc_threshold=0.9999,
+        rtol=0.05,
+        atol=0.065,
+        frobenius_threshold=0.015,
     )
 
 

--- a/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_group_norm.py
@@ -323,6 +323,117 @@ def test_group_norm_with_block_sharded_v2_8x4_grid(device, N, C, H, W, num_group
 
 
 @pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
+@pytest.mark.parametrize("N, C, H, W, num_groups", [(1, 1280, 16, 16, 32)])
+@pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
+@pytest.mark.parametrize(
+    "core_grid, grid_offset, orientation",
+    [
+        ((4, 4), ttnn.CoreCoord(2, 0), ttnn.ShardOrientation.COL_MAJOR),
+        ((4, 4), ttnn.CoreCoord(0, 2), ttnn.ShardOrientation.COL_MAJOR),
+        ((4, 4), ttnn.CoreCoord(2, 0), ttnn.ShardOrientation.ROW_MAJOR),
+        ((4, 4), ttnn.CoreCoord(0, 2), ttnn.ShardOrientation.ROW_MAJOR),
+    ],
+)
+def test_group_norm_with_offset_shard_grid(
+    device, N, C, H, W, num_groups, use_welford, core_grid, grid_offset, orientation
+):
+    """Sharded groupnorm must work when the shard grid does not start at core (0, 0), for both orientations."""
+    torch.manual_seed(0)
+
+    grid_size = ttnn.CoreGrid(y=core_grid[1], x=core_grid[0])
+
+    # For BLOCK sharding the channel dim C is split across grid.y for COL_MAJOR and across
+    # grid.x for ROW_MAJOR; the input mask / gamma / beta are laid out per that core count.
+    col_major = orientation == ttnn.ShardOrientation.COL_MAJOR
+    channel_cores = grid_size.y if col_major else grid_size.x
+
+    torch_input_tensor = torch.rand((N, C, H, W), dtype=torch.bfloat16)
+    torch_weight = torch.rand((C,), dtype=torch.bfloat16)
+    torch_bias = torch.rand((C,), dtype=torch.bfloat16)
+    torch_output_tensor = torch.nn.functional.group_norm(
+        torch_input_tensor, num_groups, weight=torch_weight, bias=torch_bias
+    )
+    torch_output_tensor = torch_output_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+
+    input_tensor = torch_input_tensor.permute(0, 2, 3, 1).view(N, 1, W * H, C)
+    input_tensor = ttnn.from_torch(
+        input_tensor,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+
+    input_mask_tensor = ttnn.create_group_norm_input_mask(C, num_groups, channel_cores, ttnn.DataType.BFLOAT8_B)
+    input_mask_tensor = ttnn.to_device(input_mask_tensor, device)
+
+    gamma = ttnn.create_group_norm_weight_bias_rm(torch_weight, C, channel_cores)
+    beta = ttnn.create_group_norm_weight_bias_rm(torch_bias, C, channel_cores)
+
+    gamma_t = ttnn.from_torch(
+        gamma,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    beta_t = ttnn.from_torch(
+        beta,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    shard_end = ttnn.CoreCoord(core_grid[0] + grid_offset.x - 1, core_grid[1] + grid_offset.y - 1)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(grid_offset, shard_end)})
+    # COL_MAJOR splits height across grid.x and C across grid.y; ROW_MAJOR is transposed.
+    if col_major:
+        shard_shape = N * H * W // grid_size.x, C // grid_size.y
+    else:
+        shard_shape = N * H * W // grid_size.y, C // grid_size.x
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, orientation)
+    sharded_mem_config = ttnn.MemoryConfig(
+        ttnn.types.TensorMemoryLayout.BLOCK_SHARDED, ttnn.types.BufferType.L1, shard_spec
+    )
+    input_tensor = ttnn.to_memory_config(input_tensor, sharded_mem_config)
+
+    output_tensor = ttnn.group_norm(
+        input_tensor,
+        num_groups=num_groups,
+        input_mask=input_mask_tensor,
+        weight=gamma_t,
+        bias=beta_t,
+        memory_config=sharded_mem_config,
+        core_grid=grid_size,
+        use_welford=use_welford,
+    )
+
+    output_tensor = ttnn.to_memory_config(output_tensor, ttnn.L1_MEMORY_CONFIG)
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    if use_welford:
+        pcc_threshold = 0.99975
+        rtol = 0.14
+        atol = 0.085
+        frobenius_threshold = 0.02
+    else:
+        pcc_threshold = 0.9999
+        rtol = 0.065
+        atol = 0.065
+        frobenius_threshold = 0.015
+    assert_numeric_metrics(
+        torch_output_tensor,
+        output_tensor,
+        pcc_threshold=pcc_threshold,
+        rtol=rtol,
+        atol=atol,
+        frobenius_threshold=frobenius_threshold,
+    )
+
+
+@pytest.mark.parametrize("device_params", DEVICE_PARAMS_L1_SMALL_SIZE, indirect=True)
 @pytest.mark.parametrize("N, C, H, W, num_groups", BLOCK_SHARDED_V2_8X8_SHAPES)
 @pytest.mark.parametrize("use_welford", welford_flavors, ids=welford_ids)
 @pytest.mark.parametrize("specify_grid", [True])

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_device_operation.cpp
@@ -68,6 +68,19 @@ void GroupNormDeviceOperation::validate_on_program_cache_miss(
         tile_height);
 
     if (a.is_sharded()) {
+        const auto& shard_spec = a.shard_spec().value();
+        const auto bbox = shard_spec.grid.bounding_box();
+        const auto bbox_grid = ttnn::operations::normalization::core_grid_from_shard_bounding_box(bbox);
+        const uint32_t bbox_num_cores = bbox_grid.x * bbox_grid.y;
+        TT_FATAL(
+            shard_spec.grid.num_cores() == bbox_num_cores,
+            "Sharded groupnorm does not support non-rectangular core grids. "
+            "The shard spec grid has {} cores but its bounding box spans {} cores ({} x {}).",
+            shard_spec.grid.num_cores(),
+            bbox_num_cores,
+            bbox_grid.x,
+            bbox_grid.y);
+
         const auto program_grid =
             std::visit([](const auto& config) { return config.compute_with_storage_grid_size; }, args.program_config);
         ttnn::operations::normalization::detail::validate_sharded_input(

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -111,7 +111,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     uint32_t num_datum_row_per_group_mod_tile_w =
         num_datum_row_per_group % tile_width == 0 ? tile_width : num_datum_row_per_group % tile_width;
     uint32_t group_size = W / num_groups;
-    auto all_cores = a.shard_spec().value().grid;
+    auto all_cores = a.shard_spec().value().grid.merge_ranges();
+    TT_FATAL(all_cores.ranges().size() == 1, "sharded groupnorm requires a rectangular shard grid");
     uint32_t num_cores = all_cores.num_cores();
     auto shard_orientation = a.shard_spec().value().orientation;
     const auto shard_bbox = all_cores.bounding_box();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/groupnorm_sharded_program_factory.cpp
@@ -111,12 +111,20 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
     uint32_t num_datum_row_per_group_mod_tile_w =
         num_datum_row_per_group % tile_width == 0 ? tile_width : num_datum_row_per_group % tile_width;
     uint32_t group_size = W / num_groups;
-    // grid
-    uint32_t num_cores_c = grid_size.x;
-    uint32_t num_cores_r = grid_size.y;
     auto all_cores = a.shard_spec().value().grid;
     uint32_t num_cores = all_cores.num_cores();
     auto shard_orientation = a.shard_spec().value().orientation;
+    const auto shard_bbox = all_cores.bounding_box();
+    // grid
+    uint32_t num_cores_c = shard_bbox.end_coord.x - shard_bbox.start_coord.x + 1;
+    uint32_t num_cores_r = shard_bbox.end_coord.y - shard_bbox.start_coord.y + 1;
+    TT_FATAL(
+        grid_size.x == num_cores_c && grid_size.y == num_cores_r,
+        "program_config compute_with_storage_grid_size ({}x{}) must match shard grid dimensions ({}x{})",
+        grid_size.x,
+        grid_size.y,
+        num_cores_c,
+        num_cores_r);
     // split each batch into multiple cores
     uint32_t num_shards_r = H / per_core_M;
     uint32_t num_cores_per_batch = num_batches > num_shards_r ? 1 : num_shards_r / num_batches;
@@ -358,7 +366,7 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
 
     // create a vector of cores, in either RM or CM
     std::vector<CoreCoord> core_coords =
-        grid_to_cores(num_cores, num_cores_c, num_cores_r, shard_orientation == ShardOrientation::ROW_MAJOR);
+        corerange_to_cores(all_cores, num_cores, shard_orientation == ShardOrientation::ROW_MAJOR);
     for ([[maybe_unused]] const auto& core_coord : core_coords) {
         log_debug(tt::LogOp, "worker coord: {} {}", core_coord.x, core_coord.y);
     }
@@ -369,7 +377,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
                 std::vector<CoreCoord> temp;
                 temp.reserve(num_cores_per_group);
                 for (uint32_t k = 0; k < num_cores_per_group; ++k) {
-                    temp.push_back(CoreCoord{(std::size_t)(k + (i * num_cores_per_group)), (std::size_t)j});
+                    const uint32_t idx = j * num_cores_c + i * num_cores_per_group + k;
+                    temp.push_back(core_coords[idx]);
                 }
                 core_coords2D.push_back(temp);
             }
@@ -380,7 +389,8 @@ tt::tt_metal::ProgramDescriptor GroupNormDeviceOperation::GroupNormShardedProgra
                 std::vector<CoreCoord> temp;
                 temp.reserve(num_cores_per_group);
                 for (uint32_t k = 0; k < num_cores_per_group; ++k) {
-                    temp.push_back(CoreCoord{(std::size_t)j, (std::size_t)(k + (i * num_cores_per_group))});
+                    const uint32_t idx = j * num_cores_r + k + i * num_cores_per_group;
+                    temp.push_back(core_coords[idx]);
                 }
                 core_coords2D.push_back(temp);
             }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm.cpp
@@ -266,14 +266,14 @@ Tensor group_norm(
             // rather than recomputing from scratch, so that program_config's
             // grid_size matches the cores where kernels are actually placed.
             const auto bbox = shard_spec_opt->grid.bounding_box();
-            core_grid = ttnn::CoreGrid(bbox.end_coord.x + 1, bbox.end_coord.y + 1);
+            core_grid = ttnn::operations::normalization::core_grid_from_shard_bounding_box(bbox);
         } else if (reciprocals.has_value() && reciprocals->is_sharded()) {
             // The reciprocals LUT is sharded on a specific grid; its length
             // encodes num_virtual_rows which must match the compute grid.
             // Infer the grid from the reciprocals tensor so the kernel sees a
             // consistent LUT.
             const auto bbox = reciprocals->shard_spec()->grid.bounding_box();
-            core_grid = ttnn::CoreGrid(bbox.end_coord.x + 1, bbox.end_coord.y + 1);
+            core_grid = ttnn::operations::normalization::core_grid_from_shard_bounding_box(bbox);
         } else {
             const auto dev_grid = input_tensor.device()->compute_with_storage_grid_size();
             auto dram_grid = ttnn::operations::normalization::find_expected_dram_grid(
@@ -323,16 +323,15 @@ Tensor group_norm(
         // Precondition above guarantees is_sharded() and shard_spec().has_value()
         // whenever reciprocals is provided.
         const auto recip_bbox = reciprocals->shard_spec()->grid.bounding_box();
-        const uint32_t recip_x = recip_bbox.end_coord.x + 1;
-        const uint32_t recip_y = recip_bbox.end_coord.y + 1;
+        const auto recip_grid = ttnn::operations::normalization::core_grid_from_shard_bounding_box(recip_bbox);
         TT_FATAL(
-            recip_x == core_grid->x && recip_y == core_grid->y,
+            recip_grid.x == core_grid->x && recip_grid.y == core_grid->y,
             "group_norm: reciprocals shard grid (x={}, y={}) must match the compute core_grid "
             "(x={}, y={}). The reciprocals LUT length and per-bank addresses are baked for a "
             "specific grid; running the kernel on a different grid will read past the LUT or "
             "use unallocated banks.",
-            recip_x,
-            recip_y,
+            recip_grid.x,
+            recip_grid.y,
             core_grid->x,
             core_grid->y);
     }

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.cpp
@@ -13,6 +13,12 @@
 
 namespace ttnn::operations::normalization {
 
+ttnn::CoreGrid core_grid_from_shard_bounding_box(const tt::tt_metal::CoreRange& bbox) {
+    return ttnn::CoreGrid(
+        static_cast<uint32_t>(bbox.end_coord.x - bbox.start_coord.x + 1),
+        static_cast<uint32_t>(bbox.end_coord.y - bbox.start_coord.y + 1));
+}
+
 namespace {
 
 uint32_t find_closest_largest_divisor(uint32_t num, uint32_t start_divisor) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/groupnorm_grid_utils.hpp
@@ -13,6 +13,9 @@
 
 namespace ttnn::operations::normalization {
 
+// Returns the size (width x height) of a shard grid's bounding box as a CoreGrid.
+ttnn::CoreGrid core_grid_from_shard_bounding_box(const tt::tt_metal::CoreRange& bbox);
+
 struct GroupNormShardedConfigAndGridSize {
     ttnn::MemoryConfig memory_config;
     ttnn::CoreGrid core_grid;


### PR DESCRIPTION
### PR Category

Bug fix

### Summary

- Fixes #43197

Sharded GroupNorm assumed the shard grid always started at core (0,0).

When a tensor was sharded on an offset grid - e.g. a `4x4` block placed at core `(2,0)` instead of the origin - the op computed grid dimensions, kernel placement, and multicast routing for the wrong set of cores. The result was incorrect output or reads/writes to unallocated banks.

Two root causes, both fixed:

1. **Grid size from `end_coord + 1`**: This only equals the true grid width/height when the grid starts at `(0,0)`; for an offset grid it folds the offset into the size (a `4x4` grid at `(2,0)` reported `6x4`). Replaced with a `core_grid_from_shard_bounding_box` helper that uses the actual span `end - start + 1`, reused across all inference and validation sites in `groupnorm.cpp`.

2. **Coordinates synthesized from scratch**: The sharded program factory built core coords via `grid_to_cores()`, which always emits (0,0)-rooted coordinates. It now walks the tensor's actual `CoreRangeSet` via `corerange_to_cores()` and indexes into it (offset-aware) when building the batch/group multicast layout, for both `ROW_MAJOR` and `COL_MAJOR` orientations.

Also added two guards:

* reject non-rectangular shard grids
* assert the program-config grid matches the shard bounding-box dimensions

### Notes for reviewers
Core change is in `groupnorm_sharded_program_factory.cpp` - it now uses the shard tensor's actual core grid instead of assuming a `(0,0)` origin. Behaviour is unchanged for grids starting at (0,0); the new offset test `test_group_norm_with_offset_shard_grid` covers both orientations.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/sudha-grid-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/sudha-grid-groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/sudha-grid-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/sudha-grid-groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/sudha-grid-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/sudha-grid-groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/sudha-grid-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/sudha-grid-groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/sudha-grid-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/sudha-grid-groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/sudha-grid-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/sudha-grid-groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/sudha-grid-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/sudha-grid-groupnorm)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/sudha-grid-groupnorm)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/sudha-grid-groupnorm)