### PR TITLE
#46424: fix CLIPEncoder.forward() call in SDXL test_common

### DIFF
--- a/models/demos/stable_diffusion_xl_base/tests/test_common.py
+++ b/models/demos/stable_diffusion_xl_base/tests/test_common.py
@@ -340,7 +340,7 @@ def batch_encode_prompt_on_device(
                 mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
             )
 
-            tt_sequence_output, tt_pooled_output = text_encoder(tt_tokens, ttnn_device)
+            tt_sequence_output, tt_pooled_output = text_encoder(tt_tokens)
 
             tt_sequence_output_torch = ttnn.to_torch(
                 tt_sequence_output[-2],
@@ -427,7 +427,7 @@ def batch_encode_prompt_on_device(
                 device=ttnn_device,
                 mesh_mapper=ttnn.ShardTensorToMesh(ttnn_device, dim=0),
             )
-            tt_sequence_output_neg, tt_pooled_output_neg = text_encoder(tt_tokens, ttnn_device)
+            tt_sequence_output_neg, tt_pooled_output_neg = text_encoder(tt_tokens)
             tt_sequence_output_neg_torch = ttnn.to_torch(
                 tt_sequence_output_neg[-2],
                 mesh_composer=ConcatMeshToTensor(ttnn_device, dim=0),


### PR DESCRIPTION
### Problem
SDXL demo tests fail with:
```
TypeError: CLIPEncoder.forward() takes 2 positional arguments but 3 were given
```
on both wormhole_b0 and blackhole. Closes #46424. Closes #46426.

### Root cause
The Pipeline refactor (#44201) changed `CLIPEncoder.forward` (`models/tt_dit/encoders/clip/model_clip.py`) to take only `prompt_tokenized` (projection is now decided at construction from config). Two call sites in `models/demos/stable_diffusion_xl_base/tests/test_common.py` (`batch_encode_prompt_on_device`, used by the on-device encode path) still passed `ttnn_device` positionally.

### Fix
Drop the stale positional `ttnn_device` arg at both encoder call sites (lines 343 and 430), matching the already-correct single-arg usage in `warmup_tt_text_encoders`. `ttnn_device` remains in scope for the surrounding `from_torch`/`ConcatMeshToTensor` calls. The change is in shared Python code, so it fixes the failure on both wormhole_b0 and blackhole.

### Verification
`models/demos/stable_diffusion_xl_base/demo/demo.py` `device_vae and device_encoders and with_trace and no_cfg_parallel and 512x512` passes locally on wormhole_b0 (encode step completes; 1 passed).
