### PR TITLE
Add Galaxy ring-joint SDPA perf checks to DeepSeek prefill CI

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -273,7 +273,7 @@ models:
     wh_llmbox_perf: 1290
     wh_galaxy: 345
     wh_galaxy_perf: 150
-    bh_galaxy: 395
+    bh_galaxy: 410
     wh_n150: 500
     wh_n150_civ2: 300
     wh_n300: 600

--- a/.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
@@ -19,6 +19,10 @@ on:
         required: false
         type: string
         default: "all"
+      exclude-test-group:
+        required: false
+        type: string
+        default: ""
   workflow_dispatch:
 
 jobs:
@@ -60,8 +64,14 @@ jobs:
           # value or any "all" token means run the full matrix; otherwise keep entries
           # whose test_type OR test_group matches any selected token.
           TEST_TYPE="${{ inputs.test-type }}"
+          EXCLUDE_GROUP="${{ inputs.exclude-test-group }}"
           if [ -z "$TEST_TYPE" ] || \
             echo "$TEST_TYPE" | tr ',' '\n' | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | grep -Fxq "all"; then
+            # Optionally drop a test_group from the "all" run (e.g. perf checks that
+            # need their own profiler build are run via a separate impl invocation).
+            if [ -n "$EXCLUDE_GROUP" ]; then
+              MATRIX=$(echo "$MATRIX" | jq -c --arg g "$EXCLUDE_GROUP" '[.[] | select(.test_group != $g)]')
+            fi
             echo "matrix<<EOF" >> $GITHUB_OUTPUT
             echo "$MATRIX" >> $GITHUB_OUTPUT
             echo "EOF" >> $GITHUB_OUTPUT

--- a/.github/workflows/galaxy-deepseek-prefill-tests.yaml
+++ b/.github/workflows/galaxy-deepseek-prefill-tests.yaml
@@ -12,7 +12,8 @@ on:
           Empty or "all" runs every stage. Valid stages: moe_gate, mla, mla_chunked,
           kv_cache_table, prefill_block, prefill_transformer, kimi_mla, kimi_moe,
           kimi_prefill_block, prefill_block_determinism, prefill_transformer_determinism.
-          The "module" group also runs every stage.
+          The "module" group also runs every stage; the "sdpa_perf" group runs the
+          ring joint SDPA perf checks (built with the profiler).
         required: false
         type: string
         default: "all"
@@ -75,6 +76,8 @@ jobs:
 
   build-artifact:
     needs: [validate-test-type, check-harbor]
+    # Skip when only the perf checks were requested — they use the profiler build below.
+    if: ${{ needs.validate-test-type.outputs.test-type != 'sdpa_perf' }}
     uses: ./.github/workflows/build-artifact.yaml
     permissions:
       contents: read
@@ -86,8 +89,31 @@ jobs:
       build-wheel: true
       platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
       enable-lto: ${{ inputs.enable-lto || false }}
+
+  # Separate profiler (tracy) build used only by the ring joint SDPA perf checks, which
+  # call run_device_profiler. Keeps the functional prefill jobs on the plain build above.
+  build-artifact-profiler:
+    needs: [validate-test-type, check-harbor]
+    # Only build the profiler artifact when the perf job will actually run: the normalized
+    # selection is "all" or contains the sdpa_perf group (e.g. "mla,sdpa_perf").
+    if: ${{ needs.validate-test-type.outputs.test-type == 'all' || contains(needs.validate-test-type.outputs.test-type, 'sdpa_perf') }}
+    uses: ./.github/workflows/build-artifact.yaml
+    permissions:
+      contents: read
+      packages: write
+    secrets: inherit
+    with:
+      harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
+      build-type: ${{ inputs.build-type || 'Release' }}
+      tracy: true
+      build-wheel: true
+      platform: ${{ inputs.platform || 'Ubuntu 22.04' }}
+      enable-lto: ${{ inputs.enable-lto || false }}
+
   Galaxy-DeepSeek-Prefill-tests:
     needs: [validate-test-type, check-harbor, build-artifact]
+    # Skip when only the perf checks were requested (they run on the profiler build below).
+    if: ${{ needs.validate-test-type.outputs.test-type != 'sdpa_perf' }}
     secrets: inherit
     uses: ./.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
     with:
