### PR TITLE
ds_prefill(scripts) - update prefill stress/timing helper scripts

### DIFF
--- a/models/demos/deepseek_v3_d_p/scripts/common.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/common.sh
@@ -26,7 +26,7 @@ LOG_DIR="/data/$USER/$LOG_NAME"
 
 # Test selection — single source of truth.
 TEST_FILE="$TT_METAL_HOME/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py"
-KFILTER="pretrained and e256_device_fp32 and fabric2d-mesh-8x4 and 61_layers and balanced and right_pad and smoke and iter25 and 25600 and longbook"
+KFILTER="ds_prefill and pretrained and e256_device_fp32 and fabric2d-mesh-8x4 and 61_layers and balanced and right_pad and smoke and no_determinism and iter25 and 25600 and longbook"
 
 # Inner-iteration count, derived from the iterNN token in the filter above.
 INNER_ITERS=$(grep -oE 'iter[0-9]+' <<<"$KFILTER" | grep -oE '[0-9]+' | head -1)
@@ -47,7 +47,7 @@ scan_log_dir() {
   pass=0; fail=0; hang=0; running=0; pending=0
   details=()
 
-  local i f next N iter layer mtime now idle elapsed
+  local i f next N iter layer mtime now idle elapsed loading progress
   for i in $(seq 1 "$LOOP"); do
     f=$(log_for "$dir" "$i")
     next=$(log_for "$dir" $((i + 1)))
@@ -70,14 +70,22 @@ scan_log_dir() {
       now=$(date +%s)
       idle=$((now - mtime))
 
+      # Before the forward loop starts there are no forward_layer markers; show
+      # which layer's weights are currently being loaded from cache instead.
+      progress="$layer"
+      if [ -z "$layer" ]; then
+        loading=$(grep 'Loaded cache for' "$f" 2>/dev/null | grep -oE 'layer_[0-9]+' | tail -1)
+        [ -n "$loading" ] && progress="loading weights $loading"
+      fi
+
       if [ -f "$next" ]; then
-        details+=("  $N: HANG?  iter=$iter/$INNER_ITERS  $layer")
+        details+=("  $N: HANG?  iter=$iter/$INNER_ITERS  $progress")
         ((hang++))
       elif [ "$idle" -gt "$STALE_SECS" ]; then
-        details+=("  $N: STALE ${idle}s  iter=$iter/$INNER_ITERS  $layer")
+        details+=("  $N: STALE ${idle}s  iter=$iter/$INNER_ITERS  $progress")
         ((running++))
       else
-        details+=("  $N: RUN    iter=$iter/$INNER_ITERS  $layer  (idle ${idle}s)")
+        details+=("  $N: RUN    iter=$iter/$INNER_ITERS  $progress  (idle ${idle}s)")
         ((running++))
       fi
     fi

--- a/models/demos/deepseek_v3_d_p/scripts/common.sh
+++ b/models/demos/deepseek_v3_d_p/scripts/common.sh
@@ -26,7 +26,7 @@ LOG_DIR="/data/$USER/$LOG_NAME"
 
 # Test selection — single source of truth.
 TEST_FILE="$TT_METAL_HOME/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py"
-KFILTER="pretrained and e256_device_fp32 and mesh-8x4 and 61_layers and balanced and right_pad and smoke and iter25 and 25600 and pie960"
+KFILTER="pretrained and e256_device_fp32 and fabric2d-mesh-8x4 and 61_layers and balanced and right_pad and smoke and iter25 and 25600 and longbook"
 
 # Inner-iteration count, derived from the iterNN token in the filter above.
 INNER_ITERS=$(grep -oE 'iter[0-9]+' <<<"$KFILTER" | grep -oE '[0-9]+' | head -1)

--- a/models/demos/deepseek_v3_d_p/scripts/parse_iteration_times.py
+++ b/models/demos/deepseek_v3_d_p/scripts/parse_iteration_times.py
@@ -4,31 +4,36 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import argparse
+import os
 import re
 import statistics
 import subprocess
 from datetime import datetime
+from glob import glob
 
 
 def parse_timestamp(ts_str):
     return datetime.strptime(ts_str, "%Y-%m-%d %H:%M:%S.%f")
 
 
-def filter_outliers(values, threshold=2.0):
-    if len(values) < 2:
-        return values, []
-    median = statistics.median(values)
-    cutoff = median * threshold
-    filtered = [v for v in values if v <= cutoff]
-    outliers = [v for v in values if v > cutoff]
-    return filtered, outliers
+def print_stats(title, values):
+    print(f"=== {title} ===")
+    if not values:
+        print("No data")
+        return
+    first, rest = values[0], values[1:]
+    print(f"First: {first:.3f}s")
+    if rest:
+        avg = statistics.mean(rest)
+        median = statistics.median(rest)
+        stddev = statistics.stdev(rest) if len(rest) > 1 else 0.0
+        print(f"Rest ({len(rest)} samples): Avg: {avg:.3f}s | Median: {median:.3f}s | Stddev: {stddev:.3f}s")
+        print(f"Min: {min(rest):.3f}s | Max: {max(rest):.3f}s")
+    else:
+        print("No additional samples")
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Parse iteration timing from log files")
-    parser.add_argument("-f", "--file", required=True, help="Log file path")
-    args = parser.parse_args()
-
+def parse_file(path, show_sync=False):
     iter_pattern = re.compile(r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}).*Starting iteration: (\d+)")
     sync_pattern = re.compile(
         r"(\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\.\d{3}).*Starting completion sync on iteration: (\d+)"
@@ -38,7 +43,7 @@ def main():
     syncs = {}
 
     proc = subprocess.Popen(
-        ["grep", "Starting", args.file],
+        ["grep", "Starting", path],
         stdout=subprocess.PIPE,
         text=True,
     )
@@ -65,29 +70,40 @@ def main():
             delta = (iterations[curr] - iterations[prev]).total_seconds()
             iter_deltas.append(delta)
 
-    sync_deltas = []
-    for sync_num, sync_ts in syncs.items():
-        next_iter = sync_num + 1
-        if next_iter in iterations:
-            delta = (iterations[next_iter] - sync_ts).total_seconds()
-            sync_deltas.append(delta)
+    print_stats("Iteration Period", iter_deltas)
 
-    print("=== Iteration Period ===")
-    if iter_deltas:
-        filtered, outliers = filter_outliers(iter_deltas)
-        print(f"Samples: {len(filtered)} (filtered {len(outliers)} outliers)")
-        print(f"Min: {min(filtered):.3f}s | Avg: {statistics.mean(filtered):.3f}s | Max: {max(filtered):.3f}s")
-    else:
-        print("No data")
+    if show_sync:
+        sync_deltas = []
+        for sync_num in sorted(syncs.keys()):
+            next_iter = sync_num + 1
+            if next_iter in iterations:
+                delta = (iterations[next_iter] - syncs[sync_num]).total_seconds()
+                sync_deltas.append(delta)
 
-    print()
-    print("=== Sync to Next Iteration ===")
-    if sync_deltas:
-        filtered, outliers = filter_outliers(sync_deltas)
-        print(f"Samples: {len(filtered)} (filtered {len(outliers)} outliers)")
-        print(f"Min: {min(filtered):.3f}s | Avg: {statistics.mean(filtered):.3f}s | Max: {max(filtered):.3f}s")
+        print()
+        print_stats("Sync to Next Iteration", sync_deltas)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Parse iteration timing from log files")
+    parser.add_argument("-f", "--file", required=True, help="Log file or directory containing log_* files")
+    parser.add_argument(
+        "-n", "--sync", action="store_true", help="Also show 'Sync to Next Iteration' stats (default: off)"
+    )
+    args = parser.parse_args()
+
+    if os.path.isdir(args.file):
+        log_files = sorted(glob(os.path.join(args.file, "log_*")))
+        if not log_files:
+            print(f"No log_* files found in {args.file}")
+            return
+        for i, path in enumerate(log_files):
+            if i:
+                print()
+            print(f"########## {os.path.basename(path)} ##########")
+            parse_file(path, show_sync=args.sync)
     else:
-        print("No sync data found")
+        parse_file(args.file, show_sync=args.sync)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- `parse_iteration_times.py`: report the first iteration separately (always slower) plus avg/median/stddev of the rest instead of median-threshold outlier filtering; accept a directory and parse every `log_*` file in it; make the "Sync to Next Iteration" stats opt-in via `-n`/`--sync`.
- `common.sh` (`scan_log_dir`): during the pre-loop weight-loading phase there are no `forward_layer_*` markers, so the watch status looked idle — now derive the layer currently loading from the `Loaded cache for .../layer_NN` lines and show `loading weights layer_NN`.
- `common.sh` (`KFILTER`): tighten the test selector so it resolves to exactly one test — add the `ds_prefill` marker and pin the determinism axis with `no_determinism`.

## Test plan
- Scripts-only change (DeepSeek prefill stress/timing helpers); no kernel/op/model code touched. CI intentionally skipped.
- Verified `parse_iteration_times.py` against real logs (file and directory modes).
- Verified the `KFILTER` collects a single test via `pytest --collect-only -k`.
- Verified the weight-loading layer extraction against captured stress logs.

[skip ci]

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2606_prefill_scripts_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2606_prefill_scripts_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2606_prefill_scripts_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2606_prefill_scripts_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2606_prefill_scripts_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2606_prefill_scripts_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2606_prefill_scripts_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2606_prefill_scripts_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2606_prefill_scripts_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2606_prefill_scripts_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2606_prefill_scripts_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2606_prefill_scripts_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2606_prefill_scripts_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2606_prefill_scripts_update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2606_prefill_scripts_update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2606_prefill_scripts_update)