### PR TITLE
[DCAMP-995] Verify a regenerated topology still satisfies a skinny descriptor

### DIFF
--- a/tools/scaleout/CMakeLists.txt
+++ b/tools/scaleout/CMakeLists.txt
@@ -50,6 +50,7 @@ target_sources(
             cabling_generator/regen_descriptors.hpp
             connector/connector.hpp
             factory_system_descriptor/utils.hpp
+            factory_system_descriptor/subset_check.hpp
             node/node_types.hpp
     PRIVATE
         node/node.cpp
@@ -59,6 +60,7 @@ target_sources(
         cabling_generator/regen_descriptors.cpp
         connector/connector.cpp
         factory_system_descriptor/utils.cpp
+        factory_system_descriptor/subset_check.cpp
         ${GENERATED_PROTO_SRCS}
 )
 

--- a/tools/scaleout/exabox/README.md
+++ b/tools/scaleout/exabox/README.md
@@ -245,6 +245,8 @@ Look for `All Detected Links are healthy` in the output. If you see `could not a
 ./tools/scaleout/exabox/recover.sh --hosts <hosts> --validation-args "--min-connections 3" --rerun-on-retrain
 ```
 
+**Deploying around a dead cable:** when a cable can't be retrained, recovery automatically regenerates FSD/cabling/deployment descriptors with the dead cable pruned, so you can deploy on the degraded topology. Optionally pass `--skinny-fsd <path>` to gate the deploy on whether the regenerated topology still contains a minimal "skinny" workload subset. See [Deploying Around a Dead Cable](./TROUBLESHOOTING.md#deploying-around-a-dead-cable-regenerate-descriptors).
+
 Any other `run_cluster_validation` flag (e.g. `--hard-fail`, `--print-connectivity`, `--log-ethernet-metrics`) can be forwarded via `--validation-args`.
 
 ## Troubleshooting

--- a/tools/scaleout/exabox/TROUBLESHOOTING.md
+++ b/tools/scaleout/exabox/TROUBLESHOOTING.md
@@ -29,6 +29,7 @@ Real issues encountered and their solutions.
   - [UMD Firmware Version Mismatch - Links Not Detected](#umd-firmware-version-mismatch---links-not-detected)
   - [QSFP Connections Missing Between Hosts](#qsfp-connections-missing-between-hosts)
   - [Diagnosing Bad Cables via Swap Test](#diagnosing-bad-cables-via-swap-test)
+  - [Deploying Around a Dead Cable (Regenerate Descriptors)](#deploying-around-a-dead-cable-regenerate-descriptors)
   - [Transient Ethernet Connectivity Loss](#transient-ethernet-connectivity-loss)
   - [Z Ports Showing Down](#z-ports-showing-down)
   - [Trace Connections Hanging After Reset](#trace-connections-hanging-after-reset-30-failure-rate)
@@ -665,6 +666,35 @@ To determine if the issue is with the cable or the port, swap the suspect cable 
 - Host pair affected
 - Tray IDs and port IDs
 - Results of the swap test
+
+---
+
+## Deploying Around a Dead Cable (Regenerate Descriptors)
+
+**Symptom**: A cable is confirmed bad (won't retrain) and can't be replaced right
+away, but you still need to bring the cluster up on the remaining good links.
+
+When `recover.sh` validation fails because links cannot be retrained, it writes
+`unretrainable_channels.yaml` and automatically runs `run_regen_descriptors`,
+which prunes every cable containing a dead channel and emits a fresh set of FSD,
+cabling, and deployment descriptors describing the degraded-but-working topology.
+Deploy from the regenerated descriptors to skip the dead cable.
+
+```bash
+# Regen runs automatically on failure; pass --no-regenerate-on-failure to skip it.
+./recover.sh --hosts <hosts> --output <dir>
+```
+
+**Optional skinny deploy-gate**: if your workload only needs a minimal subset of
+links, provide that subset as a "skinny" FSD. After regenerating, the tool checks
+that the degraded topology still contains every skinny connection and refuses to
+deploy (non-zero exit) if any are missing:
+
+```bash
+./recover.sh --hosts <hosts> --output <dir> --skinny-fsd <skinny_fsd.textproto>
+```
+
+Run `./recover.sh --help` or `run_regen_descriptors --help` for the full flag list.
 
 ---
 

--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -56,6 +56,11 @@ Optional:
                                             In --use-docker mode regen runs inside the image on the first host.
                                             Regen is skipped automatically when only --factory-descriptor-path is
                                             in use (cabling+deployment are required inputs).
+    --skinny-fsd <path>                     After regeneration, check whether the regenerated (good) topology
+                                            still contains every connection in this skinny factory system
+                                            descriptor (.textproto). If so, the degraded cluster can still run a
+                                            workload validated on the skinny topology; otherwise the required
+                                            connections missing from the cluster are listed.
     --help                                  Display this help message and exit
 
 ================================================================================
@@ -94,6 +99,7 @@ OUTPUT_DIR="recover-logs"
 RERUN_ON_RETRAIN=false
 VALIDATION_EXTRA_ARGS=()
 REGENERATE_ON_FAILURE=true
+SKINNY_FSD=""
 
 CABLING_DESCRIPTOR_PATH_DEFAULT="/data/scaleout_configs/bh_glx_exabox/cabling_descriptor.textproto"
 DEPLOYMENT_DESCRIPTOR_PATH_DEFAULT="/data/scaleout_configs/bh_glx_exabox/deployment_descriptor.textproto"
@@ -246,6 +252,14 @@ while [[ $# -gt 0 ]]; do
             REGENERATE_ON_FAILURE=false
             shift
             ;;
+        --skinny-fsd)
+            if [[ -z "$2" ]] || [[ "$2" == --* ]]; then
+                echo "Error: --skinny-fsd requires a non-empty value"
+                exit 1
+            fi
+            SKINNY_FSD="$2"
+            shift 2
+            ;;
         --help)
             show_help
             exit 0
@@ -380,6 +394,9 @@ if [[ ${#VALIDATION_EXTRA_ARGS[@]} -gt 0 ]]; then
     echo "Extra validation args: ${VALIDATION_EXTRA_ARGS[*]}"
 fi
 echo "Regenerate on failure: $REGENERATE_ON_FAILURE"
+if [[ -n "$SKINNY_FSD" ]]; then
+    echo "Skinny FSD (subset check): $SKINNY_FSD"
+fi
 echo "=========================================="
 echo ""
 
@@ -465,6 +482,9 @@ if [[ "$REGENERATE_ON_FAILURE" == true && $VALIDATION_EXIT -ne 0 ]]; then
                 --unretrainable-channels "$UNRETRAINABLE_YAML"
                 --output-dir "$REGEN_DIR"
             )
+            # When a skinny descriptor is given, run_regen_descriptors also checks the regenerated
+            # topology still contains it (and exits non-zero if not).
+            [[ -n "$SKINNY_FSD" ]] && REGEN_ARGS+=(--skinny-fsd "$SKINNY_FSD")
             echo ""
             echo "Validation exited unrecoverable; regenerating descriptors without unretrainable cables..."
             if [[ -n "$DOCKER_IMAGE" ]]; then
@@ -473,28 +493,28 @@ if [[ "$REGENERATE_ON_FAILURE" == true && $VALIDATION_EXIT -ne 0 ]]; then
                 # descriptor inputs and the output dir so paths resolve identically in-container.
                 # Relative input paths resolve against the container's working dir, which differs
                 # from the host cwd, so warn the operator to use absolute paths.
-                if [[ "$CABLING_DESCRIPTOR_PATH" != /* || "$DEPLOYMENT_DESCRIPTOR_PATH" != /* ]]; then
-                    echo "Warning: --cabling-descriptor-path / --deployment-descriptor-path are relative;"
-                    echo "         in --use-docker mode they may not resolve inside the container."
-                    echo "         Use absolute paths if regeneration fails to find the descriptors."
+                if [[ "$CABLING_DESCRIPTOR_PATH" != /* || "$DEPLOYMENT_DESCRIPTOR_PATH" != /* || \
+                      ( -n "$SKINNY_FSD" && "$SKINNY_FSD" != /* ) ]]; then
+                    echo "Warning: a descriptor path is relative; in --use-docker mode it may not resolve"
+                    echo "         inside the container. Use absolute paths if regeneration fails to find inputs."
                 fi
                 FIRST_HOST="${HOSTS%%,*}"
                 REGEN_VOLUMES=(--volume /data/scaleout_configs --volume "$OUTPUT_DIR")
                 # Mount the directories holding the input descriptors too, in case they live
-                # outside /data/scaleout_configs (custom --cabling/--deployment paths).
-                CABLING_DIR="$(cd "$(dirname "$CABLING_DESCRIPTOR_PATH")" && pwd)"
-                DEPLOYMENT_DIR="$(cd "$(dirname "$DEPLOYMENT_DESCRIPTOR_PATH")" && pwd)"
-                REGEN_VOLUMES+=(--volume "$CABLING_DIR" --volume "$DEPLOYMENT_DIR")
+                # outside /data/scaleout_configs (custom --cabling/--deployment/--skinny paths).
+                REGEN_VOLUMES+=(--volume "$(cd "$(dirname "$CABLING_DESCRIPTOR_PATH")" && pwd)")
+                REGEN_VOLUMES+=(--volume "$(cd "$(dirname "$DEPLOYMENT_DESCRIPTOR_PATH")" && pwd)")
+                [[ -n "$SKINNY_FSD" ]] && REGEN_VOLUMES+=(--volume "$(cd "$(dirname "$SKINNY_FSD")" && pwd)")
                 ./tools/scaleout/exabox/mpi-docker --image "$DOCKER_IMAGE" \
                     --empty-entrypoint \
                     --mpi-interface "$MPI_IF" \
                     "${REGEN_VOLUMES[@]}" \
                     --host "$FIRST_HOST" -np 1 \
                     ./build/tools/scaleout/run_regen_descriptors \
-                    "${REGEN_ARGS[@]}" || echo "Warning: descriptor regeneration failed (see error above)"
+                    "${REGEN_ARGS[@]}" || echo "Warning: regeneration / skinny check reported a problem (see above)."
             else
                 ./build/tools/scaleout/run_regen_descriptors \
-                    "${REGEN_ARGS[@]}" || echo "Warning: descriptor regeneration failed (see error above)"
+                    "${REGEN_ARGS[@]}" || echo "Warning: regeneration / skinny check reported a problem (see above)."
             fi
         fi
     fi

--- a/tools/scaleout/factory_system_descriptor/subset_check.cpp
+++ b/tools/scaleout/factory_system_descriptor/subset_check.cpp
@@ -1,0 +1,69 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "subset_check.hpp"
+
+#include <algorithm>
+#include <fstream>
+#include <iterator>
+#include <stdexcept>
+
+#include <google/protobuf/text_format.h>
+
+#include <board/board.hpp>
+
+#include "protobuf/factory_system_descriptor.pb.h"
+
+namespace tt::scaleout_tools {
+
+namespace {
+
+// Load an FSD textproto into a hostname-keyed, endpoint-canonicalized set of channel connections.
+// Keying by hostname (not the FSD's per-file host_id index) is what makes two FSDs with different
+// host orderings comparable.
+std::set<PhysicalChannelConnection> load_fsd_connections(const std::string& fsd_path) {
+    std::ifstream fsd_file(fsd_path);
+    if (!fsd_file.is_open()) {
+        throw std::runtime_error("Failed to open FSD file: " + fsd_path);
+    }
+    std::string contents((std::istreambuf_iterator<char>(fsd_file)), std::istreambuf_iterator<char>());
+
+    fsd::proto::FactorySystemDescriptor fsd;
+    if (!google::protobuf::TextFormat::ParseFromString(contents, &fsd)) {
+        throw std::runtime_error("Failed to parse FSD protobuf from file: " + fsd_path);
+    }
+
+    const auto& hosts = fsd.hosts();
+    auto endpoint = [&](const auto& e) {
+        if (e.host_id() >= static_cast<uint32_t>(hosts.size())) {
+            throw std::runtime_error(
+                "FSD '" + fsd_path + "' references host_id " + std::to_string(e.host_id()) + " but only has " +
+                std::to_string(hosts.size()) + " hosts");
+        }
+        return PhysicalChannelEndpoint{
+            hosts[e.host_id()].hostname(), TrayId(e.tray_id()), AsicChannel{e.asic_location(), ChanId(e.chan_id())}};
+    };
+
+    std::set<PhysicalChannelConnection> connections;
+    for (const auto& connection : fsd.eth_connections().connection()) {
+        auto a = endpoint(connection.endpoint_a());
+        auto b = endpoint(connection.endpoint_b());
+        connections.emplace(std::min(a, b), std::max(a, b));
+    }
+    return connections;
+}
+
+}  // namespace
+
+std::set<PhysicalChannelConnection> missing_skinny_connections(
+    const std::string& skinny_fsd_path, const std::string& good_fsd_path) {
+    auto skinny = load_fsd_connections(skinny_fsd_path);
+    auto good = load_fsd_connections(good_fsd_path);
+
+    std::set<PhysicalChannelConnection> missing;
+    std::set_difference(skinny.begin(), skinny.end(), good.begin(), good.end(), std::inserter(missing, missing.end()));
+    return missing;
+}
+
+}  // namespace tt::scaleout_tools

--- a/tools/scaleout/factory_system_descriptor/subset_check.hpp
+++ b/tools/scaleout/factory_system_descriptor/subset_check.hpp
@@ -1,0 +1,25 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <set>
+#include <string>
+
+#include <cabling_generator/cabling_generator.hpp>
+
+namespace tt::scaleout_tools {
+
+// Return the connections required by the skinny FSD that are absent from the good FSD
+// (skinny \ good). An empty result means skinny is a subset of good: the good (currently
+// working) topology still provides everything the skinny (minimum validated) topology needs,
+// so a workload validated on skinny can run on the degraded cluster.
+//
+// Connections are matched by hostname (resolved from each FSD's own host_id index) and by
+// canonicalized endpoint order, so the result is independent of host ordering within either FSD.
+// Throws std::runtime_error on missing file, parse failure, or out-of-range host_id.
+std::set<PhysicalChannelConnection> missing_skinny_connections(
+    const std::string& skinny_fsd_path, const std::string& good_fsd_path);
+
+}  // namespace tt::scaleout_tools

--- a/tools/scaleout/src/run_regen_descriptors.cpp
+++ b/tools/scaleout/src/run_regen_descriptors.cpp
@@ -11,16 +11,23 @@
 #include <cxxopts.hpp>
 
 #include <cabling_generator/regen_descriptors.hpp>
+#include <factory_system_descriptor/subset_check.hpp>
 
 using namespace tt::scaleout_tools;
 
 namespace {
+
+// Exit codes (stable for CI/automation gating).
+constexpr int kExitOk = 0;             // regen succeeded (and skinny subset satisfied, if checked)
+constexpr int kExitSkinnyMissing = 2;  // regen succeeded but the regenerated topology lacks skinny connections
+constexpr int kExitError = 1;          // bad input / parse failure
 
 struct InputConfig {
     std::string cabling_descriptor_path;
     std::string deployment_descriptor_path;
     std::string unretrainable_channels_path;
     std::string output_dir;
+    std::string skinny_fsd_path;  // optional
 };
 
 bool file_exists(const std::string& path) {
@@ -57,7 +64,11 @@ InputConfig parse_arguments(int argc, char** argv) {
         "Path to unretrainable_channels.yaml emitted by run_cluster_validation",
         cxxopts::value<std::string>())(
         "o,output-dir", "Directory to write the regenerated descriptor set into", cxxopts::value<std::string>())(
-        "h,help", "Print usage information");
+        "s,skinny-fsd",
+        "Optional: skinny (minimum required) FSD (.textproto). After regeneration, check whether the\n"
+        "regenerated topology still contains every connection it lists; if not, the missing ones are\n"
+        "reported and the tool exits 2.",
+        cxxopts::value<std::string>())("h,help", "Print usage information");
 
     try {
         auto result = options.parse(argc, argv);
@@ -84,6 +95,7 @@ InputConfig parse_arguments(int argc, char** argv) {
             .deployment_descriptor_path = result["deployment"].as<std::string>(),
             .unretrainable_channels_path = result["unretrainable-channels"].as<std::string>(),
             .output_dir = result["output-dir"].as<std::string>(),
+            .skinny_fsd_path = result.contains("skinny-fsd") ? result["skinny-fsd"].as<std::string>() : "",
         };
 
         if (!file_exists(config.cabling_descriptor_path) && !directory_exists(config.cabling_descriptor_path)) {
@@ -97,12 +109,15 @@ InputConfig parse_arguments(int argc, char** argv) {
             throw std::invalid_argument(
                 "Unretrainable channels YAML not found: '" + config.unretrainable_channels_path + "'");
         }
+        if (!config.skinny_fsd_path.empty() && !file_exists(config.skinny_fsd_path)) {
+            throw std::invalid_argument("Skinny FSD not found: '" + config.skinny_fsd_path + "'");
+        }
 
         return config;
     } catch (const cxxopts::exceptions::exception& e) {
         std::cerr << "Error parsing arguments: " << e.what() << std::endl;
         std::cerr << options.help() << std::endl;
-        std::exit(1);
+        std::exit(kExitError);
     }
 }
 
@@ -141,9 +156,26 @@ int main(int argc, char** argv) {
             }
         }
 
-        return 0;
+        // Optional: confirm the regenerated topology still satisfies a skinny (minimum) topology.
+        if (!config.skinny_fsd_path.empty()) {
+            auto missing = missing_skinny_connections(config.skinny_fsd_path, summary.output_fsd_path);
+            std::cout << "\nSkinny check against " << config.skinny_fsd_path << ":" << std::endl;
+            if (missing.empty()) {
+                std::cout << "  PASS: regenerated topology contains the full skinny topology; safe to deploy on skinny."
+                          << std::endl;
+            } else {
+                std::cerr << "  FAIL: " << missing.size()
+                          << " skinny-required connection(s) missing from the regenerated topology:" << std::endl;
+                for (const auto& [endpoint_a, endpoint_b] : missing) {
+                    std::cerr << "    - " << endpoint_a << " <-> " << endpoint_b << std::endl;
+                }
+                return kExitSkinnyMissing;
+            }
+        }
+
+        return kExitOk;
     } catch (const std::exception& e) {
         std::cerr << "Error: " << e.what() << std::endl;
-        return 1;
+        return kExitError;
     }
 }

--- a/tools/tests/scaleout/test_factory_system_descriptor.cpp
+++ b/tools/tests/scaleout/test_factory_system_descriptor.cpp
@@ -12,6 +12,7 @@
 
 #include <cabling_generator/cabling_generator.hpp>
 #include <factory_system_descriptor/utils.hpp>
+#include <factory_system_descriptor/subset_check.hpp>
 #include <node/node_types.hpp>
 
 // Include generated protobuf headers
@@ -440,6 +441,96 @@ TEST(CablingGenerator, PruneDeadChannelsIgnoresUnknownChannel) {
 
     EXPECT_TRUE(gen.prune_dead_channels({bogus}).empty());  // no cable matched
     EXPECT_EQ(gen.get_chip_connections().size(), before);   // FSD unchanged
+}
+
+// Write an FSD textproto to `path`. `hosts` are in host_id order; `connections` are
+// (host_id_a, tray_a, asic_a, chan_a, host_id_b, tray_b, asic_b, chan_b) tuples.
+namespace {
+struct FsdConn {
+    uint32_t ha, ta, aa, ca, hb, tb, ab, cb;
+};
+void write_fsd(const std::string& path, const std::vector<std::string>& hosts, const std::vector<FsdConn>& conns) {
+    std::ofstream f(path);
+    for (const auto& h : hosts) {
+        f << "hosts { hostname: \"" << h << "\" }\n";
+    }
+    f << "eth_connections {\n";
+    for (const auto& c : conns) {
+        f << "  connection {\n";
+        f << "    endpoint_a { host_id: " << c.ha << " tray_id: " << c.ta << " asic_location: " << c.aa
+          << " chan_id: " << c.ca << " }\n";
+        f << "    endpoint_b { host_id: " << c.hb << " tray_id: " << c.tb << " asic_location: " << c.ab
+          << " chan_id: " << c.cb << " }\n";
+        f << "  }\n";
+    }
+    f << "}\n";
+}
+}  // namespace
+
+TEST(SkinnySubset, IsHostOrderingIndependent) {
+    // skinny: hosts [A, B], one connection A<->B on tray1/asic0/chan0.
+    const std::string skinny = root_output_dir + "subset/skinny_order.textproto";
+    std::filesystem::create_directories(std::filesystem::path(skinny).parent_path());
+    write_fsd(skinny, {"A", "B"}, {{0, 1, 0, 0, 1, 1, 0, 0}});
+
+    // good: hosts listed in REVERSED order [B, A] so the same physical connection has swapped
+    // host_id indices, plus an extra connection. If the check keyed on host_id it would mismatch;
+    // keying on hostname it must still see skinny as a subset.
+    const std::string good = root_output_dir + "subset/good_order.textproto";
+    write_fsd(good, {"B", "A"}, {{1, 1, 0, 0, 0, 1, 0, 0}, {1, 1, 0, 1, 0, 1, 0, 1}});
+
+    // Despite the reversed host ordering in `good`, skinny's connection is found -> subset (empty).
+    EXPECT_TRUE(missing_skinny_connections(skinny, good).empty());
+
+    std::filesystem::remove(skinny);
+    std::filesystem::remove(good);
+}
+
+TEST(SkinnySubset, ReportsMissingRequiredConnection) {
+    // skinny requires two connections; good only provides one -> not a subset, the other is missing.
+    const std::string skinny = root_output_dir + "subset/skinny_missing.textproto";
+    std::filesystem::create_directories(std::filesystem::path(skinny).parent_path());
+    write_fsd(skinny, {"A", "B"}, {{0, 1, 0, 0, 1, 1, 0, 0}, {0, 1, 0, 1, 1, 1, 0, 1}});
+
+    const std::string good = root_output_dir + "subset/good_missing.textproto";
+    write_fsd(good, {"A", "B"}, {{0, 1, 0, 0, 1, 1, 0, 0}});
+
+    auto missing = missing_skinny_connections(skinny, good);
+    EXPECT_EQ(missing.size(), 1u);
+
+    std::filesystem::remove(skinny);
+    std::filesystem::remove(good);
+}
+
+TEST(SkinnySubset, RegeneratedFsdRemainsSupersetOfSkinny) {
+    // Realistic end-to-end: a pruned (degraded) FSD is a subset of the full FSD, and the full FSD
+    // is NOT a subset of the pruned one (the pruned cable is the missing required connection).
+    CablingGenerator full(
+        "tools/tests/scaleout/cabling_descriptors/5_n300_lb_superpod.textproto",
+        "tools/tests/scaleout/deployment_descriptors/5_lb_deployment.textproto");
+    const std::string full_fsd = root_output_dir + "subset/full.textproto";
+    std::filesystem::create_directories(std::filesystem::path(full_fsd).parent_path());
+    full.emit_factory_system_descriptor(full_fsd);
+
+    // Prune one real cable to produce the degraded "good" topology.
+    CablingGenerator degraded(
+        "tools/tests/scaleout/cabling_descriptors/5_n300_lb_superpod.textproto",
+        "tools/tests/scaleout/deployment_descriptors/5_lb_deployment.textproto");
+    const auto& first = degraded.get_chip_connections().front().first;
+    PhysicalChannelEndpoint dead{
+        degraded.get_deployment_hosts().at(*first.host_id).hostname, first.tray_id, first.asic_channel};
+    degraded.prune_dead_channels({dead});
+    const std::string degraded_fsd = root_output_dir + "subset/degraded.textproto";
+    degraded.emit_factory_system_descriptor(degraded_fsd);
+
+    // degraded (skinny) is a subset of full (good): the working set still covers the smaller one.
+    EXPECT_TRUE(missing_skinny_connections(degraded_fsd, full_fsd).empty());
+
+    // full (skinny) is NOT a subset of degraded (good): the pruned cable is required but missing.
+    EXPECT_GT(missing_skinny_connections(full_fsd, degraded_fsd).size(), 0u);
+
+    std::filesystem::remove(full_fsd);
+    std::filesystem::remove(degraded_fsd);
 }
 
 }  // namespace tt::scaleout_tools


### PR DESCRIPTION
### PR Category
Feature

### Summary
After a degraded cluster's descriptors are regenerated (parent PR, merged), this answers the deploy gate: does the regenerated ("good") topology still contain everything a chosen "skinny" (minimum validated) topology needs? If skinny ⊆ good, a workload validated on skinny can still run and if not, the missing required connections are listed.

- New `missing_skinny_connections(skinny_fsd, good_fsd)` → connections skinny needs that good lacks (empty = subset). Matches the existing `validate_fsd_against_gsd` return idiom.
- Folded into `run_regen_descriptors --skinny-fsd`: reports PASS, or lists missing and exits 2 (0 ok / 2 skinny unsatisfied / 1 error). `recover.sh --skinny-fsd` passes it through.

### Notes for reviewers
- Connections are matched by hostname (not host_id index), so host ordering between the two FSDs doesn't matter.
- No new binary, the good FSD only comes from regen, so the check lives there.

### Tests
- host-ordering independence
- missing-connection reporting
- pruned ⊆ full / full ⊄ pruned.
- Tested locally with full and skinny descriptors

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jpanasiuk/descs_subset_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jpanasiuk/descs_subset_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jpanasiuk/descs_subset_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jpanasiuk/descs_subset_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jpanasiuk/descs_subset_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jpanasiuk/descs_subset_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jpanasiuk/descs_subset_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jpanasiuk/descs_subset_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jpanasiuk/descs_subset_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jpanasiuk/descs_subset_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jpanasiuk/descs_subset_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jpanasiuk/descs_subset_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jpanasiuk/descs_subset_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jpanasiuk/descs_subset_check)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jpanasiuk/descs_subset_check)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jpanasiuk/descs_subset_check)