@@ -96,3 +122,19 @@ jobs:
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       enabled-skus: bh_galaxy
       test-type: ${{ needs.validate-test-type.outputs.test-type }}
+      # Perf checks need the profiler build, so keep them out of the "all" plain-build run.
+      exclude-test-group: sdpa_perf
+
+  Galaxy-DeepSeek-Prefill-SDPA-Perf-tests:
+    needs: [validate-test-type, check-harbor, build-artifact-profiler]
+    # Runs for the default "all" and when the sdpa_perf group is selected (alone or with others).
+    if: ${{ needs.validate-test-type.outputs.test-type == 'all' || contains(needs.validate-test-type.outputs.test-type, 'sdpa_perf') }}
+    secrets: inherit
+    uses: ./.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
+    with:
+      docker-image: ${{ needs.build-artifact-profiler.outputs.dev-docker-image }}
+      build-artifact-name: ${{ needs.build-artifact-profiler.outputs.build-artifact-name }}
+      wheel-artifact-name: ${{ needs.build-artifact-profiler.outputs.wheel-artifact-name }}
+      enabled-skus: bh_galaxy
+      # Select the perf entry by its test_group so adding more perf checks needs no workflow edit.
+      test-type: sdpa_perf

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -3312,12 +3312,22 @@ def test_ring_joint_attention_create_perf_table(model_name):
 # Symmetric +/- band — catches both regressions and unexpected speedups.
 RING_JOINT_PERF_MARGIN = 0.01
 
