### PR TITLE
deepseek_v3_d_p MLA: allocate persistent buffers once per model (non-chunked + chunked)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -305,30 +305,19 @@ class ttMLA:
 
         # Ring-attention persistent buffers. Chunked prefill (ring_mla) and the standard ring
         # joint SDPA use disjoint buffer sets, so allocate only the one the configured mode needs --
-        # holding both would waste DRAM.
-        # TODO: the chunked _chunked_kv_buf is still allocated per-layer; hoist it into TT_CCL like the
-        # non-chunked branch below (it's a scratch gather buffer, uniform across layers).
+        # holding both would waste DRAM. Both sets are owned once per model by TT_CCL and shared by
+        # every layer's MLA (uniform across layers, scratch / no per-layer state) instead of
+        # re-allocated per layer.
         if self.is_chunked:
-            # Single combined gathered-KV buffer for ring_mla: K and V both come from the latent
-            # kvpe cache, so one (cache_batch, 1, seq_len, kvpe_dim) buffer replaces the separate
-            # per-K/per-V ring-SDPA buffers (and the dummy joint tensors) used in the other mode.
-            #
-            # TODO: reduce DRAM pressure -- ring_mla only ever gathers into the single
-            # kv_cache_batch_idx slot, but the op's TT_FATAL forces gathered-KV batch == cache
-            # batch (slot_num * layer_num). Allocating the full batch wastes DRAM for all but one
-            # slot; relaxing the op to index the gathered buffer independently (always slot 0)
-            # would let this be a batch-1 buffer.
-            cache_batch = self.slot_num * self.layer_num
-            kvpe_dim = self.kv_lora_rank + self.qk_rope_head_dim
-            self._chunked_kv_buf = ttnn.from_torch(
-                torch.zeros(cache_batch, 1, seq_len, kvpe_dim),
-                device=self.mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat8_b,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=[None, None]
-                ),
+            # Single combined gathered-KV scratch buffer for ring_mla: K and V both come from the
+            # latent kvpe cache, so one (cache_batch, 1, seq_len, kvpe_dim) buffer replaces the
+            # separate per-K/per-V ring-SDPA buffers (and the dummy joint tensors) used in the other
+            # mode. cache_batch = slot_num * layer_num is forced by the op's TT_FATAL (gathered-KV
+            # batch == cache batch) even though only the kv_cache_batch_idx slot is ever gathered.
+            self._chunked_kv_buf = self.tt_ccl.get_mla_chunked_kv_buffer(
+                cache_batch=self.slot_num * self.layer_num,
+                seq_len=seq_len,
+                kvpe_dim=self.kv_lora_rank + self.qk_rope_head_dim,
             )
         else:
             # All-gather K/V outputs + dummy joint_q/kv/v placeholders are uniform across layers

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -306,10 +306,8 @@ class ttMLA:
         # Ring-attention persistent buffers. Chunked prefill (ring_mla) and the standard ring
         # joint SDPA use disjoint buffer sets, so allocate only the one the configured mode needs --
         # holding both would waste DRAM.
-        # TODO: these are scratch buffers reused across the whole ring op and don't hold per-layer
-        # state, so they should be allocated ONCE and shared by all layers. With the current per-layer
-        # ttMLA instance they are re-allocated for every layer -- wasted DRAM that scales with depth.
-        # Hoist them to a shared owner (or pass them in) when ttMLA instances are created per layer.
+        # TODO: the chunked _chunked_kv_buf is still allocated per-layer; hoist it into TT_CCL like the
+        # non-chunked branch below (it's a scratch gather buffer, uniform across layers).
         if self.is_chunked:
             # Single combined gathered-KV buffer for ring_mla: K and V both come from the latent
             # kvpe cache, so one (cache_batch, 1, seq_len, kvpe_dim) buffer replaces the separate
@@ -333,71 +331,24 @@ class ttMLA:
                 ),
             )
         else:
