### PR TITLE
Quasar Test Only - Int8 Etlwise Binary and Binary Broadcast Testing

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -122,7 +122,7 @@ def apply_l1_accumulation(
     Simulate L1 accumulation by summing partial results.
 
     With L1 acc enabled, the packer accumulates into the same output tile
-    slots across multiple passes. For sub-32-bit integer formats the hardware
+    slots across multiple passes. For integer formats the hardware
     saturates at every step instead of wrapping, so the golden must
     clamp the running sum to the output range after each addition.
 
@@ -135,7 +135,7 @@ def apply_l1_accumulation(
     Returns:
         Element-wise sum of all partials (saturated per-step for integers).
     """
-    needs_saturation = data_format.is_integer() and not data_format.is_32_bit()
+    needs_saturation = data_format.is_integer()
 
     accumulated = partials[0].clone()
     for partial in partials[1:]:

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -122,7 +122,7 @@ def apply_l1_accumulation(
     Simulate L1 accumulation by summing partial results.
 
     With L1 acc enabled, the packer accumulates into the same output tile
-    slots across multiple passes. For integer formats the hardware
+    slots across multiple passes. For sub-32-bit integer formats the hardware
     saturates at every step instead of wrapping, so the golden must
     clamp the running sum to the output range after each addition.
 
@@ -135,7 +135,7 @@ def apply_l1_accumulation(
     Returns:
         Element-wise sum of all partials (saturated per-step for integers).
     """
-    needs_saturation = data_format.is_integer()
+    needs_saturation = data_format.is_integer() and not data_format.is_32_bit()
 
     accumulated = partials[0].clone()
     for partial in partials[1:]:
@@ -2427,6 +2427,60 @@ class EltwiseBinaryGolden(FidelityMasking):
 
         return result
 
+    def _binary_int_op(self, op, t1, t2, data_format):
+        """Integer eltwise op in int32. Int8 operands cannot overflow int32."""
+        torch_format = format_dict[data_format]
+        t1_int32 = t1.to(torch.int32)
+        t2_int32 = t2.to(torch.int32)
+        if op == MathOperation.Elwadd:
+            res = t1_int32 + t2_int32
+        elif op == MathOperation.Elwsub:
+            res = t1_int32 - t2_int32
+        elif op == MathOperation.Elwmul:
+            res = t1_int32 * t2_int32
+        else:
+            raise ValueError(f"Unsupported integer eltwise operation: {op}")
+        return res.to(torch_format)
+
+    def _eltwise_integer(
+        self,
+        op,
+        operand1,
+        operand2,
+        data_format,
+        input_format,
+        acc_to_dest,
+        tile_shape,
+        num_tiles_per_accumulation,
+    ):
+
+        t1 = to_tensor(operand1, input_format)
+        t2 = to_tensor(operand2, input_format)
+
+        if acc_to_dest:
+            tile_size = tile_shape.total_tile_size()
+            num_total_tiles = t1.numel() // tile_size
+            num_blocks = num_total_tiles // num_tiles_per_accumulation
+
+            t1_tiles = t1.view(num_total_tiles, tile_size)
+            t2_tiles = t2.view(num_total_tiles, tile_size)
+
+            accumulated = []
+            for block in range(num_blocks):
+                partials = [
+                    self._binary_int_op(
+                        op,
+                        t1_tiles[block * num_tiles_per_accumulation + tile],
+                        t2_tiles[block * num_tiles_per_accumulation + tile],
+                        data_format,
+                    )
+                    for tile in range(num_tiles_per_accumulation)
+                ]
+                accumulated.append(apply_l1_accumulation(partials, data_format))
+            return torch.cat(accumulated)
+
+        return self._binary_int_op(op, t1, t2, data_format)
+
     def __call__(
         self,
         op,
@@ -2450,6 +2504,18 @@ class EltwiseBinaryGolden(FidelityMasking):
         # If explicitly passed as None, it means "already quantized, skip".
         if input_format_B is EltwiseBinaryGolden._UNSET:
             input_format_B = input_format
+
+        if input_format is not None and input_format.is_integer():
+            return self._eltwise_integer(
+                op,
+                operand1,
+                operand2,
+                data_format,
+                input_format,
+                acc_to_dest,
+                tile_shape,
+                num_tiles_per_accumulation,
+            )
 
         # On Quasar with IMPLIED_MATH_FORMAT=Yes, the HW dest register's
         # physical storage is implied from the SrcA tag: Float16 input →

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
@@ -96,11 +96,10 @@ def test_eltwise_binary_broadcast_quasar(
     boot_mode=BootMode.DEFAULT,
 ):
 
-    stimuli_spec = (
-        StimuliSpec.uniform(low=-127.0, high=127.0)
-        if formats.input_format == DataFormat.Int8
-        else None
-    )
+    if formats.input_format == DataFormat.Int8:
+        stimuli_spec = StimuliSpec.uniform(low=-127.0, high=127.0)
+    else:
+        stimuli_spec = StimuliSpec.uniform(low=0.0, high=1.0)
     src_A, tile_cnt_A, src_B, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_broadcast_quasar.py
@@ -7,7 +7,7 @@ from helpers.constraints import (
     get_valid_dest_accumulation_modes,
     get_valid_math_fidelities,
 )
-from helpers.format_config import DataFormat
+from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import (
     BroadcastGolden,
     EltwiseBinaryGolden,
@@ -17,6 +17,7 @@ from helpers.llk_params import (
     BroadcastType,
     DestSync,
     ImpliedMathFormat,
+    MathFidelity,
     MathOperation,
     format_dict,
 )
@@ -26,7 +27,7 @@ from helpers.param_config import (
     parametrize,
 )
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import generate_stimuli
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import BootMode, TestConfig
 from helpers.test_variant_parameters import (
     BROADCAST_TYPE,
@@ -55,7 +56,8 @@ FACE_ELEMS = 16 * 16
             DataFormat.MxInt4,
             DataFormat.MxInt2,
         ],
-    ),
+    )
+    + [InputOutputFormat(DataFormat.Int8, DataFormat.Int32)],
     dest_acc=lambda formats: get_valid_dest_accumulation_modes(formats),
     mathop=[
         MathOperation.Elwadd,
@@ -67,7 +69,11 @@ FACE_ELEMS = 16 * 16
         BroadcastType.Row,
         BroadcastType.Scalar,
     ],
-    math_fidelity=lambda formats, mathop: get_valid_math_fidelities(formats, mathop),
+    math_fidelity=lambda formats, mathop: (
+        [MathFidelity.LoFi]
+        if formats.input_format == DataFormat.Int8
+        else get_valid_math_fidelities(formats, mathop)
+    ),
     implied_math_format=lambda formats: (
         [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
         if not formats.input_format.is_mx_format()
@@ -90,11 +96,18 @@ def test_eltwise_binary_broadcast_quasar(
     boot_mode=BootMode.DEFAULT,
 ):
 
+    stimuli_spec = (
+        StimuliSpec.uniform(low=-127.0, high=127.0)
+        if formats.input_format == DataFormat.Int8
+        else None
+    )
     src_A, tile_cnt_A, src_B, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
+        spec_A=stimuli_spec,
+        spec_B=stimuli_spec,
     )
 
     generate_broadcast_golden = get_golden_generator(BroadcastGolden)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -205,7 +205,7 @@ def test_eltwise_binary(
         boot_mode=boot_mode,
         # MX formats require disable_format_inference to match C++ IMPLIED_MATH_FORMAT setting
         # This ensures Python-side format inference uses Float16_b for MX internal math
-        disable_format_inference=(implied_math_format == ImpliedMathFormat.Yes),
+        disable_format_inference=formats.input_format.is_mx_format(),
     )
 
     res_from_L1 = configuration.run().result

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -3,7 +3,7 @@
 
 import pytest
 import torch
-from helpers.format_config import DataFormat
+from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import (
     EltwiseBinaryGolden,
     get_golden_generator,
@@ -22,7 +22,7 @@ from helpers.param_config import (
     parametrize,
 )
 from helpers.stimuli_config import StimuliConfig
-from helpers.stimuli_generator import generate_stimuli
+from helpers.stimuli_generator import StimuliSpec, generate_stimuli
 from helpers.test_config import BootMode, TestConfig
 from helpers.test_variant_parameters import (
     ACC_TO_DEST,
@@ -39,11 +39,14 @@ from helpers.test_variant_parameters import (
 from helpers.tile_shape import construct_tile_shape
 from helpers.utils import passed_test
 
-ELTWISE_DIMENSIONS = [
-    (dest_sync, dims, DestAccumulation.No)
-    for dest_sync in (DestSync.Half, DestSync.Full)
-    for dims in generate_unary_input_dimensions(DestAccumulation.No, dest_sync)
-]
+
+def eltwise_dimensions_dest_sync(dest_acc_modes):
+    return [
+        (dest_sync, dims, dest_acc)
+        for dest_sync in (DestSync.Half, DestSync.Full)
+        for dest_acc in dest_acc_modes
+        for dims in generate_unary_input_dimensions(dest_acc, dest_sync)
+    ]
 
 
 # For acc_to_dest setting, accumulate two result tiles into dest. Can be extended.
@@ -71,29 +74,33 @@ def valid_acc_to_dest(dest_sync_dims_dest_acc) -> list:
     return [False]
 
 
+ELTWISE_FORMATS = input_output_formats(
+    [
+        DataFormat.MxFp8R,
+        DataFormat.MxFp8P,
+        DataFormat.MxFp4,
+        DataFormat.MxInt8,
+        DataFormat.MxInt4,
+        DataFormat.MxInt2,
+        DataFormat.Float16_b,
+        DataFormat.Float16,
+    ],
+) + [InputOutputFormat(DataFormat.Int8, DataFormat.Int32)]
+
+
 @pytest.mark.quasar
 @parametrize(
-    formats=input_output_formats(
-        [
-            DataFormat.MxFp8R,
-            DataFormat.MxFp8P,
-            DataFormat.MxFp4,
-            DataFormat.MxInt8,
-            DataFormat.MxInt4,
-            DataFormat.MxInt2,
-            DataFormat.Float16_b,
-            DataFormat.Float16,
-        ],
-    ),
+    formats=ELTWISE_FORMATS,
     mathop=[
         MathOperation.Elwadd,
         MathOperation.Elwsub,
         MathOperation.Elwmul,
     ],
-    # Math fidelity only affects multiplication; for add/sub only LoFi is meaningful.
-    math_fidelity=lambda mathop: (
+    # Math fidelity only affects multiplication; for add/sub and Int8 only LoFi is meaningful.
+    math_fidelity=lambda mathop, formats: (
         [MathFidelity.LoFi]
         if mathop in [MathOperation.Elwadd, MathOperation.Elwsub]
+        or formats.input_format == DataFormat.Int8
         else [
             MathFidelity.LoFi,
             MathFidelity.HiFi2,
@@ -109,7 +116,11 @@ def valid_acc_to_dest(dest_sync_dims_dest_acc) -> list:
         if not formats.input_format.is_mx_format()
         else [ImpliedMathFormat.Yes]
     ),
-    dest_sync_dims_dest_acc=ELTWISE_DIMENSIONS,
+    dest_sync_dims_dest_acc=lambda formats: (
+        eltwise_dimensions_dest_sync((DestAccumulation.Yes,))
+        if formats.input_format == DataFormat.Int8
+        else eltwise_dimensions_dest_sync((DestAccumulation.No,))
+    ),
     acc_to_dest=valid_acc_to_dest,
     num_faces=[4],
 )
@@ -127,11 +138,17 @@ def test_eltwise_binary(
 
     num_tiles_per_accumulation = get_num_tiles_per_accumulation(acc_to_dest)
 
+    if formats.input_format == DataFormat.Int8:
+        stimuli_spec = StimuliSpec.uniform(low=-127.0, high=127.0)
+    else:
+        stimuli_spec = StimuliSpec.uniform(low=0.0, high=1.0)
     src_A, tile_cnt_A, src_B, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,
         input_dimensions_A=input_dimensions,
         stimuli_format_B=formats.input_format,
         input_dimensions_B=input_dimensions,
+        spec_A=stimuli_spec,
+        spec_B=stimuli_spec,
         output_format=formats.output_format,
     )
 

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_broadcast_quasar_test.cpp
@@ -76,8 +76,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
-    DataFormat src_format = static_cast<DataFormat>(formats.math);
-    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(src_format, src_format);
+    DataFormat math_format     = static_cast<DataFormat>(formats.math);
+    DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+    if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+    }
+    else
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
+    }
 
     // Matches TestConfig NUM_FACES(4) + TEST_FACE_DIMS() (full 32x32 tile).
     _llk_math_eltwise_binary_broadcast_init_<ELTWISE_BINARY_OP, BROADCAST_TYPE, MATH_FIDELITY>(DEFAULT_TENSOR_SHAPE);

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_binary_test.cpp
@@ -97,9 +97,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
     set_up_dest_dvalid_per_thread<dest_dvalid_client::FPU>({dest_dvalid_client::FPU, dest_dvalid_client::PACK});
 
     // Configure math hardware with proper Quasar API
-    DataFormat src_format = static_cast<DataFormat>(formats.math);
-    _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, is_int_fpu_en>(src_format, src_format);
-
+    DataFormat math_format     = static_cast<DataFormat>(formats.math);
+    DataFormat pack_src_format = static_cast<DataFormat>(formats.pack_src);
+    if (is_fp32_dest_acc_en && pack_src_format == DataFormat::Int32)
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, false /*fp32_dest*/, true /*int32_dest*/>(math_format, math_format);
+    }
+    else
+    {
+        _llk_math_srcAB_hw_configure_<IMPLIED_MATH_FORMAT, is_fp32_dest_acc_en, false /*int32_dest*/>(math_format, math_format);
+    }
     // Initialize eltwise binary operation with default 32x32 tensor shape
     _llk_math_eltwise_binary_init_<ELTWISE_BINARY_OP, MATH_FIDELITY>(ckernel::DEFAULT_TENSOR_SHAPE, ACC_TO_DEST); // tiny-tile testing not yet supported
 


### PR DESCRIPTION
### PR Category
Test only

### Summary
Relates to #45777 
Extends `test_eltwise_binary_quasar.py` and `test_eltwise_binary_quasar.py` with an Int8 → Int32 format case
Int8 cases are constrained to DestAccumulation.Yes and MathFidelity.LoFi

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmohammed/int8-testing-eltwise-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmohammed/int8-testing-eltwise-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmohammed/int8-testing-eltwise-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmohammed/int8-testing-eltwise-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmohammed/int8-testing-eltwise-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmohammed/int8-testing-eltwise-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmohammed/int8-testing-eltwise-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmohammed/int8-testing-eltwise-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmohammed/int8-testing-eltwise-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmohammed/int8-testing-eltwise-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmohammed/int8-testing-eltwise-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmohammed/int8-testing-eltwise-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmohammed/int8-testing-eltwise-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmohammed/int8-testing-eltwise-binary)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmohammed/int8-testing-eltwise-binary)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmohammed/int8-testing-eltwise-binary)