### PR TITLE
#44910: Restore BH perf nightly determinism via per-test chip reset

### DIFF
--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -123,18 +123,27 @@ jobs:
         if: always()
         with:
           name: perf-junit-report-${{ env.CHIP_ARCH }}-${{ matrix.test-group.split_group }}
-          # Match the merged report, the compile report, and the per-file
-          # `-<tname>-run` reports so that BH per-test reports are still
-          # uploaded even when a timeout prevents the final merge step.
+          # Match the merged report, the compile report, the BH per-slice
+          # `-<tname>-run` reports, and the WH `-run` report so that per-test
+          # reports are still uploaded even when a timeout prevents the merge.
           path: |
             ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}.xml
             ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}-*-run.xml
+            ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}-run.xml
             ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}-compile.xml
 
       - name: Publish Test Results
         uses: mikepenz/action-junit-report@v5
         if: always()
         with:
-          report_paths: ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}.xml
+          # Read the per-phase / per-slice result reports directly (compile +
+          # run for WH, per-slice run for BH) rather than only the merged
+          # report, so results are still published if a shard times out before
+          # the merge step. The three patterns are disjoint and exclude the
+          # merged report, so no test is counted twice.
+          report_paths: |
+            ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}-compile.xml
+            ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}-run.xml
+            ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}-*-run.xml
           include_passed: true
           annotate_only: true

--- a/.github/workflows/llk-perf-impl.yaml
+++ b/.github/workflows/llk-perf-impl.yaml
@@ -123,7 +123,13 @@ jobs:
         if: always()
         with:
           name: perf-junit-report-${{ env.CHIP_ARCH }}-${{ matrix.test-group.split_group }}
-          path: ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}.xml
+          # Match the merged report, the compile report, and the per-file
+          # `-<tname>-run` reports so that BH per-test reports are still
+          # uploaded even when a timeout prevents the final merge step.
+          path: |
+            ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}.xml
+            ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}-*-run.xml
+            ${{ env.LLK_PATH }}/tests/python_tests/pytest-report-*-${{ matrix.test-group.split_group }}-compile.xml
 
       - name: Publish Test Results
         uses: mikepenz/action-junit-report@v5

--- a/tests/pipeline_reorg/llk_perf_tests.yaml
+++ b/tests/pipeline_reorg/llk_perf_tests.yaml
@@ -16,7 +16,7 @@
     ./tests/run_llk_perf_wormhole.sh {split_group} 5
   skus:
     wh_n150_civ2:
-      timeout: 69
+      timeout: 90
   owner_id: U07J3K6KS1K
 
 - name: llk_perf_wormhole group 2/5
@@ -27,7 +27,7 @@
     ./tests/run_llk_perf_wormhole.sh {split_group} 5
   skus:
     wh_n150_civ2:
-      timeout: 69
+      timeout: 90
   owner_id: U07J3K6KS1K
 
 - name: llk_perf_wormhole group 3/5
@@ -38,7 +38,7 @@
     ./tests/run_llk_perf_wormhole.sh {split_group} 5
   skus:
     wh_n150_civ2:
-      timeout: 69
+      timeout: 90
   owner_id: U07J3K6KS1K
 
 - name: llk_perf_wormhole group 4/5
@@ -49,7 +49,7 @@
     ./tests/run_llk_perf_wormhole.sh {split_group} 5
   skus:
     wh_n150_civ2:
-      timeout: 69
+      timeout: 90
   owner_id: U07J3K6KS1K
 
 - name: llk_perf_wormhole group 5/5
@@ -60,7 +60,7 @@
     ./tests/run_llk_perf_wormhole.sh {split_group} 5
   skus:
     wh_n150_civ2:
-      timeout: 69
+      timeout: 90
   owner_id: U07J3K6KS1K
 
 - name: llk_perf_blackhole group 1/5

--- a/tests/pipeline_reorg/llk_perf_tests.yaml
+++ b/tests/pipeline_reorg/llk_perf_tests.yaml
@@ -3,23 +3,17 @@
 # One matrix row per --group, like tests/pipeline_reorg/ttnn-tests.yaml.
 # LLK perf tests are no longer triggered on PR label "llk:performance"
 # ci-quiet log mode is hard-coded.
+# {split_group} is substituted with each row's split_group by prepare_test_matrix.py,
+# so every group below shares one identical cmd that calls a shared runner in
+# tt_metal/tt-llk/tests/: run_llk_perf_wormhole.sh (plain pytest-split) and
+# run_llk_perf_blackhole.sh (slice-level bin-pack + per-slice tt-smi reset).
 
 - name: llk_perf_wormhole group 1/5
   split_group: 1
   team: llk
   cmd: |
     set -euo pipefail
-    cd tests/python_tests
-    mkdir -p perf_data
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf" --timeout=60 \
-      --splits 5 --group 1 \
-      --junitxml=pytest-report-wormhole-1-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf" --timeout=60 \
-      --splits 5 --group 1 \
-      --junitxml=pytest-report-wormhole-1-run.xml .
-    junitparser merge pytest-report-wormhole-1-compile.xml pytest-report-wormhole-1-run.xml pytest-report-wormhole-1.xml
+    ./tests/run_llk_perf_wormhole.sh {split_group} 5
   skus:
     wh_n150_civ2:
       timeout: 69
@@ -30,17 +24,7 @@
   team: llk
   cmd: |
     set -euo pipefail
-    cd tests/python_tests
-    mkdir -p perf_data
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf" --timeout=60 \
-      --splits 5 --group 2 \
-      --junitxml=pytest-report-wormhole-2-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf" --timeout=60 \
-      --splits 5 --group 2 \
-      --junitxml=pytest-report-wormhole-2-run.xml .
-    junitparser merge pytest-report-wormhole-2-compile.xml pytest-report-wormhole-2-run.xml pytest-report-wormhole-2.xml
+    ./tests/run_llk_perf_wormhole.sh {split_group} 5
   skus:
     wh_n150_civ2:
       timeout: 69
@@ -51,17 +35,7 @@
   team: llk
   cmd: |
     set -euo pipefail
-    cd tests/python_tests
-    mkdir -p perf_data
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf" --timeout=60 \
-      --splits 5 --group 3 \
-      --junitxml=pytest-report-wormhole-3-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf" --timeout=60 \
-      --splits 5 --group 3 \
-      --junitxml=pytest-report-wormhole-3-run.xml .
-    junitparser merge pytest-report-wormhole-3-compile.xml pytest-report-wormhole-3-run.xml pytest-report-wormhole-3.xml
+    ./tests/run_llk_perf_wormhole.sh {split_group} 5
   skus:
     wh_n150_civ2:
       timeout: 69
@@ -72,17 +46,7 @@
   team: llk
   cmd: |
     set -euo pipefail
-    cd tests/python_tests
-    mkdir -p perf_data
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf" --timeout=60 \
-      --splits 5 --group 4 \
-      --junitxml=pytest-report-wormhole-4-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf" --timeout=60 \
-      --splits 5 --group 4 \
-      --junitxml=pytest-report-wormhole-4-run.xml .
-    junitparser merge pytest-report-wormhole-4-compile.xml pytest-report-wormhole-4-run.xml pytest-report-wormhole-4.xml
+    ./tests/run_llk_perf_wormhole.sh {split_group} 5
   skus:
     wh_n150_civ2:
       timeout: 69
@@ -93,17 +57,7 @@
   team: llk
   cmd: |
     set -euo pipefail
-    cd tests/python_tests
-    mkdir -p perf_data
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf" --timeout=60 \
-      --splits 5 --group 5 \
-      --junitxml=pytest-report-wormhole-5-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf" --timeout=60 \
-      --splits 5 --group 5 \
-      --junitxml=pytest-report-wormhole-5-run.xml .
-    junitparser merge pytest-report-wormhole-5-compile.xml pytest-report-wormhole-5-run.xml pytest-report-wormhole-5.xml
+    ./tests/run_llk_perf_wormhole.sh {split_group} 5
   skus:
     wh_n150_civ2:
       timeout: 69
@@ -114,106 +68,7 @@
   team: llk
   cmd: |
     set -euo pipefail
