### PR TITLE
[Feature] Allow separate location of cached KV cache tensors

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -494,6 +494,7 @@ jobs:
           export HF_MODEL="${{ matrix.test-group.model }}"
           MODEL_NAME="${HF_MODEL/\//--}"
           export TT_CACHE_PATH="$TT_CACHE_HOME/$MODEL_NAME"
+          export TT_KV_CACHE_PATH="$TT_CACHE_PATH"
 
           # vLLM environment variables
           export VLLM_RPC_TIMEOUT=300000

--- a/models/demos/gemma4/tt/attention/kv_cache.py
+++ b/models/demos/gemma4/tt/attention/kv_cache.py
@@ -12,6 +12,7 @@ import torch
 
 import ttnn
 from models.demos.gemma4.utils.general_utils import get_cache_file_name
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 
 
 def init_kv_cache(
@@ -74,6 +75,7 @@ def init_kv_cache(
         ]
 
     mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device) if is_mesh else None
+    kv_cache_path = get_tt_kv_cache_path(tensor_cache_path)
 
     k_cache = ttnn.as_tensor(
         torch.zeros(cache_shape),
@@ -81,7 +83,7 @@ def init_kv_cache(
         layout=ttnn.TILE_LAYOUT,
         dtype=cache_dtype,
         mesh_mapper=mesh_mapper,
-        cache_file_name=get_cache_file_name(tensor_cache_path, f"k_cache_{cache_shape}"),
+        cache_file_name=get_cache_file_name(kv_cache_path, f"k_cache_{cache_shape}"),
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
@@ -91,7 +93,7 @@ def init_kv_cache(
         layout=ttnn.TILE_LAYOUT,
         dtype=cache_dtype,
         mesh_mapper=mesh_mapper,
-        cache_file_name=get_cache_file_name(tensor_cache_path, f"v_cache_{cache_shape}"),
+        cache_file_name=get_cache_file_name(kv_cache_path, f"v_cache_{cache_shape}"),
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 

--- a/models/demos/gpt_oss/tt/attention/kv_cache.py
+++ b/models/demos/gpt_oss/tt/attention/kv_cache.py
@@ -7,6 +7,7 @@ import ttnn
 from models.common.utility_functions import nearest_y
 from models.demos.gpt_oss.config import MeshConfig
 from models.demos.gpt_oss.utils.general_utils import get_cache_file_name
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 
 from .config import AttentionConfig
 
@@ -58,13 +59,14 @@ def init_kv_cache(
         if config.users_row_sharded
         else ttnn.ReplicateTensorToMesh(mesh_device)
     )
+    kv_cache_path = get_tt_kv_cache_path(tensor_cache_path)
     k_cache = ttnn.as_tensor(
         torch.zeros(cache_shape),
         device=mesh_device,
         layout=ttnn.TILE_LAYOUT,
         dtype=cache_dtype,
         mesh_mapper=mesh_mapper,
-        cache_file_name=get_cache_file_name(tensor_cache_path, f"k_cache_{cache_shape}"),
+        cache_file_name=get_cache_file_name(kv_cache_path, f"k_cache_{cache_shape}"),
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 
@@ -75,7 +77,7 @@ def init_kv_cache(
         layout=ttnn.TILE_LAYOUT,
         dtype=cache_dtype,
         mesh_mapper=mesh_mapper,
-        cache_file_name=get_cache_file_name(tensor_cache_path, f"v_cache_{cache_shape}"),
+        cache_file_name=get_cache_file_name(kv_cache_path, f"v_cache_{cache_shape}"),
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
 

--- a/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
+++ b/models/demos/llama3_70b_galaxy/tt/generator_vllm.py
@@ -9,10 +9,12 @@ from models.demos.llama3_70b_galaxy.tt.generator import Generator
 from models.demos.llama3_70b_galaxy.tt.llama_model import TtTransformer
 from models.demos.llama3_70b_galaxy.tt.model_config import LlamaOptimizations, TtModelArgs
 from models.demos.llama3_70b_galaxy.tt.qwen_model_config import TtQwenModelArgs
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 from models.tt_transformers.tt.generator import create_submeshes
 
 
 def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, model: TtTransformer, tt_cache_path):
+    tt_cache_path = get_tt_kv_cache_path(tt_cache_path)
     submesh_devices = [model.mesh_device]
     kv_cache = []
 

--- a/models/demos/llama3_70b_galaxy/tt/llama_attention.py
+++ b/models/demos/llama3_70b_galaxy/tt/llama_attention.py
@@ -6,6 +6,7 @@ import torch
 import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.rmsnorm import RMSNorm
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 
 
 class TtLlamaAttention(LightweightModule):
@@ -336,6 +337,9 @@ class TtLlamaAttention(LightweightModule):
         """
         Generates empty KV cache and pushed to device memory
         """
+        kv_cache_path = (
+            get_tt_kv_cache_path(weight_cache_path) if weight_cache_path and not configuration.dummy_weights else None
+        )
 
         if self.paged_attention_config:
             cache_k = torch.zeros(
@@ -380,9 +384,7 @@ class TtLlamaAttention(LightweightModule):
                 device=self.mesh_device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
-                cache_file_name=f"{weight_cache_path}/kvcache_{k_or_v.shape}"
-                if weight_cache_path and not configuration.dummy_weights
-                else None,
+                cache_file_name=kv_cache_path / f"kvcache_{k_or_v.shape}" if kv_cache_path else None,
             )
             for k_or_v in [cache_k, cache_v]
         ]

--- a/models/demos/qwen25_vl/tt/generator_vllm.py
+++ b/models/demos/qwen25_vl/tt/generator_vllm.py
@@ -25,10 +25,12 @@ from models.demos.qwen25_vl.tt.common import merge_vision_tokens, multimodal_rop
 from models.demos.qwen25_vl.tt.generator import Generator as QwenVLGenerator
 from models.demos.qwen25_vl.tt.model import DropInVisionTransformer, Transformer
 from models.demos.qwen25_vl.tt.model_config import VisionModelArgs
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs
 
 
 def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, model: Transformer, model_args: ModelArgs, tt_cache_path):
+    tt_cache_path = get_tt_kv_cache_path(tt_cache_path)
     for layer_idx in range(num_layers):
         cache_kv = torch.zeros(kv_cache_shape, dtype=dtype)
 

--- a/models/demos/qwen3_vl/tt/attention.py
+++ b/models/demos/qwen3_vl/tt/attention.py
@@ -10,6 +10,7 @@ from loguru import logger
 import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.tt_transformers.tt.ccl import tt_all_gather, tt_all_reduce
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 
 # Potential warning that we don't want to show for every layer and token
 global_padded_head_warning_shown = False
@@ -305,6 +306,9 @@ class Attention(LightweightModule):
         """
         Generates empty KV cache and pushed to device memory
         """
+        kv_cache_path = (
+            get_tt_kv_cache_path(weight_cache_path) if weight_cache_path and not configuration.dummy_weights else None
+        )
 
         if self.paged_attention_config:
             cache_k = torch.zeros(
@@ -349,11 +353,7 @@ class Attention(LightweightModule):
                 device=self.mesh_device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
-                cache_file_name=(
-                    f"{weight_cache_path}/kvcache_{k_or_v.shape}"
-                    if weight_cache_path and not configuration.dummy_weights
-                    else None
-                ),
+                cache_file_name=kv_cache_path / f"kvcache_{k_or_v.shape}" if kv_cache_path else None,
             )
             for k_or_v in [cache_k, cache_v]
         ]

--- a/models/demos/qwen3_vl/tt/generator_vllm.py
+++ b/models/demos/qwen3_vl/tt/generator_vllm.py
@@ -29,10 +29,12 @@ from models.demos.qwen3_vl.tt.common import (
 from models.demos.qwen3_vl.tt.generator import Generator as QwenVLGenerator
 from models.demos.qwen3_vl.tt.model import DropInVisionTransformer, Transformer
 from models.demos.qwen3_vl.tt.model_config import VisionModelArgs
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs
 
 
 def allocate_vllm_kv_cache(kv_cache_shape, dtype, num_layers, model: Transformer, model_args: ModelArgs, tt_cache_path):
+    tt_cache_path = get_tt_kv_cache_path(tt_cache_path)
     for layer_idx in range(num_layers):
         cache_kv = torch.zeros(kv_cache_shape, dtype=dtype)
 

--- a/models/demos/t3000/falcon40b/tt/falcon_attention.py
+++ b/models/demos/t3000/falcon40b/tt/falcon_attention.py
@@ -10,6 +10,7 @@ import torch
 import ttnn
 from models.common.utility_functions import nearest_32
 from models.demos.t3000.falcon40b.tt.model_utils import determine_tensor_deallocation, falcon_prefill_matmul
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 from ttnn import ReplicateTensorToMesh, ShardTensorToMesh
 
 
@@ -207,7 +208,7 @@ class TtFalconAttention:
                 self.max_position_embeddings,
                 self.head_dim,
             )
-            kv_cache_path = self.tt_cache_path / f"empty_attn_cache{attn_cache_shape}"
+            kv_cache_path = get_tt_kv_cache_path(self.tt_cache_path) / (f"empty_attn_cache{attn_cache_shape}")
             k_cache = []
             v_cache = []
 

--- a/models/demos/t3000/llama2_70b/tt/generator_vllm.py
+++ b/models/demos/t3000/llama2_70b/tt/generator_vllm.py
@@ -13,6 +13,7 @@ import ttnn
 from models.demos.t3000.llama2_70b.reference.llama.llama.model import ModelArgs as ReferenceModelArgs
 from models.demos.t3000.llama2_70b.tt.llama_common import check_mesh_device, load_llama_state_dict, setup_llama_env
 from models.demos.t3000.llama2_70b.tt.llama_generation import TtLlamaModelForGeneration
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 
 
 class TtLlamaForCausalLM(TtLlamaModelForGeneration):
@@ -72,6 +73,7 @@ class TtLlamaForCausalLM(TtLlamaModelForGeneration):
         return super().prefill_forward(tokens, 0, page_table, kv_cache, prompt_lens)
 
     def allocate_kv_cache(self, kv_cache_shape, dtype, num_layers):
+        kv_cache_path = get_tt_kv_cache_path(self.cache_path)
         cache_kv = torch.zeros(kv_cache_shape, dtype=dtype)
         kv_tt = []
         for _ in tqdm(range(num_layers), desc=f"Allocating TT kv caches for each layer"):
@@ -85,7 +87,7 @@ class TtLlamaForCausalLM(TtLlamaModelForGeneration):
                     layout=ttnn.TILE_LAYOUT,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                     dtype=ttnn.bfloat8_b,
-                    cache_file_name=self.cache_path / f"empty_cache_paged_attention{kv_cache_shape}",
+                    cache_file_name=kv_cache_path / f"empty_cache_paged_attention{kv_cache_shape}",
                 )
                 for lp in (cache_kv, cache_kv)
             ]

