### PR TITLE
Skip bge_m3 test_model_full_end_to_end[S4096] and vllm dense embedding (#46445)

### DIFF
--- a/models/demos/wormhole/bge_m3/tests/pcc/test_generator_vllm.py
+++ b/models/demos/wormhole/bge_m3/tests/pcc/test_generator_vllm.py
@@ -117,6 +117,7 @@ def _load_reference_outputs(device, model_name, sequence_length, model_location_
     }
 
 
+@pytest.mark.skip(reason="https://github.com/tenstorrent/tt-metal/issues/46445")
 @pytest.mark.parametrize("model_name, sequence_length", [(MODEL_NAME, MAX_MODEL_LEN)])
 def test_bge_m3_vllm_dense_embedding(device, model_name, sequence_length, model_location_generator):
     outputs = _load_reference_outputs(device, model_name, sequence_length, model_location_generator)

--- a/models/demos/wormhole/bge_m3/tests/pcc/test_model.py
+++ b/models/demos/wormhole/bge_m3/tests/pcc/test_model.py
@@ -34,7 +34,19 @@ def model_artifacts(model_location_generator):
 
 
 @pytest.mark.slow
-@pytest.mark.parametrize("seq_len", SEQUENCE_LENGTHS, ids=[f"S{seq_len}" for seq_len in SEQUENCE_LENGTHS])
+@pytest.mark.parametrize(
+    "seq_len",
+    [
+        pytest.param(
+            seq_len,
+            id=f"S{seq_len}",
+            marks=pytest.mark.skip(reason="https://github.com/tenstorrent/tt-metal/issues/46445")
+            if seq_len == 4096
+            else [],
+        )
+        for seq_len in SEQUENCE_LENGTHS
+    ],
+)
 def test_model_full_end_to_end(device, model_artifacts, seq_len, reset_seeds):
     require_single_device(device)
     backbone, state_dict, model_id_or_path = model_artifacts


### PR DESCRIPTION
Skips two `bge_m3` tests — `test_model_full_end_to_end[S4096]` and `test_bge_m3_vllm_dense_embedding[BAAI/bge-m3-512]` — to make the **(Single-card) Frequent model and ttnn tests** workflow green again. Both regressed after #45959: `S4096` dropped to PCC 0.9055 (< 0.94), and the vLLM dense embedding fails `torch.allclose(rtol=0.01)`. The vLLM failure was masked by the dispatch's `-x` (it stops at the earlier `S4096` failure) until `S4096` was skipped. A hardware A/B bisection of #45959 vs its parent — full bge_m3 suite without `-x` — confirms these are the only two bge_m3 tests it breaks. Tracked in #46445.

Frequent models run (bge_m3 only) on this branch: https://github.com/tenstorrent/tt-metal/actions/runs/27199790336

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=astancov/bge_m3_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:astancov/bge_m3_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=astancov/bge_m3_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:astancov/bge_m3_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=astancov/bge_m3_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:astancov/bge_m3_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=astancov/bge_m3_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:astancov/bge_m3_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=astancov/bge_m3_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:astancov/bge_m3_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=astancov/bge_m3_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:astancov/bge_m3_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=astancov/bge_m3_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:astancov/bge_m3_skip)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=astancov/bge_m3_skip)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:astancov/bge_m3_skip)