### PR TITLE
#40182: Corrected int->smag conversion

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
@@ -15,11 +15,8 @@ inline void calculate_bitwise_or(const uint value) {
         vInt input = dst_reg[0];
         vInt scalar_value = value;
         vInt res = input | scalar_value;
-        v_if(res > INT_MIN && res < 0) {
-            res = 0 - res;
-            res = copysgn(res, scalar_value);
-        }
-        v_endif dst_reg[0] = res;
+        // FIXME: BH doesn;t convert to SMag automatically
+        dst_reg[0] = sfpi::convert<vSMag>(res);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
@@ -15,7 +15,7 @@ inline void calculate_bitwise_or(const uint value) {
         vInt input = dst_reg[0];
         vInt scalar_value = value;
         vInt res = input | scalar_value;
-        // FIXME: BH doesn;t convert to SMag automatically
+        // FIXME: BH doesn't convert to SMag automatically
         dst_reg[0] = sfpi::convert<vSMag>(res);
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
@@ -20,7 +20,7 @@ inline void calculate_bitwise_xor(const uint value) {
         vInt input = dst_reg[0];
         vInt v = value;
         vInt res = input ^ v;
-        // FIXME: BH doesn;t convert to SMag automatically
+        // FIXME: BH doesn't convert to SMag automatically
         dst_reg[0] = sfpi::convert<vSMag>(res);
         dst_reg++;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
@@ -20,11 +20,8 @@ inline void calculate_bitwise_xor(const uint value) {
         vInt input = dst_reg[0];
         vInt v = value;
         vInt res = input ^ v;
-        v_if(res > INT_MIN && res < 0) {
-            res = 0 - res;
-            res = copysgn(res, v);
-        }
-        v_endif dst_reg[0] = res;
+        // FIXME: BH doesn;t convert to SMag automatically
+        dst_reg[0] = sfpi::convert<vSMag>(res);
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_or.h
@@ -15,11 +15,7 @@ inline void calculate_bitwise_or(const uint value) {
         vInt input = dst_reg[0];
         vInt scalar_value = value;
         vInt res = input | scalar_value;
-        v_if(res > INT_MIN && res < 0) {
-            res = 0 - res;
-            res = copysgn(res, scalar_value);
-        }
-        v_endif dst_reg[0] = res;
+        dst_reg[0] = res;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_bitwise_xor.h
@@ -20,11 +20,7 @@ inline void calculate_bitwise_xor(const uint value) {
         vInt input = dst_reg[0];
         vInt v = value;
         vInt res = input ^ v;
-        v_if(res > INT_MIN && res < 0) {
-            res = 0 - res;
-            res = copysgn(res, v);
-        }
-        v_endif dst_reg[0] = res;
+        dst_reg[0] = res;
         dst_reg++;
     }
 }


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
My recent cleanup of the sfpi API broke this code, but also permits it to be simplified.  Which this does.
It's unfortunate this isn't being exercised in a test I run :(

The whole int<->smag conversion thing is a bit of a mess :(

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/setsgn-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/setsgn-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/setsgn-40182)