### PR TITLE
Centralize the trace buffer size definitions for all our models

### DIFF
--- a/.github/workflows/models-t2-e2e-tests.yaml
+++ b/.github/workflows/models-t2-e2e-tests.yaml
@@ -20,7 +20,7 @@ on:
           - qwen3-32b
           - qwen2.5-32b
           - qwen2.5-coder-32b
-          - qwen2.5-72b-vl
+          - qwen2.5-vl-72b
           - mistral-7b
           - gemma-3-4b
           - gemma-3-27b

--- a/.github/workflows/models-t2-unit-tests.yaml
+++ b/.github/workflows/models-t2-unit-tests.yaml
@@ -19,7 +19,7 @@ on:
           - qwen3-32b
           - qwen2.5-32b
           - qwen2.5-coder-32b
-          - qwen2.5-72b-vl
+          - qwen2.5-vl-72b
           - mistral-7b
           - gemma-3-4b
           - gemma-3-27b

--- a/conftest.py
+++ b/conftest.py
@@ -579,17 +579,17 @@ def mesh_device(request, silicon_arch_name, device_params):
             )
         mesh_shape = ttnn.MeshShape(1, param)
 
-    override_trace_region_size = get_supported_trace_region_size(request, param)
-
-    if override_trace_region_size is None:
-        logger.info(f"No trace region size for {param!r}")
+    if "trace_region_size" not in device_params:
+        override_trace_region_size = get_supported_trace_region_size(request, param)
+        if override_trace_region_size is None:
+            logger.info(f"No trace region size for {param!r}")
+        else:
+            device_params["trace_region_size"] = override_trace_region_size
     else:
-        prior_trace_region_size = device_params.get("trace_region_size")
-        device_params["trace_region_size"] = override_trace_region_size
-        if prior_trace_region_size is not None:
-            logger.info(
-                f"Test had {prior_trace_region_size!r}, overriding trace region size to {override_trace_region_size!r} from YAML"
-            )
+        logger.info(
+            f"Keeping trace_region_size={device_params['trace_region_size']!r} "
+            f"from device_params (TRACE_MODEL_KEY path)"
+        )
 
     updated_device_params = get_updated_device_params(device_params)
     updated_device_params.pop("require_exact_physical_num_devices", False)

--- a/conftest.py
+++ b/conftest.py
@@ -17,7 +17,6 @@ import pytest
 import torch
 from loguru import logger
 
-from models.demos.utils.trace_region_sizes import apply_trace_region_override
 from models.tt_transformers.demo.trace_region_config import get_supported_trace_region_size
 from tests.scripts.common import get_updated_device_params, run_process_and_get_result
 
@@ -579,9 +578,16 @@ def mesh_device(request, silicon_arch_name, device_params):
         mesh_shape = ttnn.MeshShape(1, param)
 
     override_trace_region_size = get_supported_trace_region_size(request, param)
-    applied_trace_region_size = apply_trace_region_override(device_params, override_trace_region_size)
-    if applied_trace_region_size == override_trace_region_size:
-        logger.info(f"Overriding trace region size to {override_trace_region_size}")
+
+    if override_trace_region_size is None:
+        logger.info(f"No trace region size for {param!r}")
+    else:
+        prior_trace_region_size = device_params.get("trace_region_size")
+        device_params["trace_region_size"] = override_trace_region_size
+        if prior_trace_region_size is not None:
+            logger.info(
+                f"Test had {prior_trace_region_size!r}, overriding trace region size to {override_trace_region_size!r} from YAML"
+            )
 
     updated_device_params = get_updated_device_params(device_params)
     updated_device_params.pop("require_exact_physical_num_devices", False)

--- a/conftest.py
+++ b/conftest.py
@@ -17,6 +17,7 @@ import pytest
 import torch
 from loguru import logger
 
+from models.demos.utils.trace_region_sizes import apply_trace_region_override
 from models.tt_transformers.demo.trace_region_config import get_supported_trace_region_size
 from tests.scripts.common import get_updated_device_params, run_process_and_get_result
 
@@ -578,8 +579,8 @@ def mesh_device(request, silicon_arch_name, device_params):
         mesh_shape = ttnn.MeshShape(1, param)
 
     override_trace_region_size = get_supported_trace_region_size(request, param)
-    if override_trace_region_size:
-        device_params["trace_region_size"] = override_trace_region_size
+    applied_trace_region_size = apply_trace_region_override(device_params, override_trace_region_size)
+    if applied_trace_region_size == override_trace_region_size:
         logger.info(f"Overriding trace region size to {override_trace_region_size}")
 
     updated_device_params = get_updated_device_params(device_params)

--- a/conftest.py
+++ b/conftest.py
@@ -17,7 +17,8 @@ import pytest
 import torch
 from loguru import logger
 
-from models.tt_transformers.demo.trace_region_config import get_supported_trace_region_size
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM, resolve_trace_region_size
+from models.tt_transformers.demo.trace_region_config import get_logical_sku, get_supported_trace_region_size
 from tests.scripts.common import get_updated_device_params, run_process_and_get_result
 
 # Constants for device configurations
@@ -295,9 +296,9 @@ def get_tt_cache_path():
 
 @pytest.fixture(scope="function")
 def device_params(request):
-    from models.demos.utils.trace_region_sizes import apply_trace_model_key
-
-    return apply_trace_model_key(getattr(request, "param", {}))
+    # Return a copy so the mesh_device fixture can resolve/pop TRACE_MODEL_KEY_PARAM
+    # (using the logical submesh SKU) without mutating the shared parametrize dict.
+    return dict(getattr(request, "param", {}))
 
 
 @pytest.fixture(scope="module")
@@ -579,16 +580,26 @@ def mesh_device(request, silicon_arch_name, device_params):
             )
         mesh_shape = ttnn.MeshShape(1, param)
 
-    if "trace_region_size" not in device_params:
+    # Resolve trace_region_size against the SKU of the submesh actually opened.
+    # TRACE_MODEL_KEY_PARAM is resolved here (not at device_params/collection time) so the
+    # logical SKU reflects request.param/data_parallel/MESH_DEVICE, not the physical cluster.
+    trace_model_key = device_params.pop(TRACE_MODEL_KEY_PARAM, None)
+    if "trace_region_size" in device_params:
+        logger.info(
+            f"Keeping trace_region_size={device_params['trace_region_size']!r} from device_params (already set)"
+        )
+    elif trace_model_key is not None:
+        sku = get_logical_sku(request, param)
+        if sku is None:
+            logger.info(f"No SKU for {param!r}; not setting trace_region_size for model {trace_model_key!r}")
+        else:
+            device_params["trace_region_size"] = resolve_trace_region_size(trace_model_key, sku)
+    else:
         override_trace_region_size = get_supported_trace_region_size(request, param)
         if override_trace_region_size is None:
             logger.info(f"No trace region size for {param!r}")
         else:
             device_params["trace_region_size"] = override_trace_region_size
-    else:
-        logger.info(
-            f"Keeping trace_region_size={device_params['trace_region_size']!r} from device_params (already set)"
-        )
 
     updated_device_params = get_updated_device_params(device_params)
     updated_device_params.pop("require_exact_physical_num_devices", False)

--- a/conftest.py
+++ b/conftest.py
@@ -587,8 +587,7 @@ def mesh_device(request, silicon_arch_name, device_params):
             device_params["trace_region_size"] = override_trace_region_size
     else:
         logger.info(
-            f"Keeping trace_region_size={device_params['trace_region_size']!r} "
-            f"from device_params (TRACE_MODEL_KEY path)"
+            f"Keeping trace_region_size={device_params['trace_region_size']!r} from device_params (already set)"
         )
 
     updated_device_params = get_updated_device_params(device_params)

--- a/conftest.py
+++ b/conftest.py
@@ -295,7 +295,9 @@ def get_tt_cache_path():
 
 @pytest.fixture(scope="function")
 def device_params(request):
-    return getattr(request, "param", {})
+    from models.demos.utils.trace_region_sizes import apply_trace_model_key
+
+    return apply_trace_model_key(getattr(request, "param", {}))
 
 
 @pytest.fixture(scope="module")

--- a/models/MIGRATING_TO_TIERED_CI.md
+++ b/models/MIGRATING_TO_TIERED_CI.md
@@ -544,9 +544,9 @@ entry is on the books so it's not forgotten.
 
 Trace buffer sizes live in [`models/model_trace_region_sizes.yaml`](./model_trace_region_sizes.yaml).
 Add a `(model, SKU)` block with `trace_region_size: <bytes>` whenever a
-demo or test needs tracing and the default (`DEFAULT_TRACE_REGION_SIZE`
-in [`demos/utils/trace_region_sizes.py`](./demos/utils/trace_region_sizes.py))
-is insufficient.
+demo or test needs tracing. Every `(model, SKU)` pair must be configured in
+the YAML; [`resolve_trace_region_size`](./demos/utils/trace_region_sizes.py)
+raises `TraceRegionSizeNotConfiguredError` if an entry is missing.
 
 - **Model keys** — same short kebab-case + `aliases` convention as `model_targets.yaml`.
 - **SKU keys** — canonical names (`wh_n150`, `wh_llmbox_perf`, `bh_p150`, …); legacy labels like `T3K` / `P150x4` resolve via `normalize_sku`.

--- a/models/MIGRATING_TO_TIERED_CI.md
+++ b/models/MIGRATING_TO_TIERED_CI.md
@@ -583,8 +583,12 @@ from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 )
 ```
 
-Root and per-demo `conftest.py` call `apply_trace_model_key()` on
-`device_params` before the device is opened.
+The `mesh_device` fixture pops `TRACE_MODEL_KEY_PARAM` and resolves it to
+`trace_region_size` at device-open time, using the SKU of the **logical
+submesh** actually opened (derived from the mesh shape / `data_parallel` /
+`MESH_DEVICE`) — not the physical cluster. This matters for runs that open a
+sub-slice of a larger machine (e.g. a `1x4` slice of a Galaxy, or
+`MESH_DEVICE=N300` on a T3K).
 
 For demos that open a device directly (no shared fixture), use
 `build_trace_device_params(model_key)`:

--- a/models/MIGRATING_TO_TIERED_CI.md
+++ b/models/MIGRATING_TO_TIERED_CI.md
@@ -540,6 +540,19 @@ populate it after the first CI run. The resolver skips TODO entries
 by default so the test doesn't fail on missing numbers, but the
 entry is on the books so it's not forgotten.
 
+### Trace region sizes
+
+Trace buffer sizes live in [`models/model_trace_region_sizes.yaml`](./model_trace_region_sizes.yaml).
+Add a `(model, SKU)` block with `trace_region_size: <bytes>` whenever a
+demo or test needs tracing and the default (`DEFAULT_TRACE_REGION_SIZE`
+in [`demos/utils/trace_region_sizes.py`](./demos/utils/trace_region_sizes.py))
+is insufficient.
+
+- **Model keys** — same short kebab-case + `aliases` convention as `model_targets.yaml`.
+- **SKU keys** — canonical names (`wh_n150`, `wh_llmbox_perf`, `bh_p150`, …); legacy labels like `T3K` / `P150x4` resolve via `normalize_sku`.
+- **`tt_transformers`** — `get_supported_trace_region_size` in [`demo/trace_region_config.py`](./tt_transformers/demo/trace_region_config.py) loads from the YAML automatically when `HF_MODEL` is set.
+- **Other demos** — call `resolve_trace_region_size(HF_MODEL, get_current_device_sku_name())` from [`demos/utils/trace_region_sizes.py`](./demos/utils/trace_region_sizes.py).
+
 ---
 
 ## Verifying before merge

--- a/models/MIGRATING_TO_TIERED_CI.md
+++ b/models/MIGRATING_TO_TIERED_CI.md
@@ -544,9 +544,11 @@ entry is on the books so it's not forgotten.
 
 Trace buffer sizes live in [`models/model_trace_region_sizes.yaml`](./model_trace_region_sizes.yaml).
 Add a `(model, SKU)` block with `trace_region_size: <bytes>` whenever a
-demo or test needs tracing. Every `(model, SKU)` pair must be configured in
-the YAML; [`resolve_trace_region_size`](./demos/utils/trace_region_sizes.py)
-raises `TraceRegionSizeNotConfiguredError` if an entry is missing.
+demo or test needs a specific reserved trace region. Unconfigured `(model,
+SKU)` pairs are **not** an error: [`resolve_trace_region_size`](./demos/utils/trace_region_sizes.py)
+logs an info message and falls back to `TRACE_REGION_SIZE_DYNAMIC` (`0`,
+dynamic allocation). Add an explicit entry when a model needs a fixed
+reserved size rather than dynamic allocation.
 
 - **Model keys** — same short kebab-case + `aliases` convention as `model_targets.yaml`.
 - **SKU keys** — canonical names (`wh_n150`, `wh_llmbox_perf`, `bh_p150`, …); legacy labels like `T3K` / `P150x4` / `wh_llmbox` / `bh_galaxy` resolve via `normalize_sku` in [`model_targets.py`](./demos/utils/model_targets.py).
@@ -595,19 +597,22 @@ device_params = build_trace_device_params("deepseek-v3")
 
 #### Dynamic allocation (`trace_region_size: 0`)
 
-Some models let the runtime size trace buffers at launch. Set
-`trace_region_size: 0` in the YAML (see `deepseek-v3`) and use the named
-constant `TRACE_REGION_SIZE_DYNAMIC` from `trace_region_sizes.py` when
-referencing the value in code or comments. Do **not** assign
-`trace_region_size = …` in demo code — always go through the resolver or
-`build_trace_device_params`.
+Dynamic allocation lets the runtime size trace buffers at launch instead of
+reserving a fixed region. It is the **default** for any `(model, SKU)` pair
+not present in the YAML (resolution logs an info message and returns
+`TRACE_REGION_SIZE_DYNAMIC`). A model can also opt in explicitly by setting
+`trace_region_size: 0` (see `deepseek-v3`); use the named constant
+`TRACE_REGION_SIZE_DYNAMIC` from `trace_region_sizes.py` when referencing the
+value in code or comments. Do **not** assign `trace_region_size = …` in demo
+code — always go through the resolver or `build_trace_device_params`.
 
 #### CI coverage test
 
 [`models/tt_transformers/tests/test_trace_region_sizes.py`](./tt_transformers/tests/test_trace_region_sizes.py)
-cross-checks every tiered CI job that sets `HF_MODEL` (including per-SKU
-`hf_model` placeholders in device-perf entries) against the YAML. Run locally
-(without hardware):
+checks that every tiered CI job that sets `HF_MODEL` (including per-SKU
+`hf_model` placeholders in device-perf entries) resolves to a valid size —
+either an explicit YAML entry or the dynamic-allocation fallback (`0`). Run
+locally (without hardware):
 
 ```bash
 pytest models/tt_transformers/tests/test_trace_region_sizes.py --noconftest -v

--- a/models/MIGRATING_TO_TIERED_CI.md
+++ b/models/MIGRATING_TO_TIERED_CI.md
@@ -549,9 +549,69 @@ the YAML; [`resolve_trace_region_size`](./demos/utils/trace_region_sizes.py)
 raises `TraceRegionSizeNotConfiguredError` if an entry is missing.
 
 - **Model keys** — same short kebab-case + `aliases` convention as `model_targets.yaml`.
-- **SKU keys** — canonical names (`wh_n150`, `wh_llmbox_perf`, `bh_p150`, …); legacy labels like `T3K` / `P150x4` resolve via `normalize_sku`.
-- **`tt_transformers`** — `get_supported_trace_region_size` in [`demo/trace_region_config.py`](./tt_transformers/demo/trace_region_config.py) loads from the YAML automatically when `HF_MODEL` is set.
-- **Other demos** — call `resolve_trace_region_size(HF_MODEL, get_current_device_sku_name())` from [`demos/utils/trace_region_sizes.py`](./demos/utils/trace_region_sizes.py).
+- **SKU keys** — canonical names (`wh_n150`, `wh_llmbox_perf`, `bh_p150`, …); legacy labels like `T3K` / `P150x4` / `wh_llmbox` / `bh_galaxy` resolve via `normalize_sku` in [`model_targets.py`](./demos/utils/model_targets.py).
+- **`tt_transformers`** — `get_supported_trace_region_size` in [`demo/trace_region_config.py`](./tt_transformers/demo/trace_region_config.py) loads from the YAML automatically when `HF_MODEL` is set (root [`conftest.py`](../conftest.py) applies the override on `mesh_device`).
+- **Other demos** — call `resolve_trace_region_size(model_name, get_current_device_sku_name())` from [`demos/utils/trace_region_sizes.py`](./demos/utils/trace_region_sizes.py).
+
+#### Galaxy and other bypass demos
+
+Galaxy e2e/sweep jobs use **different** trace sizes than the matching
+`tt_transformers` model on the same SKU. Do not reuse the tt_transformers
+key — add a separate model block, e.g.:
+
+| Model key | SKU | Notes |
+|---|---|---|
+| `llama3.3-70b-galaxy` | `wh_galaxy_perf` | Full e2e / prefix-caching (216 580 672 bytes) |
+| `llama3.3-70b-galaxy-decode` | `wh_galaxy_perf` | Decode-only benchmarks (23 887 872 bytes) |
+| `llama3.3-70b-galaxy-qwen` | `wh_galaxy_perf` | Qwen-on-galaxy stack |
+| `qwen3-32b-galaxy` | `wh_galaxy_perf` | Galaxy e2e (102 000 000 bytes) |
+| `qwen3-32b-galaxy-decode` | `wh_galaxy_perf` | Galaxy decode benchmarks |
+
+For pytest demos that open a device via the shared `device_params` /
+`mesh_device` fixtures, pass the YAML model key through parametrize instead
+of hardcoding bytes:
+
+```python
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"fabric_config": ..., TRACE_MODEL_KEY_PARAM: "llama3.3-70b-galaxy"}],
+    indirect=True,
+)
+```
+
+Root and per-demo `conftest.py` call `apply_trace_model_key()` on
+`device_params` before the device is opened.
+
+For demos that open a device directly (no shared fixture), use
+`build_trace_device_params(model_key)`:
+
+```python
+from models.demos.utils.trace_region_sizes import build_trace_device_params
+
+device_params = build_trace_device_params("deepseek-v3")
+```
+
+#### Dynamic allocation (`trace_region_size: 0`)
+
+Some models let the runtime size trace buffers at launch. Set
+`trace_region_size: 0` in the YAML (see `deepseek-v3`) and use the named
+constant `TRACE_REGION_SIZE_DYNAMIC` from `trace_region_sizes.py` when
+referencing the value in code or comments. Do **not** assign
+`trace_region_size = …` in demo code — always go through the resolver or
+`build_trace_device_params`.
+
+#### CI coverage test
+
+[`models/tt_transformers/tests/test_trace_region_sizes.py`](./tt_transformers/tests/test_trace_region_sizes.py)
+cross-checks every tiered CI job that sets `HF_MODEL` (including per-SKU
+`hf_model` placeholders in device-perf entries) against the YAML. Run locally
+(without hardware):
+
+```bash
+pytest models/tt_transformers/tests/test_trace_region_sizes.py --noconftest -v
+```
 
 ---
 

--- a/models/demos/deepseek_v3/demo/demo.py
+++ b/models/demos/deepseek_v3/demo/demo.py
@@ -26,6 +26,7 @@ from models.demos.deepseek_v3.utils.config_helpers import (
 )
 from models.demos.deepseek_v3.utils.hf_model_utils import load_tokenizer
 from models.demos.deepseek_v3.utils.test_utils import system_name_to_mesh_shape
+from models.demos.utils.trace_region_sizes import build_trace_device_params
 
 
 def _prompt_text_for_index(prompts: list[str] | None, random_weights: bool, index: int) -> str:
