### PR TITLE
Kimi K2.6 variant support in prefill runner

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
@@ -8,15 +8,18 @@ from pathlib import Path
 
 import torch
 from loguru import logger
-from transformers import AutoConfig
 
 import ttnn
-from models.common.utility_functions import is_blackhole
-from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
-from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
 from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_gate_prefill import GateComputeMode
 from models.demos.deepseek_v3_d_p.tt.runners.h2d_socket_sync_op import h2d_socket_sync
-from models.demos.deepseek_v3_d_p.tt.runners.runner_utils import prepare_prefill_input_tensor
+from models.demos.deepseek_v3_d_p.tt.runners.runner_utils import (
+    build_h2d_service,
+    get_variant,
+    load_hf_config,
+    open_mesh_device,
+    prepare_prefill_input_tensor,
+    resolve_weight_cache_path,
+)
 from models.demos.deepseek_v3_d_p.tt.tt_deepseek_prefill_pipeline import (
     TtDeepSeekPrefillPipeline,
     TtPrefillPipelineConfig,
@@ -46,14 +49,18 @@ H2D_MAPPER_CONFIG = ttnn.MeshMapperConfig(
     placements=[ttnn.PlacementShard(0), ttnn.PlacementReplicate()],
 )
 
+
+VARIANT = get_variant(os.environ.get("PREFILL_MODEL_VARIANT", "deepseek_v3_d_p"))
+MODEL_CFG = VARIANT.model_config
+
 _sp = int(os.environ.get("PREFILL_SP", 8))
 _tp = int(os.environ.get("PREFILL_TP", 4))
 GLOBAL_MESH_SHAPE = (_sp, _tp)
 NUM_LAYERS = int(os.environ.get("PREFILL_NUM_LAYERS", 61))
 MAX_SEQ_LEN = int(os.environ.get("PREFILL_MAX_SEQ_LEN", 3200 * _sp))
-IS_BALANCED = os.environ.get("PREFILL_IS_BALANCED", "1") == "1"
+IS_BALANCED = os.environ.get("PREFILL_IS_BALANCED", "1" if VARIANT.default_is_balanced else "0") == "1"
 CAPACITY_FACTOR = int(os.environ.get("PREFILL_CAPACITY_FACTOR", 8))
-_gate_mode_name = os.environ.get("PREFILL_GATE_FALLBACK_MODE", "DEVICE_FP32")
+_gate_mode_name = os.environ.get("PREFILL_GATE_FALLBACK_MODE", VARIANT.default_gate_mode)
 
 _shutdown = False
 
@@ -63,118 +70,16 @@ def _handle_sigterm(signum, frame):
     _shutdown = True
 
 
-def _is_shutdown() -> bool:
-    return _shutdown
-
-
-def _load_hf_config():
-    model_path = os.environ.get("DEEPSEEK_V3_HF_MODEL") or "models/demos/deepseek_v3/reference"
-    logger.info(f"Loading HF config from {model_path}")
-    return AutoConfig.from_pretrained(model_path, trust_remote_code=True)
-
-
-def _open_mesh_device():
-    sp = GLOBAL_MESH_SHAPE[0]
-    fabric_config = ttnn.FabricConfig.FABRIC_1D if sp <= 8 else ttnn.FabricConfig.FABRIC_2D
-
-    fabric_router_config = create_fabric_router_config(
-        max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE,
-    )
-
-    ttnn.set_fabric_config(
-        fabric_config,
-        ttnn.FabricReliabilityMode.RELAXED_INIT,
-        None,
-        ttnn.FabricTensixConfig.DISABLED,
-        ttnn.FabricUDMMode.DISABLED,
-        ttnn.FabricManagerMode.DEFAULT,
-        fabric_router_config,
-    )
-    return ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(*GLOBAL_MESH_SHAPE))
-
-
-DEFAULT_TTNN_CACHE = "/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure"
 DEFAULT_HOST_REF_CACHE = "/tmp/prefill_ref_cache"
 