-            # ring attention setup
-            persistent_v_shard_dims = [None, None]
-            persistent_v_shard_dims[self.tp_axis] = 1  # TP heads
-            persistent_k_shard_dims = [None, None]
-
-            ag_output_shape_k = (1, 1, seq_len, self.kv_lora_rank + self.qk_rope_head_dim)
-            ag_output_shape_v = (1, self.num_heads, seq_len, self.v_head_dim)
-
-            self.persistent_k_output_buffer = ttnn.from_torch(
-                torch.zeros(ag_output_shape_k),
-                device=self.mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat8_b,  # hardcoded for now
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=persistent_k_shard_dims
-                ),
+            # All-gather K/V outputs + dummy joint_q/kv/v placeholders are uniform across layers
+            # (config + seq_len + mesh), so they're owned once per model by TT_CCL and shared by every
+            # layer's MLA instead of re-allocated per layer. forward() reads them off self exactly as
+            # before. See TT_CCL.get_mla_ring_attention_buffers.
+            ring_buffers = self.tt_ccl.get_mla_ring_attention_buffers(
+                seq_len=seq_len,
+                kv_lora_rank=self.kv_lora_rank,
+                qk_rope_head_dim=self.qk_rope_head_dim,
+                qk_head_dim=self.qk_head_dim,
+                v_head_dim=self.v_head_dim,
+                num_heads=self.num_heads,
+                tp_axis=self.tp_axis,
             )
