### PR TITLE
Fix shard grid validation for MatmulMultiCoreReuse with offset grids

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
@@ -777,6 +777,7 @@ class TestPerfDemos:
             tB,
         )
 
+    @pytest.mark.requires_grid_size((2, 8))
     @pytest.mark.parametrize(
         "perf_mode", ["none"]
     )  # "cold_start", "e2e", "device_fw" — disabled for CI, enable if measuring performance

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/demo/test_fused_demo.py
@@ -777,7 +777,6 @@ class TestPerfDemos:
             tB,
         )
 
-    @pytest.mark.requires_grid_size((2, 8))
     @pytest.mark.parametrize(
         "perf_mode", ["none"]
     )  # "cold_start", "e2e", "device_fw" — disabled for CI, enable if measuring performance

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -318,6 +318,7 @@ void validate_matmul_sharded_operand_grids_within_program_compute_grid(
 
 void validate_matmul_work_distribution_and_gather_ring_topology(
     const Tensor& input_tensor_a,
+    const Tensor& input_tensor_b,
     const ttnn::Shape& a_shape_padded,
     const ttnn::Shape& b_shape_padded,
     const tt::tt_metal::Tile& in0_tile,
@@ -417,13 +418,15 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                // When input is sharded the factory places output on the input shard grid, not on
-                // an origin-anchored compute_with_storage_grid_size rectangle. Use the device grid
-                // as the extent so offset grids (e.g. column 1) are not incorrectly rejected.
+                // The factory selects all_cores from the first available shard spec: in0, then in1,
+                // then output. Any of those can produce an offset grid (e.g. column 1 in a fused
+                // chain). Use the device grid as the extent whenever any operand is sharded so we
+                // don't incorrectly reject those grids against the origin-anchored config rect.
                 const auto device_extent = input_tensor_a.device()->compute_with_storage_grid_size();
-                const auto effective_extent = input_tensor_a.memory_config().is_sharded()
-                                                  ? device_extent
-                                                  : program_config.compute_with_storage_grid_size;
+                const bool any_sharded = input_tensor_a.memory_config().is_sharded() ||
+                                         input_tensor_b.memory_config().is_sharded() || output_mem_config.is_sharded();
+                const auto effective_extent =
+                    any_sharded ? device_extent : program_config.compute_with_storage_grid_size;
                 check_output_shard_grid_within_extent(
                     output_mem_config, effective_extent, "MatmulMultiCoreReuseProgramConfig");
             } else {
@@ -819,6 +822,7 @@ void MatmulDeviceOperation::validate_on_program_cache_miss(
         input_tensor_a, input_tensor_b, chosen_program_config);
     validate_matmul_work_distribution_and_gather_ring_topology(
         input_tensor_a,
+        input_tensor_b,
         a_shape_padded,
         b_shape_padded,
         in0_tile,

--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -298,9 +298,19 @@ void validate_matmul_sharded_operand_grids_within_program_compute_grid(
         [&](const auto& program_config) {
             using ProgramConfigType = std::decay_t<decltype(program_config)>;
             if constexpr (std::is_same_v<ProgramConfigType, operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
-                const auto& grid = program_config.compute_with_storage_grid_size;
-                check_tensor_in_grid(input_tensor_a, grid);
-                check_tensor_in_grid(input_tensor_b, grid);
+                // When an input is sharded, the factory uses shard_spec.grid directly as all_cores
+                // and ignores compute_with_storage_grid_size entirely. Validating the shard grid
+                // against the origin-anchored compute_with_storage_grid_size rectangle incorrectly
+                // rejects grids that don't start at (0,0) (e.g. column 1 in a multi-chain fused op).
+                // The only physical constraint is that the shard grid fits within the device grid.
+                // For non-sharded inputs the config grid drives split_work_to_cores, so the
+                // origin-anchored check is still correct there.
+                const auto& config_grid = program_config.compute_with_storage_grid_size;
+                const auto device_grid = input_tensor_a.device()->compute_with_storage_grid_size();
+                auto effective_grid_a = input_tensor_a.memory_config().is_sharded() ? device_grid : config_grid;
+                auto effective_grid_b = input_tensor_b.memory_config().is_sharded() ? device_grid : config_grid;
+                check_tensor_in_grid(input_tensor_a, effective_grid_a);
+                check_tensor_in_grid(input_tensor_b, effective_grid_b);
             }
         },
         chosen_program_config);
@@ -407,10 +417,15 @@ void validate_matmul_work_distribution_and_gather_ring_topology(
             } else if constexpr (std::is_same_v<
                                      ProgramConfigType,
                                      operations::matmul::MatmulMultiCoreReuseProgramConfig>) {
+                // When input is sharded the factory places output on the input shard grid, not on
+                // an origin-anchored compute_with_storage_grid_size rectangle. Use the device grid
+                // as the extent so offset grids (e.g. column 1) are not incorrectly rejected.
+                const auto device_extent = input_tensor_a.device()->compute_with_storage_grid_size();
+                const auto effective_extent = input_tensor_a.memory_config().is_sharded()
+                                                  ? device_extent
+                                                  : program_config.compute_with_storage_grid_size;
                 check_output_shard_grid_within_extent(
-                    output_mem_config,
-                    program_config.compute_with_storage_grid_size,
-                    "MatmulMultiCoreReuseProgramConfig");
+                    output_mem_config, effective_extent, "MatmulMultiCoreReuseProgramConfig");
             } else {
                 (void)transpose_a;
                 (void)transpose_b;


### PR DESCRIPTION
## Summary

Fixes #45758.

When a matmul input is sharded, `MatmulMultiCoreReuseOptimized` places the output on the input's `shard_spec.grid` directly and ignores `compute_with_storage_grid_size`. The existing validation was comparing the shard grid against the origin-anchored `compute_with_storage_grid_size` rectangle, which incorrectly rejected valid grids that don't start at (0,0) — e.g. grids on column 1 in a multi-chain fused op.

**Fix:** for sharded inputs, validate against the full device grid (`device->compute_with_storage_grid_size()`) instead of the config grid. For non-sharded inputs the config grid still drives `split_work_to_cores`, so the origin-anchored check is preserved there.

- `validate_matmul_sharded_operand_grids_within_program_compute_grid`: use device grid as extent for sharded tensors
- `validate_matmul_work_distribution_and_gather_ring_topology`: same fix for output shard grid check

## Test plan

- [x] `test_parallel_chains_ln_mm_rms_mm_fused` was the direct repro from the issue — now passes
- [x] Full `test_fused_demo.py` suite: 33 passed, 1 skipped (kernel buffer size limit, unrelated), 2 failures are pre-existing numeric issues unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/shard_grid_inside_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/shard_grid_inside_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rmillerTT/shard_grid_inside_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rmillerTT/shard_grid_inside_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/shard_grid_inside_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/shard_grid_inside_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/shard_grid_inside_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/shard_grid_inside_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rmillerTT/shard_grid_inside_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rmillerTT/shard_grid_inside_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/shard_grid_inside_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/shard_grid_inside_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/shard_grid_inside_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/shard_grid_inside_compute)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/shard_grid_inside_compute)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/shard_grid_inside_compute)