### PR TITLE
[Bug fix] Update Quasar l1 cache functions

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -129,7 +129,6 @@ inline void run_triscs(uint32_t enables) {
            subordinate_sync->allNeo1 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE ||
            subordinate_sync->allNeo2 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE ||
            subordinate_sync->allNeo3 != RUN_SYNC_MSG_ALL_SUBORDINATES_DONE) {
-        invalidate_l1_cache();
     }
     DPRINT("DM-FW: running TRISCs {}\n", enables);
     invalidate_trisc_instruction_cache();
@@ -230,7 +229,6 @@ extern "C" uint32_t _start1() {
             while (((go_message_signal = mailboxes->go_messages[mailboxes->go_message_index].signal) != RUN_MSG_GO) &&
                    !(mailboxes->launch[mailboxes->launch_msg_rd_ptr].kernel_config.preload &
                      DISPATCH_ENABLE_FLAG_PRELOAD)) {
-                invalidate_l1_cache();
                 // While the go signal for kernel execution is not sent, check if the worker was signalled
                 // to reset its launch message read pointer.
                 if ((go_message_signal == RUN_MSG_RESET_READ_PTR) ||
@@ -276,10 +274,6 @@ extern "C" uint32_t _start1() {
                 // }
                 // Copies from L1 to IRAM on chips where NCRISC has IRAM
                 uintptr_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, hartid);
-                // Invalidate the i$ now the kernels have loaded and before running
-                // volatile tt_reg_ptr uint32_t* cfg_regs = core.cfg_regs_base(0);
-                // cfg_regs[RISCV_IC_INVALIDATE_InvalidateAll_ADDR32] =
-                //     RISCV_IC_BRISC_MASK | RISCV_IC_TRISC_ALL_MASK | RISCV_IC_NCRISC_MASK;
 
                 run_triscs(enables);
 
@@ -322,7 +316,8 @@ extern "C" uint32_t _start1() {
                 if (enables & (1u << index)) {
                     uintptr_t kernel_lma =
                         (kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index]);
-                    asm("FENCE.i");
+                    // Invalidate the i$ now the kernels have loaded and before running
+                    invalidate_l1_icache();
                     uint32_t* kernel_ptr = reinterpret_cast<uint32_t*>(kernel_lma);
                     auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();
                     record_stack_usage(stack_free);
@@ -412,7 +407,8 @@ extern "C" uint32_t _start1() {
         while (*((volatile uint8_t*)&(subordinate_sync->dm1) + hartid - 1) != RUN_SYNC_MSG_GO) {
             asm("nop; nop; nop; nop; nop");
         }
-        asm("FENCE.i");
+        // Invalidate the i$ now the kernels have loaded and before running
+        invalidate_l1_icache();
         auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();
 
         record_stack_usage(stack_free);

--- a/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/trisc.cc
@@ -149,7 +149,6 @@ extern "C" uint32_t _start1() {
                     *trisc_run = RUN_SYNC_MSG_DONE;
                 }
             }
-            invalidate_l1_cache();
         }
         DeviceZoneScopedMainN("TRISC-FW");
         uint32_t launch_msg_rd_ptr = mailboxes->launch_msg_rd_ptr;

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -287,13 +287,10 @@ inline void invalidate_l2_cache(uint32_t hartid) {
 // Combined Cache Operations
 // -----------------------------------------------------------------------------
 
-// Invalidate entire L1 cache (D$ + I$) on this core.
-// Provided for API compatibility with previous architectures.
-// Uses flush (not invalidate) for D$ since older architectures had write-through caches.
-inline void invalidate_l1_cache() {
-    flush_l1_dcache(0);
-    invalidate_l1_icache();
-}
+// No-op for Quasar DM cores. The data movement cores are completely coherent with each other.
+// Most cases that previous architectures invalidated the l1 cache either do not need
+// invalidation for Quasar or should invalidate the l2 cache instead.
+inline void invalidate_l1_cache() {}
 
 // Invalidate entire cache hierarchy: L2 + L1 D$ + L1 I$.
 // Must be called from all DM cores for proper synchronization.
@@ -303,7 +300,8 @@ inline void invalidate_cache_all(uint32_t hartid) {
     invalidate_l2_cache(hartid);
 
     // 2. Invalidate local L1 (D$ + I$)
-    invalidate_l1_cache();
+    invalidate_l1_dcache(0);
+    invalidate_l1_icache();
 }
 
 #endif  // ARCH_QUASAR && COMPILE_FOR_DM

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -290,7 +290,8 @@ inline void invalidate_l2_cache(uint32_t hartid) {
 // No-op for Quasar DM cores. The data movement cores are completely coherent with each other.
 // Most cases that previous architectures invalidated the l1 cache either do not need
 // invalidation for Quasar or should invalidate the l2 cache instead.
-inline void invalidate_l1_cache() {}
+inline __attribute__((always_inline)) void invalidate_l1_cache() {
+}
 
 // Invalidate entire cache hierarchy: L2 + L1 D$ + L1 I$.
 // Must be called from all DM cores for proper synchronization.


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
#45886 

In Quasar, the data movement cores are completely coherent with each other. We only need to invalidate the DM l1 instruction cache right before the kernel runs.

However, `invalidate_l1_cache` is scattered throughout the codebase for Blackhole. Therefore, this fix is doing 2 things:
- Make `invalidate_l1_cache` a no-op for Quasar, so the existing calls for BH won't cause problems for Quasar
- Update the few places we actually want to invalidate the Quasar l1 d$ & i$ with the new commands to do so

Also, removed unnecessary (and now useless) calls to `invalidate_l1_cache` in Quasar-specific code.

Tested with nightly Quasar emulation tests

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/issue_45886)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/issue_45886)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/issue_45886)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/issue_45886)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kstevens/issue_45886)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kstevens/issue_45886)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/issue_45886)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/issue_45886)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/issue_45886)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/issue_45886)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/issue_45886)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/issue_45886)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/issue_45886)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/issue_45886)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/issue_45886)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/issue_45886)