-    cd tests/python_tests
-    mkdir -p perf_data
-
-    GROUP=1
-    N_GROUPS=5
-
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-
-    # Slice-level greedy bin-pack with an adaptive target, mirroring how
-    # pytest-split distributes items across shards. Files larger than the
-    # target are cut into K slices (no upper cap on K) so an oversized test
-    # overflows into multiple slices/bins instead of pinning a single bin.
-    # Each slice is its own pytest invocation with its own preceding
-    # `tt-smi -r 0` (the reset-between-tests fix this branch exists for).
-    ASSIGNMENTS=$(python3 - "$GROUP" "$N_GROUPS" <<'PY'
-    import subprocess, sys, glob, re, math
-
-    group = int(sys.argv[1])
-    n_groups = int(sys.argv[2])
-
-    # 1. Collect item counts per file (CPU only, no chip access).
-    files = sorted(glob.glob("perf_*.py"))
-    counts = {}
-    for f in files:
-        out = subprocess.run(
-            ["pytest", "--collect-only", "-q", "-m", "perf", f],
-            capture_output=True, text=True
-        ).stdout
-        n = 0
-        for line in out.splitlines():
-            m = re.match(r"^\s*(\d+) tests? collected", line)
-            if m:
-                n = int(m.group(1))
-                break
-        counts[f] = n
-
-    # 2. Adaptive target: half of an ideal bin, floored at 1500. Scales
-    #    with suite size so it auto-adapts as tests are added or grow.
-    total = sum(counts.values())
-    target = max(1500, total // (2 * n_groups))
-
-    # 3. Slice each file into K parts (no upper cap on K).
-    slices = []  # (file, group_idx, total_splits, items)
-    for f, c in counts.items():
-        K = max(1, math.ceil(c / target)) if c > 0 else 1
-        base = c // K if K > 0 else 0
-        rem = c - base * K
-        # Even split; the rem extra items spill into the earliest slices.
-        for i in range(K):
-            slice_items = base + (1 if i < rem else 0)
-            slices.append((f, i + 1, K, slice_items))
-
-    # 4. Greedy bin-pack slices into n_groups bins (first-fit-decreasing).
-    bins = [[0, []] for _ in range(n_groups)]
-    for s in sorted(slices, key=lambda x: -x[3]):
-        bins.sort(key=lambda b: (b[0], len(b[1])))  # lightest bin first
-        bins[0][0] += s[3]
-        bins[0][1].append(s)
-
-    # 5. Emit this group's slices as file:group_idx:total_splits:items.
-    for f, idx, total_splits, items in sorted(bins[group - 1][1]):
-        print(f"{f}:{idx}:{total_splits}:{items}")
-    PY
-    )
-    echo "Group ${GROUP}/${N_GROUPS} slices:"
-    echo "$ASSIGNMENTS"
-
-    # Per slice: compile only this slice's items (producer), reset the board,
-    # then measure (consumer). Slicing the producer keeps each item compiled
-    # exactly once across the run (like main's --splits/--group) instead of
-    # recompiling whole giant files in every group holding one of their slices
-    # — the over-compile that was timing the producer out before the consumer
-    # ever ran.
-    while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
-      [ -z "$FILE" ] && continue
-      tname="${FILE%.py}"
-
-      if [ "$TOTAL" = "1" ]; then
-        SPLIT_ARGS=""
-        REPORT_NAME="${tname}-run"
-      else
-        SPLIT_ARGS="--splits ${TOTAL} --group ${GIDX}"
-        REPORT_NAME="${tname}-s${GIDX}of${TOTAL}-run"
-      fi
-
-      pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 \
-        -m "perf" --timeout=60 \
-        $SPLIT_ARGS \
-        "$FILE"
-      tt-smi -r 0
-      pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 \
-        -m "perf" --timeout=60 \
-        $SPLIT_ARGS \
-        --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
-        "$FILE"
-    done <<< "$ASSIGNMENTS"
-
-    junitparser merge pytest-report-blackhole-${GROUP}-*-run.xml \
-      pytest-report-blackhole-${GROUP}.xml
+    ./tests/run_llk_perf_blackhole.sh {split_group} 5
   skus:
     bh_p150b_civ2:
       timeout: 120
@@ -224,106 +79,7 @@
   team: llk
   cmd: |
     set -euo pipefail
-    cd tests/python_tests
-    mkdir -p perf_data
-
-    GROUP=2
-    N_GROUPS=5
-
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-
-    # Slice-level greedy bin-pack with an adaptive target, mirroring how
-    # pytest-split distributes items across shards. Files larger than the
-    # target are cut into K slices (no upper cap on K) so an oversized test
-    # overflows into multiple slices/bins instead of pinning a single bin.
-    # Each slice is its own pytest invocation with its own preceding
-    # `tt-smi -r 0` (the reset-between-tests fix this branch exists for).
-    ASSIGNMENTS=$(python3 - "$GROUP" "$N_GROUPS" <<'PY'
-    import subprocess, sys, glob, re, math
-
-    group = int(sys.argv[1])
-    n_groups = int(sys.argv[2])
-
-    # 1. Collect item counts per file (CPU only, no chip access).
-    files = sorted(glob.glob("perf_*.py"))
-    counts = {}
-    for f in files:
-        out = subprocess.run(
-            ["pytest", "--collect-only", "-q", "-m", "perf", f],
-            capture_output=True, text=True
-        ).stdout
-        n = 0
-        for line in out.splitlines():
-            m = re.match(r"^\s*(\d+) tests? collected", line)
-            if m:
-                n = int(m.group(1))
-                break
-        counts[f] = n
-
-    # 2. Adaptive target: half of an ideal bin, floored at 1500. Scales
-    #    with suite size so it auto-adapts as tests are added or grow.
-    total = sum(counts.values())
-    target = max(1500, total // (2 * n_groups))
-
-    # 3. Slice each file into K parts (no upper cap on K).
-    slices = []  # (file, group_idx, total_splits, items)
-    for f, c in counts.items():
-        K = max(1, math.ceil(c / target)) if c > 0 else 1
-        base = c // K if K > 0 else 0
-        rem = c - base * K
-        # Even split; the rem extra items spill into the earliest slices.
-        for i in range(K):
-            slice_items = base + (1 if i < rem else 0)
-            slices.append((f, i + 1, K, slice_items))
-
-    # 4. Greedy bin-pack slices into n_groups bins (first-fit-decreasing).
-    bins = [[0, []] for _ in range(n_groups)]
-    for s in sorted(slices, key=lambda x: -x[3]):
-        bins.sort(key=lambda b: (b[0], len(b[1])))  # lightest bin first
-        bins[0][0] += s[3]
-        bins[0][1].append(s)
-
-    # 5. Emit this group's slices as file:group_idx:total_splits:items.
-    for f, idx, total_splits, items in sorted(bins[group - 1][1]):
-        print(f"{f}:{idx}:{total_splits}:{items}")
-    PY
-    )
-    echo "Group ${GROUP}/${N_GROUPS} slices:"
-    echo "$ASSIGNMENTS"
-
-    # Per slice: compile only this slice's items (producer), reset the board,
-    # then measure (consumer). Slicing the producer keeps each item compiled
-    # exactly once across the run (like main's --splits/--group) instead of
-    # recompiling whole giant files in every group holding one of their slices
-    # — the over-compile that was timing the producer out before the consumer
-    # ever ran.
-    while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
-      [ -z "$FILE" ] && continue
-      tname="${FILE%.py}"
-
-      if [ "$TOTAL" = "1" ]; then
-        SPLIT_ARGS=""
-        REPORT_NAME="${tname}-run"
-      else
-        SPLIT_ARGS="--splits ${TOTAL} --group ${GIDX}"
-        REPORT_NAME="${tname}-s${GIDX}of${TOTAL}-run"
-      fi
-
-      pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 \
-        -m "perf" --timeout=60 \
-        $SPLIT_ARGS \
-        "$FILE"
-      tt-smi -r 0
-      pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 \
-        -m "perf" --timeout=60 \
-        $SPLIT_ARGS \
-        --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
-        "$FILE"
-    done <<< "$ASSIGNMENTS"
-
-    junitparser merge pytest-report-blackhole-${GROUP}-*-run.xml \
-      pytest-report-blackhole-${GROUP}.xml
+    ./tests/run_llk_perf_blackhole.sh {split_group} 5
   skus:
     bh_p150b_civ2:
       timeout: 120
@@ -334,106 +90,7 @@
   team: llk
   cmd: |
     set -euo pipefail
-    cd tests/python_tests
-    mkdir -p perf_data
-
-    GROUP=3
-    N_GROUPS=5
-
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-
-    # Slice-level greedy bin-pack with an adaptive target, mirroring how
-    # pytest-split distributes items across shards. Files larger than the
-    # target are cut into K slices (no upper cap on K) so an oversized test
-    # overflows into multiple slices/bins instead of pinning a single bin.
-    # Each slice is its own pytest invocation with its own preceding
-    # `tt-smi -r 0` (the reset-between-tests fix this branch exists for).
-    ASSIGNMENTS=$(python3 - "$GROUP" "$N_GROUPS" <<'PY'
-    import subprocess, sys, glob, re, math
-
-    group = int(sys.argv[1])
-    n_groups = int(sys.argv[2])
-
-    # 1. Collect item counts per file (CPU only, no chip access).
-    files = sorted(glob.glob("perf_*.py"))
-    counts = {}
-    for f in files:
-        out = subprocess.run(
-            ["pytest", "--collect-only", "-q", "-m", "perf", f],
-            capture_output=True, text=True
-        ).stdout
-        n = 0
-        for line in out.splitlines():
-            m = re.match(r"^\s*(\d+) tests? collected", line)
-            if m:
-                n = int(m.group(1))
-                break
-        counts[f] = n
-
-    # 2. Adaptive target: half of an ideal bin, floored at 1500. Scales
-    #    with suite size so it auto-adapts as tests are added or grow.
-    total = sum(counts.values())
-    target = max(1500, total // (2 * n_groups))
-
-    # 3. Slice each file into K parts (no upper cap on K).
-    slices = []  # (file, group_idx, total_splits, items)
-    for f, c in counts.items():
-        K = max(1, math.ceil(c / target)) if c > 0 else 1
-        base = c // K if K > 0 else 0
-        rem = c - base * K
-        # Even split; the rem extra items spill into the earliest slices.
-        for i in range(K):
-            slice_items = base + (1 if i < rem else 0)
-            slices.append((f, i + 1, K, slice_items))
-
-    # 4. Greedy bin-pack slices into n_groups bins (first-fit-decreasing).
-    bins = [[0, []] for _ in range(n_groups)]
-    for s in sorted(slices, key=lambda x: -x[3]):
-        bins.sort(key=lambda b: (b[0], len(b[1])))  # lightest bin first
-        bins[0][0] += s[3]
-        bins[0][1].append(s)
-
-    # 5. Emit this group's slices as file:group_idx:total_splits:items.
-    for f, idx, total_splits, items in sorted(bins[group - 1][1]):
-        print(f"{f}:{idx}:{total_splits}:{items}")
-    PY
-    )
-    echo "Group ${GROUP}/${N_GROUPS} slices:"
-    echo "$ASSIGNMENTS"
-
-    # Per slice: compile only this slice's items (producer), reset the board,
-    # then measure (consumer). Slicing the producer keeps each item compiled
-    # exactly once across the run (like main's --splits/--group) instead of
-    # recompiling whole giant files in every group holding one of their slices
-    # — the over-compile that was timing the producer out before the consumer
-    # ever ran.
-    while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
-      [ -z "$FILE" ] && continue
-      tname="${FILE%.py}"
-
-      if [ "$TOTAL" = "1" ]; then
-        SPLIT_ARGS=""
-        REPORT_NAME="${tname}-run"
-      else
-        SPLIT_ARGS="--splits ${TOTAL} --group ${GIDX}"
-        REPORT_NAME="${tname}-s${GIDX}of${TOTAL}-run"
-      fi
-
-      pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 \
-        -m "perf" --timeout=60 \
-        $SPLIT_ARGS \
-        "$FILE"
-      tt-smi -r 0
-      pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 \
-        -m "perf" --timeout=60 \
-        $SPLIT_ARGS \
-        --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
-        "$FILE"
-    done <<< "$ASSIGNMENTS"
-
-    junitparser merge pytest-report-blackhole-${GROUP}-*-run.xml \
-      pytest-report-blackhole-${GROUP}.xml
+    ./tests/run_llk_perf_blackhole.sh {split_group} 5
   skus:
     bh_p150b_civ2:
       timeout: 120
@@ -444,106 +101,7 @@
   team: llk
   cmd: |
     set -euo pipefail
-    cd tests/python_tests
-    mkdir -p perf_data
-
-    GROUP=4
-    N_GROUPS=5
-
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-
-    # Slice-level greedy bin-pack with an adaptive target, mirroring how
-    # pytest-split distributes items across shards. Files larger than the
-    # target are cut into K slices (no upper cap on K) so an oversized test
-    # overflows into multiple slices/bins instead of pinning a single bin.
-    # Each slice is its own pytest invocation with its own preceding
-    # `tt-smi -r 0` (the reset-between-tests fix this branch exists for).
-    ASSIGNMENTS=$(python3 - "$GROUP" "$N_GROUPS" <<'PY'
-    import subprocess, sys, glob, re, math
-
-    group = int(sys.argv[1])
-    n_groups = int(sys.argv[2])
-
-    # 1. Collect item counts per file (CPU only, no chip access).
-    files = sorted(glob.glob("perf_*.py"))
-    counts = {}
-    for f in files:
-        out = subprocess.run(
-            ["pytest", "--collect-only", "-q", "-m", "perf", f],
-            capture_output=True, text=True
-        ).stdout
-        n = 0
-        for line in out.splitlines():
-            m = re.match(r"^\s*(\d+) tests? collected", line)
-            if m:
-                n = int(m.group(1))
-                break
-        counts[f] = n
-
-    # 2. Adaptive target: half of an ideal bin, floored at 1500. Scales
-    #    with suite size so it auto-adapts as tests are added or grow.
-    total = sum(counts.values())
-    target = max(1500, total // (2 * n_groups))
-
-    # 3. Slice each file into K parts (no upper cap on K).
-    slices = []  # (file, group_idx, total_splits, items)
-    for f, c in counts.items():
-        K = max(1, math.ceil(c / target)) if c > 0 else 1
-        base = c // K if K > 0 else 0
-        rem = c - base * K
-        # Even split; the rem extra items spill into the earliest slices.
-        for i in range(K):
-            slice_items = base + (1 if i < rem else 0)
-            slices.append((f, i + 1, K, slice_items))
-
-    # 4. Greedy bin-pack slices into n_groups bins (first-fit-decreasing).
-    bins = [[0, []] for _ in range(n_groups)]
-    for s in sorted(slices, key=lambda x: -x[3]):
-        bins.sort(key=lambda b: (b[0], len(b[1])))  # lightest bin first
-        bins[0][0] += s[3]
-        bins[0][1].append(s)
-
-    # 5. Emit this group's slices as file:group_idx:total_splits:items.
-    for f, idx, total_splits, items in sorted(bins[group - 1][1]):
-        print(f"{f}:{idx}:{total_splits}:{items}")
-    PY
-    )
-    echo "Group ${GROUP}/${N_GROUPS} slices:"
-    echo "$ASSIGNMENTS"
-
-    # Per slice: compile only this slice's items (producer), reset the board,
-    # then measure (consumer). Slicing the producer keeps each item compiled
-    # exactly once across the run (like main's --splits/--group) instead of
-    # recompiling whole giant files in every group holding one of their slices
-    # — the over-compile that was timing the producer out before the consumer
-    # ever ran.
-    while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
-      [ -z "$FILE" ] && continue
-      tname="${FILE%.py}"
-
-      if [ "$TOTAL" = "1" ]; then
-        SPLIT_ARGS=""
-        REPORT_NAME="${tname}-run"
-      else
-        SPLIT_ARGS="--splits ${TOTAL} --group ${GIDX}"
-        REPORT_NAME="${tname}-s${GIDX}of${TOTAL}-run"
-      fi
-
-      pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 \
-        -m "perf" --timeout=60 \
-        $SPLIT_ARGS \
-        "$FILE"
-      tt-smi -r 0
-      pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 \
-        -m "perf" --timeout=60 \
-        $SPLIT_ARGS \
-        --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
-        "$FILE"
-    done <<< "$ASSIGNMENTS"
-
-    junitparser merge pytest-report-blackhole-${GROUP}-*-run.xml \
-      pytest-report-blackhole-${GROUP}.xml
+    ./tests/run_llk_perf_blackhole.sh {split_group} 5
   skus:
     bh_p150b_civ2:
       timeout: 120
@@ -554,106 +112,7 @@
   team: llk
   cmd: |
     set -euo pipefail
-    cd tests/python_tests
-    mkdir -p perf_data
-
-    GROUP=5
-    N_GROUPS=5
-
-    PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
-    PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-
-    # Slice-level greedy bin-pack with an adaptive target, mirroring how
-    # pytest-split distributes items across shards. Files larger than the
-    # target are cut into K slices (no upper cap on K) so an oversized test
-    # overflows into multiple slices/bins instead of pinning a single bin.
-    # Each slice is its own pytest invocation with its own preceding
-    # `tt-smi -r 0` (the reset-between-tests fix this branch exists for).
-    ASSIGNMENTS=$(python3 - "$GROUP" "$N_GROUPS" <<'PY'
-    import subprocess, sys, glob, re, math
-
-    group = int(sys.argv[1])
-    n_groups = int(sys.argv[2])
-
-    # 1. Collect item counts per file (CPU only, no chip access).
-    files = sorted(glob.glob("perf_*.py"))
-    counts = {}
-    for f in files:
-        out = subprocess.run(
-            ["pytest", "--collect-only", "-q", "-m", "perf", f],
-            capture_output=True, text=True
-        ).stdout
-        n = 0
-        for line in out.splitlines():
-            m = re.match(r"^\s*(\d+) tests? collected", line)
-            if m:
-                n = int(m.group(1))
-                break
-        counts[f] = n
-
-    # 2. Adaptive target: half of an ideal bin, floored at 1500. Scales
-    #    with suite size so it auto-adapts as tests are added or grow.
-    total = sum(counts.values())
-    target = max(1500, total // (2 * n_groups))
-
-    # 3. Slice each file into K parts (no upper cap on K).
-    slices = []  # (file, group_idx, total_splits, items)
-    for f, c in counts.items():
-        K = max(1, math.ceil(c / target)) if c > 0 else 1
-        base = c // K if K > 0 else 0
-        rem = c - base * K
-        # Even split; the rem extra items spill into the earliest slices.
-        for i in range(K):
-            slice_items = base + (1 if i < rem else 0)
-            slices.append((f, i + 1, K, slice_items))
-
-    # 4. Greedy bin-pack slices into n_groups bins (first-fit-decreasing).
-    bins = [[0, []] for _ in range(n_groups)]
-    for s in sorted(slices, key=lambda x: -x[3]):
-        bins.sort(key=lambda b: (b[0], len(b[1])))  # lightest bin first
-        bins[0][0] += s[3]
-        bins[0][1].append(s)
-
-    # 5. Emit this group's slices as file:group_idx:total_splits:items.
-    for f, idx, total_splits, items in sorted(bins[group - 1][1]):
-        print(f"{f}:{idx}:{total_splits}:{items}")
-    PY
-    )
-    echo "Group ${GROUP}/${N_GROUPS} slices:"
-    echo "$ASSIGNMENTS"
-
-    # Per slice: compile only this slice's items (producer), reset the board,
-    # then measure (consumer). Slicing the producer keeps each item compiled
-    # exactly once across the run (like main's --splits/--group) instead of
-    # recompiling whole giant files in every group holding one of their slices
-    # — the over-compile that was timing the producer out before the consumer
-    # ever ran.
-    while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
-      [ -z "$FILE" ] && continue
-      tname="${FILE%.py}"
-
-      if [ "$TOTAL" = "1" ]; then
-        SPLIT_ARGS=""
-        REPORT_NAME="${tname}-run"
-      else
-        SPLIT_ARGS="--splits ${TOTAL} --group ${GIDX}"
-        REPORT_NAME="${tname}-s${GIDX}of${TOTAL}-run"
-      fi
-
-      pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 \
-        -m "perf" --timeout=60 \
-        $SPLIT_ARGS \
-        "$FILE"
-      tt-smi -r 0
-      pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 \
-        -m "perf" --timeout=60 \
-        $SPLIT_ARGS \
-        --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
-        "$FILE"
-    done <<< "$ASSIGNMENTS"
-
-    junitparser merge pytest-report-blackhole-${GROUP}-*-run.xml \
-      pytest-report-blackhole-${GROUP}.xml
+    ./tests/run_llk_perf_blackhole.sh {split_group} 5
   skus:
     bh_p150b_civ2:
       timeout: 120

--- a/tests/pipeline_reorg/llk_perf_tests.yaml
+++ b/tests/pipeline_reorg/llk_perf_tests.yaml
@@ -116,15 +116,104 @@
     set -euo pipefail
     cd tests/python_tests
     mkdir -p perf_data
+
+    GROUP=1
+    N_GROUPS=5
+
     PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
     PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf" --timeout=60 \
-      --splits 5 --group 1 \
-      --junitxml=pytest-report-blackhole-1-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf" --timeout=60 \
-      --splits 5 --group 1 \
-      --junitxml=pytest-report-blackhole-1-run.xml .
-    junitparser merge pytest-report-blackhole-1-compile.xml pytest-report-blackhole-1-run.xml pytest-report-blackhole-1.xml
+
+    # Slice-level greedy bin-pack with an adaptive target, mirroring how
+    # pytest-split distributes items across shards. Files larger than the
+    # target are cut into K slices (no upper cap on K) so an oversized test
+    # overflows into multiple slices/bins instead of pinning a single bin.
+    # Each slice is its own pytest invocation with its own preceding
+    # `tt-smi -r 0` (the reset-between-tests fix this branch exists for).
+    ASSIGNMENTS=$(python3 - "$GROUP" "$N_GROUPS" <<'PY'
+    import subprocess, sys, glob, re, math
+
+    group = int(sys.argv[1])
+    n_groups = int(sys.argv[2])
+
+    # 1. Collect item counts per file (CPU only, no chip access).
+    files = sorted(glob.glob("perf_*.py"))
+    counts = {}
+    for f in files:
+        out = subprocess.run(
+            ["pytest", "--collect-only", "-q", "-m", "perf", f],
+            capture_output=True, text=True
+        ).stdout
+        n = 0
+        for line in out.splitlines():
+            m = re.match(r"^\s*(\d+) tests? collected", line)
+            if m:
+                n = int(m.group(1))
+                break
+        counts[f] = n
+
+    # 2. Adaptive target: half of an ideal bin, floored at 1500. Scales
+    #    with suite size so it auto-adapts as tests are added or grow.
+    total = sum(counts.values())
+    target = max(1500, total // (2 * n_groups))
+
+    # 3. Slice each file into K parts (no upper cap on K).
+    slices = []  # (file, group_idx, total_splits, items)
+    for f, c in counts.items():
+        K = max(1, math.ceil(c / target)) if c > 0 else 1
+        base = c // K if K > 0 else 0
+        rem = c - base * K
+        # Even split; the rem extra items spill into the earliest slices.
+        for i in range(K):
+            slice_items = base + (1 if i < rem else 0)
+            slices.append((f, i + 1, K, slice_items))
+
+    # 4. Greedy bin-pack slices into n_groups bins (first-fit-decreasing).
+    bins = [[0, []] for _ in range(n_groups)]
+    for s in sorted(slices, key=lambda x: -x[3]):
+        bins.sort(key=lambda b: (b[0], len(b[1])))  # lightest bin first
+        bins[0][0] += s[3]
+        bins[0][1].append(s)
+
+    # 5. Emit this group's slices as file:group_idx:total_splits:items.
+    for f, idx, total_splits, items in sorted(bins[group - 1][1]):
+        print(f"{f}:{idx}:{total_splits}:{items}")
+    PY
+    )
+    echo "Group ${GROUP}/${N_GROUPS} slices:"
+    echo "$ASSIGNMENTS"
+
+    # Per slice: compile only this slice's items (producer), reset the board,
+    # then measure (consumer). Slicing the producer keeps each item compiled
+    # exactly once across the run (like main's --splits/--group) instead of
+    # recompiling whole giant files in every group holding one of their slices
+    # — the over-compile that was timing the producer out before the consumer
+    # ever ran.
+    while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
+      [ -z "$FILE" ] && continue
+      tname="${FILE%.py}"
+
+      if [ "$TOTAL" = "1" ]; then
+        SPLIT_ARGS=""
+        REPORT_NAME="${tname}-run"
+      else
+        SPLIT_ARGS="--splits ${TOTAL} --group ${GIDX}"
+        REPORT_NAME="${tname}-s${GIDX}of${TOTAL}-run"
+      fi
+
+      pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 \
+        -m "perf" --timeout=60 \
+        $SPLIT_ARGS \
+        "$FILE"
+      tt-smi -r 0
+      pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 \
+        -m "perf" --timeout=60 \
+        $SPLIT_ARGS \
+        --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
+        "$FILE"
+    done <<< "$ASSIGNMENTS"
+
+    junitparser merge pytest-report-blackhole-${GROUP}-*-run.xml \
+      pytest-report-blackhole-${GROUP}.xml
   skus:
     bh_p150b_civ2:
       timeout: 120
@@ -137,15 +226,104 @@
     set -euo pipefail
     cd tests/python_tests
     mkdir -p perf_data
+
+    GROUP=2
+    N_GROUPS=5
+
     PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
     PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf" --timeout=60 \
-      --splits 5 --group 2 \
-      --junitxml=pytest-report-blackhole-2-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf" --timeout=60 \
-      --splits 5 --group 2 \
-      --junitxml=pytest-report-blackhole-2-run.xml .
-    junitparser merge pytest-report-blackhole-2-compile.xml pytest-report-blackhole-2-run.xml pytest-report-blackhole-2.xml
+
+    # Slice-level greedy bin-pack with an adaptive target, mirroring how
+    # pytest-split distributes items across shards. Files larger than the
+    # target are cut into K slices (no upper cap on K) so an oversized test
+    # overflows into multiple slices/bins instead of pinning a single bin.
+    # Each slice is its own pytest invocation with its own preceding
+    # `tt-smi -r 0` (the reset-between-tests fix this branch exists for).
+    ASSIGNMENTS=$(python3 - "$GROUP" "$N_GROUPS" <<'PY'
+    import subprocess, sys, glob, re, math
+
+    group = int(sys.argv[1])
+    n_groups = int(sys.argv[2])
+
+    # 1. Collect item counts per file (CPU only, no chip access).
+    files = sorted(glob.glob("perf_*.py"))
+    counts = {}
+    for f in files:
+        out = subprocess.run(
+            ["pytest", "--collect-only", "-q", "-m", "perf", f],
+            capture_output=True, text=True
+        ).stdout
+        n = 0
+        for line in out.splitlines():
+            m = re.match(r"^\s*(\d+) tests? collected", line)
+            if m:
+                n = int(m.group(1))
+                break
+        counts[f] = n
+
+    # 2. Adaptive target: half of an ideal bin, floored at 1500. Scales
+    #    with suite size so it auto-adapts as tests are added or grow.
+    total = sum(counts.values())
+    target = max(1500, total // (2 * n_groups))
+
+    # 3. Slice each file into K parts (no upper cap on K).
+    slices = []  # (file, group_idx, total_splits, items)
+    for f, c in counts.items():
+        K = max(1, math.ceil(c / target)) if c > 0 else 1
+        base = c // K if K > 0 else 0
+        rem = c - base * K
+        # Even split; the rem extra items spill into the earliest slices.
+        for i in range(K):
+            slice_items = base + (1 if i < rem else 0)
+            slices.append((f, i + 1, K, slice_items))
+
+    # 4. Greedy bin-pack slices into n_groups bins (first-fit-decreasing).
+    bins = [[0, []] for _ in range(n_groups)]
+    for s in sorted(slices, key=lambda x: -x[3]):
+        bins.sort(key=lambda b: (b[0], len(b[1])))  # lightest bin first
+        bins[0][0] += s[3]
+        bins[0][1].append(s)
+
+    # 5. Emit this group's slices as file:group_idx:total_splits:items.
+    for f, idx, total_splits, items in sorted(bins[group - 1][1]):
+        print(f"{f}:{idx}:{total_splits}:{items}")
+    PY
+    )
+    echo "Group ${GROUP}/${N_GROUPS} slices:"
+    echo "$ASSIGNMENTS"
+
+    # Per slice: compile only this slice's items (producer), reset the board,
+    # then measure (consumer). Slicing the producer keeps each item compiled
+    # exactly once across the run (like main's --splits/--group) instead of
+    # recompiling whole giant files in every group holding one of their slices
+    # — the over-compile that was timing the producer out before the consumer
+    # ever ran.
+    while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
+      [ -z "$FILE" ] && continue
+      tname="${FILE%.py}"
+
+      if [ "$TOTAL" = "1" ]; then
+        SPLIT_ARGS=""
+        REPORT_NAME="${tname}-run"
+      else
+        SPLIT_ARGS="--splits ${TOTAL} --group ${GIDX}"
+        REPORT_NAME="${tname}-s${GIDX}of${TOTAL}-run"
+      fi
+
+      pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 \
+        -m "perf" --timeout=60 \
+        $SPLIT_ARGS \
+        "$FILE"
+      tt-smi -r 0
+      pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 \
+        -m "perf" --timeout=60 \
+        $SPLIT_ARGS \
+        --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
+        "$FILE"
+    done <<< "$ASSIGNMENTS"
+
+    junitparser merge pytest-report-blackhole-${GROUP}-*-run.xml \
+      pytest-report-blackhole-${GROUP}.xml
   skus:
     bh_p150b_civ2:
       timeout: 120
@@ -158,15 +336,104 @@
     set -euo pipefail
     cd tests/python_tests
     mkdir -p perf_data
+
+    GROUP=3
+    N_GROUPS=5
+
     PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
     PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf" --timeout=60 \
-      --splits 5 --group 3 \
-      --junitxml=pytest-report-blackhole-3-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf" --timeout=60 \
-      --splits 5 --group 3 \
-      --junitxml=pytest-report-blackhole-3-run.xml .
-    junitparser merge pytest-report-blackhole-3-compile.xml pytest-report-blackhole-3-run.xml pytest-report-blackhole-3.xml
+
+    # Slice-level greedy bin-pack with an adaptive target, mirroring how
+    # pytest-split distributes items across shards. Files larger than the
+    # target are cut into K slices (no upper cap on K) so an oversized test
+    # overflows into multiple slices/bins instead of pinning a single bin.
+    # Each slice is its own pytest invocation with its own preceding
+    # `tt-smi -r 0` (the reset-between-tests fix this branch exists for).
+    ASSIGNMENTS=$(python3 - "$GROUP" "$N_GROUPS" <<'PY'
+    import subprocess, sys, glob, re, math
+
+    group = int(sys.argv[1])
+    n_groups = int(sys.argv[2])
+
+    # 1. Collect item counts per file (CPU only, no chip access).
+    files = sorted(glob.glob("perf_*.py"))
+    counts = {}
+    for f in files:
+        out = subprocess.run(
+            ["pytest", "--collect-only", "-q", "-m", "perf", f],
+            capture_output=True, text=True
+        ).stdout
+        n = 0
+        for line in out.splitlines():
+            m = re.match(r"^\s*(\d+) tests? collected", line)
+            if m:
+                n = int(m.group(1))
+                break
+        counts[f] = n
+
+    # 2. Adaptive target: half of an ideal bin, floored at 1500. Scales
+    #    with suite size so it auto-adapts as tests are added or grow.
+    total = sum(counts.values())
+    target = max(1500, total // (2 * n_groups))
+
+    # 3. Slice each file into K parts (no upper cap on K).
+    slices = []  # (file, group_idx, total_splits, items)
+    for f, c in counts.items():
+        K = max(1, math.ceil(c / target)) if c > 0 else 1
+        base = c // K if K > 0 else 0
+        rem = c - base * K
+        # Even split; the rem extra items spill into the earliest slices.
+        for i in range(K):
+            slice_items = base + (1 if i < rem else 0)
+            slices.append((f, i + 1, K, slice_items))
+
+    # 4. Greedy bin-pack slices into n_groups bins (first-fit-decreasing).
+    bins = [[0, []] for _ in range(n_groups)]
+    for s in sorted(slices, key=lambda x: -x[3]):
+        bins.sort(key=lambda b: (b[0], len(b[1])))  # lightest bin first
+        bins[0][0] += s[3]
+        bins[0][1].append(s)
+
+    # 5. Emit this group's slices as file:group_idx:total_splits:items.
+    for f, idx, total_splits, items in sorted(bins[group - 1][1]):
+        print(f"{f}:{idx}:{total_splits}:{items}")
+    PY
+    )
+    echo "Group ${GROUP}/${N_GROUPS} slices:"
+    echo "$ASSIGNMENTS"
+
+    # Per slice: compile only this slice's items (producer), reset the board,
+    # then measure (consumer). Slicing the producer keeps each item compiled
+    # exactly once across the run (like main's --splits/--group) instead of
+    # recompiling whole giant files in every group holding one of their slices
+    # — the over-compile that was timing the producer out before the consumer
+    # ever ran.
+    while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
+      [ -z "$FILE" ] && continue
+      tname="${FILE%.py}"
+
+      if [ "$TOTAL" = "1" ]; then
+        SPLIT_ARGS=""
+        REPORT_NAME="${tname}-run"
+      else
+        SPLIT_ARGS="--splits ${TOTAL} --group ${GIDX}"
+        REPORT_NAME="${tname}-s${GIDX}of${TOTAL}-run"
+      fi
+
+      pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 \
+        -m "perf" --timeout=60 \
+        $SPLIT_ARGS \
+        "$FILE"
+      tt-smi -r 0
+      pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 \
+        -m "perf" --timeout=60 \
+        $SPLIT_ARGS \
+        --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
+        "$FILE"
+    done <<< "$ASSIGNMENTS"
+
+    junitparser merge pytest-report-blackhole-${GROUP}-*-run.xml \
+      pytest-report-blackhole-${GROUP}.xml
   skus:
     bh_p150b_civ2:
       timeout: 120
@@ -179,15 +446,104 @@
     set -euo pipefail
     cd tests/python_tests
     mkdir -p perf_data
+
+    GROUP=4
+    N_GROUPS=5
+
     PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
     PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf" --timeout=60 \
-      --splits 5 --group 4 \
-      --junitxml=pytest-report-blackhole-4-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf" --timeout=60 \
-      --splits 5 --group 4 \
-      --junitxml=pytest-report-blackhole-4-run.xml .
-    junitparser merge pytest-report-blackhole-4-compile.xml pytest-report-blackhole-4-run.xml pytest-report-blackhole-4.xml
+
+    # Slice-level greedy bin-pack with an adaptive target, mirroring how
+    # pytest-split distributes items across shards. Files larger than the
+    # target are cut into K slices (no upper cap on K) so an oversized test
+    # overflows into multiple slices/bins instead of pinning a single bin.
+    # Each slice is its own pytest invocation with its own preceding
+    # `tt-smi -r 0` (the reset-between-tests fix this branch exists for).
+    ASSIGNMENTS=$(python3 - "$GROUP" "$N_GROUPS" <<'PY'
+    import subprocess, sys, glob, re, math
+
+    group = int(sys.argv[1])
+    n_groups = int(sys.argv[2])
+
+    # 1. Collect item counts per file (CPU only, no chip access).
+    files = sorted(glob.glob("perf_*.py"))
+    counts = {}
+    for f in files:
+        out = subprocess.run(
+            ["pytest", "--collect-only", "-q", "-m", "perf", f],
+            capture_output=True, text=True
+        ).stdout
+        n = 0
+        for line in out.splitlines():
+            m = re.match(r"^\s*(\d+) tests? collected", line)
+            if m:
+                n = int(m.group(1))
+                break
+        counts[f] = n
+
+    # 2. Adaptive target: half of an ideal bin, floored at 1500. Scales
+    #    with suite size so it auto-adapts as tests are added or grow.
+    total = sum(counts.values())
+    target = max(1500, total // (2 * n_groups))
+
+    # 3. Slice each file into K parts (no upper cap on K).
+    slices = []  # (file, group_idx, total_splits, items)
+    for f, c in counts.items():
+        K = max(1, math.ceil(c / target)) if c > 0 else 1
+        base = c // K if K > 0 else 0
+        rem = c - base * K
+        # Even split; the rem extra items spill into the earliest slices.
+        for i in range(K):
+            slice_items = base + (1 if i < rem else 0)
+            slices.append((f, i + 1, K, slice_items))
+
+    # 4. Greedy bin-pack slices into n_groups bins (first-fit-decreasing).
+    bins = [[0, []] for _ in range(n_groups)]
+    for s in sorted(slices, key=lambda x: -x[3]):
+        bins.sort(key=lambda b: (b[0], len(b[1])))  # lightest bin first
+        bins[0][0] += s[3]
+        bins[0][1].append(s)
+
+    # 5. Emit this group's slices as file:group_idx:total_splits:items.
+    for f, idx, total_splits, items in sorted(bins[group - 1][1]):
+        print(f"{f}:{idx}:{total_splits}:{items}")
+    PY
+    )
+    echo "Group ${GROUP}/${N_GROUPS} slices:"
+    echo "$ASSIGNMENTS"
+
+    # Per slice: compile only this slice's items (producer), reset the board,
+    # then measure (consumer). Slicing the producer keeps each item compiled
+    # exactly once across the run (like main's --splits/--group) instead of
+    # recompiling whole giant files in every group holding one of their slices
+    # — the over-compile that was timing the producer out before the consumer
+    # ever ran.
+    while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
+      [ -z "$FILE" ] && continue
+      tname="${FILE%.py}"
+
+      if [ "$TOTAL" = "1" ]; then
+        SPLIT_ARGS=""
+        REPORT_NAME="${tname}-run"
+      else
+        SPLIT_ARGS="--splits ${TOTAL} --group ${GIDX}"
+        REPORT_NAME="${tname}-s${GIDX}of${TOTAL}-run"
+      fi
+
+      pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 \
+        -m "perf" --timeout=60 \
+        $SPLIT_ARGS \
+        "$FILE"
+      tt-smi -r 0
+      pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 \
+        -m "perf" --timeout=60 \
+        $SPLIT_ARGS \
+        --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
+        "$FILE"
+    done <<< "$ASSIGNMENTS"
+
+    junitparser merge pytest-report-blackhole-${GROUP}-*-run.xml \
+      pytest-report-blackhole-${GROUP}.xml
   skus:
     bh_p150b_civ2:
       timeout: 120
@@ -200,15 +556,104 @@
     set -euo pipefail
     cd tests/python_tests
     mkdir -p perf_data
+
+    GROUP=5
+    N_GROUPS=5
+
     PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
     PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
-    pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf" --timeout=60 \
-      --splits 5 --group 5 \
-      --junitxml=pytest-report-blackhole-5-compile.xml .
-    pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf" --timeout=60 \
-      --splits 5 --group 5 \
-      --junitxml=pytest-report-blackhole-5-run.xml .
-    junitparser merge pytest-report-blackhole-5-compile.xml pytest-report-blackhole-5-run.xml pytest-report-blackhole-5.xml
+
+    # Slice-level greedy bin-pack with an adaptive target, mirroring how
+    # pytest-split distributes items across shards. Files larger than the
+    # target are cut into K slices (no upper cap on K) so an oversized test
+    # overflows into multiple slices/bins instead of pinning a single bin.
+    # Each slice is its own pytest invocation with its own preceding
+    # `tt-smi -r 0` (the reset-between-tests fix this branch exists for).
+    ASSIGNMENTS=$(python3 - "$GROUP" "$N_GROUPS" <<'PY'
+    import subprocess, sys, glob, re, math
+
+    group = int(sys.argv[1])
+    n_groups = int(sys.argv[2])
+
+    # 1. Collect item counts per file (CPU only, no chip access).
+    files = sorted(glob.glob("perf_*.py"))
+    counts = {}
+    for f in files:
+        out = subprocess.run(
+            ["pytest", "--collect-only", "-q", "-m", "perf", f],
+            capture_output=True, text=True
+        ).stdout
+        n = 0
+        for line in out.splitlines():
+            m = re.match(r"^\s*(\d+) tests? collected", line)
+            if m:
+                n = int(m.group(1))
+                break
+        counts[f] = n
+
+    # 2. Adaptive target: half of an ideal bin, floored at 1500. Scales
+    #    with suite size so it auto-adapts as tests are added or grow.
+    total = sum(counts.values())
+    target = max(1500, total // (2 * n_groups))
+
+    # 3. Slice each file into K parts (no upper cap on K).
+    slices = []  # (file, group_idx, total_splits, items)
+    for f, c in counts.items():
+        K = max(1, math.ceil(c / target)) if c > 0 else 1
+        base = c // K if K > 0 else 0
+        rem = c - base * K
+        # Even split; the rem extra items spill into the earliest slices.
+        for i in range(K):
+            slice_items = base + (1 if i < rem else 0)
+            slices.append((f, i + 1, K, slice_items))
+
+    # 4. Greedy bin-pack slices into n_groups bins (first-fit-decreasing).
+    bins = [[0, []] for _ in range(n_groups)]
+    for s in sorted(slices, key=lambda x: -x[3]):
+        bins.sort(key=lambda b: (b[0], len(b[1])))  # lightest bin first
+        bins[0][0] += s[3]
+        bins[0][1].append(s)
+
+    # 5. Emit this group's slices as file:group_idx:total_splits:items.
+    for f, idx, total_splits, items in sorted(bins[group - 1][1]):
+        print(f"{f}:{idx}:{total_splits}:{items}")
+    PY
+    )
+    echo "Group ${GROUP}/${N_GROUPS} slices:"
+    echo "$ASSIGNMENTS"
+
+    # Per slice: compile only this slice's items (producer), reset the board,
+    # then measure (consumer). Slicing the producer keeps each item compiled
+    # exactly once across the run (like main's --splits/--group) instead of
+    # recompiling whole giant files in every group holding one of their slices
+    # — the over-compile that was timing the producer out before the consumer
+    # ever ran.
+    while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
+      [ -z "$FILE" ] && continue
+      tname="${FILE%.py}"
+
+      if [ "$TOTAL" = "1" ]; then
+        SPLIT_ARGS=""
+        REPORT_NAME="${tname}-run"
+      else
+        SPLIT_ARGS="--splits ${TOTAL} --group ${GIDX}"
+        REPORT_NAME="${tname}-s${GIDX}of${TOTAL}-run"
+      fi
+
+      pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 \
+        -m "perf" --timeout=60 \
+        $SPLIT_ARGS \
+        "$FILE"
+      tt-smi -r 0
+      pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 \
+        -m "perf" --timeout=60 \
+        $SPLIT_ARGS \
+        --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
+        "$FILE"
+    done <<< "$ASSIGNMENTS"
+
+    junitparser merge pytest-report-blackhole-${GROUP}-*-run.xml \
+      pytest-report-blackhole-${GROUP}.xml
   skus:
     bh_p150b_civ2:
       timeout: 120

--- a/tt_metal/tt-llk/tests/perf_bin_pack.py
+++ b/tt_metal/tt-llk/tests/perf_bin_pack.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+"""Slice-level greedy bin-pack for the Blackhole LLK perf shards.
+
+Mirrors how pytest-split distributes items across shards, but at slice
+granularity: files larger than an adaptive target are cut into K slices
+(no upper cap on K) so an oversized test overflows into multiple
+slices/bins instead of pinning a single bin. Each emitted slice becomes
+its own pytest invocation (with its own preceding `tt-smi -r 0`) in
+run_llk_perf_blackhole.sh.
+
+Usage: perf_bin_pack.py <group> <n_groups>
+
+Prints this group's slices, one per line, as
+file:group_idx:total_splits:items. Run from the directory containing the
+perf_*.py files (collection is CPU only -- no chip access).
+"""
+
+import glob
+import math
+import re
+import subprocess
+import sys
+
+
+def collect_counts(files):
+    """Return {file: collected perf-test count} via `pytest --collect-only`."""
+    counts = {}
+    for f in files:
+        out = subprocess.run(
+            ["pytest", "--collect-only", "-q", "-m", "perf", f],
+            capture_output=True,
+            text=True,
+        ).stdout
+        n = 0
+        for line in out.splitlines():
+            m = re.match(r"^\s*(\d+) tests? collected", line)
+            if m:
+                n = int(m.group(1))
+                break
+        counts[f] = n
+    return counts
+
+
+def assign(counts, group, n_groups):
+    """Bin-pack sliced files into n_groups bins; return this group's slices.
+
+    Returns a sorted list of (file, group_idx, total_splits, items) tuples
+    for the requested 1-based group.
+    """
+    # Adaptive target: half of an ideal bin, floored at 1500. Scales with
+    # suite size so it auto-adapts as tests are added or grow.
+    total = sum(counts.values())
+    target = max(1500, total // (2 * n_groups))
+
+    # Slice each file into K parts (no upper cap on K).
+    slices = []  # (file, group_idx, total_splits, items)
+    for f, c in counts.items():
+        K = max(1, math.ceil(c / target)) if c > 0 else 1
+        base = c // K if K > 0 else 0
+        rem = c - base * K
+        # Even split; the rem extra items spill into the earliest slices.
+        for i in range(K):
+            slice_items = base + (1 if i < rem else 0)
+            slices.append((f, i + 1, K, slice_items))
+
+    # Greedy bin-pack slices into n_groups bins (first-fit-decreasing).
+    bins = [[0, []] for _ in range(n_groups)]
+    for s in sorted(slices, key=lambda x: -x[3]):
+        bins.sort(key=lambda b: (b[0], len(b[1])))  # lightest bin first
+        bins[0][0] += s[3]
+        bins[0][1].append(s)
+
+    return sorted(bins[group - 1][1])
+
+
+def main():
+    if len(sys.argv) != 3:
+        sys.exit("usage: perf_bin_pack.py <group> <n_groups>")
+    group = int(sys.argv[1])
+    n_groups = int(sys.argv[2])
+
+    files = sorted(glob.glob("perf_*.py"))
+    counts = collect_counts(files)
+    for f, idx, total_splits, items in assign(counts, group, n_groups):
+        print(f"{f}:{idx}:{total_splits}:{items}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tt_metal/tt-llk/tests/perf_bin_pack.py
+++ b/tt_metal/tt-llk/tests/perf_bin_pack.py
@@ -25,22 +25,48 @@ import sys
 
 
 def collect_counts(files):
-    """Return {file: collected perf-test count} via `pytest --collect-only`."""
+    """Return {file: collected perf-test count} via `pytest --collect-only`.
+
+    Fails loudly on a genuine collection error -- silently recording 0 would
+    corrupt the bin-pack and produce oversized shards / timeouts. pytest exit
+    code 5 ("no tests collected") is a legitimate 0, not an error.
+    """
     counts = {}
     for f in files:
-        out = subprocess.run(
+        proc = subprocess.run(
             ["pytest", "--collect-only", "-q", "-m", "perf", f],
             capture_output=True,
             text=True,
-        ).stdout
-        n = 0
-        for line in out.splitlines():
-            m = re.match(r"^\s*(\d+) tests? collected", line)
-            if m:
-                n = int(m.group(1))
-                break
-        counts[f] = n
+        )
+        if proc.returncode == 5:  # pytest: no tests collected for this file
+            counts[f] = 0
+            continue
+        if proc.returncode != 0:
+            sys.exit(
+                f"pytest collection failed for {f} (exit {proc.returncode}):\n"
+                f"{proc.stdout}\n{proc.stderr}"
+            )
+        counts[f] = _parse_count(f, proc.stdout)
     return counts
+
+
+def _parse_count(f, out):
+    """Parse the collected-test count from `pytest --collect-only -q` output.
+
+    Handles both summary spellings pytest has used -- "<N> tests collected"
+    and "collected <N> items" -- and falls back to counting collected node
+    IDs, so a future format change can't silently read as 0.
+    """
+    for line in out.splitlines():
+        m = re.search(r"(\d+) tests? collected", line) or re.search(
+            r"collected (\d+) items?", line
+        )
+        if m:
+            return int(m.group(1))
+    nodes = [ln for ln in out.splitlines() if "::" in ln]
+    if nodes:
+        return len(nodes)
+    sys.exit(f"could not parse collected test count for {f}:\n{out}")
 
 
 def assign(counts, group, n_groups):
@@ -65,7 +91,8 @@ def assign(counts, group, n_groups):
             slice_items = base + (1 if i < rem else 0)
             slices.append((f, i + 1, K, slice_items))
 
-    # Greedy bin-pack slices into n_groups bins (first-fit-decreasing).
+    # Greedy LPT (longest-processing-time) bin-pack: take slices largest
+    # first and drop each into the currently lightest bin.
     bins = [[0, []] for _ in range(n_groups)]
     for s in sorted(slices, key=lambda x: -x[3]):
         bins.sort(key=lambda b: (b[0], len(b[1])))  # lightest bin first

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -1361,6 +1361,10 @@ class TestConfig:
 
     BRISC_ELF_LOADED: ClassVar[bool] = False
     LAST_LOADED_ELFS: ClassVar[Path] = Path()
+    # Max BRISC bring-up attempts after a reset. A board-wide `tt-smi -r 0`
+    # can leave a core slow-to-boot or wedged; each attempt re-issues the
+    # soft-reset kick (re-polling alone cannot recover a wedged core).
+    BRISC_BOOT_MAX_ATTEMPTS: ClassVar[int] = 3
 
     def run_elf_files(self) -> list:
         boot_mode = (
@@ -1391,28 +1395,46 @@ class TestConfig:
         if boot_mode == BootMode.BRISC:
             if not TestConfig.BRISC_ELF_LOADED:
                 commit_tensix_soft_reset(1, location=TestConfig.TENSIX_LOCATION)
-                TestConfig.BRISC_ELF_LOADED = True
                 load_elf(
                     elf_file=str((TestConfig.SHARED_ELF_DIR / "brisc.elf").absolute()),
                     location=TestConfig.TENSIX_LOCATION,
                     risc_name="brisc",
                     verify_write=True,
                 )
-                # Pre-clear BriscCounter so we cannot latch onto a stale
-                # boot-ready sentinel left in L1 by a prior pytest process —
-                # mailboxes live at fixed L1 addresses outside any ELF
-                # section, so they survive ELF reload.
-                write_words_to_device(
-                    TestConfig.TENSIX_LOCATION,
-                    device_module.Mailboxes.BriscCounter.value,
-                    [0],
-                )
-                commit_tensix_soft_reset(
-                    0, [RiscCore.BRISC], TestConfig.TENSIX_LOCATION
-                )
-                wait_brisc_boot_ready(
-                    TestConfig.TENSIX_LOCATION, timeout=brisc_cmd_timeout
-                )
+                # Bring BRISC up, retrying the soft-reset kick until it reaches
+                # its polling loop. A board-wide `tt-smi -r 0` can leave a core
+                # slow-to-boot or wedged; re-polling alone never recovers a
+                # wedged core, so each attempt re-asserts then de-asserts the
+                # BRISC soft reset. BRISC_ELF_LOADED is latched only after
+                # boot-ready succeeds, so a failed bring-up is retried on the
+                # next test instead of poisoning the rest of this worker's run.
+                last_err = None
+                for attempt in range(TestConfig.BRISC_BOOT_MAX_ATTEMPTS):
+                    if attempt:
+                        commit_tensix_soft_reset(1, location=TestConfig.TENSIX_LOCATION)
+                    # Pre-clear BriscCounter so we cannot latch onto a stale
+                    # boot-ready sentinel left in L1 by a prior pytest process —
+                    # mailboxes live at fixed L1 addresses outside any ELF
+                    # section, so they survive ELF reload.
+                    write_words_to_device(
+                        TestConfig.TENSIX_LOCATION,
+                        device_module.Mailboxes.BriscCounter.value,
+                        [0],
+                    )
+                    commit_tensix_soft_reset(
+                        0, [RiscCore.BRISC], TestConfig.TENSIX_LOCATION
+                    )
+                    try:
+                        wait_brisc_boot_ready(
+                            TestConfig.TENSIX_LOCATION, timeout=brisc_cmd_timeout
+                        )
+                    except TimeoutError as err:
+                        last_err = err
+                        continue
+                    TestConfig.BRISC_ELF_LOADED = True
+                    break
+                else:
+                    raise last_err
 
             # Reset only TRISCs, BRISC stays alive in its polling loop
             commit_brisc_command(

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -1434,7 +1434,10 @@ class TestConfig:
                     TestConfig.BRISC_ELF_LOADED = True
                     break
                 else:
-                    raise last_err
+                    raise TimeoutError(
+                        f"BRISC bring-up did not become ready after "
+                        f"{TestConfig.BRISC_BOOT_MAX_ATTEMPTS} attempts"
+                    ) from last_err
 
             # Reset only TRISCs, BRISC stays alive in its polling loop
             commit_brisc_command(

--- a/tt_metal/tt-llk/tests/run_llk_perf_blackhole.sh
+++ b/tt_metal/tt-llk/tests/run_llk_perf_blackhole.sh
@@ -49,12 +49,21 @@ while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
     $SPLIT_ARGS \
     "$FILE"
   tt-smi -r 0
-  pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 \
+  pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x \
     -m "perf" --timeout=60 \
     $SPLIT_ARGS \
     --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
     "$FILE"
 done <<< "$ASSIGNMENTS"
 
-junitparser merge pytest-report-blackhole-${GROUP}-*-run.xml \
-  pytest-report-blackhole-${GROUP}.xml
+# Merge this group's per-slice run reports. Guard the glob with nullglob so an
+# early exit that produced no per-slice reports doesn't turn a real failure
+# into a confusing junitparser "file not found".
+shopt -s nullglob
+run_reports=(pytest-report-blackhole-${GROUP}-*-run.xml)
+shopt -u nullglob
+if [ "${#run_reports[@]}" -gt 0 ]; then
+  junitparser merge "${run_reports[@]}" pytest-report-blackhole-${GROUP}.xml
+else
+  echo "No per-slice run reports for group ${GROUP}; skipping merge."
+fi

--- a/tt_metal/tt-llk/tests/run_llk_perf_blackhole.sh
+++ b/tt_metal/tt-llk/tests/run_llk_perf_blackhole.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Blackhole LLK perf runner, shared by the 5 bh matrix groups in
+# tests/pipeline_reorg/llk_perf_tests.yaml (the group index is passed in).
+#
+# Per slice: compile only this slice's items (producer), reset the board,
+# then measure (consumer). Slicing the producer keeps each item compiled
+# exactly once across the run (like main's --splits/--group) instead of
+# recompiling whole giant files in every group holding one of their slices
+# -- the over-compile that was timing the producer out before the consumer
+# ever ran. The per-slice `tt-smi -r 0` is the reset-between-tests fix this
+# branch exists for.
+#
+# Usage: run_llk_perf_blackhole.sh <group> <n_groups>
+set -euo pipefail
+
+GROUP="${1:?usage: run_llk_perf_blackhole.sh <group> <n_groups>}"
+N_GROUPS="${2:?usage: run_llk_perf_blackhole.sh <group> <n_groups>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/python_tests"
+mkdir -p perf_data
+
+PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
+PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
+
+# Slice-level greedy bin-pack with an adaptive target (see perf_bin_pack.py).
+# Emits this group's slices as file:group_idx:total_splits:items.
+ASSIGNMENTS=$(python3 "$SCRIPT_DIR/perf_bin_pack.py" "$GROUP" "$N_GROUPS")
+echo "Group ${GROUP}/${N_GROUPS} slices:"
+echo "$ASSIGNMENTS"
+
+while IFS=":" read -r FILE GIDX TOTAL ITEMS; do
+  [ -z "$FILE" ] && continue
+  tname="${FILE%.py}"
+
+  if [ "$TOTAL" = "1" ]; then
+    SPLIT_ARGS=""
+    REPORT_NAME="${tname}-run"
+  else
+    SPLIT_ARGS="--splits ${TOTAL} --group ${GIDX}"
+    REPORT_NAME="${tname}-s${GIDX}of${TOTAL}-run"
+  fi
+
+  pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 \
+    -m "perf" --timeout=60 \
+    $SPLIT_ARGS \
+    "$FILE"
+  tt-smi -r 0
+  pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 \
+    -m "perf" --timeout=60 \
+    $SPLIT_ARGS \
+    --junitxml="pytest-report-blackhole-${GROUP}-${REPORT_NAME}.xml" \
+    "$FILE"
+done <<< "$ASSIGNMENTS"
+
+junitparser merge pytest-report-blackhole-${GROUP}-*-run.xml \
+  pytest-report-blackhole-${GROUP}.xml

--- a/tt_metal/tt-llk/tests/run_llk_perf_wormhole.sh
+++ b/tt_metal/tt-llk/tests/run_llk_perf_wormhole.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+# Wormhole LLK perf runner, shared by the 5 wh matrix groups in
+# tests/pipeline_reorg/llk_perf_tests.yaml (the group index is passed in).
+#
+# Standard pytest-split sharding: compile this shard's items (producer),
+# then measure them (consumer) -- one invocation each over the whole perf
+# suite. The Blackhole runner (run_llk_perf_blackhole.sh) additionally
+# slice-packs oversized files and resets the board per slice; Wormhole
+# needs neither.
+#
+# Usage: run_llk_perf_wormhole.sh <group> <n_groups>
+set -euo pipefail
+
+GROUP="${1:?usage: run_llk_perf_wormhole.sh <group> <n_groups>}"
+N_GROUPS="${2:?usage: run_llk_perf_wormhole.sh <group> <n_groups>}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/python_tests"
+mkdir -p perf_data
+
+PYTEST_COMPILE_EXTRA="-q --override-ini=log_cli=false"
+PYTEST_RUN_EXTRA="-q --override-ini=log_cli=false"
+
+pytest $PYTEST_COMPILE_EXTRA --speed-of-light --compile-producer -n 10 -m "perf" --timeout=60 \
+  --splits "$N_GROUPS" --group "$GROUP" \
+  --junitxml="pytest-report-wormhole-${GROUP}-compile.xml" .
+pytest $PYTEST_RUN_EXTRA --speed-of-light --compile-consumer -n 15 -x -m "perf" --timeout=60 \
+  --splits "$N_GROUPS" --group "$GROUP" \
+  --junitxml="pytest-report-wormhole-${GROUP}-run.xml" .
+junitparser merge pytest-report-wormhole-${GROUP}-compile.xml pytest-report-wormhole-${GROUP}-run.xml pytest-report-wormhole-${GROUP}.xml


### PR DESCRIPTION
# Restore BH perf nightly determinism via per-test chip reset

Fixes #44910.

## TL;DR

BH perf nightlies have been wobbling by up to ~35% on the matmul family
since the brisc.cpp polling-loop rewrite landed (full investigation,
local reproduction, and bisection data in #44910). The drift traces to
BRISC state accumulating across the lifetime of each pytest worker —
the per-test tensix soft reset that pre-March nightlies relied on was
removed when BRISC became persistent. This PR inserts a `tt-smi -r 0`
between each test in the LLK perf workflow, with a variant-count-balanced
slice-level shard distribution that keeps each of the 5 BH matrix shards
within the 120-min budget. WH is untouched (it was already clean across
all eras).

Validated by **three same-sha CI runs** all landing within the State A
intrinsic-jitter floor (max <= 1.29% same-sha drift on every previously
noisy test). Full numbers below.

## The problem this solves

Same-sha consecutive BH nightlies (where neither the code nor the SHA
changed run-to-run) were producing measurably different numbers on a
specific subset of tests. Worst observed pre-fix same-sha drift, by test:

| Test | Pre-fix max same-sha \|Δ\| | Rows hot (>1% drift) |
|---|---:|---:|
| `perf_math_matmul` | **35.05%** | 0.7% of sweep |
| `perf_matmul` | **25.30%** | 0.3% |
| `perf_reduce` | **8.70%** | 20.1% |
| `perf_unpack_tilize` | **6.01%** | 20.1% |
| `perf_eltwise_unary_sfpu` | 1.75% | 0.6% |
| (others in the suite — clean) | <= 1% | 0% |

Root cause is a combination effect:

- **`brisc.cpp` was rewritten** into a persistent polling-loop firmware in
  tt-llk (PR
  [tenstorrent/tt-llk#1529](https://github.com/tenstorrent/tt-llk/pull/1529),
  merged 2026-03-25). Before that PR, the per-test infra also called
  `set_tensix_soft_reset(1, ALL_CORES)` unconditionally before every
  kernel launch via `run_elf_files()`. After it, the test infra was changed
  to load BRISC's ELF once per pytest worker process and never reset BRISC
  again — subsequent kernel launches only reset the 3 TRISCs via a brisc
  command, leaving BRISC's polling state to accumulate across hundreds of
  parametrizations in a single pytest invocation.
- **The `--speed-of-light` SoL methodology**, introduced by PR
  [tenstorrent/tt-llk#1463](https://github.com/tenstorrent/tt-llk/pull/1463)
  and enabled in nightly CI by
  [tenstorrent/tt-llk#1483](https://github.com/tenstorrent/tt-llk/pull/1483),
  compiles every runtime arg as a separate compile-time kernel variant.
  Different variants sit at different addresses, have different cache
  footprints, and the persistent BRISC polling loop interacts with each
  one slightly differently. That's what produces the per-row drift.

`tt-smi -r 0` is the only reset path that actually clears the relevant
BRISC state. The clean determinism we used to see pre-March 26 came from
the equivalent sledgehammer the test infra was applying *before every
kernel launch*. This PR restores an equivalent reset cadence at a coarser
granularity (per pytest invocation rather than per kernel launch) — local
same-machine experiments and CI validation confirm that's sufficient.

## What changed

Three files. WH entries in the workflow are untouched; this is BH-only.

### `tests/pipeline_reorg/llk_perf_tests.yaml` (+485 / -40)

The 5 BH matrix entries' `cmd:` blocks are rewritten to:

1. **Collect item counts per perf test file** via
   `pytest --collect-only -q -m perf <file>` (CPU-only, no chip access,
   ~30-60 s total one-time cost).
2. **Slice large files** by computing `K = max(1, ceil(items / target))`
   per file, with target adaptively set to `max(1500, total_items / (2 * n_groups))`.
3. **Greedy bin-pack the slices into 5 bins** (first-fit-decreasing). The
   slices of `perf_math_matmul` (~20k items) and `perf_matmul` (~10k)
   distribute across multiple shards; smaller files stay whole.
4. **Compile-producer over each shard's assigned slices** in one pytest
   invocation (CPU-only).
5. **Consumer loop: for each assigned slice**, run `tt-smi -r 0` then a
   single `pytest -n 15 --speed-of-light --compile-consumer
   --splits N --group G <file>` invocation. The fresh pytest process
   after each reset re-initializes the BRISC firmware cleanly.

WH entries: unchanged. WH stays at original `pytest --splits 5 --group N`
distribution with no per-test reset; same-sha WH drift was already <= 4.58%
pre-fix and doesn't justify the per-test reset overhead.

### `.github/workflows/llk-perf-impl.yaml` (+7 / -1)

Broadens the JUnit upload glob from
`pytest-report-*-${split_group}.xml` to
`pytest-report-*${split_group}*.xml` so per-slice report filenames also
get uploaded. Without this fix, when a shard timed out before the merge
step ran, no junit artifact would be uploaded at all (the merge produces
the file matching the original narrow glob).

### `tt_metal/tt-llk/tests/python_tests/helpers/test_config.py` (+38 / -16)

Retry the BRISC bring-up sequence (up to 3 attempts) after a chip reset.
`tt-smi -r 0` occasionally leaves a core slow-to-boot or in a state where
the first soft-reset kick doesn't bring BRISC to ready before
`wait_brisc_boot_ready`'s timeout. Re-polling alone never recovers a
wedged core — each attempt has to re-assert and de-assert the soft reset.
`BRISC_ELF_LOADED` is now only latched after `wait_brisc_boot_ready`
succeeds, so a failed bring-up retries on the next test instead of
poisoning the rest of the worker's run.

## Verification

### Three same-sha CI runs on this branch (sha `7b5be7fc`)

- https://github.com/tenstorrent/tt-metal/actions/runs/26950246023
- https://github.com/tenstorrent/tt-metal/actions/runs/26956634173
- https://github.com/tenstorrent/tt-metal/actions/runs/26982101246

All three completed successfully, all 5 BH shards in 1h23-1h52. Per-shard
wall times are well-balanced: BH 1/5 was 1h45, BH 2/5 was 1h49, BH 3/5
was 1h45, BH 4/5 was 1h37, BH 5/5 was 1h23 (run 3 numbers).

### Same-sha drift, before vs. after the fix

Pairs compared: any two of the three same-sha runs above. **Suite total:
29,124 BH parametrizations.**

| Test | Pre-fix max \|Δ\| | Post-fix max \|Δ\| | Status |
|---|---:|---:|---|
| `perf_math_matmul` | 35.05% | **0.08%** | ✅ |
| `perf_matmul` | 25.30% | **1.85%** | ✅ (within State A jitter) |
| `perf_reduce` | 8.70% | **0.14%** | ✅ |
| `perf_unpack_tilize` | 6.01% | **0.38%** | ✅ |
| `perf_eltwise_unary_sfpu` | 1.75% | **0.67%** | ✅ |
| `perf_unpack_transpose` | 1.39% | **0.00%** | ✅ |
| `perf_fast_untilize` | (n/a in §1.5) | 1.64% | ✅ |
| `perf_eltwise_binary_fpu` | 0.73% | **0.12%** | ✅ |
| `perf_pack_untilize` | 0.22% | **5.30%** | ⚠️ pre-existing, not from this PR — see Known caveat |
| `perf_unpack_untilize` | 0.12% | **0.19%** | ✅ |
| (8 other smaller tests) | ≤ 0.40% | ≤ 0.36% | ✅ |

**Aggregate: 97.7% of all 29,124 sweep parametrizations are byte-equal**
between same-sha runs post-fix. The remaining 0.5-2% are at the State A
intrinsic-jitter floor (~0.4% max for most tests, up to ~1.6% on a few
where multiple cycle-accurate measurements straddle a rounding boundary).

### Cross-sha (vs. recent main, sha `51a1c212`, run `26798500693`)

Confirms the fix doesn't change kernel timings beyond expected State A
movement:

- 28,502 of 29,124 rows (97.9%) within ±0.5% vs. recent main
- 485 rows (1.7%) measurably faster (up to +25% on rows where pre-fix CI
  was wobbling on the slow side — those now pin to the fast State A point)
- 137 rows (0.5%) measurably slower — concentrated almost entirely on the
  pack_untilize Bfp8_b path (see Known caveat below)

### Workflow expectations

- Compile-producer: still CPU-only via `pytest --compile-producer -n 10`,
  one invocation per shard. Producer cost dominates short shards.
- Compile-consumer: one invocation per slice with `tt-smi -r 0` before
  each. Reset cost ~15-20 s × ~4-8 slices per shard ≈ ~2 min overhead
  per shard.
- Fresh xdist workers per slice (no stale mmaps surviving the chip reset
  — earlier `-n 1` + autouse-fixture attempt hit `SIGBUS` from exactly
  that and was rejected in favor of this design).
- Junit aggregation still produces a merged `pytest-report-blackhole-N.xml`
  per shard at the end of the loop, plus per-slice reports for the case
  where a shard times out before merge.

## Known caveat — `perf_pack_untilize` Bfp8_b bimodality

Three same-sha runs on this branch revealed a pre-existing, unrelated
non-determinism on **27 of `perf_pack_untilize`'s 832 parametrizations**:
`formats.input_A = Bfp8_b AND formats.input_B = Bfp8_b AND tile_cnt >= 32`.
Those rows produce one of two stable cycle counts ~5% apart, with the
landing point varying per CI run. The chip reset does not clamp this.

This is **not introduced or worsened by this PR**. Bisection (see linked
issue) traces it to PR
[#44596](https://github.com/tenstorrent/tt-metal/pull/44596) (merged
2026-05-19), which removed a `TTI_STALLWAIT(STALL_CFG, THCON)`
synchronization barrier from the BH pack_untilize MOP for a ~35% perf
gain. The same 27 rows were byte-identical across same-sha CI pairs in
all cached pre-#44596 nightlies (Feb-May 2026). The bimodality was
masked in pre-fix CI by the larger BRISC-state noise; this PR exposes it
by clamping everything else to State A.

Filed separately as: **#46474**.

For the purposes of this PR's verification, the pack_untilize Bfp8_b
rows show the same ~5% same-sha drift envelope on both pre-fix main and
post-fix branch runs — it's a pre-existing issue that should be tracked
and resolved on its own track without blocking this measurement-fidelity
improvement.

## Test plan

- [x] BH groups 1-5 complete within the 120-min `timeout:` (verified
      across 3 runs: max wall time 1h52, well under budget)
- [x] All previously-noisy tests show <= 1.29% same-sha drift (verified)
- [x] No regression on tests that were clean pre-fix (verified)
- [x] No `SIGBUS` or worker crashes from chip-reset/mmap interaction
      (verified — earlier `-n 1` + per-item-reset attempt had this; this
      design avoids it by spawning fresh workers per slice)
- [x] BRISC bring-up retry catches the slow-boot case without poisoning
      the rest of the worker (verified — present-and-functional in the
      three validation runs)
- [ ] One additional same-sha run after merge to confirm behavior on
      the merge commit's SHA (recommended but not blocking)

## Risk + rollback

- Workflow-only change in the BH path; WH and other workflows are
  unaffected. If a future change in `perf_*.py` breaks the
  `--collect-only` parsing, the matrix `cmd:` will fail loudly (no
  silent test skips).
- Rollback is a single revert. The BRISC bring-up retry in
  `test_config.py` could be kept on its own if reverting the workflow
  yaml (it's strictly more robust than the prior code).
- No production code changes — kernel code, source files, sweep
  parameters all untouched. Same compiled binaries run; only the
  measurement methodology differs.


### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrsmanovic/llk-perf-instability)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrsmanovic/llk-perf-instability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrsmanovic/llk-perf-instability)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrsmanovic/llk-perf-instability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrsmanovic/llk-perf-instability)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrsmanovic/llk-perf-instability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrsmanovic/llk-perf-instability)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrsmanovic/llk-perf-instability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrsmanovic/llk-perf-instability)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrsmanovic/llk-perf-instability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrsmanovic/llk-perf-instability)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrsmanovic/llk-perf-instability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrsmanovic/llk-perf-instability)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrsmanovic/llk-perf-instability)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrsmanovic/llk-perf-instability)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrsmanovic/llk-perf-instability)