### PR TITLE
fix(deepseek tests): don't symlink-resolve the HF_MODEL env path

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -329,7 +329,12 @@ def get_or_download_model(variant: TestVariant, layer_idx: int = 0, num_layers: 
             index_file = model_path / "model.safetensors.index.json"
             if index_file.exists():
                 logger.info(f"Using existing model from {variant.env_var}: {model_path}")
-                return model_path.resolve()
+                # Keep the user path absolute but do NOT symlink-resolve it: resolve() would follow a
+                # dot-free symlink (e.g. Kimi-K2_6) back to a dotted real dir (Kimi-K2.6), and HF
+                # trust_remote_code cannot import a dynamic module whose name contains a '.'. The
+                # safetensors load works through the symlink either way; only the config import cares.
+                # This matches _resolve_config_only, which already loads config from the raw env path.
+                return model_path.absolute()
             else:
                 logger.warning(f"{variant.env_var} set but missing index file: {index_file}")
 


### PR DESCRIPTION
## What

`get_or_download_model` returned `model_path.resolve()` for the `*_HF_MODEL` env-var branch, which **follows a dot-free symlink back to a dotted real dir** (e.g. `Kimi-K2_6` → `Kimi-K2.6`). HF `trust_remote_code` then can't import a dynamic module whose name contains a `.` (`No module named 'transformers_modules.Kimi-K2'`), so the `hf_config` fixture fails and pretrained tests depending on it (e.g. `test_mla_chunked_prefill` with `KIMI_K2_6_HF_MODEL`) **skip** with "failed to load HF config" — even though `config_only` works, since it loads from the raw (unresolved) env path.

Return `model_path.absolute()` instead: absolute but **not** symlink-resolved, so the dot-free basename is preserved for `trust_remote_code`. The safetensors/state-dict load is unaffected (it opens files through the symlink). This makes `hf_config` consistent with `_resolve_config_only`.

## Trade-off

This makes the dot-free-**symlink** workaround work; it does not fix pointing the env var **directly** at a dotted dir (basename still has a `.`). The fully general fix would stage `config.json` + the custom `*.py` into a temp dot-free dir purely for the `trust_remote_code` load — heavier; can follow up if wanted.

## Testing

Unblocks Kimi real-weight runs via a dot-free symlink (`KIMI_K2_6_HF_MODEL=/…/Kimi-K2_6` → dotted real dir): `hf_config` now loads and `test_mla_chunked_prefill` proceeds to `weights=pretrained` instead of skipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] [![galaxy-deepseek-prefill-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ipotkonjak/conftest_dotted_hf_checkpoint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ipotkonjak/conftest_dotted_hf_checkpoint_fix) 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/conftest_dotted_hf_checkpoint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/conftest_dotted_hf_checkpoint_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/conftest_dotted_hf_checkpoint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/conftest_dotted_hf_checkpoint_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/conftest_dotted_hf_checkpoint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/conftest_dotted_hf_checkpoint_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/conftest_dotted_hf_checkpoint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/conftest_dotted_hf_checkpoint_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/conftest_dotted_hf_checkpoint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/conftest_dotted_hf_checkpoint_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/conftest_dotted_hf_checkpoint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/conftest_dotted_hf_checkpoint_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/conftest_dotted_hf_checkpoint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/conftest_dotted_hf_checkpoint_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/conftest_dotted_hf_checkpoint_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/conftest_dotted_hf_checkpoint_fix)