### PR TITLE
#MINFRA-782: Re-host runtime + microbench tests from QBAE to BH-LoudBox

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -163,11 +163,13 @@ runtime:
     bh_p150b_civ2_viommu: 5
     bh_p100a_civ2_viommu: 74
     bh_quietbox: 20
+    bh_loudbox: 20
     wh_galaxy: 35
   integration:
     wh_n150_civ2: 360
     bh_p150b_civ2: 360
     bh_quietbox: 25
+    bh_loudbox: 25
   perf:
     wh_n300_civ2: 55
     bh_p150_perf: 40

--- a/.github/workflows/metal-run-microbenchmarks-impl.yaml
+++ b/.github/workflows/metal-run-microbenchmarks-impl.yaml
@@ -73,9 +73,9 @@ jobs:
             }, # Tomer Levin
             {
               arch: blackhole,
-              # Run on LLMBox to ensure at least 4 devices
-              runs-on: ["BH-LLMBox", "pipeline-perf", "in-service"],
-              name: "BH Quietbox ubench - Fabric BW & Latency",
+              # Run on LoudBox to ensure at least 4 devices (re-hosted from BH-LLMBox per MINFRA-782)
+              runs-on: ["BH-LoudBox", "pipeline-functional", "in-service"],
+              name: "BH LoudBox ubench - Fabric BW & Latency",
               cmd: "TT_METAL_CLEAR_L1=1 ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config ${TT_METAL_HOME}/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_ubench_at_least_2x2_mesh.yaml",
             }, # Nolen Zhao
           ]

--- a/.github/workflows/runtime-integration-tests.yaml
+++ b/.github/workflows/runtime-integration-tests.yaml
@@ -70,10 +70,10 @@ jobs:
       enabled-skus: >-
         ${{
           github.event_name == 'schedule'
-            && 'wh_n150_civ2,bh_p150b_civ2,bh_quietbox'
+            && 'wh_n150_civ2,bh_p150b_civ2,bh_quietbox,bh_loudbox'
             || format('{0}{1}',
               inputs.wormhole && 'wh_n150_civ2' || '',
-              inputs.blackhole && format('{0}bh_p150b_civ2,bh_quietbox',
+              inputs.blackhole && format('{0}bh_p150b_civ2,bh_quietbox,bh_loudbox',
                 inputs.wormhole && ',' || '') || ''
             )
         }}

--- a/.github/workflows/runtime-unit-tests-impl.yaml
+++ b/.github/workflows/runtime-unit-tests-impl.yaml
@@ -67,7 +67,7 @@ jobs:
     container:
       image: >-
         ${{
-          !contains(fromJSON('["bh_quietbox","wh_galaxy"]'), matrix.test-group.sku) &&
+          !contains(fromJSON('["bh_quietbox","wh_galaxy","bh_loudbox"]'), matrix.test-group.sku) &&
             format('{0}{1}', inputs.harbor-prefix, inputs.docker-image) ||
           inputs.docker-image || 'docker-image-unresolved!'
         }}

--- a/.github/workflows/runtime-unit-tests.yaml
+++ b/.github/workflows/runtime-unit-tests.yaml
@@ -69,10 +69,10 @@ jobs:
       enabled-skus: >-
         ${{
           github.event_name == 'schedule'
-            && 'wh_n150_civ2,wh_n300_civ2,bh_p150b_civ2,bh_p100a_civ2_viommu,bh_p150b_civ2_viommu,bh_quietbox,wh_galaxy'
+            && 'wh_n150_civ2,wh_n300_civ2,bh_p150b_civ2,bh_p100a_civ2_viommu,bh_p150b_civ2_viommu,bh_quietbox,bh_loudbox,wh_galaxy'
             || format('{0}{1}',
               inputs.wormhole && 'wh_n150_civ2,wh_n300_civ2,wh_galaxy' || '',
-              inputs.blackhole && format('{0}bh_p150b_civ2,bh_p100a_civ2_viommu,bh_p150b_civ2_viommu,bh_quietbox',
+              inputs.blackhole && format('{0}bh_p150b_civ2,bh_p100a_civ2_viommu,bh_p150b_civ2_viommu,bh_quietbox,bh_loudbox',
                 inputs.wormhole && ',' || '') || ''
             )
         }}

--- a/tests/pipeline_reorg/runtime_integration_tests.yaml
+++ b/tests/pipeline_reorg/runtime_integration_tests.yaml
@@ -26,6 +26,8 @@
   skus:
     bh_quietbox:
       timeout: 15
+    bh_loudbox:
+      timeout: 15
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
@@ -34,6 +36,8 @@
   cmd: ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter='*HDSocketFixture*'
   skus:
     bh_quietbox:
+      timeout: 10
+    bh_loudbox:
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -320,6 +320,8 @@
   skus:
     bh_quietbox:
       timeout: 5
+    bh_loudbox:
+      timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
@@ -330,6 +332,8 @@
     TT_METAL_DISABLE_MULTI_AERISC=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter='UnitMeshRandomProgramTraceFixture.ActiveEthTestProgramsTrace'
   skus:
     bh_quietbox:
+      timeout: 10
+    bh_loudbox:
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime


### PR DESCRIPTION
## Summary
- Re-host four runtime BH multi-card tests (`bh_multicard_debug_tools`, `bh_multicard_dispatch`, `bh_multicard_eth`, `bh_multicard_sockets`) by adding the `bh_loudbox` SKU alongside `bh_quietbox`. After MINFRA-742 removes `bh_quietbox`, these tests will continue on LoudBox.
- Re-host the perf microbenchmark `BH Quietbox ubench - Fabric BW & Latency` onto `BH-LoudBox` (rename → `BH LoudBox ubench - Fabric BW & Latency`). Runs-on labels swap from `[BH-LLMBox, pipeline-perf, in-service]` to `[BH-LoudBox, pipeline-functional, in-service]`.
- Add `runtime.unit.bh_loudbox: 20` and `runtime.integration.bh_loudbox: 25` to `time_budget.yaml` so the matrix verifier accepts the new SKU.
- `bh_multicard_system_health` (runtime sanity) already had `bh_loudbox`; no change needed.

## Test plan
- [x] All 4 edited YAML files parse cleanly (`yaml.safe_load`)
- [x] `(Runtime) Unit tests` scheduled run dispatches `bh_multicard_{debug_tools,dispatch}` onto `BH-LoudBox`
- [x] `(Runtime) Integration tests` scheduled run dispatches `bh_multicard_{eth,sockets}` onto `BH-LoudBox`
- [x] `(Metal) Microbenchmarks` schedules `BH LoudBox ubench - Fabric BW & Latency` onto a `BH-LoudBox + pipeline-functional` runner
- [ ] Sean Nijjar / Nolen Zhao confirm the microbenchmark performs as expected on LoudBox

## Known limitations
- This PR is independent of [MINFRA-742](https://tenstorrent.atlassian.net/browse/MINFRA-742) but expects to land alongside it. If MINFRA-742 lands first, the `bh_quietbox` SKU rows in these tests vanish and the tests continue on `bh_loudbox` alone — desired end state. If this PR lands first, both `bh_quietbox` and `bh_loudbox` are active simultaneously until -742 lands.
- Microbenchmark moves from `pipeline-perf` to `pipeline-functional` because `bh_loudbox` SKU only carries the functional tag. If a dedicated LoudBox perf pool is added later, switch this back.

---
**Jira:** [MINFRA-782](https://tenstorrent.atlassian.net/browse/MINFRA-782)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mchiou/MINFRA-782-rehost-runtime-ubench-to-loudbox)