### PR TITLE
[Bug fix] Fix pack_config_t word-2 field ordering on Wormhole

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_config_register.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_config_register.cpp
@@ -212,12 +212,18 @@ const std::vector<std::string> field_names_pack_config_wormhole = {
     "l1_dest_addr",
     "uncompress",
     "add_l1_dest_addr_offset",
-    "reserved_0",
+    "addr_cnt_context",
     "out_data_format",
     "in_data_format",
-    "reserved_1",
+    "dis_shared_exp_assembler",
+    "force_pack_per_max_xy_plane",
+    "enable_out_fifo",
+    "sub_l1_tile_header_size",
     "src_if_sel",
-    "pack_per_xy_plane",
+    "all_pack_disable_zero_compress",
+    "all_pack_disable_zero_compress_ovrd",
+    "add_tile_header_size",
+    "reserved_1",
     "l1_src_addr",
     "downsample_mask",
     "downsample_shift_count",
@@ -226,8 +232,8 @@ const std::vector<std::string> field_names_pack_config_wormhole = {
     "pack_l1_acc_disable_pack_zero_flag",
     "reserved_2",
     "exp_threshold"};
-const std::vector<uint32_t> field_values_pack_config_wormhole = {
-    12, 24, 16, 0, 1, 0, 5, 5, 0, 1, 0, 8, 12, 4, 0, 1, 2, 0, 12};
+const std::vector<uint32_t> field_values_pack_config_wormhole = {12, 24, 16, 0, 1, 0,  5, 5, 0, 0, 0, 0, 1,
+                                                                 0,  0,  0,  0, 8, 12, 4, 0, 1, 2, 0, 12};
 
 // Configuration for Data Flow Test involving Reader, Datacopy, and Writer
 struct ConfigRegPrintTestConfig {

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_config_register.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_config_register.cpp
@@ -232,8 +232,10 @@ const std::vector<std::string> field_names_pack_config_wormhole = {
     "pack_l1_acc_disable_pack_zero_flag",
     "reserved_2",
     "exp_threshold"};
-const std::vector<uint32_t> field_values_pack_config_wormhole = {12, 24, 16, 0, 1, 0,  5, 5, 0, 0, 0, 0, 1,
-                                                                 0,  0,  0,  0, 8, 12, 4, 0, 1, 2, 0, 12};
+// REG8 banks (REG_ID 2/4) differ above src_if_sel, so keep all_pack_disable_zero_compress <= 1
+// and ovrd/add_tile_header_size at 0 for readback to match across all 4 banks.
+const std::vector<uint32_t> field_values_pack_config_wormhole = {12, 24, 16, 0, 1, 2,  5, 5, 1, 1, 1, 1, 1,
+                                                                 1,  0,  0,  0, 8, 12, 4, 0, 1, 2, 0, 12};
 
 // Configuration for Data Flow Test involving Reader, Datacopy, and Writer
 struct ConfigRegPrintTestConfig {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp
@@ -94,21 +94,38 @@ void generate_pack_config(ckernel::packer::pack_config_t& config) {
     config.l1_dest_addr = 16;
     config.uncompress = 0;
     config.add_l1_dest_addr_offset = 1;
+#ifdef ARCH_WORMHOLE
+    config.addr_cnt_context = 0;
+#else
     config.reserved_0 = 0;
+#endif
     config.out_data_format = 5;
     config.in_data_format = 5;
     config.src_if_sel = 1;
     config.l1_src_addr = 8;
-#if defined(ARCH_WORMHOLE) or defined(ARCH_GRAYSKULL)
+#ifdef ARCH_WORMHOLE
+    config.dis_shared_exp_assembler = 0;
+    config.force_pack_per_max_xy_plane = 0;
+    config.enable_out_fifo = 0;
+    config.sub_l1_tile_header_size = 0;
+    config.all_pack_disable_zero_compress = 0;
+    config.all_pack_disable_zero_compress_ovrd = 0;
+    config.add_tile_header_size = 0;
+    config.reserved_1 = 0;
+    config.downsample_mask = 12;
+    config.downsample_shift_count = 4;
+    config.read_mode = 0;
+    config.exp_threshold_en = 1;
+    config.pack_l1_acc_disable_pack_zero_flag = 2;
+    config.reserved_2 = 0;
+    config.exp_threshold = 12;
+#elif defined(ARCH_GRAYSKULL)
     config.reserved_1 = 0;
     config.pack_per_xy_plane = 0;
     config.downsample_mask = 12;
     config.downsample_shift_count = 4;
     config.read_mode = 0;
     config.exp_threshold_en = 1;
-#ifdef ARCH_WORMHOLE
-    config.pack_l1_acc_disable_pack_zero_flag = 2;
-#endif
     config.reserved_2 = 0;
     config.exp_threshold = 12;
 #endif

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_config_reg.cpp
@@ -95,8 +95,8 @@ void generate_pack_config(ckernel::packer::pack_config_t& config) {
     config.uncompress = 0;
     config.add_l1_dest_addr_offset = 1;
 #ifdef ARCH_WORMHOLE
-    config.addr_cnt_context = 0;
-#else
+    config.addr_cnt_context = 2;
+#elif defined(ARCH_BLACKHOLE)
     config.reserved_0 = 0;
 #endif
     config.out_data_format = 5;
@@ -104,11 +104,14 @@ void generate_pack_config(ckernel::packer::pack_config_t& config) {
     config.src_if_sel = 1;
     config.l1_src_addr = 8;
 #ifdef ARCH_WORMHOLE
-    config.dis_shared_exp_assembler = 0;
-    config.force_pack_per_max_xy_plane = 0;
-    config.enable_out_fifo = 0;
-    config.sub_l1_tile_header_size = 0;
-    config.all_pack_disable_zero_compress = 0;
+    config.dis_shared_exp_assembler = 1;
+    config.force_pack_per_max_xy_plane = 1;
+    config.enable_out_fifo = 1;
+    config.sub_l1_tile_header_size = 1;
+    // REG8 banks have a different word-2 layout than REG1 (no all_pack_* fields,
+    // add_tile_header_size at bit 17 per cfg_defines.h), so REG1-layout bits 18-23
+    // read back 0 there; keep these mirror-compatible across all 4 banks
+    config.all_pack_disable_zero_compress = 1;
     config.all_pack_disable_zero_compress_ovrd = 0;
     config.add_tile_header_size = 0;
     config.reserved_1 = 0;
@@ -117,15 +120,6 @@ void generate_pack_config(ckernel::packer::pack_config_t& config) {
     config.read_mode = 0;
     config.exp_threshold_en = 1;
     config.pack_l1_acc_disable_pack_zero_flag = 2;
-    config.reserved_2 = 0;
-    config.exp_threshold = 12;
-#elif defined(ARCH_GRAYSKULL)
-    config.reserved_1 = 0;
-    config.pack_per_xy_plane = 0;
-    config.downsample_mask = 12;
-    config.downsample_shift_count = 4;
-    config.read_mode = 0;
-    config.exp_threshold_en = 1;
     config.reserved_2 = 0;
     config.exp_threshold = 12;
 #endif

--- a/tt_metal/hw/inc/api/debug/dprint_tensix_pack.h
+++ b/tt_metal/hw/inc/api/debug/dprint_tensix_pack.h
@@ -36,9 +36,17 @@ inline void dprint_tensix_pack_config_add_l1_dest_addr_offset(const ckernel::pac
     DPRINT("0x{:x}\n", config.add_l1_dest_addr_offset);
 }
 
+#if defined(ARCH_BLACKHOLE)
 inline void dprint_tensix_pack_config_reserved_0(const ckernel::packer::pack_config_t& config) {
     DPRINT("0x{:x}\n", config.reserved_0);
 }
+#endif
+
+#if defined(ARCH_WORMHOLE)
+inline void dprint_tensix_pack_config_addr_cnt_context(const ckernel::packer::pack_config_t& config) {
+    DPRINT("0x{:x}\n", config.addr_cnt_context);
+}
+#endif
 
 inline void dprint_tensix_pack_config_out_data_format(const ckernel::packer::pack_config_t& config) {
     dprint_data_format(config.out_data_format);
@@ -51,8 +59,20 @@ inline void dprint_tensix_pack_config_in_data_format(const ckernel::packer::pack
 }
 
 #if defined(ARCH_WORMHOLE)
-inline void dprint_tensix_pack_config_reserved_1(const ckernel::packer::pack_config_t& config) {
-    DPRINT("0x{:x}\n", config.reserved_1);
+inline void dprint_tensix_pack_config_dis_shared_exp_assembler(const ckernel::packer::pack_config_t& config) {
+    DPRINT("0x{:x}\n", config.dis_shared_exp_assembler);
+}
+
+inline void dprint_tensix_pack_config_force_pack_per_max_xy_plane(const ckernel::packer::pack_config_t& config) {
+    DPRINT("0x{:x}\n", config.force_pack_per_max_xy_plane);
+}
+
+inline void dprint_tensix_pack_config_enable_out_fifo(const ckernel::packer::pack_config_t& config) {
+    DPRINT("0x{:x}\n", config.enable_out_fifo);
+}
+
+inline void dprint_tensix_pack_config_sub_l1_tile_header_size(const ckernel::packer::pack_config_t& config) {
+    DPRINT("{}\n", config.sub_l1_tile_header_size);
 }
 #endif
 
@@ -61,8 +81,21 @@ inline void dprint_tensix_pack_config_src_if_sel(const ckernel::packer::pack_con
 }
 
 #if defined(ARCH_WORMHOLE)
-inline void dprint_tensix_pack_config_pack_per_xy_plane(const ckernel::packer::pack_config_t& config) {
-    DPRINT("{}\n", config.pack_per_xy_plane);
+inline void dprint_tensix_pack_config_all_pack_disable_zero_compress(const ckernel::packer::pack_config_t& config) {
+    DPRINT("0x{:x}\n", config.all_pack_disable_zero_compress);
+}
+
+inline void dprint_tensix_pack_config_all_pack_disable_zero_compress_ovrd(
+    const ckernel::packer::pack_config_t& config) {
+    DPRINT("0x{:x}\n", config.all_pack_disable_zero_compress_ovrd);
+}
+
+inline void dprint_tensix_pack_config_add_tile_header_size(const ckernel::packer::pack_config_t& config) {
+    DPRINT("{}\n", config.add_tile_header_size);
+}
+
+inline void dprint_tensix_pack_config_reserved_1(const ckernel::packer::pack_config_t& config) {
+    DPRINT("0x{:x}\n", config.reserved_1);
 }
 #endif
 
@@ -153,18 +186,30 @@ inline void dprint_tensix_pack_config_helper(const ckernel::packer::pack_config_
     dprint_tensix_pack_config_uncompressed(config);
     DPRINT("add_l1_dest_addr_offset: ");
     dprint_tensix_pack_config_add_l1_dest_addr_offset(config);
-    DPRINT("reserved_0: ");
-    dprint_tensix_pack_config_reserved_0(config);
+    DPRINT("addr_cnt_context: ");
+    dprint_tensix_pack_config_addr_cnt_context(config);
     DPRINT("out_data_format: ");
     dprint_tensix_pack_config_out_data_format(config);
     DPRINT("in_data_format: ");
     dprint_tensix_pack_config_in_data_format(config);
-    DPRINT("reserved_1: ");
-    dprint_tensix_pack_config_reserved_1(config);
+    DPRINT("dis_shared_exp_assembler: ");
+    dprint_tensix_pack_config_dis_shared_exp_assembler(config);
+    DPRINT("force_pack_per_max_xy_plane: ");
+    dprint_tensix_pack_config_force_pack_per_max_xy_plane(config);
+    DPRINT("enable_out_fifo: ");
+    dprint_tensix_pack_config_enable_out_fifo(config);
+    DPRINT("sub_l1_tile_header_size: ");
+    dprint_tensix_pack_config_sub_l1_tile_header_size(config);
     DPRINT("src_if_sel: ");
     dprint_tensix_pack_config_src_if_sel(config);
-    DPRINT("pack_per_xy_plane: ");
-    dprint_tensix_pack_config_pack_per_xy_plane(config);
+    DPRINT("all_pack_disable_zero_compress: ");
+    dprint_tensix_pack_config_all_pack_disable_zero_compress(config);
+    DPRINT("all_pack_disable_zero_compress_ovrd: ");
+    dprint_tensix_pack_config_all_pack_disable_zero_compress_ovrd(config);
+    DPRINT("add_tile_header_size: ");
+    dprint_tensix_pack_config_add_tile_header_size(config);
+    DPRINT("reserved_1: ");
+    dprint_tensix_pack_config_reserved_1(config);
     DPRINT("l1_src_addr: ");
     dprint_tensix_pack_config_l1_src_addr(config);
     DPRINT("downsample_mask: ");

--- a/tt_metal/hw/inc/api/debug/dprint_tensix_pack.h
+++ b/tt_metal/hw/inc/api/debug/dprint_tensix_pack.h
@@ -590,6 +590,8 @@ inline void dprint_tensix_pack_counters(uint reg_id = 0) {
 }
 
 // Choose what register you want by id (1-4). 0 for all.
+// On Wormhole, REG_IDs 2 and 4 are the REG8 banks, whose word-2 layout differs from REG1
+// (bits 17-23, see cfg_defines.h); fields above src_if_sel are mislabeled for those banks.
 inline void dprint_tensix_pack_config(uint reg_id = 0) {
     std::array<ckernel::packer::pack_config_t, ckernel::packer::NUM_PACKERS> config_vec;
     MATH(

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -410,7 +410,7 @@ inline void set_packer_config(
     //           THCON_SEC0_REG1_L1_Dest_addr = cfg_reg_array[1][32 +: 32];
     // THCON_SEC0_REG1_Disable_zero_compress = cfg_reg_array[1][64 +: 1];
     // THCON_SEC0_REG1_Add_l1_dest_addr_offset = cfg_reg_array[1][65 +: 1];
-    // THCON_SEC0_REG1_Unused0 = cfg_reg_array[1][66 +: 2];
+    // THCON_SEC0_REG1_Addr_cnt_context = cfg_reg_array[1][66 +: 2];
     // THCON_SEC0_REG1_Out_data_format = cfg_reg_array[1][68 +: 4];
     // THCON_SEC0_REG1_In_data_format = cfg_reg_array[1][72 +: 4];
     // THCON_SEC0_REG1_Dis_shared_exp_assembler = cfg_reg_array[1][76 +: 1];

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -31,6 +31,9 @@ constexpr std::uint32_t replay_buf_offset = 16; // split replay buffer usage bet
                                                 // fist 16 for sfpu, next 16 for fpu
 
 // Pack config
+// Word-2 layout matches THCON_SEC[01]_REG1. The REG8 banks differ: bits 17-23 are not
+// implemented as below (no All_pack_disable_zero_compress/_ovrd; Add_tile_header_size is
+// at bit 17 per cfg_defines.h), so REG8 readback can't be interpreted with this struct.
 typedef struct
 {
     // word 0

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/cpack_common.h
@@ -39,15 +39,21 @@ typedef struct
     // word 1
     std::uint32_t l1_dest_addr : 32;
     // word 2
-    std::uint32_t uncompress              : 1;
-    std::uint32_t add_l1_dest_addr_offset : 1;
-    std::uint32_t reserved_0              : 2;
-    std::uint32_t out_data_format : DATA_FORMAT_BIT_COUNT;
-    std::uint32_t in_data_format : DATA_FORMAT_BIT_COUNT;
-    std::uint32_t reserved_1        : 4;
-    std::uint32_t src_if_sel        : 1;
-    std::uint32_t pack_per_xy_plane : 7;
-    std::uint32_t l1_src_addr       : 8;
+    std::uint32_t uncompress              : 1;             // bit0  Disable_zero_compress
+    std::uint32_t add_l1_dest_addr_offset : 1;             // bit1
+    std::uint32_t addr_cnt_context        : 2;             // bits2-3
+    std::uint32_t out_data_format : DATA_FORMAT_BIT_COUNT; // bits4-7
+    std::uint32_t in_data_format : DATA_FORMAT_BIT_COUNT;  // bits8-11
+    std::uint32_t dis_shared_exp_assembler            : 1; // bit12
+    std::uint32_t force_pack_per_max_xy_plane         : 1; // bit13
+    std::uint32_t enable_out_fifo                     : 1; // bit14
+    std::uint32_t sub_l1_tile_header_size             : 1; // bit15
+    std::uint32_t src_if_sel                          : 1; // bit16  Source_interface_selection
+    std::uint32_t all_pack_disable_zero_compress      : 4; // bits17-20
+    std::uint32_t all_pack_disable_zero_compress_ovrd : 1; // bit21
+    std::uint32_t add_tile_header_size                : 1; // bit22
+    std::uint32_t reserved_1                          : 1; // bit23 unused
+    std::uint32_t l1_src_addr                         : 8; // bits24-31
     // word 3
     std::uint32_t downsample_mask                    : 16;
     std::uint32_t downsample_shift_count             : 3;
@@ -380,10 +386,9 @@ inline void set_packer_config(
             ? 0
             : (partial_face ? 1 : num_faces); // set to num_faces as exp section size is not used for non-bfp formats except for lf8/int8
 
-    config.f.uncompress        = 1;
-    config.f.out_data_format   = pack_dst_format;
-    config.f.in_data_format    = pack_src_format;
-    config.f.pack_per_xy_plane = 1;
+    config.f.uncompress      = 1;
+    config.f.out_data_format = pack_dst_format;
+    config.f.in_data_format  = pack_src_format;
 
     config.f.exp_threshold_en = 0;
     config.f.exp_threshold    = 0;
@@ -408,9 +413,15 @@ inline void set_packer_config(
     // THCON_SEC0_REG1_Unused0 = cfg_reg_array[1][66 +: 2];
     // THCON_SEC0_REG1_Out_data_format = cfg_reg_array[1][68 +: 4];
     // THCON_SEC0_REG1_In_data_format = cfg_reg_array[1][72 +: 4];
-    // THCON_SEC0_REG1_Unused00 = cfg_reg_array[1][76 +: 4];
+    // THCON_SEC0_REG1_Dis_shared_exp_assembler = cfg_reg_array[1][76 +: 1];
+    // THCON_SEC0_REG1_Force_pack_per_max_xy_plane = cfg_reg_array[1][77 +: 1];
+    // THCON_SEC0_REG1_Enable_out_fifo = cfg_reg_array[1][78 +: 1];
+    // THCON_SEC0_REG1_Sub_l1_tile_header_size = cfg_reg_array[1][79 +: 1];
     // THCON_SEC0_REG1_Source_interface_selection = cfg_reg_array[1][80 +: 1];
-    // THCON_SEC0_REG1_Packs_per_xy_plane = cfg_reg_array[1][81 +: 7];
+    // THCON_SEC0_REG1_All_pack_disable_zero_compress = cfg_reg_array[1][81 +: 4];
+    // THCON_SEC0_REG1_All_pack_disable_zero_compress_ovrd = cfg_reg_array[1][85 +: 1];
+    // THCON_SEC0_REG1_Add_tile_header_size = cfg_reg_array[1][86 +: 1];
+    // THCON_SEC0_REG1_Unused00 = cfg_reg_array[1][87 +: 1];
     // THCON_SEC0_REG1_L1_source_addr = cfg_reg_array[1][88 +: 8];
     // THCON_SEC0_REG1_Downsample_mask = cfg_reg_array[1][96 +: 16];
     // THCON_SEC0_REG1_Downsample_shift_count = cfg_reg_array[1][112 +: 3];


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

Wormhole's `pack_config_t` (`cpack_common.h`) had a stale word-2 layout where
bits 2-3, 12-15, and 17-23 used field names that no longer match
`THCON_SEC0_REG1` in the generated `cfg_defines.h`. Reorder/rename them to
match the actual register layout:

- bits 2-3: `reserved_0` → `addr_cnt_context`
- bits 12-15: `reserved_1` → `dis_shared_exp_assembler` / `force_pack_per_max_xy_plane` / `enable_out_fifo` / `sub_l1_tile_header_size`
- bits 17-23: `pack_per_xy_plane` → `all_pack_disable_zero_compress` / `all_pack_disable_zero_compress_ovrd` / `add_tile_header_size` / `reserved_1`

Total struct width is unchanged (`static_assert(sizeof == 16)` still holds).
Blackhole's struct was already correct and is left untouched.

Also drops the legacy `config.f.pack_per_xy_plane = 1` write in
`set_packer_config`: that field no longer exists in REG1. The write was
effectively inert — it set bit 17 (`All_pack_disable_zero_compress[0]`), but
without the override bit (21) set, HW ignores it and uses each packer's own
per-packer disable bit. The real pack-per-xy-plane count is programmed via
`PACK_COUNTERS_SEC0`. Removal is behavior-preserving and aligns with Blackhole.

Propagates the renames to the `ARCH_WORMHOLE` section of `dprint_tensix_pack.h`
to keep the debug printer consistent with the updated struct. Mirrors the
existing `ARCH_BLACKHOLE` section structure.

Relates to https://github.com/tenstorrent/tt-llk/issues/273

### Notes for reviewers

- `cpack_common.h` is Wormhole-only; no Blackhole or Quasar paths touched.
- The dropped `pack_per_xy_plane = 1` write: see the commit message for a full
  analysis of why it was inert. Short version: override bit 21 is never set, so
  HW uses per-packer Disable_zero_compress, not the global field.
- `dprint_tensix_pack.h`: the `ARCH_BLACKHOLE` `reserved_0` printer gains an
  `#if defined(ARCH_BLACKHOLE)` guard (it referenced a BH-only field); WH gets
  its own `addr_cnt_context` printer in its place.
- Verified: all 816 WH kernel variants compile (incl. bfp zero-compress paths);
  BH datacopy 903/903 pass; WH on-silicon functional run pass;
  both debug-printer arch paths host-syntax-check.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/issue-273-pack-config-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/issue-273-pack-config-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/issue-273-pack-config-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/issue-273-pack-config-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/issue-273-pack-config-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/issue-273-pack-config-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/issue-273-pack-config-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/issue-273-pack-config-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/issue-273-pack-config-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/issue-273-pack-config-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/issue-273-pack-config-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/issue-273-pack-config-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/issue-273-pack-config-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/issue-273-pack-config-ordering)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/issue-273-pack-config-ordering)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/issue-273-pack-config-ordering)