### PR TITLE
Restore instrn_buffer to be a constant pointer

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisc.cc
@@ -60,9 +60,7 @@ volatile tt_reg_ptr uint* PTR_CONST reg_base = reinterpret_cast<volatile uint*>(
 volatile tt_reg_ptr uint* PTR_CONST pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
 volatile tt_reg_ptr uint* PTR_CONST regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
 #undef PTR_CONST
-#if defined(__INSTRN_BUFFER_TOS)
 volatile tt_reg_ptr uint32_t* const instrn_buffer = reinterpret_cast<volatile uint32_t*>(INSTRN_BUF_BASE);
-#endif
 uint32_t cfg_state_id __attribute__((used)) = 0;    // Flip between 0 and 1 to keep state between kernel calls
 uint32_t dest_offset_id __attribute__((used)) = 0;  // Flip between 0 and 1 to keep dest pointer between kernel calls
 

--- a/tt_metal/hw/firmware/src/tt-1xx/trisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/trisck.cc
@@ -35,9 +35,7 @@ namespace ckernel {
 #endif
 volatile tt_reg_ptr uint* PTR_CONST regfile = reinterpret_cast<volatile uint*>(REGFILE_BASE);
 volatile tt_reg_ptr uint* PTR_CONST pc_buf_base = reinterpret_cast<volatile uint*>(PC_BUF_BASE);
-#if defined(__INSTRN_BUFFER_TOS)
 volatile tt_reg_ptr uint32_t* const instrn_buffer = reinterpret_cast<volatile uint32_t*>(INSTRN_BUF_BASE);
-#endif
 volatile tt_reg_ptr uint* PTR_CONST mailbox_base[4] = {
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX0_BASE),
     reinterpret_cast<volatile uint tt_reg_ptr*>(TENSIX_MAILBOX1_BASE),

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/c_tensix_core.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/c_tensix_core.h
@@ -22,15 +22,7 @@ public:
 #if defined(COMPILE_FOR_BRISC)
     // Only accessible on brisc
     static vptr_uint instrn_buf_base(uint32_t thread_id) {
-#if defined(__INSTRN_BUFFER_TOS)
-        return &instrn_buffer[thread_id * (INSTRN_BUF_STRIDE / sizeof(uint32_t))];
-#else
-        // This must be declared consistently with the global scope,
-        // because of the way GCC handles such declarations. I blame
-        // me and the way I implemented a piece of C++20 modules.
-        extern volatile uint32_t __instrn_buffer[];
-        return &__instrn_buffer[thread_id * (INSTRN_BUF_STRIDE / sizeof(uint32_t))];
-#endif
+        return &reinterpret_cast<uint32_t*>(INSTRN_BUF_BASE)[thread_id * (INSTRN_BUF_STRIDE / sizeof(uint32_t))];
     }
 #endif
     static vptr_pc_buf pc_buf_base(uint32_t thread_id) {

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/c_tensix_core.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/c_tensix_core.h
@@ -21,15 +21,7 @@ public:
 #if defined(COMPILE_FOR_BRISC)
     // Only accessible on brisc
     static vptr_uint instrn_buf_base(uint32_t thread_id) {
-#if defined(__INSTRN_BUFFER_TOS)
-        return &instrn_buffer[thread_id * (INSTRN_BUF_STRIDE / sizeof(uint32_t))];
-#else
-        // This must be declared consistently with the global scope,
-        // because of the way GCC handles such declarations. I blame
-        // me and the way I implemented a piece of C++20 modules.
-        extern volatile uint32_t __instrn_buffer[];
-        return &__instrn_buffer[thread_id * (INSTRN_BUF_STRIDE / sizeof(uint32_t))];
-#endif
+        return &reinterpret_cast<uint32_t*>(INSTRN_BUF_BASE)[thread_id * (INSTRN_BUF_STRIDE / sizeof(uint32_t))];
     }
 #endif
     static vptr_pc_buf pc_buf_base(uint32_t thread_id) {

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/c_tensix_core.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/c_tensix_core.h
@@ -23,15 +23,7 @@ public:
 #if defined(COMPILE_FOR_BRISC)
     // Only accessible on brisc
     static vptr_uint instrn_buf_base(uint32_t thread_id) {
-#if defined(__INSTRN_BUFFER_TOS)
-        return &instrn_buffer[thread_id * (INSTRN_BUF_STRIDE / sizeof(uint32_t))];
-#else
-        // This must be declared consistently with the global scope,
-        // because of the way GCC handles such declarations. I blame
-        // me and the way I implemented a piece of C++20 modules.
-        extern volatile uint32_t __instrn_buffer[];
-        return &__instrn_buffer[thread_id * (INSTRN_BUF_STRIDE / sizeof(uint32_t))];
-#endif
+        return &reinterpret_cast<uint32_t*>(INSTRN_BUF_BASE)[thread_id * (INSTRN_BUF_STRIDE / sizeof(uint32_t))];
     }
 #endif
     static vptr_pc_buf pc_buf_base(uint32_t thread_id) {

--- a/tt_metal/tt-llk/tests/helpers/include/ckernel_helper.h
+++ b/tt_metal/tt-llk/tests/helpers/include/ckernel_helper.h
@@ -14,6 +14,7 @@ namespace ckernel
 #ifndef ARCH_QUASAR
 volatile std::uint32_t tt_reg_ptr *pc_buf_base     = reinterpret_cast<volatile std::uint32_t *>(PC_BUF_BASE);
 volatile std::uint32_t tt_reg_ptr *regfile         = reinterpret_cast<volatile std::uint32_t *>(REGFILE_BASE);
+volatile tt_reg_ptr std::uint32_t *const instrn_buffer = reinterpret_cast<volatile std::uint32_t *>(INSTRN_BUF_BASE);
 volatile std::uint32_t tt_reg_ptr *mailbox_base[4] = {
     reinterpret_cast<volatile std::uint32_t tt_reg_ptr *>(TENSIX_MAILBOX0_BASE),
     reinterpret_cast<volatile std::uint32_t tt_reg_ptr *>(TENSIX_MAILBOX1_BASE),

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/ckernel.h
@@ -62,13 +62,7 @@ constexpr std::uint32_t KERNEL_COMPLETE    = 0xFF;
 extern volatile std::uint32_t tt_reg_ptr *reg_base;
 extern volatile std::uint32_t tt_reg_ptr *pc_buf_base;
 extern volatile std::uint32_t tt_reg_ptr *regfile;
-} // namespace ckernel
-
-extern volatile std::uint32_t __instrn_buffer[];
-
-namespace ckernel
-{
-constexpr inline volatile std::uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
+extern volatile std::uint32_t tt_reg_ptr *const instrn_buffer;
 extern volatile std::uint32_t tt_reg_ptr *mailbox_base[4];
 
 extern std::uint32_t cfg_state_id;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/ckernel.h
@@ -56,13 +56,7 @@ constexpr std::uint32_t KERNEL_COMPLETE    = 0xFF;
 extern volatile std::uint32_t tt_reg_ptr *reg_base;
 extern volatile std::uint32_t tt_reg_ptr *pc_buf_base;
 extern volatile std::uint32_t tt_reg_ptr *regfile;
-} // namespace ckernel
-
-extern volatile std::uint32_t __instrn_buffer[];
-
-namespace ckernel
-{
-constexpr inline volatile std::uint32_t(tt_reg_ptr &instrn_buffer)[] = __instrn_buffer;
+extern volatile std::uint32_t tt_reg_ptr *const instrn_buffer;
 extern volatile std::uint32_t tt_reg_ptr *mailbox_base[4];
 
 extern std::uint32_t cfg_state_id;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
This resurrects my restoration of instrn_buf as a pointer, rather than a symbol.  Now that llk is not a submodule it's simpler to do the reversion.

Being a constant here means the compiler knows the value and can use a single insn to load the value -- rather than a lo/hi pair.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/ibufnew-33994)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/ibufnew-33994)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/ibufnew-33994)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/ibufnew-33994)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/ibufnew-33994)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/ibufnew-33994)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/ibufnew-33994)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/ibufnew-33994)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/ibufnew-33994)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/ibufnew-33994)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/ibufnew-33994)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/ibufnew-33994)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/ibufnew-33994)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/ibufnew-33994)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/ibufnew-33994)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/ibufnew-33994)