### PR TITLE
[Feature] Add Metal 2.0 offline (AOT) kernel compile + load for ProgramSpec

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_offline_compile.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_offline_compile.cpp
@@ -1,0 +1,191 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Real-hardware tests for the Metal 2.0 offline (AOT) compile + load APIs:
+//   experimental::CompileProgramSpecOffline  (produce)
+//   experimental::SetProgramPrecompiledConfig (load)
+//
+// These require a Wormhole B0 or Blackhole device. They prove the round trip:
+//   produce ELFs from a ProgramSpec -> load them into a fresh Program built from the same
+//   spec -> compile finds the AOT binaries (no JIT) -> and the negative paths (missing dir,
+//   hash-bucket mismatch, late call) all fail loudly.
+//
+// Requires: TT_METAL_SLOW_DISPATCH_MODE=1 (mirrors test_program_spec_hw.cpp).
+
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+
+#include <chrono>
+#include <cstddef>
+#include <filesystem>
+#include <stdexcept>
+#include <string>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/tt_metal.hpp>  // detail::CompileProgram
+#include <tt-metalium/experimental/offline_kernel_compile.hpp>
+#include <tt-metalium/experimental/metal2_host_api/offline_compile.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+
+#include "device_fixture.hpp"
+#include "test_helpers.hpp"
+
+namespace tt::tt_metal::experimental {
+namespace {
+
+namespace fs = std::filesystem;
+
+using BinaryPolicy = PrecompiledKernelConfig::FallbackPolicy;
+using test_helpers::MakeMinimalGen1ValidProgramSpec;
+
+// RAII temp directory, auto-removed on destruction.
+struct ScopedTempDir {
+    explicit ScopedTempDir(const std::string& tag) {
+        const auto timestamp_ns = std::chrono::steady_clock::now().time_since_epoch().count();
+        path_ = fs::temp_directory_path() / (tag + "_" + std::to_string(timestamp_ns));
+        fs::create_directories(path_);
+    }
+    ~ScopedTempDir() {
+        std::error_code ec;
+        fs::remove_all(path_, ec);
+    }
+    ScopedTempDir(const ScopedTempDir&) = delete;
+    ScopedTempDir& operator=(const ScopedTempDir&) = delete;
+
+    std::string string() const { return path_.string(); }
+
+    fs::path path_;
+};
+
+// Count regular files anywhere under `root` (the emitted ELFs live in nested per-kernel dirs).
+size_t count_regular_files(const fs::path& root) {
+    size_t count = 0;
+    if (!fs::exists(root)) {
+        return 0;
+    }
+    for (const auto& entry : fs::recursive_directory_iterator(root)) {
+        if (entry.is_regular_file()) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+PrecompiledKernelConfig make_config(const std::string& dir, BinaryPolicy policy) {
+    return PrecompiledKernelConfig{.precompiled_dir = dir, .fallback_policy = policy};
+}
+
+class OfflineCompileHWTest : public tt::tt_metal::MeshDeviceFixture {
+protected:
+    void SetUp() override {
+        MeshDeviceFixture::SetUp();
+        if (this->IsSkipped()) {
+            return;
+        }
+        if (devices_.at(0)->arch() != tt::ARCH::WORMHOLE_B0 && devices_.at(0)->arch() != tt::ARCH::BLACKHOLE) {
+            GTEST_SKIP() << "Skipping: test requires Wormhole B0 or Blackhole hardware";
+        }
+    }
+};
+
+// Produce: CompileProgramSpecOffline emits AOT artifacts under output_dir.
+TEST_F(OfflineCompileHWTest, ProduceEmitsBinaries) {
+    auto mesh_device = devices_.at(0);
+    ScopedTempDir out_dir("metal2_offline_produce");
+
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    CompileProgramSpecOffline(*mesh_device, spec, out_dir.string());
+
+    EXPECT_GT(count_regular_files(out_dir.path_), 0u)
+        << "CompileProgramSpecOffline emitted no files under " << out_dir.string();
+}
+
+// Load hit: a fresh program from the same spec, pointed at the produced dir with the strict
+// Error policy, compiles without throwing -> the AOT binaries were found at exactly the path
+// the runtime loader searches (the production code itself is the exact-path assertion).
+TEST_F(OfflineCompileHWTest, LoadHitUsesPrecompiledBinaries) {
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    ScopedTempDir out_dir("metal2_offline_loadhit");
+
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    CompileProgramSpecOffline(*mesh_device, spec, out_dir.string());
+
+    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    SetProgramPrecompiledConfig(program, make_config(out_dir.string(), BinaryPolicy::Error));
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+// Load miss (empty dir): strict Error policy against a dir with no binaries throws.
+TEST_F(OfflineCompileHWTest, LoadMissEmptyDirThrows) {
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    ScopedTempDir empty_dir("metal2_offline_empty");
+
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    SetProgramPrecompiledConfig(program, make_config(empty_dir.string(), BinaryPolicy::Error));
+
+    EXPECT_THROW(detail::CompileProgram(device, program), PrecompiledKernelNotFoundError);
+}
+
+// Load miss (hash-bucket mismatch): produce from spec A, then load a structurally different
+// spec B (different kernel source -> different compile hash) from the same dir. The kernel's
+// recomputed hash bucket is absent, so strict Error throws. This is the same failure mode as a
+// produce-time/load-time build_key mismatch (watcher/dprint/opt-level divergence).
+TEST_F(OfflineCompileHWTest, LoadMissOnHashMismatchThrows) {
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    ScopedTempDir out_dir("metal2_offline_mismatch");
+
+    ProgramSpec produced = MakeMinimalGen1ValidProgramSpec();
+    CompileProgramSpecOffline(*mesh_device, produced, out_dir.string());
+
+    // Same structure, but mutate one kernel's source so its compile hash changes.
+    ProgramSpec divergent = MakeMinimalGen1ValidProgramSpec();
+    divergent.kernels.at(0).source = KernelSpec::SourceCode{"void kernel_main() { volatile int x = 7; (void)x; }"};
+
+    Program program = MakeProgramFromSpec(*mesh_device, divergent);
+    SetProgramPrecompiledConfig(program, make_config(out_dir.string(), BinaryPolicy::Error));
+
+    EXPECT_THROW(detail::CompileProgram(device, program), PrecompiledKernelNotFoundError);
+}
+
+// Load fallback: JitCompile policy against an empty dir silently JIT-compiles (no throw).
+TEST_F(OfflineCompileHWTest, LoadMissJitFallbackCompiles) {
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    ScopedTempDir empty_dir("metal2_offline_jitfallback");
+
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    SetProgramPrecompiledConfig(program, make_config(empty_dir.string(), BinaryPolicy::JitCompile));
+
+    EXPECT_NO_THROW(detail::CompileProgram(device, program));
+}
+
+// Guard: empty output_dir is rejected.
+TEST_F(OfflineCompileHWTest, ProduceEmptyOutputDirThrows) {
+    auto mesh_device = devices_.at(0);
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    EXPECT_THROW(CompileProgramSpecOffline(*mesh_device, spec, ""), std::runtime_error);
+}
+
+// Guard: SetProgramPrecompiledConfig must be called before the program is compiled.
+TEST_F(OfflineCompileHWTest, SetConfigAfterCompileThrows) {
+    auto mesh_device = devices_.at(0);
+    IDevice* device = mesh_device->get_devices()[0];
+    ScopedTempDir out_dir("metal2_offline_late");
+
+    ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+    Program program = MakeProgramFromSpec(*mesh_device, spec);
+    detail::CompileProgram(device, program);  // compiles (JIT) -> program is now compiled
+
+    EXPECT_THROW(
+        SetProgramPrecompiledConfig(program, make_config(out_dir.string(), BinaryPolicy::Error)), std::runtime_error);
+}
+
+}  // namespace
+}  // namespace tt::tt_metal::experimental

--- a/tests/tt_metal/tt_metal/api/sources.cmake
+++ b/tests/tt_metal/tt_metal/api/sources.cmake
@@ -24,6 +24,7 @@ set(UNIT_TESTS_API_SOURCES
     dataflow_buffer/test_dataflow_buffer_configs.cpp
     dataflow_buffer/test_borrowed_memory_dataflow_buffer.cpp
     distribution_spec/test_buffer_distribution_spec.cpp
+    metal2_host_api/test_offline_compile.cpp
     metal2_host_api/test_program_spec.cpp
     metal2_host_api/test_program_spec_hw.cpp
     metal2_host_api/test_program_run_args.cpp

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/offline_compile.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/offline_compile.hpp
@@ -17,9 +17,11 @@ namespace tt::tt_metal::experimental {
 // Metal 2.0 offline (AOT) compile + load APIs
 // (experimental namespace free functions)
 //
-// Live-device only: both APIs require a live MeshDevice so the producer and loader share
-// identical kernel hashing by construction (the producer reuses the real detail::CompileProgram
-// path, and the loader recomputes the same hash at dispatch time).
+// Requires an initialized MeshDevice: both APIs go through the real on-device CompileProgram
+// path, so the producer and loader compute identical kernel hashes by construction
+// (the loader recomputes the same hash at dispatch time). The device's build env (arch +
+// build flags, folded into build_key) must match the device the AOT binaries will run on;
+// a mock MeshDevice configured for the target arch is sufficient to produce them.
 //------------------------------------------------
 
 // Produce: compile every kernel in `spec` against `mesh_device` and emit AOT artifacts under

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/offline_compile.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/offline_compile.hpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <string>
+
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/experimental/offline_kernel_compile.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+
+namespace tt::tt_metal::experimental {
+
+//------------------------------------------------
+// Metal 2.0 offline (AOT) compile + load APIs
+// (experimental namespace free functions)
+//
+// Live-device only: both APIs require a live MeshDevice so the producer and loader share
+// identical kernel hashing by construction (the producer reuses the real detail::CompileProgram
+// path, and the loader recomputes the same hash at dispatch time).
+//------------------------------------------------
+
+// Produce: compile every kernel in `spec` against `mesh_device` and emit AOT artifacts under
+// `output_dir`. The on-disk layout matches the precompiled loader's search path, so a later
+// SetProgramPrecompiledConfig(program, {output_dir, ...}) call will find these binaries.
+//
+// Existing files under `output_dir` are overwritten (copy_file with overwrite_existing); the
+// directory is otherwise left intact. `output_dir` must be non-empty.
+//
+// `mesh_device` is taken by const ref (only get_devices()/build env are read). Only the first
+// device's build env is used; a warning is logged for larger meshes.
+//
+// PRECONDITION: unsupported when the remote JIT compile server is enabled
+// (jit_server::JitCompileRpcClient::enabled()); the call TT_FATALs in that case.
+void CompileProgramSpecOffline(
+    const distributed::MeshDevice& mesh_device, const ProgramSpec& spec, const std::string& output_dir);
+
+// Load: mark every kernel in `program` to load precompiled binaries from config.precompiled_dir
+// (with the given FallbackPolicy). Mirrors CreateKernelFromPrecompiled for Metal 2.0.
+//
+// CONTRACT: Must be called before the program is first compiled. ProgramImpl::compile
+// short-circuits once a build key has been compiled, so a late call would silently be a no-op;
+// this function TT_FATALs if the program is already compiled to make that loud instead of silent.
+//
+// PRECONDITION: unsupported when the remote JIT compile server is enabled
+// (the remote compile path does not honor precompiled config); the call TT_FATALs in that case.
+void SetProgramPrecompiledConfig(Program& program, const PrecompiledKernelConfig& config);
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/metal2_host_api/offline_compile.cpp
+++ b/tt_metal/impl/metal2_host_api/offline_compile.cpp
@@ -1,0 +1,147 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <tt-metalium/experimental/metal2_host_api/offline_compile.hpp>
+
+#include <cstdint>
+#include <filesystem>
+#include <memory>
+#include <string>
+#include <type_traits>
+#include <vector>
+
+#include <tt-logger/tt-logger.hpp>
+
+#include <tt-metalium/device.hpp>
+#include <tt-metalium/tt_metal.hpp>                              // detail::CompileProgram
+#include <tt-metalium/experimental/metal2_host_api/program.hpp>  // MakeProgramFromSpec
+
+#include "impl/context/metal_context.hpp"
+#include "impl/jit_server/jit_compile_rpc_client.hpp"
+#include "impl/kernels/kernel.hpp"
+#include "impl/program/program_impl.hpp"
+#include "jit_build/build_env_manager.hpp"
+#include "llrt/hal.hpp"
+
+namespace tt::tt_metal::experimental {
+
+namespace {
+
+// Iterate every kernel in `program_impl`, in programmable-core-type order.
+//
+// NOTE: get_kernels(idx) returns the per-core-type map; num_kernels() is a total count and is
+// NOT an index space, so it must not be used to drive this loop. The number of programmable
+// core types comes from the HAL (matching how ProgramImpl sizes its kernels_ vector).
+template <typename Fn>
+void for_each_kernel(detail::ProgramImpl& program_impl, const Fn& fn) {
+    const uint32_t core_type_count = MetalContext::instance().hal().get_programmable_core_type_count();
+    for (uint32_t core_type_idx = 0; core_type_idx < core_type_count; ++core_type_idx) {
+        for (auto& [kernel_handle, kernel] : program_impl.get_kernels(core_type_idx)) {
+            fn(kernel);
+        }
+    }
+}
+
+// Copy every generated ELF for `kernel` from the live device's JIT kernel root into `output_dir`.
+// Both source and destination paths are computed by BuildEnvManager::get_kernel_binary_path so the
+// emitted layout matches exactly what the runtime precompiled-loader path searches for.
+void copy_kernel_elfs_to_output_dir(
+    const std::shared_ptr<Kernel>& kernel,
+    BuildEnvManager& build_env_manager,
+    ChipId build_id,
+    const Hal& hal,
+    const std::string& source_kernel_root,
+    const std::string& output_dir) {
+    const uint32_t programmable_core_type_idx =
+        hal.get_programmable_core_type_index(kernel->get_kernel_programmable_core_type());
+    const uint32_t processor_class_idx =
+        static_cast<std::underlying_type_t<HalProcessorClassType>>(kernel->get_kernel_processor_class());
+
+    for (uint8_t binary_index = 0; binary_index < kernel->expected_num_binaries(); ++binary_index) {
+        const uint32_t processor_id = kernel->get_kernel_processor_type(binary_index);
+        const std::string source_elf_path = build_env_manager.get_kernel_binary_path(
+            build_id,
+            programmable_core_type_idx,
+            processor_class_idx,
+            processor_id,
+            source_kernel_root,
+            kernel->get_full_kernel_name());
+        const std::string dest_elf_path = build_env_manager.get_kernel_binary_path(
+            build_id,
+            programmable_core_type_idx,
+            processor_class_idx,
+            processor_id,
+            output_dir,
+            kernel->get_full_kernel_name());
+
+        std::filesystem::create_directories(std::filesystem::path(dest_elf_path).parent_path());
+        std::filesystem::copy_file(source_elf_path, dest_elf_path, std::filesystem::copy_options::overwrite_existing);
+    }
+}
+
+}  // namespace
+
+void CompileProgramSpecOffline(
+    const distributed::MeshDevice& mesh_device, const ProgramSpec& spec, const std::string& output_dir) {
+    TT_FATAL(
+        !output_dir.empty(),
+        "CompileProgramSpecOffline: output_dir must be non-empty; an empty string would emit artifacts "
+        "relative to the process current working directory.");
+    TT_FATAL(
+        !jit_server::JitCompileRpcClient::enabled(),
+        "CompileProgramSpecOffline is not supported when the remote JIT compile server is enabled "
+        "(TT_METAL_JIT_SERVER_ENABLE). The remote compile path does not emit local ELFs for AOT load.");
+
+    const std::vector<IDevice*> devices = mesh_device.get_devices();
+    TT_FATAL(!devices.empty(), "CompileProgramSpecOffline: mesh_device has no devices.");
+    if (devices.size() > 1) {
+        log_warning(
+            tt::LogBuildKernels,
+            "CompileProgramSpecOffline: mesh_device has {} devices; only the first device's build env is used "
+            "for offline compilation.",
+            devices.size());
+    }
+    IDevice* device = devices[0];
+
+    // Compile via the real live-device path: this writes ELFs to the JIT cache and sets each
+    // kernel's full_name to "<name>/<hash>/" (the suffix the loader recomputes at dispatch time).
+    Program program = MakeProgramFromSpec(mesh_device, spec);
+    detail::CompileProgram(device, program);
+
+    auto& build_env_manager = BuildEnvManager::get_instance();
+    const DeviceBuildEnv& device_build_env = build_env_manager.get_device_build_env(device->build_id());
+    const std::string source_kernel_root = device_build_env.build_env.get_out_kernel_root_path();
+    const Hal& hal = MetalContext::instance().hal();
+
+    for_each_kernel(program.impl(), [&](const std::shared_ptr<Kernel>& kernel) {
+        // Log build_key + full_name per kernel so produce-time/load-time build-key mismatches
+        // (watcher, dprint, opt level, etc. fold into build_key) are diagnosable.
+        log_debug(
+            tt::LogBuildKernels,
+            "CompileProgramSpecOffline: emitting AOT binaries. kernel_name={}, full_name={}, build_key={}, "
+            "output_dir={}",
+            kernel->name(),
+            kernel->get_full_kernel_name(),
+            device_build_env.build_key(),
+            output_dir);
+        copy_kernel_elfs_to_output_dir(
+            kernel, build_env_manager, device->build_id(), hal, source_kernel_root, output_dir);
+    });
+}
+
+void SetProgramPrecompiledConfig(Program& program, const PrecompiledKernelConfig& config) {
+    TT_FATAL(
+        !jit_server::JitCompileRpcClient::enabled(),
+        "SetProgramPrecompiledConfig is not supported when the remote JIT compile server is enabled "
+        "(TT_METAL_JIT_SERVER_ENABLE). The remote compile path does not honor precompiled config.");
+    TT_FATAL(
+        !program.impl().is_compiled(),
+        "SetProgramPrecompiledConfig must be called before the program is compiled. ProgramImpl::compile "
+        "short-circuits once a build key has been compiled, so a late call would silently be a no-op.");
+
+    for_each_kernel(
+        program.impl(), [&](const std::shared_ptr<Kernel>& kernel) { kernel->set_precompiled_config(config); });
+}
+
+}  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/metal2_host_api/offline_compile.cpp
+++ b/tt_metal/impl/metal2_host_api/offline_compile.cpp
@@ -43,7 +43,7 @@ void for_each_kernel(detail::ProgramImpl& program_impl, const Fn& fn) {
     }
 }
 
-// Copy every generated ELF for `kernel` from the live device's JIT kernel root into `output_dir`.
+// Copy every generated ELF for `kernel` from the device's JIT kernel root into `output_dir`.
 // Both source and destination paths are computed by BuildEnvManager::get_kernel_binary_path so the
 // emitted layout matches exactly what the runtime precompiled-loader path searches for.
 void copy_kernel_elfs_to_output_dir(
@@ -104,8 +104,9 @@ void CompileProgramSpecOffline(
     }
     IDevice* device = devices[0];
 
-    // Compile via the real live-device path: this writes ELFs to the JIT cache and sets each
-    // kernel's full_name to "<name>/<hash>/" (the suffix the loader recomputes at dispatch time).
+    // Compile via the real on-device CompileProgram path: this writes ELFs to the JIT cache and
+    // sets each kernel's full_name to "<name>/<hash>/" (the suffix the loader recomputes at
+    // dispatch time).
     Program program = MakeProgramFromSpec(mesh_device, spec);
     detail::CompileProgram(device, program);
 
@@ -115,16 +116,6 @@ void CompileProgramSpecOffline(
     const Hal& hal = MetalContext::instance().hal();
 
     for_each_kernel(program.impl(), [&](const std::shared_ptr<Kernel>& kernel) {
-        // Log build_key + full_name per kernel so produce-time/load-time build-key mismatches
-        // (watcher, dprint, opt level, etc. fold into build_key) are diagnosable.
-        log_debug(
-            tt::LogBuildKernels,
-            "CompileProgramSpecOffline: emitting AOT binaries. kernel_name={}, full_name={}, build_key={}, "
-            "output_dir={}",
-            kernel->name(),
-            kernel->get_full_kernel_name(),
-            device_build_env.build_key(),
-            output_dir);
         copy_kernel_elfs_to_output_dir(
             kernel, build_env_manager, device->build_id(), hal, source_kernel_root, output_dir);
     });

--- a/tt_metal/impl/metal2_host_api/offline_compile.cpp
+++ b/tt_metal/impl/metal2_host_api/offline_compile.cpp
@@ -102,11 +102,10 @@ void CompileProgramSpecOffline(
             "for offline compilation.",
             devices.size());
     }
-    // Kernel binaries are keyed by build_key (a hash of dispatch config, num CQs, and build
-    // flags), not by physical chip. Devices that share a build_key share the same binary cache,
-    // so a single compile covers all of them. A homogeneous mesh shares one build_key; meshes
-    // whose devices resolve to different build_keys (e.g. differing harvesting masks when
-    // coordinate virtualization is disabled) are not covered by compiling on one device.
+    // CompileProgram needs a mutable IDevice*, but we only hold a const MeshDevice&; get_devices()
+    // is const-qualified yet returns non-const IDevice*, so it is how we obtain a device to compile
+    // on. Compiling on devices[0] aligns with the runtime JIT path, which compiles each program
+    // once against MeshDevice::build_id() (== reference_device() == devices[0]), not per chip.
     IDevice* device = devices[0];
 
     // Compile via the real on-device CompileProgram path: this writes ELFs to the JIT cache and

--- a/tt_metal/impl/metal2_host_api/offline_compile.cpp
+++ b/tt_metal/impl/metal2_host_api/offline_compile.cpp
@@ -102,6 +102,11 @@ void CompileProgramSpecOffline(
             "for offline compilation.",
             devices.size());
     }
+    // Kernel binaries are keyed by build_key (a hash of dispatch config, num CQs, and build
+    // flags), not by physical chip. Devices that share a build_key share the same binary cache,
+    // so a single compile covers all of them. A homogeneous mesh shares one build_key; meshes
+    // whose devices resolve to different build_keys (e.g. differing harvesting masks when
+    // coordinate virtualization is disabled) are not covered by compiling on one device.
     IDevice* device = devices[0];
 
     // Compile via the real on-device CompileProgram path: this writes ELFs to the JIT cache and

--- a/tt_metal/impl/sources.cmake
+++ b/tt_metal/impl/sources.cmake
@@ -53,6 +53,7 @@ set(IMPL_SRC
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/tilize_utils.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/data_format/uint8.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/dataflow_buffer/dataflow_buffer.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/offline_compile.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/program_spec.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/metal2_host_api/program_run_args.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/kernels/kernel.cpp

--- a/tt_metal/sources.cmake
+++ b/tt_metal/sources.cmake
@@ -65,6 +65,7 @@ set(TT_METAL_PUBLIC_API
     api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
     api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
     api/tt-metalium/experimental/metal2_host_api/node_coord.hpp
+    api/tt-metalium/experimental/metal2_host_api/offline_compile.hpp
     api/tt-metalium/experimental/metal2_host_api/program.hpp
     api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
     api/tt-metalium/experimental/metal2_host_api/program_spec.hpp


### PR DESCRIPTION
### PR Category
Feature

### Summary
Adds two live-device experimental APIs:
- CompileProgramSpecOffline: compiles every kernel in a ProgramSpec via the real detail::CompileProgram path and copies the ELFs into an output dir, using BuildEnvManager::get_kernel_binary_path so the emitted layout matches the runtime precompiled-loader's search path.
- SetProgramPrecompiledConfig: marks every kernel in a Program to load precompiled binaries, mirroring CreateKernelFromPrecompiled.

Producer and loader share identical kernel hashing by construction since both go through the live-device compile path. Guards cover empty output_dir, empty device list (warn on multi-device), remote JIT server (unsupported), and calling the loader after the program is already compiled.

Adds HW tests covering produce, load-hit, load-miss (empty dir and hash mismatch), JIT fallback, and both guard paths.


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ruizhang/metal2-offline-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ruizhang/metal2-offline-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ruizhang/metal2-offline-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ruizhang/metal2-offline-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ruizhang/metal2-offline-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ruizhang/metal2-offline-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ruizhang/metal2-offline-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ruizhang/metal2-offline-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ruizhang/metal2-offline-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ruizhang/metal2-offline-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ruizhang/metal2-offline-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ruizhang/metal2-offline-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ruizhang/metal2-offline-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ruizhang/metal2-offline-compile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ruizhang/metal2-offline-compile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ruizhang/metal2-offline-compile)