--- a/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
+++ b/models/demos/t3000/llama2_70b/tt/llama_attention_optimized.py
@@ -8,6 +8,7 @@ import torch
 
 import ttnn
 from models.demos.t3000.falcon40b.tt.model_utils import matmul_2d_config_from_tensor_shapes
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 from ttnn import ShardTensorToMesh
 
 
@@ -70,6 +71,7 @@ class TtLlamaAttention_optimized:
         """
         Generates empty KV cache and pushed to device memory
         """
+        kv_cache_path = get_tt_kv_cache_path(self.cache_path)
 
         if self.paged_attention_config:
             cache_k = torch.zeros(
@@ -115,7 +117,7 @@ class TtLlamaAttention_optimized:
                     layout=ttnn.TILE_LAYOUT,
                     memory_config=ttnn.DRAM_MEMORY_CONFIG,
                     dtype=self.kv_dtype,
-                    cache_file_name=self.cache_path / f"empty_attn_cache{cache_k.shape}",
+                    cache_file_name=kv_cache_path / f"empty_attn_cache{cache_k.shape}",
                 ),
                 self.mesh_device,
             )

--- a/models/experimental/grok/tt/grok_attention.py
+++ b/models/experimental/grok/tt/grok_attention.py
@@ -5,8 +5,9 @@
 import torch
 import ttnn
 from models.common.utility_functions import nearest_32