-RING_JOINT_PERF_CHECK_CONFIGS = [
-    # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
-    # 4-device ring (QuietBox)
-    ("wan2_2_1xGLX", 288, 512, 4, 68.9),
-    ("mla_100k", 160, 320, 4, 63.2),
-]
+# Ring/TP geometry and per-device shapes are auto-selected by MeshConfig.detect():
+#   QuietBox -> 4-device ring (sp=4, tp=1);  Galaxy -> 8-device ring x 4 TP shards (sp=8, tp=4).
+if MESH_CONFIG.is_galaxy:
+    RING_JOINT_PERF_CHECK_CONFIGS = [
+        # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
+        # 8-device ring (Galaxy, sp=8 tp=4)
+        ("wan2_2_1xGLX", 288, 512, 8, 70.7),
+        ("mla_100k", 160, 320, 8, 65.0),
+    ]
+else:
+    RING_JOINT_PERF_CHECK_CONFIGS = [
+        # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
+        # 4-device ring (QuietBox, sp=4 tp=1)
+        ("wan2_2_1xGLX", 288, 512, 4, 68.9),
+        ("mla_100k", 160, 320, 4, 63.2),
+    ]
 
 
 @pytest.mark.skipif(
@@ -3821,14 +3831,21 @@ def test_ring_mla_create_chunked_perf_table(model_name, q_chunk_size, k_chunk_si
 
 
 # === TEST 9: CHUNKED-PREFILL ring_mla PERF CHECK (CI-gated by SDPA_PERF_CHECKS=1) ===
-# Simulates the kimi 50k+5k galaxy chunk (final, most compute-bound chunk of the kimi50k
-# chunked prefill) on the 4-device QuietBox. Symmetric +/- band, same as the ring joint
-# perf check above.
-RING_MLA_CHUNKED_PERF_CHECK_CONFIGS = [
-    # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
-    # 4-device ring (QuietBox, 100 SDPA cores)
-    ("kimi50k", 32, 640, 4, 66.05),
-]
+# Profiles the kimi 50k+5k galaxy chunk (final, most compute-bound chunk of the kimi50k chunked
+# prefill): natively on Galaxy (sp=8, tp=4) and simulated on the 4-device QuietBox (sp=4, tp=1).
+# Symmetric +/- band, same as the ring joint perf check.
+if MESH_CONFIG.is_galaxy:
+    RING_MLA_CHUNKED_PERF_CHECK_CONFIGS = [
+        # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
+        # 8-device ring (Galaxy, sp=8 tp=4, 100 SDPA cores)
+        ("kimi50k", 32, 640, 8, 68.5),
+    ]
+else:
+    RING_MLA_CHUNKED_PERF_CHECK_CONFIGS = [
+        # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
+        # 4-device ring (QuietBox, 100 SDPA cores)
+        ("kimi50k", 32, 640, 4, 66.05),
+    ]
 
 
 @pytest.mark.skipif(
@@ -3907,7 +3924,7 @@ def test_ring_mla_chunked_perf_check(model_name, q_chunk_size, k_chunk_size, rin
     upper = expected_util * (1 + RING_JOINT_PERF_MARGIN)
 
     logger.info(
-        f"ring_mla chunked 50k+5k (galaxy-simulated) perf check {config_id}: "
+        f"ring_mla chunked 50k+5k perf check {config_id}: "
         f"duration={duration_ns/1e6:.3f} ms, math_util={utilization:.2f}% "
         f"(expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}])"
     )

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -3316,17 +3316,20 @@ RING_JOINT_PERF_MARGIN = 0.01
 #   QuietBox -> 4-device ring (sp=4, tp=1);  Galaxy -> 8-device ring x 4 TP shards (sp=8, tp=4).
 if MESH_CONFIG.is_galaxy:
     RING_JOINT_PERF_CHECK_CONFIGS = [
-        # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
+        # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util, margin)
         # 8-device ring (Galaxy, sp=8 tp=4)
-        ("wan2_2_1xGLX", 288, 512, 8, 70.7),
-        ("mla_100k", 160, 320, 8, 65.0),
+        ("wan2_2_1xGLX", 288, 512, 8, 70.7, RING_JOINT_PERF_MARGIN),
+        # mla_100k on Galaxy is noisier than the other cases: observed run-to-run util spans
+        # ~64.8-67.8% (midpoint ~66.3%, ~+/-2.3%), well beyond the default +/-1% band. Widen to
+        # +/-3% so the gate tracks regressions without flagging this case's normal variance.
+        ("mla_100k", 160, 320, 8, 66.3, 0.03),
     ]
 else:
     RING_JOINT_PERF_CHECK_CONFIGS = [
-        # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)
+        # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util, margin)
         # 4-device ring (QuietBox, sp=4 tp=1)
-        ("wan2_2_1xGLX", 288, 512, 4, 68.9),
-        ("mla_100k", 160, 320, 4, 63.2),
+        ("wan2_2_1xGLX", 288, 512, 4, 68.9, RING_JOINT_PERF_MARGIN),
+        ("mla_100k", 160, 320, 4, 63.2, RING_JOINT_PERF_MARGIN),
     ]
 
 
@@ -3335,12 +3338,14 @@ else:
     reason="Set SDPA_PERF_CHECKS=1 to run (CI: sdpa perf tests job)",
 )
 @pytest.mark.parametrize(
-    "model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util",
+    "model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util, margin",
     RING_JOINT_PERF_CHECK_CONFIGS,
     ids=[f"{cfg[0]}-q{cfg[1]}-k{cfg[2]}-ring{cfg[3]}" for cfg in RING_JOINT_PERF_CHECK_CONFIGS],
 )
-def test_ring_joint_attention_perf_check(model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util):
-    """Measure ring joint SDPA math utilization via tracy and assert within +/- RING_JOINT_PERF_MARGIN."""
+def test_ring_joint_attention_perf_check(
+    model_name, q_chunk_size, k_chunk_size, ring_size_expected, expected_util, margin
+):
+    """Measure ring joint SDPA math utilization via tracy and assert within the config's +/- margin."""
     from tracy.process_model_log import run_device_profiler
 
     if MESH_CONFIG.sp_size != ring_size_expected:
@@ -3389,8 +3394,8 @@ def test_ring_joint_attention_perf_check(model_name, q_chunk_size, k_chunk_size,
         local_seq_len, sq, model.d_q, model.d_v, local_nhq, duration_ns, effective_cores, model.is_causal
     )
 
-    lower = expected_util * (1 - RING_JOINT_PERF_MARGIN)
-    upper = expected_util * (1 + RING_JOINT_PERF_MARGIN)
+    lower = expected_util * (1 - margin)
+    upper = expected_util * (1 + margin)
 
     logger.info(
         f"Ring joint SDPA perf check {config_id}: "
@@ -3400,7 +3405,7 @@ def test_ring_joint_attention_perf_check(model_name, q_chunk_size, k_chunk_size,
 
     assert lower <= utilization <= upper, (
         f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
-        f"(expected {expected_util:.2f}%, margin +/- {RING_JOINT_PERF_MARGIN*100:.1f}%)"
+        f"(expected {expected_util:.2f}%, margin +/- {margin*100:.1f}%)"
     )
 
 

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -154,3 +154,25 @@
       timeout: 30
   owner_id: U08RL15T4N8
   team: models
+
+# Ring joint SDPA math-utilization perf checks (1 WAN, 1 MLA-100k, 1 Kimi chunked ring_mla).
+# Needs a profiler (tracy) build for run_device_profiler, so it is routed to the dedicated
+# build-artifact-profiler invocation (test_group: sdpa_perf) and excluded from the plain build.
+# sp/tp are auto-selected by MeshConfig.detect() on Galaxy (sp=8, tp=4).
+- name: "(Galaxy) Ring Joint SDPA - perf checks"
+  # Run both perf checks unconditionally (so both report numbers) but fail the step if either
+  # fails — the harness only propagates the last command's exit code, so aggregate it ourselves.
+  cmd: |
+    export MESH_DEVICE=TG
+    rc=0
+    SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_perf_check -svv || rc=1
+    SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_mla_chunked_perf_check -svv || rc=1
+    (exit $rc)
+  test_type: ring_joint_sdpa_perf
+  test_group: sdpa_perf
+  skus:
+    bh_galaxy:
+      # Both perf checks run in ~5.6 min; 15 leaves ~2.7x headroom for tracy/Galaxy variance.
+      timeout: 15
+  owner_id: U08RL15T4N8
+  team: models


### PR DESCRIPTION
## Summary

Adds the ring-joint SDPA math-utilization perf checks to the Galaxy DeepSeek prefill CI.

These checks profile the device (tracy), so they run on a separate profiler build and as a separate job from the functional prefill tests. They report numbers for both the WAN and MLA-100k ring-joint configs plus the Kimi chunked ring-MLA config, and fail if measured math utilization drifts outside a per-config ±band around the expected value (default ±1%, widened where a case is inherently noisier).

## Changes

- **galaxy-deepseek-prefill-tests.yaml**: add a tracy profiler build and a dedicated `sdpa_perf` job; gate each build behind its consumer so a targeted dispatch doesn't pay for an unused build.
- **galaxy-deepseek-prefill-tests-impl.yaml**: add `exclude-test-group` so the plain-build `all` run skips the perf group (it runs on the profiler build instead).
- **test_ring_joint_sdpa.py**: select 8-device ring configs on Galaxy (sp=8, tp=4) vs the 4-device QuietBox path, with calibrated Galaxy targets (WAN 70.7, MLA-100k 66.3, Kimi chunked 68.5). Add a per-config perf margin: MLA-100k on Galaxy is noisier than the other cases (observed run-to-run util ~64.8–67.8%, midpoint ~66.3%), so it uses a ±3% band while every other config keeps the default ±1%.
- **galaxy_deepseek_prefill_tests.yaml**: add the perf-check entry (aggregates the two pytest exit codes; 15-min timeout — the checks run in ~6 min).
- **time_budget.yaml**: bump models/demo/bh_galaxy budget to 410.

## CI runs (on latest main)

| test-type | run |
|---|---|
| `all` (functional + perf) | https://github.com/tenstorrent/tt-metal/actions/runs/27635021792 |
| `sdpa_perf` (perf only) | https://github.com/tenstorrent/tt-metal/actions/runs/27635023874 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/galaxy-deepseek-sdpa-perf-checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/galaxy-deepseek-sdpa-perf-checks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/galaxy-deepseek-sdpa-perf-checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/galaxy-deepseek-sdpa-perf-checks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/galaxy-deepseek-sdpa-perf-checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/galaxy-deepseek-sdpa-perf-checks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/galaxy-deepseek-sdpa-perf-checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/galaxy-deepseek-sdpa-perf-checks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/galaxy-deepseek-sdpa-perf-checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/galaxy-deepseek-sdpa-perf-checks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/galaxy-deepseek-sdpa-perf-checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/galaxy-deepseek-sdpa-perf-checks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/galaxy-deepseek-sdpa-perf-checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/galaxy-deepseek-sdpa-perf-checks)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/galaxy-deepseek-sdpa-perf-checks)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/galaxy-deepseek-sdpa-perf-checks)
