### PR TITLE
fix: hardcode torch seed in tt-llk tests for better stability

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -112,7 +112,10 @@ _LLK_TEST_SEED = os.environ.get("LLK_TEST_SEED")
 try:
     _DEFAULT_TORCH_SEED = int(_LLK_TEST_SEED, 0) if _LLK_TEST_SEED is not None else 42
 except ValueError as e:
-    raise pytest.UsageError(f"LLK_TEST_SEED must be an integer, got {_LLK_TEST_SEED!r}") from e
+    raise pytest.UsageError(
+        f"LLK_TEST_SEED must be an integer, got {_LLK_TEST_SEED!r}"
+    ) from e
+
 
 @pytest.fixture(autouse=True)
 def _seed_torch_rng():

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -39,6 +39,7 @@ if _SHOULD_RUN_SIMULATOR and _SIMULATOR_PATH and _SIMULATOR_PATH.endswith(".so")
 import helpers.order_processing as order_processing
 import helpers.utils as utils_module
 import pytest
+import torch
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.device import LLKAssertException
 from helpers.exalens_server import ExalensServer
@@ -103,6 +104,23 @@ init_llk_home()
 @pytest.fixture()
 def regenerate_cpp(request):
     return not request.config.getoption("--skip-codegen")
+
+
+# Default seed for deterministic stimuli. Override via LLK_TEST_SEED to reproduce
+# a specific run or to sweep different random inputs.
+_DEFAULT_TORCH_SEED = int(os.environ.get("LLK_TEST_SEED", "42"))
+
+
+@pytest.fixture(autouse=True)
+def _seed_torch_rng():
+    """Lock torch's global RNG before every test to avoid flaky failures.
+
+    Stimuli that don't set an explicit StimuliSpec.seed fall back to torch's
+    global generator, so seeding here makes both generate_stimuli() and any
+    direct torch.rand/randn/randint/uniform_ calls reproducible.
+    """
+    torch.manual_seed(_DEFAULT_TORCH_SEED)
+    yield
 
 
 # Define the possible custom command line options

--- a/tt_metal/tt-llk/tests/python_tests/conftest.py
+++ b/tt_metal/tt-llk/tests/python_tests/conftest.py
@@ -108,8 +108,11 @@ def regenerate_cpp(request):
 
 # Default seed for deterministic stimuli. Override via LLK_TEST_SEED to reproduce
 # a specific run or to sweep different random inputs.
-_DEFAULT_TORCH_SEED = int(os.environ.get("LLK_TEST_SEED", "42"))
-
+_LLK_TEST_SEED = os.environ.get("LLK_TEST_SEED")
+try:
+    _DEFAULT_TORCH_SEED = int(_LLK_TEST_SEED, 0) if _LLK_TEST_SEED is not None else 42
+except ValueError as e:
+    raise pytest.UsageError(f"LLK_TEST_SEED must be an integer, got {_LLK_TEST_SEED!r}") from e
 
 @pytest.fixture(autouse=True)
 def _seed_torch_rng():


### PR DESCRIPTION
### PR Category
Test Only.

### Summary
Add default seed for deterministic stimuli and fixture to seed torch's RNG before tests.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fvranicTT-patch-1)