### PR TITLE
[Cleanup] Migrate interleaved_to_sharded to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -5,6 +5,9 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
 
@@ -23,21 +26,21 @@ void kernel_main() {
     constexpr uint32_t num_trids = get_compile_time_arg_val(2);
     constexpr auto src_args = TensorAccessorArgs<3>();
 
+    Noc noc;
     CircularBuffer cb_in0(cb_id_in0);
     CircularBuffer cb_in1(cb_id_in1);
 
     const auto s0 = TensorAccessor(src_args, src_addr + aligned_input_width_offset_bytes);
     uint32_t stick_id = start_id;
     cb_in0.reserve_back(block_height);
-    uint32_t dest_write_addr = cb_in0.get_write_ptr();
     if (aligned) {
+        uint32_t dest_off = 0;
         for (uint32_t h = 0; h < block_height; ++h) {
-            uint64_t src_noc_addr = s0.get_noc_addr(stick_id);
-            noc_async_read(src_noc_addr, dest_write_addr, block_width_bytes);
+            noc.async_read(s0, cb_in0, block_width_bytes, {.page_id = stick_id}, {.offset_bytes = dest_off});
             stick_id++;
-            dest_write_addr += padded_block_width_bytes;
+            dest_off += padded_block_width_bytes;
         }
-        noc_async_read_barrier();
+        noc.async_read_barrier();
     } else {
         enum SlotState : uint8_t {
             IDLE = 0,
@@ -49,18 +52,25 @@ void kernel_main() {
         constexpr uint32_t trid_base = 1;
 
         cb_in1.reserve_back(num_trids);
-        uint32_t scratch_write_addr_base = cb_in1.get_write_ptr();
         uint32_t scratch_cb_page_size = get_local_cb_interface(cb_id_in1).fifo_page_size;
         SlotState slot_states[num_trids];
-        uint32_t dest_write_addrs[num_trids];
-        uint32_t scratch_write_addrs[num_trids];
+        uint32_t dest_offsets[num_trids];
+        uint32_t scratch_offsets[num_trids];
 
         // Initialize slots
         for (uint32_t i = 0; i < num_trids; i++) {
             slot_states[i] = SlotState::IDLE;
-            scratch_write_addrs[i] = scratch_write_addr_base + i * scratch_cb_page_size;
+            scratch_offsets[i] = i * scratch_cb_page_size;
         }
 
+        // Local NoC coordinates for the scratch->dest loopback reads.
+        UnicastEndpoint self_ep;
+        const uint32_t my_noc_x = my_x[noc.get_noc_id()];
+        const uint32_t my_noc_y = my_y[noc.get_noc_id()];
+        // Base L1 address of the scratch CB (resolved once for relative offset math).
+        const uint32_t scratch_l1_base = cb_in1.get_write_ptr();
+
+        uint32_t dest_off = 0;         // running offset into cb_in0
         uint32_t rows_issued = 0;      // Number of src->scratch transfers started
         uint32_t rows_completed = 0;   // Number of scratch->dest transfers completed
 
@@ -69,35 +79,44 @@ void kernel_main() {
                 uint32_t active_trid = trid_base + slot;
 
                 if (slot_states[slot] == SlotState::IDLE && rows_issued < block_height) {
-                    // Start new src->scratch transfer
-                    noc_async_read_set_trid(active_trid);
-                    uint64_t src_noc_addr = s0.get_noc_addr(stick_id);
-                    noc_async_read(src_noc_addr, scratch_write_addrs[slot], aligned_block_width_bytes);
-                    dest_write_addrs[slot] = dest_write_addr;
+                    // Start new src->scratch transfer (TRID-tagged).
+                    noc.async_read<NocOptions::TXN_ID>(
+                        s0,
+                        cb_in1,
+                        aligned_block_width_bytes,
+                        {.page_id = stick_id},
+                        {.offset_bytes = scratch_offsets[slot]},
+                        NocOptVals{.trid = static_cast<uint8_t>(active_trid)});
+                    dest_offsets[slot] = dest_off;
                     slot_states[slot] = SlotState::SRC_PENDING;
 
                     stick_id++;
-                    dest_write_addr += padded_block_width_bytes;
+                    dest_off += padded_block_width_bytes;
                     rows_issued++;
                 }
                 if (slot_states[slot] == SlotState::SRC_PENDING) {
                     // Check if src->scratch is complete
-                    if (ncrisc_noc_read_with_transaction_id_flushed(noc_index, active_trid) == 1) {
+                    if (noc.is_read_trid_flushed(active_trid)) {
                         slot_states[slot] = SlotState::SCRATCH_READY;
                     }
                 }
                 if (slot_states[slot] == SlotState::SCRATCH_READY) {
-                    // Start scratch->dest transfer
-                    noc_async_read_set_trid(active_trid);
-
-                    uint64_t scratch_noc_read_addr = get_noc_addr(scratch_write_addrs[slot] + aligned_offset);
-                    noc_async_read(scratch_noc_read_addr, dest_write_addrs[slot], block_width_bytes);
+                    // Start scratch->dest transfer: local L1 loopback read tagged with the same trid.
+                    noc.async_read<NocOptions::TXN_ID>(
+                        self_ep,
+                        cb_in0,
+                        block_width_bytes,
+                        {.noc_x = my_noc_x,
+                         .noc_y = my_noc_y,
+                         .addr = scratch_l1_base + scratch_offsets[slot] + aligned_offset},
+                        {.offset_bytes = dest_offsets[slot]},
+                        NocOptVals{.trid = static_cast<uint8_t>(active_trid)});
 
                     slot_states[slot] = SlotState::SCRATCH_PENDING;
                 }
                 if (slot_states[slot] == SlotState::SCRATCH_PENDING) {
                     // Check if scratch->dest is complete
-                    if (ncrisc_noc_read_with_transaction_id_flushed(noc_index, active_trid) == 1) {
+                    if (noc.is_read_trid_flushed(active_trid)) {
                         slot_states[slot] = SlotState::IDLE;
                         rows_completed++;
                     }
@@ -106,6 +125,9 @@ void kernel_main() {
         }
 
     }
+    // Reset the sticky NOC_PACKET_TAG register for downstream untagged reads.
+    // No Device 2.0 wrapper exists for this config-only register write; this is
+    // not a NoC transaction.
     noc_async_read_set_trid(0);
     cb_in0.push_back(block_height);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -63,11 +63,11 @@ void kernel_main() {
             scratch_offsets[i] = i * scratch_cb_page_size;
         }
 
-        // Local NoC coordinates for the scratch->dest loopback reads.
+        // Local NoC coordinates for the scratch->dest reads.
         UnicastEndpoint self_ep;
         const uint32_t my_noc_x = my_x[noc.get_noc_id()];
         const uint32_t my_noc_y = my_y[noc.get_noc_id()];
-        // Base L1 address of the scratch CB (resolved once for relative offset math).
+        // Base L1 address of the scratch CB
         const uint32_t scratch_l1_base = cb_in1.get_write_ptr();
 
         uint32_t dest_off = 0;         // running offset into cb_in0

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_blocks_start_id.cpp
@@ -4,8 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
-#include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     // run-time args
@@ -20,39 +21,30 @@ void kernel_main() {
 
     // compile-time args
     constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
 
     // single-tile ublocks
     const uint32_t tile_bytes = get_tile_size(cb_id_out);
 
-    using tensor_shard_info = ShardedInfo<
-        get_compile_time_arg_val(1),   // Memory layout
-        get_compile_time_arg_val(2),   // The number of sharding cores
-        get_compile_time_arg_val(3),   // The page size we offset each write to
-        get_compile_time_arg_val(4),   // The number of pages in each sharding row not including padding pages
-        get_compile_time_arg_val(5),   // This defines times when contiguous pages can't be calculated
-        get_compile_time_arg_val(6),   // pages_per_shard_x
-        get_compile_time_arg_val(7)>;  // pages_per_shard_y
+    const auto s = TensorAccessor(dst_args, dst_addr);
 
-    const auto [mapping_table, rt_increment] =
-        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(8));
-    experimental::ShardedAddrGen<tensor_shard_info> s = {.bank_base_address = dst_addr, .shard_array = mapping_table};
-
+    Noc noc;
     CircularBuffer cb_out(cb_id_out);
 
     uint32_t row_start_tile_id = start_id_base + start_id_offset;
     cb_out.wait_front(block_width_padded_num_tiles);
-    uint32_t l1_read_addr = cb_out.get_read_ptr();
+    uint32_t l1_read_offset = 0;
     for (uint32_t h = 0; h < block_height_tiles; h++) {
         uint32_t tile_id = row_start_tile_id;
         for (uint32_t w = 0; w < block_width_tiles; w++) {
-            uint64_t dst_noc_addr = s.get_noc_addr(tile_id);
-            noc_async_write(l1_read_addr, dst_noc_addr, tile_bytes);
+            noc.async_write(
+                cb_out, s, tile_bytes, {.offset_bytes = l1_read_offset}, {.page_id = tile_id, .offset_bytes = 0});
             tile_id++;
-            l1_read_addr += tile_bytes;
+            l1_read_offset += tile_bytes;
         }
-        l1_read_addr += padded_offset;
+        l1_read_offset += padded_offset;
         row_start_tile_id += output_width_tiles;
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
     cb_out.pop_front(block_width_padded_num_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded_stick_layout_start_id.cpp
@@ -4,8 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
-#include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     // run-time args
@@ -18,31 +19,22 @@ void kernel_main() {
 
     // compile-time args
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
+    constexpr auto dst_args = TensorAccessorArgs<1>();
 
-    using tensor_shard_info = ShardedInfo<
-        get_compile_time_arg_val(1),   // Memory layout
-        get_compile_time_arg_val(2),   // The number of sharding cores
-        get_compile_time_arg_val(3),   // The page size we offset each write to
-        get_compile_time_arg_val(4),   // The number of pages in each sharding row not including padding pages
-        get_compile_time_arg_val(5),   // This defines times when contiguous pages can't be calculated
-        get_compile_time_arg_val(6),   // pages_per_shard_x
-        get_compile_time_arg_val(7)>;  // pages_per_shard_y
+    const auto s = TensorAccessor(dst_args, dst_addr);
 
-    const auto [mapping_table, rt_increment] =
-        experimental::shard_addr_gen_utils::get_shard_map<tensor_shard_info>(get_arg_addr(6));
-    experimental::ShardedAddrGen<tensor_shard_info> s = {.bank_base_address = dst_addr, .shard_array = mapping_table};
-
+    Noc noc;
     CircularBuffer cb_out(cb_id_out0);
 
     uint32_t stick_id = start_id;
     cb_out.wait_front(block_height);
-    uint32_t l1_read_addr = cb_out.get_read_ptr();
+    uint32_t cb_read_offset = 0;
     for (uint32_t h = 0; h < block_height; ++h) {
-        uint64_t dst_noc_addr = s.get_noc_addr(stick_id);
-        noc_async_write(l1_read_addr, dst_noc_addr, block_width_bytes);
+        noc.async_write(
+            cb_out, s, block_width_bytes, {.offset_bytes = cb_read_offset}, {.page_id = stick_id, .offset_bytes = 0});
         stick_id += output_width_in_pages;
-        l1_read_addr += padded_block_width_bytes;
+        cb_read_offset += padded_block_width_bytes;
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
     cb_out.pop_front(block_height);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/interleaved_to_sharded/device/interleaved_to_sharded_program_factory.cpp
@@ -227,7 +227,7 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
                 "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
                 "writer_unary_sharded_stick_layout_start_id.cpp";
         }
-        shard_builder::extend_sharding_compile_time_args(output, writer_compile_time_args);
+        TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
     } else {
         writer_desc.kernel_source =
             "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
@@ -309,9 +309,6 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
                 writer_rt.push_back(num_units_offset);
                 writer_rt.push_back(curr_idx_h + curr_idx_w);
                 writer_rt.push_back(starting_idx_h);
-                std::vector<uint32_t> extra;
-                shard_builder::extend_sharding_run_time_args(output, extra);
-                writer_rt.append(extra);
                 writer_desc.emplace_runtime_args(core, writer_rt);
             } else {
                 writer_desc.emplace_runtime_args(core, {curr_num_units_per_shard});
@@ -411,9 +408,6 @@ ProgramDescriptor InterleavedToShardedProgramFactory::create_descriptor(
                 writer_rt.push_back(padded_offset_bytes);
                 writer_rt.push_back(start_id);
                 writer_rt.push_back(output_width_in_pages);
-                std::vector<uint32_t> extra;
-                shard_builder::extend_sharding_run_time_args(output, extra);
-                writer_rt.append(extra);
                 writer_desc.emplace_runtime_args(core, writer_rt);
             } else {
                 writer_desc.emplace_runtime_args(core, {curr_num_units_per_shard});


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Relates to https://github.com/tenstorrent/tt-metal/issues/45003.

Migrate the three remaining Device 1.x kernels under `data_movement/sharded/device/kernels/dataflow/` borrowed by `interleaved_to_sharded`, plus the matching factory. After this change every dataflow kernel run by `interleaved_to_sharded` uses the `Noc` / `CircularBuffer` / `UnicastEndpoint` wrappers exclusively.

**Writers** (`writer_unary_sharded_blocks_start_id.cpp`, `writer_unary_sharded_stick_layout_start_id.cpp`) drop the legacy `experimental::ShardedAddrGen` and use a `TensorAccessor`. Inner loops switch to `noc.async_write(cb_out, accessor, ...)` .
  
**Reader** (`reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp`) ports both code paths to `Noc`. The aligned path becomes `noc.async_read(s0, cb_in0, ...)`. The TRID-based non-aligned path uses
  `noc.async_read<NocOptions::TXN_ID>(...)` for src→scratch reads and a `UnicastEndpoint` for the local scratch→dest loopback. The tail `noc_async_read_set_trid(0)` is kept with an inline comment.
  
  **Factory** (`interleaved_to_sharded_program_factory.cpp`) simplifies the `dst_is_dram` branch: replace
  `shard_builder::extend_sharding_compile_time_args` with `TensorAccessorArgs.append_to()` and drop the corresponding `extend_sharding_run_time_args` calls in writer_rt blocks.

### Notes for reviewers
- The reader's non-aligned path is a non-trivial port — especially the `TXN_ID` and `UnicastEndpoint` plumbing against the original `noc_async_read` + manual `NOC_PACKET_TAG` sequence.
- The retained `noc_async_read_set_trid(0)` is intentional (config-only register write, no Device 2.0 wrapper exists)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/data_movement_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/data_movement_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/data_movement_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/data_movement_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/data_movement_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/data_movement_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/data_movement_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/data_movement_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/data_movement_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/data_movement_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/data_movement_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/data_movement_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/data_movement_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/data_movement_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/data_movement_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/data_movement_device_2_0)