@@ -536,13 +537,13 @@ def run_demo(
     logger.info(f"Opening mesh device with shape {mesh_shape}")
     if enable_trace:
         logger.info("Enabling trace for decode forward pass")
-        # NOTE: A trace_region_size of 0 lets the runtime/device allocate trace buffers dynamically
-        # instead of reserving a fixed region up front. This avoids overcommitting memory, at the
-        # cost of giving us less explicit control over reserved trace capacity.
-        trace_region_size = 0
-        logger.info(f"Trace region size set to {trace_region_size}")
+        # trace_region_size=0 (deepseek-v3 YAML) lets the runtime allocate trace buffers dynamically.
+        trace_open_params = build_trace_device_params("deepseek-v3")
+        logger.info(f"Trace region size set to {trace_open_params['trace_region_size']}")
         mesh_device = ttnn.open_mesh_device(
-            mesh_shape=mesh_shape, trace_region_size=trace_region_size, dispatch_core_config=dispatch_core_config
+            mesh_shape=mesh_shape,
+            **trace_open_params,
+            dispatch_core_config=dispatch_core_config,
         )
     else:
         mesh_device = ttnn.open_mesh_device(mesh_shape=mesh_shape, dispatch_core_config=dispatch_core_config)

--- a/models/demos/gemma4/tests/unit/test_vllm_parity.py
+++ b/models/demos/gemma4/tests/unit/test_vllm_parity.py
@@ -1894,7 +1894,7 @@ def test_full_model_parity_warmup_then_inference(layer_set, decode_steps, pli, m
         max_batch_size=1,
         num_blocks=uniform_num_blocks,
         can_sample_on_device=False,
-        non_greedy_decoding_on_device=False,
+        greedy_only=True,
     )
 
     # vLLM warmup — replicate the bridge's pre-decode setup so the
@@ -1911,7 +1911,7 @@ def test_full_model_parity_warmup_then_inference(layer_set, decode_steps, pli, m
             max_batch_size=1,
             num_blocks=warmup_num_blocks,
             can_sample_on_device=False,
-            non_greedy_decoding_on_device=False,
+            greedy_only=True,
         )
     finally:
         if hasattr(tt_model_vllm, "_active_page_tables_per_layer"):

--- a/models/demos/gemma4/tests/unit/test_vllm_parity.py
+++ b/models/demos/gemma4/tests/unit/test_vllm_parity.py
@@ -1894,7 +1894,7 @@ def test_full_model_parity_warmup_then_inference(layer_set, decode_steps, pli, m
         max_batch_size=1,
         num_blocks=uniform_num_blocks,
         can_sample_on_device=False,
-        greedy_only=True,
+        non_greedy_decoding_on_device=False,
     )
 
     # vLLM warmup — replicate the bridge's pre-decode setup so the
@@ -1911,7 +1911,7 @@ def test_full_model_parity_warmup_then_inference(layer_set, decode_steps, pli, m
             max_batch_size=1,
             num_blocks=warmup_num_blocks,
             can_sample_on_device=False,
-            greedy_only=True,
+            non_greedy_decoding_on_device=False,
         )
     finally:
         if hasattr(tt_model_vllm, "_active_page_tables_per_layer"):

--- a/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_experts.py
+++ b/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_experts.py
@@ -41,6 +41,7 @@ from models.demos.gpt_oss.tt.experts_throughput.config import (
 )
 from models.demos.gpt_oss.tt.experts_throughput.decode import decode_forward
 from models.demos.gpt_oss.tt.experts_throughput.weights import load_throughput_expert_weights
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from tools.tracy.process_model_log import get_latest_ops_log_filename, run_device_profiler
 
@@ -694,7 +695,7 @@ def _skip_single_device_ccl():
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 30000000,
+            TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
         }
     ],
     indirect=True,
@@ -785,7 +786,7 @@ def test_gpt_oss_experts(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 30000000,
+            TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
         }
     ],
     indirect=True,

--- a/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_experts_mlp.py
+++ b/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_experts_mlp.py
@@ -30,6 +30,7 @@ from models.demos.gpt_oss.tests.test_factory import TestFactory
 from models.demos.gpt_oss.tt.experts_throughput.config import ThroughputExpertConfig, ThroughputProgramConfig
 from models.demos.gpt_oss.tt.experts_throughput.decode import expert_mlp_forward
 from models.demos.gpt_oss.tt.experts_throughput.weights import ThroughputExpertWeights, load_throughput_expert_weights
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from tools.tracy.process_model_log import get_latest_ops_log_filename, run_device_profiler
 
@@ -640,7 +641,7 @@ def _run_experts_mlp_test(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 30000000,
+            TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
         }
     ],
     indirect=True,
@@ -721,7 +722,7 @@ def test_gpt_oss_experts_mlp(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 30000000,
+            TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
         }
     ],
     indirect=True,

--- a/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_moe.py
+++ b/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_moe.py
@@ -30,6 +30,7 @@ from models.common.utility_functions import comp_pcc, profiler, skip_for_blackho
 from models.demos.gpt_oss.tests.test_factory import TestFactory
 from models.demos.gpt_oss.tt.mlp import MLP
 from models.demos.gpt_oss.utils.general_utils import throughput_experts_supported_on_arch
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 
 DEVICE_PERF_ENV_VAR = "GPT_OSS_MOE_DEVICE_PERF"
@@ -350,7 +351,7 @@ def _skip_single_device_ccl():
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 30000000,
+            TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
         }
     ],
     indirect=True,
@@ -433,7 +434,7 @@ def test_gpt_oss_moe(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 30000000,
+            TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
         }
     ],
     indirect=True,

--- a/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_prepare_expert_tensors.py
+++ b/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_prepare_expert_tensors.py
@@ -26,6 +26,7 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import comp_pcc, profiler
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from tools.tracy.process_model_log import get_latest_ops_log_filename, run_device_profiler
 
@@ -607,7 +608,7 @@ def _skip_single_device_no_ccl():
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 30000000,
+            TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
         }
     ],
     indirect=True,
@@ -691,7 +692,7 @@ def test_gpt_oss_prepare_expert_tensors(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 30000000,
+            TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
         }
     ],
     indirect=True,

--- a/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_prepare_expert_weights.py
+++ b/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_prepare_expert_weights.py
@@ -30,6 +30,7 @@ import ttnn
 from models.common.utility_functions import comp_pcc, profiler
 from models.demos.gpt_oss.tests.test_factory import TestFactory
 from models.demos.gpt_oss.tt.experts_throughput.decode import prepare_expert_weights
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from tools.tracy.process_model_log import get_latest_ops_log_filename, run_device_profiler
 
@@ -519,7 +520,7 @@ def _run_prepare_expert_weights_test(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 30000000,
+            TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
         }
     ],
     indirect=True,
@@ -596,7 +597,7 @@ def test_gpt_oss_prepare_expert_weights(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 30000000,
+            TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
         }
     ],
     indirect=True,

--- a/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_router.py
+++ b/models/demos/gpt_oss/tests/fused_op_unit_tests/test_gpt_oss_router.py
@@ -32,6 +32,7 @@ from models.common.utility_functions import comp_pcc, profiler, skip_for_blackho
 from models.demos.gpt_oss.tests.test_factory import TestFactory
 from models.demos.gpt_oss.tt.topk import TopKRouter
 from models.demos.gpt_oss.utils.general_utils import throughput_experts_supported_on_arch
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkData, BenchmarkProfiler
 from tools.tracy.process_model_log import get_latest_ops_log_filename, run_device_profiler
 
@@ -705,7 +706,7 @@ def _run_router_single_device_test(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 30000000,
+            TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
         }
     ],
     indirect=True,
