### PR TITLE
Feature/Performance: MoE: proper(er) TP sharding for shared expert in `moe_compute`

### DIFF
--- a/models/common/modules/moe/tt_moe_decode.py
+++ b/models/common/modules/moe/tt_moe_decode.py
@@ -392,7 +392,13 @@ class _TTMoEDecodeExpertState:
             )
             routed_w0, routed_w1, routed_w2 = tt_w0, tt_w1, tt_w2
             tt_w0, tt_w1, tt_w2 = ttnn.experimental.add_shared_expert_weights(
-                routed_w0, routed_w1, routed_w2, tt_shared_w0, tt_shared_w1, tt_shared_w2
+                routed_w0,
+                routed_w1,
+                routed_w2,
+                tt_shared_w0,
+                tt_shared_w1,
+                tt_shared_w2,
+                cluster_axis=cluster_axis,
             )
             for t in (routed_w0, routed_w1, routed_w2, tt_shared_w0, tt_shared_w1, tt_shared_w2):
                 ttnn.deallocate(t)

--- a/models/common/modules/moe/tt_moe_decode.py
+++ b/models/common/modules/moe/tt_moe_decode.py
@@ -163,6 +163,17 @@ class _TTMoEDecodeExpertState:
                     f"shared_expert_ids_to_devices has {len(shared_expert_ids_to_devices)} entries "
                     f"but num_shared_experts={num_shared_experts}"
                 )
+
+            shared_experts_per_device = [0] * num_devices
+            for edl in shared_expert_ids_to_devices.values():
+                for d in edl:
+                    shared_experts_per_device[d] += 1
+            if len(set(shared_experts_per_device)) > 1 or 0 in shared_experts_per_device:
+                raise ValueError(
+                    "Every device, should have the same number of, and at least 1 shared expert:"
+                    f" {shared_experts_per_device=}"
+                )
+
             expected_ids = set(range(num_routed_experts, num_routed_experts + num_shared_experts))
             if set(shared_expert_ids_to_devices.keys()) != expected_ids:
                 raise ValueError(

--- a/models/common/modules/moe/tt_moe_decode_config.py
+++ b/models/common/modules/moe/tt_moe_decode_config.py
@@ -220,11 +220,14 @@ class ComputeConfig(_TTOpKwargs):
     has_bias: bool
     activation_type: ActivationFunction
     intermediate_size: int
-    num_shared_experts: int
+    # Splatted into moe_compute as `num_shared_experts_per_device`. This is the *physical*
+    # per-device shared-expert count, derived by the parent from `shared_expert_ids_to_devices`
+    # (see TTMoEDecodeConfig._shared_experts_per_device) — NOT the logical `num_shared_experts`.
+    num_shared_experts_per_device: int
 
     @classmethod
     def adopt_fields(cls) -> set[str]:
-        return {"cluster_axis", "has_bias", "num_shared_experts"}
+        return {"cluster_axis", "has_bias", "num_shared_experts_per_device"}
 
 
 class PostCombineTilizeConfig(_TTOpKwargs):
@@ -480,6 +483,35 @@ class TTMoEDecodeConfig(BaseModel):
         "topology",
     )
 
