### PR TITLE
Cleanup: MoE annotate unused variables in decode kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
@@ -15,43 +15,43 @@ void kernel_main() {
     constexpr uint32_t indices_tensor_cb_id = get_compile_time_arg_val(1);
     constexpr uint32_t mapping_tensor_cb_id = get_compile_time_arg_val(2);
 
-    constexpr uint32_t input_pages = get_compile_time_arg_val(5);
-    constexpr uint32_t indices_pages = get_compile_time_arg_val(6);
-    constexpr uint32_t mapping_pages = get_compile_time_arg_val(7);
+    [[maybe_unused]] constexpr uint32_t input_pages = get_compile_time_arg_val(5);
+    [[maybe_unused]] constexpr uint32_t indices_pages = get_compile_time_arg_val(6);
+    [[maybe_unused]] constexpr uint32_t mapping_pages = get_compile_time_arg_val(7);
 
     constexpr uint32_t input_page_size = get_compile_time_arg_val(10);
     constexpr uint32_t indices_page_size = get_compile_time_arg_val(11);
     constexpr uint32_t mapping_page_size = get_compile_time_arg_val(12);
     constexpr uint32_t metadata_page_size = get_compile_time_arg_val(14);
 
-    constexpr uint32_t num_devices = get_compile_time_arg_val(15);
-    constexpr uint32_t selected_experts_k = get_compile_time_arg_val(18);
+    [[maybe_unused]] constexpr uint32_t num_devices = get_compile_time_arg_val(15);
+    [[maybe_unused]] constexpr uint32_t selected_experts_k = get_compile_time_arg_val(18);
     constexpr uint32_t num_shared_experts = get_compile_time_arg_val(20);
 
     constexpr uint32_t tokens_per_device = get_compile_time_arg_val(21);
 
     constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(23);
 
-    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(24);
-    constexpr uint32_t src_chip_id = get_compile_time_arg_val(25);
+    [[maybe_unused]] constexpr uint32_t src_mesh_id = get_compile_time_arg_val(24);
+    [[maybe_unused]] constexpr uint32_t src_chip_id = get_compile_time_arg_val(25);
 
-    constexpr uint32_t mesh_rows = get_compile_time_arg_val(26);
-    constexpr uint32_t mesh_cols = get_compile_time_arg_val(27);  // ew_dim
+    [[maybe_unused]] constexpr uint32_t mesh_rows = get_compile_time_arg_val(26);
+    [[maybe_unused]] constexpr uint32_t mesh_cols = get_compile_time_arg_val(27);  // ew_dim
 
-    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(29);
-    constexpr uint32_t aligned_mapping_page_size = get_compile_time_arg_val(30);
+    [[maybe_unused]] constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(29);
+    [[maybe_unused]] constexpr uint32_t aligned_mapping_page_size = get_compile_time_arg_val(30);
     constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(32);
 
     constexpr uint32_t metadata_buffer_id = get_compile_time_arg_val(35);
 
-    constexpr bool write_page_by_page = get_compile_time_arg_val(36);
+    [[maybe_unused]] constexpr bool write_page_by_page = get_compile_time_arg_val(36);
     constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(37);
 
     constexpr uint32_t dispatch_devices = get_compile_time_arg_val(38);
 
     // scores tensor compile time args
     constexpr uint32_t scores_tensor_cb_id = get_compile_time_arg_val(39);
-    constexpr uint32_t scores_pages = get_compile_time_arg_val(40);
+    [[maybe_unused]] constexpr uint32_t scores_pages = get_compile_time_arg_val(40);
     constexpr uint32_t scores_page_size = get_compile_time_arg_val(41);
     constexpr uint32_t aligned_output_scores_page_size = get_compile_time_arg_val(44);
 
@@ -67,7 +67,7 @@ void kernel_main() {
     uint32_t indices_tensor_address = get_arg_val<uint32_t>(rt_ags++);
     uint32_t scores_tensor_address = get_arg_val<uint32_t>(rt_ags++);
     uint32_t mapping_tensor_address = get_arg_val<uint32_t>(rt_ags++);
-    uint32_t output_tensor_address = get_arg_val<uint32_t>(rt_ags++);
+    [[maybe_unused]] uint32_t output_tensor_address = get_arg_val<uint32_t>(rt_ags++);
     uint32_t metadata_tensor_address = get_arg_val<uint32_t>(rt_ags++);
     [[maybe_unused]] uint32_t scores_out_tensor_address = get_arg_val<uint32_t>(rt_ags++);
 
@@ -91,7 +91,8 @@ void kernel_main() {
     const auto indices_addr_gen = TensorAccessor(indices_args, indices_tensor_address, indices_page_size);
     const auto scores_addr_gen = TensorAccessor(scores_args, scores_tensor_address, scores_page_size);
     const auto mapping_addr_gen = TensorAccessor(mapping_args, mapping_tensor_address, mapping_page_size);
-    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address, metadata_page_size);
+    [[maybe_unused]] const auto metadata_addr_gen =
+        TensorAccessor(metadata_args, metadata_tensor_address, metadata_page_size);
 
     if (token_start_idx == token_end_idx) {
         return;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/writer_all_to_all_dispatch_metadata.cpp
@@ -60,7 +60,7 @@ FORCE_INLINE void fabric_multicast_bidirectional_write_ring_1d_async(
     uint32_t src_addr,
     uint64_t noc_addr,
     int32_t size_bytes,
-    uint32_t alignment) {
+    [[maybe_unused]] uint32_t alignment) {
     using ttnn::operations::ccl::common::ReplicateGroup;
 
     // Split the ring: positive direction gets half, negative direction gets the other half
@@ -783,21 +783,21 @@ void kernel_main() {
     constexpr uint32_t packet_header_cb_id = get_compile_time_arg_val(3);
     constexpr uint32_t send_preparation_buffer_cb_id = get_compile_time_arg_val(4);
 
-    constexpr uint32_t input_pages = get_compile_time_arg_val(5);
-    constexpr uint32_t indices_pages = get_compile_time_arg_val(6);
+    [[maybe_unused]] constexpr uint32_t input_pages = get_compile_time_arg_val(5);
+    [[maybe_unused]] constexpr uint32_t indices_pages = get_compile_time_arg_val(6);
     constexpr uint32_t mapping_pages = get_compile_time_arg_val(7);
-    constexpr uint32_t output_pages = get_compile_time_arg_val(8);
-    constexpr uint32_t metadata_pages = get_compile_time_arg_val(9);
+    [[maybe_unused]] constexpr uint32_t output_pages = get_compile_time_arg_val(8);
+    [[maybe_unused]] constexpr uint32_t metadata_pages = get_compile_time_arg_val(9);
 
     constexpr uint32_t input_page_size = get_compile_time_arg_val(10);
-    constexpr uint32_t indices_page_size = get_compile_time_arg_val(11);
-    constexpr uint32_t mapping_page_size = get_compile_time_arg_val(12);
+    [[maybe_unused]] constexpr uint32_t indices_page_size = get_compile_time_arg_val(11);
+    [[maybe_unused]] constexpr uint32_t mapping_page_size = get_compile_time_arg_val(12);
     constexpr uint32_t output_page_size = get_compile_time_arg_val(13);
     constexpr uint32_t metadata_page_size = get_compile_time_arg_val(14);
 
     constexpr uint32_t num_devices = get_compile_time_arg_val(15);
-    constexpr uint32_t hidden_size = get_compile_time_arg_val(16);
-    constexpr uint32_t batch_size = get_compile_time_arg_val(17);
+    [[maybe_unused]] constexpr uint32_t hidden_size = get_compile_time_arg_val(16);
+    [[maybe_unused]] constexpr uint32_t batch_size = get_compile_time_arg_val(17);
     constexpr uint32_t selected_experts_k = get_compile_time_arg_val(18);
     constexpr uint32_t experts = get_compile_time_arg_val(19);
     constexpr uint32_t num_shared_experts = get_compile_time_arg_val(20);
@@ -805,30 +805,30 @@ void kernel_main() {
 
     constexpr uint32_t shared_and_selected_experts = selected_experts_k + num_shared_experts;
 
-    constexpr uint32_t num_links = get_compile_time_arg_val(22);
+    [[maybe_unused]] constexpr uint32_t num_links = get_compile_time_arg_val(22);
     constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(23);
 
-    constexpr uint32_t src_mesh_id = get_compile_time_arg_val(24);
-    constexpr uint32_t src_chip_id = get_compile_time_arg_val(25);
+    [[maybe_unused]] constexpr uint32_t src_mesh_id = get_compile_time_arg_val(24);
+    [[maybe_unused]] constexpr uint32_t src_chip_id = get_compile_time_arg_val(25);
     constexpr uint32_t mesh_rows = get_compile_time_arg_val(26);
     constexpr uint32_t mesh_cols = get_compile_time_arg_val(27);  // ew_dim
-    constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(28);
-    constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(29);
-    constexpr uint32_t aligned_mapping_page_size = get_compile_time_arg_val(30);
-    constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(31);
+    [[maybe_unused]] constexpr uint32_t aligned_input_page_size = get_compile_time_arg_val(28);
+    [[maybe_unused]] constexpr uint32_t aligned_indices_page_size = get_compile_time_arg_val(29);
+    [[maybe_unused]] constexpr uint32_t aligned_mapping_page_size = get_compile_time_arg_val(30);
+    [[maybe_unused]] constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(31);
     constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(32);
 
     constexpr uint32_t fabric_max_packet_size = get_compile_time_arg_val(33);
     constexpr uint32_t alignment = get_compile_time_arg_val(34);
     constexpr uint32_t metadata_buffer_id = get_compile_time_arg_val(35);
-    constexpr uint32_t write_page_by_page = get_compile_time_arg_val(36);
+    [[maybe_unused]] constexpr uint32_t write_page_by_page = get_compile_time_arg_val(36);
     constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(37);
 
     constexpr uint32_t dispatch_devices = get_compile_time_arg_val(38);
 
     // scores tensor compile time args
     constexpr uint32_t scores_tensor_cb_id = get_compile_time_arg_val(39);
-    constexpr uint32_t scores_pages = get_compile_time_arg_val(40);
+    [[maybe_unused]] constexpr uint32_t scores_pages = get_compile_time_arg_val(40);
     constexpr uint32_t output_scores_page_size = get_compile_time_arg_val(43);
     constexpr uint32_t aligned_output_scores_page_size = get_compile_time_arg_val(44);
 
@@ -851,10 +851,10 @@ void kernel_main() {
 #endif
 
     size_t rt_args_idx = 0;
-    uint32_t input_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t indices_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t scores_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t mapping_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
+    [[maybe_unused]] uint32_t input_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
+    [[maybe_unused]] uint32_t indices_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
+    [[maybe_unused]] uint32_t scores_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
+    [[maybe_unused]] uint32_t mapping_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t output_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t metadata_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t scores_out_tensor_address = get_arg_val<uint32_t>(rt_args_idx++);
@@ -873,8 +873,8 @@ void kernel_main() {
     uint32_t payload_size = get_arg_val<uint32_t>(rt_args_idx++);
     bool is_primary_payload_worker = get_arg_val<uint32_t>(rt_args_idx++) == 1;
 
-    constexpr uint8_t dest_chip_ids[num_devices] = DEST_CHIP_ID;
-    constexpr uint8_t dest_mesh_ids[num_devices] = DEST_MESH_ID;
+    [[maybe_unused]] constexpr uint8_t dest_chip_ids[num_devices] = DEST_CHIP_ID;
+    [[maybe_unused]] constexpr uint8_t dest_mesh_ids[num_devices] = DEST_MESH_ID;
 
     constexpr uint32_t num_directions = 4;
     constexpr std::array<bool, num_directions> directions = DIRECTIONS;
@@ -984,8 +984,9 @@ void kernel_main() {
     constexpr uint32_t device_stride = axis == ReplicateGroup::COLS ? mesh_cols : 1;
 
     const auto output_addr_gen = TensorAccessor(output_args, output_tensor_address, output_page_size);
-    const auto metadata_addr_gen = TensorAccessor(metadata_args, metadata_tensor_address, metadata_page_size);
-    const auto output_scores_addr_gen =
+    [[maybe_unused]] const auto metadata_addr_gen =
+        TensorAccessor(metadata_args, metadata_tensor_address, metadata_page_size);
+    [[maybe_unused]] const auto output_scores_addr_gen =
         TensorAccessor(scores_out_args, scores_out_tensor_address, output_scores_page_size);
 
     uint32_t packet_header_buffer_address = get_read_ptr(packet_header_cb_id);
@@ -1002,8 +1003,8 @@ void kernel_main() {
         reinterpret_cast<volatile PACKET_HEADER_TYPE*>(packet_header_buffer_address + 5 * sizeof(PACKET_HEADER_TYPE));
     // packet headers at +6 and +7 are currently unused (reserved for future split sends)
 
-    uint32_t base_indices_addr = get_read_ptr(indices_tensor_cb_id);
-    uint32_t base_scores_addr = get_read_ptr(scores_tensor_cb_id);
+    [[maybe_unused]] uint32_t base_indices_addr = get_read_ptr(indices_tensor_cb_id);
+    [[maybe_unused]] uint32_t base_scores_addr = get_read_ptr(scores_tensor_cb_id);
 
     detail::zero_buffer_barrier();
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/compute.cpp
@@ -92,7 +92,7 @@ void kernel_main() {
     constexpr uint32_t num_cores = get_named_compile_time_arg_val("num_cores");
 
     constexpr uint32_t num_experts = get_named_compile_time_arg_val("num_experts");
-    constexpr uint32_t layer_id = get_named_compile_time_arg_val("layer_id");
+    [[maybe_unused]] constexpr uint32_t layer_id = get_named_compile_time_arg_val("layer_id");
     constexpr auto activation_type =
         ttnn::experimental::prim::detail::MoEActivationFunction(get_named_compile_time_arg_val("activation_function"));
 
@@ -101,15 +101,15 @@ void kernel_main() {
 
     // Run-time arguments
     uint32_t argidx = 0;
-    const auto dram_bank_id = get_arg_val<uint32_t>(argidx++);
-    const auto vchannel = get_arg_val<uint32_t>(argidx++);
-    const auto w0_w1_addr = get_arg_val<uint32_t>(argidx++);
-    const auto w2_addr = get_arg_val<uint32_t>(argidx++);
-    const auto out_addr = get_arg_val<uint32_t>(argidx++);
-    const auto ring_semaphore_id = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const auto dram_bank_id = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const auto vchannel = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const auto w0_w1_addr = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const auto w2_addr = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const auto out_addr = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const auto ring_semaphore_id = get_arg_val<uint32_t>(argidx++);
     const auto ring_core_id = get_arg_val<uint32_t>(argidx++);
-    const auto ring_neighbor_physical_x = get_arg_val<uint32_t>(argidx++);
-    const auto ring_neighbor_physical_y = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const auto ring_neighbor_physical_x = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const auto ring_neighbor_physical_y = get_arg_val<uint32_t>(argidx++);
 
     // CBs
     constexpr auto cb_s2c_in = tt::CBIndex::c_0;     // tilize_output_cb_id
@@ -136,11 +136,11 @@ void kernel_main() {
     constexpr uint32_t num_w0_w1_tiles_h = Ht;
     constexpr uint32_t num_w2_tiles_h = Nt;
 
-    const uint32_t num_w0_w1_tiles_w = shard_tiles_lut[ring_core_id];
+    [[maybe_unused]] const uint32_t num_w0_w1_tiles_w = shard_tiles_lut[ring_core_id];
     const uint32_t num_w2_tiles_w = w2_shard_tiles_lut[ring_core_id];
 
-    const uint32_t num_in2_tiles = num_w2_tiles_w;
-    const uint32_t num_mm2_tiles = num_w2_tiles_w;
+    [[maybe_unused]] const uint32_t num_in2_tiles = num_w2_tiles_w;
+    [[maybe_unused]] const uint32_t num_mm2_tiles = num_w2_tiles_w;
 
     //-------------------------------------------------------------------------
     // W0 and W1 reading constants
@@ -154,14 +154,14 @@ void kernel_main() {
     // W2 reading constants (base-constant aliases only; derived values come from Cfg)
     constexpr auto w2_tiles_per_iter_w = moe_ring::W2_TILES_PER_A2A_ITER_W;
     constexpr uint32_t w2_tiles_per_block = moe_ring::W2_TILES_PER_TXN * moe_ring::W2_TXNS_PER_BLOCK;  // 14 * 2 = 28
-    constexpr uint32_t w2_tiles_per_iter_h = moe_ring::W2_TILES_PER_A2A_ITER_H;
+    [[maybe_unused]] constexpr uint32_t w2_tiles_per_iter_h = moe_ring::W2_TILES_PER_A2A_ITER_H;
 
     //-------------------------------------------------------------------------
     // Ring setup
     //-------------------------------------------------------------------------
     constexpr uint32_t w2_blocks_per_a2a_iter = Cfg::w2_blocks_per_expert / Cfg::num_a2a_iters;
 
-    constexpr uint32_t num_a2a_steps_per_iter = num_cores;
+    [[maybe_unused]] constexpr uint32_t num_a2a_steps_per_iter = num_cores;
 
     constexpr uint32_t tiles_per_step = Cfg::in2_tiles_per_step;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm0.cpp
@@ -54,7 +54,7 @@ void kernel_main() {
 
     constexpr auto w0_w1_args = TensorAccessorArgs<0>();
     constexpr auto w2_args = TensorAccessorArgs<w0_w1_args.next_compile_time_args_offset()>();
-    constexpr auto out_args = TensorAccessorArgs<w2_args.next_compile_time_args_offset()>();
+    [[maybe_unused]] constexpr auto out_args = TensorAccessorArgs<w2_args.next_compile_time_args_offset()>();
 
     // Run-time arguments. dm0 and dm1 share one rt-arg layout emitted by the host
     // (matmul_runtime_args in program_factory.cpp), so dm0 has to consume the layout
@@ -84,20 +84,20 @@ void kernel_main() {
     // CBs
     constexpr auto cb_s2c_in = tt::CBIndex::c_0;     // tilize_output_cb_id
     constexpr auto cb_r2c_w0_w1 = tt::CBIndex::c_3;  // cb_r2c_w0
-    constexpr auto cb_c2w_rdy = tt::CBIndex::c_4;
-    constexpr auto cb_w2c_rdy = tt::CBIndex::c_5;
+    [[maybe_unused]] constexpr auto cb_c2w_rdy = tt::CBIndex::c_4;
+    [[maybe_unused]] constexpr auto cb_w2c_rdy = tt::CBIndex::c_5;
     constexpr auto cb_s2c_in2 = tt::CBIndex::c_6;
-    constexpr auto cb_w2c_md = tt::CBIndex::c_7;
+    [[maybe_unused]] constexpr auto cb_w2c_md = tt::CBIndex::c_7;
 
     // CB Aliases
-    constexpr auto cb_c2s_out = tt::CBIndex::c_1;  // matmul_writer_cb_id
+    [[maybe_unused]] constexpr auto cb_c2s_out = tt::CBIndex::c_1;  // matmul_writer_cb_id
     constexpr auto cb_r2c_w2 = tt::CBIndex::c_3;   // reuse cb_r2c_w0_w1
 
     // Tile sizes
-    constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in);
+    [[maybe_unused]] constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in);
     constexpr uint32_t w0_w1_tile_size = get_tile_size(cb_r2c_w0_w1);
     constexpr uint32_t w2_tile_size = get_tile_size(cb_r2c_w2);
-    constexpr uint32_t in2_tile_size = get_tile_size(cb_s2c_in2);
+    [[maybe_unused]] constexpr uint32_t in2_tile_size = get_tile_size(cb_s2c_in2);
 
     //-------------------------------------------------------------------------
     // W0 and W1 reading constants
@@ -116,7 +116,7 @@ void kernel_main() {
     //-------------------------------------------------------------------------
     constexpr uint32_t w0_w1_bytes_per_block = w0_w1_tiles_per_block * w0_w1_tile_size;
     constexpr uint32_t w0_w1_bytes_per_txn = w0_w1_tiles_per_txn * w0_w1_tile_size;
-    constexpr uint32_t w2_bytes_per_block = w2_tiles_per_block * w2_tile_size;
+    [[maybe_unused]] constexpr uint32_t w2_bytes_per_block = w2_tiles_per_block * w2_tile_size;
     constexpr uint32_t w2_bytes_per_txn = w2_tiles_per_txn * w2_tile_size;
 
     // Bank-run loop invariant: w0_w1 and w2 each track their own cur_shard_idx_* but share

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/dm1.cpp
@@ -15,7 +15,7 @@ void kernel_main() {
 
     // Compile time arguments
     constexpr uint32_t num_experts = get_named_compile_time_arg_val("num_experts");
-    constexpr uint32_t layer_id = get_named_compile_time_arg_val("layer_id");
+    [[maybe_unused]] constexpr uint32_t layer_id = get_named_compile_time_arg_val("layer_id");
 
     // For synchronization with tilize cores
     constexpr uint32_t metadata_ready_semaphore_id = get_named_compile_time_arg_val("metadata_ready_semaphore_id");
@@ -60,15 +60,15 @@ void kernel_main() {
 
     constexpr auto w0_w1_args = TensorAccessorArgs<0>();
     constexpr auto w2_args = TensorAccessorArgs<w0_w1_args.next_compile_time_args_offset()>();
-    constexpr auto out_args = TensorAccessorArgs<w2_args.next_compile_time_args_offset()>();
+    [[maybe_unused]] constexpr auto out_args = TensorAccessorArgs<w2_args.next_compile_time_args_offset()>();
 
     // Run-time arguments
     uint32_t argidx = 0;
-    const auto dram_bank_id = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const auto dram_bank_id = get_arg_val<uint32_t>(argidx++);
     const auto vchannel = get_arg_val<uint32_t>(argidx++);
-    const auto w0_w1_addr = get_arg_val<uint32_t>(argidx++);
-    const auto w2_addr = get_arg_val<uint32_t>(argidx++);
-    const auto out_addr = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const auto w0_w1_addr = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const auto w2_addr = get_arg_val<uint32_t>(argidx++);
+    [[maybe_unused]] const auto out_addr = get_arg_val<uint32_t>(argidx++);
     const auto ring_semaphore_id = get_arg_val<uint32_t>(argidx++);
     const auto ring_core_id = get_arg_val<uint32_t>(argidx++);
     const auto ring_neighbor_physical_x = get_arg_val<uint32_t>(argidx++);
@@ -87,9 +87,9 @@ void kernel_main() {
     constexpr auto cb_r2c_w2 = tt::CBIndex::c_3;   // reuse cb_r2c_w0_w1
 
     // Tile sizes
-    constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in);
-    constexpr uint32_t w0_w1_tile_size = get_tile_size(cb_r2c_w0_w1);
-    constexpr uint32_t w2_tile_size = get_tile_size(cb_r2c_w2);
+    [[maybe_unused]] constexpr uint32_t in_tile_size = get_tile_size(cb_s2c_in);
+    [[maybe_unused]] constexpr uint32_t w0_w1_tile_size = get_tile_size(cb_r2c_w0_w1);
+    [[maybe_unused]] constexpr uint32_t w2_tile_size = get_tile_size(cb_r2c_w2);
     constexpr uint32_t in2_tile_size = get_tile_size(cb_s2c_in2);
 
     // Pre-computed shard lookup tables — same LUT definitions as compute.cpp.
@@ -99,8 +99,8 @@ void kernel_main() {
 
     // Constants for MoE — derived from compile-time shape args
     constexpr uint32_t num_w0_w1_tiles_h = Ht;
-    const uint32_t num_w0_w1_tiles_w = shard_tiles_lut[ring_core_id];
-    const uint32_t num_w2_tiles_w = w2_shard_tiles_lut[ring_core_id];
+    [[maybe_unused]] const uint32_t num_w0_w1_tiles_w = shard_tiles_lut[ring_core_id];
+    [[maybe_unused]] const uint32_t num_w2_tiles_w = w2_shard_tiles_lut[ring_core_id];
 
     using Cfg = moe_ring::MoeRingConfig<Ht, Nt, num_cores, has_bias>;
 
@@ -332,7 +332,7 @@ void kernel_main() {
             cb_wait_front(cb_c2s_out, num_w0_w1_tiles_h);
 
             const uint32_t source_base_l1_addr = get_read_ptr(cb_c2s_out);
-            const uint32_t elts_per_page = source_width_tiles * tile_width;
+            [[maybe_unused]] const uint32_t elts_per_page = source_width_tiles * tile_width;
 
             while (width_tiles_to_send > 0) {
                 const uint32_t width_tile_start = width_tile_base + width_tiles_sent;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_reader.cpp
@@ -33,9 +33,9 @@ template <
     uint32_t MeshCols,
     ReplicateGroup Axis>
 inline uint32_t get_device_idx_from_global_token_idx(const uint32_t t) {
-    constexpr uint32_t Replicate_Group = (Axis == ReplicateGroup::NONE)   ? MeshRows * MeshCols
-                                         : (Axis == ReplicateGroup::COLS) ? MeshRows
-                                                                          : MeshCols;
+    [[maybe_unused]] constexpr uint32_t Replicate_Group = (Axis == ReplicateGroup::NONE)   ? MeshRows * MeshCols
+                                                          : (Axis == ReplicateGroup::COLS) ? MeshRows
+                                                                                           : MeshCols;
     const uint32_t device_in_group = t / TokensPerDevice;
 
     if constexpr (Axis == ReplicateGroup::NONE) {
@@ -271,7 +271,7 @@ void kernel_main() {
     constexpr uint32_t mapping_pages = get_named_compile_time_arg_val("mapping_pages");
 
     // Page sizes
-    constexpr uint32_t indices_page_size = get_named_compile_time_arg_val("indices_page_size");
+    [[maybe_unused]] constexpr uint32_t indices_page_size = get_named_compile_time_arg_val("indices_page_size");
     constexpr uint32_t per_expert_total_tokens_output_page_size =
         get_named_compile_time_arg_val("per_expert_total_tokens_output_page_size");
     constexpr uint32_t expert_activation_output_page_size =
@@ -295,7 +295,7 @@ void kernel_main() {
     constexpr uint32_t tokens_per_chunk = get_named_compile_time_arg_val("tokens_per_chunk");
 
     // Mesh
-    constexpr uint32_t num_devices = get_named_compile_time_arg_val("num_devices");
+    [[maybe_unused]] constexpr uint32_t num_devices = get_named_compile_time_arg_val("num_devices");
     constexpr uint32_t mesh_rows = get_named_compile_time_arg_val("mesh_rows");
     constexpr uint32_t mesh_cols = get_named_compile_time_arg_val("mesh_cols");
     constexpr uint32_t linearized_mesh_coord = get_named_compile_time_arg_val("linearized_mesh_coord");
@@ -315,7 +315,7 @@ void kernel_main() {
     constexpr uint32_t tilize_bounding_box_num_cores = get_named_compile_time_arg_val("tilize_bounding_box_num_cores");
 
     // Multicast coordinates for signalling MM cores
-    constexpr uint32_t num_matmul_cores = get_named_compile_time_arg_val("num_matmul_cores");
+    [[maybe_unused]] constexpr uint32_t num_matmul_cores = get_named_compile_time_arg_val("num_matmul_cores");
 
     constexpr uint32_t matmul_mcast_start_x = get_named_compile_time_arg_val("matmul_mcast_start_x");
     constexpr uint32_t matmul_mcast_start_y = get_named_compile_time_arg_val("matmul_mcast_start_y");
@@ -396,7 +396,7 @@ void kernel_main() {
     // indices not used by reader
     // scores not used by reader
     const auto mapping_tensor_addr_gen = TensorAccessor(mapping_args, mapping_tensor_address);
-    const auto per_expert_total_tokens_output_tensor_addr_gen =
+    [[maybe_unused]] const auto per_expert_total_tokens_output_tensor_addr_gen =
         TensorAccessor(per_expert_total_tokens_output_args, per_expert_total_tokens_output_tensor_address);
     const auto expert_activation_output_tensor_addr_gen =
         TensorAccessor(expert_activation_output_args, expert_activation_output_address);
@@ -410,7 +410,7 @@ void kernel_main() {
 
     constexpr ReplicateGroup axis = ReplicateGroup(cluster_axis);
     constexpr uint32_t dispatch_devices = axis == ReplicateGroup::COLS ? mesh_rows : mesh_cols;
-    constexpr uint32_t dispatch_index =
+    [[maybe_unused]] constexpr uint32_t dispatch_index =
         axis == ReplicateGroup::COLS ? linearized_mesh_coord / mesh_cols : linearized_mesh_coord % mesh_cols;
     constexpr uint32_t tokens_per_device = tokens / dispatch_devices;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/device/kernels/tilize_writer.cpp
@@ -74,9 +74,9 @@ template <
     uint32_t MeshCols,
     ReplicateGroup Axis>
 inline uint32_t get_device_idx_from_global_token_idx(const uint32_t t) {
-    constexpr uint32_t Replicate_Group = (Axis == ReplicateGroup::NONE)   ? MeshRows * MeshCols
-                                         : (Axis == ReplicateGroup::COLS) ? MeshRows
-                                                                          : MeshCols;
+    [[maybe_unused]] constexpr uint32_t Replicate_Group = (Axis == ReplicateGroup::NONE)   ? MeshRows * MeshCols
+                                                          : (Axis == ReplicateGroup::COLS) ? MeshRows
+                                                                                           : MeshCols;
     const uint32_t device_in_group = t / TokensPerDevice;
 
     if constexpr (Axis == ReplicateGroup::NONE) {
@@ -213,8 +213,8 @@ void kernel_main() {
 
     // For parallel metadata processing - BRISC processes second half of this core's token range
     // Note: These are computed at runtime based on core_token_start/end in Step 3
-    constexpr uint32_t brisc_token_start = tokens / 2;
-    constexpr uint32_t brisc_token_end = tokens;
+    [[maybe_unused]] constexpr uint32_t brisc_token_start = tokens / 2;
+    [[maybe_unused]] constexpr uint32_t brisc_token_end = tokens;
     constexpr ReplicateGroup axis = ReplicateGroup(cluster_axis);
     constexpr uint32_t dispatch_devices = axis == ReplicateGroup::COLS ? mesh_rows : mesh_cols;
     constexpr uint32_t tokens_per_device = tokens / dispatch_devices;


### PR DESCRIPTION
### Summary
- Silence the warnings

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/moe-compute-remove-unused)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/moe-compute-remove-unused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/moe-compute-remove-unused)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/moe-compute-remove-unused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amorrison/moe-compute-remove-unused)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/moe-compute-remove-unused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/moe-compute-remove-unused)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/moe-compute-remove-unused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/moe-compute-remove-unused)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/moe-compute-remove-unused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/moe-compute-remove-unused)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/moe-compute-remove-unused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/moe-compute-remove-unused)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/moe-compute-remove-unused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/moe-compute-remove-unused)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/moe-compute-remove-unused)