### PR TITLE
[tt-train][test] Fix flaky Softmax test

### DIFF
--- a/tt-train/sources/ttml/test_utils/random_data.hpp
+++ b/tt-train/sources/ttml/test_utils/random_data.hpp
@@ -30,6 +30,22 @@ inline void fill_uniform(std::span<T> data, const T min, const T max, const uint
     }
 }
 
+// This is a workaround for the Softmax test. Should be removed when we have a better way to generate
+// deterministic multi-threaded random data. See #46837
+template <typename T>
+inline void fill_uniform_sequential(std::span<T> data, const T min, const T max, const uint32_t seed) {
+    if constexpr (std::is_integral_v<T>) {
+        ttml::core::legacy::sequential_generate(
+            data, [min, max]() { return std::uniform_int_distribution<T>(min, max); }, seed);
+    } else {
+        using DistScalar = std::conditional_t<std::is_floating_point_v<T>, T, float>;
+        const DistScalar min_v = static_cast<DistScalar>(min);
+        const DistScalar max_v = static_cast<DistScalar>(max);
+        ttml::core::sequential_generate(
+            data, [min_v, max_v]() { return std::uniform_real_distribution<DistScalar>(min_v, max_v); }, seed);
+    }
+}
+
 template <typename T>
 inline std::vector<T> make_uniform_vector(const std::size_t vec_size, const T min, const T max, const uint32_t seed) {
     std::vector<T> data(vec_size);
@@ -37,7 +53,7 @@ inline std::vector<T> make_uniform_vector(const std::size_t vec_size, const T mi
     return data;
 }
 
-template <typename T, typename Shape>
+template <typename T, typename Shape, bool deterministic = false>
 inline xt::xarray<T> make_uniform_xarray(const Shape& shape, const T min, const T max, const uint32_t seed) {
     std::vector<std::size_t> xt_shape;
     xt_shape.reserve(std::size(shape));
@@ -45,7 +61,11 @@ inline xt::xarray<T> make_uniform_xarray(const Shape& shape, const T min, const 
         xt_shape.push_back(static_cast<std::size_t>(dim));
     }
     xt::xarray<T> x = xt::empty<T>(xt_shape);
-    fill_uniform<T>(std::span<T>{x.data(), x.size()}, min, max, seed);
+    if constexpr (deterministic) {
+        fill_uniform_sequential<T>(std::span<T>{x.data(), x.size()}, min, max, seed);
+    } else {
+        fill_uniform<T>(std::span<T>{x.data(), x.size()}, min, max, seed);
+    }
     return x;
 }
 

--- a/tt-train/tests/ops/softmax_test.cpp
+++ b/tt-train/tests/ops/softmax_test.cpp
@@ -17,8 +17,7 @@
 #include "test_utils/random_data.hpp"
 #include "ttnn_fixed/trivial_ttnn_ops.hpp"
 
-// used for moreh softmax
-#include <cmath>
+using shape_type = std::array<std::size_t, 4>;
 
 class SoftmaxTest : public ::testing::Test {
 protected:
@@ -45,40 +44,47 @@ TEST_F(SoftmaxTest, SoftmaxTest_Batch) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 59U, W = 197U;
-    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = shape_type{N, C, H, W};
     int32_t dim = 3U;
 
     auto& rng = ttml::autograd::ctx().get_generator();
     uint32_t seed = rng();
     xt::xarray<float> input_tensor =
-        ttml::test_utils::make_uniform_xarray<float>(std::array<std::size_t, 4>{N, C, H, W}, -10.0F, 10.0F, seed);
+        ttml::test_utils::make_uniform_xarray<float, shape_type, true>(shape, -10.0F, 10.0F, seed);
 
     auto input = core::from_xtensor(input_tensor, &autograd::ctx().get_device());
 
-    auto result = ttml::metal::softmax(input, dim);
+    ttnn::Tensor ttml_softmax = ttml::metal::softmax(input, dim);
+    auto ttml_softmax_xtensor = core::to_xtensor(ttml_softmax);
 
-    auto ttnn_softmax = ttnn_fixed::softmax(input, dim);
+    tt::tt_metal::Tensor ttnn_softmax = ttnn_fixed::softmax(input, dim);
     auto ttnn_softmax_xtensor = core::to_xtensor(ttnn_softmax);
 
+    // Host side reference using FP32 and xtensor
     auto expected_result = xt_softmax(input_tensor, dim);
 
-    // Check if the result is close to the expected result
-    auto result_xtensor = core::to_xtensor(result);
-    assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ASSERT_EQ(ttml_softmax_xtensor.shape(), expected_result.shape());
+
+    // ttml vs host
+    EXPECT_TRUE(xt::allclose(ttml_softmax_xtensor, expected_result, 3e-2F, 1e-2F));
+
+    // ttnn vs host
+    EXPECT_TRUE(xt::allclose(ttnn_softmax_xtensor, expected_result, 3e-2F, 1e-2F));
+
+    // ttml vs ttnn
+    EXPECT_TRUE(xt::allclose(ttml_softmax_xtensor, ttnn_softmax_xtensor, 3e-2F, 1e-2F));
 }
 
 TEST_F(SoftmaxTest, SoftmaxTest_Big_Batch) {
     using namespace ttml;
 
     const uint32_t N = 1U, C = 1U, H = 32U, W = 128007U;
-    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = shape_type{N, C, H, W};
     int32_t dim = 3U;
 
     auto& rng = ttml::autograd::ctx().get_generator();
     uint32_t seed = rng();
-    xt::xarray<float> input_tensor =
-        ttml::test_utils::make_uniform_xarray<float>(std::array<std::size_t, 4>{N, C, H, W}, -10.0F, 10.0F, seed);
+    xt::xarray<float> input_tensor = ttml::test_utils::make_uniform_xarray<float>(shape, -10.0F, 10.0F, seed);
 
     auto input = core::from_xtensor(input_tensor, &autograd::ctx().get_device());
 
@@ -88,7 +94,7 @@ TEST_F(SoftmaxTest, SoftmaxTest_Big_Batch) {
 
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
-    assert((result_xtensor.shape() == expected_result.shape()));
+    ASSERT_EQ(result_xtensor.shape(), expected_result.shape());
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
 }
 
@@ -96,13 +102,13 @@ TEST_F(SoftmaxTest, NIGHTLY_SoftmaxTest_Huge_Batch) {
     using namespace ttml;
 
     const uint32_t N = 64U, C = 1U, H = 32U, W = 128000U;
-    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
+    const auto shape = shape_type{N, C, H, W};
     int32_t dim = 3U;
 
     auto& rng = ttml::autograd::ctx().get_generator();
     uint32_t seed = rng();
     xt::xarray<float> input_tensor =
-        ttml::test_utils::make_uniform_xarray<float>(std::array<std::size_t, 4>{N, C, H, W}, -10.0F, 10.0F, seed);
+        ttml::test_utils::make_uniform_xarray<float, shape_type, true>(shape, -10.0F, 10.0F, seed);
 
     auto input = core::from_xtensor(input_tensor, &autograd::ctx().get_device());
 
@@ -112,15 +118,13 @@ TEST_F(SoftmaxTest, NIGHTLY_SoftmaxTest_Huge_Batch) {
 
     // Check if the result is close to the expected result
     auto result_xtensor = core::to_xtensor(result);
-    assert((result_xtensor.shape() == expected_result.shape()));
+    ASSERT_EQ(result_xtensor.shape(), expected_result.shape());
     EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
 }
 
 TEST_F(SoftmaxTest, SoftmaxTest_Large_Values) {
     using namespace ttml;
 
-    const uint32_t N = 1U, C = 1U, H = 1U, W = 256U;
-    const auto shape = ttsl::SmallVector<uint32_t>{N, C, H, W};
     int32_t dim = 3U;
 
     xt::xarray<float> input_tensor = {
@@ -164,15 +168,23 @@ TEST_F(SoftmaxTest, SoftmaxTest_Large_Values) {
 
     auto input = core::from_xtensor(input_tensor, &autograd::ctx().get_device());
 
-    auto result = ttml::metal::softmax(input, dim);
+    ttnn::Tensor ttml_softmax = ttml::metal::softmax(input, dim);
+    auto ttml_softmax_xtensor = core::to_xtensor(ttml_softmax);
 
-    auto ttnn_softmax = ttnn_fixed::softmax(input, dim);
+    tt::tt_metal::Tensor ttnn_softmax = ttnn_fixed::softmax(input, dim);
     auto ttnn_softmax_xtensor = core::to_xtensor(ttnn_softmax);
 
+    // Host side reference using FP32 and xtensor
     auto expected_result = xt_softmax(input_tensor, dim);
 
-    // Check if the result is close to the expected result
-    auto result_xtensor = core::to_xtensor(result);
-    assert((result_xtensor.shape() == expected_result.shape()));
-    EXPECT_TRUE(xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F));
+    ASSERT_EQ(ttml_softmax_xtensor.shape(), expected_result.shape());
+
+    // ttml vs host
+    EXPECT_TRUE(xt::allclose(ttml_softmax_xtensor, expected_result, 3e-2F, 1e-2F));
+
+    // ttnn vs host
+    EXPECT_TRUE(xt::allclose(ttnn_softmax_xtensor, expected_result, 3e-2F, 1e-2F));
+
+    // ttml vs ttnn
+    EXPECT_TRUE(xt::allclose(ttml_softmax_xtensor, ttnn_softmax_xtensor, 3e-2F, 1e-2F));
 }


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/46422

Issue has inaccurate "selected occurrences" table. Oldest logs are expired, some of the jobs are green. Oldest confirmed test failure is this one:

Date | Run | Hardware
-- | -- | --
2026-03-24 | [23476020861](https://github.com/tenstorrent/tt-metal/actions/runs/23476020861) | N150

```text
Note: Google Test filter = SoftmaxTest.SoftmaxTest_Batch
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from SoftmaxTest
[ RUN      ] SoftmaxTest.SoftmaxTest_Batch
2026-03-24 06:48:13.495 | info     |             UMD | Creating TopologyDiscovery for architecture: wormhole_b0 (topology_discovery.cpp:69)
2026-03-24 06:48:13.518 | info     |             UMD | Established firmware bundle version: 19.2.0 (topology_discovery.cpp:471)
2026-03-24 06:48:13.552 | info     |          Device | Opening user mode device driver (tt_cluster.cpp:224)
2026-03-24 06:48:13.552 | info     |             UMD | Creating TopologyDiscovery for architecture: wormhole_b0 (topology_discovery.cpp:69)
2026-03-24 06:48:13.574 | info     |             UMD | Established firmware bundle version: 19.2.0 (topology_discovery.cpp:471)
2026-03-24 06:48:13.610 | info     |             UMD | Creating TopologyDiscovery for architecture: wormhole_b0 (topology_discovery.cpp:69)
2026-03-24 06:48:13.632 | info     |             UMD | Established firmware bundle version: 19.2.0 (topology_discovery.cpp:471)
2026-03-24 06:48:13.680 | info     |             UMD | Harvesting masks for chip 0 tensix: 0x4 dram: 0x0 eth: 0x0 pcie: 0x0 l2cpu: 0x0 (cluster.cpp:325)
2026-03-24 06:48:13.716 | info     |             UMD | Initializing iommu for sysmem (size: 0x40000000). (silicon_sysmem_manager.cpp:275)
2026-03-24 06:48:13.716 | info     |             UMD | Allocating sysmem without hugepages (size: 0x40000000). (silicon_sysmem_manager.cpp:281)
2026-03-24 06:48:14.040 | info     |             UMD | Opening local chip ids/PCIe ids: {0}/[0] and remote chip ids {} (cluster.cpp:180)
2026-03-24 06:48:14.041 | info     |             UMD | IOMMU: enabled (cluster.cpp:155)
2026-03-24 06:48:14.041 | info     |             UMD | KMD version: 2.7.0 (cluster.cpp:158)
2026-03-24 06:48:14.042 | info     |             UMD | Starting devices in cluster (cluster.cpp:951)
2026-03-24 06:48:15.144 | info     |             UMD | Mapped sysmem without hugepages to IOVA 0x40000000; NOC address 0x800000000 (silicon_sysmem_manager.cpp:329)
2026-03-24 06:48:15.175 | info     |     Distributed | Using auto discovery to generate mesh graph. (metal_env.cpp:329)
2026-03-24 06:48:15.175 | info     |     Distributed | Constructing control plane using auto-discovery (no mesh graph descriptor). (metal_env.cpp:391)
2026-03-24 06:48:15.176 | info     |             UMD | Creating TopologyDiscovery for architecture: wormhole_b0 (topology_discovery.cpp:69)
2026-03-24 06:48:15.213 | info     |             UMD | Established firmware bundle version: 19.2.0 (topology_discovery.cpp:471)
2026-03-24 06:48:15.253 | info     |          Fabric | TopologyMapper: Logical Multi-Mesh Adjacency Map: (topology_mapper.cpp:1474)
2026-03-24 06:48:15.253 | info     |          Fabric | 
=== Logical Mesh-Level Graph Adjacency Map ===
Total nodes: 1
Degree histogram: {0:1}
 (topology_solver.tpp:89)
2026-03-24 06:48:15.253 | info     |          Fabric | 
=== Logical Mesh 0 Internal Graph Adjacency Map ===
Total nodes: 1
Degree histogram: {0:1}
 (topology_solver.tpp:89)
2026-03-24 06:48:15.253 | info     |          Fabric | TopologyMapper: Physical Multi-Mesh Adjacency Map: (topology_mapper.cpp:1485)
2026-03-24 06:48:15.253 | info     |          Fabric | 
=== Physical Mesh-Level Graph Adjacency Map ===
Total nodes: 1
Degree histogram: {0:1}
 (topology_solver.tpp:89)
2026-03-24 06:48:15.253 | info     |          Fabric | 
=== Physical Mesh 0 Internal Graph Adjacency Map ===
Total nodes: 1
Degree histogram: {0:1}
 (topology_solver.tpp:89)
2026-03-24 06:48:15.253 | info     |          Fabric | Starting multi-mesh mapping: 1 logical mesh(es) to 1 physical mesh(es) (topology_mapper_utils.cpp:1107)
2026-03-24 06:48:15.253 | info     |          Fabric | Multi-mesh mapping attempt 1/2: Trying inter-mesh mapping (topology_mapper_utils.cpp:1148)
2026-03-24 06:48:15.253 | info     |          Fabric | Attempt 1: Inter-mesh mapping succeeded, found 1 mesh pair(s) (topology_mapper_utils.cpp:1177)
2026-03-24 06:48:15.253 | info     |          Fabric | Multi-mesh mapping succeeded after 1 attempt(s): 1 mesh pair(s) mapped (topology_mapper_utils.cpp:1316)
2026-03-24 06:48:15.266 | info     |    BuildKernels | Using pre-compiled firmware from: /work/tt_metal/pre-compiled/11052347773339950396/ (build_env_manager.cpp:259)
/work/tt-train/tests/ops/softmax_test.cpp:70: Failure
Value of: xt::allclose(result_xtensor, expected_result, 3e-2F, 1e-2F)
  Actual: false
Expected: true
[  FAILED  ] SoftmaxTest.SoftmaxTest_Batch (5686 ms)
[----------] 1 test from SoftmaxTest (5686 ms total)
```

### PR Category
Test

### Summary
Test instability stems from the non-deterministic input generation. Despite the specified seed, input data differs because of parallel generation for tensors larger than `1<<12`. Number of threads depends on `hardware_concurrency()`, i.e. particular machine. Every thread gets its own `seed+i`.
Input generated by 2 threads != 3 threads.

Also softmax tests totally ignored TTNN results, variable was unused. Added extra comparison TTML vs TTNN.

### Testing

After this change test locally pass 100 iterations (without nightly). Command to verify:
`TT_METAL_LOGGER_LEVEL=ERROR ./build/tt-train/tests/ttml_tests --gtest_filter="SoftmaxTest.SoftmaxTest*" --gtest_repeat=100`

#### Absolute tolerance:

| Test                           | Comparison   | Max abs diff | Tolerance (atol) | Actual      | Expected    | Index              |
| ------------------------------ | ------------ | ------------ | ---------------- | ----------- | ----------- | ------------------ |
| SoftmaxTest_Batch              | ttml vs host | 0.00574957   | 0.01             | 0.172852    | 0.167102    | [47, 0, 54, 84]    |
| SoftmaxTest_Batch              | ttnn vs host | 0.00568633   | 0.01             | 0.140625    | 0.146311    | [28, 0, 26, 26]    |
| SoftmaxTest_Batch              | ttml vs ttnn | 0.00195312   | 0.01             | 0.123047    | 0.121094    | [2, 0, 30, 127]    |
| SoftmaxTest_Big_Batch          | ttml vs host | 5.58575e-06  | 0.01             | 0.000160217 | 0.000154632 | [0, 0, 13, 93340]  |
| NIGHTLY_SoftmaxTest_Huge_Batch | ttml vs host | 5.76714e-06  | 0.01             | 0.000160217 | 0.00015445  | [10, 0, 26, 33456] |

#### Relative tolerance

Relative tolerance doesn't affect result when absolute tolerance is below atol. So, despite terrible numbers in the table below (due to division by tiny value), tests pass. Formula is following (formatting original):

```cpp
auto d = math::abs(internal_type(a) - internal_type(b));
return d <= m_atol
       || d <= m_rtol
                   * double((std::max)(math::abs(internal_type(a)), math::abs(internal_type(b)))
                   );
```

| Test                           | Comparison   | Max rel diff | Tolerance (rtol) | Actual      | Expected    | Index              |
| ------------------------------ | ------------ | ------------ | ---------------- | ----------- | ----------- | ------------------ |
| SoftmaxTest_Batch              | ttml vs host | 0.0540841    | 0.03             | 3.16504e-10 | 3.00265e-10 | [15, 0, 8, 87]     |
| SoftmaxTest_Batch              | ttnn vs host | 0.10881      | 0.03             | 2.06637e-09 | 2.31867e-09 | [29, 0, 28, 85]    |
| SoftmaxTest_Batch              | ttml vs ttnn | 0.0952381    | 0.03             | 7.53062e-10 | 6.87578e-10 | [56, 0, 54, 47]    |
| SoftmaxTest_Big_Batch          | ttml vs host | 0.0377564    | 0.03             | 5.04485e-13 | 4.86131e-13 | [0, 0, 0, 91629]   |
| NIGHTLY_SoftmaxTest_Huge_Batch | ttml vs host | 0.0384663    | 0.03             | 0.000123024 | 0.000118467 | [53, 0, 16, 22219] |

### Performance
Random generation is now sequential, which impacts performance.

| Test  | Sequential (ms) | Parallel (ms) |
|-------|-----|------------|
| SoftmaxTest_Batch | 2152  | 2254   |
| SoftmaxTest_Big_Batch    | 3044  | 2515   |
| NIGHTLY_SoftmaxTest_Huge_Batch  | 164407  | 123565 |
| SoftmaxTest_Large_Values | 1145 | 1184 |
| **Total** | 170749 | 129521 |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vlad/softmax-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vlad/softmax-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vlad/softmax-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vlad/softmax-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vlad/softmax-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vlad/softmax-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vlad/softmax-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vlad/softmax-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vlad/softmax-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vlad/softmax-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vlad/softmax-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vlad/softmax-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vlad/softmax-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vlad/softmax-test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vlad/softmax-test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vlad/softmax-test)