### PR TITLE
#32019: Enable native path for RM width/block-sharded permute

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_permute.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_permute.py
@@ -662,6 +662,21 @@ def test_permute_tile_sharded_uneven(shape, dims, mc_factory, device):
             id="WH_RM_interleaved_to_block",
         ),
         pytest.param(
+            (1, 1, 32, 128),
+            (0, 1, 3, 2),
+            lambda _d: L1_INTERLEAVED,
+            lambda d: _width_shard_config((1, 1, 128, 32), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="WH_RM_interleaved_to_width",
+        ),
+        pytest.param(
+            # Irregular output: interleaved input + BLOCK-sharded output, exercises noc_async_write_sharded with a tile-padded spec.
+            (1, 1, 48, 65),
+            (0, 1, 3, 2),
+            lambda _d: L1_INTERLEAVED,
+            lambda d: _block_shard_config((1, 1, 65, 48), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="WH_RM_interleaved_irregular_to_block",
+        ),
+        pytest.param(
             (1, 1, 64, 64),
             (0, 1, 3, 2),
             lambda d: _block_shard_config((1, 1, 64, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 #include <algorithm>
 #include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
@@ -113,13 +114,8 @@ void kernel_main() {
         // Read along the X dimension
         for (uint32_t x = x_start; x < x_end; ++x) {
             uint64_t addr_offset = base_addr_offset + x * X_stride;
-            CoreLocalMem<uint32_t> dst(src_buffer_l1_addr + page_offset);
-            noc.async_read(
-                s0,
-                dst,
-                w_read_size_bytes,
-                {.page_id = (uint32_t)addr_offset, .offset_bytes = w_offset},
-                {.offset_bytes = 0});
+            tt::data_movement::common::noc_async_read_sharded(
+                src_buffer_l1_addr + page_offset, s0, addr_offset, w_offset, w_read_size_bytes);
 
             // Advance output pointer by one page size for next row
             page_offset += input_cb_page_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_row_invariant.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
@@ -22,10 +23,10 @@ void kernel_main() {
     CircularBuffer cb(tt::CBIndex::c_0);
     Noc noc;
 
-    uint32_t curr_addr = src_addr;
     for (uint32_t row = start_row; row < end_row; ++row) {
         cb.reserve_back(1);
-        noc.async_read(s0, cb, page_size, {.page_id = row}, {.offset_bytes = 0});
+        uint32_t l1_write_addr = cb.get_write_ptr();
+        tt::data_movement::common::noc_async_read_sharded(l1_write_addr, s0, row, 0, page_size);
         noc.async_read_barrier();
         cb.push_back(1);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
@@ -154,17 +154,9 @@ void kernel_main() {
                 dest_linear_idx += dest_multi_idx[x_dim_in_dest] * dest_strides[x_dim_in_dest];
             }
 
-            // Compute the L1 address from which to write (offset by W-block pages)
             uint32_t l1_addr = transposed_buffer_read_addr + (w - w_start) * output_cb_page_size;
-
-            // Perform an asynchronous write of the X-block to the destination
-            CoreLocalMem<uint32_t> src(l1_addr);
-            noc.async_write(
-                src,
-                s0,
-                x_read_size_bytes,
-                {.offset_bytes = 0},
-                {.page_id = dest_linear_idx, .offset_bytes = x_offset});
+            tt::data_movement::common::noc_async_write_sharded(
+                l1_addr, s0, dest_linear_idx, x_offset, x_read_size_bytes);
         }
 
         // Wait until all writes are completed before proceeding to the next block

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
@@ -4,6 +4,7 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
@@ -54,7 +55,8 @@ void kernel_main() {
             dest_linear_idx += dest_multi_idx[i] * dest_strides[i];
         }
         cb.wait_front(1);
-        noc.async_write(cb, s0, page_size, {.offset_bytes = 0}, {.page_id = dest_linear_idx, .offset_bytes = 0});
+        uint32_t l1_read_addr = cb.get_read_ptr();
+        tt::data_movement::common::noc_async_write_sharded(l1_read_addr, s0, dest_linear_idx, 0, page_size);
         noc.async_write_barrier();
         cb.pop_front(1);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/permute.cpp
@@ -5,7 +5,6 @@
 #include "permute.hpp"
 
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
-#include "ttnn/operations/data_movement/transpose/device/transpose_utils.hpp"
 #include "ttnn/operations/data_movement/permute/device/permute_device_operation.hpp"
 
 #include <tt-metalium/hal.hpp>
@@ -26,15 +25,6 @@ inline bool is_rm_block_or_width_sharded(const ttnn::Tensor& t) {
            ml == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED;
 }
 
-inline bool is_block_or_width_sharded_mc(const std::optional<MemoryConfig>& mc) {
-    if (!mc.has_value() || !mc->is_sharded()) {
-        return false;
-    }
-    auto ml = mc->memory_layout();
-    return ml == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
-           ml == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED;
-}
-
 ttnn::Tensor permute_impl(
     const ttnn::Tensor& a,
     const ttnn::SmallVector<uint32_t>& dims,
@@ -42,27 +32,17 @@ ttnn::Tensor permute_impl(
     float pad_value = 0.0f) {
     uint32_t rank = a.logical_shape().rank();
 
-    // RM width/block sharded rows span multiple cores; unshard first, then
-    // permute on interleaved data and reshard if needed.
-    const bool in_bad = is_rm_block_or_width_sharded(a);
-    const bool out_bad = a.layout() == Layout::ROW_MAJOR && is_block_or_width_sharded_mc(output_mem_config);
-    if (in_bad || out_bad) {
+    // Irregular RM block/width sharded hits a pages_per_shard misread in noc_async_*_sharded.
+    // Input-side guard only; irregular output shapes are safe (writers emit full rows, compute_output_specs synthesises
+    // a valid spec).
+    const auto& input_logical = a.logical_shape();
+    const bool irregular_hw = input_logical.rank() >= 2 && (input_logical[-1] % tt::constants::TILE_WIDTH != 0 ||
+                                                            input_logical[-2] % tt::constants::TILE_HEIGHT != 0);
+    if (is_rm_block_or_width_sharded(a) && irregular_hw) {
         const auto interleaved_l1 =
             MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
-        auto x = in_bad ? ttnn::to_memory_config(a, interleaved_l1, std::nullopt) : a;
-        auto intermediate_mc = out_bad ? std::optional<MemoryConfig>(interleaved_l1) : output_mem_config;
-        // Safe: x is interleaved and intermediate_mc is interleaved, so re-entry skips this block.
-        auto result = permute_impl(x, dims, intermediate_mc, pad_value);
-        if (out_bad) {
-            MemoryConfig final_mc = output_mem_config.value();
-            if (!final_mc.shard_spec().has_value()) {
-                auto shard_spec =
-                    transpose::generate_transpose_shard_spec(result, result.padded_shape(), final_mc.memory_layout());
-                final_mc = final_mc.with_shard_spec(shard_spec);
-            }
-            result = ttnn::to_memory_config(result, final_mc, std::nullopt);
-        }
-        return result;
+        auto x = ttnn::to_memory_config(a, interleaved_l1, std::nullopt);
+        return permute_impl(x, dims, output_mem_config, pad_value);
     }
 
     auto prim_permute = [&](const ttnn::Tensor& input) -> ttnn::Tensor {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/transpose.cpp
@@ -189,40 +189,18 @@ ttnn::Tensor transpose_impl(
     const std::optional<MemoryConfig>& memory_config_arg,
     float pad_value = 0.0f) {
     {
-        // Two temporary L1-interleaved hops for RM + BLOCK/WIDTH-sharded endpoints:
-        //   out_bad (interleaved → sharded): permute writer can't split a row across shards
-        //                                    (#32019). Remove once permute handles sharded RM
-        //                                    outputs.
-        //   in_bad  (sharded → anything, irregular only): noc_async_*_sharded helpers misread
-        //                                                 pages_per_shard for irregular RM
-        //                                                 geometries → data corruption. Regular
-        //                                                 shapes go native. Remove once the
-        //                                                 sharded helpers handle irregular RM.
+        // Irregular RM block/width sharded hits a pages_per_shard misread in noc_async_*_sharded.
+        // Unshard until the kernel-side helpers handle irregular RM geometries.
         const bool rm = input_tensor.layout() == Layout::ROW_MAJOR;
         const bool in_sharded = detail::is_block_or_width_sharded_mc(input_tensor.memory_config());
         const auto& input_logical = input_tensor.logical_shape();
         const bool irregular_hw = input_logical.rank() >= 2 && (input_logical[-1] % tt::constants::TILE_WIDTH != 0 ||
                                                                 input_logical[-2] % tt::constants::TILE_HEIGHT != 0);
-        const bool in_bad = rm && in_sharded && irregular_hw;
-        const bool out_bad = rm && !in_sharded && memory_config_arg.has_value() &&
-                             detail::is_block_or_width_sharded_mc(memory_config_arg.value());
-        if (in_bad || out_bad) {
+        if (rm && in_sharded && irregular_hw) {
             const auto interleaved_l1 =
                 tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
-            Tensor x = in_bad ? ttnn::to_memory_config(input_tensor, interleaved_l1, std::nullopt) : input_tensor;
-            const std::optional<MemoryConfig> intermediate_mc =
-                out_bad ? std::optional<MemoryConfig>(interleaved_l1) : memory_config_arg;
-            Tensor result = transpose_impl(x, dim1, dim2, intermediate_mc, pad_value);
-            if (out_bad) {
-                MemoryConfig final_mc = memory_config_arg.value();
-                if (!final_mc.shard_spec().has_value()) {
-                    auto shard_spec = operations::data_movement::transpose::generate_transpose_shard_spec(
-                        result, result.padded_shape(), final_mc.memory_layout());
-                    final_mc = final_mc.with_shard_spec(shard_spec);
-                }
-                result = ttnn::to_memory_config(result, final_mc, std::nullopt);
-            }
-            return result;
+            Tensor x = ttnn::to_memory_config(input_tensor, interleaved_l1, std::nullopt);
+            return transpose_impl(x, dim1, dim2, memory_config_arg, pad_value);
         }
     }
     const auto& input_shape = input_tensor.logical_shape();


### PR DESCRIPTION
### Ticket
Link to GitHub Issue #32019

### Problem
`ttnn::prim::permute` lacked native support for **RM + BLOCK/WIDTH-sharded I/O**. Two data-movement gaps existed:

1. **Sharded reader gap**: the four RM dataflow kernels (`reader_permute_interleaved_rm_blocked_generic`, `writer_permute_interleaved_rm_blocked_generic`, `reader_permute_interleaved_rm_row_invariant`, `writer_permute_interleaved_rm_row_invariant`) were ported to the device-2.0 API in PR #42130 but the calls to `noc_async_*_sharded` were dropped at that time. All RM block/width-sharded data movement fell back to the slower non-sharded path.

2. **Host-side `out_bad` fallback in `permute.cpp` and `transpose.cpp`**: PR #44726 (transpose FP32 fix) introduced a composite guard that routed `interleaved RM input → BLOCK/WIDTH-sharded RM output` through a temporary L1-interleaved hop because the permute writer could not split a logical row across shards. PR #44726 tagged this with "Remove once `ttnn::prim::permute` supports universal I/O".

Both gaps are closed by this PR.

### What this PR does

- **Restore `noc_async_read_sharded` / `noc_async_write_sharded` in all 4 RM permute kernels.** Cherry-picks the data-movement helper calls back into the blocked-generic and row-invariant reader/writer kernels, re-enabling native BLOCK/WIDTH-sharded I/O for all RM permute paths.
- **Remove `out_bad` from `permute.cpp`.** The composite L1-interleaved hop for `interleaved RM → BLOCK/WIDTH-sharded RM output` is no longer needed; the restored writers handle it natively.
- **Remove `out_bad` from `transpose.cpp`.** The same fallback guard existed in transpose (waiting for permute to catch up). With permute's writers fixed it is removed here too, closing the last composite hop tagged by PR #44726.
- **Narrow `in_bad` in both `permute.cpp` and `transpose.cpp`.** The remaining L1-interleaved hop covers only `irregular_hw` inputs (last two logical dims not tile-aligned) where `noc_async_*_sharded` misreads `pages_per_shard`. Regular BLOCK/WIDTH-sharded RM shapes now flow fully native.
- **Add `WH_RM_interleaved_to_width` test case.** Closes the one gap vs the transpose universal-IO test matrix (which already covered both `WH_RM_interleaved_to_block` and `WH_RM_interleaved_to_width`).

### Routing summary (RM only — TILE inputs always go native)

| Input | Output | Shape | Path |
|-------|--------|-------|------|
| interleaved | interleaved / HEIGHT-sharded | any | native |
| interleaved | BLOCK / WIDTH-sharded | any | **native** (was `out_bad` fallback, fixed here) |
| HEIGHT-sharded | any | any | native |
| BLOCK / WIDTH-sharded | any | **regular** (last-2 dims tile-aligned) | **native** |
| BLOCK / WIDTH-sharded | any | **irregular** (last-2 dims not tile-aligned) | fallback (`in_bad`, `pages_per_shard` misread — kernel-side follow-up) |

### Performance

Measured on WH N150 (50 iterations, wall-clock, `ttnn.synchronize_device` after batch):

| Shape | Shard type | Perm | Native | Composite (old) | Speedup |
|-------|-----------|------|--------|-----------------|---------|
| 2×4×32×64 | block | (0,1,3,2) | 48 µs | 82 µs | **1.70x** |
| 4×4×64×128 | block | (0,1,3,2) | 46 µs | 82 µs | **1.78x** |
| 2×4×32×64 | block | (2,0,1,3) | 40 µs | 79 µs | **1.95x** |
| 2×4×32×128 | width | (2,0,1,3) | 43 µs | 79 µs | **1.81x** |
| 1×8×64×256 | block | (0,1,3,2) | 47 µs | 79 µs | **1.66x** |

Composite = `to_memory_config(input, L1_INTERLEAVED)` + `permute`. Native path eliminates the extra DMA hop, giving ~1.7–2× speedup for typical model tensor sizes.

### Tests

All on Wormhole B0 (local clean build, N150):

- `test_permute_row_major_sharded` (9 cases × 2 dtypes = 18) — **18/18 PASS** including:
  - `WH_RM_block_to_interleaved`, `WH_RM_width_to_interleaved` (native read path)
  - `WH_RM_interleaved_to_block`, `WH_RM_interleaved_to_width` (native write path, was `out_bad`)
  - `WH_RM_block_to_block` (read + write sharded)
  - `2013_RM_block_to_interleaved`, `2013_RM_width_to_interleaved` (non-WH perm, native read)
- `test_permute_irregular_shapes_sharded` — **passes** (irregular RM block/width routes via `in_bad` fallback; correct output, expected path)
- `test_permute_universal_io` (79 cases) — **79/79 PASS**
- Full expanded suite (182 cases, local only) — **166 passed / 16 skipped** (all skips are pre-existing limitations: `bfloat8_b` + HC sharded, `float32` L1 overflow on large full-reverse)

### Notes for Reviewers

- The one remaining `in_bad` guard (irregular RM block/width sharded input) is tracked as a kernel-team follow-up. The `noc_async_*_sharded` helpers misread `pages_per_shard` when `logical[-1] % TILE_WIDTH != 0 || logical[-2] % TILE_HEIGHT != 0` — every irregular case in `test_permute_irregular_shapes_sharded` hits this; every regular RM block/width case skips it and goes native.
- `transpose.cpp` `out_bad` removal is safe: the transpose op delegates RM permute to `ttnn::prim::permute`, so the permute writer fix automatically covers transpose's sharded-output paths. Verified by `test_transpose_universal_io_row_major[WH_RM_interleaved_to_block]` and `[WH_RM_interleaved_to_width]`.
- Related: PR #44726 (transpose FP32 fix, already merged) which introduced `common.hpp` `noc_async_*_sharded` fixes and tagged the permute gaps with `TODO(#32019)`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/permute_native_path)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/permute_native_path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/permute_native_path)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/permute_native_path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mouliraj/permute_native_path)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mouliraj/permute_native_path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/permute_native_path)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/permute_native_path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/permute_native_path)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/permute_native_path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/permute_native_path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/permute_native_path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/permute_native_path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/permute_native_path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/permute_native_path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/permute_native_path)