### PR TITLE
ds_prefill - Removing duplicated OP tests from T3K e2e and BH e2e, fix for L2-nightly

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -122,7 +122,7 @@ ttsim:
 
 shield:
   e2e:
-    wh_llmbox: 110
+    wh_llmbox: 60
 
 # Former fabric + scaleout budgets merged under team scaleout (see tests/pipeline_reorg).
 scaleout:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -122,7 +122,7 @@ ttsim:
 
 shield:
   e2e:
-    wh_llmbox: 60
+    wh_llmbox: 110
 
 # Former fabric + scaleout budgets merged under team scaleout (see tests/pipeline_reorg).
 scaleout:

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -310,7 +310,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or not fabric2d" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or not fabric2d) and not small-dims-validate-pcc" || exit_code=$?
     exit $exit_code
   skus:
     bh_p150b_civ2:
@@ -336,10 +336,10 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (2x2 and pcc_check and not fabric2d)) and not small-dims-validate-pcc" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or (2x2 and pcc_check and not fabric2d)" || exit_code=$?
     exit $exit_code
   skus:
     bh_quietbox_2:
-      timeout: 20
+      timeout: 60
   owner_id: U094PKWHNJ0 # Petar Milojevic
   team: models

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -256,7 +256,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (4x2 and pcc_check and not fabric2d)) and (not test_rope_prefill or 4x2) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4)" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (4x2 and pcc_check and not fabric2d)) and (not test_rope_prefill or 4x2) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4) and not small-dims-validate-pcc" || exit_code=$?
     exit $exit_code
   skus:
     bh_loudbox:
@@ -297,7 +297,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or (2x2 and pcc_check and not fabric2d)" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (2x2 and pcc_check and not fabric2d)) and not small-dims-validate-pcc" || exit_code=$?
     exit $exit_code
   skus:
     bh_llmbox:
@@ -323,7 +323,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or not fabric2d" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or not fabric2d) and not small-dims-validate-pcc" || exit_code=$?
     exit $exit_code
   skus:
     bh_p300:
@@ -336,7 +336,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or (2x2 and pcc_check and not fabric2d)" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (2x2 and pcc_check and not fabric2d)) and not small-dims-validate-pcc" || exit_code=$?
     exit $exit_code
   skus:
     bh_quietbox_2:

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -240,8 +240,6 @@
   cmd: |
     exit_code=0
     pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64 and not fabric2d-" --timeout 1800 || exit_code=$?
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and pcc_check and not fabric2d' -vvv --tb=short || exit_code=$?
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_rope_prefill.py -k '4x2' -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge and cpu and 2x4 and line and not multiuser" -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "balanced and not non_balanced and fabric2d" -vvv --tb=short --timeout=900 || exit_code=$?
@@ -258,7 +256,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (4x2 and pcc_check)) and (not test_rope_prefill or 4x2) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4)" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "(not test_ring_joint_mla or (4x2 and pcc_check and not fabric2d)) and (not test_rope_prefill or 4x2) and (not update_padded_kv_cache or 2x4) and (not rotary_embedding_indexed or 2x4)" || exit_code=$?
     exit $exit_code
   skus:
     bh_loudbox:
@@ -287,7 +285,6 @@
   model-name: deepseek_prefill
   cmd: |
     pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64 and not fabric2d-" --timeout 1800
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2 and pcc_check and not fabric2d' -vvv --tb=short
     pytest models/demos/deepseek_v3_d_p/tests/cache/ -vvv --tb=short
   skus:
     bh_quietbox_2:
@@ -300,7 +297,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or (2x2 and pcc_check)" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or (2x2 and pcc_check and not fabric2d)" || exit_code=$?
     exit $exit_code
   skus:
     bh_llmbox:
@@ -313,7 +310,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or not fabric2d" || exit_code=$?
     exit $exit_code
   skus:
     bh_p150b_civ2:
@@ -326,7 +323,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or not fabric2d" || exit_code=$?
     exit $exit_code
   skus:
     bh_p300:
@@ -339,7 +336,7 @@
   model-name: deepseek_prefill
   cmd: |
     exit_code=0
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or (2x2 and pcc_check)" || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/ -vvv --tb=short -k "not test_ring_joint_mla or (2x2 and pcc_check and not fabric2d)" || exit_code=$?
     exit $exit_code
   skus:
     bh_quietbox_2:

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -124,12 +124,7 @@
 
 - name: t3k_DeepSeek_PREFILL
   cmd: |
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py -vvv --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-"
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py -vvv  --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-"
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py -vvv --tb=short -k "2048 and (linear-4x1 or mesh-4x2 or mesh-2x4)"
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py -vvv --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-"
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -vvv --tb=short -k "mesh-4x2" --timeout 900
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and single_run and pcc_check and not fabric2d' -vvv --tb=short
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge and cpu and 2x4 and line and not multiuser" -vvv --tb=short
   skus:

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -129,7 +129,7 @@
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge and cpu and 2x4 and line and not multiuser" -vvv --tb=short
   skus:
     wh_llmbox:
-      timeout: 75
+      timeout: 25
   owner_id: U08E1JCMAJF # Marko Bezulj
   team: shield
   model-name: deepseek_prefill

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_extract.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_extract.py
@@ -110,7 +110,9 @@ def test_valid_inputs_2d_index_first_dim_one(device):
 
 
 def test_global_tensor_wrong_dtype(device):
-    g = _make_global(device, dtype=ttnn.bfloat16)
+    # The op accepts BFLOAT8_B and BFLOAT16 (bf16 is used by the PCC test path);
+    # float32 is a genuinely-invalid global_tensor dtype that must be rejected.
+    g = _make_global(device, dtype=ttnn.float32)
     s = _make_index(device)
     c = _make_index(device)
     with pytest.raises(RuntimeError):


### PR DESCRIPTION
### Problem description
DeepSeek V3 Prefill multi-chip OP tests were not all in the right folder for OP tests, so now they are being moved to the right one.

### What's changed
- Reducing time_budget for T3K e2e tests
- Removing duplicated OP tests `from tests/pipeline_reorg/blackhole_e2e_tests.yaml` and `tests/pipeline_reorg/t3k_e2e_tests.yaml`
- L2-nightly fixes for `tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_moe_post_combine_reduce.py` and `tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/test_deepseek_prefill_extract.py`

### DeepSeek CI

- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/OPtests-quickfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/OPtests-quickfix)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/OPtests-quickfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/OPtests-quickfix)
- [x] [![(L2-nightly) tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/OPtests-quickfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/OPtests-quickfix)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/OPtests-quickfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/OPtests-quickfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/OPtests-quickfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/OPtests-quickfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilojevic/OPtests-quickfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilojevic/OPtests-quickfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/OPtests-quickfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/OPtests-quickfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/OPtests-quickfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/OPtests-quickfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/OPtests-quickfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/OPtests-quickfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/OPtests-quickfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/OPtests-quickfix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/OPtests-quickfix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/OPtests-quickfix)