-
-            self.persistent_v_output_buffer = ttnn.from_torch(
-                torch.zeros(ag_output_shape_v),
-                device=self.mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat8_b,  # hardcoded for now
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=persistent_v_shard_dims
-                ),
-            )
-
-            # Pre-allocate dummy joint tensors for ring_joint_scaled_dot_product_attention (seq_len=0)
-            num_heads_local = self.num_heads // self.tp_factor
-            joint_shard_dims = [None, None]
-            joint_shard_dims[self.tp_axis] = 1  # shard on head dimension
-
-            self.joint_q = ttnn.from_torch(
-                torch.zeros(1, num_heads_local, 0, self.qk_head_dim),
-                device=self.mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat8_b,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=joint_shard_dims
-                ),
-            )
-
-            self.joint_kv = ttnn.from_torch(
-                torch.zeros(1, 1, 0, self.kv_lora_rank + self.qk_rope_head_dim),
-                device=self.mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat8_b,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                mesh_mapper=ttnn.ReplicateTensorToMesh(self.mesh_device),
-            )
-
-            self.joint_v = ttnn.from_torch(
-                torch.zeros(1, num_heads_local, 0, self.v_head_dim),
-                device=self.mesh_device,
-                layout=ttnn.TILE_LAYOUT,
-                dtype=ttnn.bfloat8_b,
-                memory_config=ttnn.DRAM_MEMORY_CONFIG,
-                mesh_mapper=ttnn.ShardTensor2dMesh(
-                    self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=joint_shard_dims
-                ),
-            )
+            self.persistent_k_output_buffer = ring_buffers["persistent_k_output_buffer"]
+            self.persistent_v_output_buffer = ring_buffers["persistent_v_output_buffer"]
+            self.joint_q = ring_buffers["joint_q"]
+            self.joint_kv = ring_buffers["joint_kv"]
+            self.joint_v = ring_buffers["joint_v"]
 
         # Load weights to TT device
         weights = self._convert_and_cache_weights(

--- a/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
@@ -131,6 +131,10 @@ class TT_CCL:
         # signature. One set for the whole model. See get_mla_ring_attention_buffers.
         self.mla_ring_attention_buffers: dict[tuple, dict] = {}
 
+        # Persistent chunked-prefill (ring_mla) gathered-KV scratch buffers shared by every layer's
+        # MLA, keyed by shape signature. See get_mla_chunked_kv_buffer.
+        self.mla_chunked_kv_buffers: dict[tuple, "ttnn.Tensor"] = {}
+
     def get_mla_ring_attention_buffers(
         self,
         *,
@@ -192,6 +196,29 @@ class TT_CCL:
         }
         self.mla_ring_attention_buffers[key] = buffers
         return buffers
+
+    def get_mla_chunked_kv_buffer(self, *, cache_batch, seq_len, kvpe_dim, dtype=ttnn.bfloat8_b):
+        """Lazily allocate (once per mesh) and return the combined gathered-KV scratch buffer used by
+        the chunked-prefill ring_mla op (persistent_output_buffer_kv). It's scratch -- each layer's
+        gather overwrites it, it holds no per-layer state -- and uniform across layers (cache_batch =
+        slot_num*layer_num, seq_len, mesh are all fixed for a model), so one buffer is shared by every
+        layer's MLA instead of re-allocating a full slot_num*layer_num buffer per layer. Replicated
+        across the mesh ([None, None]); cached by shape signature."""
+        import torch
+
+        key = (cache_batch, seq_len, kvpe_dim, dtype)
+        if key not in self.mla_chunked_kv_buffers:
+            self.mla_chunked_kv_buffers[key] = ttnn.from_torch(
+                torch.zeros(cache_batch, 1, seq_len, kvpe_dim),
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=dtype,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    self.mesh_device, mesh_shape=tuple(self.mesh_device.shape), dims=[None, None]
+                ),
+            )
+        return self.mla_chunked_kv_buffers[key]
 
     def get_shared_rs_intermediate(self, input_tensor):
         """Lazily allocate (once per mesh) and return the shared reduce_scatter intermediate

--- a/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
@@ -127,6 +127,72 @@ class TT_CCL:
         # keeps the memory cost flat. See TtSharedExpert.forward.
         self.shared_rs_intermediate = None
 
+        # Persistent ring-attention buffers shared by every layer's MLA, keyed by their shape
+        # signature. One set for the whole model. See get_mla_ring_attention_buffers.
+        self.mla_ring_attention_buffers: dict[tuple, dict] = {}
+
+    def get_mla_ring_attention_buffers(
+        self,
+        *,
+        seq_len,
+        kv_lora_rank,
+        qk_rope_head_dim,
+        qk_head_dim,
+        v_head_dim,
+        num_heads,
+        tp_axis,
+        dtype=ttnn.bfloat8_b,
+    ):
+        """Lazily allocate (once per mesh) and return the persistent ring-attention buffers shared by
+        every layer's MLA: the all-gather K/V output buffers plus the dummy joint_q/kv/v placeholders
+        (seq_len=0) that ring_joint_scaled_dot_product_attention requires. All MLA layers share one
+        config + seq_len + mesh, so a single set is reused at a stable address across layers -- layers
+        run sequentially (no in-flight overlap), and the fixed address also keeps the op's fabric
+        reduction order identical for bit-exact determinism. Cached by shape signature so distinct
+        configs/seq_lens on the same mesh get their own set. Returns a dict of ttnn.Tensor."""
+        import torch
+
+        key = (seq_len, kv_lora_rank, qk_rope_head_dim, qk_head_dim, v_head_dim, num_heads, tp_axis, dtype)
+        if key in self.mla_ring_attention_buffers:
+            return self.mla_ring_attention_buffers[key]
+
+        mesh_shape = tuple(self.mesh_device.shape)
+        num_heads_local = num_heads // self.mesh_device.shape[tp_axis]
+        v_shard_dims = [None, None]
+        v_shard_dims[tp_axis] = 1  # TP heads
+        k_shard_dims = [None, None]  # replicated across the mesh
+        joint_shard_dims = [None, None]
+        joint_shard_dims[tp_axis] = 1  # shard on head dimension
+
+        def _alloc(tensor, *, shard_dims=None, replicate=False):
+            mapper = (
+                ttnn.ReplicateTensorToMesh(self.mesh_device)
+                if replicate
+                else ttnn.ShardTensor2dMesh(self.mesh_device, mesh_shape=mesh_shape, dims=shard_dims)
+            )
+            return ttnn.from_torch(
+                tensor,
+                device=self.mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=dtype,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=mapper,
+            )
+
+        buffers = {
+            "persistent_k_output_buffer": _alloc(
+                torch.zeros(1, 1, seq_len, kv_lora_rank + qk_rope_head_dim), shard_dims=k_shard_dims
+            ),
+            "persistent_v_output_buffer": _alloc(
+                torch.zeros(1, num_heads, seq_len, v_head_dim), shard_dims=v_shard_dims
+            ),
+            "joint_q": _alloc(torch.zeros(1, num_heads_local, 0, qk_head_dim), shard_dims=joint_shard_dims),
+            "joint_kv": _alloc(torch.zeros(1, 1, 0, kv_lora_rank + qk_rope_head_dim), replicate=True),
+            "joint_v": _alloc(torch.zeros(1, num_heads_local, 0, v_head_dim), shard_dims=joint_shard_dims),
+        }
+        self.mla_ring_attention_buffers[key] = buffers
+        return buffers
+
     def get_shared_rs_intermediate(self, input_tensor):
         """Lazily allocate (once per mesh) and return the shared reduce_scatter intermediate
         accumulator. Line (Linear) topology needs a double-sized leading dim for the

