### PR TITLE
[Bug fix] Invalidating DM l2 cache prior to each kernel run

### DIFF
--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -46,7 +46,8 @@ thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
-bool trigger_cache_invalidation = false;
+volatile uint32_t cache_invalidation_seq = 0;
+thread_local uint32_t last_cache_invalidation_seq = 0;
 
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
 thread_local uint32_t rta_count __attribute__((used));
@@ -277,7 +278,9 @@ extern "C" uint32_t _start1() {
                 uintptr_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, hartid);
 
                 // Tell all other DMs to invalidate their portion of the l2 cache
-                trigger_cache_invalidation = true;
+                // by swapping between 0 and 1
+                cache_invalidation_seq = 1 - cache_invalidation_seq;
+                flush_l2_cache_line((uintptr_t)&cache_invalidation_seq);
                 // Flush and save DM0's stack to SRAM
                 extern thread_local uint32_t __stack_base_lwm[];
                 uintptr_t stack_bottom = reinterpret_cast<uintptr_t>(__stack_base_lwm);
@@ -287,8 +290,6 @@ extern "C" uint32_t _start1() {
                 // Trigger the invalidation of the DM cache. This call will wait until all DMs
                 // invalidate their portion of the l2 cache.
                 invalidate_cache_all(hartid);
-                // Turn off the flag to trigger the cache invalidation
-                trigger_cache_invalidation = false;
 
                 run_triscs(enables);
 
@@ -398,7 +399,8 @@ extern "C" uint32_t _start1() {
         while (true) {
             // If DM0 triggers the cache invalidation before the next kernel is run.
             // This will occur before DM0 sends the GO message to the subordinate.
-            if (trigger_cache_invalidation) {
+            uint32_t seq = cache_invalidation_seq;
+            if (seq != last_cache_invalidation_seq) {
                 // Flush and save the subordinate's stack to SRAM
                 extern thread_local uint32_t __stack_base_lwm[];
                 uintptr_t stack_bottom = reinterpret_cast<uintptr_t>(__stack_base_lwm);
@@ -408,6 +410,7 @@ extern "C" uint32_t _start1() {
                 // Trigger the invalidation of the subordinate's cache. This call will wait until all DMs
                 // invalidate their portion of the l2 cache.
                 invalidate_cache_all(hartid);
+                last_cache_invalidation_seq = seq;
             }
             if (*((volatile uint8_t*)&(subordinate_sync->dm1) + hartid - 1) == RUN_SYNC_MSG_GO ||
                 *((volatile uint8_t*)&(subordinate_sync->dm1) + hartid - 1) == RUN_SYNC_MSG_LOAD) {

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -322,12 +322,10 @@ extern "C" uint32_t _start1() {
                 WAYPOINT("R");
                 if (enables & (1u << index)) {
                     uintptr_t kernel_lma =
-                        (kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index] +
-                         MEM_L1_UNCACHED_BASE);
+                        (kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index]);
                     // Invalidate the i$ now the kernels have loaded and before running
                     invalidate_kernel_binary_l2_cache(kernel_lma, launch_msg_address, index);
                     invalidate_l1_icache();
-                    uint32_t* kernel_ptr = reinterpret_cast<uint32_t*>(kernel_lma);
                     auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();
                     record_stack_usage(stack_free);
                 } else {
@@ -402,7 +400,7 @@ extern "C" uint32_t _start1() {
         int index = hartid;
 
         uintptr_t kernel_lma =
-            kernel_config_base + launch_msg->kernel_config.kernel_text_offset[index] + MEM_L1_UNCACHED_BASE;
+            kernel_config_base + launch_msg->kernel_config.kernel_text_offset[index];
 
         uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(MEM_L1_UNCACHED_BASE + kernel_config_base +
                                                                 launch_msg->kernel_config.local_cb_offset);

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -46,9 +46,6 @@ thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
-volatile uint32_t cache_invalidation_seq = 0;
-thread_local uint32_t last_cache_invalidation_seq = 0;
-
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
 thread_local uint32_t rta_count __attribute__((used));
 thread_local uint32_t crta_count __attribute__((used));
@@ -63,6 +60,14 @@ int32_t bank_to_l1_offset[NUM_L1_BANKS] __attribute__((used));
 
 tt_l1_ptr mailboxes_t* const mailboxes = (tt_l1_ptr mailboxes_t*)(UNCACHED_MEM_MAILBOX_BASE);
 tt_l1_ptr subordinate_map_t* const subordinate_sync = (subordinate_map_t*)mailboxes->subordinate_sync.map;
+
+inline void invalidate_kernel_binary_l2_cache(uintptr_t kernel_lma, launch_msg_t* launch_msg, uint32_t processor_index) {
+    uint32_t kernel_size = launch_msg->kernel_config.kernel_text_size[processor_index];
+    if (kernel_size == 0) {
+        return;
+    }
+    invalidate_l2_cache_range(kernel_lma, kernel_size);
+}
 
 void set_deassert_addresses() {
     WRITE_REG(NEO_REGS_0__LOCAL_REGS_DEBUG_REGS_TRISC0_RESET_PC_REG_ADDR, MEM_TRISC0_FIRMWARE_BASE);
@@ -277,20 +282,6 @@ extern "C" uint32_t _start1() {
                 // Copies from L1 to IRAM on chips where NCRISC has IRAM
                 uintptr_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, hartid);
 
-                // Tell all other DMs to invalidate their portion of the l2 cache
-                // by swapping between 0 and 1
-                cache_invalidation_seq = 1 - cache_invalidation_seq;
-                flush_l2_cache_line((uintptr_t)&cache_invalidation_seq);
-                // Flush and save DM0's stack to SRAM
-                extern thread_local uint32_t __stack_base_lwm[];
-                uintptr_t stack_bottom = reinterpret_cast<uintptr_t>(__stack_base_lwm);
-                uintptr_t stack_top = reinterpret_cast<uintptr_t>(__builtin_thread_pointer()) + MEM_DM_LOCAL_SIZE;
-                uint32_t stack_size_bytes = stack_top - stack_bottom;
-                flush_l2_cache_range(stack_bottom, stack_size_bytes);
-                // Trigger the invalidation of the DM cache. This call will wait until all DMs
-                // invalidate their portion of the l2 cache.
-                invalidate_cache_all(hartid);
-
                 run_triscs(enables);
 
                 // noc_index = launch_msg_address->kernel_config.brisc_noc_id;
@@ -334,6 +325,7 @@ extern "C" uint32_t _start1() {
                         (kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index] +
                          MEM_L1_UNCACHED_BASE);
                     // Invalidate the i$ now the kernels have loaded and before running
+                    invalidate_kernel_binary_l2_cache(kernel_lma, launch_msg_address, index);
                     invalidate_l1_icache();
                     uint32_t* kernel_ptr = reinterpret_cast<uint32_t*>(kernel_lma);
                     auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();
@@ -397,21 +389,6 @@ extern "C" uint32_t _start1() {
         // WAYPOINT("GW");
         WAYPOINT("W1");
         while (true) {
-            // If DM0 triggers the cache invalidation before the next kernel is run.
-            // This will occur before DM0 sends the GO message to the subordinate.
-            uint32_t seq = cache_invalidation_seq;
-            if (seq != last_cache_invalidation_seq) {
-                // Flush and save the subordinate's stack to SRAM
-                extern thread_local uint32_t __stack_base_lwm[];
-                uintptr_t stack_bottom = reinterpret_cast<uintptr_t>(__stack_base_lwm);
-                uintptr_t stack_top = reinterpret_cast<uintptr_t>(__builtin_thread_pointer()) + MEM_DM_LOCAL_SIZE;
-                uint32_t stack_size_bytes = stack_top - stack_bottom;
-                flush_l2_cache_range(stack_bottom, stack_size_bytes);
-                // Trigger the invalidation of the subordinate's cache. This call will wait until all DMs
-                // invalidate their portion of the l2 cache.
-                invalidate_cache_all(hartid);
-                last_cache_invalidation_seq = seq;
-            }
             if (*((volatile uint8_t*)&(subordinate_sync->dm1) + hartid - 1) == RUN_SYNC_MSG_GO ||
                 *((volatile uint8_t*)&(subordinate_sync->dm1) + hartid - 1) == RUN_SYNC_MSG_LOAD) {
                 break;
@@ -441,6 +418,7 @@ extern "C" uint32_t _start1() {
             asm("nop; nop; nop; nop; nop");
         }
         // Invalidate the i$ now the kernels have loaded and before running
+        invalidate_kernel_binary_l2_cache(kernel_lma, launch_msg, index);
         invalidate_l1_icache();
         auto stack_free = reinterpret_cast<uint32_t (*)()>(kernel_lma)();
 

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -46,6 +46,8 @@ thread_local uint32_t tt_l1_ptr* rta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* crta_l1_base __attribute__((used));
 thread_local uint32_t tt_l1_ptr* sem_l1_base[ProgrammableCoreType::COUNT] __attribute__((used));
 
+bool trigger_cache_invalidation = false;
+
 #if defined(WATCHER_ENABLED) && !defined(WATCHER_DISABLE_ASSERT)
 thread_local uint32_t rta_count __attribute__((used));
 thread_local uint32_t crta_count __attribute__((used));
@@ -274,6 +276,20 @@ extern "C" uint32_t _start1() {
                 // Copies from L1 to IRAM on chips where NCRISC has IRAM
                 uintptr_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, hartid);
 
+                // Tell all other DMs to invalidate their portion of the l2 cache
+                trigger_cache_invalidation = true;
+                // Flush and save DM0's stack to SRAM
+                extern thread_local uint32_t __stack_base_lwm[];
+                uintptr_t stack_bottom = reinterpret_cast<uintptr_t>(__stack_base_lwm);
+                uintptr_t stack_top = reinterpret_cast<uintptr_t>(__builtin_thread_pointer()) + MEM_DM_LOCAL_SIZE;
+                uint32_t stack_size_bytes = stack_top - stack_bottom;
+                flush_l2_cache_range(stack_bottom, stack_size_bytes);
+                // Trigger the invalidation of the DM cache. This call will wait until all DMs
+                // invalidate their portion of the l2 cache.
+                invalidate_cache_all(hartid);
+                // Turn off the flag to trigger the cache invalidation
+                trigger_cache_invalidation = false;
+
                 run_triscs(enables);
 
                 // noc_index = launch_msg_address->kernel_config.brisc_noc_id;
@@ -380,6 +396,19 @@ extern "C" uint32_t _start1() {
         // WAYPOINT("GW");
         WAYPOINT("W1");
         while (true) {
+            // If DM0 triggers the cache invalidation before the next kernel is run.
+            // This will occur before DM0 sends the GO message to the subordinate.
+            if (trigger_cache_invalidation) {
+                // Flush and save the subordinate's stack to SRAM
+                extern thread_local uint32_t __stack_base_lwm[];
+                uintptr_t stack_bottom = reinterpret_cast<uintptr_t>(__stack_base_lwm);
+                uintptr_t stack_top = reinterpret_cast<uintptr_t>(__builtin_thread_pointer()) + MEM_DM_LOCAL_SIZE;
+                uint32_t stack_size_bytes = stack_top - stack_bottom;
+                flush_l2_cache_range(stack_bottom, stack_size_bytes);
+                // Trigger the invalidation of the subordinate's cache. This call will wait until all DMs
+                // invalidate their portion of the l2 cache.
+                invalidate_cache_all(hartid);
+            }
             if (*((volatile uint8_t*)&(subordinate_sync->dm1) + hartid - 1) == RUN_SYNC_MSG_GO ||
                 *((volatile uint8_t*)&(subordinate_sync->dm1) + hartid - 1) == RUN_SYNC_MSG_LOAD) {
                 break;

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -162,6 +162,8 @@ struct kernel_config_msg_t {
     volatile uint8_t mode;     // dispatch mode host/dev
     volatile uint8_t pad2[3];  // CODEGEN:skip
     volatile uint32_t kernel_text_offset[MaxProcessorsPerCoreType];
+    volatile uint32_t kernel_text_size[MaxProcessorsPerCoreType];
+    volatile uint8_t pad4[(MaxProcessorsPerCoreType % 2) * 12]; // CODEGEN:skip
     volatile uint64_t local_cb_mask;
 
     volatile uint8_t brisc_noc_id;
@@ -195,6 +197,7 @@ static_assert(offsetof(kernel_config_msg_t, local_cb_offset) % sizeof(uint16_t) 
 static_assert(offsetof(kernel_config_msg_t, remote_cb_offset) % sizeof(uint16_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, rta_offset) % sizeof(uint16_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, kernel_text_offset) % sizeof(uint32_t) == 0);
+static_assert(offsetof(kernel_config_msg_t, kernel_text_size) % sizeof(uint32_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, local_cb_mask) % sizeof(uint64_t) == 0);
 static_assert(offsetof(kernel_config_msg_t, host_assigned_id) % sizeof(uint32_t) == 0);
 

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/dev_mem_map.h
@@ -110,7 +110,7 @@
 // Hardcode below due to compiler bug that cannot statically resolve the expression see GH issue #19265
 #define MEM_MAILBOX_BASE 96  // (MEM_NCRISC_L1_INLINE_BASE + (MEM_L1_INLINE_SIZE_PER_NOC * 2) * 2)  // 2 nocs * 2 (B,NC)
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12912
+#define MEM_MAILBOX_SIZE 13168
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 #define MEM_ZEROS_BASE ((MEM_MAILBOX_END + 31) & ~31)
 

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
@@ -86,7 +86,7 @@
 #define MEM_L1_BARRIER 12
 #define MEM_MAILBOX_BASE 16
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 12912
+#define MEM_MAILBOX_SIZE 13168
 // These are used in ncrisc-halt.S, asserted in ncrisc.cc to be valid
 #define MEM_NCRISC_HALT_STACK_MAILBOX_ADDRESS (MEM_MAILBOX_BASE + 4)
 #define MEM_SUBORDINATE_RUN_MAILBOX_ADDRESS (MEM_MAILBOX_BASE + 8)

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/dev_mem_map.h
@@ -92,7 +92,7 @@
 #define MEM_MAILBOX_BASE 16
 #define UNCACHED_MEM_MAILBOX_BASE (0x400010)  // workaround for https://github.com/tenstorrent/tt-metal/issues/19265
 // Magic size must be big enough to hold dev_msgs_t.  static_asserts will fire if this is too small
-#define MEM_MAILBOX_SIZE 57696
+#define MEM_MAILBOX_SIZE 58464
 #define MEM_MAILBOX_END (MEM_MAILBOX_BASE + MEM_MAILBOX_SIZE)
 
 #define MEM_LLK_DEBUG_BASE ((MEM_MAILBOX_END + 31) & ~31)

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -264,6 +264,9 @@ inline __attribute__((always_inline)) void flush_l2_cache_range(uintptr_t start_
 // Invalidate a range of addresses from L2 to TL1.
 // Invalidates all cache lines covering [start_addr, start_addr + size).
 inline __attribute__((always_inline)) void invalidate_l2_cache_range(uintptr_t start_addr, size_t size) {
+    if (size == 0) {
+        return;
+    }
     uintptr_t aligned_start = start_addr & ~(uintptr_t)63;  // align to 64B
     uintptr_t end_addr = start_addr + size;
 

--- a/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/risc_common.h
@@ -261,6 +261,17 @@ inline __attribute__((always_inline)) void flush_l2_cache_range(uintptr_t start_
     }
 }
 
+// Invalidate a range of addresses from L2 to TL1.
+// Invalidates all cache lines covering [start_addr, start_addr + size).
+inline __attribute__((always_inline)) void invalidate_l2_cache_range(uintptr_t start_addr, size_t size) {
+    uintptr_t aligned_start = start_addr & ~(uintptr_t)63;  // align to 64B
+    uintptr_t end_addr = start_addr + size;
+
+    for (uintptr_t addr = aligned_start; addr < end_addr; addr += 64) {
+        invalidate_l2_cache_line(addr);
+    }
+}
+
 // Flush entire L2 cache to TL1.
 // Iterates FLUSH64 over all cacheable TL1 addresses (4MB).
 inline void flush_l2_cache_full() {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -397,6 +397,7 @@ uint32_t finalize_kernel_bins(
                 for (uint32_t processor_index : processor_indices) {
                     kg->kernel_text_offsets[processor_index] = kernel_text_offset;
                     kernel_config.kernel_text_offset()[processor_index] = kernel_text_offset;
+                    kernel_config.kernel_text_size()[processor_index] = binaries[i]->get_packed_size();
                     hal.set_iram_text_size(
                         kg->launch_msg.view(),
                         programmable_core_type,


### PR DESCRIPTION
### PR Category
Bug fix
Closes #46504 

### Summary
We are currently bypassing the cache for most operations and not properly flushing/invalidating the cache before starting kernels. As a temporary work-around, this change invalidates the portion of the l2 cache occupied by the kernel program immediately before launching a kernel. This will make sure the kernel binary is properly updated in the cache.

Verified with test_dispatch & test_prefetch unit tests plus all daily Quasar tests including a simple back-to-back test.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kstevens/issue_46504)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kstevens/issue_46504)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kstevens/issue_46504)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kstevens/issue_46504)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kstevens/issue_46504)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kstevens/issue_46504)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kstevens/issue_46504)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kstevens/issue_46504)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kstevens/issue_46504)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kstevens/issue_46504)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kstevens/issue_46504)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kstevens/issue_46504)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kstevens/issue_46504)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kstevens/issue_46504)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kstevens/issue_46504)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kstevens/issue_46504)