+    @staticmethod
+    def _shared_experts_per_device(shared_expert_ids_to_devices: Any, num_devices: int, num_shared_experts: int) -> int:
+        """Number of *physical* shared experts resident on each device.
+
+        This is what `moe_compute` wants as `num_shared_experts_per_device`, and it is
+        NOT the logical `num_shared_experts`. It is derived from
+        `shared_expert_ids_to_devices` (global shared-expert id → list of hosting device
+        linear ids): fully-replicated placement puts every shared expert on every device
+        (per-device count == num_shared_experts), while a distributed placement (each
+        shared expert on a subset of devices) yields a smaller, uniform per-device count.
+        e.g. 2 shared experts each residing on half the devices → 1 per device.
+        """
+        if not num_shared_experts:
+            return 0
+        # None or the "fully_replicated" convenience keyword (not yet expanded at this
+        # point): every shared expert resides on every device.
+        if shared_expert_ids_to_devices is None or isinstance(shared_expert_ids_to_devices, str):
+            return num_shared_experts
+        counts = [0] * num_devices
+        for devices in shared_expert_ids_to_devices.values():
+            for device_id in devices:
+                counts[device_id] += 1
+        if len(set(counts)) != 1:
+            raise ValueError(
+                "shared_expert_ids_to_devices must place an equal number of shared experts on every "
+                f"device to derive num_shared_experts_per_device; got per-device counts {counts}"
+            )
+        return counts[0]
+
     @classmethod
     def _adoptable(cls, data: dict[str, Any]) -> dict[str, Any]:
         """Full lookup of values sub-configs may adopt by name.
@@ -523,6 +555,20 @@ class TTMoEDecodeConfig(BaseModel):
         pre_split_chunk = resolved["hidden_size"] // num_fast_reduce_outputs
         split_size = ((pre_split_chunk + align_unit - 1) // align_unit) * align_unit
 
+        # Derive the *physical* per-device shared-expert count moe_compute wants from the
+        # experts sub-config's device assignment. Use only `.values()` (device-id lists),
+        # so the dict/str/None and JSON-stringified-key forms all work uniformly.
+        experts_data = data.get("experts")
+        if isinstance(experts_data, BaseModel):
+            shared_expert_ids_to_devices = getattr(experts_data, "shared_expert_ids_to_devices", None)
+        elif isinstance(experts_data, dict):
+            shared_expert_ids_to_devices = experts_data.get("shared_expert_ids_to_devices")
+        else:
+            shared_expert_ids_to_devices = None
+        num_shared_experts_per_device = cls._shared_experts_per_device(
+            shared_expert_ids_to_devices, prod(resolved["mesh_shape"]), resolved["num_shared_experts"]
+        )
+
         return {
             **resolved,
             # derived
@@ -530,6 +576,7 @@ class TTMoEDecodeConfig(BaseModel):
             "split_size": split_size,
             "num_fast_reduce_outputs": num_fast_reduce_outputs,
             "effective_experts_k": resolved["select_experts_k"] + resolved["num_shared_experts"],
+            "num_shared_experts_per_device": num_shared_experts_per_device,
         }
 
     @model_validator(mode="before")

--- a/models/common/modules/moe/tt_moe_decode_config.py
+++ b/models/common/modules/moe/tt_moe_decode_config.py
@@ -220,10 +220,11 @@ class ComputeConfig(_TTOpKwargs):
     has_bias: bool
     activation_type: ActivationFunction
     intermediate_size: int
+    num_shared_experts: int
 
     @classmethod
     def adopt_fields(cls) -> set[str]:
-        return {"cluster_axis", "has_bias"}
+        return {"cluster_axis", "has_bias", "num_shared_experts"}
 
 
 class PostCombineTilizeConfig(_TTOpKwargs):

--- a/models/common/modules/moe/tt_moe_decode_config.py
+++ b/models/common/modules/moe/tt_moe_decode_config.py
@@ -626,22 +626,6 @@ class TTMoEDecodeConfig(BaseModel):
             elif isinstance(dispatch_data, BaseModel) and getattr(dispatch_data, "shared_expert_ids", None) is None:
                 data["dispatch"] = dispatch_data.model_copy(update={"shared_expert_ids": shared_ids})
 
-        # The YAML/input `reduce.shared_expert_scale` is the LOGICAL scale (single
-        # contribution per token). Each replica device emits the shared-expert output
-        # independently and reduce-scatter sums them, so the kernel-ready scale is
-        # `logical / num_replicated`. Apply here so the stored field == what the
-        # kernel sees; callers that need to round-trip must un-scale first
-        # (`with_mesh_shape` does this).
-        num_replicated = adoptable["mesh_shape"][1 - adoptable["cluster_axis"]]
-        if num_replicated > 1:
-            reduce_data = data.get("reduce")
-            if isinstance(reduce_data, dict) and reduce_data.get("shared_expert_scale") is not None:
-                reduce_data["shared_expert_scale"] = reduce_data["shared_expert_scale"] / num_replicated
-            elif isinstance(reduce_data, BaseModel) and getattr(reduce_data, "shared_expert_scale", None) is not None:
-                data["reduce"] = reduce_data.model_copy(
-                    update={"shared_expert_scale": reduce_data.shared_expert_scale / num_replicated}
-                )
-
         return data
 
     # ---- Test-only mesh slicing ----
@@ -700,30 +684,7 @@ class TTMoEDecodeConfig(BaseModel):
         # the new num_routed_experts.
         if isinstance(data.get("dispatch"), dict):
             data["dispatch"].pop("shared_expert_ids", None)
-        # The dumped `reduce.shared_expert_scale` is the kernel-ready value
-        # (logical / old_num_replicated). Restore the logical value so the
-        # pre-validator can re-divide by the new num_replicated.
-        self._unscale_shared_expert_scale(data)
         return type(self).model_validate(data)
-
-    def _unscale_shared_expert_scale(self, data: dict) -> None:
-        """In-place: convert a dumped `reduce.shared_expert_scale` from the stored
-        kernel-ready value (logical / num_replicated) back to the logical value.
-
-        The pre-validator divides the logical input by `num_replicated` so the
-        stored field matches what the kernel sees. Any path that feeds dumped data
-        back through `model_validate` (mesh slicing, YAML round-trip) must undo that
-        first, otherwise the pre-validator divides a second time and under-scales.
-
-        TODO (AM): This is only necessary because the moe_compute flow does not properly TP shard the shared expert yet
-        https://github.com/tenstorrent/tt-metal/issues/45060
-
-        """
-        num_replicated = self.mesh_shape[1 - self.cluster_axis]
-        if num_replicated > 1 and isinstance(data.get("reduce"), dict):
-            reduce_data = data["reduce"]
-            if reduce_data.get("shared_expert_scale") is not None:
-                reduce_data["shared_expert_scale"] *= num_replicated
 
     @staticmethod
     def _drop_derived_fields(data: dict) -> None:
@@ -746,7 +707,6 @@ class TTMoEDecodeConfig(BaseModel):
         import yaml
 
         data = self.model_dump(mode="json", exclude_defaults=exclude_defaults, exclude_none=exclude_none, **dump_kwargs)
-        self._unscale_shared_expert_scale(data)
         self._drop_derived_fields(data)
         return yaml.safe_dump(data, sort_keys=False)
 

--- a/models/common/tests/modules/moe/test_tt_moe_decode.py
+++ b/models/common/tests/modules/moe/test_tt_moe_decode.py
@@ -252,14 +252,17 @@ def _create_shared_expert_weights(
     c_n = 0.5  # (81.0 / n) ** 0.5
     shared_w0 = {
         sid: ((torch.rand((num_layers, 1, h, n), dtype=torch.float32) - 0.5) * (2.0 * c_h)).to(torch.bfloat16)
+        # sid: torch.ones((num_layers, 1, h, n), dtype=torch.bfloat16)
         for sid in shared_expert_ids
     }
     shared_w1 = {
         sid: ((torch.rand((num_layers, 1, h, n), dtype=torch.float32) - 0.5) * (2.0 * c_h)).to(torch.bfloat16)
+        # sid: torch.ones((num_layers, 1, h, n), dtype=torch.bfloat16)
         for sid in shared_expert_ids
     }
     shared_w2 = {
         sid: ((torch.rand((num_layers, 1, n, h2), dtype=torch.float32) - 0.5) * (2.0 * c_n)).to(torch.bfloat16)
+        # sid: torch.ones((num_layers, 1, n, h2), dtype=torch.bfloat16)
         for sid in shared_expert_ids
     }
     return shared_w0, shared_w1, shared_w2
@@ -286,6 +289,57 @@ def _add_shared_experts_to_golden(
         for t in range(batch):
             contrib = _matmul_golden(tokens[t], w0, w1, w2, activation_type)
             out[t] = out[t] + shared_expert_scale * contrib
+    return out
+
+
+def _add_shared_experts_to_golden_tp(
+    out: torch.Tensor,
+    tokens: torch.Tensor,
+    batch: int,
+    shared_w0: dict[int, torch.Tensor],
+    shared_w1: dict[int, torch.Tensor],
+    shared_w2: dict[int, torch.Tensor],
+    shared_expert_scale: float,
+    activation_type: MoEActivationFunction,
+    num_tp: int,
+) -> torch.Tensor:
+    """Shared-expert golden that mimics the tensor-parallel device path step-for-step.
+
+    Each shared expert's intermediate dim `N` is partitioned into `num_tp` contiguous
+    chunks — one per device along the TP axis (`1 - cluster_axis`). Each device's chunk is
+    zero-padded back to full `N` (front block `[0:N/num_tp]` real, rest zero — exactly the
+    layout `add_shared_expert_weights` produces: W0/W1 padded on the intermediate dim, W2
+    on its row dim), the full-`N` FFN is run on the padded weights to get that device's
+    partial, and the partials are summed (the reduce-scatter), then scaled by
+    `shared_expert_scale`.
+
+    Because SiLU/SwiGLU/GELU are column-separable and each device's W2 rows are zero outside
+    its chunk, the summed partials equal the full FFN — so this matches
+    `_add_shared_experts_to_golden` exactly (modulo bf16 accumulation order). It's written
+    this way on purpose: it tracks what each device actually computes, so if the device
+    output diverges from this golden the fault is in the kernel's handling of the
+    zero-padded TP layout, not the decomposition. No `num_replicated` factor — the sum of
+    disjoint partials is one full copy, not `num_tp` copies.
+    """
+    for sid in shared_w0:
+        w0, w1, w2 = shared_w0[sid], shared_w1[sid], shared_w2[sid]
+        n = w0.shape[-1]
+        assert n % num_tp == 0, f"shared expert intermediate dim {n} not divisible by num_tp {num_tp}"
+        chunk = n // num_tp
+        for t in range(batch):
+            partial_sum = torch.zeros_like(out[t])
+            for d in range(num_tp):
+                lo, hi = d * chunk, (d + 1) * chunk
+                # Device d: its chunk, front-block zero-padded to full N. W0/W1 partition the
+                # intermediate (last) dim; W2 partitions its row (second-to-last) dim.
+                w0_d = torch.zeros_like(w0)
+                w1_d = torch.zeros_like(w1)
+                w2_d = torch.zeros_like(w2)
+                w0_d[..., :chunk] = w0[..., lo:hi]
+                w1_d[..., :chunk] = w1[..., lo:hi]
+                w2_d[..., :chunk, :] = w2[..., lo:hi, :]
+                partial_sum = partial_sum + _matmul_golden(tokens[t], w0_d, w1_d, w2_d, activation_type)
+            out[t] = out[t] + shared_expert_scale * partial_sum
     return out
 
 
@@ -514,19 +568,22 @@ def test_tt_moe_decode(
             b2_per_expert=b2_per_expert,
         )
         if shared_id_to_torch_w0 is not None:
-            # config.reduce.shared_expert_scale is the kernel-ready value (logical / num_replicated).
-            # The post-RS TT output sums num_replicated replicas, so the effective scale at the
-            # final output is the logical value — multiply back.
-            num_replicated = mesh_shape[1 - cluster_axis]
-            golden = _add_shared_experts_to_golden(
+            # The device TP-shards each shared expert's intermediate dim across the replicated
+            # axis (num_tp = mesh_shape[1 - cluster_axis]) and sums the per-device partials, so
+            # the golden mimics that exactly: partition -> zero-pad -> per-device FFN -> sum,
+            # scaled by the raw shared_expert_scale. No num_replicated factor — the disjoint
+            # partials sum to a single full copy (matches the removal of the scale division).
+            num_tp = mesh_shape[1 - cluster_axis]
+            golden = _add_shared_experts_to_golden_tp(
                 golden,
                 tokens,
                 batch,
                 shared_id_to_torch_w0,
                 shared_id_to_torch_w1,
                 shared_id_to_torch_w2,
-                shared_expert_scale=config.reduce.shared_expert_scale * num_replicated,
+                shared_expert_scale=config.reduce.shared_expert_scale,
                 activation_type=config.compute.activation_type,
+                num_tp=num_tp,
             )
         output_goldens.append(golden)
 

--- a/models/common/tests/modules/moe/test_tt_moe_decode.py
+++ b/models/common/tests/modules/moe/test_tt_moe_decode.py
@@ -565,11 +565,6 @@ def test_tt_moe_decode(
             b2_per_expert=b2_per_expert,
         )
         if shared_id_to_torch_w0 is not None:
-            # The device TP-shards each shared expert's intermediate dim across the replicated
-            # axis (num_tp = mesh_shape[1 - cluster_axis]) and sums the per-device partials, so
-            # the golden mimics that exactly: partition -> zero-pad -> per-device FFN -> sum,
-            # scaled by the raw shared_expert_scale. No num_replicated factor — the disjoint
-            # partials sum to a single full copy (matches the removal of the scale division).
             num_tp = mesh_shape[1 - cluster_axis]
             golden = _add_shared_experts_to_golden_tp(
                 golden,
@@ -603,9 +598,6 @@ def test_tt_moe_decode(
             else:
                 final_output = output
             tt_outputs.append(final_output)
-
-            # Surface async device errors immediately rather than letting them
-            # silently corrupt state and then deadlock at mesh_device teardown.
             ttnn.synchronize_device(mesh_device, sub_device_ids=[ttnn.SubDeviceId(0)])
         except Exception as e:
             _print_exception_and_fail(f"forward iteration {it} failed: {type(e).__name__}")

--- a/models/common/tests/modules/moe/test_tt_moe_decode.py
+++ b/models/common/tests/modules/moe/test_tt_moe_decode.py
@@ -252,17 +252,14 @@ def _create_shared_expert_weights(
     c_n = 0.5  # (81.0 / n) ** 0.5
     shared_w0 = {
         sid: ((torch.rand((num_layers, 1, h, n), dtype=torch.float32) - 0.5) * (2.0 * c_h)).to(torch.bfloat16)
-        # sid: torch.ones((num_layers, 1, h, n), dtype=torch.bfloat16)
         for sid in shared_expert_ids
     }
     shared_w1 = {
         sid: ((torch.rand((num_layers, 1, h, n), dtype=torch.float32) - 0.5) * (2.0 * c_h)).to(torch.bfloat16)
-        # sid: torch.ones((num_layers, 1, h, n), dtype=torch.bfloat16)
         for sid in shared_expert_ids
     }
     shared_w2 = {
         sid: ((torch.rand((num_layers, 1, n, h2), dtype=torch.float32) - 0.5) * (2.0 * c_n)).to(torch.bfloat16)
-        # sid: torch.ones((num_layers, 1, n, h2), dtype=torch.bfloat16)
         for sid in shared_expert_ids
     }
     return shared_w0, shared_w1, shared_w2

--- a/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
+++ b/models/demos/deepseek_v3/tests/fused_op_unit_tests/moe/test_optimized_moe_decode_block.py
@@ -9,18 +9,14 @@ import pytest
 import torch
 from loguru import logger
 from ttnn.experimental.moe_compute_utils import (
-    add_shared_expert_weights,
-    get_shared_experts_per_device,
     get_weight_core_shard_maps,
     get_weight_mem_configs,
-    map_shared_experts,
     prepare_w0_w1_tensor_for_moe_compute,
     prepare_w2_tensor_for_moe_compute,
 )
 
 import ttnn
 from models.common.utility_functions import comp_allclose, comp_pcc
-from tests.nightly.tg.ccl.moe.test_all_to_all_dispatch_metadata_6U import get_shared_expert_to_device_map
 
 
 def tt_to_torch_dtype(tt_dtype):
@@ -387,34 +383,6 @@ def gen_combine_golden(
     return torch_combine_ref_tensor, valid_mask
 
 
-def _add_shared_experts_to_combine_golden(
-    batch,
-    torch_combine_golden,
-    torch_combine_valid_mask,
-    torch_dispatch_input_tensor,
-    shared_id_to_w0,
-    shared_id_to_w1,
-    shared_id_to_w2,
-):
-    combine_output_shape = torch_combine_golden.shape
-
-    shared_expert_contrib_shape = [len(shared_id_to_w0)] + list(combine_output_shape)[1:]
-    shared_expert_contribs = torch.zeros(shared_expert_contrib_shape, dtype=torch_combine_golden.dtype)
-    shared_valid_mask = torch.zeros(len(shared_id_to_w0), torch_combine_valid_mask.shape[1], dtype=torch.bool)
-
-    for e, (w0, w1, w2) in enumerate(zip(shared_id_to_w0.values(), shared_id_to_w1.values(), shared_id_to_w2.values())):
-        for b in range(batch):
-            token = torch_dispatch_input_tensor[b, :, :, :]
-            contrib = gen_matmul_golden(token, w0, w1, w2)
-            shared_expert_contribs[e, b, :] = contrib[0, 0, 0, :]
-            shared_valid_mask[e, b] = True
-
-    return (
-        torch.cat([torch_combine_golden, shared_expert_contribs], dim=0),
-        torch.cat([torch_combine_valid_mask, shared_valid_mask], dim=0),
-    )
-
-
 def verify_combine(
     iteration, mesh_device, mesh_shape, cluster_axis, tt_combine_tensor, torch_combine_golden, torch_combine_valid_mask
 ):
@@ -499,25 +467,6 @@ def gen_output_golden(
     return output_reference
 
 
-def _add_shared_experts_to_output_golden(
-    batch,
-    torch_output_golden,
-    torch_dispatch_input_tensor,
-    shared_id_to_w0,
-    shared_id_to_w1,
-    shared_id_to_w2,
-    torch_shared_expert_scores,
-):
-    for e, (w0, w1, w2) in enumerate(zip(shared_id_to_w0.values(), shared_id_to_w1.values(), shared_id_to_w2.values())):
-        for b in range(batch):
-            token = torch_dispatch_input_tensor[b, :, :, :]
-            contrib = gen_matmul_golden(token, w0, w1, w2)
-
-            torch_output_golden[b, :, :, :] += torch_shared_expert_scores[b, 0, 0, e] * contrib[0]
-
-    return torch_output_golden
-
-
 def verify_output(
     iteration,
     mesh_device,
@@ -560,31 +509,6 @@ def verify_output(
     return pcc_passed and allclose_passed
 
 
-def _expert_list_to_tensor(expert_list: list[torch.Tensor]) -> torch.Tensor:
-    """Convert list of expert tensors to a single concatenated tensor.
-
-    Args:
-        expert_list: List of tensors, each of shape (layers, 1, ...)
-
-    Returns:
-        Single tensor of shape (layers, num_experts, ...)
-    """
-    return torch.cat(expert_list, dim=1)
-
-
-def _expert_tensor_to_list(expert_tensor: torch.Tensor) -> list[torch.Tensor]:
-    """Convert concatenated expert tensor back to list of individual expert tensors.
-
-    Args:
-        expert_tensor: Tensor of shape (layers, num_experts, ...)
-
-    Returns:
-        List of tensors, each of shape (layers, 1, ...)
-    """
-    num_experts = expert_tensor.shape[1]
-    return [expert_tensor[:, i : i + 1, ...] for i in range(num_experts)]
-
-
 @pytest.mark.requires_device(["QUAD"])
 @pytest.mark.skipif(
     (os.getenv("USE_TORUS_MODE", "0") == "0"),
@@ -624,7 +548,6 @@ def _expert_tensor_to_list(expert_tensor: torch.Tensor) -> list[torch.Tensor]:
     ids=["fabric_1D_ring"],
     indirect=True,
 )
-@pytest.mark.parametrize("shared_expert_mode", ["no_shared", "all_shared", "alternate_shared"])
 @torch.no_grad()
 def test_optimized_moe_decode_block(
     mesh_shape,
@@ -645,7 +568,6 @@ def test_optimized_moe_decode_block(
     combine_token_parallel_core_dim,
     enable_trace,
     num_iterations,
-    shared_expert_mode,
 ):
     ############################################
     # initial setup
@@ -663,22 +585,6 @@ def test_optimized_moe_decode_block(
 
     routed_experts = routed_experts_per_device * num_devices
     routed_experts_per_cluster = routed_experts // num_replicated_devices
-
-    shared_expert_ids_to_devices = get_shared_expert_to_device_map(routed_experts, num_devices, shared_expert_mode)
-    if shared_expert_ids_to_devices is not None:
-        total_experts_per_device = (
-            routed_experts_per_device + get_shared_experts_per_device(shared_expert_ids_to_devices, num_devices)[0]
-        )
-        total_experts = total_experts_per_device * num_devices
-        total_experts_per_cluster = total_experts_per_device * num_dispatch_devices
-        num_shared_experts = len(shared_expert_ids_to_devices)
-        effective_experts_k = select_experts_k + num_shared_experts
-    else:
-        total_experts_per_device = routed_experts_per_device
-        total_experts = routed_experts
-        total_experts_per_cluster = routed_experts_per_cluster
-        effective_experts_k = select_experts_k
-        num_shared_experts = 0
 
     if cluster_axis == 1:
         shard_dims = (None, shard_dim)
@@ -709,7 +615,7 @@ def test_optimized_moe_decode_block(
     ############################################
     # create constant input tensors
     ############################################
-    logger.info(f"Begin creating constant input tensors. {total_experts=} {total_experts_per_device=}")
+    logger.info(f"Begin creating constant input tensors. {routed_experts=} {routed_experts_per_device=}")
 
     expert_mapping_dtype = ttnn.uint16
     torch_expert_mapping = create_torch_expert_mapping_tensor(
@@ -721,14 +627,6 @@ def test_optimized_moe_decode_block(
         routed_experts_per_device,
         expert_mapping_dtype,
     )
-
-    shared_expert_score = 1 / 2.5
-    if shared_expert_ids_to_devices is not None:
-        torch_expert_mapping = map_shared_experts(
-            torch_expert_mapping, shared_expert_ids_to_devices, mesh_shape, cluster_axis
-        )
-        # the inverse of the routed scaling factor
-        torch_shared_expert_scores = torch.full([batch, 1, seq, num_shared_experts], shared_expert_score)
 
     tt_expert_mapping = ttnn.from_torch(
         torch_expert_mapping,
@@ -746,50 +644,6 @@ def test_optimized_moe_decode_block(
     torch_w1_tensors = create_torch_w1_tensors(num_layers, routed_experts, hidden_size, matmul_N)
     torch_w2_tensors = create_torch_w2_tensors(num_layers, routed_experts, matmul_N, hidden_size)
 
-    if shared_expert_ids_to_devices is not None:
-        logger.info("Creating and adding shared expert weights")
-        shared_id_to_w0 = {
-            sid: create_torch_w0_tensors(num_layers, 1, hidden_size, matmul_N)[0]
-            for sid in shared_expert_ids_to_devices
-        }
-        shared_id_to_w1 = {
-            sid: create_torch_w1_tensors(num_layers, 1, hidden_size, matmul_N)[0]
-            for sid in shared_expert_ids_to_devices
-        }
-        shared_id_to_w2 = {
-            sid: create_torch_w2_tensors(num_layers, 1, matmul_N, hidden_size)[0]
-            for sid in shared_expert_ids_to_devices
-        }
-
-        # Convert lists to tensors for add_shared_expert_weights
-        routed_w0_tensor = _expert_list_to_tensor(torch_w0_tensors)
-        routed_w1_tensor = _expert_list_to_tensor(torch_w1_tensors)
-        routed_w2_tensor = _expert_list_to_tensor(torch_w2_tensors)
-
-        # Add shared expert weights
-        # note the API of this function is consistent with usage in the model but requires a couple of helpers in this
-        # test setup
-        combined_w0_tensor, combined_w1_tensor, combined_w2_tensor = add_shared_expert_weights(
-            routed_w0_tensor,
-            routed_w1_tensor,
-            routed_w2_tensor,
-            shared_id_to_w0,
-            shared_id_to_w1,
-            shared_id_to_w2,
-            shared_expert_ids_to_devices,
-            num_devices,
-        )
-
-        # Convert back to lists for compatibility with the rest of the test
-        torch_total_w0_tensors = _expert_tensor_to_list(combined_w0_tensor)
-        torch_total_w1_tensors = _expert_tensor_to_list(combined_w1_tensor)
-        torch_total_w2_tensors = _expert_tensor_to_list(combined_w2_tensor)
-        logger.info("Done adding shared expert weights")
-    else:
-        torch_total_w0_tensors = torch_w0_tensors
-        torch_total_w1_tensors = torch_w1_tensors
-        torch_total_w2_tensors = torch_w2_tensors
-
     w0_w1_shard_map, w2_shard_map, compute_matmul_dram_core_range_set = get_weight_core_shard_maps(
         mesh_device, hidden_size, matmul_N
     )
@@ -799,23 +653,23 @@ def test_optimized_moe_decode_block(
     # Finally, order merged weights in accordance to linearized_mesh_coord ordering
     torch_w0_w1_reordered_tensors = [None] * num_devices
     torch_w2_reordered_tensors = [None] * num_devices
-    for e in range(0, total_experts, total_experts_per_device):
+    for e in range(0, routed_experts, routed_experts_per_device):
         # [L, 1, H, N] -> [L, E/D, H, N]
-        torch_w0 = torch.cat([torch_total_w0_tensors[e + i] for i in range(total_experts_per_device)], dim=1)
+        torch_w0 = torch.cat([torch_w0_tensors[e + i] for i in range(routed_experts_per_device)], dim=1)
         # [L, 1, H, N] -> [L, E/D, H, N]
-        torch_w1 = torch.cat([torch_total_w1_tensors[e + i] for i in range(total_experts_per_device)], dim=1)
+        torch_w1 = torch.cat([torch_w1_tensors[e + i] for i in range(routed_experts_per_device)], dim=1)
         # [L, 1, N, H] -> [L, E/D, N, H]
-        torch_w2 = torch.cat([torch_total_w2_tensors[e + i] for i in range(total_experts_per_device)], dim=1)
+        torch_w2 = torch.cat([torch_w2_tensors[e + i] for i in range(routed_experts_per_device)], dim=1)
 
         torch_w0_w1_reordered = prepare_w0_w1_tensor_for_moe_compute(
-            torch_w0, torch_w1, num_layers, total_experts_per_device, hidden_size, matmul_N, w0_w1_shard_map
+            torch_w0, torch_w1, num_layers, routed_experts_per_device, hidden_size, matmul_N, w0_w1_shard_map
         )
         torch_w2_reordered = prepare_w2_tensor_for_moe_compute(
-            torch_w2, num_layers, total_experts_per_device, matmul_N, hidden_size, w2_shard_map, w0_w1_shard_map
+            torch_w2, num_layers, routed_experts_per_device, matmul_N, hidden_size, w2_shard_map, w0_w1_shard_map
         )
 
         linearized_mesh_coord = get_linearized_mesh_coord(
-            num_replicated_devices, cluster_axis, e, total_experts_per_cluster, total_experts_per_device
+            num_replicated_devices, cluster_axis, e, routed_experts_per_cluster, routed_experts_per_device
         )
         torch_w0_w1_reordered_tensors[linearized_mesh_coord] = torch_w0_w1_reordered
         torch_w2_reordered_tensors[linearized_mesh_coord] = torch_w2_reordered
@@ -829,7 +683,7 @@ def test_optimized_moe_decode_block(
     # ------------------------------------------------------------------------
     w0_w1_mem_config, w2_mem_config, _, _ = get_weight_mem_configs(
         num_layers,
-        total_experts_per_device,
+        routed_experts_per_device,
         hidden_size,
         matmul_N,
         w0_w1_shard_map,
@@ -908,7 +762,6 @@ def test_optimized_moe_decode_block(
         dispatch_input_expert_indices_dtype = ttnn.uint16
 
         torch_dispatch_input_tensor = create_torch_dispatch_input_tensor(batch, seq, hidden_size, dispatch_input_dtype)
-        # inputs to dispatch are based on routed experts only, outputs from dispatch add shared experts
         torch_dispatch_input_expert_indices_tensor = create_torch_dispatch_input_expert_indices_tensor(
             scheme,
             num_devices,
@@ -976,17 +829,6 @@ def test_optimized_moe_decode_block(
             hidden_size,
             select_experts_k,
         )
-        # append shared experts if necessary
-        if shared_expert_ids_to_devices is not None:
-            torch_combine_golden, torch_combine_valid_mask = _add_shared_experts_to_combine_golden(
-                batch,
-                torch_combine_golden,
-                torch_combine_valid_mask,
-                torch_dispatch_input_tensor,
-                shared_id_to_w0,
-                shared_id_to_w1,
-                shared_id_to_w2,
-            )
 
         torch_combine_goldens.append(torch_combine_golden)
         torch_combine_valid_masks.append(torch_combine_valid_mask)
@@ -1002,17 +844,6 @@ def test_optimized_moe_decode_block(
             hidden_size,
             select_experts_k,
         )
-        # add shared expert contribs, shape is the same.
-        if shared_expert_ids_to_devices is not None:
-            torch_output_golden = _add_shared_experts_to_output_golden(
-                batch,
-                torch_output_golden,
-                torch_dispatch_input_tensor,
-                shared_id_to_w0,
-                shared_id_to_w1,
-                shared_id_to_w2,
-                torch_shared_expert_scores,
-            )
         torch_output_goldens.append(torch_output_golden)
 
     logger.info(f"Done creating dynamic input tensors and goldens")
@@ -1037,7 +868,7 @@ def test_optimized_moe_decode_block(
     # same shard spec for indices and scores
     dispatch_output_shard_spec = ttnn.ShardSpec(
         ttnn.CoreRangeSet({ttnn.CoreRange(compute_tilize_drain_core, compute_tilize_drain_core)}),
-        [total_tokens, effective_experts_k],
+        [total_tokens, select_experts_k],
         ttnn.ShardOrientation.ROW_MAJOR,
     )
 
@@ -1048,7 +879,7 @@ def test_optimized_moe_decode_block(
         dispatch_output_shard_spec,
     )
     dispatch_output_expert_indices_dtype = ttnn.uint16
-    dispatch_output_expert_indices_shape = [num_dispatch_devices, total_tokens, effective_experts_k]
+    dispatch_output_expert_indices_shape = [num_dispatch_devices, total_tokens, select_experts_k]
     tt_preallocated_dispatch_output_expert_indices = ttnn.from_torch(
         torch.zeros(
             dispatch_output_expert_indices_shape, dtype=tt_to_torch_dtype(dispatch_output_expert_indices_dtype)
@@ -1067,7 +898,7 @@ def test_optimized_moe_decode_block(
         dispatch_output_shard_spec,
     )
     dispatch_output_expert_scores_dtype = ttnn.bfloat16
-    dispatch_output_expert_scores_shape = [num_dispatch_devices, total_tokens, effective_experts_k]
+    dispatch_output_expert_scores_shape = [num_dispatch_devices, total_tokens, select_experts_k]
     tt_preallocated_dispatch_output_expert_scores = ttnn.from_torch(
         torch.zeros(dispatch_output_expert_scores_shape, dtype=tt_to_torch_dtype(dispatch_output_expert_scores_dtype)),
         device=mesh_device,
@@ -1089,7 +920,7 @@ def test_optimized_moe_decode_block(
     tt_preallocated_combine_outputs = [
         ttnn.from_torch(
             torch.zeros(
-                [effective_experts_k, tokens_per_device, hidden_size],
+                [select_experts_k, tokens_per_device, hidden_size],
                 dtype=tt_to_torch_dtype(dispatch_output_sparse_buffer_dtype),
             ),
             device=mesh_device,
@@ -1113,7 +944,7 @@ def test_optimized_moe_decode_block(
             shard_shape=[32, 1024],
             grid=ttnn.CoreRangeSet(
                 {
-                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, effective_experts_k - 1)),
+                    ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(6, select_experts_k - 1)),
                 }
             ),
             orientation=ttnn.ShardOrientation.ROW_MAJOR,
@@ -1179,11 +1010,11 @@ def test_optimized_moe_decode_block(
         # create persistent output tensor for combine
         # runtime since it needs to be a zeroed out tensor (for each layer)
         # allocated before dispatch, as dispatch serves as the barrier to ensure the tensor is allocated on all devices
-        # [effective_experts_k (includes shared experts), tokens_per_device, hidden_size] per device
+        # [select_experts_k, tokens_per_device, hidden_size] per device
 
         #         # TODO (AM) REMOVE ME ONCE TESTED ON QUAD
         #         tt_preallocated_combine_output = ttnn.moreh_full(
-        #             shape=[effective_experts_k, tokens_per_device, hidden_size],
+        #             shape=[select_experts_k, tokens_per_device, hidden_size],
         #             fill_value=0,
         #             device=mesh_device,
         #             layout=ttnn.ROW_MAJOR_LAYOUT,
@@ -1200,7 +1031,6 @@ def test_optimized_moe_decode_block(
             tt_dispatch_input_expert_indices_tensor,
             tt_dispatch_input_expert_scores_tensor,
             tt_expert_mapping,
-            shared_expert_ids=list(shared_expert_ids_to_devices) if shared_expert_ids_to_devices else None,
             cluster_axis=cluster_axis,
             num_links=4,
             drain_sync_tilizer_core=None,
@@ -1272,8 +1102,6 @@ def test_optimized_moe_decode_block(
             split_size=int(tt_tilized_compute_output.shape[-1] // num_replicated_devices),
             output_memory_config=fast_reduce_output_memory_config,
             scores_tensor=topk_experts_weights,
-            num_shared_experts=num_shared_experts,
-            shared_expert_scale=shared_expert_score,
         )
 
         ttnn.deallocate(tt_dispatch_input_expert_indices_tensor)

--- a/tests/nightly/tg/ccl/moe/test_moe_compute_utils_tt.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_utils_tt.py
@@ -44,7 +44,7 @@ def is_mesh_graph_descriptor_set(expected_path):
     return os.environ.get("TT_MESH_GRAPH_DESC_PATH") == expected_path
 
 
-MESH_PARAMS = [
+_MESH_PARAM_8x4 = (
     pytest.param(
         (8, 4),
         (8, 4),
@@ -54,6 +54,9 @@ MESH_PARAMS = [
         ),
         id="8x4",
     ),
+)
+
+_MESH_PARAM_1x16 = (
     pytest.param(
         (1, 16),
         (1, 16),
@@ -63,7 +66,9 @@ MESH_PARAMS = [
         ),
         id="1x16",
     ),
-]
+)
+
+MESH_PARAMS = [_MESH_PARAM_8x4, _MESH_PARAM_1x16]
 
 # (hidden_size, intermediate_size) — DeepSeek matches the production layout; the
 # small config catches edge cases in the shard formulas (Nt = num_cores, etc.).
@@ -447,8 +452,10 @@ def _build_shared_test_setup(num_layers, num_devices, hidden_size, N, E_total):
     )
 
 
+# Note, only test this on linear meshes as the C++ version now includes TP sharding across the replicate axis and has
+# thus diverged from the OG python.
 @pytest.mark.parametrize("device_params", DEVICE_PARAMS, indirect=True)
-@pytest.mark.parametrize("mesh_shape, mesh_device", MESH_PARAMS, indirect=["mesh_device"])
+@pytest.mark.parametrize("mesh_shape, mesh_device", [_MESH_PARAM_1x16], indirect=["mesh_device"])
 @pytest.mark.parametrize("hidden_size, N", DIM_PARAMS)
 @pytest.mark.parametrize("num_layers, experts_per_device", [(1, 2)])
 @torch.no_grad()
@@ -456,6 +463,7 @@ def test_add_shared_expert_weights_parity(mesh_device, mesh_shape, hidden_size, 
     torch.manual_seed(2003)
     num_devices = mesh_shape[0] * mesh_shape[1]
     E_total = experts_per_device * num_devices
+    cluster_axis = 1
 
     routed_w0 = torch.randn(num_layers, E_total, hidden_size, N, dtype=torch.bfloat16)
     routed_w1 = torch.randn(num_layers, E_total, hidden_size, N, dtype=torch.bfloat16)
@@ -496,6 +504,7 @@ def test_add_shared_expert_weights_parity(mesh_device, mesh_shape, hidden_size, 
         tt_shared_w0,
         tt_shared_w1,
         tt_shared_w2,
+        cluster_axis=cluster_axis,
     )
     ttnn.synchronize_device(mesh_device)
 

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
@@ -44,7 +44,7 @@ void MeshPartitionDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(operation_attributes.dim < rank, "dim must be less than the rank of the input tensor");
 
     const uint32_t cluster_axis_size = detail::get_cluster_axis_size(input_tensor, operation_attributes.cluster_axis);
-    std::cout << "Cluster axis size: " << cluster_axis_size << std::endl;
+
     TT_FATAL(
         cluster_axis_size > 1,
         "Partition has only been tested with mesh axis size > 1, but has {} devices",

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_device_operation.cpp
@@ -44,7 +44,7 @@ void MeshPartitionDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(operation_attributes.dim < rank, "dim must be less than the rank of the input tensor");
 
     const uint32_t cluster_axis_size = detail::get_cluster_axis_size(input_tensor, operation_attributes.cluster_axis);
-
+    std::cout << "Cluster axis size: " << cluster_axis_size << std::endl;
     TT_FATAL(
         cluster_axis_size > 1,
         "Partition has only been tested with mesh axis size > 1, but has {} devices",

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/all_to_all_dispatch_metadata_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/all_to_all_dispatch_metadata_nanobind.cpp
@@ -105,6 +105,8 @@ void bind_all_to_all_dispatch_metadata(nb::module_& mod) {
             expert_mapping_tensor (ttnn.Tensor): The one-hot encoded expert to device mapping tensor containing the location of the experts among each device and each mesh. The tensor is expected to be [1, 1, E, D] per device, fully replicated across all devices. Each row corresponds to an expert, and the value in each corresponding column is 1 if the expert is on the device, 0 otherwise. The tensor is expected to be in Row Major, Interleaved format. This tensor is expected to be the same across all devices.
 
         Keyword Args:
+            shared_expert_ids (List[int], optional): the global expert ids designated as shared experts. Every token is dispatched to all of these experts in addition to its top-K routed experts. Defaults to `None` (no shared experts).
+                Note: the number of ids here (`num_shared_experts`) counts all *logical* shared experts. This differs from `num_shared_experts_per_device` in `ttnn.experimental.moe_compute`, which counts the *physical* shared experts resident per device, eg: 2x routed shared experts each residing on half of the devices would be num_shared_experts=2 here and num_shared_experts_per_device=1 there.
             cluster_axis (int, optional): the cluster axis to dispatch along. Defaults to `None` though we assert out when it is not specified.
             num_links (number, optional): the number of cross-device links to use for dispatching the tokens. Defaults to `None`, for which the number of links is determined automatically.
             output_tensors (Tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor], optional): the optional output tensors to use for the dispatched tokens, indices, and scores. Defaults to `None`.
@@ -113,6 +115,7 @@ void bind_all_to_all_dispatch_metadata(nb::module_& mod) {
             dispatch_algorithm (ttnn.DispatchAlgorithm, optional): the algorithm for routing tokens to destination devices. Defaults to `ttnn.DispatchAlgorithm.SPARSE_MCAST_SHORTEST_PATH`.
             worker_core_range_set (ttnn.CoreRangeSet, optional): the cores to use for dispatch workers. Defaults to cores (0,0) to (0,7) - 8 cores for 4 links.
             mux_core_range_set (ttnn.CoreRangeSet, optional): the cores to use for mux workers when worker_mode uses mux. Defaults to cores (1,0) to (1,7) - 8 cores (2 per link × 4 links).
+            cross_device_semaphore (ttnn.GlobalSemaphore, optional): a persistent global semaphore that enables semaphore-free (persistent) mode. When provided, all three `output_tensors` must also be provided as persistent buffers so all fabric write targets are persistent and the per-call `init_semaphore` can be skipped. Defaults to `None`.
 
         Returns:
             Tuple[ttnn.Tensor, ttnn.Tensor, ttnn.Tensor]: The sparse output tokens tensor, indices tensor, and scores tensor. The output tensor on each device is sparsely populated with all the tokens that are dispatched to that device. The non-dispatched tokens have placeholder rows populated with garbage. The indices and scores tensors are all-gathered and L1 sharded to the drain_sync_tilizer_core.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -93,6 +93,9 @@ void kernel_main() {
 
     constexpr uint32_t num_experts = get_named_compile_time_arg_val("num_experts");
     [[maybe_unused]] constexpr uint32_t layer_id = get_named_compile_time_arg_val("layer_id");
+    constexpr uint32_t num_shared_experts = get_named_compile_time_arg_val("num_shared_experts");
+    constexpr uint32_t shared_expert_tp_factor = get_named_compile_time_arg_val("shared_expert_tp_factor");
+
     constexpr auto activation_type =
         ttnn::experimental::prim::detail::MoEActivationFunction(get_named_compile_time_arg_val("activation_function"));
 
@@ -149,7 +152,7 @@ void kernel_main() {
     constexpr uint32_t w0_w1_tiles_per_txn = moe_ring::W0_W1_TILES_PER_TXN;
     constexpr uint32_t w0_w1_tiles_per_block = w0_w1_tiles_per_txn * w0_w1_txns_per_block;  // 14 * 2 = 28
 
-    using Cfg = moe_ring::MoeRingConfig<Ht, Nt, num_cores, has_bias>;
+    using Cfg = moe_ring::MoeRingConfig<Ht, Nt, num_cores, has_bias, shared_expert_tp_factor>;
 
     // W2 reading constants (base-constant aliases only; derived values come from Cfg)
     constexpr auto w2_tiles_per_iter_w = moe_ring::W2_TILES_PER_A2A_ITER_W;
@@ -160,6 +163,7 @@ void kernel_main() {
     // Ring setup
     //-------------------------------------------------------------------------
     constexpr uint32_t w2_blocks_per_a2a_iter = Cfg::w2_blocks_per_expert / Cfg::num_a2a_iters;
+    constexpr uint32_t w2_blocks_per_a2a_iter_shared_expert = Cfg::w2_blocks_per_shared_expert / Cfg::num_a2a_iters;
 
     [[maybe_unused]] constexpr uint32_t num_a2a_steps_per_iter = num_cores;
 
@@ -350,7 +354,10 @@ void kernel_main() {
                 tile_regs_acquire();
 
                 uint32_t w2_k_tracker = 0;
-                for (uint32_t block_id = 0; block_id < w2_blocks_per_a2a_iter; ++block_id) {
+                const auto w2_blocks_per_a2a_iter_using = (expert_id >= num_experts - num_shared_experts)
+                                                              ? w2_blocks_per_a2a_iter_shared_expert
+                                                              : w2_blocks_per_a2a_iter;
+                for (uint32_t block_id = 0; block_id < w2_blocks_per_a2a_iter_using; ++block_id) {
                     cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
                     for (uint32_t k = 0; k < w2_tiles_per_block; k += w2_tiles_per_iter_w) {
                         if constexpr (has_bias) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -93,7 +93,7 @@ void kernel_main() {
 
     constexpr uint32_t num_experts = get_named_compile_time_arg_val("num_experts");
     [[maybe_unused]] constexpr uint32_t layer_id = get_named_compile_time_arg_val("layer_id");
-    constexpr uint32_t num_shared_experts = get_named_compile_time_arg_val("num_shared_experts");
+    [[maybe_unused]] constexpr uint32_t num_shared_experts = get_named_compile_time_arg_val("num_shared_experts");
     constexpr uint32_t shared_expert_tp_factor = get_named_compile_time_arg_val("shared_expert_tp_factor");
 
     constexpr auto activation_type =
@@ -163,7 +163,6 @@ void kernel_main() {
     // Ring setup
     //-------------------------------------------------------------------------
     constexpr uint32_t w2_blocks_per_a2a_iter = Cfg::w2_blocks_per_expert / Cfg::num_a2a_iters;
-    constexpr uint32_t w2_blocks_per_a2a_iter_shared_expert = Cfg::w2_blocks_per_shared_expert / Cfg::num_a2a_iters;
 
     [[maybe_unused]] constexpr uint32_t num_a2a_steps_per_iter = num_cores;
 
@@ -354,10 +353,14 @@ void kernel_main() {
                 tile_regs_acquire();
 
                 uint32_t w2_k_tracker = 0;
-                const auto w2_blocks_per_a2a_iter_using = (expert_id >= num_experts - num_shared_experts)
-                                                              ? w2_blocks_per_a2a_iter_shared_expert
-                                                              : w2_blocks_per_a2a_iter;
-                for (uint32_t block_id = 0; block_id < w2_blocks_per_a2a_iter_using; ++block_id) {
+                // Shared experts contract the FULL Nt K-extent, identical to routed experts. Their
+                // W0/W1 and W2 weights are zero-padded to full Nt (add_shared_expert_weights), so the
+                // padding K rows/cols contribute zero and the full ring walk is correct. The TpNt
+                // work-distribution optimization (shortening the contraction) is deferred: a partial
+                // walk over zero-padded weights selects a core-relative window, not the real [0,TpNt)
+                // slice, so it is incorrect. Realizing it requires a true TpNt ring geometry -- see
+                // the shared-expert-tp design note.
+                for (uint32_t block_id = 0; block_id < w2_blocks_per_a2a_iter; ++block_id) {
                     cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
                     for (uint32_t k = 0; k < w2_tiles_per_block; k += w2_tiles_per_iter_w) {
                         if constexpr (has_bias) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -93,7 +93,7 @@ void kernel_main() {
 
     constexpr uint32_t num_experts = get_named_compile_time_arg_val("num_experts");
     [[maybe_unused]] constexpr uint32_t layer_id = get_named_compile_time_arg_val("layer_id");
-    [[maybe_unused]] constexpr uint32_t num_shared_experts = get_named_compile_time_arg_val("num_shared_experts");
+    constexpr uint32_t num_shared_experts = get_named_compile_time_arg_val("num_shared_experts");
     constexpr uint32_t shared_expert_tp_factor = get_named_compile_time_arg_val("shared_expert_tp_factor");
 
     constexpr auto activation_type =
@@ -167,6 +167,7 @@ void kernel_main() {
     [[maybe_unused]] constexpr uint32_t num_a2a_steps_per_iter = num_cores;
 
     constexpr uint32_t tiles_per_step = Cfg::in2_tiles_per_step;
+    constexpr uint32_t tiles_per_step_shared = Cfg::in2_tiles_per_step_shared;
 
     //-------------------------------------------------------------------------
     // Compute
@@ -255,7 +256,13 @@ void kernel_main() {
             //---------------------------------------------------------------------
             // Compute in @ {W0,W1}
             //---------------------------------------------------------------------
-            for (uint32_t tile_id = 0; tile_id < tiles_per_step; tile_id += 2) {
+            // Shared experts are TP-split + front-packed: produce only the real TpNt prefix
+            // (dm0 reads the matching shortened W0/W1), then zero-fill the rest of the full
+            // tiles_per_step stride below. The unchanged full W2 walk then contracts real×real
+            // in the prefix and (zero in2)×(front-packed zero W2) past it.
+            const bool is_shared_expert = expert_id >= num_experts - num_shared_experts;
+            const uint32_t prod_tiles_per_step = is_shared_expert ? tiles_per_step_shared : tiles_per_step;
+            for (uint32_t tile_id = 0; tile_id < prod_tiles_per_step; tile_id += 2) {
                 uint32_t in0_index = use_second_half_buffer ? num_w0_w1_tiles_h : 0;
 
                 tile_regs_acquire();
@@ -325,6 +332,21 @@ void kernel_main() {
                 tile_regs_release();
             }
 
+            // Zero-fill the unproduced tail [prod_tiles_per_step, tiles_per_step) of this core's in2
+            // stride for shared experts, so the full W2 walk reads zeros there (annihilated by the
+            // front-packed zero W2 rows) rather than stale data from a prior expert.
+            if (is_shared_expert) {
+                tile_regs_acquire();
+                fill_tile_init();
+                fill_tile(0, 0.0f);
+                tile_regs_commit();
+                tile_regs_wait();
+                for (uint32_t tile_id = prod_tiles_per_step; tile_id < tiles_per_step; ++tile_id) {
+                    pack_tile</*out_of_order_output=*/true>(0, cb_s2c_in2, /*output_tile_index=*/tile_id);
+                }
+                tile_regs_release();
+            }
+
             // Signal to DM1 that the output from this core is ready
             cb_reserve_back(cb_c2w_rdy, 1);
             cb_push_back(cb_c2w_rdy, 1);
@@ -353,13 +375,6 @@ void kernel_main() {
                 tile_regs_acquire();
 
                 uint32_t w2_k_tracker = 0;
-                // Shared experts contract the FULL Nt K-extent, identical to routed experts. Their
-                // W0/W1 and W2 weights are zero-padded to full Nt (add_shared_expert_weights), so the
-                // padding K rows/cols contribute zero and the full ring walk is correct. The TpNt
-                // work-distribution optimization (shortening the contraction) is deferred: a partial
-                // walk over zero-padded weights selects a core-relative window, not the real [0,TpNt)
-                // slice, so it is incorrect. Realizing it requires a true TpNt ring geometry -- see
-                // the shared-expert-tp design note.
                 for (uint32_t block_id = 0; block_id < w2_blocks_per_a2a_iter; ++block_id) {
                     cb_wait_front(cb_r2c_w2, w2_tiles_per_block);
                     for (uint32_t k = 0; k < w2_tiles_per_block; k += w2_tiles_per_iter_w) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
@@ -30,7 +30,9 @@ void kernel_main() {
     constexpr uint32_t num_cores = get_named_compile_time_arg_val("num_cores");
 
     constexpr uint32_t num_experts = get_named_compile_time_arg_val("num_experts");
-    constexpr uint32_t num_shared_experts = get_named_compile_time_arg_val("num_shared_experts");
+    // Unused since shared experts now read the full Nt-tall W2 (see W2 loop comment); kept for the
+    // forthcoming TpNt-geometry work.
+    [[maybe_unused]] constexpr uint32_t num_shared_experts = get_named_compile_time_arg_val("num_shared_experts");
     constexpr uint32_t shared_expert_tp_factor = get_named_compile_time_arg_val("shared_expert_tp_factor");
 
     using Cfg = moe_ring::MoeRingConfig<Ht, Nt, num_cores, has_bias, shared_expert_tp_factor>;
@@ -343,10 +345,12 @@ void kernel_main() {
             //-------------------------------------------------------------------------
             uint32_t w2_global_page = w2_slice_first_global_page;
 
-            const auto w2_blocks_per_expert = (expert_id >= num_experts - num_shared_experts)
-                                                  ? Cfg::w2_blocks_per_shared_expert
-                                                  : Cfg::w2_blocks_per_expert;
-            for (uint32_t block_id = 0; block_id < w2_blocks_per_expert; ++block_id) {
+            // Read the FULL Nt-tall W2 for every expert, including shared experts. Shared-expert W2
+            // is zero-padded to full Nt height (add_shared_expert_weights); the zero rows are inert
+            // under the full contraction the compute kernel performs. Shortening the read to TpNt is
+            // incorrect with the current zero-padded weight layout and is deferred to the
+            // TpNt-geometry work (see the shared-expert-tp design note).
+            for (uint32_t block_id = 0; block_id < Cfg::w2_blocks_per_expert; ++block_id) {
                 noc_async_read_set_trid(trid_to_issue);
 
                 // First transaction:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
@@ -30,9 +30,7 @@ void kernel_main() {
     constexpr uint32_t num_cores = get_named_compile_time_arg_val("num_cores");
 
     constexpr uint32_t num_experts = get_named_compile_time_arg_val("num_experts");
-    // Unused since shared experts now read the full Nt-tall W2 (see W2 loop comment); kept for the
-    // forthcoming TpNt-geometry work.
-    [[maybe_unused]] constexpr uint32_t num_shared_experts = get_named_compile_time_arg_val("num_shared_experts");
+    constexpr uint32_t num_shared_experts = get_named_compile_time_arg_val("num_shared_experts");
     constexpr uint32_t shared_expert_tp_factor = get_named_compile_time_arg_val("shared_expert_tp_factor");
 
     using Cfg = moe_ring::MoeRingConfig<Ht, Nt, num_cores, has_bias, shared_expert_tp_factor>;
@@ -257,6 +255,14 @@ void kernel_main() {
     for (uint32_t expert_id = 0; expert_id < num_experts; ++expert_id) {
         uint32_t num_expert_chunks = NUM_CHUNKS_PER_EXPERT[expert_id];
 
+        // Shared experts are TP-split on the intermediate dim and front-packed (real TpNt slice at
+        // the front of each core's full-Nt shard, zeros after -- add_shared_expert_weights). Read
+        // only the real prefix: W0/W1 layout is Nt-outer, so the prefix is a contiguous shortened
+        // read. The compute kernel zero-fills the produced in2 gap so the full W2 walk stays correct.
+        const bool is_shared_expert = expert_id >= num_experts - num_shared_experts;
+        const uint32_t w0_w1_blocks_this_expert =
+            is_shared_expert ? Cfg::w0_w1_blocks_per_shared_expert : Cfg::w0_w1_blocks_per_expert;
+
         // Per-expert slice's first GLOBAL page id (in the FULL flat tensor across all banks).
         const uint32_t w0_w1_slice_first_global_page =
             w0_w1_ring_core_first_global_page + expert_id * w0_w1_pages_per_logical_shard;
@@ -278,7 +284,7 @@ void kernel_main() {
             // [0, num_banks); we translate to the chip bank id via shard_to_bank[].
             uint32_t w0_w1_global_page = w0_w1_slice_first_global_page;
 
-            for (uint32_t block_id = 0; block_id < Cfg::w0_w1_blocks_per_expert; ++block_id) {
+            for (uint32_t block_id = 0; block_id < w0_w1_blocks_this_expert; ++block_id) {
                 // Set trid (persists in NOC_PACKET_TAG cmd_buf; subsequent fast_reads inherit it).
                 noc_async_read_set_trid(trid_to_issue);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
@@ -29,10 +29,12 @@ void kernel_main() {
     constexpr uint32_t Nt = get_named_compile_time_arg_val("intermediate_tiles");
     constexpr uint32_t num_cores = get_named_compile_time_arg_val("num_cores");
 
-    using Cfg = moe_ring::MoeRingConfig<Ht, Nt, num_cores, has_bias>;
-
-    // Compile time arguments
     constexpr uint32_t num_experts = get_named_compile_time_arg_val("num_experts");
+    constexpr uint32_t num_shared_experts = get_named_compile_time_arg_val("num_shared_experts");
+    constexpr uint32_t shared_expert_tp_factor = get_named_compile_time_arg_val("shared_expert_tp_factor");
+
+    using Cfg = moe_ring::MoeRingConfig<Ht, Nt, num_cores, has_bias, shared_expert_tp_factor>;
+
     constexpr uint32_t layer_id = get_named_compile_time_arg_val("layer_id");
     // Number of physical DRAM banks the HEIGHT_SHARDED weight tensor lives on. WH=12 (1:1
     // with ring N=12). BH=8 always; ring N can be 8, 12, or 16. When N exceeds num_banks
@@ -341,7 +343,10 @@ void kernel_main() {
             //-------------------------------------------------------------------------
             uint32_t w2_global_page = w2_slice_first_global_page;
 
-            for (uint32_t block_id = 0; block_id < Cfg::w2_blocks_per_expert; ++block_id) {
+            const auto w2_blocks_per_expert = (expert_id >= num_experts - num_shared_experts)
+                                                  ? Cfg::w2_blocks_per_shared_expert
+                                                  : Cfg::w2_blocks_per_expert;
+            for (uint32_t block_id = 0; block_id < w2_blocks_per_expert; ++block_id) {
                 noc_async_read_set_trid(trid_to_issue);
 
                 // First transaction:

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
@@ -353,9 +353,7 @@ void kernel_main() {
 
             // Read the FULL Nt-tall W2 for every expert, including shared experts. Shared-expert W2
             // is zero-padded to full Nt height (add_shared_expert_weights); the zero rows are inert
-            // under the full contraction the compute kernel performs. Shortening the read to TpNt is
-            // incorrect with the current zero-padded weight layout and is deferred to the
-            // TpNt-geometry work (see the shared-expert-tp design note).
+            // under the full contraction the compute kernel performs.
             for (uint32_t block_id = 0; block_id < Cfg::w2_blocks_per_expert; ++block_id) {
                 noc_async_read_set_trid(trid_to_issue);
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
@@ -186,7 +186,7 @@ void kernel_main() {
     for (uint32_t expert_id = 0; expert_id < num_experts; ++expert_id) {
         uint32_t num_tokens = num_tokens_per_expert_ptr[expert_id];
         NUM_TOKENS_PER_EXPERT[expert_id] = num_tokens;
-        NUM_CHUNKS_PER_EXPERT[expert_id] = detail::div_up(num_tokens, tokens_per_chunk);
+        NUM_CHUNKS_PER_EXPERT[expert_id] = moe_ring::detail::div_up(num_tokens, tokens_per_chunk);
     }
 
     // Tilize core we signal to that tilize cores can send another chunk of tiles

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/moe_ring_common.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/moe_ring_common.h
@@ -120,6 +120,15 @@ struct MoeRingConfig {
     static constexpr uint32_t in2_tiles_per_step = (((Nt + num_cores - 1) / num_cores) + 1) & ~1u;
     static constexpr uint32_t w0_w1_blocks_per_expert = w0_w1_blocks_per_col * in2_tiles_per_step / 2;
 
+    // Shared-expert (TpNt) variants: the intermediate dim is TP-split to TpNt = ceil(Nt/tp).
+    // After add_shared_expert_weights front-packs each core's real TpNt slice to the front of its
+    // full-Nt shard, the kernel reads/produces only the real prefix (in2_tiles_per_step_shared per
+    // core) and zero-fills the remainder of the full stride; the full W2 walk then contracts
+    // real×real in the prefix and zero×zero past it. See the shared-expert-tp design note.
+    static constexpr uint32_t TpNt = detail::div_up<Nt, SharedExpertTp>();
+    static constexpr uint32_t in2_tiles_per_step_shared = (((TpNt + num_cores - 1) / num_cores) + 1) & ~1u;
+    static constexpr uint32_t w0_w1_blocks_per_shared_expert = w0_w1_blocks_per_col * in2_tiles_per_step_shared / 2;
+
     // W2
     static constexpr uint32_t max_w2_tiles_per_core = (Ht + num_cores - 1) / num_cores;
     static constexpr uint32_t num_a2a_iters =

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/moe_ring_common.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/moe_ring_common.h
@@ -124,7 +124,7 @@ struct MoeRingConfig {
     // After add_shared_expert_weights front-packs each core's real TpNt slice to the front of its
     // full-Nt shard, the kernel reads/produces only the real prefix (in2_tiles_per_step_shared per
     // core) and zero-fills the remainder of the full stride; the full W2 walk then contracts
-    // real×real in the prefix and zero×zero past it. See the shared-expert-tp design note.
+    // real×real in the prefix and zero×zero past it.
     static constexpr uint32_t TpNt = detail::div_up<Nt, SharedExpertTp>();
     static constexpr uint32_t in2_tiles_per_step_shared = (((TpNt + num_cores - 1) / num_cores) + 1) & ~1u;
     static constexpr uint32_t w0_w1_blocks_per_shared_expert = w0_w1_blocks_per_col * in2_tiles_per_step_shared / 2;
@@ -135,8 +135,6 @@ struct MoeRingConfig {
         (max_w2_tiles_per_core + W2_TILES_PER_A2A_ITER_W - 1) / W2_TILES_PER_A2A_ITER_W;
     static constexpr uint32_t w2_tiles_per_expert_w = num_a2a_iters * W2_TILES_PER_A2A_ITER_W;
     static constexpr uint32_t w2_blocks_per_expert = get_w2_blocks_per_expert<Nt, has_bias, w2_tiles_per_expert_w>();
-    static constexpr uint32_t w2_blocks_per_shared_expert =
-        get_w2_blocks_per_expert<Nt, has_bias, w2_tiles_per_expert_w, SharedExpertTp>();
 };
 
 }  // namespace moe_ring

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/moe_ring_common.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/moe_ring_common.h
@@ -8,6 +8,8 @@
 
 #include "../hostdevcommon/config.hpp"
 
+namespace moe_ring {
+
 namespace detail {
 inline uint32_t div_up(const uint32_t a, const uint32_t b) { return (a + b - 1) / b; }
 
@@ -17,8 +19,6 @@ constexpr uint32_t div_up() {
 }
 
 }  // namespace detail
-
-namespace moe_ring {
 
 constexpr uint32_t W0_W1_TXNS_PER_BLOCK = 2;
 constexpr uint32_t W0_W1_TILES_PER_TXN = 14;
@@ -98,10 +98,20 @@ constexpr ShardLUT<n_cores> make_w2_offset_lut() {
     return lut;
 }
 
+template <uint32_t Nt, bool has_bias, uint32_t W2TilesPerExpertW, uint32_t SharedExpertTp = 1>
+constexpr uint32_t get_w2_blocks_per_expert() {
+    constexpr uint32_t TpNt = moe_ring::detail::div_up<Nt, SharedExpertTp>();
+    constexpr uint32_t w2_dram_tiles_h = has_bias ? TpNt + 1 : TpNt;
+    constexpr uint32_t w2_tiles_per_expert_h =
+        ((w2_dram_tiles_h + W2_TILES_PER_A2A_ITER_H - 1) / W2_TILES_PER_A2A_ITER_H) * W2_TILES_PER_A2A_ITER_H;
+
+    return W2TilesPerExpertW * w2_tiles_per_expert_h / (W2_TXNS_PER_BLOCK * W2_TILES_PER_TXN);
+}
+
 //-----------------------------------------------------------------------------
 // Derived ring constants — single source of truth for compute, dm0, dm1.
 //-----------------------------------------------------------------------------
-template <uint32_t Ht, uint32_t Nt, uint32_t num_cores, bool has_bias>
+template <uint32_t Ht, uint32_t Nt, uint32_t num_cores, bool has_bias, uint32_t SharedExpertTp = 1>
 struct MoeRingConfig {
     // W0/W1
     static constexpr uint32_t w0_w1_dram_tiles_h = has_bias ? Ht + 1 : Ht;
@@ -115,11 +125,9 @@ struct MoeRingConfig {
     static constexpr uint32_t num_a2a_iters =
         (max_w2_tiles_per_core + W2_TILES_PER_A2A_ITER_W - 1) / W2_TILES_PER_A2A_ITER_W;
     static constexpr uint32_t w2_tiles_per_expert_w = num_a2a_iters * W2_TILES_PER_A2A_ITER_W;
-    static constexpr uint32_t w2_dram_tiles_h = has_bias ? Nt + 1 : Nt;
-    static constexpr uint32_t w2_tiles_per_expert_h =
-        ((w2_dram_tiles_h + W2_TILES_PER_A2A_ITER_H - 1) / W2_TILES_PER_A2A_ITER_H) * W2_TILES_PER_A2A_ITER_H;
-    static constexpr uint32_t w2_blocks_per_expert =
-        w2_tiles_per_expert_w * w2_tiles_per_expert_h / (W2_TXNS_PER_BLOCK * W2_TILES_PER_TXN);
+    static constexpr uint32_t w2_blocks_per_expert = get_w2_blocks_per_expert<Nt, has_bias, w2_tiles_per_expert_w>();
+    static constexpr uint32_t w2_blocks_per_shared_expert =
+        get_w2_blocks_per_expert<Nt, has_bias, w2_tiles_per_expert_w, SharedExpertTp>();
 };
 
 }  // namespace moe_ring

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -189,9 +189,9 @@ void MoEComputeDeviceOperation::validate_on_program_cache_miss(
 
     const uint32_t experts_per_device = tensor_args.matmul_w0_w1_tensor.logical_shape()[2];
     TT_FATAL(
-        args.num_shared_experts <= experts_per_device,
-        "num_shared_experts ({}) must be <= experts_per_device ({})",
-        args.num_shared_experts,
+        args.num_shared_experts_per_device <= experts_per_device,
+        "num_shared_experts_per_device ({}) must be <= experts_per_device ({})",
+        args.num_shared_experts_per_device,
         experts_per_device);
 }
 
@@ -403,7 +403,7 @@ std::vector<ttnn::Tensor> moe_compute(
     const std::optional<ttnn::experimental::prim::detail::MoEActivationFunction>& activation_type,
     const bool compute_only,
     const std::optional<uint32_t>& bh_ring_size,
-    const std::optional<uint32_t>& num_shared_experts) {
+    const std::optional<uint32_t>& num_shared_experts_per_device) {
     using OperationType = ttnn::experimental::prim::MoEComputeDeviceOperation;
 
     const auto& input_shape = tilize_input_tensor.tensor_spec().logical_shape();
@@ -493,7 +493,7 @@ std::vector<ttnn::Tensor> moe_compute(
             .layer_id = layer_id,
             .output_height_shard_dim = output_height_shard_dim,
             .intermediate_size = intermediate_size,
-            .num_shared_experts = num_shared_experts,
+            .num_shared_experts_per_device = num_shared_experts_per_device,
             .has_bias = has_bias,
             .num_token_parallel_cores = num_token_parallel_cores,
             .num_data_parallel_cores = num_data_parallel_cores,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -186,6 +186,13 @@ void MoEComputeDeviceOperation::validate_on_program_cache_miss(
     const uint32_t tiles_per_step = (tiles_per_step_raw + 1) & ~1u;
     TT_FATAL(
         tiles_per_step >= 2 && tiles_per_step % 2 == 0, "tiles_per_step ({}) must be even and >= 2", tiles_per_step);
+
+    const uint32_t experts_per_device = tensor_args.matmul_w0_w1_tensor.logical_shape()[2];
+    TT_FATAL(
+        args.num_shared_experts <= experts_per_device,
+        "num_shared_experts ({}) must be <= experts_per_device ({})",
+        args.num_shared_experts,
+        experts_per_device);
 }
 
 MoEComputeDeviceOperation::spec_return_value_t MoEComputeDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.cpp
@@ -395,7 +395,8 @@ std::vector<ttnn::Tensor> moe_compute(
     const std::optional<GlobalSemaphore>& optional_cross_device_semaphore,
     const std::optional<ttnn::experimental::prim::detail::MoEActivationFunction>& activation_type,
     const bool compute_only,
-    const std::optional<uint32_t>& bh_ring_size) {
+    const std::optional<uint32_t>& bh_ring_size,
+    const std::optional<uint32_t>& num_shared_experts) {
     using OperationType = ttnn::experimental::prim::MoEComputeDeviceOperation;
 
     const auto& input_shape = tilize_input_tensor.tensor_spec().logical_shape();
@@ -485,6 +486,7 @@ std::vector<ttnn::Tensor> moe_compute(
             .layer_id = layer_id,
             .output_height_shard_dim = output_height_shard_dim,
             .intermediate_size = intermediate_size,
+            .num_shared_experts = num_shared_experts,
             .has_bias = has_bias,
             .num_token_parallel_cores = num_token_parallel_cores,
             .num_data_parallel_cores = num_data_parallel_cores,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.hpp
@@ -58,7 +58,7 @@ std::vector<Tensor> moe_compute(
     const std::optional<ttnn::experimental::prim::detail::MoEActivationFunction>& activation_type = std::nullopt,
     bool compute_only = false,
     const std::optional<uint32_t>& bh_ring_size = std::nullopt,
-    const std::optional<uint32_t>& num_shared_experts = std::nullopt);
+    const std::optional<uint32_t>& num_shared_experts_per_device = std::nullopt);
 
 using ttnn::experimental::prim::get_moe_combine_cores;
 using ttnn::experimental::prim::get_moe_worker_mcast_bounding_box;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation.hpp
@@ -57,7 +57,8 @@ std::vector<Tensor> moe_compute(
     const std::optional<GlobalSemaphore>& optional_cross_device_semaphore,
     const std::optional<ttnn::experimental::prim::detail::MoEActivationFunction>& activation_type = std::nullopt,
     bool compute_only = false,
-    const std::optional<uint32_t>& bh_ring_size = std::nullopt);
+    const std::optional<uint32_t>& bh_ring_size = std::nullopt,
+    const std::optional<uint32_t>& num_shared_experts = std::nullopt);
 
 using ttnn::experimental::prim::get_moe_combine_cores;
 using ttnn::experimental::prim::get_moe_worker_mcast_bounding_box;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
@@ -29,7 +29,7 @@ struct MoEComputeParams {
     uint32_t layer_id = 0;
     uint32_t output_height_shard_dim = 0;
     uint32_t intermediate_size = 0;
-    std::optional<uint32_t> num_shared_experts;
+    std::optional<uint32_t> num_shared_experts_per_device;
     bool has_bias = false;
 
     // Number of token-parallel and data-parallel cores. These govern matmul output shard layout
@@ -64,7 +64,7 @@ struct MoEComputeParams {
         attrs.emplace_back("layer_id", layer_id);
         attrs.emplace_back("output_height_shard_dim", output_height_shard_dim);
         attrs.emplace_back("intermediate_size", intermediate_size);
-        attrs.emplace_back("num_shared_experts", num_shared_experts);
+        attrs.emplace_back("num_shared_experts_per_device", num_shared_experts_per_device);
         attrs.emplace_back("has_bias", has_bias);
         attrs.emplace_back("num_token_parallel_cores", num_token_parallel_cores);
         attrs.emplace_back("num_data_parallel_cores", num_data_parallel_cores);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
@@ -29,6 +29,9 @@ struct MoEComputeParams {
     uint32_t layer_id = 0;
     uint32_t output_height_shard_dim = 0;
     uint32_t intermediate_size = 0;
+    // Number of shared experts (nullopt when unset / no shared experts). Plumbed through to
+    // the program factory; stored in attributes() so the program cache distinguishes it.
+    std::optional<uint32_t> num_shared_experts;
     bool has_bias = false;
 
     // Number of token-parallel and data-parallel cores. These govern matmul output shard layout
@@ -63,6 +66,7 @@ struct MoEComputeParams {
         attrs.emplace_back("layer_id", layer_id);
         attrs.emplace_back("output_height_shard_dim", output_height_shard_dim);
         attrs.emplace_back("intermediate_size", intermediate_size);
+        attrs.emplace_back("num_shared_experts", num_shared_experts);
         attrs.emplace_back("has_bias", has_bias);
         attrs.emplace_back("num_token_parallel_cores", num_token_parallel_cores);
         attrs.emplace_back("num_data_parallel_cores", num_data_parallel_cores);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_device_operation_types.hpp
@@ -29,8 +29,6 @@ struct MoEComputeParams {
     uint32_t layer_id = 0;
     uint32_t output_height_shard_dim = 0;
     uint32_t intermediate_size = 0;
-    // Number of shared experts (nullopt when unset / no shared experts). Plumbed through to
-    // the program factory; stored in attributes() so the program cache distinguishes it.
     std::optional<uint32_t> num_shared_experts;
     bool has_bias = false;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -457,7 +457,7 @@ MoEComputeMeshWorkloadFactory::create_at(
     const uint32_t intermediate_size = args.intermediate_size;
     const uint32_t hidden_tiles = hidden_size / 32;
     const uint32_t intermediate_tiles = intermediate_size / 32;
-    const uint32_t num_shared_experts = args.num_shared_experts.value_or(0);
+    const uint32_t num_shared_experts = args.num_shared_experts_per_device.value_or(0);
 
     // Cores
     const auto

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -457,10 +457,7 @@ MoEComputeMeshWorkloadFactory::create_at(
     const uint32_t intermediate_size = args.intermediate_size;
     const uint32_t hidden_tiles = hidden_size / 32;
     const uint32_t intermediate_tiles = intermediate_size / 32;
-
-    // Number of shared experts (nullopt when unset). Plumbed through from the op kwarg;
-    // TODO: consume in the program build (kernel CT/RT args) once the behavior is defined.
-    [[maybe_unused]] const std::optional<uint32_t> num_shared_experts = args.num_shared_experts;
+    const uint32_t num_shared_experts = args.num_shared_experts.value_or(0);
 
     // Cores
     const auto
@@ -1294,10 +1291,22 @@ MoEComputeMeshWorkloadFactory::create_at(
         "moe_compute: w2 total pages ({}) not divisible by num_cores ({})",
         w2_total_pages_buf,
         matmul_num_cores);
+
+    uint32_t shared_expert_tp_factor;
+    if (args.path == MoEComputePath::ComputeOnly) {
+        // concept of a shared expert doesn't hold in the compute only case.
+        shared_expert_tp_factor = 1;
+    } else {
+        auto* mesh_device = tilize_input_tensor.device();
+        const auto& mesh_shape = mesh_device->get_view().shape();
+        shared_expert_tp_factor = mesh_shape[1 - args.cluster_axis().value()];
+    }
     const uint32_t w0_w1_pages_per_ring_core_total = w0_w1_total_pages_buf / matmul_num_cores;
     const uint32_t w2_pages_per_ring_core_total = w2_total_pages_buf / matmul_num_cores;
     std::unordered_map<std::string, uint32_t> matmul_named_compile_time_args = {
         {"num_experts", experts_per_device},
+        {"num_shared_experts", num_shared_experts},
+        {"shared_expert_tp_factor", shared_expert_tp_factor},
         {"layer_id", args.layer_id},
         {"has_bias", args.has_bias ? 1u : 0u},
         {"num_cores", static_cast<uint32_t>(matmul_num_cores)},

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/moe_compute_program_factory.cpp
@@ -458,6 +458,10 @@ MoEComputeMeshWorkloadFactory::create_at(
     const uint32_t hidden_tiles = hidden_size / 32;
     const uint32_t intermediate_tiles = intermediate_size / 32;
 
+    // Number of shared experts (nullopt when unset). Plumbed through from the op kwarg;
+    // TODO: consume in the program build (kernel CT/RT args) once the behavior is defined.
+    [[maybe_unused]] const std::optional<uint32_t> num_shared_experts = args.num_shared_experts;
+
     // Cores
     const auto
         [tilize_cores,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute.cpp
@@ -31,7 +31,7 @@ std::vector<ttnn::Tensor> moe_compute(
     const std::optional<ttnn::experimental::prim::detail::MoEActivationFunction>& activation_type,
     const bool compute_only,
     const std::optional<uint32_t>& bh_ring_size,
-    const std::optional<uint32_t>& num_shared_experts) {
+    const std::optional<uint32_t>& num_shared_experts_per_device) {
     return ttnn::prim::moe_compute(
         tilize_input_tensor,
         tilize_expert_indices_tensor,
@@ -53,7 +53,7 @@ std::vector<ttnn::Tensor> moe_compute(
         activation_type,
         compute_only,
         bh_ring_size,
-        num_shared_experts);
+        num_shared_experts_per_device);
 }
 
 std::vector<ttnn::CoreCoord> get_moe_combine_cores(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute.cpp
@@ -30,7 +30,8 @@ std::vector<ttnn::Tensor> moe_compute(
     const std::optional<ttnn::GlobalSemaphore>& optional_cross_device_semaphore,
     const std::optional<ttnn::experimental::prim::detail::MoEActivationFunction>& activation_type,
     const bool compute_only,
-    const std::optional<uint32_t>& bh_ring_size) {
+    const std::optional<uint32_t>& bh_ring_size,
+    const std::optional<uint32_t>& num_shared_experts) {
     return ttnn::prim::moe_compute(
         tilize_input_tensor,
         tilize_expert_indices_tensor,
@@ -51,7 +52,8 @@ std::vector<ttnn::Tensor> moe_compute(
         optional_cross_device_semaphore,
         activation_type,
         compute_only,
-        bh_ring_size);
+        bh_ring_size,
+        num_shared_experts);
 }
 
 std::vector<ttnn::CoreCoord> get_moe_combine_cores(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute.hpp
@@ -36,7 +36,7 @@ std::vector<ttnn::Tensor> moe_compute(
     const std::optional<ttnn::experimental::prim::detail::MoEActivationFunction>& activation_type = std::nullopt,
     bool compute_only = false,
     const std::optional<uint32_t>& bh_ring_size = std::nullopt,
-    const std::optional<uint32_t>& num_shared_experts = std::nullopt);
+    const std::optional<uint32_t>& num_shared_experts_per_device = std::nullopt);
 
 std::vector<ttnn::CoreCoord> get_moe_combine_cores(
     ttnn::MeshDevice* mesh_device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute.hpp
@@ -35,7 +35,8 @@ std::vector<ttnn::Tensor> moe_compute(
     const std::optional<ttnn::GlobalSemaphore>& optional_cross_device_semaphore,
     const std::optional<ttnn::experimental::prim::detail::MoEActivationFunction>& activation_type = std::nullopt,
     bool compute_only = false,
-    const std::optional<uint32_t>& bh_ring_size = std::nullopt);
+    const std::optional<uint32_t>& bh_ring_size = std::nullopt,
+    const std::optional<uint32_t>& num_shared_experts = std::nullopt);
 
 std::vector<ttnn::CoreCoord> get_moe_combine_cores(
     ttnn::MeshDevice* mesh_device,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
@@ -69,22 +69,55 @@ void bind_moe_compute(nb::module_& mod) {
         ``intermediate_size``. Callers must match the layout the device op expects or
         use the reference packer from ``ttnn.experimental.moe_compute_utils`` (see below).
 
+        **Input tensors**
+
+        The first four tensors are the per-device outputs of the A2A dispatch op:
+
+        - ``tilize_input_tensor``: The dispatched token activations (sparse buffer) for
+          the experts that live on this device. ``hidden_size`` is inferred from its last
+          dim and ``total_tokens`` from its first two dims.
+        - ``tilize_expert_indices_tensor``: Per-token selected expert ids;
+          ``select_experts_k`` is inferred from its last dim.
+        - ``tilize_expert_scores_tensor``: Per-token routing scores (gates) applied to
+          the expert outputs.
+        - ``tilize_expert_mapping_tensor``: The expert → device mapping that tells the
+          kernel which experts are resident locally.
+
         **Key parameters**
 
         - ``intermediate_size`` (**required**, added in this version): The MoE
           intermediate (expert FFN) dimension. Together with ``hidden_size`` (inferred
           from the input tensor), this determines the per-core tile shard counts via
           ``shard_tiles()`` / ``w2_shard_tiles()`` and the number of data-parallel
-          cores (``num_data_parallel_cores``). Previously, tile distributions were
-          selected by a model-specific enum; this parameter replaces that mechanism.
+          cores (``num_data_parallel_cores``).
 
         - ``output_height_shard_dim``: Number of token-parallel (height) cores used
-          for the combine output. The width (data-parallel) core count is auto-derived
-          from ``hidden_size`` and the matmul ring size (``bh_ring_size`` on BH, 12 on WH):
-          largest divisor d of ``hidden_tiles`` with d <= 4 and ``ring_n % d == 0``.
-          Use ``auto_output_width_shard_dim(hidden_size, matmul_ring_size=...)`` from
-          ``moe_compute_utils`` (with ``effective_matmul_ring_size``) so test tensors
-          match the device op.
+          for the combine output.
+
+        - ``num_shared_experts_per_device`` (optional, default ``None`` ≡ 0): How many
+          of the per-device experts are **shared** experts (run on every token) rather
+          than routed. Shared experts occupy the **tail** slots of the experts dimension
+          Note: this parameter differs from `num_shared_experts` used by all_to_all_dispatch_metadata
+          that op counts all logical shared experts. This one counts *physical* shared experts
+          per device, eg: 2x routed shared experts each residing on half of the devices
+          would be num_shared_experts_per_device=1 and num_shared_experts=2
+
+        - ``layer_id`` (**required**): Selects which layer's weight block to read when
+          multiple layers are packed into a single DRAM-resident weight tensor.
+
+        - ``activation_type`` (optional, default ``None`` ≡ ``SILU``): The expert FFN
+          activation function — one of ``ttnn.experimental.MoEActivationFunction``
+          ``{SILU, SWIGLU, GELU}`` — applied between the W0/W1 and W2 projections.
+
+        - ``compute_only`` (default ``False``): When ``True``, run only the expert
+          matmuls and skip the A2A combine. The op then returns **5** tensors (the
+          matmul output is the final output, slot 4) instead of 6, and all combine-path
+          arguments below must be left unset (notably ``cluster_axis`` must be ``None``).
+
+        - ``bh_ring_size`` (optional, default ``None`` ≡ ``12``): Matmul ring size on
+          Blackhole; must be one of ``{8, 12, 16}``. Ignored on Wormhole, which always
+          uses 12 (one per DRAM bank). Must match the value passed to the ``prepare_*`` /
+          ``get_weight_mem_configs`` helpers that packed the weights.
 
         **Bias support (optional)**
 
@@ -102,22 +135,43 @@ void bind_moe_compute(nb::module_& mod) {
         ``has_bias`` must match the actual layout of the provided tensors; mismatch
         produces silent wrong results or UB.
 
-        **Reference packer (optional)**
+        **Combine path (Full mode only)**
+
+        These arguments configure the cross-device A2A combine that reduces expert
+        outputs. They apply only when ``compute_only=False``; with ``compute_only=True``
+        they must be left at their defaults.
+
+        - ``cluster_axis`` (**required when** ``compute_only=False``): The mesh axis along
+          which the combine reduces. Must be ``None`` when ``compute_only=True``.
+        - ``topology`` (optional, default ``None`` ≡ fabric default): Combine fabric
+          topology; only ``ttnn.Topology.Linear`` and ``ttnn.Topology.Ring`` are
+          supported. If the fabric default is Torus/Mesh, pass ``Linear`` or ``Ring``
+          explicitly (BH Loudbox callers must pass ``Linear``).
+        - ``num_links`` (optional, default ``None``): Number of fabric links for the
+          combine; auto-detected from the mesh and ``cluster_axis`` when ``None``.
+        - ``mux_core_range_set`` (optional, default ``None`` ≡ empty): Cores assigned to
+          the fabric mux on the combine path.
+        - ``output_memory_config`` (optional, default ``None`` ≡ ``DRAM_MEMORY_CONFIG``):
+          Memory config for the combine output tensor.
+        - ``optional_output_tensor`` (optional): Preallocated tensor to receive the
+          combine output instead of allocating a new one. Must be ``None`` when
+          ``compute_only=True`` (no combine output is produced).
+        - ``optional_cross_device_semaphore`` (optional): Global semaphore used to
+          synchronize the cross-device combine.
+
+        **Reference input packer **
 
         ``ttnn.experimental.moe_compute_utils`` provides reference implementations that
         produce the expected layout:
 
-        - No bias: ``prepare_w0_w1_tensor_for_moe_compute``,
-          ``prepare_w2_tensor_for_moe_compute``
-        - With bias: ``prepare_w0_w1_tensor_with_bias``,
-          ``prepare_w2_tensor_with_bias``
-        - Shard maps: ``get_weight_core_shard_maps(mesh_device, hidden_size, intermediate_size)``
-        - Memory configs: ``get_weight_mem_configs(...)``
-        - Output shard dim: ``auto_output_width_shard_dim(hidden_size, matmul_ring_size=...)``
+        - add_shared_expert_weights
+        - prepare_w0_w1_tensor_for_moe_compute/prepare_w0_w1_tensor_with_bias
+        - prepare_w2_tensor_for_moe_compute/prepare_w2_tensor_with_bias
+        - quantize_weights_via_host (slower but higer quality) or ttnn.typecast (faster)
 
         These functions are kept in sync with the test suite and can be used as
         "executable documentation" for the layout contract; they are not a required
-        public API.
+        public API but they are recommended.
 
         See also: ``ttnn.experimental.moe_compute_utils`` module docstring for full
         layout details, constants (TILES_PER_TXN, ring tables), and constraints.
@@ -147,7 +201,7 @@ void bind_moe_compute(nb::module_& mod) {
         nb::arg("activation_type") = nb::none(),
         nb::arg("compute_only") = false,
         nb::arg("bh_ring_size") = nb::none(),
-        nb::arg("num_shared_experts") = nb::none());
+        nb::arg("num_shared_experts_per_device") = nb::none());
 }
 
 void bind_get_moe_combine_cores(nb::module_& mod) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
@@ -242,12 +242,9 @@ void bind_moe_compute_utils(nb::module_& mod) {
         pre-arranged ``shared_w*`` tensors.
 
         The shared experts are tensor-parallel split on the intermediate dim across
-        ``1 - cluster_axis`` (via ``mesh_partition``). For W0/W1 the per-device real
-        columns are interleaved with zero padding in ``num_cores`` equal chunks so
-        each matmul core sees ``tp_n / num_cores`` real columns then zeros; W2 keeps
-        its real rows front-packed (the kernel reads fewer row blocks for shared
-        experts). ``num_cores`` is the matmul core count the W0/W1 intermediate dim
-        is sharded across (``len(get_weight_core_shard_maps(...).w0_w1_shard_map)``).
+        ``1 - cluster_axis`` (via ``mesh_partition``). All three weight sets keep
+        real rows front-packed ( but only the W2 part of the kernel reads fewer row
+        blocks for shared experts).
 
         Returns ``(output_w0, output_w1, output_w2)``, each the result of
         concatenating routed + shared along dim 1.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
@@ -241,7 +241,15 @@ void bind_moe_compute_utils(nb::module_& mod) {
         Callers own the device → shared-expert mapping and produce the
         pre-arranged ``shared_w*`` tensors.
 
-        Returns ``(output_w0, output_w1, output_w2)`` in TILE_LAYOUT, each the result of
+        The shared experts are tensor-parallel split on the intermediate dim across
+        ``1 - cluster_axis`` (via ``mesh_partition``). For W0/W1 the per-device real
+        columns are interleaved with zero padding in ``num_cores`` equal chunks so
+        each matmul core sees ``tp_n / num_cores`` real columns then zeros; W2 keeps
+        its real rows front-packed (the kernel reads fewer row blocks for shared
+        experts). ``num_cores`` is the matmul core count the W0/W1 intermediate dim
+        is sharded across (``len(get_weight_core_shard_maps(...).w0_w1_shard_map)``).
+
+        Returns ``(output_w0, output_w1, output_w2)``, each the result of
         concatenating routed + shared along dim 1.
         )doc",
         &ttnn::experimental::add_shared_expert_weights,
@@ -250,7 +258,8 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("routed_w2").noconvert(),
         nb::arg("shared_w0").noconvert(),
         nb::arg("shared_w1").noconvert(),
-        nb::arg("shared_w2").noconvert());
+        nb::arg("shared_w2").noconvert(),
+        nb::arg("cluster_axis"));
 
     ttnn::bind_function<"prepare_w0_w1_tensor_for_moe_compute", "ttnn.experimental.">(
         mod,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
@@ -146,7 +146,8 @@ void bind_moe_compute(nb::module_& mod) {
         nb::arg("optional_cross_device_semaphore") = nb::none(),
         nb::arg("activation_type") = nb::none(),
         nb::arg("compute_only") = false,
-        nb::arg("bh_ring_size") = nb::none());
+        nb::arg("bh_ring_size") = nb::none(),
+        nb::arg("num_shared_experts") = nb::none());
 }
 
 void bind_get_moe_combine_cores(nb::module_& mod) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
@@ -242,9 +242,15 @@ void bind_moe_compute_utils(nb::module_& mod) {
         pre-arranged ``shared_w*`` tensors.
 
         The shared experts are tensor-parallel split on the intermediate dim across
-        ``1 - cluster_axis`` (via ``mesh_partition``). All three weight sets keep
-        real rows front-packed ( but only the W2 part of the kernel reads fewer row
-        blocks for shared experts).
+        ``1 - cluster_axis`` (via ``mesh_partition``). Each ring core's real TpNt
+        slice is front-packed into the front of that core's full-Nt shard (zeros
+        after), using the same per-core shard maps the kernel derives, and the
+        identical mapping is applied to W0/W1 (intermediate dim) and W2 (contraction
+        dim) so real columns stay paired with their real W2 rows. This keeps the
+        downstream prep + DRAM layout uniform (full-Nt per-expert stride) while
+        letting the kernel walk only the per-core prefixes as a balanced TpNt ring.
+        ``bh_ring_size`` selects the ring size for the shard-map generator (must
+        match the value used for ``prepare_*`` / ``get_weight_mem_configs``).
 
         Returns ``(output_w0, output_w1, output_w2)``, each the result of
         concatenating routed + shared along dim 1.
@@ -256,7 +262,8 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("shared_w0").noconvert(),
         nb::arg("shared_w1").noconvert(),
         nb::arg("shared_w2").noconvert(),
-        nb::arg("cluster_axis"));
+        nb::arg("cluster_axis"),
+        nb::arg("bh_ring_size") = 12);
 
     ttnn::bind_function<"prepare_w0_w1_tensor_for_moe_compute", "ttnn.experimental.">(
         mod,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
@@ -89,7 +89,7 @@ ttnn::Tensor stack_along(const std::vector<ttnn::Tensor>& tensors, int dim) {
 // correct partial contraction once the kernel walks only the per-core prefixes.
 ttnn::Tensor front_pack_per_core(
     const ttnn::Tensor& real, int axis, const std::vector<uint32_t>& full_map, const std::vector<uint32_t>& tp_map) {
-    const auto shape = real.logical_shape();
+    const auto& shape = real.logical_shape();
     const int rank = static_cast<int>(shape.rank());
     const int ax = axis < 0 ? rank + axis : axis;
     const uint32_t num_cores = static_cast<uint32_t>(full_map.size());

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
@@ -366,11 +366,38 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
     const ttnn::Tensor& routed_w2,
     const ttnn::Tensor& shared_w0,
     const ttnn::Tensor& shared_w1,
-    const ttnn::Tensor& shared_w2) {
-    auto output_w0 = ttnn::concat({routed_w0, shared_w0}, 1);
-    auto output_w1 = ttnn::concat({routed_w1, shared_w1}, 1);
-    auto output_w2 = ttnn::concat({routed_w2, shared_w2}, 1);
-    return {output_w0, output_w1, output_w2};
+    const ttnn::Tensor& shared_w2,
+    const uint32_t cluster_axis) {
+    const auto intermediate_dim = routed_w0.logical_shape()[-1];
+    const auto tp_axis = 1 - cluster_axis;
+
+    auto working_shared_w0 = ttnn::mesh_partition(shared_w0, -1, tp_axis);
+
+    const auto padding = intermediate_dim - working_shared_w0.logical_shape()[-1];
+    const std::array<4, std::tuple<uint32_t, uint32_t>> padding_spec01 = {{0, 0}, {0, 0}, {0, 0}, {0, padding}};
+    working_shared_w0 = ttnn::pad(working_shared_w0, padding_spec01);
+
+    auto output_w0 = ttnn::concat({routed_w0, working_shared_w0}, 1);
+    auto tile_w0 = ttnn::to_layout(output_w0, ttnn::Layout::TILE);
+    working_shared_w0.deallocate(/*force*/ = true);
+    output_w0.deallocate(/*force=*/true);
+
+    auto working_shared_w1 = ttnn::mesh_partition(shared_w1, -1, tp_axis);
+    working_shared_w0 = ttnn::pad(working_shared_w1, padding_spec01);
+
+    auto output_w1 = ttnn::concat({routed_w1, working_shared_w0}, 1);
+    auto tile_w1 = ttnn::to_layout(output_w1, ttnn::Layout::TILE);
+    working_shared_w1.deallocate(/*force*/ = true);
+    output_w1.deallocate(/*force=*/true);
+
+    auto working_shared_w2 = ttnn::mesh_partition(shared_w2, -2, tp_axis);
+    const std::array<4, std::tuple<uint32_t, uint32_t>> padding_spec2 = {{0, 0}, {0, 0}, {0, padding}, {0, 0}};
+    working_shared_w2 = ttnn::pad(working_shared_w2, padding_spec2);
+
+    auto output_w2 = ttnn::concat({routed_w2, working_shared_w2}, 1);
+    auto tile_w2 = ttnn::to_layout(output_w2, ttnn::Layout::TILE);
+    output_w2.deallocate(/*force=*/true);
+    return {tile_w0, tile_w1, tile_w2};
 }
 
 ttnn::Tensor prepare_w0_w1_tensor_for_moe_compute(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
@@ -360,43 +360,62 @@ WeightMemoryConfigs get_weight_mem_configs(
     return {w0_w1_mem_config, w2_mem_config};
 }
 
+// std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
+//     const ttnn::Tensor& routed_w0,
+//     const ttnn::Tensor& routed_w1,
+//     const ttnn::Tensor& routed_w2,
+//     const ttnn::Tensor& shared_w0,
+//     const ttnn::Tensor& shared_w1,
+//     const ttnn::Tensor& shared_w2,
+//     const uint32_t cluster_axis) {
+//     const auto intermediate_dim = routed_w0.logical_shape()[-1];
+//     const auto tp_axis = 1 - cluster_axis;
+//
+//     auto working_shared_w0 = ttnn::mesh_partition(shared_w0, -1, tp_axis);
+//
+//     const auto padding = intermediate_dim - working_shared_w0.logical_shape()[-1];
+//     const std::array<4, std::tuple<uint32_t, uint32_t>> padding_spec01 = {{0, 0}, {0, 0}, {0, 0}, {0, padding}};
+//     working_shared_w0 = ttnn::pad(working_shared_w0, padding_spec01);
+//
+//     auto output_w0 = ttnn::concat({routed_w0, working_shared_w0}, 1);
+//     auto tile_w0 = ttnn::to_layout(output_w0, ttnn::Layout::TILE);
+//     working_shared_w0.deallocate(/*force*/ = true);
+//     output_w0.deallocate(/*force=*/true);
+//
+//     auto working_shared_w1 = ttnn::mesh_partition(shared_w1, -1, tp_axis);
+//     working_shared_w0 = ttnn::pad(working_shared_w1, padding_spec01);
+//
+//     auto output_w1 = ttnn::concat({routed_w1, working_shared_w0}, 1);
+//     auto tile_w1 = ttnn::to_layout(output_w1, ttnn::Layout::TILE);
+//     working_shared_w1.deallocate(/*force*/ = true);
+//     output_w1.deallocate(/*force=*/true);
+//
+//     auto working_shared_w2 = ttnn::mesh_partition(shared_w2, -2, tp_axis);
+//     const std::array<4, std::tuple<uint32_t, uint32_t>> padding_spec2 = {{0, 0}, {0, 0}, {0, padding}, {0, 0}};
+//     working_shared_w2 = ttnn::pad(working_shared_w2, padding_spec2);
+//
+//     auto output_w2 = ttnn::concat({routed_w2, working_shared_w2}, 1);
+//     auto tile_w2 = ttnn::to_layout(output_w2, ttnn::Layout::TILE);
+//     output_w2.deallocate(/*force=*/true);
+//     return {tile_w0, tile_w1, tile_w2};
+// }
+
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
     const ttnn::Tensor& routed_w0,
     const ttnn::Tensor& routed_w1,
     const ttnn::Tensor& routed_w2,
     const ttnn::Tensor& shared_w0,
     const ttnn::Tensor& shared_w1,
-    const ttnn::Tensor& shared_w2,
-    const uint32_t cluster_axis) {
-    const auto intermediate_dim = routed_w0.logical_shape()[-1];
-    const auto tp_axis = 1 - cluster_axis;
-
-    auto working_shared_w0 = ttnn::mesh_partition(shared_w0, -1, tp_axis);
-
-    const auto padding = intermediate_dim - working_shared_w0.logical_shape()[-1];
-    const std::array<4, std::tuple<uint32_t, uint32_t>> padding_spec01 = {{0, 0}, {0, 0}, {0, 0}, {0, padding}};
-    working_shared_w0 = ttnn::pad(working_shared_w0, padding_spec01);
-
-    auto output_w0 = ttnn::concat({routed_w0, working_shared_w0}, 1);
+    const ttnn::Tensor& shared_w2) {
+    auto output_w0 = ttnn::concat({routed_w0, shared_w0}, 1);
     auto tile_w0 = ttnn::to_layout(output_w0, ttnn::Layout::TILE);
-    working_shared_w0.deallocate(/*force*/ = true);
-    output_w0.deallocate(/*force=*/true);
-
-    auto working_shared_w1 = ttnn::mesh_partition(shared_w1, -1, tp_axis);
-    working_shared_w0 = ttnn::pad(working_shared_w1, padding_spec01);
-
-    auto output_w1 = ttnn::concat({routed_w1, working_shared_w0}, 1);
+    output_w0.deallocate(/*force=*/false);
+    auto output_w1 = ttnn::concat({routed_w1, shared_w1}, 1);
     auto tile_w1 = ttnn::to_layout(output_w1, ttnn::Layout::TILE);
-    working_shared_w1.deallocate(/*force*/ = true);
-    output_w1.deallocate(/*force=*/true);
-
-    auto working_shared_w2 = ttnn::mesh_partition(shared_w2, -2, tp_axis);
-    const std::array<4, std::tuple<uint32_t, uint32_t>> padding_spec2 = {{0, 0}, {0, 0}, {0, padding}, {0, 0}};
-    working_shared_w2 = ttnn::pad(working_shared_w2, padding_spec2);
-
-    auto output_w2 = ttnn::concat({routed_w2, working_shared_w2}, 1);
+    output_w1.deallocate(/*force=*/false);
+    auto output_w2 = ttnn::concat({routed_w2, shared_w2}, 1);
     auto tile_w2 = ttnn::to_layout(output_w2, ttnn::Layout::TILE);
-    output_w2.deallocate(/*force=*/true);
+    output_w2.deallocate(/*force=*/false);
     return {tile_w0, tile_w1, tile_w2};
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
@@ -79,6 +79,61 @@ ttnn::Tensor stack_along(const std::vector<ttnn::Tensor>& tensors, int dim) {
     return ttnn::concat(unsqueezed, dim);
 }
 
+// Lay a TP-split shared-expert weight out so each ring core's real TpNt slice
+// sits at the FRONT of that core's full-Nt shard, zero-filling the rest. `axis`
+// is the intermediate (Nt) dim: last dim for W0/W1, dim -2 for W2. `full_map[c]`
+// is core c's tile count under the full-Nt shard (sum = Nt); `tp_map[c]` is core
+// c's count under the TpNt shard (sum = TpNt). The real tiles are consumed in
+// order, so applying the SAME (full_map, tp_map) pair to W0/W1 (axis=-1) and W2
+// (axis=-2) keeps each real intermediate column paired with its W2 row — i.e. a
+// correct partial contraction once the kernel walks only the per-core prefixes.
+//
+// This replaces a single global right-pad-to-Nt, which front-packed the real
+// data GLOBALLY (concentrated in the low ring cores) and so could not be walked
+// as a balanced per-core TpNt ring.
+ttnn::Tensor front_pack_per_core(
+    const ttnn::Tensor& real, int axis, const std::vector<uint32_t>& full_map, const std::vector<uint32_t>& tp_map) {
+    const auto shape = real.logical_shape();
+    const int rank = static_cast<int>(shape.rank());
+    const int ax = axis < 0 ? rank + axis : axis;
+    const uint32_t num_cores = static_cast<uint32_t>(full_map.size());
+
+    std::vector<ttnn::Tensor> pieces;
+    uint32_t cursor = 0;  // real tiles consumed so far (along `ax`)
+    for (uint32_t c = 0; c < num_cores; ++c) {
+        const uint32_t r = tp_map[c];
+        const uint32_t s = full_map[c];
+        TT_FATAL(r <= s, "TpNt shard ({}) exceeds full-Nt shard ({}) at core {}", r, s, c);
+        if (r > 0) {
+            ttsl::SmallVector<int32_t> begins(rank, 0);
+            ttsl::SmallVector<int32_t> ends;
+            ends.reserve(rank);
+            for (int d = 0; d < rank; ++d) {
+                ends.push_back(static_cast<int32_t>(shape[d]));
+            }
+            begins[ax] = static_cast<int32_t>(cursor * TILE_SIZE);
+            ends[ax] = static_cast<int32_t>((cursor + r) * TILE_SIZE);
+            pieces.push_back(slice_basic(real, begins, ends));
+            cursor += r;
+        }
+        if (s > r) {
+            std::vector<uint32_t> zshape;
+            zshape.reserve(rank);
+            for (int d = 0; d < rank; ++d) {
+                zshape.push_back(static_cast<uint32_t>(shape[d]));
+            }
+            zshape[ax] = (s - r) * TILE_SIZE;
+            pieces.push_back(
+                ttnn::zeros(ttnn::Shape(zshape), real.dtype(), real.layout(), *real.device(), real.memory_config()));
+        }
+    }
+    auto out = ttnn::concat(pieces, ax);
+    for (auto& p : pieces) {
+        p.deallocate(/*force=*/true);
+    }
+    return out;
+}
+
 // W2 packer without the trailing N-pad — used by the bias-aware path so the
 // bias tile row can be concatenated before the alignment pad is applied.
 ttnn::Tensor prepare_w2_no_n_pad(
@@ -370,31 +425,52 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
     const ttnn::Tensor& shared_w0,
     const ttnn::Tensor& shared_w1,
     const ttnn::Tensor& shared_w2,
-    const uint32_t cluster_axis) {
-    const auto intermediate_dim = routed_w0.logical_shape()[-1];
+    const uint32_t cluster_axis,
+    const uint32_t bh_ring_size) {
+    const auto intermediate_dim = static_cast<uint32_t>(routed_w0.logical_shape()[-1]);
+    const auto hidden_dim = static_cast<uint32_t>(routed_w0.logical_shape()[-2]);
     const auto tp_axis = 1 - cluster_axis;
+    auto* device = routed_w0.device();
 
-    auto working_shared_w0 = ttnn::mesh_partition(shared_w0, -1, tp_axis);
+    // Per-core shard maps, generated with the SAME moe_ring::shard_tiles the kernel's
+    // shard LUT uses (so host layout and kernel geometry agree by construction):
+    //  - full_map: how the uniform prep slices EVERY expert's full-Nt intermediate.
+    //  - tp_map:   the TpNt sub-shard the shared expert actually contracts.
+    // We front-pack each core's real TpNt tiles into the front of its full-Nt shard
+    // (zeros after), applying the same mapping to W0/W1 and W2. This keeps the whole
+    // downstream prep + DRAM layout uniform (full-Nt per-expert stride) while letting
+    // the kernel walk only the real per-core prefixes as a balanced TpNt ring.
+    const auto full_map =
+        get_weight_core_shard_maps(device, hidden_dim, intermediate_dim, bh_ring_size).w0_w1_shard_map;
 
-    const auto padding = intermediate_dim - working_shared_w0.logical_shape()[-1];
-    const ttsl::SmallVector<std::array<uint32_t, 2>> padding_spec01 = {{0, 0}, {0, 0}, {0, 0}, {0, padding}};
-    working_shared_w0 = ttnn::pad(working_shared_w0, padding_spec01, /*value=*/0.0f);
+    auto mp_w0 = ttnn::mesh_partition(shared_w0, -1, tp_axis);
+    const auto tp_intermediate = static_cast<uint32_t>(mp_w0.logical_shape()[-1]);
+    TT_FATAL(
+        tp_intermediate % TILE_SIZE == 0,
+        "TP-split intermediate ({}) must be tile-aligned (TILE_SIZE={})",
+        tp_intermediate,
+        TILE_SIZE);
+    const auto tp_map = get_weight_core_shard_maps(device, hidden_dim, tp_intermediate, bh_ring_size).w0_w1_shard_map;
 
+    auto working_shared_w0 = front_pack_per_core(mp_w0, /*axis=*/-1, full_map, tp_map);
+    mp_w0.deallocate(/*force=*/false);
     auto output_w0 = ttnn::concat({routed_w0, working_shared_w0}, 1);
     working_shared_w0.deallocate(/*force=*/false);
 
-    auto working_shared_w1 = ttnn::mesh_partition(shared_w1, -1, tp_axis);
-    working_shared_w1 = ttnn::pad(working_shared_w1, padding_spec01, /*value=*/0.0f);
-
+    auto mp_w1 = ttnn::mesh_partition(shared_w1, -1, tp_axis);
+    auto working_shared_w1 = front_pack_per_core(mp_w1, /*axis=*/-1, full_map, tp_map);
+    mp_w1.deallocate(/*force=*/false);
     auto output_w1 = ttnn::concat({routed_w1, working_shared_w1}, 1);
     working_shared_w1.deallocate(/*force=*/false);
 
-    auto working_shared_w2 = ttnn::mesh_partition(shared_w2, -2, tp_axis);
-    const ttsl::SmallVector<std::array<uint32_t, 2>> padding_spec2 = {{0, 0}, {0, 0}, {0, padding}, {0, 0}};
-    working_shared_w2 = ttnn::pad(working_shared_w2, padding_spec2, /*value=*/0.0f);
-
+    // W2's intermediate (contraction K) is dim -2. Same maps -> each real W2 row pairs
+    // with its real W0/W1 column.
+    auto mp_w2 = ttnn::mesh_partition(shared_w2, -2, tp_axis);
+    auto working_shared_w2 = front_pack_per_core(mp_w2, /*axis=*/-2, full_map, tp_map);
+    mp_w2.deallocate(/*force=*/false);
     auto output_w2 = ttnn::concat({routed_w2, working_shared_w2}, 1);
     working_shared_w2.deallocate(/*force=*/false);
+
     return {output_w0, output_w1, output_w2};
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
@@ -87,10 +87,6 @@ ttnn::Tensor stack_along(const std::vector<ttnn::Tensor>& tensors, int dim) {
 // order, so applying the SAME (full_map, tp_map) pair to W0/W1 (axis=-1) and W2
 // (axis=-2) keeps each real intermediate column paired with its W2 row — i.e. a
 // correct partial contraction once the kernel walks only the per-core prefixes.
-//
-// This replaces a single global right-pad-to-Nt, which front-packed the real
-// data GLOBALLY (concentrated in the low ring cores) and so could not be walked
-// as a balanced per-core TpNt ring.
 ttnn::Tensor front_pack_per_core(
     const ttnn::Tensor& real, int axis, const std::vector<uint32_t>& full_map, const std::vector<uint32_t>& tp_map) {
     const auto shape = real.logical_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
@@ -98,6 +98,10 @@ ttnn::Tensor front_pack_per_core(
     const int ax = axis < 0 ? rank + axis : axis;
     const uint32_t num_cores = static_cast<uint32_t>(full_map.size());
 
+    ttsl::SmallVector<int32_t> begins(rank, 0);
+    ttsl::SmallVector<int32_t> ends(rank, 0);
+    ttsl::SmallVector<uint32_t> zshape(rank, 0);
+
     std::vector<ttnn::Tensor> pieces;
     uint32_t cursor = 0;  // real tiles consumed so far (along `ax`)
     for (uint32_t c = 0; c < num_cores; ++c) {
@@ -105,24 +109,26 @@ ttnn::Tensor front_pack_per_core(
         const uint32_t s = full_map[c];
         TT_FATAL(r <= s, "TpNt shard ({}) exceeds full-Nt shard ({}) at core {}", r, s, c);
         if (r > 0) {
-            ttsl::SmallVector<int32_t> begins(rank, 0);
-            ttsl::SmallVector<int32_t> ends;
-            ends.reserve(rank);
             for (int d = 0; d < rank; ++d) {
-                ends.push_back(static_cast<int32_t>(shape[d]));
+                if (d == ax) {
+                    begins[d] = cursor * TILE_SIZE;
+                    ends[d] = (cursor + r) * TILE_SIZE;
+                } else {
+                    ends[d] = shape[d];
+                    begins[d] = 0;
+                }
             }
-            begins[ax] = static_cast<int32_t>(cursor * TILE_SIZE);
-            ends[ax] = static_cast<int32_t>((cursor + r) * TILE_SIZE);
             pieces.push_back(slice_basic(real, begins, ends));
             cursor += r;
         }
         if (s > r) {
-            std::vector<uint32_t> zshape;
-            zshape.reserve(rank);
             for (int d = 0; d < rank; ++d) {
-                zshape.push_back(static_cast<uint32_t>(shape[d]));
+                if (d == ax) {
+                    zshape[d] = (s - r) * TILE_SIZE;
+                } else {
+                    zshape[d] = shape[d];
+                }
             }
-            zshape[ax] = (s - r) * TILE_SIZE;
             pieces.push_back(
                 ttnn::zeros(ttnn::Shape(zshape), real.dtype(), real.layout(), *real.device(), real.memory_config()));
         }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
@@ -5,6 +5,7 @@
 #include "moe_compute_utils.hpp"
 
 #include <algorithm>
+#include <array>
 #include <cstddef>
 #include <cstdint>
 #include <numeric>
@@ -21,11 +22,13 @@
 #include <tt_stl/small_vector.hpp>
 #include <tt_stl/span.hpp>
 
+#include "ttnn/operations/ccl/mesh_partition/mesh_partition.hpp"
 #include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/core/to_dtype/to_dtype_op.hpp"
 #include "ttnn/operations/core/to_layout/to_layout_op.hpp"
 #include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/operations/data_movement/concat/concat.hpp"
+#include "ttnn/operations/data_movement/pad/pad.hpp"
 #include "ttnn/operations/data_movement/permute/permute.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
 #include "ttnn/operations/data_movement/slice/slice.hpp"
@@ -360,63 +363,39 @@ WeightMemoryConfigs get_weight_mem_configs(
     return {w0_w1_mem_config, w2_mem_config};
 }
 
-// std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
-//     const ttnn::Tensor& routed_w0,
-//     const ttnn::Tensor& routed_w1,
-//     const ttnn::Tensor& routed_w2,
-//     const ttnn::Tensor& shared_w0,
-//     const ttnn::Tensor& shared_w1,
-//     const ttnn::Tensor& shared_w2,
-//     const uint32_t cluster_axis) {
-//     const auto intermediate_dim = routed_w0.logical_shape()[-1];
-//     const auto tp_axis = 1 - cluster_axis;
-//
-//     auto working_shared_w0 = ttnn::mesh_partition(shared_w0, -1, tp_axis);
-//
-//     const auto padding = intermediate_dim - working_shared_w0.logical_shape()[-1];
-//     const std::array<4, std::tuple<uint32_t, uint32_t>> padding_spec01 = {{0, 0}, {0, 0}, {0, 0}, {0, padding}};
-//     working_shared_w0 = ttnn::pad(working_shared_w0, padding_spec01);
-//
-//     auto output_w0 = ttnn::concat({routed_w0, working_shared_w0}, 1);
-//     auto tile_w0 = ttnn::to_layout(output_w0, ttnn::Layout::TILE);
-//     working_shared_w0.deallocate(/*force*/ = true);
-//     output_w0.deallocate(/*force=*/true);
-//
-//     auto working_shared_w1 = ttnn::mesh_partition(shared_w1, -1, tp_axis);
-//     working_shared_w0 = ttnn::pad(working_shared_w1, padding_spec01);
-//
-//     auto output_w1 = ttnn::concat({routed_w1, working_shared_w0}, 1);
-//     auto tile_w1 = ttnn::to_layout(output_w1, ttnn::Layout::TILE);
-//     working_shared_w1.deallocate(/*force*/ = true);
-//     output_w1.deallocate(/*force=*/true);
-//
-//     auto working_shared_w2 = ttnn::mesh_partition(shared_w2, -2, tp_axis);
-//     const std::array<4, std::tuple<uint32_t, uint32_t>> padding_spec2 = {{0, 0}, {0, 0}, {0, padding}, {0, 0}};
-//     working_shared_w2 = ttnn::pad(working_shared_w2, padding_spec2);
-//
-//     auto output_w2 = ttnn::concat({routed_w2, working_shared_w2}, 1);
-//     auto tile_w2 = ttnn::to_layout(output_w2, ttnn::Layout::TILE);
-//     output_w2.deallocate(/*force=*/true);
-//     return {tile_w0, tile_w1, tile_w2};
-// }
-
 std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
     const ttnn::Tensor& routed_w0,
     const ttnn::Tensor& routed_w1,
     const ttnn::Tensor& routed_w2,
     const ttnn::Tensor& shared_w0,
     const ttnn::Tensor& shared_w1,
-    const ttnn::Tensor& shared_w2) {
-    auto output_w0 = ttnn::concat({routed_w0, shared_w0}, 1);
-    auto tile_w0 = ttnn::to_layout(output_w0, ttnn::Layout::TILE);
-    output_w0.deallocate(/*force=*/false);
-    auto output_w1 = ttnn::concat({routed_w1, shared_w1}, 1);
-    auto tile_w1 = ttnn::to_layout(output_w1, ttnn::Layout::TILE);
-    output_w1.deallocate(/*force=*/false);
-    auto output_w2 = ttnn::concat({routed_w2, shared_w2}, 1);
-    auto tile_w2 = ttnn::to_layout(output_w2, ttnn::Layout::TILE);
-    output_w2.deallocate(/*force=*/false);
-    return {tile_w0, tile_w1, tile_w2};
+    const ttnn::Tensor& shared_w2,
+    const uint32_t cluster_axis) {
+    const auto intermediate_dim = routed_w0.logical_shape()[-1];
+    const auto tp_axis = 1 - cluster_axis;
+
+    auto working_shared_w0 = ttnn::mesh_partition(shared_w0, -1, tp_axis);
+
+    const auto padding = intermediate_dim - working_shared_w0.logical_shape()[-1];
+    const ttsl::SmallVector<std::array<uint32_t, 2>> padding_spec01 = {{0, 0}, {0, 0}, {0, 0}, {0, padding}};
+    working_shared_w0 = ttnn::pad(working_shared_w0, padding_spec01, /*value=*/0.0f);
+
+    auto output_w0 = ttnn::concat({routed_w0, working_shared_w0}, 1);
+    working_shared_w0.deallocate(/*force=*/false);
+
+    auto working_shared_w1 = ttnn::mesh_partition(shared_w1, -1, tp_axis);
+    working_shared_w1 = ttnn::pad(working_shared_w1, padding_spec01, /*value=*/0.0f);
+
+    auto output_w1 = ttnn::concat({routed_w1, working_shared_w1}, 1);
+    working_shared_w1.deallocate(/*force=*/false);
+
+    auto working_shared_w2 = ttnn::mesh_partition(shared_w2, -2, tp_axis);
+    const ttsl::SmallVector<std::array<uint32_t, 2>> padding_spec2 = {{0, 0}, {0, 0}, {0, padding}, {0, 0}};
+    working_shared_w2 = ttnn::pad(working_shared_w2, padding_spec2, /*value=*/0.0f);
+
+    auto output_w2 = ttnn::concat({routed_w2, working_shared_w2}, 1);
+    working_shared_w2.deallocate(/*force=*/false);
+    return {output_w0, output_w1, output_w2};
 }
 
 ttnn::Tensor prepare_w0_w1_tensor_for_moe_compute(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp
@@ -75,7 +75,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
     const ttnn::Tensor& routed_w2,
     const ttnn::Tensor& shared_w0,
     const ttnn::Tensor& shared_w1,
-    const ttnn::Tensor& shared_w2);
+    const ttnn::Tensor& shared_w2 uint32_t cluster_axis);
 
 // Pack W0/W1 into the interleaved, padded, per-core layout the MoE kernel reads.
 // Output local shape: ``(num_cores, L, E, groups_per_core, K_padded, 4*TILE)``.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp
@@ -76,7 +76,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
     const ttnn::Tensor& shared_w0,
     const ttnn::Tensor& shared_w1,
     const ttnn::Tensor& shared_w2,
-    uint32_t cluster_axis);
+    uint32_t cluster_axis,
+    uint32_t bh_ring_size = 12);
 
 // Pack W0/W1 into the interleaved, padded, per-core layout the MoE kernel reads.
 // Output local shape: ``(num_cores, L, E, groups_per_core, K_padded, 4*TILE)``.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp
@@ -75,8 +75,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
     const ttnn::Tensor& routed_w2,
     const ttnn::Tensor& shared_w0,
     const ttnn::Tensor& shared_w1,
-    const ttnn::Tensor& shared_w2);
-// uint32_t cluster_axis);
+    const ttnn::Tensor& shared_w2,
+    uint32_t cluster_axis);
 
 // Pack W0/W1 into the interleaved, padded, per-core layout the MoE kernel reads.
 // Output local shape: ``(num_cores, L, E, groups_per_core, K_padded, 4*TILE)``.

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp
@@ -75,7 +75,8 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
     const ttnn::Tensor& routed_w2,
     const ttnn::Tensor& shared_w0,
     const ttnn::Tensor& shared_w1,
-    const ttnn::Tensor& shared_w2 uint32_t cluster_axis);
+    const ttnn::Tensor& shared_w2);
+// uint32_t cluster_axis);
 
 // Pack W0/W1 into the interleaved, padded, per-core layout the MoE kernel reads.
 // Output local shape: ``(num_cores, L, E, groups_per_core, K_padded, 4*TILE)``.

--- a/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/reduction/deepseek_moe_fast_reduce_nc_fused/deepseek_moe_fast_reduce_nc_fused_nanobind.cpp
@@ -44,6 +44,19 @@ void bind_deepseek_moe_fast_reduce_nc_fused(nb::module_& mod) {
                 ROW_MAJOR layout, DRAM. If omitted, calls :func:`~ttnn.experimental.deepseek_moe_fast_reduce_nc`
                 instead (no fused multiply by scores). The expert_indices_tensor /
                 expert_mapping_tensor / cluster_axis arguments are ignored on that fallback path.
+            num_shared_experts (int, optional): number of shared experts occupying the trailing
+                slots of the reduce dimension, whose size is
+                ``reduction_dim_size = num_routed_experts + num_shared_experts``. The leading
+                ``num_routed_experts`` slots are scaled by per-token ``scores_tensor`` values; the
+                trailing shared-expert slots are scaled by the constant ``shared_expert_scale``
+                instead. The ``scores_tensor`` last dim must equal ``num_routed_experts``
+                (``= reduction_dim_size - num_shared_experts``). This is the *logical* shared-expert
+                count — matching the all_to_all_dispatch / ``select_experts_k + num_shared_experts``
+                layout — NOT the per-device ``num_shared_experts_per_device`` used by
+                ``ttnn.experimental.moe_compute``. Defaults to 0.
+            shared_expert_scale (float, optional): constant scale applied to each shared expert's
+                contribution inside the reduce loop, used in place of the per-token scores that
+                exist only for routed experts. Defaults to 1.0.
             compute_kernel_config (ttnn.DeviceComputeKernelConfig): optional compute config.
 
         Returns:


### PR DESCRIPTION
https://github.com/tenstorrent/tt-metal/issues/45060
### Summary
- Previously, `moe_compute` would treat the shared expert compute like any other expert. This was correct and actually pretty decent perf but still involved redundant work and required an awkward scaling.
- Implement shared expert TP weight sharding in weight setup function, as well as reordering and padding to allow proper work distribution.
- ~~Only matmul off axis w2 shards~~
- Off axis w0/w1 sharded and distributed properly, w2 operates on full weight dimension, much of the data is padding.
- Remove awkward off axis scaling from decode module
- Remove shared expert testing from DeepSeek_v3 test, since we don't use the feature there and it has now diverged here, and is tested elsewhere.

### Notes for reviewers
- TP sharded work distribution is not implemented for the w2 contraction, this part still operates on the full dimension, much of it padding. It is much more complicated and invasive to add the proper w2 distribution and we are currently getting 2/3 of the perf benefit. 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/tt-moe-decode-tp-shared)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/tt-moe-decode-tp-shared)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/tt-moe-decode-tp-shared)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/tt-moe-decode-tp-shared)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amorrison/tt-moe-decode-tp-shared)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/tt-moe-decode-tp-shared)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/tt-moe-decode-tp-shared)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/tt-moe-decode-tp-shared)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/tt-moe-decode-tp-shared)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/tt-moe-decode-tp-shared)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/tt-moe-decode-tp-shared)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/tt-moe-decode-tp-shared)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/tt-moe-decode-tp-shared)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/tt-moe-decode-tp-shared)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/tt-moe-decode-tp-shared)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/tt-moe-decode-tp-shared)