-# TtPrefillTransformer reads these env vars directly and aborts if unset.
-# Export defaults here so the runner works without the caller having to set them.
-os.environ.setdefault("TT_DS_PREFILL_TTNN_CACHE", DEFAULT_TTNN_CACHE)
+# Default the variant's TTNN-cache env so resolve_weight_cache_path works
+# without the caller exporting anything. TtPrefillTransformer additionally
+# *guards* on TT_DS_PREFILL_{TTNN,HOST_REF}_CACHE being set (it only validates
+# they're non-None — the real weights come from `weight_cache_path`), so seed
+# those too. For DeepSeek the variant env IS TT_DS_PREFILL_TTNN_CACHE.
+os.environ.setdefault(VARIANT.ttnn_cache_env, VARIANT.ttnn_cache_default)
+os.environ.setdefault("TT_DS_PREFILL_TTNN_CACHE", VARIANT.ttnn_cache_default)
 os.environ.setdefault("TT_DS_PREFILL_HOST_REF_CACHE", DEFAULT_HOST_REF_CACHE)
-
-
-def _resolve_weight_cache_path() -> Path | None:
-    """Mirror the layout produced by the pytest weight_cache_path fixture so
-    we read the same files the cache-populate run wrote:
-      $TT_DS_PREFILL_TTNN_CACHE / deepseek_v3_d_p_{arch}_{N}dev / {sp}x{tp}
-    Defaults to DEFAULT_TTNN_CACHE; returns None only if explicitly set empty."""
-    env_cache = os.environ.get("TT_DS_PREFILL_TTNN_CACHE", DEFAULT_TTNN_CACHE)
-    if not env_cache:
-        return None
-    arch = "bh" if is_blackhole() else "wh"
-    num_devices = ttnn.get_num_devices()
-    sp, tp = GLOBAL_MESH_SHAPE
-    path = Path(env_cache) / f"deepseek_v3_d_p_{arch}_{num_devices}dev" / f"{sp}x{tp}"
-    path.mkdir(parents=True, exist_ok=True)
-    return path
-
-
-def _build_h2d_service(mesh_device: ttnn.MeshDevice) -> ttnn.H2DStreamService:
-    """Construct an H2DStreamService whose per-shard backing tensor matches
-    what `prepare_prefill_input_tensor` would have produced.
-
-    Per-shard target: `(1, 1, isl_per_chip)` uint32 ROW_MAJOR DRAM.
-    Achieved by setting global_spec.shape = `(sp_factor, 1, isl_per_chip)` and
-    mapping `[Shard(0), Replicate]` on a `(sp, tp)` mesh — first axis of the
-    tensor is sharded across mesh rows (sp), nothing else is split.
-
-    No `worker_cores`, no metadata: Mode 1 only. Per-iter usage is
-    `forward_to_tensor_bytes(...) -> barrier() -> consume the backing tensor
-    via the standard FD-dispatched embedding op` (see run_standalone_loop).
-    """
-    sp_factor, tp_factor = GLOBAL_MESH_SHAPE
-    assert MAX_SEQ_LEN % sp_factor == 0, f"MAX_SEQ_LEN={MAX_SEQ_LEN} must be divisible by sp_factor={sp_factor}"
-    isl_per_chip = MAX_SEQ_LEN // sp_factor
-    per_chip_bytes = isl_per_chip * 4  # uint32
-
-    global_spec = _make_global_spec()
-    mapper = ttnn.create_mesh_mapper(
-        mesh_device,
-        H2D_MAPPER_CONFIG,
-    )
-    # worker_cores set so the service-core kernel multicasts a data-ready inc
-    # after each transfer; h2d_socket_sync() waits on that on-device, which
-    # avoids the host-side barrier() round-trip per iteration.
-    # metadata_size_bytes set so the producer can ship per-iter control bytes
-    # (slot_id, actual_start, actual_end) inline with the token push.
-    service = ttnn.H2DStreamService(
-        mesh_device=mesh_device,
-        global_spec=global_spec,
-        fifo_size_bytes=8 * per_chip_bytes,  # 8 in-flight pages of headroom
-        scratch_cb_size_bytes=per_chip_bytes,  # one page; service requires >= page_size
-        mapper=mapper,
-        worker_cores=H2D_SYNC_WORKER_CORES,
-        metadata_size_bytes=H2D_METADATA_SIZE_BYTES,
-    )
-    logger.info(
-        f"[h2d] H2DStreamService built: global_shape=({sp_factor},1,{isl_per_chip}) "
-        f"uint32 ROW_MAJOR DRAM, per_chip_bytes={per_chip_bytes}, "
-        f"worker_cores={H2D_SYNC_WORKER_CORES}"
-    )
-    return service
-
-
-def _make_global_spec() -> ttnn.TensorSpec:
-    """Per-iter input spec used by `_build_h2d_service` to set the service's
-    global tensor shape (the producer matches it on the host side).
-    Shape `(sp_factor, 1, isl_per_chip)` uint32 ROW_MAJOR DRAM."""
-    sp_factor = GLOBAL_MESH_SHAPE[0]
-    isl_per_chip = MAX_SEQ_LEN // sp_factor
-    return ttnn.TensorSpec(
-        shape=ttnn.Shape([sp_factor, 1, isl_per_chip]),
-        dtype=ttnn.uint32,
-        layout=ttnn.ROW_MAJOR_LAYOUT,
-        buffer_type=ttnn.BufferType.DRAM,
-    )
 
 
 def run_standalone_loop(pipeline: TtDeepSeekPrefillPipeline) -> None:
@@ -296,8 +201,10 @@ def _print_config() -> None:
     """Print all env var values at startup so the config is visible in logs."""
     UNSET = "<NOT SET>"
     rows = [
-        ("DEEPSEEK_V3_HF_MODEL", os.environ.get("DEEPSEEK_V3_HF_MODEL", UNSET)),
-        ("TT_DS_PREFILL_TTNN_CACHE", os.environ.get("TT_DS_PREFILL_TTNN_CACHE", DEFAULT_TTNN_CACHE)),
+        ("PREFILL_MODEL_VARIANT", VARIANT.name),
+        (VARIANT.hf_model_env, os.environ.get(VARIANT.hf_model_env, VARIANT.hf_model_default)),
+        (VARIANT.ttnn_cache_env, os.environ.get(VARIANT.ttnn_cache_env, VARIANT.ttnn_cache_default)),
+        ("resolved weight_cache_path", str(resolve_weight_cache_path(VARIANT, GLOBAL_MESH_SHAPE))),
         ("PREFILL_SP", str(_sp)),
         ("PREFILL_TP", str(_tp)),
         ("PREFILL_NUM_LAYERS", str(NUM_LAYERS)),
@@ -332,12 +239,12 @@ def main() -> None:
         f"migration={'ON (KV chunk table publish)' if enable_migration else 'OFF'}"
     )
 
-    mesh_device = _open_mesh_device()
+    mesh_device = open_mesh_device(GLOBAL_MESH_SHAPE, MODEL_CFG)
 
-    hf_config = _load_hf_config()
+    hf_config = load_hf_config(VARIANT)
     hf_config.max_seq_len = MAX_SEQ_LEN
 