-from ttnn import ShardTensorToMesh, ReplicateTensorToMesh
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 from models.experimental.grok.tt.grok_common import LightweightModule
+from ttnn import ShardTensorToMesh, ReplicateTensorToMesh
 
 
 class TtGrokAttention(LightweightModule):
@@ -115,6 +116,11 @@ class TtGrokAttention(LightweightModule):
             )
         )
         layer_past = [cache_k, cache_v]
+        kv_cache_name = None
+        if not args.dummy_weights:
+            kv_cache_name = get_tt_kv_cache_path(self.model_args.weight_cache_path(dtype)) / (
+                f"{layer_name}.empty_attn_cache_{cache_k.shape}"
+            )
         self.layer_past = [
             ttnn.as_tensor(
                 lp,
@@ -123,7 +129,7 @@ class TtGrokAttention(LightweightModule):
                 dtype=ttnn.bfloat8_b,
                 layout=self.model_config["ATTN_W_LAYOUT_TILE"],
                 memory_config=self.model_config["ATTN_CACHE_WEIGHTS_MEMCFG"],
-                cache_file_name=cache_name(f"empty_attn_cache_{cache_k.shape}"),
+                cache_file_name=kv_cache_name,
             )
             for lp in layer_past
         ]

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -11,7 +11,7 @@ from models.common.lightweightmodule import LightweightModule
 from models.common.rmsnorm import RMSNorm
 from models.common.utility_functions import nearest_32
 from models.tt_transformers.tt.ccl import tt_all_gather, tt_all_reduce
-from models.tt_transformers.tt.common import Mode
+from models.tt_transformers.tt.common import Mode, get_tt_kv_cache_path
 from models.tt_transformers.tt.model_config import OpGroup, TensorGroup, num_to_corerange
 
 
@@ -383,6 +383,9 @@ class Attention(LightweightModule):
         """
         Generates empty KV cache and pushed to device memory
         """
