### PR TITLE
Have more accurate batch_norm for training

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/batch_norm.cpp
@@ -107,9 +107,13 @@ Tensor batch_norm(
         // propagate the precision requirement here so that the output `batch_mean`/`batch_var` are in
         // higher precision rather than inheriting the `dtype` of input.
         batch_mean = operations::normalization::mean_NHW(input, memory_config, compute_kernel_config);
-        auto mean_sq = operations::normalization::mean_NHW(
-            ttnn::square(input, memory_config), memory_config, compute_kernel_config);
-        batch_var = ttnn::subtract(mean_sq, ttnn::square(batch_mean, memory_config), std::nullopt, memory_config);
+        // Use the centered two-pass form E[(x - mean)^2] instead of E[x^2] - E[x]^2.
+        // The latter suffers catastrophic cancellation when the batch mean is large
+        // relative to the batch variance, which can drive the variance slightly
+        // negative and produce NaNs in the normalization step.
+        auto centered = ttnn::subtract(input, batch_mean, std::nullopt, memory_config);
+        batch_var = operations::normalization::mean_NHW(
+            ttnn::square(centered, memory_config), memory_config, compute_kernel_config);
     } else {
         TT_FATAL(
             (running_mean.has_value() && running_var.has_value()),


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bbradel-0_batch_norm_accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bbradel-0_batch_norm_accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bbradel-0_batch_norm_accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bbradel-0_batch_norm_accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bbradel-0_batch_norm_accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bbradel-0_batch_norm_accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bbradel-0_batch_norm_accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bbradel-0_batch_norm_accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bbradel-0_batch_norm_accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bbradel-0_batch_norm_accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bbradel-0_batch_norm_accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bbradel-0_batch_norm_accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bbradel-0_batch_norm_accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bbradel-0_batch_norm_accuracy)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bbradel-0_batch_norm_accuracy)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bbradel-0_batch_norm_accuracy)