-    cache_path = _resolve_weight_cache_path()
+    cache_path = resolve_weight_cache_path(VARIANT, GLOBAL_MESH_SHAPE)
     pipeline_config = TtPrefillPipelineConfig(
         num_layers=NUM_LAYERS,
         max_seq_len=MAX_SEQ_LEN,
@@ -347,6 +254,7 @@ def main() -> None:
         capacity_factor=CAPACITY_FACTOR,
         gate_fallback_mode=GateComputeMode[_gate_mode_name],
         weight_cache_path=cache_path,
+        model_cfg=MODEL_CFG,
     )
 
     pipeline = TtDeepSeekPrefillPipeline(
@@ -395,7 +303,14 @@ def main() -> None:
         # service cores don't fit a single custom sub-device. Revert to the
         # default whole-chip sub-device so the service program validates.
         mesh_device.clear_loaded_sub_device_manager()
-        h2d_service = _build_h2d_service(mesh_device)
+        h2d_service = build_h2d_service(
+            mesh_device,
+            mesh_shape=GLOBAL_MESH_SHAPE,
+            max_seq_len=MAX_SEQ_LEN,
+            mapper_config=H2D_MAPPER_CONFIG,
+            worker_cores=H2D_SYNC_WORKER_CORES,
+            metadata_size_bytes=H2D_METADATA_SIZE_BYTES,
+        )
         service_id = os.environ.get("PREFILL_H2D_SERVICE_ID", "ds_prefill")
         descriptor_path = h2d_service.export_descriptor(service_id)
         logger.info(

--- a/models/demos/deepseek_v3_d_p/tt/runners/runner_utils.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/runner_utils.py
@@ -8,11 +8,211 @@ on blaze (`_migration`, `_mpi_test_helpers`). Migration-coupled diagnostics
 live in blaze at `disaggregation/migration/python/prefill_runner_util.py`.
 """
 
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
 import torch
 from loguru import logger
+from transformers import AutoConfig
 
 import ttnn
+from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
 from models.demos.deepseek_v3_d_p.tt.mla.utils import create_balanced_chunk_order, reorder_tensor_chunks
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import create_fabric_router_config
+
+
+# ---------------------------------------------------------------------------
+# Model-variant registry
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class RunnerVariant:
+    """Per-model knobs the runner needs to build a DeepSeek-V3-family model.
+
+    The TT layer code is variant-agnostic — it takes `model_config` (the static
+    dimension constants) + the HF `config`. Everything here is the runner-side
+    plumbing that differs per model: where to find the HF config and the TTNN
+    weight cache, and the sensible defaults for input layout / gate mode.
+    """
+
+    name: str  # matches the pytest weight-cache dir prefix: {name}_{arch}_{N}dev
+    model_config: type  # DeepSeekV3Config | KimiK26Config
+    hf_model_env: str  # env var holding the HF model dir (for config.json)
+    hf_model_default: str
+    ttnn_cache_env: str  # env var holding the TTNN weight-cache root
+    ttnn_cache_default: str
+    default_is_balanced: bool
+    default_gate_mode: str  # GateComputeMode name
+
+
+VARIANTS = {
+    "deepseek_v3_d_p": RunnerVariant(
+        name="deepseek_v3_d_p",
+        model_config=DeepSeekV3Config,
+        hf_model_env="DEEPSEEK_V3_HF_MODEL",
+        hf_model_default="models/demos/deepseek_v3/reference",
+        ttnn_cache_env="TT_DS_PREFILL_TTNN_CACHE",
+        ttnn_cache_default="/mnt/models/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill_secure",
+        default_is_balanced=True,
+        default_gate_mode="DEVICE_FP32",
+    ),
+    "kimi_k2_6": RunnerVariant(
+        name="kimi_k2_6",
+        model_config=KimiK26Config,
+        hf_model_env="KIMI_K2_6_HF_MODEL",
+        # Repo-local config (dot-free, in-tree) — same default the pytest
+        # `kimi_k2_6` variant uses (model_variants.py default_local_path). The
+        # runner only needs config dims; real weights come from the TTNN cache.
+        # To use a different checkpoint, set KIMI_K2_6_HF_MODEL to a dot-free
+        # path (transformers' trust_remote_code import chokes on the "." in the
+        # canonical /mnt/models/moonshotai/Kimi-K2.6-dequantized dir name).
+        hf_model_default="models/demos/deepseek_v3_d_p/reference/kimi_k2_6",
+        ttnn_cache_env="TT_KIMI_PREFILL_TTNN_CACHE",
+        ttnn_cache_default="/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill",
+        default_is_balanced=False,  # Kimi is validated only in non_balanced layout
+        default_gate_mode="HOST_ALL",  # Kimi (1 expert group) is validated only with the host gate
+    ),
+}
+
+
+def get_variant(name: str) -> RunnerVariant:
+    """Resolve a RunnerVariant by name; raises KeyError with the valid set."""
+    try:
+        return VARIANTS[name]
+    except KeyError:
+        raise KeyError(f"Unknown PREFILL_MODEL_VARIANT={name!r}; valid: {sorted(VARIANTS)}")
+
+
+# ---------------------------------------------------------------------------
+# HF config loading
+# ---------------------------------------------------------------------------
+def unwrap_multimodal_config(cfg):
+    """Unwrap Kimi K2.5/K2.6's multimodal wrapper config to the inner text_config.
+
+    The LM fields the rest of the code reads (hidden_size, n_routed_experts, ...)
+    live under `text_config`. Also stubs `quantization_config.weight_block_size`
+    when missing so DSv3's dequant helper's eager read doesn't fail on the
+    pre-dequantized Kimi checkpoint. Mirrors the test-side helper in conftest.py.
+    """
+    if hasattr(cfg, "text_config") and hasattr(cfg.text_config, "hidden_size"):
+        logger.info(f"Unwrapping multimodal wrapper config (inner model_type={cfg.text_config.model_type})")
+        cfg = cfg.text_config
+    qc = getattr(cfg, "quantization_config", None)
+    if isinstance(qc, dict) and not qc.get("weight_block_size"):
+        qc["weight_block_size"] = [128, 128]
+        logger.info("Stubbed quantization_config.weight_block_size for pre-dequantized checkpoint")
+    return cfg
+
+
+def load_hf_config(variant: RunnerVariant):
+    """Load (and unwrap) the HF config for a variant from its `hf_model_env`
+    (falling back to the variant's repo-local default)."""
+    model_path = os.environ.get(variant.hf_model_env) or variant.hf_model_default
+    logger.info(f"Loading HF config for variant={variant.name!r} from {model_path}")
+    cfg = AutoConfig.from_pretrained(model_path, trust_remote_code=True)
+    return unwrap_multimodal_config(cfg)
+
+
+# ---------------------------------------------------------------------------
+# Device / weight-cache / H2D-service setup
+# ---------------------------------------------------------------------------
+def open_mesh_device(mesh_shape: tuple, model_cfg: type) -> ttnn.MeshDevice:
+    """Configure fabric (1D for sp<=8, else 2D) and open the mesh device."""
+    sp = mesh_shape[0]
+    fabric_config = ttnn.FabricConfig.FABRIC_1D if sp <= 8 else ttnn.FabricConfig.FABRIC_2D
+
+    fabric_router_config = create_fabric_router_config(
+        max_payload_size=model_cfg.FABRIC_PAYLOAD_SIZE,
+    )
+
+    ttnn.set_fabric_config(
+        fabric_config,
+        ttnn.FabricReliabilityMode.RELAXED_INIT,
+        None,
+        ttnn.FabricTensixConfig.DISABLED,
+        ttnn.FabricUDMMode.DISABLED,
+        ttnn.FabricManagerMode.DEFAULT,
+        fabric_router_config,
+    )
+    return ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(*mesh_shape))
+
+
+def resolve_weight_cache_path(variant: RunnerVariant, mesh_shape: tuple) -> Optional[Path]:
+    """Mirror the layout produced by the pytest weight_cache_path fixture so
+    we read the same files the cache-populate run wrote:
+      $<variant.ttnn_cache_env> / {variant.name}_{arch}_{N}dev / {sp}x{tp}
+    Defaults to the variant's cache root; returns None only if explicitly empty."""
+    env_cache = os.environ.get(variant.ttnn_cache_env, variant.ttnn_cache_default)
+    if not env_cache:
+        return None
+    arch = "bh" if is_blackhole() else "wh"
+    num_devices = ttnn.get_num_devices()
+    sp, tp = mesh_shape
+    path = Path(env_cache) / f"{variant.name}_{arch}_{num_devices}dev" / f"{sp}x{tp}"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def make_global_spec(mesh_shape: tuple, max_seq_len: int) -> ttnn.TensorSpec:
+    """Per-iter input spec used by `build_h2d_service` to set the service's
+    global tensor shape (the producer matches it on the host side).
+    Shape `(sp_factor, 1, isl_per_chip)` uint32 ROW_MAJOR DRAM."""
+    sp_factor = mesh_shape[0]
+    isl_per_chip = max_seq_len // sp_factor
+    return ttnn.TensorSpec(
+        shape=ttnn.Shape([sp_factor, 1, isl_per_chip]),
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        buffer_type=ttnn.BufferType.DRAM,
+    )
+
+
+def build_h2d_service(
+    mesh_device: ttnn.MeshDevice,
+    *,
+    mesh_shape: tuple,
+    max_seq_len: int,
+    mapper_config: ttnn.MeshMapperConfig,
+    worker_cores: ttnn.CoreRange,
+    metadata_size_bytes: int,
+) -> ttnn.H2DStreamService:
+    """Construct an H2DStreamService whose per-shard backing tensor matches
+    what `prepare_prefill_input_tensor` would have produced.
+
+    Per-shard target: `(1, 1, isl_per_chip)` uint32 ROW_MAJOR DRAM.
+    Achieved by setting global_spec.shape = `(sp_factor, 1, isl_per_chip)` and
+    mapping `[Shard(0), Replicate]` on a `(sp, tp)` mesh — first axis of the
+    tensor is sharded across mesh rows (sp), nothing else is split.
+    """
+    sp_factor, tp_factor = mesh_shape
+    assert max_seq_len % sp_factor == 0, f"max_seq_len={max_seq_len} must be divisible by sp_factor={sp_factor}"
+    isl_per_chip = max_seq_len // sp_factor
+    per_chip_bytes = isl_per_chip * 4  # uint32
+
+    global_spec = make_global_spec(mesh_shape, max_seq_len)
+    mapper = ttnn.create_mesh_mapper(mesh_device, mapper_config)
+    # worker_cores set so the service-core kernel multicasts a data-ready inc
+    # after each transfer; h2d_socket_sync() waits on that on-device, which
+    # avoids the host-side barrier() round-trip per iteration.
+    # metadata_size_bytes set so the producer can ship per-iter control bytes
+    # (slot_id, actual_start, actual_end) inline with the token push.
+    service = ttnn.H2DStreamService(
+        mesh_device=mesh_device,
+        global_spec=global_spec,
+        fifo_size_bytes=8 * per_chip_bytes,  # 8 in-flight pages of headroom
+        scratch_cb_size_bytes=per_chip_bytes,  # one page; service requires >= page_size
+        mapper=mapper,
+        worker_cores=worker_cores,
+        metadata_size_bytes=metadata_size_bytes,
+    )
+    logger.info(
+        f"[h2d] H2DStreamService built: global_shape=({sp_factor},1,{isl_per_chip}) "
+        f"uint32 ROW_MAJOR DRAM, per_chip_bytes={per_chip_bytes}, worker_cores={worker_cores}"
+    )
+    return service
 
 
 def prepare_prefill_input_tensor(

--- a/models/demos/deepseek_v3_d_p/tt/tt_deepseek_prefill_pipeline.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_deepseek_prefill_pipeline.py
@@ -50,6 +50,10 @@ class TtPrefillPipelineConfig:
     shared_expert_activations_dtype: ttnn.DataType = ttnn.bfloat16
     shared_expert_weights_dtype: ttnn.DataType = ttnn.bfloat8_b
     weight_cache_path: Optional[Path] = None
+    # Static model-dimension constants for the variant being built
+    # (DeepSeekV3Config | KimiK26Config). Drives expert counts, dense-layer
+    # count, route groups, etc. in the TT layer code.
+    model_cfg: type = DeepSeekV3Config
 
     @property
     def sp_factor(self) -> int:
@@ -87,11 +91,15 @@ class TtDeepSeekPrefillPipeline:
             f"num_layers={self.config.num_layers}, max_seq_len={self.config.max_seq_len}, "
             f"mesh_shape={self.config.mesh_shape}, is_balanced={self.config.is_balanced}"
         )
+        model_cfg = self.config.model_cfg
         if self.config.weight_cache_path:
             num_devices = self.config.mesh_shape[0] * self.config.mesh_shape[1]
-            experts_per_chip = 256 // num_devices
+            experts_per_chip = model_cfg.NUM_ROUTED_EXPERTS // num_devices
             if TtPrefillTransformer.check_cache_complete(
-                self.config.weight_cache_path, self.config.num_layers, experts_per_chip
+                self.config.weight_cache_path,
+                self.config.num_layers,
+                experts_per_chip,
+                first_k_dense=model_cfg.NUM_DENSE_LAYERS,
             ):
                 logger.info(f"TTNN weight cache complete at {self.config.weight_cache_path}; loading from disk")
             else:
@@ -103,7 +111,7 @@ class TtDeepSeekPrefillPipeline:
         self.model = TtPrefillTransformer(
             mesh_device=self.mesh_device,
             config=self.hf_config,
-            model_cfg=DeepSeekV3Config,
+            model_cfg=model_cfg,
             state_dict=state_dict,
             num_layers=self.config.num_layers,
             seq_len=self.config.max_seq_len,


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-kimi-k2.6)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/prefill-kimi-k2.6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/prefill-kimi-k2.6)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/prefill-kimi-k2.6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jjovicic/prefill-kimi-k2.6)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jjovicic/prefill-kimi-k2.6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/prefill-kimi-k2.6)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/prefill-kimi-k2.6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/prefill-kimi-k2.6)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/prefill-kimi-k2.6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/prefill-kimi-k2.6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/prefill-kimi-k2.6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/prefill-kimi-k2.6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/prefill-kimi-k2.6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/prefill-kimi-k2.6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/prefill-kimi-k2.6)