@@ -797,7 +798,7 @@ def test_gpt_oss_router(
     [
         {
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-            "trace_region_size": 30000000,
+            TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
         }
     ],
     indirect=True,

--- a/models/demos/gpt_oss/tests/test_factory.py
+++ b/models/demos/gpt_oss/tests/test_factory.py
@@ -10,6 +10,7 @@ import torch
 from transformers import AutoConfig
 
 import ttnn
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 
 from ..config import MeshConfig
 from ..tt.ccl import CCLManager
@@ -167,7 +168,7 @@ def parametrize_mesh_with_fabric(mesh_shapes=None):
         params = [
             pytest.param(
                 (1, 1),
-                {"fabric_config": None, "trace_region_size": 100000000},
+                {"fabric_config": None, TRACE_MODEL_KEY_PARAM: "gpt-oss-120b"},
                 id="1x1",
                 marks=pytest.mark.skip(reason="No supported gpt_oss mesh shape fits on this system"),
             )
@@ -178,7 +179,7 @@ def parametrize_mesh_with_fabric(mesh_shapes=None):
                 shape,
                 {
                     "fabric_config": (None if shape == (1, 1) else ttnn.FabricConfig.FABRIC_1D_RING),
-                    "trace_region_size": 100000000,
+                    TRACE_MODEL_KEY_PARAM: "gpt-oss-120b",
                 },
                 id=f"{shape[0]}x{shape[1]}",
             )

--- a/models/demos/gpt_oss/tests/unit/test_sampling.py
+++ b/models/demos/gpt_oss/tests/unit/test_sampling.py
@@ -23,6 +23,7 @@ import ttnn
 from models.common.sampling.generator import SamplingGenerator, SamplingParams, format_sampling_params
 from models.common.sampling.tt_sampling import TTSampling
 from models.demos.gpt_oss.tt.model import compute_per_device_vocab
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 
 # Every test in this module is pinned to a 4×8 Galaxy mesh with FABRIC_1D_RING
 # (see GPT_OSS_DEVICE_PARAMS below). On systems with fewer devices — e.g. the
@@ -92,7 +93,7 @@ BATCH_SIZE = 32
 # NOT Llama Galaxy's dispatch_core_axis/worker_l1_size/small trace.
 GPT_OSS_DEVICE_PARAMS = {
     "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-    "trace_region_size": 30000000,
+    TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
 }
 
 

--- a/models/demos/gpt_oss/tests/unit/test_sampling.py
+++ b/models/demos/gpt_oss/tests/unit/test_sampling.py
@@ -13,6 +13,7 @@ vocab dimensions (201088, TP=8) to verify:
 - Sampled token IDs are always < vocab_size (no padding tokens leak through)
 """
 
+import os
 from collections import Counter
 
 import pytest
@@ -89,11 +90,17 @@ VOCAB_SIZE = 201088
 MAX_TOP_K = 32
 BATCH_SIZE = 32
 
+
+def _gpt_oss_trace_model_key() -> str:
+    hf = os.getenv("HF_MODEL", "").lower()
+    return "gpt-oss-120b" if "120b" in hf else "gpt-oss-20b"
+
+
 # GPT-OSS device params: FABRIC_1D_RING + large trace region.
 # NOT Llama Galaxy's dispatch_core_axis/worker_l1_size/small trace.
 GPT_OSS_DEVICE_PARAMS = {
     "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
-    TRACE_MODEL_KEY_PARAM: "gpt-oss-20b",
+    TRACE_MODEL_KEY_PARAM: _gpt_oss_trace_model_key(),
 }
 
 

--- a/models/demos/informer/conftest.py
+++ b/models/demos/informer/conftest.py
@@ -7,6 +7,7 @@ import pytest
 import torch
 
 import ttnn
+from models.demos.utils.trace_region_sizes import build_trace_device_params
 
 
 @pytest.fixture(scope="session")
@@ -19,7 +20,7 @@ def torch_seed():
 @pytest.fixture(scope="session")
 def device():
     """Create one shared TTNN device for PCC test sessions."""
-    dev = ttnn.open_device(device_id=0, trace_region_size=128 << 20)
+    dev = ttnn.open_device(device_id=0, **build_trace_device_params("informer"))
     dev.enable_program_cache()
 
     yield dev

--- a/models/demos/informer/demo/demo.py
+++ b/models/demos/informer/demo/demo.py
@@ -28,6 +28,7 @@ import ttnn
 from models.demos.informer.reference.torch_reference import compute_metrics, load_etth1_csv
 from models.demos.informer.tt.config import InformerConfig, informer_config_from_hf
 from models.demos.informer.tt.model import create_informer
+from models.demos.utils.trace_region_sizes import build_trace_device_params
 
 
 def load_checkpoint(path: str | None) -> tuple[dict | None, dict | None, torch.Tensor | None, torch.Tensor | None]:
@@ -74,7 +75,7 @@ def build_time_features_from_start(start, *, length: int, dim: int, freq: str) -
 
 
 def open_device(*, device_id: int) -> ttnn.Device:
-    return ttnn.open_device(device_id=device_id, trace_region_size=128 << 20)
+    return ttnn.open_device(device_id=device_id, **build_trace_device_params("informer"))
 
 
 def load_series_from_csv(path: Path, *, cfg: InformerConfig) -> tuple[list[dict], str]:

--- a/models/demos/llama3_70b_galaxy/conftest.py
+++ b/models/demos/llama3_70b_galaxy/conftest.py
@@ -5,6 +5,8 @@ import pytest
 import gc
 import ttnn
 
+from models.demos.utils.trace_region_sizes import apply_trace_model_key
+
 
 @pytest.fixture(autouse=True)
 def ensure_gc():
@@ -19,7 +21,7 @@ def ensure_devices(ensure_devices_tg):
 @pytest.fixture
 def device_params(request, galaxy_type):
     # Get param dict passed in from test parametrize (or default to empty dict)
-    params = getattr(request, "param", {}).copy()
+    params = apply_trace_model_key(getattr(request, "param", {}).copy())
 
     if "fabric_config" in params and params["fabric_config"] == True:
         params["fabric_config"] = (

--- a/models/demos/llama3_70b_galaxy/conftest.py
+++ b/models/demos/llama3_70b_galaxy/conftest.py
@@ -5,8 +5,6 @@ import pytest
 import gc
 import ttnn
 
-from models.demos.utils.trace_region_sizes import apply_trace_model_key
-
 
 @pytest.fixture(autouse=True)
 def ensure_gc():
@@ -20,8 +18,9 @@ def ensure_devices(ensure_devices_tg):
 
 @pytest.fixture
 def device_params(request, galaxy_type):
-    # Get param dict passed in from test parametrize (or default to empty dict)
-    params = apply_trace_model_key(getattr(request, "param", {}).copy())
+    # Get param dict passed in from test parametrize (or default to empty dict).
+    # TRACE_MODEL_KEY_PARAM is resolved later by the mesh_device fixture (logical SKU).
+    params = getattr(request, "param", {}).copy()
 
     if "fabric_config" in params and params["fabric_config"] == True:
         params["fabric_config"] = (

--- a/models/demos/llama3_70b_galaxy/demo/demo_decode.py
+++ b/models/demos/llama3_70b_galaxy/demo/demo_decode.py
@@ -24,6 +24,7 @@ from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import T
 from models.demos.llama3_70b_galaxy.tt.model_config import TtModelArgs
 from models.common.sampling.tt_sampling import TTSampling
 
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkProfiler, BenchmarkData
 from models.demos.llama3_70b_galaxy.tt.model_config import LlamaOptimizations
 
@@ -777,7 +778,7 @@ def run_llama3_demo(
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "trace_region_size": 23887872,
+            TRACE_MODEL_KEY_PARAM: "llama3.3-70b-galaxy-decode",
             "worker_l1_size": 1345000,
             "fabric_config": True,
         }

--- a/models/demos/llama3_70b_galaxy/demo/demo_performance.py
+++ b/models/demos/llama3_70b_galaxy/demo/demo_performance.py
@@ -18,6 +18,7 @@ from models.demos.llama3_70b_galaxy.tt.llama_embedding import TtLlamaEmbedding
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
 from models.demos.llama3_70b_galaxy.tt.model_config import TtModelArgs
 
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.demos.llama3_70b_galaxy.tt.model_config import LlamaOptimizations
 
@@ -432,7 +433,7 @@ def run_llama3_decode_performance(
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "trace_region_size": 23887872,
+            TRACE_MODEL_KEY_PARAM: "llama3.3-70b-galaxy-decode",
             "fabric_config": True,
         }
     ],

--- a/models/demos/llama3_70b_galaxy/demo/demo_qwen_decode.py
+++ b/models/demos/llama3_70b_galaxy/demo/demo_qwen_decode.py
@@ -20,6 +20,7 @@ from models.demos.llama3_70b_galaxy.tt.qwen_model_config import TtQwenModelArgs
 from models.common.sampling.tt_sampling import TTSampling
 from models.demos.llama3_70b_galaxy.demo.demo_common import load_inputs_simple
 
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkProfiler, BenchmarkData
 from models.demos.llama3_70b_galaxy.tt.model_config import LlamaOptimizations
 
@@ -664,8 +665,7 @@ def run_qwen_demo(
     [
         {
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
-            "trace_region_size": 12726272,
-            # "trace_region_size": 10459136,
+            TRACE_MODEL_KEY_PARAM: "qwen3-32b-galaxy-decode",
             "fabric_config": True,
         }
     ],

--- a/models/demos/llama3_70b_galaxy/demo/prefix_caching_benchmark.py
+++ b/models/demos/llama3_70b_galaxy/demo/prefix_caching_benchmark.py
@@ -13,6 +13,7 @@ from models.demos.llama3_70b_galaxy.demo.text_demo import create_tt_model
 from models.demos.llama3_70b_galaxy.tt.generator import Generator, SamplingParams
 from models.demos.llama3_70b_galaxy.tt.model_config import LlamaOptimizations
 from models.demos.t3000.llama2_70b.reference.llama.llama31_8b.tokenizer import Tokenizer
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkProfiler
 
 
@@ -81,7 +82,7 @@ def _check_prefill_benchmark_results(results):
     "device_params",
     [
         {
-            "trace_region_size": 216580672,
+            TRACE_MODEL_KEY_PARAM: "llama3.3-70b-galaxy",
             "num_command_queues": 1,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "worker_l1_size": 1345000,

--- a/models/demos/llama3_70b_galaxy/demo/text_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_demo.py
@@ -27,6 +27,7 @@ from models.common.utility_functions import (
 from models.demos.utils.device_sku import get_current_device_sku_name
 from models.demos.utils.llm_demo_utils import verify_perf
 from models.demos.utils.model_targets import resolve_perf_targets
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 
 
 def load_and_cache_context(context_url, cache_dir, max_length=None):
@@ -783,7 +784,7 @@ def create_tt_model(
     "device_params",
     [
         {
-            "trace_region_size": 216580672,
+            TRACE_MODEL_KEY_PARAM: "llama3.3-70b-galaxy",
             "num_command_queues": 1,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "worker_l1_size": 1345000,

--- a/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
+++ b/models/demos/llama3_70b_galaxy/demo/text_qwen_demo.py
@@ -22,6 +22,7 @@ from models.common.utility_functions import (
 from models.demos.utils.device_sku import get_current_device_sku_name
 from models.demos.utils.llm_demo_utils import verify_perf
 from models.demos.utils.model_targets import resolve_perf_targets
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 
 # Qwen-specific imports
 from models.demos.llama3_70b_galaxy.tt.qwen_model_config import TtQwenModelArgs
@@ -388,7 +389,7 @@ def create_tt_qwen_model(
     "device_params",
     [
         {
-            "trace_region_size": 184915840,
+            TRACE_MODEL_KEY_PARAM: "llama3.3-70b-galaxy-qwen",
             "num_command_queues": 1,
             "dispatch_core_axis": ttnn.DispatchCoreAxis.COL,
             "worker_l1_size": 1345000,

--- a/models/demos/multimodal/gemma3/demo/text_demo.py
+++ b/models/demos/multimodal/gemma3/demo/text_demo.py
@@ -21,6 +21,7 @@ from models.demos.multimodal.gemma3.tt.gemma_multimodal_generator import GemmaMu
 from models.demos.utils.device_sku import get_current_device_sku_name
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_accuracy, verify_perf
 from models.demos.utils.model_targets import resolve_accuracy_targets
+from models.demos.utils.trace_region_sizes import resolve_trace_region_size
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.common import PagedAttentionConfig, preprocess_inputs_prefill
 from models.tt_transformers.tt.generator import create_submeshes
@@ -313,16 +314,23 @@ def prepare_generator_args(
     return model_args, model, page_table, tt_kv_cache, tokenizer
 
 
+def _gemma3_text_demo_model_key() -> str:
+    hf_model = os.getenv("HF_MODEL", "").lower()
+    if "4b" in hf_model:
+        return "gemma-3-4b"
+    return "gemma-3-27b"
+
+
 def _gemma3_text_demo_device_params():
-    # Blackhole (e.g. P150) needs an extra CQ, L1 small, and a larger trace region than Wormhole.
+    resolved_size = resolve_trace_region_size(_gemma3_text_demo_model_key(), get_current_device_sku_name())
     if is_blackhole():
         return {
             "fabric_config": True,
-            "trace_region_size": 70000000,
+            "trace_region_size": resolved_size,
             "num_command_queues": 2,
             "l1_small_size": 24576,
         }
-    return {"fabric_config": True, "trace_region_size": 30000000, "num_command_queues": 1}
+    return {"fabric_config": True, "trace_region_size": resolved_size, "num_command_queues": 1}
 
 
 # List of supported Parameters for demo.py

--- a/models/demos/multimodal/gemma3/demo/text_demo.py
+++ b/models/demos/multimodal/gemma3/demo/text_demo.py
@@ -21,7 +21,7 @@ from models.demos.multimodal.gemma3.tt.gemma_multimodal_generator import GemmaMu
 from models.demos.utils.device_sku import get_current_device_sku_name
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_accuracy, verify_perf
 from models.demos.utils.model_targets import resolve_accuracy_targets
-from models.demos.utils.trace_region_sizes import resolve_trace_region_size
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.common import PagedAttentionConfig, preprocess_inputs_prefill
 from models.tt_transformers.tt.generator import create_submeshes
@@ -322,15 +322,16 @@ def _gemma3_text_demo_model_key() -> str:
 
 
 def _gemma3_text_demo_device_params():
-    resolved_size = resolve_trace_region_size(_gemma3_text_demo_model_key(), get_current_device_sku_name())
+    # trace_region_size is resolved by the mesh_device fixture from the logical submesh SKU.
+    model_key = _gemma3_text_demo_model_key()
     if is_blackhole():
         return {
             "fabric_config": True,
-            "trace_region_size": resolved_size,
+            TRACE_MODEL_KEY_PARAM: model_key,
             "num_command_queues": 2,
             "l1_small_size": 24576,
         }
-    return {"fabric_config": True, "trace_region_size": resolved_size, "num_command_queues": 1}
+    return {"fabric_config": True, TRACE_MODEL_KEY_PARAM: model_key, "num_command_queues": 1}
 
 
 # List of supported Parameters for demo.py

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -25,7 +25,6 @@ import torch
 
 import ttnn
 from models.common.sampling import SamplingParams
-from models.common.utility_functions import is_blackhole
 from models.demos.multimodal.gemma3.tt.gemma_e2e_model import GemmaMultimodalGenerator
 from models.demos.utils.device_sku import get_current_device_sku_name
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
@@ -148,13 +147,6 @@ def prepare_generator_args(
 
 def _gemma3_vision_demo_device_params():
     resolved_size = resolve_trace_region_size("gemma-3-27b-vision", get_current_device_sku_name())
-    if is_blackhole():
-        return {
-            "fabric_config": True,
-            "trace_region_size": resolved_size,
-            "num_command_queues": 2,
-            "l1_small_size": 24576,
-        }
     return {
         "fabric_config": True,
         "trace_region_size": resolved_size,

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -27,8 +27,10 @@ import ttnn
 from models.common.sampling import SamplingParams
 from models.common.utility_functions import is_blackhole
 from models.demos.multimodal.gemma3.tt.gemma_e2e_model import GemmaMultimodalGenerator
+from models.demos.utils.device_sku import get_current_device_sku_name
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
 from models.demos.utils.model_targets import resolve_perf_targets
+from models.demos.utils.trace_region_sizes import resolve_trace_region_size
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.common import hf_multimodal_encode
 from models.tt_transformers.tt.model_config import DecodersPrecision
@@ -145,17 +147,17 @@ def prepare_generator_args(
 
 
 def _gemma3_vision_demo_device_params():
-    # Blackhole (e.g. P150) needs a larger trace region than Wormhole.
+    resolved_size = resolve_trace_region_size("gemma-3-27b-vision", get_current_device_sku_name())
     if is_blackhole():
         return {
             "fabric_config": True,
-            "trace_region_size": 70000000,
+            "trace_region_size": resolved_size,
             "num_command_queues": 2,
             "l1_small_size": 24576,
         }
     return {
         "fabric_config": True,
-        "trace_region_size": 21448704,
+        "trace_region_size": resolved_size,
         "num_command_queues": 2,
         "l1_small_size": 24576,
     }

--- a/models/demos/multimodal/gemma3/demo/vision_demo.py
+++ b/models/demos/multimodal/gemma3/demo/vision_demo.py
@@ -26,10 +26,9 @@ import torch
 import ttnn
 from models.common.sampling import SamplingParams
 from models.demos.multimodal.gemma3.tt.gemma_e2e_model import GemmaMultimodalGenerator
-from models.demos.utils.device_sku import get_current_device_sku_name
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
 from models.demos.utils.model_targets import resolve_perf_targets
-from models.demos.utils.trace_region_sizes import resolve_trace_region_size
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.common import hf_multimodal_encode
 from models.tt_transformers.tt.model_config import DecodersPrecision
@@ -146,10 +145,10 @@ def prepare_generator_args(
 
 
 def _gemma3_vision_demo_device_params():
-    resolved_size = resolve_trace_region_size("gemma-3-27b-vision", get_current_device_sku_name())
+    # trace_region_size is resolved by the mesh_device fixture from the logical submesh SKU.
     return {
         "fabric_config": True,
-        "trace_region_size": resolved_size,
+        TRACE_MODEL_KEY_PARAM: "gemma-3-27b-vision",
         "num_command_queues": 2,
         "l1_small_size": 24576,
     }

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -36,7 +36,7 @@ def _qwen25_vl_model_key() -> str:
     hf_model = os.getenv("HF_MODEL", "")
     hf_lower = hf_model.lower()
     if "72b" in hf_lower:
-        return "qwen2.5-72b-vl"
+        return "qwen2.5-vl-72b"
     if "32b" in hf_lower:
         return "qwen2.5-vl-32b"
     return "qwen2.5-vl-7b"

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -14,7 +14,6 @@ from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import Qwen2_5_VLForCond
 
 import ttnn
 from models.common.sampling import SamplingParams
-from models.common.utility_functions import is_blackhole
 from models.demos.qwen25_vl.tt.common import (
     PagedAttentionConfig,
     merge_vision_tokens,
@@ -25,15 +24,30 @@ from models.demos.qwen25_vl.tt.common import (
 from models.demos.qwen25_vl.tt.generator import Generator
 from models.demos.qwen25_vl.tt.model import DropInVisionTransformer, Transformer
 from models.demos.qwen25_vl.tt.model_config import VisionModelArgs
+from models.demos.utils.device_sku import get_current_device_sku_name
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
 from models.demos.utils.model_targets import resolve_perf_targets
+from models.demos.utils.trace_region_sizes import resolve_trace_region_size
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs, parse_decoder_json
 
-# trace_region_size per architecture
-TRACE_REGION_SIZE = 28467200
-if is_blackhole():
-    TRACE_REGION_SIZE = 36000000
+
+def _qwen25_vl_model_key() -> str:
+    hf_model = os.getenv("HF_MODEL", "")
+    hf_lower = hf_model.lower()
+    if "72b" in hf_lower:
+        return "qwen2.5-72b-vl"
+    if "32b" in hf_lower:
+        return "qwen2.5-vl-32b"
+    return "qwen2.5-vl-7b"
+
+
+def _qwen25_vl_device_params():
+    return {
+        "fabric_config": True,
+        "trace_region_size": resolve_trace_region_size(_qwen25_vl_model_key(), get_current_device_sku_name()),
+        "num_command_queues": 1,
+    }
 
 
 def create_tt_page_table(paged_attention_config, tt_model_args):
@@ -236,7 +250,7 @@ def create_tt_model(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": True, "trace_region_size": TRACE_REGION_SIZE, "num_command_queues": 1}],
+    [_qwen25_vl_device_params()],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/demos/qwen25_vl/demo/demo.py
+++ b/models/demos/qwen25_vl/demo/demo.py
@@ -24,10 +24,9 @@ from models.demos.qwen25_vl.tt.common import (
 from models.demos.qwen25_vl.tt.generator import Generator
 from models.demos.qwen25_vl.tt.model import DropInVisionTransformer, Transformer
 from models.demos.qwen25_vl.tt.model_config import VisionModelArgs
-from models.demos.utils.device_sku import get_current_device_sku_name
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
 from models.demos.utils.model_targets import resolve_perf_targets
-from models.demos.utils.trace_region_sizes import resolve_trace_region_size
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs, parse_decoder_json
 
@@ -43,9 +42,10 @@ def _qwen25_vl_model_key() -> str:
 
 
 def _qwen25_vl_device_params():
+    # trace_region_size is resolved by the mesh_device fixture from the logical submesh SKU.
     return {
         "fabric_config": True,
-        "trace_region_size": resolve_trace_region_size(_qwen25_vl_model_key(), get_current_device_sku_name()),
+        TRACE_MODEL_KEY_PARAM: _qwen25_vl_model_key(),
         "num_command_queues": 1,
     }
 

--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -27,6 +27,7 @@ from models.demos.qwen3_vl.tt.model import DropInVisionTransformer, Transformer
 from models.demos.qwen3_vl.tt.model_config import VisionModelArgs
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_perf
 from models.demos.utils.model_targets import resolve_perf_targets
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.model_config import DecodersPrecision, ModelArgs, parse_decoder_json
 
@@ -231,7 +232,7 @@ def create_tt_model(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": True, "trace_region_size": 28467200, "num_command_queues": 1}],
+    [{"fabric_config": True, TRACE_MODEL_KEY_PARAM: "qwen3-vl", "num_command_queues": 1}],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/demos/t3000/llama2_70b/demo/demo.py
+++ b/models/demos/t3000/llama2_70b/demo/demo.py
@@ -22,6 +22,7 @@ from models.demos.t3000.llama2_70b.tt.llama_common import (
     string_similarity_score,
 )
 from models.demos.t3000.llama2_70b.tt.llama_generation import TtLlamaModelForGeneration
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 
 
 @dataclass
@@ -421,7 +422,7 @@ def top_pk_logits_efficient(logits, p=0.9, k=10, temperature=1.0, return_probs=F
     ((32, 2048), (16, 8192), (1, 128 * 1024)),
     ids=("short_context", "long_context", "128k_context"),
 )
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 14227456}], indirect=True)
+@pytest.mark.parametrize("device_params", [{TRACE_MODEL_KEY_PARAM: "llama3.1-70b-legacy"}], indirect=True)
 def test_LlamaModel_demo(
     # model args
     implementation,

--- a/models/demos/t3000/llama3_70b/demo/demo.py
+++ b/models/demos/t3000/llama3_70b/demo/demo.py
@@ -7,6 +7,7 @@ from loguru import logger
 
 from models.demos.t3000.llama2_70b.demo.demo import construct_arg, main
 from models.demos.t3000.llama2_70b.tt.llama_common import check_mesh_device, setup_llama_env
+from models.demos.utils.trace_region_sizes import TRACE_MODEL_KEY_PARAM
 from tests.tests_common.skip_reasons import LEGACY_CCL_SKIP
 
 
@@ -62,7 +63,7 @@ from tests.tests_common.skip_reasons import LEGACY_CCL_SKIP
     ((32, 2048), (16, 8192), (1, 128 * 1024)),
     ids=("short_context", "long_context", "128k_context"),
 )
-@pytest.mark.parametrize("device_params", [{"trace_region_size": 14227456}], indirect=True)
+@pytest.mark.parametrize("device_params", [{TRACE_MODEL_KEY_PARAM: "llama3.1-70b-legacy"}], indirect=True)
 def test_LlamaModel_demo(
     # model args
     implementation,

--- a/models/demos/unet_3d/demo/validate.py
+++ b/models/demos/unet_3d/demo/validate.py
@@ -14,6 +14,7 @@ from models.demos.unet_3d.demo.utils import configure_logging
 from models.demos.unet_3d.runner.performant_runner import UNet3DRunner
 from models.demos.unet_3d.torch_impl.model import UNet3DTch
 from models.demos.unet_3d.ttnn_impl.model import UNet3D
+from models.demos.utils.trace_region_sizes import build_trace_device_params
 
 logger = configure_logging()
 
@@ -71,12 +72,13 @@ def print_metrics(metrics) -> None:
 
 def get_device():
     num_devices = ttnn._ttnn.multi_device.SystemMeshDescriptor().shape().mesh_size()
+    trace_params = build_trace_device_params("unet-3d")
     return ttnn.open_mesh_device(
         mesh_shape=ttnn.MeshShape(1, num_devices),
         dispatch_core_config=ttnn.device.DispatchCoreConfig(),
         l1_small_size=2048,
-        trace_region_size=679936,
         num_command_queues=2,
+        **trace_params,
     )
 
 

--- a/models/demos/utils/model_targets.py
+++ b/models/demos/utils/model_targets.py
@@ -22,14 +22,14 @@ TARGETS_YAML_PATH_DEFAULT = str(Path(__file__).resolve().parents[2] / "model_tar
 _SKU_ALIASES = {
     "wh_n150": {"wh_n150", "n150"},
     "wh_n300": {"wh_n300", "n300"},
-    "wh_llmbox_perf": {"wh_llmbox_perf", "t3k"},
-    "wh_galaxy_perf": {"wh_galaxy_perf", "tg", "glx"},
+    "wh_llmbox_perf": {"wh_llmbox_perf", "wh_llmbox", "t3k"},
+    "wh_galaxy_perf": {"wh_galaxy_perf", "wh_galaxy", "tg", "glx"},
     "bh_p100": {"bh_p100", "p100"},
     "bh_p150": {"bh_p150", "p150"},
     "bh_p300": {"bh_p300", "p300"},
     "bh_loudbox": {"bh_loudbox", "p150x8"},
     "p300x2": {"p300x2", "p150x4", "bh_quietbox_2"},
-    "bh_galaxy_perf": {"bh_galaxy_perf", "bhglx"},
+    "bh_galaxy_perf": {"bh_galaxy_perf", "bh_galaxy", "bhglx"},
     "blackhole": {"blackhole", "bh"},
 }
 

--- a/models/demos/utils/trace_region_sizes.py
+++ b/models/demos/utils/trace_region_sizes.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared resolver for centralized trace region sizes."""
+
+from __future__ import annotations
+
+import functools
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from models.demos.utils.model_targets import _model_matches, normalize_sku
+
+TRACE_REGION_SIZES_YAML_PATH = Path(__file__).resolve().parents[2] / "model_trace_region_sizes.yaml"
+
+# Fallback when no YAML entry matches (local dev without HF_MODEL override).
+DEFAULT_TRACE_REGION_SIZE = 50_000_000
+
+
+@functools.cache
+def load_trace_region_sizes() -> dict[str, Any]:
+    """Load centralized trace region sizes YAML from the configured default path."""
+    with TRACE_REGION_SIZES_YAML_PATH.open("r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid trace region sizes file format: {TRACE_REGION_SIZES_YAML_PATH}")
+    return data
+
+
+def resolve_trace_region_size(model_name: str | None, sku: str | None) -> int | None:
+    """Resolve trace region size in bytes for a model/SKU pair, or None if not configured."""
+    if not model_name or not sku:
+        return None
+
+    sizes_doc = load_trace_region_sizes()
+    sizes = sizes_doc.get("sizes", {})
+    sku_norm = normalize_sku(sku)
+
+    for model_key, model_block in sizes.items():
+        if not isinstance(model_block, dict) or not _model_matches(model_key, model_name, model_block):
+            continue
+
+        skus = model_block.get("skus", {})
+        for sku_key, sku_block in skus.items():
+            if normalize_sku(sku_key) != sku_norm:
+                continue
+            if not isinstance(sku_block, dict):
+                continue
+            value = sku_block.get("trace_region_size")
+            if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+                return value
+    return None

--- a/models/demos/utils/trace_region_sizes.py
+++ b/models/demos/utils/trace_region_sizes.py
@@ -16,6 +16,12 @@ from models.demos.utils.model_targets import _model_matches, normalize_sku
 
 TRACE_REGION_SIZES_YAML_PATH = Path(__file__).resolve().parents[2] / "model_trace_region_sizes.yaml"
 
+# trace_region_size=0 lets the runtime allocate trace buffers dynamically (see deepseek-v3 demo).
+TRACE_REGION_SIZE_DYNAMIC = 0
+
+# Populated from device_params parametrize dict; resolved at fixture time via apply_trace_model_key().
+TRACE_MODEL_KEY_PARAM = "_trace_model_key"
+
 
 class TraceRegionSizeNotConfiguredError(ValueError):
     """Raised when trace_region_size is missing from model_trace_region_sizes.yaml."""
@@ -60,7 +66,28 @@ def resolve_trace_region_size(model_name: str | None, sku: str | None) -> int:
             if not isinstance(sku_block, dict):
                 continue
             value = sku_block.get("trace_region_size")
-            if isinstance(value, int) and not isinstance(value, bool) and value > 0:
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
                 return value
 
     raise TraceRegionSizeNotConfiguredError(_missing_trace_region_size_message(model_name, sku_norm))
+
+
+def resolve_demo_trace_region_size(model_key: str) -> int:
+    """Resolve trace region size for a demo using the current cluster SKU."""
+    from models.demos.utils.device_sku import get_current_device_sku_name
+
+    return resolve_trace_region_size(model_key, get_current_device_sku_name())
+
+
+def apply_trace_model_key(device_params: dict[str, Any]) -> dict[str, Any]:
+    """Resolve trace_region_size from YAML when TRACE_MODEL_KEY_PARAM is set in device_params."""
+    params = device_params.copy()
+    model_key = params.pop(TRACE_MODEL_KEY_PARAM, None)
+    if model_key is not None:
+        params["trace_region_size"] = resolve_demo_trace_region_size(model_key)
+    return params
+
+
+def build_trace_device_params(model_key: str, **extra: Any) -> dict[str, Any]:
+    """Build device_params dict with trace_region_size resolved from YAML."""
+    return {"trace_region_size": resolve_demo_trace_region_size(model_key), **extra}

--- a/models/demos/utils/trace_region_sizes.py
+++ b/models/demos/utils/trace_region_sizes.py
@@ -16,8 +16,16 @@ from models.demos.utils.model_targets import _model_matches, normalize_sku
 
 TRACE_REGION_SIZES_YAML_PATH = Path(__file__).resolve().parents[2] / "model_trace_region_sizes.yaml"
 
-# Fallback when no YAML entry matches (local dev without HF_MODEL override).
-DEFAULT_TRACE_REGION_SIZE = 50_000_000
+
+class TraceRegionSizeNotConfiguredError(ValueError):
+    """Raised when trace_region_size is missing from model_trace_region_sizes.yaml."""
+
+
+def _missing_trace_region_size_message(model_name: str, sku: str) -> str:
+    return (
+        f"trace_region_size is not configured for model={model_name!r} and SKU={sku!r}. "
+        f"Add a (model, SKU) entry with trace_region_size to {TRACE_REGION_SIZES_YAML_PATH}."
+    )
 
 
 @functools.cache
@@ -32,7 +40,7 @@ def load_trace_region_sizes() -> dict[str, Any]:
 
 def is_trace_region_size_placeholder(trace_region_size: int | None) -> bool:
     """Return True when a test did not set a custom trace region size."""
-    return trace_region_size is None or trace_region_size == DEFAULT_TRACE_REGION_SIZE
+    return trace_region_size is None
 
 
 def should_apply_trace_region_override(device_params: dict, override_trace_region_size: int | None) -> bool:
@@ -50,10 +58,12 @@ def apply_trace_region_override(device_params: dict, override_trace_region_size:
     return device_params.get("trace_region_size")
 
 
-def resolve_trace_region_size(model_name: str | None, sku: str | None) -> int | None:
-    """Resolve trace region size in bytes for a model/SKU pair, or None if not configured."""
-    if not model_name or not sku:
-        return None
+def resolve_trace_region_size(model_name: str | None, sku: str | None) -> int:
+    """Resolve trace region size in bytes for a model/SKU pair from the centralized YAML."""
+    if not model_name:
+        raise ValueError("model_name is required to resolve trace_region_size")
+    if not sku:
+        raise ValueError("sku is required to resolve trace_region_size")
 
     sizes_doc = load_trace_region_sizes()
     sizes = sizes_doc.get("sizes", {})
@@ -72,4 +82,5 @@ def resolve_trace_region_size(model_name: str | None, sku: str | None) -> int | 
             value = sku_block.get("trace_region_size")
             if isinstance(value, int) and not isinstance(value, bool) and value > 0:
                 return value
-    return None
+
+    raise TraceRegionSizeNotConfiguredError(_missing_trace_region_size_message(model_name, sku_norm))

--- a/models/demos/utils/trace_region_sizes.py
+++ b/models/demos/utils/trace_region_sizes.py
@@ -30,6 +30,26 @@ def load_trace_region_sizes() -> dict[str, Any]:
     return data
 
 
+def is_trace_region_size_placeholder(trace_region_size: int | None) -> bool:
+    """Return True when a test did not set a custom trace region size."""
+    return trace_region_size is None or trace_region_size == DEFAULT_TRACE_REGION_SIZE
+
+
+def should_apply_trace_region_override(device_params: dict, override_trace_region_size: int | None) -> bool:
+    """Return True when centralized YAML should replace the test's trace region size."""
+    if not override_trace_region_size:
+        return False
+    return is_trace_region_size_placeholder(device_params.get("trace_region_size"))
+
+
+def apply_trace_region_override(device_params: dict, override_trace_region_size: int | None) -> int | None:
+    """Apply centralized trace region size unless the test set a custom value."""
+    if should_apply_trace_region_override(device_params, override_trace_region_size):
+        device_params["trace_region_size"] = override_trace_region_size
+        return override_trace_region_size
+    return device_params.get("trace_region_size")
+
+
 def resolve_trace_region_size(model_name: str | None, sku: str | None) -> int | None:
     """Resolve trace region size in bytes for a model/SKU pair, or None if not configured."""
     if not model_name or not sku:

--- a/models/demos/utils/trace_region_sizes.py
+++ b/models/demos/utils/trace_region_sizes.py
@@ -2,7 +2,40 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""Shared resolver for centralized trace region sizes."""
+"""Shared resolver for centralized trace region sizes.
+
+This module is the single entry point for answering "how many bytes of
+``trace_region_size`` should I reserve when opening a device for model X on
+this machine?". The values live in one source of truth,
+``models/model_trace_region_sizes.yaml``, keyed by model and SKU (the
+cluster/board type, e.g. ``wh_n150``, ``wh_llmbox_perf``, ``bh_p150``).
+This replaces the per-model/per-SKU literals that demos and tests used to
+hardcode.
+
+Resolution:
+    ``resolve_trace_region_size(model_name, sku)`` matches ``model_name``
+    against each YAML entry's key or ``aliases`` (case-insensitive) and the
+    ``sku`` against its ``skus`` block (via ``normalize_sku`` so aliases like
+    ``t3k`` -> ``wh_llmbox_perf`` work), returning the configured size in bytes.
+
+Two ways callers consume it:
+    * Eager -- call ``resolve_trace_region_size`` /
+      ``resolve_demo_trace_region_size`` / ``build_trace_device_params``
+      directly when opening a device or building a ``device_params`` dict
+      (the SKU is read from the current cluster via ``get_current_device_sku_name``).
+    * Deferred (pytest) -- put ``TRACE_MODEL_KEY_PARAM: "<model-key>"`` in a
+      parametrized ``device_params`` dict; the ``device_params`` fixture calls
+      ``apply_trace_model_key`` to resolve it to ``trace_region_size`` just
+      before the device opens.
+
+Fail-loud by design: if a (model, SKU) pair is not configured, resolution
+raises ``TraceRegionSizeNotConfiguredError`` rather than falling back to a
+default. There is no implicit default size -- a value is only ever returned
+when it is explicitly present in the YAML. The one special value is ``0``
+(``TRACE_REGION_SIZE_DYNAMIC``): when a YAML entry sets it explicitly (e.g.
+``deepseek-v3``), it tells the runtime to allocate trace buffers dynamically
+instead of reserving a fixed region up front.
+"""
 
 from __future__ import annotations
 

--- a/models/demos/utils/trace_region_sizes.py
+++ b/models/demos/utils/trace_region_sizes.py
@@ -7,6 +7,7 @@
 from __future__ import annotations
 
 import functools
+import re
 from pathlib import Path
 from typing import Any
 
@@ -25,6 +26,30 @@ TRACE_MODEL_KEY_PARAM = "_trace_model_key"
 
 class TraceRegionSizeNotConfiguredError(ValueError):
     """Raised when trace_region_size is missing from model_trace_region_sizes.yaml."""
+
+
+def _append_unique(candidates: list[str], value: str) -> None:
+    if value and value not in candidates:
+        candidates.append(value)
+
+
+def hf_model_name_candidates(hf_model: str) -> list[str]:
+    """Build model name candidates from HF_MODEL env values, including hub cache paths."""
+    candidates: list[str] = []
+    _append_unique(candidates, hf_model)
+
+    basename = hf_model.strip("/").split("/")[-1]
+    _append_unique(candidates, basename)
+
+    hub_match = re.search(r"models--([^/]+)--([^/]+)", hf_model)
+    if hub_match:
+        _append_unique(candidates, f"{hub_match.group(1)}/{hub_match.group(2)}")
+
+    base_match = re.search(r"(.*?\d+[bB])-", basename)
+    if base_match:
+        _append_unique(candidates, base_match.group(1))
+
+    return candidates
 
 
 def _missing_trace_region_size_message(model_name: str, sku: str) -> str:

--- a/models/demos/utils/trace_region_sizes.py
+++ b/models/demos/utils/trace_region_sizes.py
@@ -28,13 +28,13 @@ Two ways callers consume it:
       ``apply_trace_model_key`` to resolve it to ``trace_region_size`` just
       before the device opens.
 
-Fail-loud by design: if a (model, SKU) pair is not configured, resolution
-raises ``TraceRegionSizeNotConfiguredError`` rather than falling back to a
-default. There is no implicit default size -- a value is only ever returned
-when it is explicitly present in the YAML. The one special value is ``0``
-(``TRACE_REGION_SIZE_DYNAMIC``): when a YAML entry sets it explicitly (e.g.
-``deepseek-v3``), it tells the runtime to allocate trace buffers dynamically
-instead of reserving a fixed region up front.
+Unconfigured pairs default to dynamic allocation: if a (model, SKU) pair is
+not present in the YAML, resolution logs an info message and returns
+``TRACE_REGION_SIZE_DYNAMIC`` (``0``), which tells the runtime to allocate
+trace buffers dynamically instead of reserving a fixed region up front. A
+non-zero size is only ever returned when it is explicitly present in the YAML;
+``deepseek-v3`` also sets ``0`` explicitly to opt into the same dynamic
+behavior.
 """
 
 from __future__ import annotations
@@ -45,6 +45,7 @@ from pathlib import Path
 from typing import Any
 
 import yaml
+from loguru import logger
 
 from models.demos.utils.model_targets import _model_matches, normalize_sku
 
@@ -55,10 +56,6 @@ TRACE_REGION_SIZE_DYNAMIC = 0
 
 # Populated from device_params parametrize dict; resolved at fixture time via apply_trace_model_key().
 TRACE_MODEL_KEY_PARAM = "_trace_model_key"
-
-
-class TraceRegionSizeNotConfiguredError(ValueError):
-    """Raised when trace_region_size is missing from model_trace_region_sizes.yaml."""
 
 
 def _append_unique(candidates: list[str], value: str) -> None:
@@ -85,13 +82,6 @@ def hf_model_name_candidates(hf_model: str) -> list[str]:
     return candidates
 
 
-def _missing_trace_region_size_message(model_name: str, sku: str) -> str:
-    return (
-        f"trace_region_size is not configured for model={model_name!r} and SKU={sku!r}. "
-        f"Add a (model, SKU) entry with trace_region_size to {TRACE_REGION_SIZES_YAML_PATH}."
-    )
-
-
 @functools.cache
 def load_trace_region_sizes() -> dict[str, Any]:
     """Load centralized trace region sizes YAML from the configured default path."""
@@ -102,32 +92,67 @@ def load_trace_region_sizes() -> dict[str, Any]:
     return data
 
 
+def _find_configured_trace_region_size(model_name: str, sku_norm: str) -> int | None:
+    """Return the configured trace_region_size for a model/normalized-SKU pair, or None."""
+    sizes = load_trace_region_sizes().get("sizes", {})
+    for model_key, model_block in sizes.items():
+        if not isinstance(model_block, dict) or not _model_matches(model_key, model_name, model_block):
+            continue
+        for sku_key, sku_block in model_block.get("skus", {}).items():
+            if normalize_sku(sku_key) != sku_norm or not isinstance(sku_block, dict):
+                continue
+            value = sku_block.get("trace_region_size")
+            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
+                return value
+    return None
+
+
 def resolve_trace_region_size(model_name: str | None, sku: str | None) -> int:
-    """Resolve trace region size in bytes for a model/SKU pair from the centralized YAML."""
+    """Resolve trace region size in bytes for a model/SKU pair from the centralized YAML.
+
+    Returns the configured value, or ``TRACE_REGION_SIZE_DYNAMIC`` (0, dynamic
+    allocation) -- with an info log -- when the pair is not configured.
+    """
     if not model_name:
         raise ValueError("model_name is required to resolve trace_region_size")
     if not sku:
         raise ValueError("sku is required to resolve trace_region_size")
 
-    sizes_doc = load_trace_region_sizes()
-    sizes = sizes_doc.get("sizes", {})
     sku_norm = normalize_sku(sku)
+    value = _find_configured_trace_region_size(model_name, sku_norm)
+    if value is not None:
+        return value
 
-    for model_key, model_block in sizes.items():
-        if not isinstance(model_block, dict) or not _model_matches(model_key, model_name, model_block):
+    logger.info(
+        f"No trace_region_size configured for model={model_name!r} and SKU={sku_norm!r}; "
+        f"defaulting to dynamic allocation (trace_region_size={TRACE_REGION_SIZE_DYNAMIC})."
+    )
+    return TRACE_REGION_SIZE_DYNAMIC
+
+
+def resolve_trace_region_size_for_candidates(model_name_candidates: list[str], sku: str | None) -> int:
+    """Resolve the first configured candidate's size, else dynamic allocation (0).
+
+    Used by the HF_MODEL env path, which derives several model-name candidates
+    from a single HF model string. A configured candidate always wins over the
+    dynamic-allocation default.
+    """
+    if not sku:
+        raise ValueError("sku is required to resolve trace_region_size")
+
+    sku_norm = normalize_sku(sku)
+    for model_name in model_name_candidates:
+        if not model_name:
             continue
+        value = _find_configured_trace_region_size(model_name, sku_norm)
+        if value is not None:
+            return value
 
-        skus = model_block.get("skus", {})
-        for sku_key, sku_block in skus.items():
-            if normalize_sku(sku_key) != sku_norm:
-                continue
-            if not isinstance(sku_block, dict):
-                continue
-            value = sku_block.get("trace_region_size")
-            if isinstance(value, int) and not isinstance(value, bool) and value >= 0:
-                return value
-
-    raise TraceRegionSizeNotConfiguredError(_missing_trace_region_size_message(model_name, sku_norm))
+    logger.info(
+        f"No trace_region_size configured for model candidates {list(model_name_candidates)!r} "
+        f"and SKU={sku_norm!r}; defaulting to dynamic allocation (trace_region_size={TRACE_REGION_SIZE_DYNAMIC})."
+    )
+    return TRACE_REGION_SIZE_DYNAMIC
 
 
 def resolve_demo_trace_region_size(model_key: str) -> int:

--- a/models/demos/utils/trace_region_sizes.py
+++ b/models/demos/utils/trace_region_sizes.py
@@ -19,14 +19,17 @@ Resolution:
     ``t3k`` -> ``wh_llmbox_perf`` work), returning the configured size in bytes.
 
 Two ways callers consume it:
-    * Eager -- call ``resolve_trace_region_size`` /
-      ``resolve_demo_trace_region_size`` / ``build_trace_device_params``
-      directly when opening a device or building a ``device_params`` dict
-      (the SKU is read from the current cluster via ``get_current_device_sku_name``).
-    * Deferred (pytest) -- put ``TRACE_MODEL_KEY_PARAM: "<model-key>"`` in a
-      parametrized ``device_params`` dict; the ``device_params`` fixture calls
-      ``apply_trace_model_key`` to resolve it to ``trace_region_size`` just
-      before the device opens.
+    * Direct (full physical device) -- call ``resolve_trace_region_size`` /
+      ``resolve_demo_trace_region_size`` / ``build_trace_device_params`` when a
+      demo opens the whole physical device itself (the SKU is read from the
+      current cluster via ``get_current_device_sku_name``, where physical ==
+      logical).
+    * Deferred (pytest mesh_device fixture) -- put
+      ``TRACE_MODEL_KEY_PARAM: "<model-key>"`` in a parametrized
+      ``device_params`` dict. The ``mesh_device`` fixture resolves it to
+      ``trace_region_size`` at device-open time using the SKU of the logical
+      submesh actually opened (derived from the mesh shape / ``data_parallel`` /
+      ``MESH_DEVICE``), not the physical cluster.
 
 Unconfigured pairs default to dynamic allocation: if a (model, SKU) pair is
 not present in the YAML, resolution logs an info message and returns
@@ -54,7 +57,8 @@ TRACE_REGION_SIZES_YAML_PATH = Path(__file__).resolve().parents[2] / "model_trac
 # trace_region_size=0 lets the runtime allocate trace buffers dynamically (see deepseek-v3 demo).
 TRACE_REGION_SIZE_DYNAMIC = 0
 
-# Populated from device_params parametrize dict; resolved at fixture time via apply_trace_model_key().
+# Set in a device_params parametrize dict; the mesh_device fixture pops it and resolves
+# trace_region_size from the YAML using the logical submesh SKU at device-open time.
 TRACE_MODEL_KEY_PARAM = "_trace_model_key"
 
 
@@ -156,19 +160,16 @@ def resolve_trace_region_size_for_candidates(model_name_candidates: list[str], s
 
 
 def resolve_demo_trace_region_size(model_key: str) -> int:
-    """Resolve trace region size for a demo using the current cluster SKU."""
+    """Resolve trace region size using the physical cluster SKU.
+
+    Intended for demos that open the full physical device directly (so physical ==
+    logical). Tests/demos that open a logical submesh via the ``mesh_device`` fixture
+    should instead pass ``TRACE_MODEL_KEY_PARAM`` in ``device_params`` so the fixture
+    resolves against the logical submesh SKU.
+    """
     from models.demos.utils.device_sku import get_current_device_sku_name
 
     return resolve_trace_region_size(model_key, get_current_device_sku_name())
-
-
-def apply_trace_model_key(device_params: dict[str, Any]) -> dict[str, Any]:
-    """Resolve trace_region_size from YAML when TRACE_MODEL_KEY_PARAM is set in device_params."""
-    params = device_params.copy()
-    model_key = params.pop(TRACE_MODEL_KEY_PARAM, None)
-    if model_key is not None:
-        params["trace_region_size"] = resolve_demo_trace_region_size(model_key)
-    return params
 
 
 def build_trace_device_params(model_key: str, **extra: Any) -> dict[str, Any]:

--- a/models/demos/utils/trace_region_sizes.py
+++ b/models/demos/utils/trace_region_sizes.py
@@ -38,26 +38,6 @@ def load_trace_region_sizes() -> dict[str, Any]:
     return data
 
 
-def is_trace_region_size_placeholder(trace_region_size: int | None) -> bool:
-    """Return True when a test did not set a custom trace region size."""
-    return trace_region_size is None
-
-
-def should_apply_trace_region_override(device_params: dict, override_trace_region_size: int | None) -> bool:
-    """Return True when centralized YAML should replace the test's trace region size."""
-    if not override_trace_region_size:
-        return False
-    return is_trace_region_size_placeholder(device_params.get("trace_region_size"))
-
-
-def apply_trace_region_override(device_params: dict, override_trace_region_size: int | None) -> int | None:
-    """Apply centralized trace region size unless the test set a custom value."""
-    if should_apply_trace_region_override(device_params, override_trace_region_size):
-        device_params["trace_region_size"] = override_trace_region_size
-        return override_trace_region_size
-    return device_params.get("trace_region_size")
-
-
 def resolve_trace_region_size(model_name: str | None, sku: str | None) -> int:
     """Resolve trace region size in bytes for a model/SKU pair from the centralized YAML."""
     if not model_name:

--- a/models/model_ci_tiers.md
+++ b/models/model_ci_tiers.md
@@ -134,6 +134,16 @@ Captures device timing for a single layer of each target model, used to track pe
 
 > **TODO:** Add pipeline links once merged to main.
 
+## Trace Region Sizes
+
+Trace buffer sizes (in bytes) for model demos and tests are centralized in [`model_trace_region_sizes.yaml`](./model_trace_region_sizes.yaml), keyed by `(model, SKU)` — the same model keys and canonical SKU names used in [`model_targets.yaml`](./model_targets.yaml) and [`models_e2e_tests.yaml`](../tests/pipeline_reorg/models_e2e_tests.yaml).
+
+When adding or tuning a model for CI:
+
+1. Add or update the `(model, SKU)` entry in `model_trace_region_sizes.yaml` with `trace_region_size: <bytes>`.
+2. Use short kebab-case model keys and `aliases` for HuggingFace repo names (mirror `model_targets.yaml` conventions).
+3. `tt_transformers` demos resolve sizes automatically via `get_supported_trace_region_size` in the root `conftest.py` `mesh_device` fixture; other demos can call `resolve_trace_region_size` from [`demos/utils/trace_region_sizes.py`](./demos/utils/trace_region_sizes.py) directly.
+
 ## Other Pipelines
 
 > **TODO:** Expand descriptions for the pipelines below.

--- a/models/model_ci_tiers.md
+++ b/models/model_ci_tiers.md
@@ -134,16 +134,6 @@ Captures device timing for a single layer of each target model, used to track pe
 
 > **TODO:** Add pipeline links once merged to main.
 
-## Trace Region Sizes
-
-Trace buffer sizes (in bytes) for model demos and tests are centralized in [`model_trace_region_sizes.yaml`](./model_trace_region_sizes.yaml), keyed by `(model, SKU)` — the same model keys and canonical SKU names used in [`model_targets.yaml`](./model_targets.yaml) and [`models_e2e_tests.yaml`](../tests/pipeline_reorg/models_e2e_tests.yaml).
-
-When adding or tuning a model for CI:
-
-1. Add or update the `(model, SKU)` entry in `model_trace_region_sizes.yaml` with `trace_region_size: <bytes>`.
-2. Use short kebab-case model keys and `aliases` for HuggingFace repo names (mirror `model_targets.yaml` conventions).
-3. `tt_transformers` demos resolve sizes automatically via `get_supported_trace_region_size` in the root `conftest.py` `mesh_device` fixture; other demos can call `resolve_trace_region_size` from [`demos/utils/trace_region_sizes.py`](./demos/utils/trace_region_sizes.py) directly.
-
 ## Other Pipelines
 
 > **TODO:** Expand descriptions for the pipelines below.

--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -964,7 +964,7 @@ targets:
               decode_t/s/u: 15.2
               prefill_time_to_first_token: 225
             accuracy: {}
-  qwen2.5-72b-vl:
+  qwen2.5-vl-72b:
     aliases: ["Qwen2.5-VL-72B", "Qwen/Qwen2.5-VL-72B-Instruct"]
     skus:
       wh_llmbox_perf:

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -1,0 +1,181 @@
+version: 1
+description: Centralized trace region sizes (bytes) for models CI.
+sizes:
+  llama3.1-8b:
+    aliases: ["Llama-3.1-8B", "meta-llama/Llama-3.1-8B-Instruct"]
+    skus:
+      wh_n150:
+        trace_region_size: 25000000
+      wh_n300:
+        trace_region_size: 38000000
+      wh_llmbox_perf:
+        trace_region_size: 50000000
+      wh_galaxy_perf:
+        trace_region_size: 50000000
+      bh_p150:
+        trace_region_size: 52000000
+      bh_p300:
+        trace_region_size: 52000000
+
+  llama3.1-70b:
+    aliases: ["Llama-3.1-70B", "meta-llama/Llama-3.1-70B-Instruct"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 90000000
+      wh_galaxy_perf:
+        trace_region_size: 90000000
+      bh_p150:
+        trace_region_size: 90000000
+      bh_p300:
+        trace_region_size: 90000000
+      p300x2:
+        trace_region_size: 90000000
+      bh_loudbox:
+        trace_region_size: 90000000
+
+  llama3.3-70b:
+    aliases: ["Llama-3.3-70B", "meta-llama/Llama-3.3-70B-Instruct"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 90000000
+      wh_galaxy_perf:
+        trace_region_size: 80000000
+      bh_p150:
+        trace_region_size: 80000000
+      bh_p300:
+        trace_region_size: 80000000
+      p300x2:
+        trace_region_size: 96000000
+      bh_loudbox:
+        trace_region_size: 84000000
+
+  llama3.2-3b:
+    aliases: ["Llama-3.2-3B", "meta-llama/Llama-3.2-3B-Instruct"]
+    skus:
+      wh_n150:
+        trace_region_size: 10000000
+
+  llama3.2-90b-vision:
+    aliases:
+      - "Llama-3.2-90B"
+      - "llama3.2-90b-vision"
+      - "Llama-3.2-90B-Vision"
+      - "meta-llama/Llama-3.2-90B-Vision-Instruct"
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 20000000
+
+  llama3.2-11b-vision:
+    aliases:
+      - "Llama-3.2-11B"
+      - "Llama-3.2-11B-Vision"
+      - "meta-llama/Llama-3.2-11B-Vision-Instruct"
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 17400000
+
+  qwen3-32b:
+    aliases: ["Qwen3-32B", "Qwen/Qwen3-32B"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 90000000
+      wh_galaxy_perf:
+        trace_region_size: 200000000
+      bh_p150:
+        trace_region_size: 90000000
+      bh_p300:
+        trace_region_size: 90000000
+      p300x2:
+        trace_region_size: 90000000
+      bh_loudbox:
+        trace_region_size: 90000000
+
+  gpt-oss-20b:
+    aliases: ["GPT-OSS-20B", "gpt-oss-20b", "openai/gpt-oss-20b"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 50000000
+      wh_galaxy_perf:
+        trace_region_size: 50000000
+
+  gpt-oss-120b:
+    aliases: ["GPT-OSS-120B", "gpt-oss-120b", "openai/gpt-oss-120b"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 50000000
+      wh_galaxy_perf:
+        trace_region_size: 50000000
+
+  qwen2.5-72b:
+    aliases: ["Qwen2.5-72B", "Qwen/Qwen2.5-72B-Instruct"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 70000000
+      wh_galaxy_perf:
+        trace_region_size: 70000000
+      bh_p150:
+        trace_region_size: 100000000
+      bh_p300:
+        trace_region_size: 100000000
+      p300x2:
+        trace_region_size: 100000000
+      bh_loudbox:
+        trace_region_size: 100000000
+      bh_galaxy_perf:
+        trace_region_size: 100000000
+
+  qwen2.5-32b:
+    aliases: ["Qwen2.5-32B", "Qwen/Qwen2.5-32B-Instruct"]
+    skus:
+      bh_p150:
+        trace_region_size: 100000000
+      bh_p300:
+        trace_region_size: 100000000
+      p300x2:
+        trace_region_size: 100000000
+      bh_loudbox:
+        trace_region_size: 100000000
+      bh_galaxy_perf:
+        trace_region_size: 100000000
+
+  qwen2.5-vl-7b:
+    aliases: ["Qwen2.5-VL-7B", "Qwen/Qwen2.5-VL-7B-Instruct"]
+    skus:
+      wh_n300:
+        trace_region_size: 10000000
+
+  gemma-3-27b:
+    aliases: ["gemma-3-27b", "google/gemma-3-27b-it", "gemma-3-27b-vision"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 70000000
+      wh_galaxy_perf:
+        trace_region_size: 70000000
+      p300x2:
+        trace_region_size: 70000000
+
+  deepseek-r1-distill-llama-70b:
+    aliases: ["DeepSeek-R1-Distill-Llama-70B"]
+    skus:
+      p300x2:
+        trace_region_size: 90000000
+
+  mixtral-8x7b:
+    aliases: ["Mixtral-8x7B", "mistralai/Mixtral-8x7B-Instruct-v0.1", "mistralai/Mixtral-8x7B-v0.1"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 250000000
+
+  mistral-small-3.1-24b:
+    aliases:
+      - "Mistral-Small-3.1-24B"
+      - "mistralai/Mistral-Small-3.1-24B-Instruct-2503"
+    skus:
+      wh_n150:
+        trace_region_size: 30000000
+      wh_n300:
+        trace_region_size: 30000000
+      wh_llmbox_perf:
+        trace_region_size: 30000000
+      wh_galaxy_perf:
+        trace_region_size: 30000000

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -321,6 +321,8 @@ sizes:
       - "google/gemma-4-E4B-it"
       - "models/demos/gemma4/configs/gemma-4-E4B-it"
     skus:
+      bh_p150:
+        trace_region_size: 70000000
       bh_p300:
         trace_region_size: 70000000
       p300x2:
@@ -335,7 +337,11 @@ sizes:
       - "google/gemma-4-26B-A4B-it"
       - "models/demos/gemma4/configs/gemma-4-26B-A4B-it"
     skus:
+      wh_n150:
+        trace_region_size: 70000000
       wh_llmbox_perf:
+        trace_region_size: 70000000
+      bh_p150:
         trace_region_size: 70000000
       p300x2:
         trace_region_size: 70000000
@@ -348,7 +354,11 @@ sizes:
       - "google/gemma-4-31B-it"
       - "models/demos/gemma4/configs/gemma-4-31B-it"
     skus:
+      wh_n150:
+        trace_region_size: 70000000
       wh_llmbox_perf:
+        trace_region_size: 70000000
+      bh_p150:
         trace_region_size: 70000000
       p300x2:
         trace_region_size: 70000000

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -16,6 +16,8 @@ sizes:
         trace_region_size: 52000000
       bh_p300:
         trace_region_size: 52000000
+      p300x2:
+        trace_region_size: 52000000
 
   llama3.1-70b:
     aliases: ["Llama-3.1-70B", "meta-llama/Llama-3.1-70B-Instruct"]

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -51,6 +51,12 @@ sizes:
       bh_loudbox:
         trace_region_size: 84000000
 
+  llama3.2-1b:
+    aliases: ["Llama-3.2-1B", "meta-llama/Llama-3.2-1B-Instruct"]
+    skus:
+      wh_n150:
+        trace_region_size: 10000000
+
   llama3.2-3b:
     aliases: ["Llama-3.2-3B", "meta-llama/Llama-3.2-3B-Instruct"]
     skus:
@@ -93,20 +99,54 @@ sizes:
         trace_region_size: 90000000
 
   gpt-oss-20b:
-    aliases: ["GPT-OSS-20B", "gpt-oss-20b", "openai/gpt-oss-20b"]
+    aliases: ["GPT-OSS-20B", "gpt-oss-20b", "openai/gpt-oss-20b", "models/demos/gpt_oss/configs/gpt-oss-20b"]
     skus:
       wh_llmbox_perf:
         trace_region_size: 50000000
       wh_galaxy_perf:
         trace_region_size: 50000000
+      wh_n150:
+        trace_region_size: 30000000
+      bh_p150:
+        trace_region_size: 30000000
+      p300x2:
+        trace_region_size: 30000000
 
   gpt-oss-120b:
-    aliases: ["GPT-OSS-120B", "gpt-oss-120b", "openai/gpt-oss-120b"]
+    aliases: ["GPT-OSS-120B", "gpt-oss-120b", "openai/gpt-oss-120b", "models/demos/gpt_oss/configs/gpt-oss-120b"]
     skus:
       wh_llmbox_perf:
         trace_region_size: 50000000
       wh_galaxy_perf:
         trace_region_size: 50000000
+      bh_galaxy_perf:
+        trace_region_size: 50000000
+      wh_n150:
+        trace_region_size: 100000000
+      p300x2:
+        trace_region_size: 100000000
+
+  informer:
+    aliases: ["informer"]
+    skus:
+      wh_n150:
+        trace_region_size: 134217728
+
+  unet-3d:
+    aliases: ["unet-3d", "shallow-unet"]
+    skus:
+      wh_n150:
+        trace_region_size: 679936
+
+  deepseek-v3:
+    aliases: ["deepseek-v3", "DeepSeek-V3"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 0
+      wh_galaxy_perf:
+        trace_region_size: 0
+      p300x2:
+        trace_region_size: 0
 
   qwen2.5-72b:
     aliases: ["Qwen2.5-72B", "Qwen/Qwen2.5-72B-Instruct"]
@@ -129,6 +169,8 @@ sizes:
   qwen2.5-32b:
     aliases: ["Qwen2.5-32B", "Qwen/Qwen2.5-32B-Instruct"]
     skus:
+      wh_llmbox_perf:
+        trace_region_size: 100000000
       bh_p150:
         trace_region_size: 100000000
       bh_p300:
@@ -146,14 +188,132 @@ sizes:
       wh_n300:
         trace_region_size: 10000000
 
-  gemma-3-27b:
-    aliases: ["gemma-3-27b", "google/gemma-3-27b-it", "gemma-3-27b-vision"]
+  qwen2.5-vl-32b:
+    aliases: ["Qwen2.5-VL-32B", "Qwen/Qwen2.5-VL-32B-Instruct"]
     skus:
       wh_llmbox_perf:
-        trace_region_size: 70000000
+        trace_region_size: 28467200
+      p300x2:
+        trace_region_size: 36000000
+
+  qwen2.5-72b-vl:
+    aliases: ["Qwen2.5-VL-72B", "Qwen/Qwen2.5-VL-72B-Instruct"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 28467200
+      p300x2:
+        trace_region_size: 36000000
+
+  qwen2.5-7b:
+    aliases: ["Qwen2.5-7B", "Qwen/Qwen2.5-7B-Instruct"]
+    skus:
+      wh_n300:
+        trace_region_size: 10000000
+
+  qwen2.5-coder-32b:
+    aliases: ["Qwen2.5-Coder-32B", "Qwen/Qwen2.5-Coder-32B-Instruct"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 100000000
+
+  qwq-32b:
+    aliases: ["QwQ-32B", "Qwen/QwQ-32B"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 90000000
+
+  qwen3-vl:
+    aliases: ["Qwen3-VL", "Qwen/Qwen3-VL"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 28467200
+
+  mistral-7b:
+    aliases: ["Mistral-7B", "mistralai/Mistral-7B-Instruct-v0.3"]
+    skus:
+      wh_n150:
+        trace_region_size: 25000000
+
+  phi-3-mini:
+    aliases: ["Phi-3-mini", "microsoft/Phi-3-mini-128k-instruct"]
+    skus:
+      wh_n150:
+        trace_region_size: 10000000
+
+  llama3.1-70b-legacy:
+    aliases: ["Llama-3.1-70B-legacy", "Llama-2-70B-legacy"]
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 14227456
+
+  llama3.3-70b-galaxy:
+    aliases: ["llama3.3-70b-galaxy"]
+    skus:
       wh_galaxy_perf:
+        trace_region_size: 216580672
+
+  llama3.3-70b-galaxy-decode:
+    aliases: ["llama3.3-70b-galaxy-decode"]
+    skus:
+      wh_galaxy_perf:
+        trace_region_size: 23887872
+
+  llama3.3-70b-galaxy-qwen:
+    aliases: ["llama3.3-70b-galaxy-qwen"]
+    skus:
+      wh_galaxy_perf:
+        trace_region_size: 184915840
+
+  qwen3-32b-galaxy:
+    aliases: ["qwen3-32b-galaxy"]
+    skus:
+      wh_galaxy_perf:
+        trace_region_size: 102000000
+
+  qwen3-32b-galaxy-decode:
+    aliases: ["qwen3-32b-galaxy-decode"]
+    skus:
+      wh_galaxy_perf:
+        trace_region_size: 12726272
+
+  gemma-3-4b:
+    aliases: ["gemma-3-4b", "google/gemma-3-4b-it"]
+    skus:
+      wh_n150:
+        trace_region_size: 30000000
+      bh_p150:
+        trace_region_size: 70000000
+
+  gemma-3-27b-vision:
+    aliases: ["gemma-3-27b-vision-demo"]
+    skus:
+      wh_n150:
+        trace_region_size: 21448704
+      wh_llmbox_perf:
+        trace_region_size: 21448704
+      bh_p150:
         trace_region_size: 70000000
       p300x2:
+        trace_region_size: 70000000
+
+  gemma-3-27b:
+    aliases: ["gemma-3-27b", "google/gemma-3-27b-it"]
+    skus:
+      wh_n150:
+        trace_region_size: 30000000
+      wh_n300:
+        trace_region_size: 30000000
+      wh_llmbox_perf:
+        trace_region_size: 30000000
+      wh_galaxy_perf:
+        trace_region_size: 30000000
+      bh_p150:
+        trace_region_size: 70000000
+      bh_p300:
+        trace_region_size: 70000000
+      p300x2:
+        trace_region_size: 70000000
+      bh_loudbox:
         trace_region_size: 70000000
 
   deepseek-r1-distill-llama-70b:

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -328,6 +328,25 @@ sizes:
       p300x2:
         trace_region_size: 70000000
 
+  gemma-4-12b:
+    aliases:
+      - "gemma-4-12b"
+      - "gemma-4-12B"
+      - "gemma-4-12B-it"
+      - "google/gemma-4-12B-it"
+      - "models/demos/gemma4/configs/gemma-4-12B-it"
+    skus:
+      wh_n150:
+        trace_region_size: 70000000
+      wh_llmbox_perf:
+        trace_region_size: 70000000
+      bh_p150:
+        trace_region_size: 70000000
+      bh_p300:
+        trace_region_size: 70000000
+      p300x2:
+        trace_region_size: 70000000
+
   gemma-4-26b-a4b:
     aliases:
       - "gemma-4-26b-a4b"

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -200,7 +200,7 @@ sizes:
       p300x2:
         trace_region_size: 36000000
 
-  qwen2.5-72b-vl:
+  qwen2.5-vl-72b:
     aliases: ["Qwen2.5-VL-72B", "Qwen/Qwen2.5-VL-72B-Instruct"]
     skus:
       wh_llmbox_perf:

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -121,6 +121,10 @@ sizes:
         trace_region_size: 50000000
       bh_galaxy_perf:
         trace_region_size: 50000000
+      bh_p150:
+        trace_region_size: 100000000
+      bh_loudbox:
+        trace_region_size: 100000000
       wh_n150:
         trace_region_size: 100000000
       p300x2:
@@ -292,6 +296,59 @@ sizes:
       wh_llmbox_perf:
         trace_region_size: 21448704
       bh_p150:
+        trace_region_size: 70000000
+      p300x2:
+        trace_region_size: 70000000
+
+  gemma-4-e2b:
+    aliases:
+      - "gemma-4-e2b"
+      - "gemma-4-E2B"
+      - "gemma-4-E2B-it"
+      - "google/gemma-4-E2B-it"
+      - "models/demos/gemma4/configs/gemma-4-E2B-it"
+    skus:
+      wh_n150:
+        trace_region_size: 30000000
+      bh_p150:
+        trace_region_size: 70000000
+
+  gemma-4-e4b:
+    aliases:
+      - "gemma-4-e4b"
+      - "gemma-4-E4B"
+      - "gemma-4-E4B-it"
+      - "google/gemma-4-E4B-it"
+      - "models/demos/gemma4/configs/gemma-4-E4B-it"
+    skus:
+      bh_p300:
+        trace_region_size: 70000000
+      p300x2:
+        trace_region_size: 70000000
+
+  gemma-4-26b-a4b:
+    aliases:
+      - "gemma-4-26b-a4b"
+      - "gemma-4-26B"
+      - "gemma-4-26B-A4B"
+      - "gemma-4-26B-A4B-it"
+      - "google/gemma-4-26B-A4B-it"
+      - "models/demos/gemma4/configs/gemma-4-26B-A4B-it"
+    skus:
+      wh_llmbox_perf:
+        trace_region_size: 70000000
+      p300x2:
+        trace_region_size: 70000000
+
+  gemma-4-31b:
+    aliases:
+      - "gemma-4-31b"
+      - "gemma-4-31B"
+      - "gemma-4-31B-it"
+      - "google/gemma-4-31B-it"
+      - "models/demos/gemma4/configs/gemma-4-31B-it"
+    skus:
+      wh_llmbox_perf:
         trace_region_size: 70000000
       p300x2:
         trace_region_size: 70000000

--- a/models/model_trace_region_sizes.yaml
+++ b/models/model_trace_region_sizes.yaml
@@ -102,9 +102,9 @@ sizes:
     aliases: ["GPT-OSS-20B", "gpt-oss-20b", "openai/gpt-oss-20b", "models/demos/gpt_oss/configs/gpt-oss-20b"]
     skus:
       wh_llmbox_perf:
-        trace_region_size: 50000000
+        trace_region_size: 30000000
       wh_galaxy_perf:
-        trace_region_size: 50000000
+        trace_region_size: 30000000
       wh_n150:
         trace_region_size: 30000000
       bh_p150:

--- a/models/tt_transformers/README.md
+++ b/models/tt_transformers/README.md
@@ -187,7 +187,7 @@ pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and long"
 
 The above examples are run in `ModelOptimizations.performance` mode. You can override this by setting the `optimizations` or the `decoder_config_file` argument in the demo. To use instead the accuracy mode you can call the above tests with `-k "accuracy and ..."` instead of performance.
 
-NOTE: trace region sizes are declared in [`models/model_trace_region_sizes.yaml`](../model_trace_region_sizes.yaml) and resolved at device-open time via [`get_supported_trace_region_size`](demo/trace_region_config.py) (which delegates to [`resolve_trace_region_size`](../demos/utils/trace_region_sizes.py)). Models without a YAML entry fall back to `DEFAULT_TRACE_REGION_SIZE` in [`simple_text_demo.py`](demo/simple_text_demo.py). If the default is insufficient, a helpful error message reports the required size — add a `(model, SKU)` entry to the YAML or override `trace_region_size` in the demo.
+NOTE: trace region sizes are declared in [`models/model_trace_region_sizes.yaml`](../model_trace_region_sizes.yaml) and resolved at device-open time via [`get_supported_trace_region_size`](demo/trace_region_config.py) (which delegates to [`resolve_trace_region_size`](../demos/utils/trace_region_sizes.py)). Every `(model, SKU)` pair used in CI must have a YAML entry; if one is missing, resolution raises `TraceRegionSizeNotConfiguredError` with instructions to add the entry.
 
 ## Details
 

--- a/models/tt_transformers/README.md
+++ b/models/tt_transformers/README.md
@@ -187,7 +187,7 @@ pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and long"
 
 The above examples are run in `ModelOptimizations.performance` mode. You can override this by setting the `optimizations` or the `decoder_config_file` argument in the demo. To use instead the accuracy mode you can call the above tests with `-k "accuracy and ..."` instead of performance.
 
-NOTE: for models that are not listed in [`get_supported_trace_region_size` function](demo/trace_region_config.py#L79), the default trace region size will be used as set in the [`demo/simple_text_demo.py` script](demo/simple_text_demo.py#L704). The default trace region size may not be sufficient for such a model and there will be a helpful error message that informs the required trace region size, which can be overridden by setting the `trace_region_size` argument in the demo.
+NOTE: trace region sizes are declared in [`models/model_trace_region_sizes.yaml`](../model_trace_region_sizes.yaml) and resolved at device-open time via [`get_supported_trace_region_size`](demo/trace_region_config.py) (which delegates to [`resolve_trace_region_size`](../demos/utils/trace_region_sizes.py)). Models without a YAML entry fall back to `DEFAULT_TRACE_REGION_SIZE` in [`simple_text_demo.py`](demo/simple_text_demo.py). If the default is insufficient, a helpful error message reports the required size — add a `(model, SKU)` entry to the YAML or override `trace_region_size` in the demo.
 
 ## Details
 

--- a/models/tt_transformers/README.md
+++ b/models/tt_transformers/README.md
@@ -187,7 +187,7 @@ pytest models/tt_transformers/demo/simple_text_demo.py -k "performance and long"
 
 The above examples are run in `ModelOptimizations.performance` mode. You can override this by setting the `optimizations` or the `decoder_config_file` argument in the demo. To use instead the accuracy mode you can call the above tests with `-k "accuracy and ..."` instead of performance.
 
-NOTE: trace region sizes are declared in [`models/model_trace_region_sizes.yaml`](../model_trace_region_sizes.yaml) and resolved at device-open time via [`get_supported_trace_region_size`](demo/trace_region_config.py) (which delegates to [`resolve_trace_region_size`](../demos/utils/trace_region_sizes.py)). Every `(model, SKU)` pair used in CI must have a YAML entry; if one is missing, resolution raises `TraceRegionSizeNotConfiguredError` with instructions to add the entry.
+NOTE: trace region sizes are declared in [`models/model_trace_region_sizes.yaml`](../model_trace_region_sizes.yaml) and resolved at device-open time via [`get_supported_trace_region_size`](demo/trace_region_config.py) (which delegates to [`resolve_trace_region_size`](../demos/utils/trace_region_sizes.py)). A `(model, SKU)` pair without a YAML entry is not an error: resolution logs an info message and falls back to `TRACE_REGION_SIZE_DYNAMIC` (`0`, dynamic allocation). Add an explicit entry when a model needs a fixed reserved trace region.
 
 ## Details
 

--- a/models/tt_transformers/conftest.py
+++ b/models/tt_transformers/conftest.py
@@ -7,11 +7,15 @@ import pytest
 
 import ttnn
 
+from models.demos.utils.trace_region_sizes import apply_trace_model_key
+
 
 @pytest.fixture
 def device_params(request, galaxy_type):
-    # Get param dict passed in from test parametrize (or default to empty dict)
-    params = getattr(request, "param", {}).copy()
+    # Get param dict passed in from test parametrize (or default to empty dict).
+    # apply_trace_model_key resolves TRACE_MODEL_KEY_PARAM -> trace_region_size from
+    # the centralized YAML (no-op when the key is absent).
+    params = apply_trace_model_key(getattr(request, "param", {}).copy())
 
     mesh_device = {"N150": (1, 1), "N300": (1, 2), "N150x4": (1, 4), "T3K": (1, 8), "TG": (8, 4), "P150x8": (1, 8)}.get(
         os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())

--- a/models/tt_transformers/conftest.py
+++ b/models/tt_transformers/conftest.py
@@ -6,7 +6,6 @@ import os
 import pytest
 
 import ttnn
-
 from models.demos.utils.trace_region_sizes import apply_trace_model_key
 
 

--- a/models/tt_transformers/conftest.py
+++ b/models/tt_transformers/conftest.py
@@ -6,15 +6,14 @@ import os
 import pytest
 
 import ttnn
-from models.demos.utils.trace_region_sizes import apply_trace_model_key
 
 
 @pytest.fixture
 def device_params(request, galaxy_type):
     # Get param dict passed in from test parametrize (or default to empty dict).
-    # apply_trace_model_key resolves TRACE_MODEL_KEY_PARAM -> trace_region_size from
-    # the centralized YAML (no-op when the key is absent).
-    params = apply_trace_model_key(getattr(request, "param", {}).copy())
+    # Any TRACE_MODEL_KEY_PARAM is left in place; the mesh_device fixture resolves it
+    # to trace_region_size using the logical submesh SKU.
+    params = getattr(request, "param", {}).copy()
 
     mesh_device = {"N150": (1, 1), "N300": (1, 2), "N150x4": (1, 4), "T3K": (1, 8), "TG": (8, 4), "P150x8": (1, 8)}.get(
         os.environ.get("MESH_DEVICE"), len(ttnn.get_device_ids())

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1088,6 +1088,7 @@ def test_demo_text(
                     k_cache = ttnn.mul(k_cache, 0, output_tensor=k_cache)
                     v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)
             generator.prev_page_table = None
+            generator._clear_prefill_traces()
 
         input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(global_batch_size, -1)
         # Use device sampling for all cases when supported (prefill + decode)

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -20,7 +20,6 @@ from models.common.sampling import SamplingParams
 from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_accuracy, verify_perf
 from models.demos.utils.model_targets import resolve_accuracy_targets, resolve_perf_targets
-from models.demos.utils.trace_region_sizes import DEFAULT_TRACE_REGION_SIZE
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.common import (
     PagedAttentionConfig,
@@ -808,7 +807,7 @@ def prepare_generator_args(
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": True, "trace_region_size": DEFAULT_TRACE_REGION_SIZE, "num_command_queues": 1}],
+    [{"fabric_config": True, "num_command_queues": 1}],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -1088,7 +1088,6 @@ def test_demo_text(
                     k_cache = ttnn.mul(k_cache, 0, output_tensor=k_cache)
                     v_cache = ttnn.mul(v_cache, 0, output_tensor=v_cache)
             generator.prev_page_table = None
-            generator._clear_prefill_traces()
 
         input_tokens_prefill_pt = torch.stack(input_tokens_prefill_pt).view(global_batch_size, -1)
         # Use device sampling for all cases when supported (prefill + decode)

--- a/models/tt_transformers/demo/simple_text_demo.py
+++ b/models/tt_transformers/demo/simple_text_demo.py
@@ -20,6 +20,7 @@ from models.common.sampling import SamplingParams
 from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.demos.utils.llm_demo_utils import create_benchmark_data, verify_accuracy, verify_perf
 from models.demos.utils.model_targets import resolve_accuracy_targets, resolve_perf_targets
+from models.demos.utils.trace_region_sizes import DEFAULT_TRACE_REGION_SIZE
 from models.perf.benchmarking_utils import BenchmarkProfiler
 from models.tt_transformers.tt.common import (
     PagedAttentionConfig,
@@ -330,13 +331,6 @@ def prepare_generator_args(
 # mode (str): Mode to run the demo in (full, prefill, decode), full will run both prefill and decode
 # optimization (ModelOptimizations): Optimization level to use for the model (performance or accuracy)
 # MESH_DEVICE (str): Fake device to use for testing (N150, N300, T3K, TG). Usage: `export MESH_DEVICE=N150`, will enable running a single-chip demo on a multi-chip system.
-_trace_region_size = (
-    100000000
-    if (is_blackhole() and os.environ.get("HF_MODEL", "").endswith(("Qwen2.5-72B-Instruct", "Qwen2.5-32B-Instruct")))
-    else 50000000
-)
-
-
 @pytest.mark.parametrize(
     "input_prompts, instruct, repeat_batches, max_seq_len, batch_size, max_generated_tokens, paged_attention, page_params, sampling_params, stop_at_eos, ci_only, data_parallel, token_accuracy, stress_test, enable_trace, num_layers, mode",
     [
@@ -814,7 +808,7 @@ _trace_region_size = (
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": True, "trace_region_size": _trace_region_size, "num_command_queues": 1}],
+    [{"fabric_config": True, "trace_region_size": DEFAULT_TRACE_REGION_SIZE, "num_command_queues": 1}],
     indirect=True,
 )
 @pytest.mark.parametrize(

--- a/models/tt_transformers/demo/simple_vision_demo.py
+++ b/models/tt_transformers/demo/simple_vision_demo.py
@@ -316,9 +316,7 @@ def prepare_generator_args(
         # 4,
     ],
 )
-@pytest.mark.parametrize(
-    "device_params", [{"fabric_config": True, "trace_region_size": 17400000, "num_command_queues": 2}], indirect=True
-)
+@pytest.mark.parametrize("device_params", [{"fabric_config": True, "num_command_queues": 2}], indirect=True)
 def test_multimodal_demo_text(
     mesh_device,
     warmup_iters,

--- a/models/tt_transformers/demo/trace_region_config.py
+++ b/models/tt_transformers/demo/trace_region_config.py
@@ -11,9 +11,8 @@ import ttnn
 from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.demos.utils.model_targets import normalize_sku
 from models.demos.utils.trace_region_sizes import (
-    TraceRegionSizeNotConfiguredError,
     hf_model_name_candidates,
-    resolve_trace_region_size,
+    resolve_trace_region_size_for_candidates,
 )
 
 # NOTE: We need to override trace_region_size before the mesh device is opened
@@ -101,16 +100,5 @@ def get_supported_trace_region_size(request, mesh_device):
     if not candidates:
         return None
 
-    last_error: TraceRegionSizeNotConfiguredError | None = None
-    for model_name in candidates:
-        try:
-            return resolve_trace_region_size(model_name, sku)
-        except TraceRegionSizeNotConfiguredError as exc:
-            last_error = exc
-
-    if last_error is not None:
-        raise TraceRegionSizeNotConfiguredError(
-            f"trace_region_size is not configured for model candidates {candidates!r} and SKU={sku!r}. "
-            f"Add a (model, SKU) entry with trace_region_size to models/model_trace_region_sizes.yaml."
-        ) from last_error
-    return None
+    # Unconfigured (model, SKU) pairs fall back to dynamic allocation (0).
+    return resolve_trace_region_size_for_candidates(candidates, sku)

--- a/models/tt_transformers/demo/trace_region_config.py
+++ b/models/tt_transformers/demo/trace_region_config.py
@@ -10,7 +10,11 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.demos.utils.model_targets import normalize_sku
-from models.demos.utils.trace_region_sizes import TraceRegionSizeNotConfiguredError, resolve_trace_region_size
+from models.demos.utils.trace_region_sizes import (
+    TraceRegionSizeNotConfiguredError,
+    hf_model_name_candidates,
+    resolve_trace_region_size,
+)
 
 # NOTE: We need to override trace_region_size before the mesh device is opened
 # NOTE: When using DP, we need to have the imlpemented logic because when we parametrize the test with a specific trace region size, all submeshes will have that trace region size
@@ -84,14 +88,7 @@ def _model_name_candidates() -> list[str]:
         base = base_model_name_from_env()
         return [base] if base else []
 
-    candidates = [hf_model]
-    basename = hf_model.strip("/").split("/")[-1]
-    if basename not in candidates:
-        candidates.append(basename)
-    base = get_base_model_name(basename)
-    if base not in candidates:
-        candidates.append(base)
-    return candidates
+    return hf_model_name_candidates(hf_model)
 
 
 def get_supported_trace_region_size(request, mesh_device):

--- a/models/tt_transformers/demo/trace_region_config.py
+++ b/models/tt_transformers/demo/trace_region_config.py
@@ -9,6 +9,8 @@ from loguru import logger
 
 import ttnn
 from models.common.utility_functions import is_blackhole, is_wormhole_b0
+from models.demos.utils.model_targets import normalize_sku
+from models.demos.utils.trace_region_sizes import resolve_trace_region_size
 
 # NOTE: We need to override trace_region_size before the mesh device is opened
 # NOTE: When using DP, we need to have the imlpemented logic because when we parametrize the test with a specific trace region size, all submeshes will have that trace region size
@@ -76,72 +78,31 @@ def device_name_based_on_data_parallel(request, num_devices, mesh_device_name):
     return get_mesh_device_name(num_devices_data_parallel, mesh_device_name)
 
 
-def get_supported_trace_region_size(request, mesh_device):
-    # TODO: If no specific trace region size is listed for a model and device, the default one will be used (the one set in simple_text_demo.py @parametrize)
-    trace_region_size_dict = {
-        "Llama-3.1-8B": {
-            "N150": 25000000,
-            "N300": 38000000,
-            "T3K": 50000000,
-            "TG": 50000000,
-            "P150": 52000000,
-            "P300": 52000000,
-        },
-        "Llama-3.3-70B": {
-            "T3K": 90000000,
-            "TG": 80000000,
-            "P150": 80000000,
-            "P300": 80000000,
-            "P150x4": 96000000,
-            "P150x8": 84000000,
-        },
-        "Llama-3.1-70B": {
-            "T3K": 90000000,
-            "TG": 90000000,
-            "P150": 90000000,
-            "P300": 90000000,
-            "P150x4": 90000000,
-            "P150x8": 90000000,
-        },
-        "Llama-3.2-90B": {
-            "T3K": 20000000,
-        },
-        "Qwen3-32B": {
-            "T3K": 90000000,
-            "TG": 200000000,
-            "P150": 90000000,
-            "P300": 90000000,
-            "P150x4": 90000000,
-            "P150x8": 90000000,
-        },
-        "GPT-OSS-20B": {
-            "T3K": 50000000,
-            "TG": 50000000,
-        },
-        "GPT-OSS-120B": {
-            "T3K": 50000000,
-            "TG": 50000000,
-        },
-        "Qwen2.5-72B": {
-            "T3K": 70000000,
-            "TG": 70000000,
-        },
-        "gemma-3-27b": {
-            "T3K": 70000000,
-            "TG": 70000000,
-            "P150x4": 70000000,
-        },
-        "DeepSeek-R1-Distill-Llama-70B": {
-            "P150x4": 90000000,
-        },
-        "Llama-3.2-3B": {
-            "N150": 10000000,
-        },
-        "Qwen2.5-VL-7B": {
-            "N300": 10000000,
-        },
-    }
+def _model_name_candidates() -> list[str]:
+    hf_model = os.getenv("HF_MODEL")
+    if not hf_model:
+        base = base_model_name_from_env()
+        return [base] if base else []
 
+    candidates = [hf_model]
+    basename = hf_model.strip("/").split("/")[-1]
+    if basename not in candidates:
+        candidates.append(basename)
+    base = get_base_model_name(basename)
+    if base not in candidates:
+        candidates.append(base)
+    return candidates
+
+
+def get_supported_trace_region_size(request, mesh_device):
+    # If no YAML entry matches, callers fall back to DEFAULT_TRACE_REGION_SIZE in device_params.
     device_name_based_on_dp = device_name_based_on_data_parallel(request, mesh_device, os.getenv("MESH_DEVICE"))
-    base_model_name = base_model_name_from_env()
-    return trace_region_size_dict.get(base_model_name, {}).get(device_name_based_on_dp, None)
+    if not device_name_based_on_dp:
+        return None
+
+    sku = normalize_sku(device_name_based_on_dp)
+    for model_name in _model_name_candidates():
+        size = resolve_trace_region_size(model_name, sku)
+        if size is not None:
+            return size
+    return None

--- a/models/tt_transformers/demo/trace_region_config.py
+++ b/models/tt_transformers/demo/trace_region_config.py
@@ -10,7 +10,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.demos.utils.model_targets import normalize_sku
-from models.demos.utils.trace_region_sizes import resolve_trace_region_size
+from models.demos.utils.trace_region_sizes import TraceRegionSizeNotConfiguredError, resolve_trace_region_size
 
 # NOTE: We need to override trace_region_size before the mesh device is opened
 # NOTE: When using DP, we need to have the imlpemented logic because when we parametrize the test with a specific trace region size, all submeshes will have that trace region size
@@ -95,14 +95,25 @@ def _model_name_candidates() -> list[str]:
 
 
 def get_supported_trace_region_size(request, mesh_device):
-    # If no YAML entry matches, callers fall back to DEFAULT_TRACE_REGION_SIZE in device_params.
     device_name_based_on_dp = device_name_based_on_data_parallel(request, mesh_device, os.getenv("MESH_DEVICE"))
     if not device_name_based_on_dp:
         return None
 
     sku = normalize_sku(device_name_based_on_dp)
-    for model_name in _model_name_candidates():
-        size = resolve_trace_region_size(model_name, sku)
-        if size is not None:
-            return size
+    candidates = _model_name_candidates()
+    if not candidates:
+        return None
+
+    last_error: TraceRegionSizeNotConfiguredError | None = None
+    for model_name in candidates:
+        try:
+            return resolve_trace_region_size(model_name, sku)
+        except TraceRegionSizeNotConfiguredError as exc:
+            last_error = exc
+
+    if last_error is not None:
+        raise TraceRegionSizeNotConfiguredError(
+            f"trace_region_size is not configured for model candidates {candidates!r} and SKU={sku!r}. "
+            f"Add a (model, SKU) entry with trace_region_size to models/model_trace_region_sizes.yaml."
+        ) from last_error
     return None

--- a/models/tt_transformers/demo/trace_region_config.py
+++ b/models/tt_transformers/demo/trace_region_config.py
@@ -96,7 +96,7 @@ def _model_name_candidates() -> list[str]:
 
 def get_supported_trace_region_size(request, mesh_device):
     device_name_based_on_dp = device_name_based_on_data_parallel(request, mesh_device, os.getenv("MESH_DEVICE"))
-    if not device_name_based_on_dp:
+    if not device_name_based_on_dp or device_name_based_on_dp == "CPU":
         return None
 
     sku = normalize_sku(device_name_based_on_dp)

--- a/models/tt_transformers/demo/trace_region_config.py
+++ b/models/tt_transformers/demo/trace_region_config.py
@@ -87,12 +87,26 @@ def _model_name_candidates() -> list[str]:
     return hf_model_name_candidates(hf_model)
 
 
-def get_supported_trace_region_size(request, mesh_device):
+def get_logical_sku(request, mesh_device):
+    """Canonical SKU for the submesh actually opened.
+
+    Derives the SKU from the parametrized mesh shape, ``data_parallel``, and
+    ``MESH_DEVICE`` rather than the physical cluster, so a logical submesh
+    (e.g. a 1x4 slice of a Galaxy, or a ``MESH_DEVICE=N300`` run on a T3K) maps
+    to the SKU of the mesh that is actually opened. Returns ``None`` for CPU or
+    when the device count is unsupported.
+    """
     device_name_based_on_dp = device_name_based_on_data_parallel(request, mesh_device, os.getenv("MESH_DEVICE"))
     if not device_name_based_on_dp or device_name_based_on_dp == "CPU":
         return None
+    return normalize_sku(device_name_based_on_dp)
 
-    sku = normalize_sku(device_name_based_on_dp)
+
+def get_supported_trace_region_size(request, mesh_device):
+    sku = get_logical_sku(request, mesh_device)
+    if sku is None:
+        return None
+
     candidates = _model_name_candidates()
     if not candidates:
         return None

--- a/models/tt_transformers/demo/trace_region_config.py
+++ b/models/tt_transformers/demo/trace_region_config.py
@@ -10,10 +10,7 @@ from loguru import logger
 import ttnn
 from models.common.utility_functions import is_blackhole, is_wormhole_b0
 from models.demos.utils.model_targets import normalize_sku
-from models.demos.utils.trace_region_sizes import (
-    hf_model_name_candidates,
-    resolve_trace_region_size_for_candidates,
-)
+from models.demos.utils.trace_region_sizes import hf_model_name_candidates, resolve_trace_region_size_for_candidates
 
 # NOTE: We need to override trace_region_size before the mesh device is opened
 # NOTE: When using DP, we need to have the imlpemented logic because when we parametrize the test with a specific trace region size, all submeshes will have that trace region size

--- a/models/tt_transformers/demo/trace_region_config.py
+++ b/models/tt_transformers/demo/trace_region_config.py
@@ -13,10 +13,10 @@ from models.demos.utils.model_targets import normalize_sku
 from models.demos.utils.trace_region_sizes import hf_model_name_candidates, resolve_trace_region_size_for_candidates
 
 # NOTE: We need to override trace_region_size before the mesh device is opened
-# NOTE: When using DP, we need to have the imlpemented logic because when we parametrize the test with a specific trace region size, all submeshes will have that trace region size
-# example of the above : T3K (DP-8-b1 ; @parametrize(trace_region_size=X) -> we efectivly have 8 N150's with trace_region_size=X which could leed to OOM if X is too large)
+# NOTE: When using DP, we need to have the implemented logic because when we parametrize the test with a specific trace region size, all submeshes will have that trace region size
+# example of the above : T3K (DP-8-b1 ; @parametrize(trace_region_size=X) -> we effectively have 8 N150's with trace_region_size=X which could lead to OOM if X is too large)
 
-# TODO: For now, each confest.py should call get_supported_trace_region_size if they want to override the trace region size
+# TODO: For now, each conftest.py should call get_supported_trace_region_size if they want to override the trace region size
 
 
 def get_base_model_name(model_name: str) -> str:

--- a/models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py
+++ b/models/tt_transformers/tests/mixtral/test_mixtral_model_prefill.py
@@ -72,7 +72,7 @@ from models.tt_transformers.tt.model_config import DecodersPrecision
         "1layer",
     ],
 )
-@pytest.mark.parametrize("device_params", [{"fabric_config": True, "trace_region_size": 250000000}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_model_inference(
     paged_attention,
     page_params,

--- a/models/tt_transformers/tests/multimodal/mistral_24b/test_pixtral_transformer.py
+++ b/models/tt_transformers/tests/multimodal/mistral_24b/test_pixtral_transformer.py
@@ -29,7 +29,7 @@ from models.tt_transformers.tt.multimodal.mistral_24b.vision_pixtral_transformer
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 30000000, "num_command_queues": 1}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "num_command_queues": 1}],
     indirect=True,
 )
 def test_image_transformer_inference(batch, num_chunks, mesh_device):

--- a/models/tt_transformers/tests/multimodal/mistral_24b/test_vision_attention.py
+++ b/models/tt_transformers/tests/multimodal/mistral_24b/test_vision_attention.py
@@ -36,7 +36,7 @@ from models.tt_transformers.tt.multimodal.mistral_24b.vision_attention import (
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 30000000, "num_command_queues": 1}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "num_command_queues": 1}],
     indirect=True,
 )
 def test_vision_attention(mesh_device, seq_len, batch_size):

--- a/models/tt_transformers/tests/multimodal/mistral_24b/test_vision_model.py
+++ b/models/tt_transformers/tests/multimodal/mistral_24b/test_vision_model.py
@@ -38,7 +38,7 @@ def get_image_features(vision_tower, projector, input_tensor, image_sizes):
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 30000000, "num_command_queues": 1}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "num_command_queues": 1}],
     indirect=True,
 )
 def test_mistral_vision_model(mesh_device, reset_seeds):

--- a/models/tt_transformers/tests/multimodal/mistral_24b/test_vision_tower.py
+++ b/models/tt_transformers/tests/multimodal/mistral_24b/test_vision_tower.py
@@ -29,7 +29,7 @@ from models.tt_transformers.tt.multimodal.mistral_24b.mistral_vision_tower impor
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 30000000, "num_command_queues": 1}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "num_command_queues": 1}],
     indirect=True,
 )
 def test_mistral_vision_tower(mesh_device, reset_seeds):

--- a/models/tt_transformers/tests/test_model_prefill.py
+++ b/models/tt_transformers/tests/test_model_prefill.py
@@ -69,7 +69,7 @@ from models.tt_transformers.tt.model_config import DecodersPrecision
     (1, None),
     ids=["1layer", "all_layers"],
 )
-@pytest.mark.parametrize("device_params", [{"fabric_config": True, "trace_region_size": 17000000}], indirect=True)
+@pytest.mark.parametrize("device_params", [{"fabric_config": True}], indirect=True)
 def test_model_inference(
     paged_attention,
     page_params,

--- a/models/tt_transformers/tests/test_trace_region_sizes.py
+++ b/models/tt_transformers/tests/test_trace_region_sizes.py
@@ -12,10 +12,10 @@ import yaml
 from models.demos.utils.trace_region_sizes import (
     TRACE_REGION_SIZE_DYNAMIC,
     TRACE_REGION_SIZES_YAML_PATH,
-    TraceRegionSizeNotConfiguredError,
     hf_model_name_candidates,
     load_trace_region_sizes,
     resolve_trace_region_size,
+    resolve_trace_region_size_for_candidates,
 )
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
@@ -91,20 +91,12 @@ def test_resolve_trace_region_size_legacy_sku_aliases(model_name, legacy_sku, ex
     assert resolve_trace_region_size(model_name, legacy_sku) == expected_size
 
 
-def test_resolve_trace_region_size_raises_when_not_configured():
-    with pytest.raises(TraceRegionSizeNotConfiguredError, match="trace_region_size is not configured"):
-        resolve_trace_region_size("unknown-model", "wh_n150")
+def test_resolve_trace_region_size_unconfigured_defaults_to_dynamic():
+    assert resolve_trace_region_size("unknown-model", "wh_n150") == TRACE_REGION_SIZE_DYNAMIC
 
 
 def _resolve_ci_trace_region_size(hf_model: str, sku: str) -> int:
-    last_error: TraceRegionSizeNotConfiguredError | None = None
-    for candidate in hf_model_name_candidates(hf_model):
-        try:
-            return resolve_trace_region_size(candidate, sku)
-        except TraceRegionSizeNotConfiguredError as exc:
-            last_error = exc
-    assert last_error is not None
-    raise last_error
+    return resolve_trace_region_size_for_candidates(hf_model_name_candidates(hf_model), sku)
 
 
 def _iter_ci_trace_region_requirements():
@@ -151,9 +143,12 @@ def test_resolve_deepseek_v3_dynamic_allocation():
     list(_iter_ci_trace_region_requirements()),
     ids=lambda val: str(val).replace("/", "_")[:120],
 )
-def test_ci_hf_model_jobs_have_trace_region_config(job_name, hf_model, sku):
+def test_ci_hf_model_jobs_resolve_trace_region_size(job_name, hf_model, sku):
     del job_name
-    _resolve_ci_trace_region_size(hf_model, sku)
+    # Every CI HF_MODEL job must resolve to a valid size; unconfigured pairs
+    # fall back to dynamic allocation (TRACE_REGION_SIZE_DYNAMIC) rather than erroring.
+    size = _resolve_ci_trace_region_size(hf_model, sku)
+    assert isinstance(size, int) and size >= 0
 
 
 @pytest.mark.parametrize(
@@ -190,15 +185,7 @@ def test_resolve_gemma4_config_path_aliases(model_path, sku, expected_size):
     ],
 )
 def test_resolve_trace_region_size_from_hf_hub_cache_path(hub_path, sku, expected_size):
-    last_error: TraceRegionSizeNotConfiguredError | None = None
-    for candidate in hf_model_name_candidates(hub_path):
-        try:
-            assert resolve_trace_region_size(candidate, sku) == expected_size
-            return
-        except TraceRegionSizeNotConfiguredError as exc:
-            last_error = exc
-    assert last_error is not None
-    raise last_error
+    assert resolve_trace_region_size_for_candidates(hf_model_name_candidates(hub_path), sku) == expected_size
 
 
 def _gpt_oss_trace_model_key_from_env() -> str:

--- a/models/tt_transformers/tests/test_trace_region_sizes.py
+++ b/models/tt_transformers/tests/test_trace_region_sizes.py
@@ -1,0 +1,121 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import yaml
+
+from models.demos.utils.model_targets import normalize_sku
+from models.demos.utils.trace_region_sizes import (
+    TRACE_REGION_SIZES_YAML_PATH,
+    load_trace_region_sizes,
+    resolve_trace_region_size,
+)
+
+# Regression table from the former trace_region_size_dict in trace_region_config.py.
+_LEGACY_TRACE_REGION_SIZE_DICT = {
+    "Llama-3.1-8B": {
+        "N150": 25000000,
+        "N300": 38000000,
+        "T3K": 50000000,
+        "TG": 50000000,
+        "P150": 52000000,
+        "P300": 52000000,
+    },
+    "Llama-3.3-70B": {
+        "T3K": 90000000,
+        "TG": 80000000,
+        "P150": 80000000,
+        "P300": 80000000,
+        "P150x4": 96000000,
+        "P150x8": 84000000,
+    },
+    "Llama-3.1-70B": {
+        "T3K": 90000000,
+        "TG": 90000000,
+        "P150": 90000000,
+        "P300": 90000000,
+        "P150x4": 90000000,
+        "P150x8": 90000000,
+    },
+    "Llama-3.2-90B": {
+        "T3K": 20000000,
+    },
+    "Qwen3-32B": {
+        "T3K": 90000000,
+        "TG": 200000000,
+        "P150": 90000000,
+        "P300": 90000000,
+        "P150x4": 90000000,
+        "P150x8": 90000000,
+    },
+    "GPT-OSS-20B": {
+        "T3K": 50000000,
+        "TG": 50000000,
+    },
+    "GPT-OSS-120B": {
+        "T3K": 50000000,
+        "TG": 50000000,
+    },
+    "Qwen2.5-72B": {
+        "T3K": 70000000,
+        "TG": 70000000,
+    },
+    "gemma-3-27b": {
+        "T3K": 70000000,
+        "TG": 70000000,
+        "P150x4": 70000000,
+    },
+    "DeepSeek-R1-Distill-Llama-70B": {
+        "P150x4": 90000000,
+    },
+    "Llama-3.2-3B": {
+        "N150": 10000000,
+    },
+    "Qwen2.5-VL-7B": {
+        "N300": 10000000,
+    },
+}
+
+
+def test_trace_region_sizes_yaml_schema():
+    doc = yaml.safe_load(TRACE_REGION_SIZES_YAML_PATH.read_text(encoding="utf-8"))
+    assert isinstance(doc, dict)
+    assert doc.get("version") == 1
+
+    sizes = doc.get("sizes")
+    assert isinstance(sizes, dict) and sizes
+
+    for model_name, model_block in sizes.items():
+        assert isinstance(model_block, dict), f"{model_name}: expected dict block"
+        skus = model_block.get("skus")
+        assert isinstance(skus, dict) and skus, f"{model_name}: missing skus"
+        for sku_name, sku_block in skus.items():
+            value = sku_block.get("trace_region_size")
+            assert isinstance(value, int) and value > 0, f"{model_name}/{sku_name}: invalid trace_region_size"
+
+
+def test_legacy_dict_values_preserved_in_yaml():
+    for model_name, device_map in _LEGACY_TRACE_REGION_SIZE_DICT.items():
+        for legacy_device, expected_size in device_map.items():
+            resolved = resolve_trace_region_size(model_name, normalize_sku(legacy_device))
+            assert resolved == expected_size, f"{model_name}/{legacy_device}"
+
+
+def test_hf_alias_resolution():
+    assert resolve_trace_region_size("meta-llama/Llama-3.1-8B-Instruct", "wh_n150") == 25000000
+
+
+def test_tt_transformers_specific_entries():
+    assert resolve_trace_region_size("meta-llama/Llama-3.2-11B-Vision-Instruct", "wh_llmbox_perf") == 17400000
+    assert resolve_trace_region_size("mistralai/Mixtral-8x7B-v0.1", "wh_llmbox_perf") == 250000000
+    assert resolve_trace_region_size("mistralai/Mistral-Small-3.1-24B-Instruct-2503", "wh_n150") == 30000000
+    assert resolve_trace_region_size("Qwen/Qwen2.5-72B-Instruct", "bh_p150") == 100000000
+    assert resolve_trace_region_size("Qwen/Qwen2.5-32B-Instruct", "bh_p300") == 100000000
+    assert resolve_trace_region_size("gpt-oss-20b", "wh_llmbox_perf") == 50000000
+
+
+def test_load_trace_region_sizes_is_cached():
+    load_trace_region_sizes.cache_clear()
+    first = load_trace_region_sizes()
+    second = load_trace_region_sizes()
+    assert first is second

--- a/models/tt_transformers/tests/test_trace_region_sizes.py
+++ b/models/tt_transformers/tests/test_trace_region_sizes.py
@@ -9,11 +9,8 @@ from models.demos.utils.model_targets import normalize_sku
 from models.demos.utils.trace_region_sizes import (
     TRACE_REGION_SIZES_YAML_PATH,
     TraceRegionSizeNotConfiguredError,
-    apply_trace_region_override,
-    is_trace_region_size_placeholder,
     load_trace_region_sizes,
     resolve_trace_region_size,
-    should_apply_trace_region_override,
 )
 
 # Regression table from the former trace_region_size_dict in trace_region_config.py.
@@ -119,32 +116,6 @@ def test_tt_transformers_specific_entries():
     assert resolve_trace_region_size("Qwen/Qwen2.5-72B-Instruct", "bh_p150") == 100000000
     assert resolve_trace_region_size("Qwen/Qwen2.5-32B-Instruct", "bh_p300") == 100000000
     assert resolve_trace_region_size("gpt-oss-20b", "wh_llmbox_perf") == 50000000
-
-
-def test_is_trace_region_size_placeholder():
-    assert is_trace_region_size_placeholder(None)
-    assert not is_trace_region_size_placeholder(50_000_000)
-    assert not is_trace_region_size_placeholder(216580672)
-    assert not is_trace_region_size_placeholder(102000000)
-
-
-def test_should_apply_trace_region_override():
-    override_size = 80000000
-    assert should_apply_trace_region_override({}, override_size)
-    assert should_apply_trace_region_override({"trace_region_size": None}, override_size)
-    assert not should_apply_trace_region_override({"trace_region_size": 216580672}, override_size)
-    assert not should_apply_trace_region_override({"trace_region_size": 102000000}, override_size)
-    assert not should_apply_trace_region_override({}, None)
-
-
-def test_apply_trace_region_override():
-    device_params = {"trace_region_size": 216580672}
-    assert apply_trace_region_override(device_params, 80000000) == 216580672
-    assert device_params["trace_region_size"] == 216580672
-
-    device_params = {}
-    assert apply_trace_region_override(device_params, 52000000) == 52000000
-    assert device_params["trace_region_size"] == 52000000
 
 
 def test_resolve_trace_region_size_raises_when_not_configured():

--- a/models/tt_transformers/tests/test_trace_region_sizes.py
+++ b/models/tt_transformers/tests/test_trace_region_sizes.py
@@ -5,7 +5,6 @@
 import pytest
 import yaml
 
-from models.demos.utils.model_targets import normalize_sku
 from models.demos.utils.trace_region_sizes import (
     TRACE_REGION_SIZES_YAML_PATH,
     TraceRegionSizeNotConfiguredError,
@@ -13,70 +12,31 @@ from models.demos.utils.trace_region_sizes import (
     resolve_trace_region_size,
 )
 
-# Regression table from the former trace_region_size_dict in trace_region_config.py.
-_LEGACY_TRACE_REGION_SIZE_DICT = {
-    "Llama-3.1-8B": {
-        "N150": 25000000,
-        "N300": 38000000,
-        "T3K": 50000000,
-        "TG": 50000000,
-        "P150": 52000000,
-        "P300": 52000000,
-    },
-    "Llama-3.3-70B": {
-        "T3K": 90000000,
-        "TG": 80000000,
-        "P150": 80000000,
-        "P300": 80000000,
-        "P150x4": 96000000,
-        "P150x8": 84000000,
-    },
-    "Llama-3.1-70B": {
-        "T3K": 90000000,
-        "TG": 90000000,
-        "P150": 90000000,
-        "P300": 90000000,
-        "P150x4": 90000000,
-        "P150x8": 90000000,
-    },
-    "Llama-3.2-90B": {
-        "T3K": 20000000,
-    },
-    "Qwen3-32B": {
-        "T3K": 90000000,
-        "TG": 200000000,
-        "P150": 90000000,
-        "P300": 90000000,
-        "P150x4": 90000000,
-        "P150x8": 90000000,
-    },
-    "GPT-OSS-20B": {
-        "T3K": 50000000,
-        "TG": 50000000,
-    },
-    "GPT-OSS-120B": {
-        "T3K": 50000000,
-        "TG": 50000000,
-    },
-    "Qwen2.5-72B": {
-        "T3K": 70000000,
-        "TG": 70000000,
-    },
-    "gemma-3-27b": {
-        "T3K": 70000000,
-        "TG": 70000000,
-        "P150x4": 70000000,
-    },
-    "DeepSeek-R1-Distill-Llama-70B": {
-        "P150x4": 90000000,
-    },
-    "Llama-3.2-3B": {
-        "N150": 10000000,
-    },
-    "Qwen2.5-VL-7B": {
-        "N300": 10000000,
-    },
-}
+
+def _iter_yaml_trace_region_entries():
+    doc = load_trace_region_sizes()
+    sizes = doc.get("sizes", {})
+    for model_key, model_block in sizes.items():
+        if not isinstance(model_block, dict):
+            continue
+
+        model_names = [model_key]
+        aliases = model_block.get("aliases", [])
+        if isinstance(aliases, list):
+            model_names.extend(aliases)
+
+        skus = model_block.get("skus", {})
+        if not isinstance(skus, dict):
+            continue
+
+        for sku_key, sku_block in skus.items():
+            if not isinstance(sku_block, dict):
+                continue
+            expected = sku_block.get("trace_region_size")
+            if not isinstance(expected, int) or isinstance(expected, bool) or expected <= 0:
+                continue
+            for model_name in model_names:
+                yield model_name, sku_key, expected
 
 
 def test_trace_region_sizes_yaml_schema():
@@ -96,26 +56,22 @@ def test_trace_region_sizes_yaml_schema():
             assert isinstance(value, int) and value > 0, f"{model_name}/{sku_name}: invalid trace_region_size"
 
 
-def test_legacy_dict_values_preserved_in_yaml():
-    for model_name, device_map in _LEGACY_TRACE_REGION_SIZE_DICT.items():
-        for legacy_device, expected_size in device_map.items():
-            resolved = resolve_trace_region_size(model_name, normalize_sku(legacy_device))
-            assert resolved == expected_size, f"{model_name}/{legacy_device}"
+@pytest.mark.parametrize("model_name,sku,expected_size", list(_iter_yaml_trace_region_entries()))
+def test_resolve_trace_region_size_matches_yaml(model_name, sku, expected_size):
+    assert resolve_trace_region_size(model_name, sku) == expected_size
 
 
-def test_hf_alias_resolution():
-    assert resolve_trace_region_size("meta-llama/Llama-3.1-8B-Instruct", "wh_n150") == 25000000
-
-
-def test_tt_transformers_specific_entries():
-    assert resolve_trace_region_size("meta-llama/Llama-3.1-8B-Instruct", "p300x2") == 52000000
-    assert resolve_trace_region_size("meta-llama/Llama-3.1-8B-Instruct", "bh_quietbox_2") == 52000000
-    assert resolve_trace_region_size("meta-llama/Llama-3.2-11B-Vision-Instruct", "wh_llmbox_perf") == 17400000
-    assert resolve_trace_region_size("mistralai/Mixtral-8x7B-v0.1", "wh_llmbox_perf") == 250000000
-    assert resolve_trace_region_size("mistralai/Mistral-Small-3.1-24B-Instruct-2503", "wh_n150") == 30000000
-    assert resolve_trace_region_size("Qwen/Qwen2.5-72B-Instruct", "bh_p150") == 100000000
-    assert resolve_trace_region_size("Qwen/Qwen2.5-32B-Instruct", "bh_p300") == 100000000
-    assert resolve_trace_region_size("gpt-oss-20b", "wh_llmbox_perf") == 50000000
+@pytest.mark.parametrize(
+    "model_name,legacy_sku,expected_size",
+    [
+        ("Llama-3.1-8B", "N150", 25000000),
+        ("Llama-3.1-8B", "T3K", 50000000),
+        ("Llama-3.3-70B", "P150x4", 96000000),
+        ("meta-llama/Llama-3.1-8B-Instruct", "bh_quietbox_2", 52000000),
+    ],
+)
+def test_resolve_trace_region_size_legacy_sku_aliases(model_name, legacy_sku, expected_size):
+    assert resolve_trace_region_size(model_name, legacy_sku) == expected_size
 
 
 def test_resolve_trace_region_size_raises_when_not_configured():

--- a/models/tt_transformers/tests/test_trace_region_sizes.py
+++ b/models/tt_transformers/tests/test_trace_region_sizes.py
@@ -6,9 +6,13 @@ import yaml
 
 from models.demos.utils.model_targets import normalize_sku
 from models.demos.utils.trace_region_sizes import (
+    DEFAULT_TRACE_REGION_SIZE,
     TRACE_REGION_SIZES_YAML_PATH,
+    apply_trace_region_override,
+    is_trace_region_size_placeholder,
     load_trace_region_sizes,
     resolve_trace_region_size,
+    should_apply_trace_region_override,
 )
 
 # Regression table from the former trace_region_size_dict in trace_region_config.py.
@@ -106,12 +110,40 @@ def test_hf_alias_resolution():
 
 
 def test_tt_transformers_specific_entries():
+    assert resolve_trace_region_size("meta-llama/Llama-3.1-8B-Instruct", "p300x2") == 52000000
+    assert resolve_trace_region_size("meta-llama/Llama-3.1-8B-Instruct", "bh_quietbox_2") == 52000000
     assert resolve_trace_region_size("meta-llama/Llama-3.2-11B-Vision-Instruct", "wh_llmbox_perf") == 17400000
     assert resolve_trace_region_size("mistralai/Mixtral-8x7B-v0.1", "wh_llmbox_perf") == 250000000
     assert resolve_trace_region_size("mistralai/Mistral-Small-3.1-24B-Instruct-2503", "wh_n150") == 30000000
     assert resolve_trace_region_size("Qwen/Qwen2.5-72B-Instruct", "bh_p150") == 100000000
     assert resolve_trace_region_size("Qwen/Qwen2.5-32B-Instruct", "bh_p300") == 100000000
     assert resolve_trace_region_size("gpt-oss-20b", "wh_llmbox_perf") == 50000000
+
+
+def test_is_trace_region_size_placeholder():
+    assert is_trace_region_size_placeholder(None)
+    assert is_trace_region_size_placeholder(DEFAULT_TRACE_REGION_SIZE)
+    assert not is_trace_region_size_placeholder(216580672)
+    assert not is_trace_region_size_placeholder(102000000)
+
+
+def test_should_apply_trace_region_override():
+    override_size = 80000000
+    assert should_apply_trace_region_override({}, override_size)
+    assert should_apply_trace_region_override({"trace_region_size": DEFAULT_TRACE_REGION_SIZE}, override_size)
+    assert not should_apply_trace_region_override({"trace_region_size": 216580672}, override_size)
+    assert not should_apply_trace_region_override({"trace_region_size": 102000000}, override_size)
+    assert not should_apply_trace_region_override({}, None)
+
+
+def test_apply_trace_region_override():
+    device_params = {"trace_region_size": 216580672}
+    assert apply_trace_region_override(device_params, 80000000) == 216580672
+    assert device_params["trace_region_size"] == 216580672
+
+    device_params = {"trace_region_size": DEFAULT_TRACE_REGION_SIZE}
+    assert apply_trace_region_override(device_params, 52000000) == 52000000
+    assert device_params["trace_region_size"] == 52000000
 
 
 def test_load_trace_region_sizes_is_cached():

--- a/models/tt_transformers/tests/test_trace_region_sizes.py
+++ b/models/tt_transformers/tests/test_trace_region_sizes.py
@@ -95,8 +95,6 @@ def test_resolve_trace_region_size_raises_when_not_configured():
 
 
 def _hf_model_name_candidates(hf_model: str) -> list[str]:
-    import re
-
     candidates = [hf_model]
     basename = hf_model.strip("/").split("/")[-1]
     if basename not in candidates:

--- a/models/tt_transformers/tests/test_trace_region_sizes.py
+++ b/models/tt_transformers/tests/test_trace_region_sizes.py
@@ -2,6 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import os
 import re
 from pathlib import Path
 
@@ -12,6 +13,7 @@ from models.demos.utils.trace_region_sizes import (
     TRACE_REGION_SIZE_DYNAMIC,
     TRACE_REGION_SIZES_YAML_PATH,
     TraceRegionSizeNotConfiguredError,
+    hf_model_name_candidates,
     load_trace_region_sizes,
     resolve_trace_region_size,
 )
@@ -94,22 +96,9 @@ def test_resolve_trace_region_size_raises_when_not_configured():
         resolve_trace_region_size("unknown-model", "wh_n150")
 
 
-def _hf_model_name_candidates(hf_model: str) -> list[str]:
-    candidates = [hf_model]
-    basename = hf_model.strip("/").split("/")[-1]
-    if basename not in candidates:
-        candidates.append(basename)
-    match = re.search(r"(.*?\d+[bB])-", basename)
-    if match:
-        base = match.group(1)
-        if base not in candidates:
-            candidates.append(base)
-    return candidates
-
-
 def _resolve_ci_trace_region_size(hf_model: str, sku: str) -> int:
     last_error: TraceRegionSizeNotConfiguredError | None = None
-    for candidate in _hf_model_name_candidates(hf_model):
+    for candidate in hf_model_name_candidates(hf_model):
         try:
             return resolve_trace_region_size(candidate, sku)
         except TraceRegionSizeNotConfiguredError as exc:
@@ -172,12 +161,58 @@ def test_ci_hf_model_jobs_have_trace_region_config(job_name, hf_model, sku):
     [
         ("models/demos/gemma4/configs/gemma-4-E2B-it", "wh_n150", 30000000),
         ("models/demos/gemma4/configs/gemma-4-E4B-it", "p300x2", 70000000),
+        ("models/demos/gemma4/configs/gemma-4-E4B-it", "bh_p150", 70000000),
         ("models/demos/gemma4/configs/gemma-4-26B-A4B-it", "wh_llmbox_perf", 70000000),
+        ("models/demos/gemma4/configs/gemma-4-26B-A4B-it", "wh_n150", 70000000),
+        ("models/demos/gemma4/configs/gemma-4-26B-A4B-it", "bh_p150", 70000000),
         ("models/demos/gemma4/configs/gemma-4-31B-it", "p300x2", 70000000),
+        ("models/demos/gemma4/configs/gemma-4-31B-it", "wh_n150", 70000000),
+        ("models/demos/gemma4/configs/gemma-4-31B-it", "bh_p150", 70000000),
     ],
 )
 def test_resolve_gemma4_config_path_aliases(model_path, sku, expected_size):
     assert resolve_trace_region_size(model_path, sku) == expected_size
+
+
+@pytest.mark.parametrize(
+    "hub_path,sku,expected_size",
+    [
+        (
+            "/mnt/MLPerf/huggingface/hub/models--google--gemma-3-27b-it/snapshots/005ad3404e59d6023443cb575daa05336842228a",
+            "wh_llmbox_perf",
+            30000000,
+        ),
+        (
+            "/mnt/MLPerf/huggingface/hub/models--google--gemma-3-4b-it/snapshots/093f9f388b31de276ce2de164bdc2081324b9767",
+            "wh_n150",
+            30000000,
+        ),
+    ],
+)
+def test_resolve_trace_region_size_from_hf_hub_cache_path(hub_path, sku, expected_size):
+    last_error: TraceRegionSizeNotConfiguredError | None = None
+    for candidate in hf_model_name_candidates(hub_path):
+        try:
+            assert resolve_trace_region_size(candidate, sku) == expected_size
+            return
+        except TraceRegionSizeNotConfiguredError as exc:
+            last_error = exc
+    assert last_error is not None
+    raise last_error
+
+
+def _gpt_oss_trace_model_key_from_env() -> str:
+    """Mirrors models.demos.gpt_oss.tests.unit.test_sampling._gpt_oss_trace_model_key."""
+    hf = os.getenv("HF_MODEL", "").lower()
+    return "gpt-oss-120b" if "120b" in hf else "gpt-oss-20b"
+
+
+def test_gpt_oss_trace_model_key_from_hf_model(monkeypatch):
+    monkeypatch.setenv("HF_MODEL", "models/demos/gpt_oss/configs/gpt-oss-120b")
+    assert _gpt_oss_trace_model_key_from_env() == "gpt-oss-120b"
+
+    monkeypatch.setenv("HF_MODEL", "models/demos/gpt_oss/configs/gpt-oss-20b")
+    assert _gpt_oss_trace_model_key_from_env() == "gpt-oss-20b"
 
 
 def test_cpu_sku_skips_trace_region_override():

--- a/models/tt_transformers/tests/test_trace_region_sizes.py
+++ b/models/tt_transformers/tests/test_trace_region_sizes.py
@@ -2,15 +2,28 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import re
+from pathlib import Path
+
 import pytest
 import yaml
 
 from models.demos.utils.trace_region_sizes import (
+    TRACE_REGION_SIZE_DYNAMIC,
     TRACE_REGION_SIZES_YAML_PATH,
     TraceRegionSizeNotConfiguredError,
     load_trace_region_sizes,
     resolve_trace_region_size,
 )
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CI_PIPELINE_FILES = (
+    REPO_ROOT / "tests/pipeline_reorg/models_e2e_tests.yaml",
+    REPO_ROOT / "tests/pipeline_reorg/models_unit_tests.yaml",
+    REPO_ROOT / "tests/pipeline_reorg/models_device_perf_tests.yaml",
+    REPO_ROOT / "tests/pipeline_reorg/models_sweep_tests.yaml",
+)
+HF_MODEL_RE = re.compile(r"HF_MODEL=([^\s]+)")
 
 
 def _iter_yaml_trace_region_entries():
@@ -33,7 +46,7 @@ def _iter_yaml_trace_region_entries():
             if not isinstance(sku_block, dict):
                 continue
             expected = sku_block.get("trace_region_size")
-            if not isinstance(expected, int) or isinstance(expected, bool) or expected <= 0:
+            if not isinstance(expected, int) or isinstance(expected, bool) or expected < 0:
                 continue
             for model_name in model_names:
                 yield model_name, sku_key, expected
@@ -53,7 +66,9 @@ def test_trace_region_sizes_yaml_schema():
         assert isinstance(skus, dict) and skus, f"{model_name}: missing skus"
         for sku_name, sku_block in skus.items():
             value = sku_block.get("trace_region_size")
-            assert isinstance(value, int) and value > 0, f"{model_name}/{sku_name}: invalid trace_region_size"
+            assert (
+                isinstance(value, int) and not isinstance(value, bool) and value >= 0
+            ), f"{model_name}/{sku_name}: invalid trace_region_size"
 
 
 @pytest.mark.parametrize("model_name,sku,expected_size", list(_iter_yaml_trace_region_entries()))
@@ -79,8 +94,80 @@ def test_resolve_trace_region_size_raises_when_not_configured():
         resolve_trace_region_size("unknown-model", "wh_n150")
 
 
+def _hf_model_name_candidates(hf_model: str) -> list[str]:
+    import re
+
+    candidates = [hf_model]
+    basename = hf_model.strip("/").split("/")[-1]
+    if basename not in candidates:
+        candidates.append(basename)
+    match = re.search(r"(.*?\d+[bB])-", basename)
+    if match:
+        base = match.group(1)
+        if base not in candidates:
+            candidates.append(base)
+    return candidates
+
+
+def _resolve_ci_trace_region_size(hf_model: str, sku: str) -> int:
+    last_error: TraceRegionSizeNotConfiguredError | None = None
+    for candidate in _hf_model_name_candidates(hf_model):
+        try:
+            return resolve_trace_region_size(candidate, sku)
+        except TraceRegionSizeNotConfiguredError as exc:
+            last_error = exc
+    assert last_error is not None
+    raise last_error
+
+
+def _iter_ci_trace_region_requirements():
+    """Yield (job_name, model_name, sku) for tiered CI jobs that set HF_MODEL."""
+    for pipeline_path in CI_PIPELINE_FILES:
+        if not pipeline_path.is_file():
+            continue
+        entries = yaml.safe_load(pipeline_path.read_text(encoding="utf-8")) or []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            model_id = str(entry.get("model", ""))
+            if model_id.startswith("gemma-4"):
+                continue
+
+            cmd = entry.get("cmd", "")
+            cmd_hf_match = HF_MODEL_RE.search(cmd)
+            cmd_hf_model = cmd_hf_match.group(1).strip("'\"") if cmd_hf_match else None
+            if cmd_hf_model and "{" in cmd_hf_model:
+                cmd_hf_model = None
+
+            job_name = entry.get("name", entry.get("model", "unknown"))
+            skus = entry.get("skus", {})
+            if not isinstance(skus, dict):
+                continue
+            for sku_key, sku_block in skus.items():
+                if not isinstance(sku_block, dict):
+                    sku_block = {}
+                hf_model = sku_block.get("hf_model") or cmd_hf_model
+                if not hf_model:
+                    continue
+                yield job_name, hf_model, sku_key
+
+
 def test_load_trace_region_sizes_is_cached():
     load_trace_region_sizes.cache_clear()
     first = load_trace_region_sizes()
     second = load_trace_region_sizes()
     assert first is second
+
+
+def test_resolve_deepseek_v3_dynamic_allocation():
+    assert resolve_trace_region_size("deepseek-v3", "wh_llmbox_perf") == TRACE_REGION_SIZE_DYNAMIC
+
+
+@pytest.mark.parametrize(
+    "job_name,hf_model,sku",
+    list(_iter_ci_trace_region_requirements()),
+    ids=lambda val: str(val).replace("/", "_")[:120],
+)
+def test_ci_hf_model_jobs_have_trace_region_config(job_name, hf_model, sku):
+    del job_name
+    _resolve_ci_trace_region_size(hf_model, sku)

--- a/models/tt_transformers/tests/test_trace_region_sizes.py
+++ b/models/tt_transformers/tests/test_trace_region_sizes.py
@@ -2,12 +2,13 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 import yaml
 
 from models.demos.utils.model_targets import normalize_sku
 from models.demos.utils.trace_region_sizes import (
-    DEFAULT_TRACE_REGION_SIZE,
     TRACE_REGION_SIZES_YAML_PATH,
+    TraceRegionSizeNotConfiguredError,
     apply_trace_region_override,
     is_trace_region_size_placeholder,
     load_trace_region_sizes,
@@ -122,7 +123,7 @@ def test_tt_transformers_specific_entries():
 
 def test_is_trace_region_size_placeholder():
     assert is_trace_region_size_placeholder(None)
-    assert is_trace_region_size_placeholder(DEFAULT_TRACE_REGION_SIZE)
+    assert not is_trace_region_size_placeholder(50_000_000)
     assert not is_trace_region_size_placeholder(216580672)
     assert not is_trace_region_size_placeholder(102000000)
 
@@ -130,7 +131,7 @@ def test_is_trace_region_size_placeholder():
 def test_should_apply_trace_region_override():
     override_size = 80000000
     assert should_apply_trace_region_override({}, override_size)
-    assert should_apply_trace_region_override({"trace_region_size": DEFAULT_TRACE_REGION_SIZE}, override_size)
+    assert should_apply_trace_region_override({"trace_region_size": None}, override_size)
     assert not should_apply_trace_region_override({"trace_region_size": 216580672}, override_size)
     assert not should_apply_trace_region_override({"trace_region_size": 102000000}, override_size)
     assert not should_apply_trace_region_override({}, None)
@@ -141,9 +142,14 @@ def test_apply_trace_region_override():
     assert apply_trace_region_override(device_params, 80000000) == 216580672
     assert device_params["trace_region_size"] == 216580672
 
-    device_params = {"trace_region_size": DEFAULT_TRACE_REGION_SIZE}
+    device_params = {}
     assert apply_trace_region_override(device_params, 52000000) == 52000000
     assert device_params["trace_region_size"] == 52000000
+
+
+def test_resolve_trace_region_size_raises_when_not_configured():
+    with pytest.raises(TraceRegionSizeNotConfiguredError, match="trace_region_size is not configured"):
+        resolve_trace_region_size("unknown-model", "wh_n150")
 
 
 def test_load_trace_region_sizes_is_cached():

--- a/models/tt_transformers/tests/test_trace_region_sizes.py
+++ b/models/tt_transformers/tests/test_trace_region_sizes.py
@@ -127,10 +127,6 @@ def _iter_ci_trace_region_requirements():
         for entry in entries:
             if not isinstance(entry, dict):
                 continue
-            model_id = str(entry.get("model", ""))
-            if model_id.startswith("gemma-4"):
-                continue
-
             cmd = entry.get("cmd", "")
             cmd_hf_match = HF_MODEL_RE.search(cmd)
             cmd_hf_model = cmd_hf_match.group(1).strip("'\"") if cmd_hf_match else None
@@ -169,3 +165,26 @@ def test_resolve_deepseek_v3_dynamic_allocation():
 def test_ci_hf_model_jobs_have_trace_region_config(job_name, hf_model, sku):
     del job_name
     _resolve_ci_trace_region_size(hf_model, sku)
+
+
+@pytest.mark.parametrize(
+    "model_path,sku,expected_size",
+    [
+        ("models/demos/gemma4/configs/gemma-4-E2B-it", "wh_n150", 30000000),
+        ("models/demos/gemma4/configs/gemma-4-E4B-it", "p300x2", 70000000),
+        ("models/demos/gemma4/configs/gemma-4-26B-A4B-it", "wh_llmbox_perf", 70000000),
+        ("models/demos/gemma4/configs/gemma-4-31B-it", "p300x2", 70000000),
+    ],
+)
+def test_resolve_gemma4_config_path_aliases(model_path, sku, expected_size):
+    assert resolve_trace_region_size(model_path, sku) == expected_size
+
+
+def test_cpu_sku_skips_trace_region_override():
+    """Data-parallel parametrization with zero sub-mesh devices must skip trace override."""
+    num_devices = 8
+    data_parallel = 16
+    device_name_based_on_dp = "CPU" if (num_devices // data_parallel) == 0 else "N150"
+    assert device_name_based_on_dp == "CPU"
+    should_skip = not device_name_based_on_dp or device_name_based_on_dp == "CPU"
+    assert should_skip

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -277,7 +277,7 @@
     uv pip install -r models/demos/qwen25_vl/requirements.txt
     export HF_MODEL=Qwen/Qwen2.5-VL-72B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen2.5-VL-72B-Instruct MESH_DEVICE=T3K
     pytest --timeout 900 models/demos/qwen25_vl/demo/demo.py
-  model: qwen2.5-72b-vl
+  model: qwen2.5-vl-72b
   skus:
     wh_llmbox_perf:
       timeout: 20

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -572,7 +572,7 @@
     uv pip install -r models/demos/qwen25_vl/requirements.txt
     export HF_MODEL=Qwen/Qwen2.5-VL-72B-Instruct TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/Qwen/Qwen2.5-VL-72B-Instruct MESH_DEVICE=T3K
     pytest --timeout 600 models/demos/qwen25_vl/tests/ --ignore=models/demos/qwen25_vl/tests/test_ci_dispatch.py --ignore=models/demos/qwen25_vl/tests/conftest.py
-  model: qwen2.5-72b-vl
+  model: qwen2.5-vl-72b
   skus:
     wh_llmbox_perf:
       timeout: 15


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Github issue:  https://github.com/tenstorrent/tt-metal/issues/42151

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

Pipeline runs: 
- https://github.com/tenstorrent/tt-metal/actions/runs/27141511514
- https://github.com/tenstorrent/tt-metal/actions/runs/27201916085 
- All Model Tests (tiers 1+2+3, unit+e2e, all models/SKUs): https://github.com/tenstorrent/tt-metal/actions/runs/27963289737
- Sanity tests: https://github.com/tenstorrent/tt-metal/actions/runs/27966671581

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:42151-Centralize-the-trace-buffer-size-definitions-for-all-our-models)




