### PR TITLE
Feature: Add environment variable to disable trace capture and execution

### DIFF
--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1238,6 +1238,10 @@ SystemMemoryManager& MeshDeviceImpl::sysmem_manager() {
 }
 
 void MeshDeviceImpl::release_mesh_trace(const MeshTraceId& trace_id) {
+    if (MetalContext::instance(context_id_).rtoptions().get_disable_trace_capture()) {
+        return;
+    }
+
     TracyTTMetalReleaseMeshTrace(this->get_device_ids(), *trace_id);
 
     validate_sub_device_manager_tracker();
@@ -1263,6 +1267,10 @@ MeshTraceId MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id) {
 }
 
 void MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
+    if (MetalContext::instance(context_id_).rtoptions().get_disable_trace_capture()) {
+        return;
+    }
+
     TracyTTMetalBeginMeshTrace(this->get_device_ids(), *trace_id);
     TT_FATAL(
         !this->mesh_command_queues_[cq_id]->trace_id().has_value(),
@@ -1290,6 +1298,10 @@ void MeshDeviceImpl::begin_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id
 }
 
 void MeshDeviceImpl::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) {
+    if (MetalContext::instance(context_id_).rtoptions().get_disable_trace_capture()) {
+        return;
+    }
+
     TracyTTMetalEndMeshTrace(this->get_device_ids(), *trace_id);
     TT_FATAL(
         this->mesh_command_queues_[cq_id]->trace_id() == trace_id,
@@ -1323,6 +1335,10 @@ void MeshDeviceImpl::end_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id) 
 
 void MeshDeviceImpl::replay_mesh_trace(uint8_t cq_id, const MeshTraceId& trace_id, bool blocking) {
     ZoneScoped;
+    if (MetalContext::instance(context_id_).rtoptions().get_disable_trace_capture()) {
+        return;
+    }
+
     TracyTTMetalReplayMeshTrace(this->get_device_ids(), *trace_id);
     auto* active_sub_device_manager = sub_device_manager_tracker_->get_active_sub_device_manager();
     const auto& trace_buffer = active_sub_device_manager->get_trace(trace_id);

--- a/tt_metal/llrt/rtoptions.cpp
+++ b/tt_metal/llrt/rtoptions.cpp
@@ -143,6 +143,7 @@ enum class EnvVarID {
     TT_METAL_NOC_DEBUG_DUMP,                       // Enable experimental NOC debug dump to detect missing barriers
     TT_METAL_DISPATCH_PROGRESS_UPDATE_MS,          // Dispatch kernel progress update period in milliseconds
     TT_METAL_DISPATCH_TELEMETRY_DISABLE,           // Dispatch telemetry
+    TT_METAL_DISABLE_TRACE_CAPTURE,                // Disable trace capture
 
     // ========================================
     // WATCHER SYSTEM
@@ -1050,6 +1051,17 @@ void RunTimeOptions::HandleEnvVar(EnvVarID id, const char* value) {
         case EnvVarID::TT_METAL_DISPATCH_TELEMETRY_DISABLE:
             this->dispatch_telemetry_disabled = is_env_enabled(value);
             break;
+
+        // TT_METAL_DISABLE_TRACE_CAPTURE
+        // Disable trace capture.
+        // Default: false (trace capture enabled)
+        // Usage: export TT_METAL_DISABLE_TRACE_CAPTURE=1
+        case EnvVarID::TT_METAL_DISABLE_TRACE_CAPTURE: {
+            if (is_env_enabled(value)) {
+                this->disable_trace_capture = true;
+            }
+            break;
+        }
 
         // ========================================
         // WATCHER SYSTEM

--- a/tt_metal/llrt/rtoptions.hpp
+++ b/tt_metal/llrt/rtoptions.hpp
@@ -320,6 +320,9 @@ class RunTimeOptions {
     // Disable dispatch telemetry
     bool dispatch_telemetry_disabled = false;
 
+    // Disable trace capture
+    bool disable_trace_capture = false;
+
     // Using MGD 2.0 syntax for mesh graph descriptor
     bool use_mesh_graph_descriptor_2_0 = false;
 
@@ -782,6 +785,8 @@ public:
     uint32_t get_dispatch_progress_update_ms() const { return dispatch_progress_update_ms; }
 
     bool get_dispatch_telemetry_disabled() const { return dispatch_telemetry_disabled; }
+
+    bool get_disable_trace_capture() const { return disable_trace_capture; }
 
     // Mesh graph descriptor version accessor
     bool get_use_mesh_graph_descriptor_2_0() const { return use_mesh_graph_descriptor_2_0; }


### PR DESCRIPTION
### PR Category
Feature

### Summary
This is meant to alleviate profiler buffer limitations when running large workloads (i.e. models) in trace mode, where we cannot dump from the profiler buffer in DRAM during a trace run since the dump calls are issued from host.

In general, this is a useful option to have to globally disable trace mode for debugging and testing.

### Notes for reviewers
None

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadeem/disable_trace_env_variable)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadeem/disable_trace_env_variable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadeem/disable_trace_env_variable)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadeem/disable_trace_env_variable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadeem/disable_trace_env_variable)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadeem/disable_trace_env_variable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadeem/disable_trace_env_variable)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadeem/disable_trace_env_variable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadeem/disable_trace_env_variable)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadeem/disable_trace_env_variable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadeem/disable_trace_env_variable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadeem/disable_trace_env_variable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadeem/disable_trace_env_variable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadeem/disable_trace_env_variable)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadeem/disable_trace_env_variable)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadeem/disable_trace_env_variable)