+        kv_cache_path = (
+            get_tt_kv_cache_path(weight_cache_path) if weight_cache_path and not configuration.dummy_weights else None
+        )
 
         if self.paged_attention_config:
             cache_k = torch.zeros(
@@ -427,11 +430,7 @@ class Attention(LightweightModule):
                 device=self.mesh_device,
                 memory_config=ttnn.DRAM_MEMORY_CONFIG,
                 mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
-                cache_file_name=(
-                    f"{weight_cache_path}/kvcache_{k_or_v.shape}"
-                    if weight_cache_path and not configuration.dummy_weights
-                    else None
-                ),
+                cache_file_name=kv_cache_path / f"kvcache_{k_or_v.shape}" if kv_cache_path else None,
             )
             for k_or_v in [cache_k, cache_v]
         ]

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -6,6 +6,7 @@ import math
 import os
 import re
 from enum import Enum
+from pathlib import Path
 from types import SimpleNamespace
 from typing import List, Optional, Union
 
@@ -798,6 +799,16 @@ def get_hf_tt_cache_path(model_path: str) -> str:
         os.makedirs(tt_cache_path, exist_ok=True)
 
     return tt_cache_path
+
+
+def get_tt_kv_cache_path(default_cache_path: Optional[Union[str, Path]]) -> Optional[Path]:
+    """Return the disk cache root for generated KV cache tensors."""
+    kv_cache_path = os.getenv("TT_KV_CACHE_PATH")
+    if kv_cache_path:
+        return Path(kv_cache_path)
+    if default_cache_path is None:
+        return None
+    return Path(default_cache_path)
 
 
 def create_tt_model(

--- a/models/tt_transformers/tt/generator_sglang.py
+++ b/models/tt_transformers/tt/generator_sglang.py
@@ -10,6 +10,7 @@ from tqdm import tqdm
 
 import ttnn
 from models.common.utility_functions import is_wormhole_b0
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 from models.tt_transformers.tt.generator import Generator, create_submeshes
 from models.tt_transformers.tt.model import Transformer
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs, TensorGroup
@@ -17,6 +18,7 @@ from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs,
 
 def allocate_sglang_kv_cache(kv_cache_shape, dtype, num_layers, dp_model: List[Transformer], tt_cache_path):
     logger.warning("[TT-METAL-SGLANG-LOG] allocate_sglang_kv_cache called in generator")
+    tt_cache_path = get_tt_kv_cache_path(tt_cache_path)
     submesh_devices = [model.mesh_device for model in dp_model]
     kv_cache = []
     for mesh_idx, submesh in enumerate(submesh_devices):

--- a/models/tt_transformers/tt/generator_vllm.py
+++ b/models/tt_transformers/tt/generator_vllm.py
@@ -27,6 +27,7 @@ from vllm.multimodal.processing import BaseDummyInputsBuilder
 import ttnn
 from models.common.llama_models import create_vision_mask
 from models.common.utility_functions import is_wormhole_b0, nearest_32
+from models.tt_transformers.tt.common import get_tt_kv_cache_path
 from models.tt_transformers.tt.generator import Generator, create_submeshes
 from models.tt_transformers.tt.model import Transformer
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs, TensorGroup
@@ -46,13 +47,14 @@ def allocate_vllm_kv_cache_per_layer(per_layer_specs, dp_model: List[Transformer
             ``tensor_idx`` get their own buffer.
         dp_model: list of replicated TT model handles, one per data-parallel
             submesh.
-        tt_cache_path: path used for on-disk weight cache file naming.
+        tt_cache_path: default path used for on-disk KV cache file naming.
 
     Returns:
         ``list[submesh][layer_idx][k_or_v]`` of TT tensors. Multiple
         ``layer_idx`` entries may refer to the same underlying tensor
         objects when they share a ``tensor_idx``.
     """
+    tt_cache_path = get_tt_kv_cache_path(tt_cache_path)
     submesh_devices = [model.mesh_device for model in dp_model]
     kv_cache = []
     for mesh_idx, submesh in enumerate(submesh_devices):


### PR DESCRIPTION
### Summary

It may be needed to store empty KV cache tensors in a different directory than $TT_CACHE_PATH, where also cached model weights are stored. This PR adds $TT_KV_CACHE_PATH to set that, with fallback to the old behavior if not present.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/tt-kv-cache-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/tt-kv-cache-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/tt-kv-cache-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/tt-kv-cache-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=viktorpus/tt-kv-cache-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/tt-kv-cache-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/tt-kv-cache-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/tt-kv-cache-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/tt-kv-cache-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/tt-kv-cache-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/tt-kv-cache-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/tt-kv-cache-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/tt-kv-cache-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/tt-kv-cache-path)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/tt-kv-cache-path)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/tt-kv-cache-path)