--- a/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_ccl.py
@@ -183,6 +183,7 @@ class TT_CCL:
                 mesh_mapper=mapper,
             )
 
+        assert num_heads_local * self.mesh_device.shape[tp_axis] == num_heads
         buffers = {
             "persistent_k_output_buffer": _alloc(
                 torch.zeros(1, 1, seq_len, kv_lora_rank + qk_rope_head_dim), shard_dims=k_shard_dims
@@ -190,9 +191,9 @@ class TT_CCL:
             "persistent_v_output_buffer": _alloc(
                 torch.zeros(1, num_heads, seq_len, v_head_dim), shard_dims=v_shard_dims
             ),
-            "joint_q": _alloc(torch.zeros(1, num_heads_local, 0, qk_head_dim), shard_dims=joint_shard_dims),
+            "joint_q": _alloc(torch.zeros(1, num_heads, 0, qk_head_dim), shard_dims=joint_shard_dims),
             "joint_kv": _alloc(torch.zeros(1, 1, 0, kv_lora_rank + qk_rope_head_dim), replicate=True),
-            "joint_v": _alloc(torch.zeros(1, num_heads_local, 0, v_head_dim), shard_dims=joint_shard_dims),
+            "joint_v": _alloc(torch.zeros(1, num_heads, 0, v_head_dim), shard_dims=joint_shard_dims),
         }
         self.mla_ring_attention_buffers[key] = buffers
         return buffers


### PR DESCRIPTION
## What

Resolves #46442. `ttMLA.__init__` allocated **5 persistent ring-attention buffers per layer** — `persistent_k_output_buffer`, `persistent_v_output_buffer`, and the three dummy `joint_q/kv/v` placeholders — so they scaled with `num_layers` even though their shapes are uniform across layers (config + `seq_len` + mesh) and they're consumed by a single, sequential op.

This moves them into `TT_CCL` (already one-per-mesh ≈ one-per-model) behind a new lazy getter `get_mla_ring_attention_buffers(...)`, cached by a shape signature, so **one set is shared by every layer's MLA**. `ttMLA.forward` is unchanged (same `self.*` attributes).

Net: `5 × num_layers` allocations → `5`. Mirrors the existing one-per-model `shared_rs_intermediate`.

## Why it's safe (no per-layer zeroing needed)

`ring_joint_scaled_dot_product_attention` bounds its reads by `logical_n` (= `seq_len_local * sp_factor`) and skips/masks anything beyond it, so the read region is freshly gathered each call and any stale tail is never read. This matches the codebase convention:
- `tt_dit`'s `CCLManager` reuses `torch.empty` CCL buffers across layers with no zeroing.
- `shared_rs_intermediate` is documented as needing no per-iteration re-zeroing ("the op overwrites the intermediate before reading it").

A single buffer (not ping-pong) is correct here: the ring SDPA is the sole, sequential consumer per layer — no concurrent op contends for it.

This is a `main`-based change because the per-layer allocation exists on the non-chunked path too.

## Testing

- ✅ Both files `py_compile`; pre-commit hooks pass.
- ⬜ **Not yet device-verified.** Needs MLA / prefill PCC tests on a real mesh (BH/WH) — `test_ds_mla`, prefill block/transformer. Draft until validated on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] [![galaxy-deepseek-prefill-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ipotkonjak/ccl_persistent_buffers_per_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ipotkonjak/ccl_persistent_buffers_per_model) 
- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ipotkonjak/ccl_persistent_buffers_per_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ipotkonjak/ccl_persistent_buffers_per_model)
- [x] [![t3000-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=ipotkonjak/ccl_persistent_buffers_per_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:ipotkonjak/ccl_persistent_buffers_per_model) 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/ccl_persistent_buffers_per_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/ccl_persistent_buffers_per_model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/ccl_persistent_buffers_per_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/ccl_persistent_buffers_per_model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/ccl_persistent_buffers_per_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/ccl_persistent_buffers_per_model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/ccl_persistent_buffers_per_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/ccl_persistent_buffers_per_model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/ccl_persistent_buffers_per_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/ccl_persistent_buffers_per_model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/ccl_persistent_buffers_per_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/ccl_persistent_buffers_per_model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/ccl_persistent_buffers_per_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/ccl_persistent_buffers_per_model)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/ccl_persistent_buffers_per_model)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/ccl_persistent_buffers_per_model)