### PR TITLE
Rebase MP ttsim mock-cluster fixes (PR #45379) onto blaze-metal-main

### DIFF
--- a/MULTICHIP_SIM_REBASE_FIXES.md
+++ b/MULTICHIP_SIM_REBASE_FIXES.md
@@ -1,0 +1,153 @@
+# Multichip Sim Rebase — Errors & Fixes
+
+This document records each fix made while rebasing the multichip MP simulator work
+onto current bases and getting the N300/P300 fabric smoke tests to run:
+
+- **craq-sim** PR: rebase `nkapre/multichip-mp-daemon` (orig PR #51) onto `main`
+  → branch `rsong/multichip-mp-daemon-rebased-main` (PR #83)
+- **tt-metal** PR: rebase `nkapre/multichip-mp-ttsim-mock-cluster-rank-binding-20260527`
+  (orig PR #45379) onto `blaze-metal-main`
+  → branch `rsong/multichip-mp-ttsim-rebased-blaze-metal-main` (PR #46536)
+
+Each section lists the commit, the error it addressed, the root cause, and the fix.
+
+---
+
+## 1. craq-sim `aa187267` — guard WH-only NCRISC IRAM paths for BH build
+
+**File:** `src/tile.cpp`
+
+### Error
+Building the Blackhole library (`TT_VERSION=1`, `_out/release_bh/tile.o`) failed:
+
+```
+tile.cpp:893: error: 'RV32_IRAM_BASE' was not declared in this scope
+tile.cpp:894: error: 'RV32_IRAM_SIZE' was not declared in this scope
+tile.cpp:897: error: 'struct TensixTile' has no member named 'ncrisc_iram'
+tile.cpp:2935: error: 'RV32_IRAM_BASE' was not declared in this scope
+tile.cpp:2955: error: 'struct TensixTile' has no member named 'ncrisc_iram'
+```
+
+### Root cause
+The MP-daemon branch added NCRISC IRAM handling (reset-PC binary-present guard and
+`t_tile_mmio_rd32` IRAM reads) using `RV32_IRAM_BASE`, `RV32_IRAM_SIZE`, and
+`TensixTile::ncrisc_iram[]`. Those symbols are **Wormhole-only** — in `sim.h` the
+`ncrisc_iram` field is declared under `#if TT_VERSION == 0`, and the IRAM constants
+likewise. The new code was compiled unconditionally, so the Blackhole build
+(`TT_VERSION == 1`) could not see them.
+
+### Fix
+Wrap the NCRISC-IRAM branches in `#if TT_VERSION == 0`:
+- In the soft-reset binary-present check, only consult `ncrisc_iram[]` for WH; on
+  other archs fall through to the L1/SRAM read and set `pc_in_iram = false`.
+- Gate the `t_tile_mmio_rd32` IRAM window read with `#if TT_VERSION == 0`.
+
+Result: both `release_wh` and `release_bh` `libttsim.so` build cleanly.
+
+---
+
+## 2. tt-metal `1308a15c23a` — blaze-metal-main build fixes after MP rebase
+
+**Files:** `tt_metal/llrt/tt_cluster.hpp`, `tt_metal/llrt/tt_cluster.cpp`,
+`tt_metal/fabric/physical_system_discovery.cpp`
+
+### Errors
+After rebasing the MP commits onto `blaze-metal-main`, the unity build failed with:
+
+```
+tt_cluster.cpp:1637: error: no member named 'sim_arm_launch_watcher' in 'tt::umd::Cluster'
+fabric_firmware_initializer.cpp:461: error: no member named 'advance_device_execution' in 'tt::Cluster'
+physical_system_discovery.cpp:273: error: unused function 'erase_one_sided_connections' [-Werror,-Wunused-function]
+```
+
+### Root cause
+The MP branch was developed against a newer UMD and a different
+`physical_system_discovery.cpp`:
+1. `Cluster::sim_arm_launch_watcher(...)` called `get_driver()->sim_arm_launch_watcher(...)`,
+   but the UMD pinned on `blaze-metal-main` (`cb0be91a`) does not expose that API.
+2. `fabric_firmware_initializer.cpp` calls `cluster_.advance_device_execution(...)`, but
+   tt-metal's `Cluster` wrapper had no such method (UMD has it; the tt-metal forwarder
+   was missing on this base).
+3. The conflict resolution kept `blaze-metal-main`'s `validate_graphs` (which uses
+   `TT_FATAL` and does **not** call `erase_one_sided_connections`), leaving that helper
+   defined-but-unused under `-Werror`.
+
+### Fix
+1. Stub `Cluster::sim_arm_launch_watcher(...)` as a no-op with a comment (UMD/craq-sim on
+   this base don't expose the underlying call yet) — keeps the debug hook compiling.
+2. Add `Cluster::advance_device_execution(ChipId)` to `tt_cluster.hpp`/`.cpp` forwarding
+   to `get_driver()->advance_device_execution(chip_id)`.
+3. Restore the `blaze-metal-main` `validate_graphs` variant that *does* call
+   `erase_one_sided_connections` (drops one-sided links with a warning instead of
+   `TT_FATAL`), so the helper is used and link retraining behavior is preserved.
+
+> Note: during the rebase the upstream commit `aeec9eb9f6e`
+> ("restore ClusterDescriptor API in physical_system_discovery") was **skipped** — it
+> reverts to a `tt::umd::ClusterDescriptor&` signature that is incompatible with
+> `blaze-metal-main`'s `tt::umd::Cluster&` API.
+
+---
+
+## 3. tt-metal `92f56a65b98` — root FD tunnel discovery only at MMIO-capable chips
+
+**File:** `tt_metal/llrt/tunnels_from_mmio_device.cpp`
+
+### Error
+The N300 (Wormhole) sim datapath test (`Fabric1DFixture.TestUnicastConnAPI` with the WH
+`libttsim.so`) aborted during `MetalContext` init:
+
+```
+TT_ASSERT @ tt_metal/llrt/tunnels_from_mmio_device.cpp:31:
+  cluster.get_cluster_description()->is_chip_mmio_capable(mmio_chip_id)
+ --- tt::llrt::discover_tunnels_from_mmio_device(tt::umd::Cluster&)
+ --- tt::Cluster::Cluster(...)
+```
+
+### Root cause
+In simulation, `Cluster::construct_chip_from_cluster` creates a directly-addressable
+`SimulationChip` for **every** chip (there is no `RemoteChip`/gateway in sim). As a
+result `Cluster::add_chip` classifies all sim chips as "local" (UMD `cluster.cpp`:
+`chip_type == ChipType::SIMULATION || ... || is_chip_mmio_capable(chip_id)`), so
+`get_target_mmio_device_ids()` returns **both** chips `{0, 1}`.
+
+`discover_tunnels_from_mmio_device` iterated that set as tunnel roots and asserted each
+was MMIO-capable. On the N300 mock descriptor only chip 0 is in `chips_with_mmio`
+(chip 1 is the remote/tunnel chip), so chip 1 tripped the assert. The P300 test passed
+only because its descriptor (`blackhole_P300_both_mmio.yaml`) marks **both** chips MMIO.
+
+### Fix
+Skip non-MMIO-capable chips when choosing tunnel roots:
+
+```cpp
+for (const auto& mmio_chip_id : cluster.get_target_mmio_device_ids()) {
+    if (!cluster.get_cluster_description()->is_chip_mmio_capable(mmio_chip_id)) {
+        continue;  // remote chips are discovered as tunnel stops below
+    }
+    ...
+}
+```
+
+This preserves the real N300 topology (chip 0 MMIO, chip 1 remote) — chip 1 is still
+discovered as a tunnel stop — and works unchanged on silicon (where every target-MMIO
+id is already MMIO-capable). Deliberately **not** worked around by marking both chips
+MMIO in the descriptor.
+
+---
+
+## Known remaining issue (in progress) — WH worker FW-init timeout
+
+With fix #3 in place the N300 WH sim test gets past tunnel discovery and device open,
+then fails later in firmware init:
+
+```
+Device 0: Timeout (10000 ms) waiting for physical cores to finish: 18-18 ... 25-25
+Device 0 init: failed to initialize FW! Try resetting the board.
+ --- tt::tt_metal::RiscFirmwareInitializer::initialize_and_launch_firmware(int)
+```
+
+The full WH worker tensix grid never reports init-FW complete within the 10 s budget
+(`firmware_wait_timeout_ms()` returns 10000 for `.so` sim backends). This is a separate,
+deeper craq-sim WH simulation/convergence issue (likely related to NCRISC IRAM execution
+and per-tile clocking) and is being investigated with the parallel-clock / teleport sim
+env vars (`TT_METAL_SIMULATOR_PARALLEL_TENSIX_TILE_CLOCK`, `..._PARALLEL_CLOCK_THREADS`,
+`..._L1_TELEPORT`, `..._DRAM_TELEPORT`). Not yet fixed.

--- a/MULTICHIP_SIM_REBASE_FIXES.md
+++ b/MULTICHIP_SIM_REBASE_FIXES.md
@@ -134,10 +134,13 @@ MMIO in the descriptor.
 
 ---
 
-## Known remaining issue (in progress) — WH worker FW-init timeout
+## 4. craq-sim `ac9c0e39` — drop per-instruction agent log in WH NCRISC RVC decode
 
-With fix #3 in place the N300 WH sim test gets past tunnel discovery and device open,
-then fails later in firmware init:
+**File:** `src/riscv_impl.h`
+
+### Error
+With fix #3 in place the N300 WH sim test got past tunnel discovery and device open,
+then failed in firmware init:
 
 ```
 Device 0: Timeout (10000 ms) waiting for physical cores to finish: 18-18 ... 25-25
@@ -145,9 +148,40 @@ Device 0 init: failed to initialize FW! Try resetting the board.
  --- tt::tt_metal::RiscFirmwareInitializer::initialize_and_launch_firmware(int)
 ```
 
-The full WH worker tensix grid never reports init-FW complete within the 10 s budget
-(`firmware_wait_timeout_ms()` returns 10000 for `.so` sim backends). This is a separate,
-deeper craq-sim WH simulation/convergence issue (likely related to NCRISC IRAM execution
-and per-tile clocking) and is being investigated with the parallel-clock / teleport sim
-env vars (`TT_METAL_SIMULATOR_PARALLEL_TENSIX_TILE_CLOCK`, `..._PARALLEL_CLOCK_THREADS`,
-`..._L1_TELEPORT`, `..._DRAM_TELEPORT`). Not yet fixed.
+### Root cause
+The worker tensix grid *was* running init FW (all 5 RISCs — brisc/trisc0-2/ncrisc —
+were released on every tile; 0 cores were parked for a missing binary). The problem was
+throughput, not a hang. `decode_and_execute_wh_ncrisc_rvc()` — on the **hot path** of
+every NCRISC compressed-instruction decode — opened, wrote, and closed an agent debug
+log (`fopen`/`fprintf`/`fclose`) per instruction. A single ~5 s run emitted **986,019**
+`ncrisc_rvc_decode` lines (vs. 320 `soft_reset_release` and a handful of others),
+throttling the simulator to ~0.6 KHz. The worker grid therefore couldn't finish init
+within `firmware_wait_timeout_ms()` (10000 ms for `.so` sim backends).
+
+This was leftover WIP instrumentation (hardcoded `sessionId "ae7d0a"`, `runId "post-fix"`,
+hardcoded debug-log path).
+
+### Fix
+Remove the per-instruction `#region agent log` block from `decode_and_execute_wh_ncrisc_rvc()`.
+Sim throughput returns to normal and the FW-init timeout no longer triggers — the test
+now advances past worker init and fabric setup.
+
+---
+
+## Known remaining issue (in progress) — unimplemented WH NCRISC compressed instruction
+
+With fix #4 the N300 WH test runs fast and reaches device open + fabric setup, then hits a
+genuine functional gap in the WH NCRISC RV32C decoder:
+
+```
+ERROR: UnimplementedFunctionality: decode_and_execute_wh_ncrisc_unimplemented_rvc:
+       WH NCRISC RVC inst=0x2c00 at pc=0xc940
+```
+
+`0x2c00` is RVC quadrant 0 / funct3 `001`, which in standard RV32C decodes to `c.fld`
+(a floating-point double load). An integer-only NCRISC firmware would never legitimately
+emit that, so the NCRISC has diverged and is decoding non-code/data as instructions at
+`pc=0xc940`. This is a separate, deeper NCRISC execution-divergence bug (previously masked
+by the logging slowdown in #4) and is the next item to investigate — likely tracing where
+NCRISC control flow leaves the real text section (IRAM/L1 view, prefetch-before-clobber,
+or reset-PC handling). Not yet fixed.

--- a/handoff.md
+++ b/handoff.md
@@ -1,0 +1,275 @@
+# MP Fabric / ttsimd Daemon — Agent Handoff
+
+Last updated: 2026-05-27
+
+## Goal
+
+Get **multiprocess (MP) fabric tests** passing under **shared `ttsimd` daemon mode** on Galaxy Slurm compute (`bh-glx-*`). These tests use `tt-run` + MPI ranks + craq-sim simulator (not real T3K hardware).
+
+Success means the **shrunk MP sweep** (`scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh`) passes all 10 suites in daemon mode, starting with `2.mp/mesh_socket_shrunk`.
+
+---
+
+## Where to work (important)
+
+| Repo | Path | Branch | PR |
+|------|------|--------|-----|
+| **tt-metal (canonical)** | `/data/rsong/tt-metal3` | `nkapre/multichip-mp-ttsim-mock-cluster-rank-binding-20260527` | [#45379](https://github.com/tenstorrent/tt-metal/pull/45379) |
+| **craq-sim** | `/data/rsong/craq-sim` | `nkapre/multichip-mp-daemon` | [#51](https://github.com/tenstorrent/craq-sim/pull/51) (draft) |
+
+**Do NOT use `/data/rsong/tt-metal-fork` as the primary tt-metal worktree.** Use it only for reference docs (`nkapre-fork-test-commands.md`, this file).
+
+Both branches are **already pushed** and up to date with their remotes as of 2026-05-27.
+
+Stale remote: `origin/nkapre/multichip-mp-ttsim-host-fixes` on tt-metal is an old single-commit tip; the canonical branch is the long PR branch above.
+
+---
+
+## Current failure (start here)
+
+**Suite:** `2.mp/mesh_socket_shrunk`
+**Latest run:** `/data/rsong/tt-metal3/craq-parity-results/mp-run-shrunk-20260527T234044Z-tt-metal3-bundled/`
+**Result:** `FAIL rc=134 duration=37s`
+
+### Failure chain (runtime evidence)
+
+1. **`ttsimd` aborts** during fabric init:
+   ```
+   [21043] ERROR: AssertionFailure: send_eth_data: Invalid file descriptor
+   ```
+   Source: `craq-sim/src/eth_io.cpp:27` — `write_fd == -1`.
+
+2. **MPI ranks lose daemon connection:**
+   ```
+   libttsim_rpc: failed to read response/callback prefix
+   Signal: Aborted (6)
+   ```
+   Stack: `FabricFirmwareInitializer::wait_for_fabric_router_sync` → `MeshDeviceImpl::create`.
+
+3. Test gets far enough to compile fabric ERISC routers and dispatch kernels, then dies at **fabric router sync polling** — not a slow timeout, but a **daemon crash** triggered by eth I/O.
+
+### What is NOT the problem anymore
+
+Previous layers of bugs were fixed on craq-sim `nkapre/multichip-mp-daemon`:
+
+| Old failure | Fix |
+|-------------|-----|
+| `rv32_step: invalid pc=0x49960` | ERISC dispatch guard in `libttsim.cpp` — skip if kernel binary missing/OOB |
+| `tensix_decode_and_execute_inner: opcode=0x0` | Tensix dispatch guard — skip if L1 has no valid RV32 instruction |
+| `rv32_mem_rd: unaligned addr=0x3` | Soft-reset / BRISC release guards + tolerant unaligned reads in `riscv_impl.h` |
+| `eth_switch_enqueue: no destination registered for MAC 0xab` | Lazy cross-mesh peer auto-pairing in `eth_switch.cpp` (`354a7977`) |
+| Per-rank chip registry collisions | `ttsimd` per-connection chip_id translation (`09266298`) |
+
+Mock cluster misconfiguration on tt-metal was also fixed: **`--mock-cluster-rank-binding`** (not `TT_METAL_MOCK_CLUSTER_DESC_PATH`, which `tt-run` blocks).
+
+---
+
+## Next debugging target: `send_eth_data: Invalid file descriptor`
+
+### Hypotheses to test (with instrumentation)
+
+1. **H_ETH_FD_UNINIT** — Eth tile `write_fd` never set via `configure_eth_io()` before first `send_eth_data()` call in daemon mode (cross-rank peer path uses fd before socketpair/pipe setup).
+
+2. **H_ETH_FD_STALE** — fd was valid in one MPI rank's registration but the daemon-side eth link table entry for the destination tile has `write_fd=-1` after lazy peer pairing.
+
+3. **H_ETH_CROSS_RANK** — Cross-rank eth traffic goes through `eth_switch` auto-pairing but the paired endpoint's I/O fds were not propagated to the sending tile's `EthSendConfig`.
+
+4. **H_CHIP_ID_MISMATCH** — With `TT_METAL_NO_CHIP_ID_REMAP=1` + `TTSIMD_PHYSICAL_CHIP_IDS=1`, UMD registers eth links on chip IDs that don't match what the eth tile send path resolves at runtime.
+
+5. **H_DAEMON_RPC_ORDER** — Multiple MPI ranks register/configure eth links concurrently; one rank's registration is overwritten or partially applied before send.
+
+### Where to instrument
+
+| File | What to log |
+|------|-------------|
+| `craq-sim/src/eth_io.cpp` | `send_eth_data(write_fd, ...)` — log fd, errno context |
+| `craq-sim/src/tile.cpp` | `e_tile_send_partial_transaction` — log `config.write_fd`, dest MAC, tile_id |
+| `craq-sim/src/eth_switch.cpp` | `eth_switch_enqueue*`, lazy peer pairing — log resolved dest, fd state |
+| `craq-sim/src/libttsim.cpp` | eth link registration from UMD — log chip/channel/MAC/fd |
+
+Debug log path (NDJSON): `/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log`
+Session ID: `ae7d0a`
+
+Existing agent logs in craq-sim (keep during debug): `#region agent log` blocks in `eth_switch.cpp`, `libttsim.cpp`, `tile.cpp`, `riscv_impl.h`.
+
+---
+
+## How to run tests
+
+### Rules (Galaxy Slurm)
+
+- **Never run sweeps on the login node.** Submit Slurm jobs only.
+- Compute guard: `scripts/lib/require-bh-glx-compute.sh`
+- Default node: `bh-glx-b06u08`, partition `bh_sc5_B2B9_D12`
+
+### Submit shrunk MP sweep
+
+From **login node**, in `/data/rsong/tt-metal3`:
+
+```bash
+./scripts/submit-nkapre-mp-ttsim-shrunk-slurm.sh
+```
+
+Single suite only:
+
+```bash
+SUITE_FILTER=mesh_socket ./scripts/submit-nkapre-mp-ttsim-shrunk-slurm.sh
+```
+
+### Manual repro on compute (after `salloc` or ssh to `bh-glx-*`)
+
+```bash
+cd /data/rsong/tt-metal3
+source python_env/bin/activate   # MUST use bundled venv (create_venv.sh --bundle-python)
+export CRAQ_SIM=/data/rsong/craq-sim
+export TTSIM_USE_DAEMON=1
+SUITE_FILTER=mesh_socket ./scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh
+```
+
+### Rebuild after code changes
+
+**craq-sim** (WH target for these tests):
+
+```bash
+cd /data/rsong/craq-sim
+python3 make.py wh release    # produces src/_out/release_wh/libttsim.so
+cd daemon && make             # produces daemon/_out/ttsimd
+```
+
+**tt-metal3**:
+
+```bash
+cd /data/rsong/tt-metal3/build_Debug
+ninja -j32 tt_metal tt-umd test_mesh_socket_main multi_host_fabric_tests test_tt_fabric \
+  distributed_multiprocess_tests unit_tests_dual_rank_2x2 unit_tests_dual_rank_2x4 unit_tests_ttnn
+```
+
+Stale binaries cause ABI mismatches (`bad_function_call`, mysterious SIGABRT). Always rebuild test binaries after `libtt_metal.so` changes.
+
+---
+
+## Launch configuration (must be correct)
+
+Every MP fabric test in the shrunk sweep uses:
+
+```
+--mock-cluster-rank-binding tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/t3k_2x4_big_mesh_cluster_desc_mapping.yaml
+```
+
+**Both 2x2 and 2x4 suites use the T3K 2x4 big-mesh mapping file.** Do not use `t3k_cluster_desc.yaml` or the env var `TT_METAL_MOCK_CLUSTER_DESC_PATH`.
+
+Daemon mode env (set by sweep script):
+
+```
+TT_METAL_NO_CHIP_ID_REMAP=1
+TTSIMD_PHYSICAL_CHIP_IDS=1
+TTSIM_USE_DAEMON=auto   # launches ttsimd before mpirun
+TT_TTSIMD_SOCKET=/tmp/ttsimd-<pid>.sock
+```
+
+Simulator artifacts copied per run:
+
+```
+CRAQ_SIM/src/_out/release_wh/libttsim.so  →  $RESULTS_DIR/sim_wh_multichip/
+tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml  →  soc_descriptor.yaml
+```
+
+---
+
+## Shrunk sweep suites (10 total)
+
+| Suite | Binary | Notes |
+|-------|--------|-------|
+| `2.mp/2x2_fabric_ubench_shrunk` | `test_tt_fabric` | Single unicast, 64 bytes |
+| `2.mp/multi_host_fabric_shrunk` | `multi_host_fabric_tests` | `MultiHopUnicast` only |
+| `2.mp/mesh_socket_shrunk` | `test_mesh_socket_main` | **Current blocker** |
+| `2.mp/BigMeshDualRankTest2x4` | `distributed_multiprocess_tests` | |
+| `2.mp/BigMeshDualRankMeshShapeSweep` | same | |
+| `2.mp/ttnn_dual_rank_2x2_shrunk` | `unit_tests_dual_rank_2x2` | |
+| `2.mp/ttnn_dual_rank_2x4_shrunk` | `unit_tests_dual_rank_2x4` | |
+| `2.mp/ttnn_launch_op` | `unit_tests_ttnn` | |
+| `2.mp/py_data_parallel` | pytest | |
+| `2.mp/py_submesh` | pytest | Often TIMEOUT (900s), not crash |
+
+Historical peak (pre-daemon-crash-fix, job 11839 on tt-metal2): **6 PASS / 3 FAIL / 1 TIMEOUT**. Fabric suites failed on MAC 0xab before eth_switch fixes. Non-fabric suites mostly pass.
+
+---
+
+## Key commits already landed
+
+### craq-sim `nkapre/multichip-mp-daemon`
+
+- `354a7977` — eth_switch lazy cross-mesh peer auto-pairing
+- `09266298` — ttsimd per-connection chip_id translation
+- `21e6570b` — park cores when kernel binary missing; tolerate unaligned reads
+
+### tt-metal3 (base: `ridvan/nkapre-multichip-metal-v2`)
+
+- `625eeccc6af` — host-side MP daemon fixes (SystemMesh chip filtering, NO_REMAP, DRAM-backed CQ, fabric router sizing, shrunk sweep scripts)
+- `3a345824c09` — `--mock-cluster-rank-binding` fix + Slurm wrappers
+
+---
+
+## Uncommitted local work (not on remote)
+
+In `/data/rsong/tt-metal2` only (WIP, do not treat as canonical):
+
+- `fabric_firmware_initializer.cpp` — `H_FAB_ROUTER_SYNC` poll logging + `advance_device_execution` in sync loop
+- `command_queue_common.cpp` — `get_cq_dispatch_go_signal()` helper
+- `llrt.cpp` — `sim_arm_launch_watcher()` after GO signal in sim mode
+- Various dispatch/device tweaks
+
+These were being used to debug a **prior** failure mode (CQ stall: `dispatch_go_signal=0`). That may still be relevant **after** the eth fd crash is fixed. Consider cherry-picking into tt-metal3 once validated.
+
+---
+
+## Architecture reminder
+
+```
+MPI rank 0 (TT_VISIBLE_DEVICES=0,1)          MPI rank 1 (TT_VISIBLE_DEVICES=2,3)
+  └─ tt-umd → libttsim_rpc.so ──┐              └─ tt-umd → libttsim_rpc.so ──┐
+                                 │  UNIX socket                                │
+                                 └──────────────► ttsimd (single process) ◄─────┘
+                                                    ├─ chip registry (global)
+                                                    ├─ eth_switch (global)
+                                                    └─ libttsim.so (loaded once)
+```
+
+Each rank sees disjoint physical chip IDs under one daemon. Eth cross-rank traffic must go through the **shared** `eth_switch`, not private per-rank state.
+
+---
+
+## Known gotchas
+
+1. **`python_env` must be bundled** — symlinked venv breaks on compute nodes (`python3: not found`). Recreate with `create_venv.sh --bundle-python` in tt-metal3 if needed.
+
+2. **Slurm job script output path** — `scripts/slurm-nkapre-mp-ttsim-shrunk-job.sh` still writes Slurm logs to `/data/rsong/tt-metal2/craq-parity-results/` (copy-paste artifact). Harmless but confusing.
+
+3. **In-process vs daemon** — In-process sim (`TTSIM_USE_DAEMON=0`) does not exercise true MP fabric. Many tests skip or pass for wrong reasons. Always test with daemon mode for MP fabric.
+
+4. **Do not add `ALLOW_LOGIN_RUN` bypasses** — workspace rule enforces Slurm-only for sweeps.
+
+5. **Debug instrumentation** — Do not remove `#region agent log` blocks until post-fix verification logs confirm success.
+
+---
+
+## Suggested next-agent workflow
+
+1. Add instrumentation to `send_eth_data` / eth tile send path / eth_switch peer pairing (hypotheses H_ETH_* above).
+2. Clear debug log: delete `/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log`.
+3. Rebuild craq-sim WH + ttsimd.
+4. Run `SUITE_FILTER=mesh_socket` shrunk sweep on compute.
+5. Analyze logs — confirm/reject each hypothesis with cited log lines.
+6. Fix with evidence; keep instrumentation for verification run.
+7. Push fixes to `craq-sim:nkapre/multichip-mp-daemon` and/or `tt-metal3` PR branch.
+8. Once mesh_socket passes, run full 10-suite shrunk sweep.
+9. If CQ stall reappears (`dispatch_go_signal=0`), pick up tt-metal2 WIP (`sim_arm_launch_watcher`, go_signal polling).
+
+---
+
+## Reference docs
+
+- Test commands (full, not shrunk): `/data/rsong/tt-metal-fork/nkapre-fork-test-commands.md`
+- Agent transcript: `/home/rsong/.cursor/projects/data-rsong-tt-metal-fork/agent-transcripts/ae7d0a21-b1f5-4de8-b388-59e2602cae57/ae7d0a21-b1f5-4de8-b388-59e2602cae57.jsonl`
+- Latest mesh_socket log: `.../mp-run-shrunk-20260527T234044Z-tt-metal3-bundled/2.mp_mesh_socket_shrunk.log`
+- Latest ttsimd log: `.../mp-run-shrunk-20260527T234044Z-tt-metal3-bundled/ttsimd.log`

--- a/handoff.md
+++ b/handoff.md
@@ -1,6 +1,51 @@
 # MP Fabric / ttsimd Daemon — Agent Handoff
 
-Last updated: 2026-05-27
+Last updated: 2026-05-28 (session 2 — sem-zero clamp fix)
+
+## Latest session breakthroughs (2026-05-28)
+
+### MAJOR WIN: mesh_socket TIMEOUT → FAIL in 22s (sem-zero clamp)
+
+Three sequential fixes landed today and reduced mesh_socket from TIMEOUT(1800s) to FAIL(22s) with full fabric init succeeded:
+
+| # | Failure | Fix | Commit |
+|---|---------|-----|--------|
+| 1 | `ImportError: write_to_device_buffer(..., CoreRangeSet*)` | Restored 7-arg overload | tt-metal `da3a463eff5` |
+| 2 | Fabric router sync timeout (cross-rank chip mismatch) | Honor `TTSIMD_PHYSICAL_CHIP_IDS` in `ttsimd::translate_chip_id_locked` | craq-sim `6c819313` |
+| 3 | `tile_mmio_rd8: addr=0xffb123a3` daemon abort | Permissive WH RISCV_DEBUG byte MMIO | craq-sim `acaaca6a` |
+| **4** | **mesh_socket TIMEOUT at "Creating sockets" (dispatch_go_signal=0 forever)** | **Clamp `t_tile_dispatch_kernel` sem-zero so it cannot overwrite BRISC kernel text** | **craq-sim `6f54fa6f`** |
+
+Fix #4 root-cause walkthrough (runtime evidence in `.cursor/debug-ae7d0a.log`):
+
+- Instrumented `tt_metal/llrt/llrt.cpp:write_binary_to_address` (H_BIN_WRITE) confirmed host writes 31076 B BRISC binary to chip(0,0) noc(18,25) tile_id=56 L1 0x81e0, first_word=0xfe010113.
+- Instrumented `craq-sim/src/tile.cpp:tile_wr_bytes` (H_TILE_WR) confirmed the write reaches the SAME `g_t_tiles[56].sram` at addr 0x81e0 size 31076.
+- Instrumented `craq-sim/src/libttsim.cpp:t_tile_dispatch_kernel` (H_DISPATCH_TENSIX) reads launch_msg fields after the write: `sem_offset=0x30, sem_base=0x8190, sem_bytes=256, kernel_entry=0x81e0`.
+- `[sem_base, sem_base+sem_bytes) = [0x8190, 0x8290)` OVERLAPS `kernel_entry=0x81e0` → the 256 B fixed sem zero wipes the first 128 B of the kernel binary. Dispatch FW boots into all-zero L1, never raises GO, host CQ stalls forever.
+- Fix clamps `sem_bytes = min(sem_bytes, kernel_text_base - sem_base)` so the zero never extends into the kernel-text window.
+
+### New failure point (next blocker)
+
+`2.mp/mesh_socket_shrunk` now reaches **"Fabric initialized on 4 devices"** on both ranks (8/8 chips), then aborts inside `libttsim_clock_all_devices` during `FabricFirmwareInitializer::wait_for_fabric_router_sync`:
+
+```
+ttsimd.log: [162528] ERROR: UndefinedBehavior: rv32_step: invalid pc=0x49960
+mpi: libttsim_rpc: failed to read response/callback prefix
+stack: TTSimCommunicator::advance_clock → libttsim_clock_all_devices → rv32_step
+```
+
+The dispatch BRISC FW is now actually executing (great — sem-zero clamp worked) and runs far enough to jump to L1 `0x49960`, where there's no valid instruction. Likely causes:
+1. FD dispatch kernel returns from a function and the stack/return-addr was scribbled (no kernel-config layout protection in sim).
+2. A jump table or vtable lookup mis-resolves to an unmapped L1 page.
+3. Out-of-bounds NOC-write from BRISC clobbers BRISC's own instruction stream.
+
+Suggested next steps:
+- Add a deeper rv32_step error message that prints surrounding L1 bytes + the last 8 PC values for diagnosis.
+- Compare BRISC's intended jump targets against `kernel_config_base + binary_size` to confirm no kernel-config writes are landing in the BRISC text region.
+- Check whether a second launch (rd_ptr=1) in the launch ring is firing with a yet-uninitialized kernel_config slot.
+
+### Latest results
+
+- Job 12830: `mesh_socket_shrunk` → `FAIL rc=134 dur=22s` (vs prior `TIMEOUT 1800s`). Results dir: `mp-run-shrunk-20260528T022207Z/`.
 
 ## Goal
 

--- a/scripts/lib/nkapre-slurm-b-aisle.sh
+++ b/scripts/lib/nkapre-slurm-b-aisle.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Galaxy Slurm helpers for nkapre parity jobs.
+# Allowed: B-aisle (bh-glx-b*) and 110-row C nodes (bh-glx-110-c*).
+# Not allowed: legacy C-aisle (bh-glx-c* without 110 prefix).
+
+NKAPRE_SLURM_PARTITION="${NKAPRE_SLURM_PARTITION:-bh_sc5_B2B9_D12}"
+NKAPRE_110_PARTITION="${NKAPRE_110_PARTITION:-bh_sp_4x32_110_C1_C10}"
+
+is_legacy_c_aisle_node() {
+    local node="$1"
+    [[ "$node" == bh-glx-c* && "$node" != bh-glx-110-c* ]]
+}
+
+is_allowed_nkapre_node() {
+    local node="$1"
+    [[ "$node" == bh-glx-b* || "$node" == bh-glx-110-c* ]]
+}
+
+validate_nkapre_node() {
+    local node="$1"
+    if is_legacy_c_aisle_node "$node"; then
+        echo "ERROR: legacy C-aisle nodes (bh-glx-c*, not 110-row) cannot run nkapre parity (got: ${node})." >&2
+        return 1
+    fi
+    if [[ -n "$node" ]] && ! is_allowed_nkapre_node "$node"; then
+        echo "ERROR: node must be bh-glx-b* or bh-glx-110-c* (got: ${node})." >&2
+        return 1
+    fi
+    return 0
+}
+
+partition_for_node() {
+    local node="$1"
+    if [[ "$node" == bh-glx-110-c* ]]; then
+        echo "${NKAPRE_110_PARTITION}"
+    else
+        echo "${NKAPRE_SLURM_PARTITION}"
+    fi
+}
+
+pick_idle_nkapre_node() {
+    local exclude_csv="${1:-}"
+    local -a exclude_arr=()
+    if [[ -n "$exclude_csv" ]]; then
+        IFS=',' read -r -a exclude_arr <<<"$exclude_csv"
+    fi
+
+    _pick_from_partition() {
+        local part="$1"
+        local pattern="$2"
+        sinfo -N -p "$part" -t idle -h -o '%N' | tr ' ' '\n' | while read -r n; do
+            [[ -n "$n" ]] || continue
+            [[ "$n" == $pattern ]] || continue
+            validate_nkapre_node "$n" || continue
+            local skip=0 ex
+            for ex in "${exclude_arr[@]}"; do
+                [[ "$n" == "$ex" ]] && skip=1 && break
+            done
+            [[ "$skip" -eq 0 ]] && echo "$n" && break
+        done
+    }
+
+    local picked
+    picked="$(_pick_from_partition "${NKAPRE_SLURM_PARTITION}" "bh-glx-b*")"
+    if [[ -n "$picked" ]]; then
+        echo "$picked"
+        return 0
+    fi
+    _pick_from_partition "${NKAPRE_110_PARTITION}" "bh-glx-110-c*"
+}
+
+# Back-compat aliases
+reject_c_aisle_node() { validate_nkapre_node "$@"; }
+pick_idle_b_aisle_node() { pick_idle_nkapre_node "$@"; }

--- a/scripts/lib/require-bh-glx-compute.sh
+++ b/scripts/lib/require-bh-glx-compute.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Abort unless running on a bh-glx Galaxy compute node (never the login node).
+require_bh_glx_compute() {
+    local host
+    host="$(hostname -s 2>/dev/null || hostname)"
+    if [[ "$host" == bh-glx-* ]]; then
+        return 0
+    fi
+
+    echo "ERROR: this must run on a bh-glx Galaxy compute node (got: ${host})." >&2
+    echo "Do not run parity or LLK sweeps on the login node." >&2
+    echo "From the login node, submit Slurm jobs only:" >&2
+    echo "  ./scripts/submit-nkapre-parity-slurm.sh" >&2
+    echo "  ./scripts/submit-nkapre-parity-ttsim-slurm.sh" >&2
+    echo "Or allocate Galaxy interactively:" >&2
+    echo "  salloc --partition bh_sc5_B2B9_D12 --nodelist bh-glx-b06u08 --cpus-per-task=1" >&2
+    echo "  srun --pty /bin/bash" >&2
+    exit 1
+}

--- a/scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh
+++ b/scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh
@@ -37,7 +37,7 @@ export TT_METAL_SIMULATOR_CQ_WAIT_CLOCKS=10000
 export LD_LIBRARY_PATH="${BUILD_DIR}/tt_metal:${BUILD_DIR}/tt_metal/third_party/umd/lib:${BUILD_DIR}/ttnn:${BUILD_DIR}/tt_stl:${BUILD_DIR}/lib:${LD_LIBRARY_PATH:-}"
 export PATH="${REPO_ROOT}/python_env/bin:${PATH}"
 
-CRAQ_SIM="${CRAQ_SIM:-/data/rsong/craq-sim}"
+CRAQ_SIM="${CRAQ_SIM:-/data/rsong/craq-sim2}"
 WH_SIM_DIR="$RESULTS_DIR/sim_wh_multichip"
 mkdir -p "$WH_SIM_DIR"
 cp "$CRAQ_SIM/src/_out/release_wh/libttsim.so" "$WH_SIM_DIR/libttsim.so"

--- a/scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh
+++ b/scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh
@@ -34,6 +34,7 @@ unset TT_METAL_SLOW_DISPATCH_MODE
 export TT_METAL_DISABLE_SFPLOADMACRO=1
 export TT_METAL_DRAM_BACKED_CQ=1
 export TT_METAL_SIMULATOR_CQ_WAIT_CLOCKS=10000
+export AGENT_LOG_PATH="${AGENT_LOG_PATH:-/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log}"
 export LD_LIBRARY_PATH="${BUILD_DIR}/tt_metal:${BUILD_DIR}/tt_metal/third_party/umd/lib:${BUILD_DIR}/ttnn:${BUILD_DIR}/tt_stl:${BUILD_DIR}/lib:${LD_LIBRARY_PATH:-}"
 export PATH="${REPO_ROOT}/python_env/bin:${PATH}"
 

--- a/scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh
+++ b/scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh
@@ -1,0 +1,277 @@
+#!/usr/bin/env bash
+# Shrunk variant of run-nkapre-mp-ttsim-sweep.sh that
+#   (1) substitutes minimal test configs / gtest filters under tt-sim,
+#   (2) raises PER_CMD_TIMEOUT to 1800s (30 min) by default,
+# so we can see which multi-process tests structurally complete (PASS)
+# vs. still TIMEOUT under the simulator after the H_REUSED_DEV_PTR and
+# H_CROSS_RANK_PEER_DROPPED fixes have landed.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/require-bh-glx-compute.sh
+source "${REPO_ROOT}/scripts/lib/require-bh-glx-compute.sh"
+require_bh_glx_compute
+
+BUILD_DIR="${BUILD_DIR:-$REPO_ROOT/build_Debug}"
+RESULTS_DIR="${RESULTS_DIR:-$REPO_ROOT/craq-parity-results/mp-run-shrunk-$(date -u +%Y%m%dT%H%M%SZ)}"
+PER_CMD_TIMEOUT="${PER_CMD_TIMEOUT:-1800}"
+
+mkdir -p "$RESULTS_DIR"
+SUMMARY="$RESULTS_DIR/summary.tsv"
+RUN_LOG="$RESULTS_DIR/run.log"
+: >"$SUMMARY"
+: >"$RUN_LOG"
+echo -e "suite\tstatus\texit_code\tduration_sec\tcommand" >>"$SUMMARY"
+
+export TT_METAL_HOME="$REPO_ROOT"
+export PYTHONPATH="${TT_METAL_HOME}${PYTHONPATH:+:$PYTHONPATH}"
+export ARCH_NAME="${ARCH_NAME:-blackhole}"
+# Mesh-Device gtest fixtures (multi_device_fixture.hpp:120) skip with
+# GTEST_SKIP() whenever getenv("TT_METAL_SLOW_DISPATCH_MODE") returns a
+# non-NULL string — they test "is set", not "value != 0". The unsetenv
+# below lets the fast-dispatch path actually run under tt-sim.
+unset TT_METAL_SLOW_DISPATCH_MODE
+export TT_METAL_DISABLE_SFPLOADMACRO=1
+export TT_METAL_DRAM_BACKED_CQ=1
+export TT_METAL_SIMULATOR_CQ_WAIT_CLOCKS=10000
+export LD_LIBRARY_PATH="${BUILD_DIR}/tt_metal:${BUILD_DIR}/tt_metal/third_party/umd/lib:${BUILD_DIR}/ttnn:${BUILD_DIR}/tt_stl:${BUILD_DIR}/lib:${LD_LIBRARY_PATH:-}"
+export PATH="${REPO_ROOT}/python_env/bin:${PATH}"
+
+CRAQ_SIM="${CRAQ_SIM:-/data/rsong/craq-sim}"
+WH_SIM_DIR="$RESULTS_DIR/sim_wh_multichip"
+mkdir -p "$WH_SIM_DIR"
+cp "$CRAQ_SIM/src/_out/release_wh/libttsim.so" "$WH_SIM_DIR/libttsim.so"
+cp "$TT_METAL_HOME/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml" "$WH_SIM_DIR/soc_descriptor.yaml"
+export TT_METAL_SIMULATOR="$WH_SIM_DIR/libttsim.so"
+export TT_METAL_SIMULATOR_HOME="$WH_SIM_DIR"
+export TT_METAL_MOCK_CLUSTER_DESC_PATH="${TT_METAL_MOCK_CLUSTER_DESC_PATH:-tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/t3k_cluster_desc.yaml}"
+export ARCH_NAME=wormhole_b0
+
+TTSIMD_BIN=""
+TTSIM_RPC_SRC=""
+for candidate in \
+    "$CRAQ_SIM/daemon/_out/ttsimd" \
+    "$CRAQ_SIM/src/_out/release_wh/ttsimd" \
+    "$CRAQ_SIM/daemon/ttsimd"; do
+    if [ -x "$candidate" ]; then
+        TTSIMD_BIN="$candidate"
+        break
+    fi
+done
+for candidate in \
+    "$CRAQ_SIM/client/_out/libttsim_rpc.so" \
+    "$CRAQ_SIM/src/_out/release_wh/libttsim_rpc.so" \
+    "$CRAQ_SIM/client/libttsim_rpc.so"; do
+    if [ -f "$candidate" ]; then
+        TTSIM_RPC_SRC="$candidate"
+        break
+    fi
+done
+if [ -n "$TTSIM_RPC_SRC" ]; then
+    cp "$TTSIM_RPC_SRC" "$WH_SIM_DIR/libttsim_rpc.so"
+fi
+
+TTSIMD_PID=""
+TTSIMD_SOCKET="${TTSIMD_SOCKET:-$RESULTS_DIR/ttsimd.sock}"
+
+stop_ttsimd() {
+    if [ -n "${TTSIMD_PID:-}" ] && kill -0 "$TTSIMD_PID" 2>/dev/null; then
+        kill -TERM "$TTSIMD_PID" 2>/dev/null || true
+        wait "$TTSIMD_PID" 2>/dev/null || true
+    fi
+}
+
+start_ttsimd() {
+    rm -f "$TTSIMD_SOCKET"
+    "$TTSIMD_BIN" --socket "$TTSIMD_SOCKET" --libttsim "$WH_SIM_DIR/libttsim.so" \
+        >>"$RESULTS_DIR/ttsimd.log" 2>&1 &
+    TTSIMD_PID=$!
+
+    local waited=0
+    while [ "$waited" -lt 30 ]; do
+        if [ -S "$TTSIMD_SOCKET" ]; then
+            return 0
+        fi
+        if ! kill -0 "$TTSIMD_PID" 2>/dev/null; then
+            echo "[mp-sweep-shrunk] ERROR: ttsimd exited early; see $RESULTS_DIR/ttsimd.log" | tee -a "$RUN_LOG"
+            tail -20 "$RESULTS_DIR/ttsimd.log" >>"$RUN_LOG" 2>/dev/null || true
+            exit 1
+        fi
+        sleep 0.1
+        waited=$((waited + 1))
+    done
+    echo "[mp-sweep-shrunk] ERROR: ttsimd did not create socket within 3s" | tee -a "$RUN_LOG"
+    exit 1
+}
+
+use_daemon=0
+case "${TTSIM_USE_DAEMON:-auto}" in
+    0|false|no|NO) use_daemon=0 ;;
+    1|true|yes|YES)
+        use_daemon=1
+        if [ -z "$TTSIMD_BIN" ] || [ ! -f "$WH_SIM_DIR/libttsim_rpc.so" ]; then
+            echo "[mp-sweep-shrunk] ERROR: TTSIM_USE_DAEMON=1 but ttsimd or libttsim_rpc.so not found under CRAQ_SIM=$CRAQ_SIM" | tee -a "$RUN_LOG"
+            exit 1
+        fi
+        ;;
+    auto|*)
+        if [ -n "$TTSIMD_BIN" ] && [ -f "$WH_SIM_DIR/libttsim_rpc.so" ]; then
+            use_daemon=1
+        fi
+        ;;
+esac
+
+if [ ! -e "$REPO_ROOT/build" ] || [ -L "$REPO_ROOT/build" ]; then
+    ln -sfn "$(basename "$BUILD_DIR")" "$REPO_ROOT/build"
+fi
+
+log() { echo "[mp-sweep-shrunk] $*" | tee -a "$RUN_LOG"; }
+
+if [ "$use_daemon" -eq 1 ]; then
+    export TTSIMD_SOCKET
+    export TT_TTSIMD_SOCKET="$TTSIMD_SOCKET"
+    export TT_METAL_SIMULATOR="$WH_SIM_DIR/libttsim_rpc.so"
+    # Each run_cmd starts its own ttsimd so a daemon crash in test N does not
+    # poison test N+1. Trap still cleans up the last one on exit.
+    trap stop_ttsimd EXIT INT TERM
+    log "daemon mode (per-test ttsimd): TT_METAL_SIMULATOR=$TT_METAL_SIMULATOR TTSIMD_SOCKET=$TTSIMD_SOCKET timeout=${PER_CMD_TIMEOUT}s"
+else
+    log "in-process ttsim: TT_METAL_SIMULATOR=$TT_METAL_SIMULATOR timeout=${PER_CMD_TIMEOUT}s"
+fi
+
+run_cmd() {
+    local suite="$1"; shift
+    local cmd=("$@")
+    local logfile="$RESULTS_DIR/$(echo "$suite" | tr '/ ' '__').log"
+    local start end dur rc status
+
+    # Allow targeting individual suites via SUITE_FILTER=substring (case-sensitive).
+    if [ -n "${SUITE_FILTER:-}" ]; then
+        case "$suite" in
+            *"$SUITE_FILTER"*) ;;
+            *) log "SKIP [$suite] (SUITE_FILTER=$SUITE_FILTER)"; return 0 ;;
+        esac
+    fi
+
+    # In daemon mode each test gets a FRESH ttsimd. The daemon currently
+    # dies (silently) part-way through some test workloads, which poisons
+    # every subsequent test with `connect() to ttsimd failed`. Restarting
+    # per-test isolates each suite so we can see real PASS/FAIL outcomes.
+    if [ "$use_daemon" -eq 1 ]; then
+        stop_ttsimd
+        : >"$RESULTS_DIR/ttsimd.log"  # truncate so per-test daemon output is visible
+        start_ttsimd
+    fi
+
+    log "RUN [$suite]: ${cmd[*]}"
+    start=$(date +%s)
+    set +e
+    # ── Optional in-flight backtrace capture (BACKTRACE_AT_SEC=N) ────────
+    # When set, after N seconds we attach gdb to all rank worker processes
+    # spawned by tt-run/prterun and dump their stack traces to <suite>.gdb.log
+    # before the timeout fires. Use when triaging silent hangs.
+    if [ -n "${BACKTRACE_AT_SEC:-}" ]; then
+        local gdb_log="$RESULTS_DIR/$(echo "$suite" | tr '/ ' '__').gdb.log"
+        (
+            sleep "$BACKTRACE_AT_SEC"
+            {
+                echo "==================================================="
+                echo "[backtrace-watcher] $(date -u +%FT%TZ) capturing stacks for suite=$suite"
+                # Worker patterns: test binary names appearing after `./build/...`
+                # Pick everything that looks like a long-running test child.
+                pgrep -af 'test_tt_fabric|test_mesh_socket_main|distributed_multiprocess_tests|unit_tests_dual_rank|unit_tests_ttnn|pytest' 2>/dev/null | grep -v 'pgrep' || true
+                echo
+                for pid in $(pgrep -f 'test_tt_fabric|test_mesh_socket_main|distributed_multiprocess_tests|unit_tests_dual_rank|unit_tests_ttnn|pytest' 2>/dev/null); do
+                    echo "================ PID $pid ================"
+                    cat "/proc/$pid/cmdline" 2>/dev/null | tr '\0' ' ' | head -c 400; echo
+                    timeout 25 gdb -batch -p "$pid" -ex "set pagination off" -ex "thread apply all bt 25" 2>&1 | head -150
+                    echo
+                done
+            } > "$gdb_log" 2>&1
+        ) &
+        local BT_WATCHER_PID=$!
+    fi
+
+    timeout "$PER_CMD_TIMEOUT" bash -lc "cd '$REPO_ROOT' && ${cmd[*]}" >"$logfile" 2>&1
+    rc=$?
+
+    if [ -n "${BACKTRACE_AT_SEC:-}" ] && [ -n "${BT_WATCHER_PID:-}" ]; then
+        # Reap watcher if still running (test ended quickly)
+        kill -TERM "$BT_WATCHER_PID" 2>/dev/null || true
+        wait "$BT_WATCHER_PID" 2>/dev/null || true
+    fi
+    set -e
+    end=$(date +%s); dur=$((end - start))
+
+    # Snapshot per-suite daemon state for post-mortem.
+    if [ "$use_daemon" -eq 1 ]; then
+        cp "$RESULTS_DIR/ttsimd.log" "$RESULTS_DIR/$(echo "$suite" | tr '/ ' '__').ttsimd.log" 2>/dev/null || true
+        if [ -n "${TTSIMD_PID:-}" ] && ! kill -0 "$TTSIMD_PID" 2>/dev/null; then
+            log "  WARN [$suite] ttsimd (pid=$TTSIMD_PID) died during run"
+        fi
+    fi
+
+    case "$rc" in
+        0) status=PASS ;;
+        124) status=TIMEOUT ;;
+        127) status=MISSING ;;
+        *) status=FAIL ;;
+    esac
+
+    log "DONE [$suite] status=$status rc=$rc duration=${dur}s"
+    echo -e "${suite}\t${status}\t${rc}\t${dur}\t${cmd[*]}" >>"$SUMMARY"
+    tail -20 "$logfile" >>"$RUN_LOG" || true
+}
+
+if ! command -v tt-run >/dev/null 2>&1; then
+    log "ERROR: tt-run not in PATH"; exit 127
+fi
+
+# 2.mp/2x2_fabric_ubench — single unicast, 1 packet, size 64.
+run_cmd "2.mp/2x2_fabric_ubench_shrunk" \
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_t3k_2x2_ttsim.yaml"
+
+# 2.mp/multi_host_fabric — smallest single gtest case.
+run_cmd "2.mp/multi_host_fabric_shrunk" \
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/multi_host_fabric_tests --gtest_filter='InterMeshSplit1x2FabricFixture.MultiHopUnicast'"
+
+# 2.mp/mesh_socket — single iteration, 1 transaction, 256-byte data.
+run_cmd "2.mp/mesh_socket_shrunk" \
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/test_mesh_socket_main --test_config tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2_ttsim.yaml"
+
+# Distributed multiprocess tests (already small, just narrow gtest filter).
+run_cmd "2.mp/BigMeshDualRankTest2x4" \
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests --gtest_filter='*BigMeshDualRankTest2x4*'"
+run_cmd "2.mp/BigMeshDualRankMeshShapeSweep" \
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests --gtest_filter='*BigMeshDualRankMeshShapeSweep*'"
+
+# ttnn dual-rank send/recv: just the first parametrized case per fixture.
+run_cmd "2.mp/ttnn_dual_rank_2x2_shrunk" \
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/ttnn/multiprocess/unit_tests_dual_rank_2x2 --gtest_filter='MeshDeviceSplit2x2SendRecvTests/MeshDeviceSplit2x2SendRecvFixture.SendRecvAsync/0'"
+run_cmd "2.mp/ttnn_dual_rank_2x4_shrunk" \
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/ttnn/multiprocess/unit_tests_dual_rank_2x4 --gtest_filter='BigMeshDualRankTest2x4.HostAllGather'"
+
+run_cmd "2.mp/ttnn_launch_op" \
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/ttnn/unit_tests_ttnn --gtest_filter='*LaunchOperation*'"
+
+run_cmd "2.mp/py_data_parallel" \
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml pytest -svv tests/ttnn/distributed/test_data_parallel_example.py"
+run_cmd "2.mp/py_submesh" \
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml pytest -svv tests/ttnn/distributed/test_submesh_not_spanning_all_ranks_T3000.py"
+
+log "Summary: $SUMMARY"
+python3 - "$SUMMARY" <<'PY'
+import sys
+from collections import Counter
+path = sys.argv[1]
+counts = Counter()
+with open(path) as f:
+    next(f)
+    for line in f:
+        parts = line.strip().split("\t")
+        if len(parts) >= 2:
+            counts[parts[1]] += 1
+print("=== MP SHRUNK RESULT COUNTS ===")
+for k in sorted(counts):
+    print(f"  {k}: {counts[k]}")
+PY

--- a/scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh
+++ b/scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh
@@ -44,8 +44,11 @@ cp "$CRAQ_SIM/src/_out/release_wh/libttsim.so" "$WH_SIM_DIR/libttsim.so"
 cp "$TT_METAL_HOME/tt_metal/soc_descriptors/wormhole_b0_80_arch.yaml" "$WH_SIM_DIR/soc_descriptor.yaml"
 export TT_METAL_SIMULATOR="$WH_SIM_DIR/libttsim.so"
 export TT_METAL_SIMULATOR_HOME="$WH_SIM_DIR"
-export TT_METAL_MOCK_CLUSTER_DESC_PATH="${TT_METAL_MOCK_CLUSTER_DESC_PATH:-tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/t3k_cluster_desc.yaml}"
 export ARCH_NAME=wormhole_b0
+# tt-run blocks TT_METAL_MOCK_CLUSTER_DESC_PATH from parent env; per-rank mock
+# descriptors must be passed via --mock-cluster-rank-binding (T3K big mesh).
+MOCK_CLUSTER_RANK_BINDING="${MOCK_CLUSTER_RANK_BINDING:-tests/tt_metal/tt_fabric/custom_mock_cluster_descriptors/t3k_2x4_big_mesh_cluster_desc_mapping.yaml}"
+TT_RUN_MOCK_ARGS="--mock-cluster-rank-binding ${MOCK_CLUSTER_RANK_BINDING}"
 
 TTSIMD_BIN=""
 TTSIM_RPC_SRC=""
@@ -131,10 +134,14 @@ if [ "$use_daemon" -eq 1 ]; then
     export TTSIMD_SOCKET
     export TT_TTSIMD_SOCKET="$TTSIMD_SOCKET"
     export TT_METAL_SIMULATOR="$WH_SIM_DIR/libttsim_rpc.so"
+    # Client ranks use physical chip IDs; ttsimd is a separate process and must
+    # match so eth peers and fabric handshakes target the same Device*.
+    export TT_METAL_NO_CHIP_ID_REMAP=1
+    export TTSIMD_PHYSICAL_CHIP_IDS=1
     # Each run_cmd starts its own ttsimd so a daemon crash in test N does not
     # poison test N+1. Trap still cleans up the last one on exit.
     trap stop_ttsimd EXIT INT TERM
-    log "daemon mode (per-test ttsimd): TT_METAL_SIMULATOR=$TT_METAL_SIMULATOR TTSIMD_SOCKET=$TTSIMD_SOCKET timeout=${PER_CMD_TIMEOUT}s"
+    log "daemon mode (per-test ttsimd): TT_METAL_SIMULATOR=$TT_METAL_SIMULATOR TTSIMD_SOCKET=$TTSIMD_SOCKET mock=$MOCK_CLUSTER_RANK_BINDING timeout=${PER_CMD_TIMEOUT}s"
 else
     log "in-process ttsim: TT_METAL_SIMULATOR=$TT_METAL_SIMULATOR timeout=${PER_CMD_TIMEOUT}s"
 fi
@@ -229,35 +236,35 @@ fi
 
 # 2.mp/2x2_fabric_ubench — single unicast, 1 packet, size 64.
 run_cmd "2.mp/2x2_fabric_ubench_shrunk" \
-    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_t3k_2x2_ttsim.yaml"
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' ${TT_RUN_MOCK_ARGS} --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/perf_microbenchmark/routing/test_tt_fabric --test_config tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_t3k_2x2_ttsim.yaml"
 
 # 2.mp/multi_host_fabric — smallest single gtest case.
 run_cmd "2.mp/multi_host_fabric_shrunk" \
-    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/multi_host_fabric_tests --gtest_filter='InterMeshSplit1x2FabricFixture.MultiHopUnicast'"
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' ${TT_RUN_MOCK_ARGS} --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/multi_host_fabric_tests --gtest_filter='InterMeshSplit1x2FabricFixture.MultiHopUnicast'"
 
 # 2.mp/mesh_socket — single iteration, 1 transaction, 256-byte data.
 run_cmd "2.mp/mesh_socket_shrunk" \
-    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/test_mesh_socket_main --test_config tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2_ttsim.yaml"
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' ${TT_RUN_MOCK_ARGS} --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/tt_metal/test_mesh_socket_main --test_config tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2_ttsim.yaml"
 
 # Distributed multiprocess tests (already small, just narrow gtest filter).
 run_cmd "2.mp/BigMeshDualRankTest2x4" \
-    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests --gtest_filter='*BigMeshDualRankTest2x4*'"
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' ${TT_RUN_MOCK_ARGS} --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests --gtest_filter='*BigMeshDualRankTest2x4*'"
 run_cmd "2.mp/BigMeshDualRankMeshShapeSweep" \
-    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests --gtest_filter='*BigMeshDualRankMeshShapeSweep*'"
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' ${TT_RUN_MOCK_ARGS} --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/tt_metal/distributed/multiprocess/distributed_multiprocess_tests --gtest_filter='*BigMeshDualRankMeshShapeSweep*'"
 
 # ttnn dual-rank send/recv: just the first parametrized case per fixture.
 run_cmd "2.mp/ttnn_dual_rank_2x2_shrunk" \
-    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/ttnn/multiprocess/unit_tests_dual_rank_2x2 --gtest_filter='MeshDeviceSplit2x2SendRecvTests/MeshDeviceSplit2x2SendRecvFixture.SendRecvAsync/0'"
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' ${TT_RUN_MOCK_ARGS} --rank-binding tests/tt_metal/distributed/config/2x2_multiprocess_rank_bindings.yaml ./build/test/ttnn/multiprocess/unit_tests_dual_rank_2x2 --gtest_filter='MeshDeviceSplit2x2SendRecvTests/MeshDeviceSplit2x2SendRecvFixture.SendRecvAsync/0'"
 run_cmd "2.mp/ttnn_dual_rank_2x4_shrunk" \
-    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/ttnn/multiprocess/unit_tests_dual_rank_2x4 --gtest_filter='BigMeshDualRankTest2x4.HostAllGather'"
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' ${TT_RUN_MOCK_ARGS} --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/ttnn/multiprocess/unit_tests_dual_rank_2x4 --gtest_filter='BigMeshDualRankTest2x4.HostAllGather'"
 
 run_cmd "2.mp/ttnn_launch_op" \
-    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/ttnn/unit_tests_ttnn --gtest_filter='*LaunchOperation*'"
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' ${TT_RUN_MOCK_ARGS} --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml build/test/ttnn/unit_tests_ttnn --gtest_filter='*LaunchOperation*'"
 
 run_cmd "2.mp/py_data_parallel" \
-    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml pytest -svv tests/ttnn/distributed/test_data_parallel_example.py"
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' ${TT_RUN_MOCK_ARGS} --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml pytest -svv tests/ttnn/distributed/test_data_parallel_example.py"
 run_cmd "2.mp/py_submesh" \
-    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml pytest -svv tests/ttnn/distributed/test_submesh_not_spanning_all_ranks_T3000.py"
+    "tt-run --mpi-args '--allow-run-as-root --oversubscribe' ${TT_RUN_MOCK_ARGS} --rank-binding tests/tt_metal/distributed/config/2x4_multiprocess_rank_bindings.yaml pytest -svv tests/ttnn/distributed/test_submesh_not_spanning_all_ranks_T3000.py"
 
 log "Summary: $SUMMARY"
 python3 - "$SUMMARY" <<'PY'

--- a/scripts/slurm-nkapre-mp-ttsim-shrunk-job.sh
+++ b/scripts/slurm-nkapre-mp-ttsim-shrunk-job.sh
@@ -18,7 +18,7 @@ require_bh_glx_compute
 
 export TT_METAL_HOME="$REPO"
 export BUILD_DIR="${REPO}/build_Debug"
-export CRAQ_SIM="${CRAQ_SIM:-/data/rsong/craq-sim}"
+export CRAQ_SIM="${CRAQ_SIM:-/data/rsong/craq-sim2}"
 export TTSIM_USE_DAEMON="${TTSIM_USE_DAEMON:-auto}"
 export PER_CMD_TIMEOUT="${PER_CMD_TIMEOUT:-1800}"
 unset TT_METAL_SIMULATOR_HOME TT_METAL_SIMULATOR TT_METAL_MOCK_CLUSTER_DESC_PATH

--- a/scripts/slurm-nkapre-mp-ttsim-shrunk-job.sh
+++ b/scripts/slurm-nkapre-mp-ttsim-shrunk-job.sh
@@ -36,7 +36,9 @@ echo "=== Compute node: $(hostname -s) ==="
 echo "=== RESULTS_DIR=${RESULTS_DIR} ==="
 
 cd "${REPO}/build_Debug"
-ninja -j32 test_mesh_socket_main multi_host_fabric_tests test_tt_fabric 2>&1 | tail -5
+ninja -j32 tt_metal ttnn test_mesh_socket_main multi_host_fabric_tests test_tt_fabric \
+    distributed_multiprocess_tests unit_tests_dual_rank_2x2 unit_tests_dual_rank_2x4 unit_tests_ttnn \
+    2>&1 | tail -15
 
 cd "${REPO}"
 "${REPO}/scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh" 2>&1 | tee "${RESULTS_DIR}/run.log"

--- a/scripts/slurm-nkapre-mp-ttsim-shrunk-job.sh
+++ b/scripts/slurm-nkapre-mp-ttsim-shrunk-job.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=nkapre-mp-shrunk
+#SBATCH --partition=bh_sc5_B2B9_D12
+#SBATCH --nodelist=bh-glx-b06u08
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
+#SBATCH --time=06:00:00
+#SBATCH --output=/data/rsong/tt-metal2/craq-parity-results/slurm-mp-shrunk-%j.out
+#SBATCH --error=/data/rsong/tt-metal2/craq-parity-results/slurm-mp-shrunk-%j.err
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO="${TT_METAL_HOME:-${SLURM_SUBMIT_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}}"
+source "${REPO}/scripts/lib/require-bh-glx-compute.sh"
+require_bh_glx_compute
+
+export TT_METAL_HOME="$REPO"
+export BUILD_DIR="${REPO}/build_Debug"
+export CRAQ_SIM="${CRAQ_SIM:-/data/rsong/craq-sim}"
+export TTSIM_USE_DAEMON="${TTSIM_USE_DAEMON:-auto}"
+export PER_CMD_TIMEOUT="${PER_CMD_TIMEOUT:-1800}"
+unset TT_METAL_SIMULATOR_HOME TT_METAL_SIMULATOR TT_METAL_MOCK_CLUSTER_DESC_PATH
+STAMP="${RESULTS_STAMP:-$(date -u +%Y%m%dT%H%M%SZ)}"
+export RESULTS_DIR="${RESULTS_DIR:-${REPO}/craq-parity-results/mp-run-shrunk-${STAMP}}"
+
+if [ -f "${REPO}/python_env/bin/activate" ]; then
+    source "${REPO}/python_env/bin/activate"
+fi
+
+mkdir -p "${RESULTS_DIR}"
+ln -sfn "$(basename "${RESULTS_DIR}")" "${REPO}/craq-parity-results/mp-latest-shrunk"
+
+echo "=== Compute node: $(hostname -s) ==="
+echo "=== RESULTS_DIR=${RESULTS_DIR} ==="
+
+cd "${REPO}/build_Debug"
+ninja -j32 test_mesh_socket_main multi_host_fabric_tests test_tt_fabric 2>&1 | tail -5
+
+cd "${REPO}"
+"${REPO}/scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh" 2>&1 | tee "${RESULTS_DIR}/run.log"

--- a/scripts/slurm-nkapre-mp-ttsim-shrunk-job.sh
+++ b/scripts/slurm-nkapre-mp-ttsim-shrunk-job.sh
@@ -40,5 +40,8 @@ ninja -j32 tt_metal ttnn test_mesh_socket_main multi_host_fabric_tests test_tt_f
     distributed_multiprocess_tests unit_tests_dual_rank_2x2 unit_tests_dual_rank_2x4 unit_tests_ttnn \
     2>&1 | tail -15
 
+# tt-run imports ttnn/ttnn/_ttnn.so from the source tree; sync after every build.
+cp -f "${BUILD_DIR}/ttnn/_ttnn.so" "${REPO}/ttnn/ttnn/_ttnn.so"
+
 cd "${REPO}"
 "${REPO}/scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh" 2>&1 | tee "${RESULTS_DIR}/run.log"

--- a/scripts/submit-nkapre-mp-ttsim-shrunk-slurm.sh
+++ b/scripts/submit-nkapre-mp-ttsim-shrunk-slurm.sh
@@ -7,7 +7,7 @@ REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 source "${REPO}/scripts/lib/nkapre-slurm-b-aisle.sh"
 
 export TT_METAL_HOME="${TT_METAL_HOME:-${REPO}}"
-export CRAQ_SIM="${CRAQ_SIM:-/data/rsong/craq-sim}"
+export CRAQ_SIM="${CRAQ_SIM:-/data/rsong/craq-sim2}"
 STAMP="${RESULTS_STAMP:-$(date -u +%Y%m%dT%H%M%SZ)}"
 export RESULTS_STAMP="${STAMP}"
 export RESULTS_DIR="${REPO}/craq-parity-results/mp-run-shrunk-${STAMP}"

--- a/scripts/submit-nkapre-mp-ttsim-shrunk-slurm.sh
+++ b/scripts/submit-nkapre-mp-ttsim-shrunk-slurm.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+# Login node: submit the SHRUNK T3K multiprocess (tt-run) sweep on Galaxy compute.
+set -euo pipefail
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# shellcheck source=scripts/lib/nkapre-slurm-b-aisle.sh
+source "${REPO}/scripts/lib/nkapre-slurm-b-aisle.sh"
+
+export TT_METAL_HOME="${TT_METAL_HOME:-${REPO}}"
+export CRAQ_SIM="${CRAQ_SIM:-/data/rsong/craq-sim}"
+STAMP="${RESULTS_STAMP:-$(date -u +%Y%m%dT%H%M%SZ)}"
+export RESULTS_STAMP="${STAMP}"
+export RESULTS_DIR="${REPO}/craq-parity-results/mp-run-shrunk-${STAMP}"
+export PER_CMD_TIMEOUT="${PER_CMD_TIMEOUT:-1800}"
+export TTSIM_USE_DAEMON="${TTSIM_USE_DAEMON:-auto}"
+
+host="$(hostname -s 2>/dev/null || hostname)"
+if [[ "$host" == bh-glx-* ]]; then
+    echo "ERROR: run from login node." >&2
+    exit 1
+fi
+
+mkdir -p "${REPO}/craq-parity-results"
+chmod +x "${REPO}/scripts/slurm-nkapre-mp-ttsim-shrunk-job.sh" "${REPO}/scripts/run-nkapre-mp-ttsim-sweep-shrunk.sh"
+
+if [[ -n "${NODE:-}" ]]; then
+    validate_nkapre_node "$NODE"
+    PARTITION="${PARTITION:-$(partition_for_node "$NODE")}"
+else
+    NODE="$(pick_idle_nkapre_node "${EXCLUDE_NODES:-}")"
+    if [[ -z "$NODE" ]]; then
+        echo "ERROR: no idle bh-glx-b* or bh-glx-110-c* node (set NODE= or EXCLUDE_NODES=)." >&2
+        exit 1
+    fi
+    PARTITION="$(partition_for_node "$NODE")"
+fi
+
+job_id=$(sbatch \
+    --partition="${PARTITION}" \
+    --nodelist="${NODE}" \
+    --time=06:00:00 \
+    --export=ALL,TT_METAL_HOME,CRAQ_SIM,RESULTS_DIR,RESULTS_STAMP,PER_CMD_TIMEOUT,TTSIM_USE_DAEMON,SUITE_FILTER,BACKTRACE_AT_SEC \
+    "${REPO}/scripts/slurm-nkapre-mp-ttsim-shrunk-job.sh" | awk '{print $4}')
+
+echo "Submitted SHRUNK multiprocess (tt-run) job ${job_id} (node=${NODE}, partition=${PARTITION})"
+echo "Suites: 10 tt-run T3K mp tests w/ shrunk configs + ${PER_CMD_TIMEOUT}s per-test cap"
+echo "RESULTS_DIR=${RESULTS_DIR}"
+echo "Monitor: squeue -j ${job_id}"
+echo "Tail:    tail -f ${RESULTS_DIR}/run.log"

--- a/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2_ttsim.yaml
+++ b/tests/tt_metal/multihost/fabric_tests/mesh_socket_t3k_2x2_ttsim.yaml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# Shrunk version of mesh_socket_t3k_2x2.yaml for tt-sim simulation.
+# Cuts iterations, transactions, and data-size so the simulator can run
+# a single representative socket end-to-end without timing out.
+
+physical_mesh:
+   mesh_descriptor_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.textproto"
+   eth_coord_mapping: [
+    [[0, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0], [0, 1, 1, 0, 0]],
+    [[0, 2, 0, 0, 0], [0, 3, 0, 0, 0], [0, 2, 1, 0, 0], [0, 3, 1, 0, 0]]
+    ]
+
+fabric_config:
+  topology: Mesh
+
+tests:
+  - name: "all_to_all_smoke"
+    num_iterations: 1
+    memory_config:
+      fifo_size: 1024
+      page_size: 256
+      data_size: 256
+      num_transactions: 1
+    pattern_expansions:
+      - type: "all_to_all_device_unicast"
+        core_coord: [0, 0]

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_t3k_2x2_ttsim.yaml
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_t3k_2x2_ttsim.yaml
@@ -1,0 +1,30 @@
+# SPDX-License-Identifier: Apache-2.0
+# Shrunk version of test_t3k_2x2.yaml for tt-sim simulation. Keeps the
+# physical topology and reduces traffic so the simulator can converge
+# within a reasonable wall-clock budget.
+
+physical_mesh:
+   mesh_descriptor_path: "tests/tt_metal/tt_fabric/custom_mesh_descriptors/t3k_2x2_mesh_graph_descriptor.textproto"
+   eth_coord_mapping: [
+    [[0, 0, 0, 0, 0], [0, 1, 0, 0, 0], [0, 0, 1, 0, 0], [0, 1, 1, 0, 0]],
+    [[0, 2, 0, 0, 0], [0, 3, 0, 0, 0], [0, 2, 1, 0, 0], [0, 3, 1, 0, 0]]
+    ]
+
+Tests:
+  # One sender, one destination, one cross-mesh hop, one packet.
+  # Exercises the per-conn chip_id translation + cross-mesh auto-peering
+  # without driving any all-to-all traffic.
+  - name: UnicastWithChipIdSmoke
+    fabric_setup:
+      topology: Mesh
+
+    defaults:
+      ftype: unicast
+      ntype: unicast_write
+      size: 64
+      num_packets: 1
+    senders:
+      - device: [0, 0]
+        patterns:
+          - destination:
+              device: [1, 0]

--- a/tt_metal/distributed/system_mesh.cpp
+++ b/tt_metal/distributed/system_mesh.cpp
@@ -23,7 +23,11 @@
 #include "tt_metal/distributed/distributed_coordinate_translator.hpp"
 
 #include "impl/context/metal_context.hpp"
+#include <llrt/tt_cluster.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
+#include <cstdio>
+#include <ctime>
+#include <unistd.h>
 
 namespace tt::tt_metal::distributed {
 // Helper type to keep track of device ID and fabric node ID for a given mesh coordinate.
@@ -110,7 +114,10 @@ SystemMesh::Impl::Impl(const tt::tt_fabric::ControlPlane& control_plane) :
         local_physical_translation_map.shape(),
         coordinate_translator_.local_shape());
 
-    // Populate chip IDs for host-local devices.
+    // Populate chip IDs for host-local devices. Control plane LOCAL scope can span the full
+    // logical mesh on each rank (host_topology 1x1); only chips in user_exposed_chip_ids()
+    // are actually opened on this process (TT_VISIBLE_DEVICES / rank binding).
+    const auto& user_exposed_chips = MetalContext::instance().get_cluster().user_exposed_chip_ids();
     for (const auto& local_coord : MeshCoordinateRange(coordinate_translator_.local_shape())) {
         TT_FATAL(
             local_physical_translation_map.at(local_coord).mesh_id() == mesh_id_,
@@ -120,14 +127,40 @@ SystemMesh::Impl::Impl(const tt::tt_fabric::ControlPlane& control_plane) :
             mesh_id_);
 
         const auto global_coord = coordinate_translator_.local_to_global(local_coord);
+        const ChipId chip_id = local_physical_translation_map.at(local_coord).chip_id();
+        const bool is_exposed = user_exposed_chips.contains(chip_id);
+        // #region agent log
+        {
+            std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+            if (f) {
+                std::fprintf(
+                    f,
+                    "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_USER_EXPOSED_FILTER\","
+                    "\"location\":\"system_mesh.cpp:Impl\",\"message\":\"coord_chip_mapping\","
+                    "\"data\":{\"chip_id\":%d,\"is_exposed\":%s,\"pid\":%d},\"timestamp\":%ld}\n",
+                    chip_id,
+                    is_exposed ? "true" : "false",
+                    (int)getpid(),
+                    (long)std::time(nullptr));
+                std::fclose(f);
+            }
+        }
+        // #endregion
+        if (!is_exposed) {
+            log_debug(
+                LogDistributed,
+                "SystemMesh: Skipping global coordinate {} — chip {} not in user_exposed_chip_ids",
+                global_coord,
+                chip_id);
+            continue;
+        }
         log_debug(
             LogDistributed,
             "SystemMesh: Populating global coordinate {} with physical coordinate {} at local coordinate {}",
             global_coord,
             local_physical_translation_map.at(local_coord),
             local_coord);
-        system_mapped_devices_.at(global_coord).device_id =
-            MaybeRemote<int>::local(local_physical_translation_map.at(local_coord).chip_id());
+        system_mapped_devices_.at(global_coord).device_id = MaybeRemote<int>::local(chip_id);
     }
 }
 
@@ -200,7 +233,8 @@ SystemMesh::MappedDevices SystemMesh::Impl::get_mapped_devices(
         system_shape);
 
     // Attempt to fit the requested mesh into the system mesh, potentially rotating it.
-    auto requested_mesh_fits = [&system_offset, &system_shape](const tt::stl::SmallVector<uint32_t>& rotated_shape) {
+    auto requested_mesh_fits = [&system_offset,
+                                &system_shape](const tt::stl::SmallVector<std::uint32_t>& rotated_shape) {
         for (int i = 0; i < system_shape.dims(); ++i) {
             if (system_offset[i] + rotated_shape[i] > system_shape[i]) {
                 return false;
@@ -209,7 +243,7 @@ SystemMesh::MappedDevices SystemMesh::Impl::get_mapped_devices(
         return true;
     };
 
-    tt::stl::SmallVector<uint32_t> rotated_shape(requested_shape.cbegin(), requested_shape.cend());
+    tt::stl::SmallVector<std::uint32_t> rotated_shape(requested_shape.cbegin(), requested_shape.cend());
     size_t rotations = 0;
     while (!requested_mesh_fits(rotated_shape) && rotations < system_dimensions) {
         std::rotate(rotated_shape.begin(), rotated_shape.begin() + 1, rotated_shape.end());
@@ -224,7 +258,7 @@ SystemMesh::MappedDevices SystemMesh::Impl::get_mapped_devices(
             system_offset);
     }
 
-    tt::stl::SmallVector<uint32_t> end_coord;
+    tt::stl::SmallVector<std::uint32_t> end_coord;
     for (int i = 0; i < system_dimensions; ++i) {
         end_coord.push_back(system_offset[i] + rotated_shape[i] - 1);
     }

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -13,6 +13,7 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
+#include <cstdint>
 
 namespace tt::tt_fabric {
 
@@ -46,8 +47,8 @@ void FabricBuilderContext::compute_max_channel_counts() {
     max_receiver_channels_per_vc_.fill(0);
 
     for (const auto& mapping : possible_mappings) {
-        uint32_t num_vcs = mapping.get_num_virtual_channels();
-        for (uint32_t vc = 0; vc < num_vcs; ++vc) {
+        std::uint32_t num_vcs = mapping.get_num_virtual_channels();
+        for (std::uint32_t vc = 0; vc < num_vcs; ++vc) {
             auto sender_count = mapping.get_num_sender_channels_for_vc(vc);
             max_sender_channels_per_vc_[vc] =
                 std::max(max_sender_channels_per_vc_[vc], static_cast<std::size_t>(sender_count));
@@ -91,7 +92,8 @@ FabricBuilderContext::FabricBuilderContext(const FabricContext& fabric_context) 
     // Log trimming report after intermesh config is known (VC1 affects expected channel counts)
     if (rtoptions.has_fabric_trimming_profile()) {
         const auto& path = rtoptions.get_fabric_trimming_profile_path();
-        generate_and_log_channel_trimming_report(path, fabric_context.get_fabric_topology(), intermesh_vc_config_.requires_vc1);
+        generate_and_log_channel_trimming_report(
+            path, fabric_context.get_fabric_topology(), intermesh_vc_config_.requires_vc1);
     }
 
     // Compute max channel counts for this fabric instance
@@ -111,6 +113,10 @@ FabricBuilderContext::FabricBuilderContext(const FabricContext& fabric_context) 
     auto num_pcie_devices = tt::tt_metal::GetNumPCIeDevices();
     if (num_devices_ != 4 && num_pcie_devices == 4) {
         num_devices_ += num_pcie_devices;
+    }
+    // TT_METAL_NO_CHIP_ID_REMAP keeps original physical chip IDs (may be sparse).
+    for (ChipId id : tt::tt_metal::MetalContext::instance().get_cluster().all_chip_ids()) {
+        num_devices_ = std::max(num_devices_, static_cast<size_t>(id) + 1);
     }
     master_router_chans_.resize(num_devices_, UNINITIALIZED_MASTER_ROUTER_CHAN);
     num_initialized_routers_.resize(num_devices_, UNINITIALIZED_ROUTERS);
@@ -165,7 +171,7 @@ void FabricBuilderContext::set_num_fabric_initialized_routers(ChipId chip_id, si
     num_initialized_routers_[chip_id] = num_routers;
 }
 
-uint32_t FabricBuilderContext::get_num_fabric_initialized_routers(ChipId chip_id) const {
+std::uint32_t FabricBuilderContext::get_num_fabric_initialized_routers(ChipId chip_id) const {
     TT_FATAL(chip_id < num_devices_, "Device ID {} exceeds maximum supported devices {}", chip_id, num_devices_);
     TT_FATAL(
         num_initialized_routers_[chip_id] != UNINITIALIZED_ROUTERS,
@@ -208,15 +214,16 @@ std::vector<size_t> FabricBuilderContext::get_fabric_router_addresses_to_clear()
     return addresses_to_clear;
 }
 
-std::pair<uint32_t, uint32_t> FabricBuilderContext::get_fabric_router_sync_address_and_status() const {
+std::pair<std::uint32_t, std::uint32_t> FabricBuilderContext::get_fabric_router_sync_address_and_status() const {
     return std::make_pair(router_config_->edm_status_address, EDMStatus::LOCAL_HANDSHAKE_COMPLETE);
 }
 
-std::optional<std::pair<uint32_t, EDMStatus>> FabricBuilderContext::get_fabric_router_ready_address_and_signal() const {
+std::optional<std::pair<std::uint32_t, EDMStatus>> FabricBuilderContext::get_fabric_router_ready_address_and_signal()
+    const {
     return std::make_pair(router_config_->edm_status_address, EDMStatus::READY_FOR_TRAFFIC);
 }
 
-std::pair<uint32_t, uint32_t> FabricBuilderContext::get_fabric_router_termination_address_and_signal() const {
+std::pair<std::uint32_t, std::uint32_t> FabricBuilderContext::get_fabric_router_termination_address_and_signal() const {
     return std::make_pair(router_config_->termination_signal_address, TerminationSignal::IMMEDIATELY_TERMINATE);
 }
 
@@ -307,6 +314,5 @@ IntermeshVCConfig FabricBuilderContext::compute_intermesh_vc_config() const {
 
     return config;
 }
-
 
 }  // namespace tt::tt_fabric

--- a/tt_metal/fabric/fabric_builder_context.cpp
+++ b/tt_metal/fabric/fabric_builder_context.cpp
@@ -13,7 +13,6 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
-#include <cstdint>
 
 namespace tt::tt_fabric {
 
@@ -47,8 +46,8 @@ void FabricBuilderContext::compute_max_channel_counts() {
     max_receiver_channels_per_vc_.fill(0);
 
     for (const auto& mapping : possible_mappings) {
-        std::uint32_t num_vcs = mapping.get_num_virtual_channels();
-        for (std::uint32_t vc = 0; vc < num_vcs; ++vc) {
+        uint32_t num_vcs = mapping.get_num_virtual_channels();
+        for (uint32_t vc = 0; vc < num_vcs; ++vc) {
             auto sender_count = mapping.get_num_sender_channels_for_vc(vc);
             max_sender_channels_per_vc_[vc] =
                 std::max(max_sender_channels_per_vc_[vc], static_cast<std::size_t>(sender_count));
@@ -171,7 +170,7 @@ void FabricBuilderContext::set_num_fabric_initialized_routers(ChipId chip_id, si
     num_initialized_routers_[chip_id] = num_routers;
 }
 
-std::uint32_t FabricBuilderContext::get_num_fabric_initialized_routers(ChipId chip_id) const {
+uint32_t FabricBuilderContext::get_num_fabric_initialized_routers(ChipId chip_id) const {
     TT_FATAL(chip_id < num_devices_, "Device ID {} exceeds maximum supported devices {}", chip_id, num_devices_);
     TT_FATAL(
         num_initialized_routers_[chip_id] != UNINITIALIZED_ROUTERS,
@@ -214,16 +213,15 @@ std::vector<size_t> FabricBuilderContext::get_fabric_router_addresses_to_clear()
     return addresses_to_clear;
 }
 
-std::pair<std::uint32_t, std::uint32_t> FabricBuilderContext::get_fabric_router_sync_address_and_status() const {
+std::pair<uint32_t, uint32_t> FabricBuilderContext::get_fabric_router_sync_address_and_status() const {
     return std::make_pair(router_config_->edm_status_address, EDMStatus::LOCAL_HANDSHAKE_COMPLETE);
 }
 
-std::optional<std::pair<std::uint32_t, EDMStatus>> FabricBuilderContext::get_fabric_router_ready_address_and_signal()
-    const {
+std::optional<std::pair<uint32_t, EDMStatus>> FabricBuilderContext::get_fabric_router_ready_address_and_signal() const {
     return std::make_pair(router_config_->edm_status_address, EDMStatus::READY_FOR_TRAFFIC);
 }
 
-std::pair<std::uint32_t, std::uint32_t> FabricBuilderContext::get_fabric_router_termination_address_and_signal() const {
+std::pair<uint32_t, uint32_t> FabricBuilderContext::get_fabric_router_termination_address_and_signal() const {
     return std::make_pair(router_config_->termination_signal_address, TerminationSignal::IMMEDIATELY_TERMINATE);
 }
 

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -6,8 +6,6 @@
 #include "tt_metal/fabric/physical_system_discovery.hpp"
 #include <tt-metalium/experimental/fabric/physical_system_descriptor.hpp>
 #include <tt-metalium/experimental/fabric/control_plane.hpp>
-
-#include <tt-logger/tt-logger.hpp>
 
 #include <unistd.h>
 #include <climits>
@@ -45,7 +43,6 @@ TrayID get_tray_id_for_chip(
     static const std::unordered_map<std::string, std::vector<uint16_t>> mobo_to_bus_ids = {
         {"SIENAD8-2L2T", {0xc1, 0x01, 0x41, 0x42}},
         {"X12DPG-QT6", {0xb1, 0xca, 0x31, 0x4b}},
-        {"H13DSG-O-CPU", {0x01, 0x21, 0x41, 0x61, 0x81, 0xa1, 0xc1, 0xe1}},
     };
 
     // BDF aliases: some motherboard variants enumerate PCIe slots differently
@@ -326,7 +323,6 @@ void validate_graphs(PhysicalSystemDescriptor& psd) {
     // Validate that the representation of the system is internally consistent.
     const auto& asic_descriptors = psd.get_asic_descriptors();
     auto& system_graph = psd.get_system_graph();
-    std::vector<OneSidedConnection> connections_to_drop;
 
     for (auto& [host, asic_group] : system_graph.asic_connectivity_graph) {
         for (auto& [src_asic, edges] : asic_group) {
@@ -335,7 +331,6 @@ void validate_graphs(PhysicalSystemDescriptor& psd) {
                 continue;
             }
             const auto& src_host = asic_descriptors.at(src_asic).host_name;
-            const auto& src_desc = asic_descriptors.at(src_asic);
 
             // Skip if host_connectivity_graph doesn't have src_host (shouldn't happen, but be defensive)
             if (!system_graph.host_connectivity_graph.contains(src_host)) {
@@ -349,7 +344,6 @@ void validate_graphs(PhysicalSystemDescriptor& psd) {
                     continue;
                 }
                 const auto& dst_host = asic_descriptors.at(dst_asic).host_name;
-                const auto& dst_desc = asic_descriptors.at(dst_asic);
 
                 bool all_local = std::all_of(
                     eth_conns.begin(), eth_conns.end(), [](const EthConnection& conn) { return conn.is_local; });
@@ -388,26 +382,12 @@ void validate_graphs(PhysicalSystemDescriptor& psd) {
                             return host_edge.first == dst_host;
                         });
 
-                    if (host_edge_it == src_host_edges.end()) {
-                        log_warning(
-                            tt::LogMetal,
-                            "Physical Discovery Warning: Global Connection between host {} and host {} is not found "
-                            "in the host connectivity graph. ASIC {} (Tray {} Location {} chan {}) -> ASIC {} "
-                            "(Tray {} Location {} chan {}). Dropping one-sided link.",
-                            src_host,
-                            dst_host,
-                            src_asic,
-                            src_desc.tray_id,
-                            src_desc.asic_location,
-                            eth_conn.src_chan,
-                            dst_asic,
-                            dst_desc.tray_id,
-                            dst_desc.asic_location,
-                            eth_conn.dst_chan);
-                        connections_to_drop.push_back(
-                            {host, src_host, dst_host, src_asic, dst_asic, eth_conn.src_chan, eth_conn.dst_chan});
-                        continue;
-                    }
+                    TT_FATAL(
+                        host_edge_it != src_host_edges.end(),
+                        "Physical Discovery Error: Global Connection between {} and {} is not found in the host "
+                        "connectivity graph. Please reset the system and try again.",
+                        src_host,
+                        dst_host);
 
                     const auto& exit_node_conns = host_edge_it->second;
                     bool exit_conn_found = std::any_of(
@@ -418,36 +398,15 @@ void validate_graphs(PhysicalSystemDescriptor& psd) {
                                    exit_node_conn.eth_conn.dst_chan == eth_conn.dst_chan;
                         });
 
-                    if (!exit_conn_found) {
-                        log_warning(
-                            tt::LogMetal,
-                            "Physical Discovery Warning: Exit node connection not found between host {} and host {}. "
-                            "ASIC {} (Tray {} Location {} chan {}) -> ASIC {} (Tray {} Location {} chan {}). "
-                            "Dropping one-sided link.",
-                            src_host,
-                            dst_host,
-                            src_asic,
-                            src_desc.tray_id,
-                            src_desc.asic_location,
-                            eth_conn.src_chan,
-                            dst_asic,
-                            dst_desc.tray_id,
-                            dst_desc.asic_location,
-                            eth_conn.dst_chan);
-                        connections_to_drop.push_back(
-                            {host, src_host, dst_host, src_asic, dst_asic, eth_conn.src_chan, eth_conn.dst_chan});
-                    }
+                    TT_FATAL(
+                        exit_conn_found,
+                        "Physical Discovery Error: Global Connection between {} and {} is not found in the "
+                        "host connectivity graph. Please reset the system and try again.",
+                        src_host,
+                        dst_host);
                 }
             }
         }
-    }
-
-    if (!connections_to_drop.empty()) {
-        log_warning(
-            tt::LogMetal,
-            "Physical Discovery: Dropping {} one-sided connection(s). Link retraining will attempt recovery.",
-            connections_to_drop.size());
-        erase_one_sided_connections(psd, connections_to_drop);
     }
 }
 

--- a/tt_metal/fabric/physical_system_discovery.cpp
+++ b/tt_metal/fabric/physical_system_discovery.cpp
@@ -323,6 +323,7 @@ void validate_graphs(PhysicalSystemDescriptor& psd) {
     // Validate that the representation of the system is internally consistent.
     const auto& asic_descriptors = psd.get_asic_descriptors();
     auto& system_graph = psd.get_system_graph();
+    std::vector<OneSidedConnection> connections_to_drop;
 
     for (auto& [host, asic_group] : system_graph.asic_connectivity_graph) {
         for (auto& [src_asic, edges] : asic_group) {
@@ -331,6 +332,7 @@ void validate_graphs(PhysicalSystemDescriptor& psd) {
                 continue;
             }
             const auto& src_host = asic_descriptors.at(src_asic).host_name;
+            const auto& src_desc = asic_descriptors.at(src_asic);
 
             // Skip if host_connectivity_graph doesn't have src_host (shouldn't happen, but be defensive)
             if (!system_graph.host_connectivity_graph.contains(src_host)) {
@@ -344,6 +346,7 @@ void validate_graphs(PhysicalSystemDescriptor& psd) {
                     continue;
                 }
                 const auto& dst_host = asic_descriptors.at(dst_asic).host_name;
+                const auto& dst_desc = asic_descriptors.at(dst_asic);
 
                 bool all_local = std::all_of(
                     eth_conns.begin(), eth_conns.end(), [](const EthConnection& conn) { return conn.is_local; });
@@ -382,12 +385,26 @@ void validate_graphs(PhysicalSystemDescriptor& psd) {
                             return host_edge.first == dst_host;
                         });
 
-                    TT_FATAL(
-                        host_edge_it != src_host_edges.end(),
-                        "Physical Discovery Error: Global Connection between {} and {} is not found in the host "
-                        "connectivity graph. Please reset the system and try again.",
-                        src_host,
-                        dst_host);
+                    if (host_edge_it == src_host_edges.end()) {
+                        log_warning(
+                            tt::LogMetal,
+                            "Physical Discovery Warning: Global Connection between host {} and host {} is not found "
+                            "in the host connectivity graph. ASIC {} (Tray {} Location {} chan {}) -> ASIC {} "
+                            "(Tray {} Location {} chan {}). Dropping one-sided link.",
+                            src_host,
+                            dst_host,
+                            src_asic,
+                            src_desc.tray_id,
+                            src_desc.asic_location,
+                            eth_conn.src_chan,
+                            dst_asic,
+                            dst_desc.tray_id,
+                            dst_desc.asic_location,
+                            eth_conn.dst_chan);
+                        connections_to_drop.push_back(
+                            {host, src_host, dst_host, src_asic, dst_asic, eth_conn.src_chan, eth_conn.dst_chan});
+                        continue;
+                    }
 
                     const auto& exit_node_conns = host_edge_it->second;
                     bool exit_conn_found = std::any_of(
@@ -398,15 +415,36 @@ void validate_graphs(PhysicalSystemDescriptor& psd) {
                                    exit_node_conn.eth_conn.dst_chan == eth_conn.dst_chan;
                         });
 
-                    TT_FATAL(
-                        exit_conn_found,
-                        "Physical Discovery Error: Global Connection between {} and {} is not found in the "
-                        "host connectivity graph. Please reset the system and try again.",
-                        src_host,
-                        dst_host);
+                    if (!exit_conn_found) {
+                        log_warning(
+                            tt::LogMetal,
+                            "Physical Discovery Warning: Exit node connection not found between host {} and host {}. "
+                            "ASIC {} (Tray {} Location {} chan {}) -> ASIC {} (Tray {} Location {} chan {}). "
+                            "Dropping one-sided link.",
+                            src_host,
+                            dst_host,
+                            src_asic,
+                            src_desc.tray_id,
+                            src_desc.asic_location,
+                            eth_conn.src_chan,
+                            dst_asic,
+                            dst_desc.tray_id,
+                            dst_desc.asic_location,
+                            eth_conn.dst_chan);
+                        connections_to_drop.push_back(
+                            {host, src_host, dst_host, src_asic, dst_asic, eth_conn.src_chan, eth_conn.dst_chan});
+                    }
                 }
             }
         }
+    }
+
+    if (!connections_to_drop.empty()) {
+        log_warning(
+            tt::LogMetal,
+            "Physical Discovery: Dropping {} one-sided connection(s). Link retraining will attempt recovery.",
+            connections_to_drop.size());
+        erase_one_sided_connections(psd, connections_to_drop);
     }
 }
 

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -886,6 +886,10 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             // After emitting, we can't coalesce with previous commands (vectors are now empty)
             can_coalesce_relay = false;
             can_coalesce_write = false;
+            const auto aligned_src_info = calculate_aligned_src(src_pinned_addr);
+            aligned_src_addr = aligned_src_info.first;
+            padding_bytes = aligned_src_info.second;
+            total_read_length = padding_bytes + data_length;
         }
 
         // Add or coalesce relay sub-command
@@ -919,6 +923,8 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             write_sub_cmd.length = data_length;
             write_sub_cmds.push_back(write_sub_cmd);
         }
+
+        relay_stream_offset += total_read_length;
     }
 
     // Emit final command pair with remaining sub-commands
@@ -1140,7 +1146,8 @@ bool write_to_device_buffer(
     tt::stl::Span<const std::uint32_t> expected_num_workers_completed,
     CoreType dispatch_core_type,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
-    const std::shared_ptr<experimental::PinnedMemory>& pinned_memory) {
+    const std::shared_ptr<experimental::PinnedMemory>& pinned_memory,
+    const CoreRangeSet* logical_core_filter) {
     SystemMemoryManager& sysmem_manager = buffer.device()->sysmem_manager();
     ContextId context_id = tt::tt_metal::extract_context_id(buffer.device());
     const auto& hal = tt::tt_metal::MetalContext::instance(context_id).hal();
@@ -1299,8 +1306,13 @@ bool write_to_device_buffer(
             remote_chip);
         const std::vector<CoreCoord>& cores = dispatch_params.buffer_page_mapping->all_cores;
 
+        bool any_core_written = false;
         //  Since we read core by core we are reading the device pages sequentially
-        for (uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
+        for (std::uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
+            if (logical_core_filter != nullptr && !logical_core_filter->contains(cores[core_id])) {
+                continue;
+            }
+            any_core_written = true;
             for (const BufferCorePageMapping& core_page_mapping :
                  dispatch_params.buffer_page_mapping->core_page_mappings[core_id]) {
                 write_sharded_buffer_to_core(
@@ -1315,34 +1327,42 @@ bool write_to_device_buffer(
                     dispatch_core_type);
             }
         }
-    } else {
-        auto root_buffer = buffer.root_buffer();
-        auto region = buffer.root_buffer_region();
-        InterleavedBufferWriteDispatchParamsVariant dispatch_params_variant =
-            initialize_interleaved_buf_dispatch_params(
-                *root_buffer,
-                cq_id,
-                expected_num_workers_completed,
-                region,
-                sub_device_ids,
-                pinned_src_noc_xy,
-                pinned_src_addr,
-                use_pinned_transfer,
-                remote_chip);
-
-        InterleavedBufferWriteDispatchParams* dispatch_params = std::visit(
-            ttsl::overloaded{
-                [](std::derived_from<InterleavedBufferWriteDispatchParams> auto& val)
-                    -> InterleavedBufferWriteDispatchParams* { return &val; },
-                [](std::monostate) -> InterleavedBufferWriteDispatchParams* { return nullptr; },
-            },
-            dispatch_params_variant);
-        TT_ASSERT(dispatch_params != nullptr);
-
-        write_interleaved_buffer_to_device(
-            src, *dispatch_params, *root_buffer, buf_dispatch_constants, sub_device_ids, dispatch_core_type);
-        return use_pinned_transfer;
+        // If the filter excluded every core, no DMA was issued, so callers must not treat the
+        // pinned transfer as in-flight (which would add spurious barrier events).
+        return use_pinned_transfer && any_core_written;
     }
+    if (logical_core_filter != nullptr) {
+        TT_FATAL(
+            logical_core_filter->empty(),
+            "logical_core_filter is only supported for sharded buffer layouts (interleaved layout does not support "
+            "per-core filtering)");
+        // Empty filter -> no-op (consistent with the sharded path); nothing was actually written.
+        return false;
+    }
+    auto root_buffer = buffer.root_buffer();
+    auto region = buffer.root_buffer_region();
+    InterleavedBufferWriteDispatchParamsVariant dispatch_params_variant = initialize_interleaved_buf_dispatch_params(
+        *root_buffer,
+        cq_id,
+        expected_num_workers_completed,
+        region,
+        sub_device_ids,
+        pinned_src_noc_xy,
+        pinned_src_addr,
+        use_pinned_transfer,
+        remote_chip);
+
+    InterleavedBufferWriteDispatchParams* dispatch_params = std::visit(
+        ttsl::overloaded{
+            [](std::derived_from<InterleavedBufferWriteDispatchParams> auto& val)
+                -> InterleavedBufferWriteDispatchParams* { return &val; },
+            [](std::monostate) -> InterleavedBufferWriteDispatchParams* { return nullptr; },
+        },
+        dispatch_params_variant);
+    TT_ASSERT(dispatch_params != nullptr);
+
+    write_interleaved_buffer_to_device(
+        src, *dispatch_params, *root_buffer, buf_dispatch_constants, sub_device_ids, dispatch_core_type);
     return use_pinned_transfer;
 }
 
@@ -1405,9 +1425,8 @@ void issue_read_buffer_dispatch_command_sequence(
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
 
-    // Mock devices don't have real hardware to read from, skip actual dispatch
-    if (tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id()).get_cluster().get_target_device_type() ==
-        tt::TargetDevice::Mock) {
+    // Mock/emulated devices don't have real hardware to read from, skip actual dispatch
+    if (tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id()).get_cluster().is_mock_or_emulated()) {
         return;
     }
 

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2025 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -886,10 +886,6 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             // After emitting, we can't coalesce with previous commands (vectors are now empty)
             can_coalesce_relay = false;
             can_coalesce_write = false;
-            const auto aligned_src_info = calculate_aligned_src(src_pinned_addr);
-            aligned_src_addr = aligned_src_info.first;
-            padding_bytes = aligned_src_info.second;
-            total_read_length = padding_bytes + data_length;
         }
 
         // Add or coalesce relay sub-command
@@ -923,8 +919,6 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             write_sub_cmd.length = data_length;
             write_sub_cmds.push_back(write_sub_cmd);
         }
-
-        relay_stream_offset += total_read_length;
     }
 
     // Emit final command pair with remaining sub-commands
@@ -1146,8 +1140,7 @@ bool write_to_device_buffer(
     tt::stl::Span<const std::uint32_t> expected_num_workers_completed,
     CoreType dispatch_core_type,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
-    const std::shared_ptr<experimental::PinnedMemory>& pinned_memory,
-    const CoreRangeSet* logical_core_filter) {
+    const std::shared_ptr<experimental::PinnedMemory>& pinned_memory) {
     SystemMemoryManager& sysmem_manager = buffer.device()->sysmem_manager();
     ContextId context_id = tt::tt_metal::extract_context_id(buffer.device());
     const auto& hal = tt::tt_metal::MetalContext::instance(context_id).hal();
@@ -1306,13 +1299,8 @@ bool write_to_device_buffer(
             remote_chip);
         const std::vector<CoreCoord>& cores = dispatch_params.buffer_page_mapping->all_cores;
 
-        bool any_core_written = false;
         //  Since we read core by core we are reading the device pages sequentially
-        for (std::uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
-            if (logical_core_filter != nullptr && !logical_core_filter->contains(cores[core_id])) {
-                continue;
-            }
-            any_core_written = true;
+        for (uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
             for (const BufferCorePageMapping& core_page_mapping :
                  dispatch_params.buffer_page_mapping->core_page_mappings[core_id]) {
                 write_sharded_buffer_to_core(
@@ -1327,42 +1315,34 @@ bool write_to_device_buffer(
                     dispatch_core_type);
             }
         }
-        // If the filter excluded every core, no DMA was issued, so callers must not treat the
-        // pinned transfer as in-flight (which would add spurious barrier events).
-        return use_pinned_transfer && any_core_written;
-    }
-    if (logical_core_filter != nullptr) {
-        TT_FATAL(
-            logical_core_filter->empty(),
-            "logical_core_filter is only supported for sharded buffer layouts (interleaved layout does not support "
-            "per-core filtering)");
-        // Empty filter -> no-op (consistent with the sharded path); nothing was actually written.
-        return false;
-    }
-    auto root_buffer = buffer.root_buffer();
-    auto region = buffer.root_buffer_region();
-    InterleavedBufferWriteDispatchParamsVariant dispatch_params_variant = initialize_interleaved_buf_dispatch_params(
-        *root_buffer,
-        cq_id,
-        expected_num_workers_completed,
-        region,
-        sub_device_ids,
-        pinned_src_noc_xy,
-        pinned_src_addr,
-        use_pinned_transfer,
-        remote_chip);
+    } else {
+        auto root_buffer = buffer.root_buffer();
+        auto region = buffer.root_buffer_region();
+        InterleavedBufferWriteDispatchParamsVariant dispatch_params_variant =
+            initialize_interleaved_buf_dispatch_params(
+                *root_buffer,
+                cq_id,
+                expected_num_workers_completed,
+                region,
+                sub_device_ids,
+                pinned_src_noc_xy,
+                pinned_src_addr,
+                use_pinned_transfer,
+                remote_chip);
 
-    InterleavedBufferWriteDispatchParams* dispatch_params = std::visit(
-        ttsl::overloaded{
-            [](std::derived_from<InterleavedBufferWriteDispatchParams> auto& val)
-                -> InterleavedBufferWriteDispatchParams* { return &val; },
-            [](std::monostate) -> InterleavedBufferWriteDispatchParams* { return nullptr; },
-        },
-        dispatch_params_variant);
-    TT_ASSERT(dispatch_params != nullptr);
+        InterleavedBufferWriteDispatchParams* dispatch_params = std::visit(
+            ttsl::overloaded{
+                [](std::derived_from<InterleavedBufferWriteDispatchParams> auto& val)
+                    -> InterleavedBufferWriteDispatchParams* { return &val; },
+                [](std::monostate) -> InterleavedBufferWriteDispatchParams* { return nullptr; },
+            },
+            dispatch_params_variant);
+        TT_ASSERT(dispatch_params != nullptr);
 
-    write_interleaved_buffer_to_device(
-        src, *dispatch_params, *root_buffer, buf_dispatch_constants, sub_device_ids, dispatch_core_type);
+        write_interleaved_buffer_to_device(
+            src, *dispatch_params, *root_buffer, buf_dispatch_constants, sub_device_ids, dispatch_core_type);
+        return use_pinned_transfer;
+    }
     return use_pinned_transfer;
 }
 
@@ -1425,8 +1405,9 @@ void issue_read_buffer_dispatch_command_sequence(
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
 
-    // Mock/emulated devices don't have real hardware to read from, skip actual dispatch
-    if (tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id()).get_cluster().is_mock_or_emulated()) {
+    // Mock devices don't have real hardware to read from, skip actual dispatch
+    if (tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id()).get_cluster().get_target_device_type() ==
+        tt::TargetDevice::Mock) {
         return;
     }
 

--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -37,6 +37,7 @@
 #include "tt_metal/api/tt-metalium/experimental/pinned_memory.hpp"
 #include <umd/device/types/core_coordinates.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
+#include <cstdint>
 
 namespace tt::tt_metal::buffer_dispatch {
 
@@ -44,32 +45,32 @@ namespace tt::tt_metal::buffer_dispatch {
 
 // Dispatch constants required for writing buffer data
 struct BufferDispatchConstants {
-    uint32_t issue_queue_cmd_limit = 0;
-    uint32_t max_prefetch_cmd_size = 0;
+    std::uint32_t issue_queue_cmd_limit = 0;
+    std::uint32_t max_prefetch_cmd_size = 0;
 };
 
 // Dispatch parameters computed during runtime. These are used
 // to assemble dispatch commands and compute src + dst offsets
 // required to write buffer data.
 struct BufferWriteDispatchParams {
-    tt::stl::Span<const uint32_t> expected_num_workers_completed;
-    uint32_t address = 0;
-    uint32_t page_size_to_write = 0;
-    uint32_t data_size_to_copy = 0;
-    uint32_t total_pages_to_write = 0;
-    uint32_t total_pages_written = 0;
-    uint32_t pages_per_txn = 0;
+    tt::stl::Span<const std::uint32_t> expected_num_workers_completed;
+    std::uint32_t address = 0;
+    std::uint32_t page_size_to_write = 0;
+    std::uint32_t data_size_to_copy = 0;
+    std::uint32_t total_pages_to_write = 0;
+    std::uint32_t total_pages_written = 0;
+    std::uint32_t pages_per_txn = 0;
     bool issue_wait = false;
     IDevice* device = nullptr;
-    uint32_t cq_id = 0;
-    uint32_t pinned_src_noc_xy = 0;
-    uint64_t pinned_src_addr = 0;
+    std::uint32_t cq_id = 0;
+    std::uint32_t pinned_src_noc_xy = 0;
+    std::uint64_t pinned_src_addr = 0;
     bool use_pinned_transfer = false;
     bool remote_chip = false;
 
     BufferWriteDispatchParams() = default;
     BufferWriteDispatchParams(
-        uint32_t src_noc_xy, uint64_t src_addr, bool src_pinned = false, bool remote_chip = false) :
+        std::uint32_t src_noc_xy, std::uint64_t src_addr, bool src_pinned = false, bool remote_chip = false) :
         pinned_src_noc_xy{src_noc_xy},
         pinned_src_addr{src_addr},
         use_pinned_transfer{src_pinned},
@@ -83,18 +84,18 @@ struct BufferWriteDispatchParams {
 // Parameters specific to interleaved buffers
 class InterleavedBufferWriteDispatchParams : public BufferWriteDispatchParams {
 public:
-    uint32_t dst_page_index = 0;
+    std::uint32_t dst_page_index = 0;
     // Number of bytes to copy on the CPU at the start of the write to align the write to the host memory alignment.
     size_t alignment_prefix_bytes = 0;
 
     InterleavedBufferWriteDispatchParams(
         const Buffer& buffer,
-        uint32_t dst_page_index,
-        uint32_t total_pages_to_write,
-        uint32_t cq_id,
-        tt::stl::Span<const uint32_t> expected_num_workers_completed,
-        uint32_t src_noc_xy,
-        uint64_t src_addr,
+        std::uint32_t dst_page_index,
+        std::uint32_t total_pages_to_write,
+        std::uint32_t cq_id,
+        tt::stl::Span<const std::uint32_t> expected_num_workers_completed,
+        std::uint32_t src_noc_xy,
+        std::uint64_t src_addr,
         bool src_pinned,
         bool remote_chip) :
         BufferWriteDispatchParams(src_noc_xy, src_addr, src_pinned, remote_chip), dst_page_index(dst_page_index) {
@@ -108,8 +109,8 @@ public:
         this->cq_id = cq_id;
         this->expected_num_workers_completed = expected_num_workers_completed;
         if (src_pinned) {
-            const uint64_t relay_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
-            const uint64_t alignment_offset = src_addr % relay_alignment;
+            const std::uint64_t relay_alignment = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+            const std::uint64_t alignment_offset = src_addr % relay_alignment;
             if (alignment_offset != 0) {
                 this->alignment_prefix_bytes = relay_alignment - alignment_offset;
             }
@@ -123,7 +124,7 @@ public:
     InterleavedBufferWriteDispatchParams(InterleavedBufferWriteDispatchParams&& other) = default;
     InterleavedBufferWriteDispatchParams& operator=(InterleavedBufferWriteDispatchParams&& other) = default;
 
-    virtual void calculate_num_pages_for_write_transaction(uint32_t num_pages_available_in_cq) {
+    virtual void calculate_num_pages_for_write_transaction(std::uint32_t num_pages_available_in_cq) {
         this->pages_per_txn = std::min(this->total_pages_to_write, num_pages_available_in_cq);
     }
 
@@ -135,7 +136,7 @@ public:
     // To handle larger page offsets move bank base address up and update page offset to be relative to the new
     // bank address
     virtual void update_params_to_be_within_bounds() {
-        const uint32_t num_pages_written_per_bank = this->dst_page_index / this->num_banks;
+        const std::uint32_t num_pages_written_per_bank = this->dst_page_index / this->num_banks;
         this->address += num_pages_written_per_bank * this->page_size_to_write;
         this->dst_page_index %= this->num_banks;
     }
@@ -148,28 +149,28 @@ public:
 
     virtual bool write_large_pages() const { return false; }
 
-    virtual uint32_t num_full_pages_written() const { return this->total_pages_written; }
+    virtual std::uint32_t num_full_pages_written() const { return this->total_pages_written; }
 
-    virtual uint32_t num_partial_pages_written_for_current_transaction_full_pages() const { return 1; }
+    virtual std::uint32_t num_partial_pages_written_for_current_transaction_full_pages() const { return 1; }
 
-    virtual uint32_t partial_page_size() const { return this->page_size_to_write; }
+    virtual std::uint32_t partial_page_size() const { return this->page_size_to_write; }
 
 protected:
-    uint32_t num_banks = 0;
+    std::uint32_t num_banks = 0;
 };
 
 class InterleavedBufferWriteLargePageDispatchParams : public InterleavedBufferWriteDispatchParams {
 public:
     InterleavedBufferWriteLargePageDispatchParams(
         const Buffer& buffer,
-        uint32_t dst_page_index,
+        std::uint32_t dst_page_index,
         const PartialPageSpec& partial_page_spec,
-        uint32_t total_pages_to_write,  // number of partial pages
-        uint32_t num_full_pages,
-        uint32_t cq_id,
-        tt::stl::Span<const uint32_t> expected_num_workers_completed,
-        uint32_t src_noc_xy,
-        uint64_t src_addr,
+        std::uint32_t total_pages_to_write,  // number of partial pages
+        std::uint32_t num_full_pages,
+        std::uint32_t cq_id,
+        tt::stl::Span<const std::uint32_t> expected_num_workers_completed,
+        std::uint32_t src_noc_xy,
+        std::uint64_t src_addr,
         bool src_pinned,
         bool remote_chip) :
         InterleavedBufferWriteDispatchParams(
@@ -192,13 +193,13 @@ public:
             this->data_size_to_copy = partial_page_spec.partial_page_size;
 
             this->end_bank_indices.push(this->num_banks);
-            for (uint32_t i = 0; i < this->num_banks; i++) {
+            for (std::uint32_t i = 0; i < this->num_banks; i++) {
                 this->curr_full_pages_curr_addresses.push_back(this->curr_full_pages_start_address);
             }
         }
     }
 
-    void calculate_num_pages_for_write_transaction(uint32_t num_pages_available_in_cq) override {
+    void calculate_num_pages_for_write_transaction(std::uint32_t num_pages_available_in_cq) override {
         TT_ASSERT(this->end_bank_indices.top() > this->dst_page_index);
         this->pages_per_txn = std::min(
             {this->full_pages_to_write,
@@ -212,13 +213,13 @@ public:
     bool is_page_offset_out_of_bounds() const override { return this->dst_page_index >= this->num_banks; }
 
     void update_params_to_be_within_bounds() override {
-        const uint32_t num_pages_written_per_bank = this->dst_page_index / this->num_banks;
+        const std::uint32_t num_pages_written_per_bank = this->dst_page_index / this->num_banks;
         this->address += num_pages_written_per_bank * this->buffer.aligned_page_size();
         this->curr_full_pages_start_address = this->address;
         this->dst_page_index %= this->num_banks;
     }
 
-    uint32_t num_partial_pages_written_for_current_transaction_full_pages() const override {
+    std::uint32_t num_partial_pages_written_for_current_transaction_full_pages() const override {
         if (this->address - this->curr_full_pages_start_address == this->buffer.aligned_page_size()) {
             return this->num_partial_pages_in_single_full_page;
         }
@@ -229,7 +230,7 @@ public:
         this->total_pages_to_write -= this->pages_per_txn;
         this->total_pages_written += this->pages_per_txn;
         this->address += this->page_size_to_write;
-        for (uint32_t i = this->dst_page_index; i < this->dst_page_index + this->pages_per_txn; i++) {
+        for (std::uint32_t i = this->dst_page_index; i < this->dst_page_index + this->pages_per_txn; i++) {
             this->curr_full_pages_curr_addresses[i] = this->address;
         }
         if (this->were_full_pages_written_in_last_write_transaction()) {
@@ -240,7 +241,7 @@ public:
                 this->address = this->curr_full_pages_curr_addresses[this->dst_page_index + this->pages_per_txn];
             } else {
                 this->curr_full_pages_start_address = this->address;
-                for (uint32_t i = 0; i < this->num_banks; i++) {
+                for (std::uint32_t i = 0; i < this->num_banks; i++) {
                     this->curr_full_pages_curr_addresses[i] = this->curr_full_pages_start_address;
                 }
             }
@@ -263,32 +264,32 @@ public:
 
     bool write_large_pages() const override { return true; }
 
-    uint32_t num_full_pages_written() const override { return this->full_pages_written; }
+    std::uint32_t num_full_pages_written() const override { return this->full_pages_written; }
 
-    uint32_t partial_page_size() const override { return this->size_of_partial_page; }
+    std::uint32_t partial_page_size() const override { return this->size_of_partial_page; }
 
 private:
     const Buffer& buffer;
-    uint32_t curr_full_pages_start_address = 0;
-    uint32_t size_of_partial_page = 0;
-    uint32_t num_partial_pages_in_single_full_page = 0;
-    uint32_t full_pages_written = 0;
-    uint32_t full_pages_to_write = 0;
-    std::stack<uint32_t> end_bank_indices;
-    std::vector<uint32_t> curr_full_pages_curr_addresses;
+    std::uint32_t curr_full_pages_start_address = 0;
+    std::uint32_t size_of_partial_page = 0;
+    std::uint32_t num_partial_pages_in_single_full_page = 0;
+    std::uint32_t full_pages_written = 0;
+    std::uint32_t full_pages_to_write = 0;
+    std::stack<std::uint32_t> end_bank_indices;
+    std::vector<std::uint32_t> curr_full_pages_curr_addresses;
 
     bool were_full_pages_written_in_last_write_transaction() const {
-        const int32_t page_size = this->address - this->curr_full_pages_start_address;
+        const std::int32_t page_size = this->address - this->curr_full_pages_start_address;
         return page_size == this->buffer.aligned_page_size();
     }
 
     bool will_full_pages_be_written_in_next_write_transaction() const {
-        const int32_t page_size = this->address + this->page_size_to_write - this->curr_full_pages_start_address;
+        const std::int32_t page_size = this->address + this->page_size_to_write - this->curr_full_pages_start_address;
         return page_size == (this->num_partial_pages_in_single_full_page * this->page_size_to_write);
     }
 
     bool will_next_full_page_be_round_robined() const {
-        const uint32_t dst_page_index_next_txn = this->dst_page_index + this->pages_per_txn;
+        const std::uint32_t dst_page_index_next_txn = this->dst_page_index + this->pages_per_txn;
         return dst_page_index_next_txn != (dst_page_index_next_txn % this->num_banks);
     }
 };
@@ -299,16 +300,16 @@ public:
     std::shared_ptr<const BufferPageMapping> buffer_page_mapping = nullptr;
     BufferCorePageMapping::Iterator core_page_mapping_it;
     CoreCoord core;
-    uint32_t core_num_pages_remaining_to_write = 0;
+    std::uint32_t core_num_pages_remaining_to_write = 0;
 
     ShardedBufferWriteDispatchParams(
         Buffer* buffer,
-        uint32_t total_pages_to_write,
-        uint32_t cq_id,
-        tt::stl::Span<const uint32_t> expected_num_workers_completed,
+        std::uint32_t total_pages_to_write,
+        std::uint32_t cq_id,
+        tt::stl::Span<const std::uint32_t> expected_num_workers_completed,
         tt::stl::Span<const SubDeviceId> sub_device_ids,
-        uint32_t pinned_noc_xy,
-        uint64_t pinned_addr,
+        std::uint32_t pinned_noc_xy,
+        std::uint64_t pinned_addr,
         bool is_pinned,
         bool remote_chip) :
         BufferWriteDispatchParams(pinned_noc_xy, pinned_addr, is_pinned, remote_chip),
@@ -360,18 +361,18 @@ public:
 
     bool write_large_pages() const { return this->are_pages_large; }
 
-    uint32_t partial_page_size() const { return this->size_of_partial_page; }
+    std::uint32_t partial_page_size() const { return this->size_of_partial_page; }
 
-    uint32_t num_partial_pages_written_for_current_transaction_full_page() const {
+    std::uint32_t num_partial_pages_written_for_current_transaction_full_page() const {
         return this->num_partial_pages_written_for_curr_full_page;
     }
 
-    void calculate_params_for_write_transaction(uint32_t num_pages_available_in_cq) {
+    void calculate_params_for_write_transaction(std::uint32_t num_pages_available_in_cq) {
         if (this->are_pages_large) {
-            const int32_t num_partial_pages_remaining_in_curr_full_page =
+            const std::int32_t num_partial_pages_remaining_in_curr_full_page =
                 this->num_partial_pages_in_single_full_page - this->num_partial_pages_written_for_curr_full_page;
             TT_ASSERT(num_partial_pages_remaining_in_curr_full_page > 0);
-            const uint32_t max_num_partial_pages_to_write_in_curr_txn =
+            const std::uint32_t max_num_partial_pages_to_write_in_curr_txn =
                 (num_partial_pages_remaining_in_curr_full_page == 1)
                     ? 1
                     : num_partial_pages_remaining_in_curr_full_page - 1;
@@ -415,33 +416,33 @@ public:
 private:
     const Buffer* buffer = nullptr;
     bool are_pages_large = false;
-    uint32_t size_of_partial_page = 0;
-    uint32_t num_partial_pages_written_for_curr_full_page = 0;
-    uint32_t num_partial_pages_in_single_full_page = 0;
+    std::uint32_t size_of_partial_page = 0;
+    std::uint32_t num_partial_pages_written_for_curr_full_page = 0;
+    std::uint32_t num_partial_pages_in_single_full_page = 0;
 };
 
-int32_t calculate_num_pages_available_in_cq(
+std::int32_t calculate_num_pages_available_in_cq(
     const BufferWriteDispatchParams& dispatch_params,
     const BufferDispatchConstants& dispatch_constants,
-    uint32_t byte_offset_in_cq) {
+    std::uint32_t byte_offset_in_cq) {
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
-    uint32_t space_availableB = std::min(
+    std::uint32_t space_availableB = std::min(
         dispatch_constants.issue_queue_cmd_limit - sysmem_manager.get_issue_queue_write_ptr(dispatch_params.cq_id),
         dispatch_constants.max_prefetch_cmd_size);
-    int32_t num_pages_available =
-        (int32_t(space_availableB) - int32_t(byte_offset_in_cq)) / int32_t(dispatch_params.page_size_to_write);
+    std::int32_t num_pages_available = (std::int32_t(space_availableB) - std::int32_t(byte_offset_in_cq)) /
+                                       std::int32_t(dispatch_params.page_size_to_write);
     return num_pages_available;
 }
 
-bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer, uint32_t num_subdevices) {
+bool are_pages_larger_than_max_prefetch_cmd_size(const Buffer& buffer, std::uint32_t num_subdevices) {
     const CoreType dispatch_core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-    const uint32_t max_data_size = calculate_max_prefetch_data_size_bytes(dispatch_core_type, num_subdevices);
+    const std::uint32_t max_data_size = calculate_max_prefetch_data_size_bytes(dispatch_core_type, num_subdevices);
     return buffer.aligned_page_size() > max_data_size;
 }
 
-uint32_t calculate_partial_page_size(const Buffer& buffer) {
+std::uint32_t calculate_partial_page_size(const Buffer& buffer) {
     const HalMemType buffer_mem_type = buffer.memory_type();
-    const uint32_t partial_page_size = tt::align(
+    const std::uint32_t partial_page_size = tt::align(
         DispatchSettings::BASE_PARTIAL_PAGE_SIZE_DISPATCH,
         MetalContext::instance().hal().get_common_alignment_with_pcie(buffer_mem_type));
     return partial_page_size;
@@ -457,7 +458,7 @@ PartialPageSpec calculate_partial_page_spec(const Buffer& buffer) {
 
 // Generate dispatch constants
 BufferDispatchConstants generate_buffer_dispatch_constants(
-    const SystemMemoryManager& sysmem_manager, CoreType /*dispatch_core_type*/, uint32_t cq_id) {
+    const SystemMemoryManager& sysmem_manager, CoreType /*dispatch_core_type*/, std::uint32_t cq_id) {
     BufferDispatchConstants buf_dispatch_constants;
 
     buf_dispatch_constants.issue_queue_cmd_limit = sysmem_manager.get_issue_queue_limit(cq_id);
@@ -467,7 +468,7 @@ BufferDispatchConstants generate_buffer_dispatch_constants(
     return buf_dispatch_constants;
 }
 
-void update_offset_on_issue_wait_cmd(uint32_t& byte_offset, bool issue_wait, uint32_t num_sub_devices) {
+void update_offset_on_issue_wait_cmd(std::uint32_t& byte_offset, bool issue_wait, std::uint32_t num_sub_devices) {
     if (issue_wait) {
         // commands prefixed with CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WAIT
         byte_offset += (MetalContext::instance().hal().get_alignment(HalMemType::HOST) * num_sub_devices);
@@ -479,22 +480,22 @@ using InterleavedBufferWriteDispatchParamsVariant =
 
 InterleavedBufferWriteDispatchParamsVariant initialize_interleaved_buf_dispatch_params(
     const Buffer& buffer,
-    uint32_t cq_id,
-    tt::stl::Span<const uint32_t> expected_num_workers_completed,
+    std::uint32_t cq_id,
+    tt::stl::Span<const std::uint32_t> expected_num_workers_completed,
     const BufferRegion& region,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
-    uint32_t pinned_src_noc_xy,
-    uint64_t pinned_src_addr,
+    std::uint32_t pinned_src_noc_xy,
+    std::uint64_t pinned_src_addr,
     bool use_pinned_transfer,
     bool remote_chip) {
     InterleavedBufferWriteDispatchParamsVariant dispatch_params;
 
-    uint32_t total_pages_to_write = region.size / buffer.page_size();
-    const uint32_t dst_page_index = region.offset / buffer.page_size();
+    std::uint32_t total_pages_to_write = region.size / buffer.page_size();
+    const std::uint32_t dst_page_index = region.offset / buffer.page_size();
 
     if (!use_pinned_transfer && are_pages_larger_than_max_prefetch_cmd_size(buffer, sub_device_ids.size())) {
         const PartialPageSpec partial_page_spec = calculate_partial_page_spec(buffer);
-        const uint32_t num_full_pages = total_pages_to_write;
+        const std::uint32_t num_full_pages = total_pages_to_write;
         total_pages_to_write = num_full_pages * partial_page_spec.num_partial_pages_per_full_page;
         dispatch_params.emplace<InterleavedBufferWriteLargePageDispatchParams>(
             buffer,
@@ -529,11 +530,12 @@ void populate_interleaved_buffer_write_dispatch_cmds(
     HugepageDeviceCommand& command_sequence,
     Buffer& buffer,
     InterleavedBufferWriteDispatchParams& dispatch_params) {
-    const uint8_t is_dram = uint8_t(buffer.is_dram());
+    const std::uint8_t is_dram = std::uint8_t(buffer.is_dram());
     TT_ASSERT(
         dispatch_params.dst_page_index <= CQ_DISPATCH_CMD_PAGED_WRITE_MAX_PAGE_INDEX,
         "Page offset needs to fit within range of uint16_t, bank_base_address was computed incorrectly!");
-    const uint16_t start_page = uint16_t(dispatch_params.dst_page_index & CQ_DISPATCH_CMD_PAGED_WRITE_MAX_PAGE_INDEX);
+    const std::uint16_t start_page =
+        std::uint16_t(dispatch_params.dst_page_index & CQ_DISPATCH_CMD_PAGED_WRITE_MAX_PAGE_INDEX);
 
     bool use_pinned_transfer = dispatch_params.use_pinned_transfer;
 
@@ -566,17 +568,17 @@ void populate_interleaved_buffer_write_dispatch_cmds(
     }
 
     if (not use_pinned_transfer) {
-        const uint32_t data_size_bytes = dispatch_params.pages_per_txn * dispatch_params.page_size_to_write;
+        const std::uint32_t data_size_bytes = dispatch_params.pages_per_txn * dispatch_params.page_size_to_write;
         // TODO: Consolidate
         if (dispatch_params.write_large_pages()) {
-            const uint32_t num_full_pages_written = dispatch_params.num_full_pages_written();
-            const uint32_t num_partial_pages_written_per_curr_full_pages =
+            const std::uint32_t num_full_pages_written = dispatch_params.num_full_pages_written();
+            const std::uint32_t num_partial_pages_written_per_curr_full_pages =
                 dispatch_params.num_partial_pages_written_for_current_transaction_full_pages();
-            uint32_t num_partial_pages_written_curr_txn = 0;
-            for (uint32_t sysmem_address_offset = 0; sysmem_address_offset < data_size_bytes;
+            std::uint32_t num_partial_pages_written_curr_txn = 0;
+            for (std::uint32_t sysmem_address_offset = 0; sysmem_address_offset < data_size_bytes;
                  sysmem_address_offset += dispatch_params.page_size_to_write) {
-                const uint64_t src_address_offset =
-                    ((uint64_t)num_full_pages_written * buffer.page_size()) +
+                const std::uint64_t src_address_offset =
+                    ((std::uint64_t)num_full_pages_written * buffer.page_size()) +
                     (num_partial_pages_written_per_curr_full_pages * dispatch_params.partial_page_size()) +
                     (num_partial_pages_written_curr_txn * buffer.page_size());
                 command_sequence.add_data(
@@ -589,7 +591,7 @@ void populate_interleaved_buffer_write_dispatch_cmds(
             DeviceAddr src_address_offset = DeviceAddr(dispatch_params.total_pages_written) * buffer.page_size();
             if (buffer.page_size() % buffer.alignment() != 0 and buffer.page_size() != buffer.size()) {
                 // If page size is not aligned, we cannot do a contiguous write
-                for (uint32_t sysmem_address_offset = 0; sysmem_address_offset < data_size_bytes;
+                for (std::uint32_t sysmem_address_offset = 0; sysmem_address_offset < data_size_bytes;
                      sysmem_address_offset += dispatch_params.page_size_to_write) {
                     command_sequence.add_data(
                         static_cast<const char*>(src) + src_address_offset,
@@ -613,7 +615,7 @@ void populate_sharded_buffer_write_dispatch_cmds(
     HugepageDeviceCommand& command_sequence,
     Buffer& buffer,
     ShardedBufferWriteDispatchParams& dispatch_params) {
-    const uint32_t data_size_bytes = dispatch_params.pages_per_txn * dispatch_params.page_size_to_write;
+    const std::uint32_t data_size_bytes = dispatch_params.pages_per_txn * dispatch_params.page_size_to_write;
     const CoreCoord virtual_core =
         buffer.device()->virtual_core_from_logical_core(dispatch_params.core, buffer.core_type());
     command_sequence.add_dispatch_write_linear(
@@ -622,9 +624,9 @@ void populate_sharded_buffer_write_dispatch_cmds(
         dispatch_params.address,
         data_size_bytes);
 
-    uint8_t* dst = command_sequence.reserve_space<uint8_t*, true>(data_size_bytes);
+    std::uint8_t* dst = command_sequence.reserve_space<std::uint8_t*, true>(data_size_bytes);
     // TODO: Expose getter for cmd_write_offsetB?
-    ptrdiff_t dst_offset = reinterpret_cast<ptrdiff_t>(dst - (uint8_t*)command_sequence.data());
+    ptrdiff_t dst_offset = reinterpret_cast<ptrdiff_t>(dst - (std::uint8_t*)command_sequence.data());
     TT_ASSERT(dst_offset >= 0, "Offset into command sequence is negative");
     if (dispatch_params.write_large_pages()) {
         const auto cur_host_page = *dispatch_params.core_page_mapping_it;
@@ -632,9 +634,9 @@ void populate_sharded_buffer_write_dispatch_cmds(
             command_sequence.align_write_offset();
             return;
         }
-        for (uint32_t i = 0; i < dispatch_params.pages_per_txn; ++i) {
-            const uint64_t src_offset =
-                (*cur_host_page * (uint64_t)buffer.page_size()) +
+        for (std::uint32_t i = 0; i < dispatch_params.pages_per_txn; ++i) {
+            const std::uint64_t src_offset =
+                (*cur_host_page * (std::uint64_t)buffer.page_size()) +
                 ((dispatch_params.num_partial_pages_written_for_current_transaction_full_page() + i) *
                  dispatch_params.partial_page_size());
             command_sequence.update_cmd_sequence(
@@ -642,15 +644,15 @@ void populate_sharded_buffer_write_dispatch_cmds(
             dst_offset += dispatch_params.page_size_to_write;
         }
     } else if (buffer.page_size() == dispatch_params.page_size_to_write) {
-        uint32_t start_device_page_offset = dispatch_params.core_page_mapping_it.device_page_offset();
-        uint32_t end_device_page_offset = start_device_page_offset + dispatch_params.pages_per_txn;
+        std::uint32_t start_device_page_offset = dispatch_params.core_page_mapping_it.device_page_offset();
+        std::uint32_t end_device_page_offset = start_device_page_offset + dispatch_params.pages_per_txn;
         while (true) {
             auto range = dispatch_params.core_page_mapping_it.next_range(end_device_page_offset);
             if (range.num_pages == 0) {
                 command_sequence.align_write_offset();
                 return;
             }
-            uint64_t src_offset = (uint64_t)(range.host_page_start) * dispatch_params.page_size_to_write;
+            std::uint64_t src_offset = (std::uint64_t)(range.host_page_start) * dispatch_params.page_size_to_write;
             auto cmd_region_offset =
                 dispatch_params.page_size_to_write * (range.device_page_offset - start_device_page_offset);
             command_sequence.update_cmd_sequence(
@@ -666,7 +668,7 @@ void populate_sharded_buffer_write_dispatch_cmds(
                 dst_offset += dispatch_params.page_size_to_write;
                 continue;
             }
-            const uint64_t src_offset = *cur_host_page * (uint64_t)buffer.page_size();
+            const std::uint64_t src_offset = *cur_host_page * (std::uint64_t)buffer.page_size();
             command_sequence.update_cmd_sequence(
                 dst_offset, static_cast<const char*>(src) + src_offset, buffer.page_size());
             dst_offset += dispatch_params.page_size_to_write;
@@ -686,25 +688,28 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
     ZoneScoped;
     ContextId context_id = tt::tt_metal::extract_context_id(buffer.device());
     const auto& hal = tt::tt_metal::MetalContext::instance(context_id).hal();
-    const uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
-    const uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
+    const std::uint32_t pcie_alignment = hal.get_alignment(HalMemType::HOST);
+    const std::uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
-    uint32_t num_worker_counters = sub_device_ids.size();
+    std::uint32_t num_worker_counters = sub_device_ids.size();
 
-    const uint8_t* src_ptr = static_cast<const uint8_t*>(src);
-    const uint64_t pinned_src_addr_base = dispatch_params.pinned_src_addr;
-    const uint32_t pinned_src_noc_xy = dispatch_params.pinned_src_noc_xy;
+    const std::uint8_t* src_ptr = static_cast<const std::uint8_t*>(src);
+    const std::uint64_t pinned_src_addr_base = dispatch_params.pinned_src_addr;
+    const std::uint32_t pinned_src_noc_xy = dispatch_params.pinned_src_noc_xy;
 
     // Build sub-commands on the fly with coalescing
     std::vector<CQDispatchWritePackedLargeUnicastSubCmd> write_sub_cmds;
     std::vector<CQPrefetchRelayLinearPackedSubCmd> relay_sub_cmds;
+    std::uint32_t relay_stream_offset = 0;
 
     const CoreCoord virtual_core = buffer.device()->virtual_core_from_logical_core(core, buffer.core_type());
-    const uint32_t noc_xy_addr = buffer.device()->get_noc_unicast_encoding(k_dispatch_downstream_noc, virtual_core);
+    const std::uint32_t noc_xy_addr =
+        buffer.device()->get_noc_unicast_encoding(k_dispatch_downstream_noc, virtual_core);
 
     // Calculate base destination address for this core
-    uint32_t dst_base_address = buffer.address() + (core_page_mapping.device_start_page * buffer.aligned_page_size());
+    std::uint32_t dst_base_address =
+        buffer.address() + (core_page_mapping.device_start_page * buffer.aligned_page_size());
     if (buffer.is_dram()) {
         dst_base_address += buffer.device()->allocator()->get_bank_offset(
             BufferType::DRAM, buffer.device()->dram_channel_from_logical_core(core));
@@ -717,7 +722,7 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             calculator.add_dispatch_wait();
         }
 
-        const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
+        const std::uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
         void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
         HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
@@ -750,7 +755,7 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             return;
         }
         // Calculate total relay length for the command
-        uint32_t total_relay_length = 0;
+        std::uint32_t total_relay_length = 0;
         for (const auto& relay_sub_cmd : relay_sub_cmds) {
             total_relay_length += relay_sub_cmd.length;
         }
@@ -810,17 +815,26 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
         // Clear for next batch
         write_sub_cmds.clear();
         relay_sub_cmds.clear();
+        relay_stream_offset = 0;
+    };
+
+    auto calculate_aligned_src = [&](std::uint64_t src_pinned_addr) {
+        const std::uint32_t relay_alignment_offset = relay_stream_offset % pcie_alignment;
+        const std::uint32_t padding_bytes =
+            (src_pinned_addr + pcie_alignment - relay_alignment_offset) % pcie_alignment;
+        return std::pair<std::uint64_t, std::uint32_t>{src_pinned_addr - padding_bytes, padding_bytes};
     };
 
     // Iterate through host ranges and build sub-commands
     for (const auto& host_range : core_page_mapping.host_ranges) {
-        uint64_t src_offset = static_cast<uint64_t>(host_range.host_page_start) * buffer.page_size();
-        const uint8_t* src_region_start = src_ptr + src_offset;
-        uint64_t src_pinned_addr = pinned_src_addr_base + src_offset;
+        std::uint64_t src_offset = static_cast<std::uint64_t>(host_range.host_page_start) * buffer.page_size();
+        const std::uint8_t* src_region_start = src_ptr + src_offset;
+        std::uint64_t src_pinned_addr = pinned_src_addr_base + src_offset;
 
-        uint32_t dst_addr = dst_base_address + ((host_range.device_page_offset - core_page_mapping.device_start_page) *
-                                                buffer.aligned_page_size());
-        uint32_t data_length = host_range.num_pages * buffer.page_size();
+        std::uint32_t dst_addr =
+            dst_base_address +
+            ((host_range.device_page_offset - core_page_mapping.device_start_page) * buffer.aligned_page_size());
+        std::uint32_t data_length = host_range.num_pages * buffer.page_size();
 
         // Assert alignments (should have been checked in write_to_device_buffer)
         TT_ASSERT(
@@ -834,15 +848,10 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             dst_addr,
             l1_alignment);
 
-        // Align source address to PCIe alignment if needed
-        uint64_t aligned_src_addr = src_pinned_addr;
-        uint32_t padding_bytes = 0;
-        if (src_pinned_addr % pcie_alignment != 0) {
-            padding_bytes = src_pinned_addr % pcie_alignment;
-            aligned_src_addr = src_pinned_addr - padding_bytes;
-        }
-
-        uint32_t total_read_length = padding_bytes + data_length;
+        // Align each read to the scratch stream position. Packed reads concatenate into scratch, so re-aligning every
+        // host range to address 0 mod PCIe alignment can violate NoC source/destination congruence after a prefix.
+        auto [aligned_src_addr, padding_bytes] = calculate_aligned_src(src_pinned_addr);
+        std::uint32_t total_read_length = padding_bytes + data_length;
 
         // Determine if relay or write can be coalesced
         bool can_coalesce_relay = false;
@@ -864,9 +873,10 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
         }
 
         // Calculate new counts after adding this range
-        uint32_t new_relay_count = relay_sub_cmds.size() + (can_coalesce_relay ? 0 : 1);
-        uint32_t new_write_count = write_sub_cmds.size() + (padding_bytes > 0 ? 1 : 0) +  // discard command if padding
-                                   (can_coalesce_write ? 0 : 1);                          // data command
+        std::uint32_t new_relay_count = relay_sub_cmds.size() + (can_coalesce_relay ? 0 : 1);
+        std::uint32_t new_write_count = write_sub_cmds.size() +
+                                        (padding_bytes > 0 ? 1 : 0) +  // discard command if padding
+                                        (can_coalesce_write ? 0 : 1);  // data command
 
         // Check if either would exceed limits
         if (new_relay_count > CQ_PREFETCH_CMD_RELAY_LINEAR_PACKED_MAX_SUB_CMDS ||
@@ -876,6 +886,10 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             // After emitting, we can't coalesce with previous commands (vectors are now empty)
             can_coalesce_relay = false;
             can_coalesce_write = false;
+            const auto aligned_src_info = calculate_aligned_src(src_pinned_addr);
+            aligned_src_addr = aligned_src_info.first;
+            padding_bytes = aligned_src_info.second;
+            total_read_length = padding_bytes + data_length;
         }
 
         // Add or coalesce relay sub-command
@@ -909,6 +923,8 @@ void issue_sharded_buffer_pinned_dispatch_command_sequence(
             write_sub_cmd.length = data_length;
             write_sub_cmds.push_back(write_sub_cmd);
         }
+
+        relay_stream_offset += total_read_length;
     }
 
     // Emit final command pair with remaining sub-commands
@@ -923,11 +939,11 @@ void issue_buffer_dispatch_command_sequence(
     T& dispatch_params,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     CoreType /*dispatch_core_type*/) {
-    uint32_t num_worker_counters = sub_device_ids.size();
+    std::uint32_t num_worker_counters = sub_device_ids.size();
     bool use_pinned_memory = dispatch_params.use_pinned_transfer;
-    uint32_t num_pages_to_write =
+    std::uint32_t num_pages_to_write =
         use_pinned_memory ? dispatch_params.total_pages_to_write : dispatch_params.pages_per_txn;
-    uint64_t data_size_bytes = uint64_t(num_pages_to_write) * dispatch_params.page_size_to_write;
+    std::uint64_t data_size_bytes = std::uint64_t(num_pages_to_write) * dispatch_params.page_size_to_write;
 
     tt::tt_metal::DeviceCommandCalculator calculator;
     if (dispatch_params.issue_wait) {
@@ -952,7 +968,7 @@ void issue_buffer_dispatch_command_sequence(
         calculator.add_data<false>(data_size_bytes);
     }
 
-    const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
+    const std::uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
 
@@ -989,8 +1005,9 @@ void issue_buffer_dispatch_command_sequence(
         // CQ_PREFETCH_CMD_RELAY_INLINE_NOFLUSH command and send it to prefetch_d
 
         // Adjust address and length if we sent alignment prefix bytes inline
-        uint64_t relay_src_addr = dispatch_params.pinned_src_addr;
-        uint64_t relay_data_size = (uint64_t)dispatch_params.total_pages_to_write * dispatch_params.page_size_to_write;
+        std::uint64_t relay_src_addr = dispatch_params.pinned_src_addr;
+        std::uint64_t relay_data_size =
+            (std::uint64_t)dispatch_params.total_pages_to_write * dispatch_params.page_size_to_write;
         if constexpr (std::is_same_v<T, InterleavedBufferWriteDispatchParams>) {
             TT_ASSERT(
                 dispatch_params.alignment_prefix_bytes % MetalContext::instance().hal().get_alignment(HalMemType::L1) ==
@@ -1006,7 +1023,7 @@ void issue_buffer_dispatch_command_sequence(
         } else {
             calculator.add_prefetch_relay_linear();
         }
-        const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
+        const std::uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
         void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
         HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
@@ -1034,7 +1051,7 @@ void write_interleaved_buffer_to_device(
     bool use_pinned_memory = dispatch_params.use_pinned_transfer;
 
     // data appended after CQ_PREFETCH_CMD_RELAY_INLINE + CQ_DISPATCH_CMD_WRITE_PAGED
-    uint32_t byte_offset_in_cq = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
+    std::uint32_t byte_offset_in_cq = MetalContext::instance().hal().get_alignment(HalMemType::HOST);
 
     dispatch_params.calculate_issue_wait();
     update_offset_on_issue_wait_cmd(byte_offset_in_cq, dispatch_params.issue_wait, sub_device_ids.size());
@@ -1052,7 +1069,7 @@ void write_interleaved_buffer_to_device(
                 dispatch_params.update_params_to_be_within_bounds();
             }
 
-            const int32_t num_pages_available_in_cq =
+            const std::int32_t num_pages_available_in_cq =
                 calculate_num_pages_available_in_cq(dispatch_params, buf_dispatch_constants, byte_offset_in_cq);
             if (num_pages_available_in_cq <= 0) {
                 SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
@@ -1072,7 +1089,7 @@ void write_interleaved_buffer_to_device(
 
 void write_sharded_buffer_to_core(
     const void* src,
-    uint32_t /*core_id*/,
+    std::uint32_t /*core_id*/,
     const BufferCorePageMapping& core_page_mapping,
     Buffer& buffer,
     ShardedBufferWriteDispatchParams& dispatch_params,
@@ -1100,11 +1117,11 @@ void write_sharded_buffer_to_core(
     } else {
         DeviceCommandCalculator calculator;
         calculator.add_dispatch_write_linear<true, false>(0);
-        uint32_t data_offset_bytes = calculator.write_offset_bytes();
+        std::uint32_t data_offset_bytes = calculator.write_offset_bytes();
         update_offset_on_issue_wait_cmd(data_offset_bytes, dispatch_params.issue_wait, sub_device_ids.size());
 
         while (dispatch_params.core_num_pages_remaining_to_write != 0) {
-            const int32_t num_pages_available_in_cq =
+            const std::int32_t num_pages_available_in_cq =
                 calculate_num_pages_available_in_cq(dispatch_params, buf_dispatch_constants, data_offset_bytes);
             if (num_pages_available_in_cq <= 0) {
                 SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
@@ -1125,8 +1142,8 @@ void write_sharded_buffer_to_core(
 bool write_to_device_buffer(
     const void* src,
     Buffer& buffer,
-    uint32_t cq_id,
-    tt::stl::Span<const uint32_t> expected_num_workers_completed,
+    std::uint32_t cq_id,
+    tt::stl::Span<const std::uint32_t> expected_num_workers_completed,
     CoreType dispatch_core_type,
     tt::stl::Span<const SubDeviceId> sub_device_ids,
     const std::shared_ptr<experimental::PinnedMemory>& pinned_memory,
@@ -1146,8 +1163,8 @@ bool write_to_device_buffer(
     // Determine whether pinned direct read is feasible, and derive src noc params
     const bool is_unpadded = (buffer.page_size() == buffer.aligned_page_size());
     const bool has_pinned_inputs = (src != nullptr && pinned_memory != nullptr);
-    uint32_t pinned_src_noc_xy = 0;
-    uint64_t pinned_src_addr = 0;
+    std::uint32_t pinned_src_noc_xy = 0;
+    std::uint64_t pinned_src_addr = 0;
     bool use_pinned_transfer = false;
     bool remote_chip = false;
     if (has_pinned_inputs && is_unpadded && !is_sharded(buffer.buffer_layout())) {
@@ -1155,13 +1172,13 @@ bool write_to_device_buffer(
         auto noc_addr_pair_opt = pinned_memory->get_noc_addr(device_id);
         if (noc_addr_pair_opt.has_value()) {
             remote_chip = noc_addr_pair_opt->device_id != device_id;
-            const uint64_t pinned_noc_base = noc_addr_pair_opt->addr;
-            const uint8_t* pinned_host_base = static_cast<const uint8_t*>(pinned_memory->get_host_ptr());
-            const uint8_t* src_ptr = static_cast<const uint8_t*>(src);
-            const uint64_t pinned_size = pinned_memory->get_buffer_size();
+            const std::uint64_t pinned_noc_base = noc_addr_pair_opt->addr;
+            const std::uint8_t* pinned_host_base = static_cast<const std::uint8_t*>(pinned_memory->get_host_ptr());
+            const std::uint8_t* src_ptr = static_cast<const std::uint8_t*>(src);
+            const std::uint64_t pinned_size = pinned_memory->get_buffer_size();
             auto region = buffer.root_buffer_region();
-            const uint8_t* src_region_start = src_ptr + region.offset;
-            const uint8_t* src_region_end = src_region_start + region.size;
+            const std::uint8_t* src_region_start = src_ptr + region.offset;
+            const std::uint8_t* src_region_end = src_region_start + region.size;
             // Check against L1 alignment because we need the copy from the prefetcher to the dispatcher to be aligned.
             if (reinterpret_cast<uintptr_t>(src_region_start) % hal.get_read_alignment(HalMemType::L1) != 0) {
                 log_info(
@@ -1179,7 +1196,7 @@ bool write_to_device_buffer(
                     reinterpret_cast<uintptr_t>(src_region_start),
                     reinterpret_cast<uintptr_t>(src_region_end));
             } else {
-                const uint64_t src_offset_base = static_cast<uintptr_t>(src_region_start - pinned_host_base);
+                const std::uint64_t src_offset_base = static_cast<uintptr_t>(src_region_start - pinned_host_base);
                 pinned_src_addr = pinned_noc_base + src_offset_base;
                 pinned_src_noc_xy = noc_addr_pair_opt->pcie_xy_enc;
                 use_pinned_transfer = true;
@@ -1194,16 +1211,16 @@ bool write_to_device_buffer(
             // host ranges; skip pinned if total data per batch would be < 512kB, as otherwise we can't pipeline the
             // reads well.
             auto buffer_page_mapping = buffer.get_buffer_page_mapping();
-            uint32_t total_host_range_count = 0;
-            for (uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
+            std::uint32_t total_host_range_count = 0;
+            for (std::uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
                 for (const auto& core_page_mapping : buffer_page_mapping->core_page_mappings[core_id]) {
                     total_host_range_count += core_page_mapping.host_ranges.size();
                 }
             }
-            constexpr uint64_t pinned_min_batch_size = 512 * 1024;
+            constexpr std::uint64_t pinned_min_batch_size = 512 * 1024;
             bool batch_large_enough =
                 total_host_range_count == 0 ||
-                static_cast<uint64_t>(buffer.size()) * CQ_PREFETCH_CMD_RELAY_LINEAR_PACKED_MAX_SUB_CMDS >=
+                static_cast<std::uint64_t>(buffer.size()) * CQ_PREFETCH_CMD_RELAY_LINEAR_PACKED_MAX_SUB_CMDS >=
                     pinned_min_batch_size * total_host_range_count;
 
             if (batch_large_enough) {
@@ -1211,23 +1228,24 @@ bool write_to_device_buffer(
                 auto noc_addr_pair_opt = pinned_memory->get_noc_addr(device_id);
                 if (noc_addr_pair_opt.has_value()) {
                     remote_chip = noc_addr_pair_opt->device_id != device_id;
-                    const uint64_t pinned_noc_base = noc_addr_pair_opt->addr;
-                    const uint8_t* pinned_host_base = static_cast<const uint8_t*>(pinned_memory->get_host_ptr());
-                    const uint8_t* src_ptr = static_cast<const uint8_t*>(src);
-                    const uint64_t pinned_size = pinned_memory->get_buffer_size();
+                    const std::uint64_t pinned_noc_base = noc_addr_pair_opt->addr;
+                    const std::uint8_t* pinned_host_base =
+                        static_cast<const std::uint8_t*>(pinned_memory->get_host_ptr());
+                    const std::uint8_t* src_ptr = static_cast<const std::uint8_t*>(src);
+                    const std::uint64_t pinned_size = pinned_memory->get_buffer_size();
 
                     // Get L1 alignment requirement
-                    const uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
+                    const std::uint32_t l1_alignment = hal.get_alignment(HalMemType::L1);
 
                     // Check all source and destination addresses for L1 alignment
                     bool all_aligned = true;
                     const std::vector<CoreCoord>& cores = buffer_page_mapping->all_cores;
 
-                    for (uint32_t core_id = 0; core_id < buffer.num_cores() && all_aligned; ++core_id) {
+                    for (std::uint32_t core_id = 0; core_id < buffer.num_cores() && all_aligned; ++core_id) {
                         for (const BufferCorePageMapping& core_page_mapping :
                              buffer_page_mapping->core_page_mappings[core_id]) {
                             // Check destination L1 address alignment
-                            uint32_t dst_address =
+                            std::uint32_t dst_address =
                                 buffer.address() + (core_page_mapping.device_start_page * buffer.aligned_page_size());
                             if (buffer.is_dram()) {
                                 dst_address += buffer.device()->allocator()->get_bank_offset(
@@ -1240,11 +1258,11 @@ bool write_to_device_buffer(
 
                             // Check source address alignment for each host range
                             for (const auto& host_range : core_page_mapping.host_ranges) {
-                                uint64_t src_offset =
-                                    static_cast<uint64_t>(host_range.host_page_start) * buffer.page_size();
-                                const uint8_t* src_region_start = src_ptr + src_offset;
-                                uint32_t data_length = host_range.num_pages * buffer.page_size();
-                                const uint8_t* src_region_end = src_region_start + data_length;
+                                std::uint64_t src_offset =
+                                    static_cast<std::uint64_t>(host_range.host_page_start) * buffer.page_size();
+                                const std::uint8_t* src_region_start = src_ptr + src_offset;
+                                std::uint32_t data_length = host_range.num_pages * buffer.page_size();
+                                const std::uint8_t* src_region_end = src_region_start + data_length;
 
                                 // Check if within pinned region
                                 if (src_region_start < pinned_host_base ||
@@ -1267,7 +1285,7 @@ bool write_to_device_buffer(
                     }
 
                     if (all_aligned) {
-                        const uint64_t src_offset_base = static_cast<uintptr_t>(src_ptr - pinned_host_base);
+                        const std::uint64_t src_offset_base = static_cast<uintptr_t>(src_ptr - pinned_host_base);
                         pinned_src_addr = pinned_noc_base + src_offset_base;
                         pinned_src_noc_xy = noc_addr_pair_opt->pcie_xy_enc;
                         use_pinned_transfer = true;
@@ -1290,7 +1308,7 @@ bool write_to_device_buffer(
 
         bool any_core_written = false;
         //  Since we read core by core we are reading the device pages sequentially
-        for (uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
+        for (std::uint32_t core_id = 0; core_id < buffer.num_cores(); ++core_id) {
             if (logical_core_filter != nullptr && !logical_core_filter->contains(cores[core_id])) {
                 continue;
             }
@@ -1352,7 +1370,7 @@ bool write_to_device_buffer(
 
 // Initialize Dispatch Parameters - reused across write txns
 ShardedBufferReadDispatchParams initialize_sharded_buf_read_dispatch_params(
-    Buffer& buffer, uint32_t cq_id, tt::stl::Span<const uint32_t> expected_num_workers_completed) {
+    Buffer& buffer, std::uint32_t cq_id, tt::stl::Span<const std::uint32_t> expected_num_workers_completed) {
     // Note that the src_page_index is the device page idx, not the host page idx
     // Since we read core by core we are reading the device pages sequentially
     ShardedBufferReadDispatchParams dispatch_params;
@@ -1371,7 +1389,7 @@ ShardedBufferReadDispatchParams initialize_sharded_buf_read_dispatch_params(
 }
 
 BufferReadDispatchParams initialize_interleaved_buf_read_dispatch_params(
-    Buffer& buffer, uint32_t cq_id, tt::stl::Span<const uint32_t> expected_num_workers_completed) {
+    Buffer& buffer, std::uint32_t cq_id, tt::stl::Span<const std::uint32_t> expected_num_workers_completed) {
     auto root_buffer = buffer.root_buffer();
     const BufferRegion region = buffer.root_buffer_region();
     IDevice* device = root_buffer->device();
@@ -1412,29 +1430,30 @@ void issue_read_buffer_dispatch_command_sequence(
         return;
     }
 
-    uint32_t num_worker_counters = sub_device_ids.size();
+    std::uint32_t num_worker_counters = sub_device_ids.size();
 
     // Precompute whether pinned direct write is feasible, and derive dst noc params
     const bool is_unpadded = (buffer.page_size() == dispatch_params.padded_page_size);
     const bool has_pinned_inputs = (dispatch_params.dst != nullptr && dispatch_params.pinned_memory != nullptr);
-    const uint64_t xfer_bytes = static_cast<uint64_t>(dispatch_params.pages_per_txn) * dispatch_params.padded_page_size;
+    const std::uint64_t xfer_bytes =
+        static_cast<std::uint64_t>(dispatch_params.pages_per_txn) * dispatch_params.padded_page_size;
     bool use_pinned_transfer = false;
-    uint32_t pinned_dst_noc_xy = 0;
-    uint64_t pinned_dst_addr = 0;
+    std::uint32_t pinned_dst_noc_xy = 0;
+    std::uint64_t pinned_dst_addr = 0;
 
     if (has_pinned_inputs && is_unpadded) {
         auto noc_addr_pair_opt = dispatch_params.pinned_memory->get_noc_addr(dispatch_params.device->id());
         if (noc_addr_pair_opt.has_value()) {
-            const uint64_t pinned_noc_base = noc_addr_pair_opt->addr;
-            const uint8_t* pinned_host_base =
-                static_cast<const uint8_t*>(dispatch_params.pinned_memory->get_host_ptr());
-            const uint8_t* dst_ptr = static_cast<const uint8_t*>(dispatch_params.dst);
-            const uint8_t* pinned_region_end = pinned_host_base + dispatch_params.pinned_memory->get_buffer_size();
-            const uint8_t* dst_region_start = dst_ptr + dispatch_params.unpadded_dst_offset;
-            const uint8_t* dst_region_end = dst_region_start + xfer_bytes;
+            const std::uint64_t pinned_noc_base = noc_addr_pair_opt->addr;
+            const std::uint8_t* pinned_host_base =
+                static_cast<const std::uint8_t*>(dispatch_params.pinned_memory->get_host_ptr());
+            const std::uint8_t* dst_ptr = static_cast<const std::uint8_t*>(dispatch_params.dst);
+            const std::uint8_t* pinned_region_end = pinned_host_base + dispatch_params.pinned_memory->get_buffer_size();
+            const std::uint8_t* dst_region_start = dst_ptr + dispatch_params.unpadded_dst_offset;
+            const std::uint8_t* dst_region_end = dst_region_start + xfer_bytes;
             if ((reinterpret_cast<uintptr_t>(dst_region_start) % hal.get_write_alignment(HalMemType::HOST) == 0) &&
                 (dst_region_start >= pinned_host_base) && (dst_region_end <= pinned_region_end)) {
-                const uint64_t dst_offset_base = static_cast<uint64_t>(dst_region_start - pinned_host_base);
+                const std::uint64_t dst_offset_base = static_cast<std::uint64_t>(dst_region_start - pinned_host_base);
                 pinned_dst_addr = dst_offset_base + pinned_noc_base;
                 pinned_dst_noc_xy = noc_addr_pair_opt->pcie_xy_enc;
                 use_pinned_transfer = true;
@@ -1444,7 +1463,7 @@ void issue_read_buffer_dispatch_command_sequence(
 
     // Build calculator with the chosen path
     tt::tt_metal::DeviceCommandCalculator calculator;
-    for (uint32_t i = 0; i < num_worker_counters; ++i) {
+    for (std::uint32_t i = 0; i < num_worker_counters; ++i) {
         calculator.add_dispatch_wait();
     }
     calculator.add_prefetch_stall();
@@ -1456,14 +1475,14 @@ void issue_read_buffer_dispatch_command_sequence(
     }
     // Prefetch relay cmd has fixed header size in calculator regardless of type
     calculator.add_prefetch_relay_paged();
-    const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
+    const std::uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
 
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
-    uint32_t last_index = num_worker_counters - 1;
+    std::uint32_t last_index = num_worker_counters - 1;
     // We only need the write barrier + prefetch stall for the last wait cmd
-    for (uint32_t i = 0; i < last_index; ++i) {
+    for (std::uint32_t i = 0; i < last_index; ++i) {
         auto offset_index = *sub_device_ids[i];
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
@@ -1513,7 +1532,7 @@ void issue_read_buffer_dispatch_command_sequence(
 
 // Top level functions to copy device buffers into the completion queue
 void copy_sharded_buffer_from_core_to_completion_queue(
-    uint32_t /*core_id*/,
+    std::uint32_t /*core_id*/,
     const BufferCorePageMapping& core_page_mapping,
     Buffer& buffer,
     ShardedBufferReadDispatchParams& dispatch_params,
@@ -1594,21 +1613,27 @@ std::shared_ptr<tt::tt_metal::CompletionReaderVariant> generate_interleaved_buff
 
 void read_completion_queue(
     void* dst,
-    uint32_t size_bytes,
+    std::uint32_t size_bytes,
     ChipId device_id,
-    uint16_t channel,
-    uint32_t completion_q_read_ptr,
-    uint32_t completion_q_data_offset,
+    std::uint16_t channel,
+    std::uint32_t completion_q_read_ptr,
+    std::uint32_t completion_q_data_offset,
     const SystemMemoryManager& sysmem_manager) {
     if (sysmem_manager.is_dram_backed()) {
-        const uint32_t dram_channel = tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
-                                          .device_manager()
-                                          ->get_active_device(device_id)
-                                          ->allocator_impl()
-                                          ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
+        // Caller passes mmio_device_id (correct for read_sysmem path), but
+        // DRAM-backed CQs live in the dispatch chip's OWN DRAM. Read from the
+        // actual device.
+        const ChipId actual_device_id = sysmem_manager.get_device_id();
+        const std::uint32_t dram_channel =
+            tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
+                .device_manager()
+                ->get_active_device(actual_device_id)
+                ->allocator_impl()
+                ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
         tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
             .get_cluster()
-            .read_dram_vec(dst, size_bytes, device_id, dram_channel, completion_q_read_ptr + completion_q_data_offset);
+            .read_dram_vec(
+                dst, size_bytes, actual_device_id, dram_channel, completion_q_read_ptr + completion_q_data_offset);
     } else {
         tt::tt_metal::MetalContext::instance(sysmem_manager.get_context_id())
             .get_cluster()
@@ -1619,22 +1644,22 @@ void read_completion_queue(
 void copy_completion_queue_data_into_user_space(
     const ReadBufferDescriptor& read_buffer_descriptor,
     ChipId mmio_device_id,
-    uint16_t channel,
-    uint32_t cq_id,
+    std::uint16_t channel,
+    std::uint32_t cq_id,
     SystemMemoryManager& sysmem_manager,
     std::atomic<bool>& exit_condition) {
     const auto& [page_size, padded_page_size, buffer_page_mapping, core_page_mapping, dst, dst_offset, num_pages_read] =
         read_buffer_descriptor;
     const DeviceAddr padded_num_bytes = ((DeviceAddr)num_pages_read * padded_page_size) + sizeof(CQDispatchCmd);
-    uint64_t contig_dst_offset = dst_offset;
+    std::uint64_t contig_dst_offset = dst_offset;
     DeviceAddr remaining_bytes_to_read = padded_num_bytes;
 
     // track the amount of bytes read in the last non-aligned page
-    uint32_t remaining_bytes_of_nonaligned_page = 0;
-    std::optional<uint32_t> host_page_id = std::nullopt;
-    uint32_t offset_in_completion_q_data = sizeof(CQDispatchCmd);
+    std::uint32_t remaining_bytes_of_nonaligned_page = 0;
+    std::optional<std::uint32_t> host_page_id = std::nullopt;
+    std::uint32_t offset_in_completion_q_data = sizeof(CQDispatchCmd);
 
-    uint32_t pad_size_bytes = padded_page_size - page_size;
+    std::uint32_t pad_size_bytes = padded_page_size - page_size;
 
     BufferCorePageMapping::Iterator core_page_mapping_it;
     if (core_page_mapping) {
@@ -1642,19 +1667,19 @@ void copy_completion_queue_data_into_user_space(
     }
 
     while (remaining_bytes_to_read != 0) {
-        uint32_t completion_queue_write_ptr_and_toggle =
+        std::uint32_t completion_queue_write_ptr_and_toggle =
             sysmem_manager.completion_queue_wait_front(cq_id, exit_condition);
 
         if (exit_condition) {
             break;
         }
 
-        uint32_t completion_q_write_ptr = (completion_queue_write_ptr_and_toggle & 0x7fffffff) << 4;
-        uint32_t completion_q_write_toggle = completion_queue_write_ptr_and_toggle >> (31);
-        uint32_t completion_q_read_ptr = sysmem_manager.get_completion_queue_read_ptr(cq_id);
-        uint32_t completion_q_read_toggle = sysmem_manager.get_completion_queue_read_toggle(cq_id);
+        std::uint32_t completion_q_write_ptr = (completion_queue_write_ptr_and_toggle & 0x7fffffff) << 4;
+        std::uint32_t completion_q_write_toggle = completion_queue_write_ptr_and_toggle >> (31);
+        std::uint32_t completion_q_read_ptr = sysmem_manager.get_completion_queue_read_ptr(cq_id);
+        std::uint32_t completion_q_read_toggle = sysmem_manager.get_completion_queue_read_toggle(cq_id);
 
-        uint32_t bytes_avail_in_completion_queue;
+        std::uint32_t bytes_avail_in_completion_queue;
         if (completion_q_write_ptr > completion_q_read_ptr and completion_q_write_toggle == completion_q_read_toggle) {
             bytes_avail_in_completion_queue = completion_q_write_ptr - completion_q_read_ptr;
         } else {
@@ -1664,16 +1689,16 @@ void copy_completion_queue_data_into_user_space(
         }
 
         // completion queue write ptr on device could have wrapped but our read ptr is lagging behind
-        uint32_t bytes_xfered =
-            static_cast<uint32_t>(std::min(remaining_bytes_to_read, (DeviceAddr)bytes_avail_in_completion_queue));
-        uint32_t num_pages_xfered = div_up(bytes_xfered, DispatchSettings::TRANSFER_PAGE_SIZE);
+        std::uint32_t bytes_xfered =
+            static_cast<std::uint32_t>(std::min(remaining_bytes_to_read, (DeviceAddr)bytes_avail_in_completion_queue));
+        std::uint32_t num_pages_xfered = div_up(bytes_xfered, DispatchSettings::TRANSFER_PAGE_SIZE);
 
         remaining_bytes_to_read -= bytes_xfered;
 
         if (buffer_page_mapping == nullptr) {
-            void* contiguous_dst = (void*)(uint64_t(dst) + contig_dst_offset);
+            void* contiguous_dst = (void*)(std::uint64_t(dst) + contig_dst_offset);
             if (page_size == padded_page_size) {
-                uint32_t data_bytes_xfered = bytes_xfered - offset_in_completion_q_data;
+                std::uint32_t data_bytes_xfered = bytes_xfered - offset_in_completion_q_data;
                 read_completion_queue(
                     contiguous_dst,
                     data_bytes_xfered,
@@ -1685,23 +1710,23 @@ void copy_completion_queue_data_into_user_space(
                 contig_dst_offset += data_bytes_xfered;
                 offset_in_completion_q_data = 0;
             } else {
-                uint32_t src_offset_bytes = offset_in_completion_q_data;
+                std::uint32_t src_offset_bytes = offset_in_completion_q_data;
                 offset_in_completion_q_data = 0;
-                uint64_t dst_offset_bytes = 0;
+                std::uint64_t dst_offset_bytes = 0;
 
                 while (src_offset_bytes < bytes_xfered) {
-                    uint32_t src_offset_increment = padded_page_size;
-                    uint32_t num_bytes_to_copy = 0;
+                    std::uint32_t src_offset_increment = padded_page_size;
+                    std::uint32_t num_bytes_to_copy = 0;
 
                     if (remaining_bytes_of_nonaligned_page > 0) {
                         // Case 1: Portion of the page was copied into user buffer on the previous completion queue pop.
-                        uint32_t num_bytes_remaining = bytes_xfered - src_offset_bytes;
+                        std::uint32_t num_bytes_remaining = bytes_xfered - src_offset_bytes;
                         num_bytes_to_copy = std::min(remaining_bytes_of_nonaligned_page, num_bytes_remaining);
                         remaining_bytes_of_nonaligned_page -= num_bytes_to_copy;
                         src_offset_increment = num_bytes_to_copy;
                         // We finished copying the page
                         if (remaining_bytes_of_nonaligned_page == 0) {
-                            uint32_t rem_bytes_in_cq = num_bytes_remaining - num_bytes_to_copy;
+                            std::uint32_t rem_bytes_in_cq = num_bytes_remaining - num_bytes_to_copy;
                             // There is more data after padding
                             if (rem_bytes_in_cq >= pad_size_bytes) {
                                 src_offset_increment += pad_size_bytes;
@@ -1714,7 +1739,7 @@ void copy_completion_queue_data_into_user_space(
                     } else if (src_offset_bytes + padded_page_size >= bytes_xfered) {
                         // Case 2: Last page of data that was popped off the completion queue
                         // Don't need to compute src_offset_increment since this is end of loop
-                        uint32_t num_bytes_remaining = bytes_xfered - src_offset_bytes;
+                        std::uint32_t num_bytes_remaining = bytes_xfered - src_offset_bytes;
                         num_bytes_to_copy = std::min(num_bytes_remaining, page_size);
                         remaining_bytes_of_nonaligned_page = page_size - num_bytes_to_copy;
                         // We've copied needed data, start of next read is offset due to remaining pad bytes
@@ -1726,7 +1751,7 @@ void copy_completion_queue_data_into_user_space(
                     }
 
                     read_completion_queue(
-                        (char*)(uint64_t(contiguous_dst) + dst_offset_bytes),
+                        (char*)(std::uint64_t(contiguous_dst) + dst_offset_bytes),
                         num_bytes_to_copy,
                         mmio_device_id,
                         channel,
@@ -1740,23 +1765,23 @@ void copy_completion_queue_data_into_user_space(
                 }
             }
         } else {
-            uint32_t src_offset_bytes = offset_in_completion_q_data;
+            std::uint32_t src_offset_bytes = offset_in_completion_q_data;
             offset_in_completion_q_data = 0;
-            uint64_t dst_offset_bytes = contig_dst_offset;
-            uint32_t num_bytes_to_copy = 0;
+            std::uint64_t dst_offset_bytes = contig_dst_offset;
+            std::uint32_t num_bytes_to_copy = 0;
 
             while (src_offset_bytes < bytes_xfered) {
-                uint32_t src_offset_increment = padded_page_size;
+                std::uint32_t src_offset_increment = padded_page_size;
                 if (remaining_bytes_of_nonaligned_page > 0) {
                     // Case 1: Portion of the page was copied into user buffer on the previous completion queue pop.
-                    uint32_t num_bytes_remaining = bytes_xfered - src_offset_bytes;
+                    std::uint32_t num_bytes_remaining = bytes_xfered - src_offset_bytes;
                     num_bytes_to_copy = std::min(remaining_bytes_of_nonaligned_page, num_bytes_remaining);
                     remaining_bytes_of_nonaligned_page -= num_bytes_to_copy;
                     src_offset_increment = num_bytes_to_copy;
                     // We finished copying the page
                     if (remaining_bytes_of_nonaligned_page == 0) {
                         ++core_page_mapping_it;
-                        uint32_t rem_bytes_in_cq = num_bytes_remaining - num_bytes_to_copy;
+                        std::uint32_t rem_bytes_in_cq = num_bytes_remaining - num_bytes_to_copy;
                         // There is more data after padding
                         if (rem_bytes_in_cq >= pad_size_bytes) {
                             src_offset_increment += pad_size_bytes;
@@ -1774,7 +1799,7 @@ void copy_completion_queue_data_into_user_space(
                     // Case 2: Last page of data that was popped off the completion queue
                     // Don't need to compute src_offset_increment since this is end of loop
                     host_page_id = *core_page_mapping_it;
-                    uint32_t num_bytes_remaining = bytes_xfered - src_offset_bytes;
+                    std::uint32_t num_bytes_remaining = bytes_xfered - src_offset_bytes;
                     num_bytes_to_copy = std::min(num_bytes_remaining, page_size);
                     remaining_bytes_of_nonaligned_page = page_size - num_bytes_to_copy;
                     // We've copied needed data, start of next read is offset due to remaining pad bytes
@@ -1783,7 +1808,7 @@ void copy_completion_queue_data_into_user_space(
                         ++core_page_mapping_it;
                     }
                     if (host_page_id.has_value()) {
-                        dst_offset_bytes = *host_page_id * uint64_t(page_size);
+                        dst_offset_bytes = *host_page_id * std::uint64_t(page_size);
                     } else {
                         src_offset_bytes += src_offset_increment;
                         continue;
@@ -1793,7 +1818,7 @@ void copy_completion_queue_data_into_user_space(
                     host_page_id = *core_page_mapping_it;
                     ++core_page_mapping_it;
                     if (host_page_id.has_value()) {
-                        dst_offset_bytes = *host_page_id * uint64_t(page_size);
+                        dst_offset_bytes = *host_page_id * std::uint64_t(page_size);
                     } else {
                         src_offset_bytes += src_offset_increment;
                         continue;
@@ -1801,7 +1826,7 @@ void copy_completion_queue_data_into_user_space(
                 }
 
                 read_completion_queue(
-                    (char*)(uint64_t(dst) + dst_offset_bytes),
+                    (char*)(std::uint64_t(dst) + dst_offset_bytes),
                     num_bytes_to_copy,
                     mmio_device_id,
                     channel,

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -366,12 +366,7 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
             dev_msgs::launch_msg_t msg = kernel->launch_msg;  // copy
             dev_msgs::go_msg_t::ConstView go_msg = kernel->go_msg.view();
             CoreCoord virtual_core = this->virtual_core_from_logical_core(logical_dispatch_core, core_type);
-            tt::llrt::write_launch_msg_to_core(
-                this->id(),
-                virtual_core,
-                msg.view(),
-                go_msg,
-                hal.get_dev_addr(this->get_programmable_core_type(virtual_core), HalL1MemAddrType::LAUNCH));
+            tt::llrt::write_launch_msg_to_core(this->id(), virtual_core, msg.view(), go_msg, true);
         }
     }
 
@@ -438,12 +433,7 @@ void Device::configure_fabric() {
             msg.kernel_config().host_assigned_id() = fabric_program_->get_runtime_id();
 
             auto physical_core = this->virtual_core_from_logical_core(logical_core, core_type);
-            tt::llrt::write_launch_msg_to_core(
-                this->id(),
-                physical_core,
-                msg,
-                go_msg,
-                hal.get_dev_addr(this->get_programmable_core_type(physical_core), HalL1MemAddrType::LAUNCH));
+            tt::llrt::write_launch_msg_to_core(this->id(), physical_core, msg, go_msg, true);
         }
     }
     log_info(tt::LogMetal, "Fabric initialized on Device {}", this->id_);

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -75,13 +75,13 @@ Device::Device(
     MetalEnv* env,
     MetalContext* context,
     ChipId device_id,
-    const uint8_t num_hw_cqs,
+    const std::uint8_t num_hw_cqs,
     size_t l1_small_size,
     size_t trace_region_size,
     tt::stl::Span<const std::uint32_t> l1_bank_remap,
     bool minimal,
-    uint32_t /*worker_thread_core*/,
-    uint32_t /*completion_queue_reader_core*/,
+    std::uint32_t /*worker_thread_core*/,
+    std::uint32_t /*completion_queue_reader_core*/,
     size_t worker_l1_size) :
     context_(context), env_(env), id_(device_id) {
     ZoneScoped;
@@ -110,7 +110,7 @@ bool Device::is_inactive_ethernet_core(CoreCoord logical_core) const {
     return inactive_ethernet_cores.contains(logical_core);
 }
 
-uint32_t Device::num_virtual_eth_cores(SubDeviceId sub_device_id) {
+std::uint32_t Device::num_virtual_eth_cores(SubDeviceId sub_device_id) {
     return this->num_worker_cores(HalProgrammableCoreType::ACTIVE_ETH, sub_device_id);
 }
 
@@ -132,7 +132,7 @@ CoreRangeSet Device::worker_cores(HalProgrammableCoreType /*core_type*/, SubDevi
     return CoreRangeSet{};
 }
 
-uint32_t Device::num_worker_cores(HalProgrammableCoreType /*core_type*/, SubDeviceId /*sub_device_id*/) const {
+std::uint32_t Device::num_worker_cores(HalProgrammableCoreType /*core_type*/, SubDeviceId /*sub_device_id*/) const {
     TT_FATAL(false, "num_worker_cores is deprecated for device");
     return 0U;
 }
@@ -172,65 +172,88 @@ void Device::configure_command_queue_programs(DispatchTopology* dispatch_topolog
     ChipId device_id = this->id();
     ChipId mmio_device_id = MetalEnvAccessor(*env_).impl().get_cluster().get_associated_mmio_device(device_id);
 
-    std::vector<uint32_t> zero = {0x0};  // Reset state in case L1 Clear is disabled.
-    std::vector<uint32_t> pointers;
-    uint32_t cq_size = this->sysmem_manager().get_cq_size();
+    std::vector<std::uint32_t> zero = {0x0};  // Reset state in case L1 Clear is disabled.
+    std::vector<std::uint32_t> pointers;
+    std::uint32_t cq_size = this->sysmem_manager().get_cq_size();
     TT_ASSERT(this->command_queue_programs_.size() == 1);
 
     Program& command_queue_program = *this->command_queue_programs_[0];
-    uint8_t num_hw_cqs = this->num_hw_cqs();
+    std::uint8_t num_hw_cqs = this->num_hw_cqs();
 
-    // Reset host-side command queue pointers for all channels controlled by this mmio device
-    if (this->is_mmio_capable()) {
-        for (ChipId serviced_device_id :
-             MetalEnvAccessor(*env_).impl().get_cluster().get_devices_controlled_by_mmio_device(device_id)) {
-            uint16_t channel =
+    // Reset host-side command queue pointers for all channels controlled by this mmio device.
+    //
+    // In real hardware / hugepage mode the MMIO chip stages every tunnel chip's
+    // CQ pointer storage into its own hugepage via PCIe and the dispatch FW for
+    // each tunnel chip reads from that single shared hugepage. Non-MMIO chips
+    // therefore correctly skip this branch.
+    //
+    // In DRAM-backed simulator mode (per-chip dram_region_staging_buffer) every
+    // chip - MMIO or tunnel - has its own DRAM-resident CQ pointer region, and
+    // the ttsim RPC layer can reach any chip's DRAM regardless of MMIO. We must
+    // therefore initialize EACH chip's own pointer storage directly, instead of
+    // funneling everything through the MMIO chip's loop. Without this the
+    // tunnel-chip COMPLETION_Q_WR word stays zero, completion_queue_wait_front
+    // observes wr_ptr=0 != rd_ptr=issue_fifo_limit on the first read and exits
+    // immediately, then the host reads uninitialized zeros from the completion
+    // FIFO and trips the CQ_DISPATCH_CMD_ILLEGAL fatal in mesh_socket and other
+    // tunnel-dispatch tests.
+    const bool dram_backed_sim = this->sysmem_manager_->is_dram_backed();
+    const bool init_pointers = this->is_mmio_capable() || dram_backed_sim;
+    if (init_pointers) {
+        std::vector<ChipId> serviced_device_ids;
+        if (dram_backed_sim) {
+            // In dram-backed sim each chip owns its own dram_region; only init
+            // THIS chip's pointers into THIS chip's DRAM. The MMIO-loop variant
+            // below would write tunnel-chip pointer values into the MMIO chip's
+            // DRAM at addresses the tunnel chip's dispatch FW never reads,
+            // leaving the tunnel chip's actual pointers zero (same class of bug
+            // as the tunnel-chip init being skipped entirely).
+            serviced_device_ids = {device_id};
+        } else {
+            const auto& mmio_devices =
+                MetalEnvAccessor(*env_).impl().get_cluster().get_devices_controlled_by_mmio_device(device_id);
+            serviced_device_ids.assign(mmio_devices.begin(), mmio_devices.end());
+        }
+        for (ChipId serviced_device_id : serviced_device_ids) {
+            std::uint16_t channel =
                 MetalEnvAccessor(*env_).impl().get_cluster().get_assigned_channel_for_device(serviced_device_id);
-            uint32_t host_issue_q_rd_ptr =
+            std::uint32_t host_issue_q_rd_ptr =
                 context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_RD);
-            uint32_t host_issue_q_wr_ptr =
+            std::uint32_t host_issue_q_wr_ptr =
                 context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
-            uint32_t host_completion_q_wr_ptr =
+            std::uint32_t host_completion_q_wr_ptr =
                 context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_WR);
-            uint32_t host_completion_q_rd_ptr =
+            std::uint32_t host_completion_q_rd_ptr =
                 context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
-            uint32_t cq_start =
+            std::uint32_t cq_start =
                 context_->dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
-            pointers.resize(cq_start / sizeof(uint32_t));
-            for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+            pointers.resize(cq_start / sizeof(std::uint32_t));
+            for (std::uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
                 // Reset the host manager's pointer for this command queue
                 this->sysmem_manager_->reset(cq_id);
 
-                const uint32_t cq_offset =
+                const std::uint32_t cq_offset =
                     this->sysmem_manager_->is_dram_backed()
                         ? get_absolute_cq_offset(
                               channel, cq_id, cq_size, this->sysmem_manager_->get_dram_region_base_addr())
                         : get_absolute_cq_offset(channel, cq_id, cq_size);
 
-                pointers[host_issue_q_rd_ptr / sizeof(uint32_t)] = (cq_start + cq_offset) >> 4;
-                pointers[host_issue_q_wr_ptr / sizeof(uint32_t)] = (cq_start + cq_offset) >> 4;
-                pointers[host_completion_q_wr_ptr / sizeof(uint32_t)] =
+                pointers[host_issue_q_rd_ptr / sizeof(std::uint32_t)] = (cq_start + cq_offset) >> 4;
+                pointers[host_issue_q_wr_ptr / sizeof(std::uint32_t)] = (cq_start + cq_offset) >> 4;
+                pointers[host_completion_q_wr_ptr / sizeof(std::uint32_t)] =
                     (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) + cq_offset) >> 4;
-                pointers[host_completion_q_rd_ptr / sizeof(uint32_t)] =
+                pointers[host_completion_q_rd_ptr / sizeof(std::uint32_t)] =
                     (cq_start + this->sysmem_manager_->get_issue_queue_size(cq_id) + cq_offset) >> 4;
 
                 if (this->sysmem_manager_->is_dram_backed()) {
-                    // With DRAM-backed CQs, each device stores its command queue in its own DRAM. The CQ
-                    // pointers for a serviced device must therefore be written into that device's DRAM, not
-                    // the MMIO device's DRAM. Writing to this->id() left non-MMIO devices with an uninitialized
-                    // (zero) completion write pointer, causing completion_queue_wait_front to return spuriously.
-                    const uint32_t dram_channel = this->allocator_impl()->get_dram_channel_from_bank_id(
+                    const std::uint32_t dram_channel = this->allocator_impl()->get_dram_channel_from_bank_id(
                         this->sysmem_manager_->get_dram_region_bank_id());
                     MetalEnvAccessor(*env_).impl().get_cluster().write_dram_vec(
-                        pointers.data(),
-                        pointers.size() * sizeof(uint32_t),
-                        serviced_device_id,
-                        dram_channel,
-                        cq_offset);
+                        pointers.data(), pointers.size() * sizeof(std::uint32_t), this->id(), dram_channel, cq_offset);
                 } else {
                     MetalEnvAccessor(*env_).impl().get_cluster().write_sysmem(
                         pointers.data(),
-                        pointers.size() * sizeof(uint32_t),
+                        pointers.size() * sizeof(std::uint32_t),
                         cq_offset,
                         mmio_device_id,
                         get_umd_channel(channel));
@@ -280,10 +303,11 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
     // Device init. TODO: remove this once dispatch init moves to one-shot.
     auto reset_launch_message_rd_ptr_virtual = [&](const CoreCoord& virtual_core,
                                                    HalProgrammableCoreType programmable_core_type) {
-        uint64_t launch_msg_buffer_read_ptr_addr =
+        std::uint64_t launch_msg_buffer_read_ptr_addr =
             hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::LAUNCH_MSG_BUFFER_RD_PTR);
-        uint32_t zero = 0;
-        cluster.write_core(&zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), launch_msg_buffer_read_ptr_addr);
+        std::uint32_t zero = 0;
+        cluster.write_core(
+            &zero, sizeof(std::uint32_t), tt_cxy_pair(id_, virtual_core), launch_msg_buffer_read_ptr_addr);
     };
     auto reset_launch_message_rd_ptr = [&](const CoreCoord& logical_core, const CoreType& core_type) {
         CoreCoord virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(id_, logical_core, core_type);
@@ -293,19 +317,20 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
     auto reset_go_message_index = [&](const CoreCoord& logical_core, const CoreType& core_type) {
         CoreCoord virtual_core = cluster.get_virtual_coordinate_from_logical_coordinates(id_, logical_core, core_type);
         auto programmable_core_type = get_programmable_core_type(virtual_core);
-        uint64_t go_message_addr = hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::GO_MSG);
-        uint32_t zero = 0;
-        cluster.write_core(&zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_addr);
+        std::uint64_t go_message_addr = hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::GO_MSG);
+        std::uint32_t zero = 0;
+        cluster.write_core(&zero, sizeof(std::uint32_t), tt_cxy_pair(id_, virtual_core), go_message_addr);
         cluster.l1_barrier(id_);
-        uint64_t go_message_index_addr = hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::GO_MSG_INDEX);
-        cluster.write_core(&zero, sizeof(uint32_t), tt_cxy_pair(id_, virtual_core), go_message_index_addr);
+        std::uint64_t go_message_index_addr =
+            hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::GO_MSG_INDEX);
+        cluster.write_core(&zero, sizeof(std::uint32_t), tt_cxy_pair(id_, virtual_core), go_message_index_addr);
     };
     std::optional<std::unique_lock<std::mutex>> watcher_lock;
     if (MetalEnvAccessor(*env_).impl().get_rtoptions().get_watcher_enabled()) {
         watcher_lock = context_->watcher_server()->get_lock();
     }
-    for (uint32_t y = 0; y < logical_grid_size().y; y++) {
-        for (uint32_t x = 0; x < logical_grid_size().x; x++) {
+    for (std::uint32_t y = 0; y < logical_grid_size().y; y++) {
+        for (std::uint32_t x = 0; x < logical_grid_size().x; x++) {
             CoreCoord logical_core(x, y);
             reset_launch_message_rd_ptr(logical_core, CoreType::WORKER);
             reset_go_message_index(logical_core, CoreType::WORKER);
@@ -333,7 +358,7 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
     }
 
     std::vector<std::vector<CoreCoord>> logical_cores = command_queue_program.impl().logical_cores();
-    for (uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
+    for (std::uint32_t index = 0; index < hal.get_programmable_core_type_count(); index++) {
         const auto& logical_dispatch_cores = logical_cores[index];
         CoreType core_type = hal.get_core_type(index);
         for (const CoreCoord& logical_dispatch_core : logical_dispatch_cores) {
@@ -359,9 +384,9 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
     }
 
     const NOC noc_index = context_->get_dispatch_query_manager().go_signal_noc();
-    uint32_t idx = 0U;
-    vector_aligned<uint32_t> noc_mcast_unicast_data;
-    for (uint32_t i = 0U; i < num_sub_devices(); ++i) {
+    std::uint32_t idx = 0U;
+    vector_aligned<std::uint32_t> noc_mcast_unicast_data;
+    for (std::uint32_t i = 0U; i < num_sub_devices(); ++i) {
         for (const auto& core_range : active_eth_core_ranges) {
             noc_mcast_unicast_data.resize(idx + core_range.size());
             for (const auto& core : core_range) {
@@ -402,7 +427,8 @@ void Device::configure_fabric() {
     env_impl.get_cluster().l1_barrier(this->id());
     std::vector<std::vector<CoreCoord>> logical_cores_used_in_program = fabric_program_->impl().logical_cores();
     const auto& hal = env_impl.get_hal();
-    for (uint32_t programmable_core_type_index = 0; programmable_core_type_index < logical_cores_used_in_program.size();
+    for (std::uint32_t programmable_core_type_index = 0;
+         programmable_core_type_index < logical_cores_used_in_program.size();
          programmable_core_type_index++) {
         CoreType core_type = hal.get_core_type(programmable_core_type_index);
         for (const auto& logical_core : logical_cores_used_in_program[programmable_core_type_index]) {
@@ -424,7 +450,7 @@ void Device::configure_fabric() {
 }
 
 bool Device::initialize(
-    const uint8_t num_hw_cqs,
+    const std::uint8_t num_hw_cqs,
     size_t l1_small_size,
     size_t trace_region_size,
     size_t worker_l1_size,
@@ -462,8 +488,9 @@ bool Device::initialize(
         max_worker_l1_size);
     log_debug(tt::LogMetal, "Worker L1 size: {} Max: {}", worker_l1_size, max_worker_l1_size);
 
-    const uint32_t max_alignment = std::max(hal.get_alignment(HalMemType::DRAM), hal.get_alignment(HalMemType::L1));
-    const uint32_t worker_l1_unreserved_start = tt::align(
+    const std::uint32_t max_alignment =
+        std::max(hal.get_alignment(HalMemType::DRAM), hal.get_alignment(HalMemType::L1));
+    const std::uint32_t worker_l1_unreserved_start = tt::align(
         hal.get_dev_addr(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) +
             hal.get_dev_size(HalProgrammableCoreType::TENSIX, HalL1MemAddrType::BASE) - worker_l1_size,
         max_alignment);
@@ -480,7 +507,7 @@ bool Device::initialize(
         // Use UMD's chip_unique_ids for globally unique chip identification.
         // This ID is computed by topology discovery from hardware-reported board_id and asic_location,
         // and is consistent across all board types (P300, N300, UBB Wormhole, UBB Blackhole, etc.).
-        uint64_t asic_id = 0;
+        std::uint64_t asic_id = 0;
 
         try {
             const auto& cluster = tt::tt_metal::MetalContext::instance().get_cluster();
@@ -572,10 +599,10 @@ int Device::num_dram_channels() const {
     return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_num_dram_views();
 }
 
-uint32_t Device::l1_size_per_core() const {
+std::uint32_t Device::l1_size_per_core() const {
     return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).worker_l1_size;
 }
-uint32_t Device::dram_size_per_channel() const {
+std::uint32_t Device::dram_size_per_channel() const {
     return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).dram_view_size;
 }
 
@@ -596,7 +623,7 @@ CoreCoord Device::compute_with_storage_grid_size() const {
     return tt::get_compute_grid_size(MetalEnvAccessor(*env_).impl(), id_, num_hw_cqs_, dispatch_core_config);
 }
 
-CoreCoord Device::virtual_noc0_coordinate(uint8_t noc_index, CoreCoord coord) const {
+CoreCoord Device::virtual_noc0_coordinate(std::uint8_t noc_index, CoreCoord coord) const {
     if (coord.x >= this->grid_size().x || coord.y >= this->grid_size().y || this->arch() == ARCH::BLACKHOLE) {
         // Coordinate already in virtual space: NOC0 and NOC1 are the same
         return coord;
@@ -656,12 +683,12 @@ CoreCoord Device::logical_core_from_ethernet_core(const CoreCoord& ethernet_core
         this->id(), ethernet_core);
 }
 
-uint32_t Device::get_noc_unicast_encoding(uint8_t noc_index, const CoreCoord& core) const {
+std::uint32_t Device::get_noc_unicast_encoding(std::uint8_t noc_index, const CoreCoord& core) const {
     auto virtual_noc_coord = this->virtual_noc0_coordinate(noc_index, core);
     return MetalEnvAccessor(*env_).impl().get_hal().noc_xy_encoding(virtual_noc_coord.x, virtual_noc_coord.y);
 }
 
-uint32_t Device::get_noc_multicast_encoding(uint8_t noc_index, const CoreRange& cores) const {
+std::uint32_t Device::get_noc_multicast_encoding(std::uint8_t noc_index, const CoreRange& cores) const {
     auto virtual_noc_start = this->virtual_noc0_coordinate(noc_index, cores.start_coord);
     auto virtual_noc_end = this->virtual_noc0_coordinate(noc_index, cores.end_coord);
     const auto& hal = MetalEnvAccessor(*env_).impl().get_hal();
@@ -689,27 +716,27 @@ const std::unique_ptr<Allocator>& Device::allocator(SubDeviceId sub_device_id) c
     return allocator->view();
 }
 
-uint32_t Device::num_sub_devices() const { return 1U; }
+std::uint32_t Device::num_sub_devices() const { return 1U; }
 
-CoreCoord Device::dram_core_from_dram_channel(uint32_t dram_channel, NOC noc) const {
+CoreCoord Device::dram_core_from_dram_channel(std::uint32_t dram_channel, NOC noc) const {
     return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_preferred_worker_core_for_dram_view(
         dram_channel, noc);
 }
 
-CoreCoord Device::logical_core_from_dram_channel(uint32_t dram_channel) const {
+CoreCoord Device::logical_core_from_dram_channel(std::uint32_t dram_channel) const {
     return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_logical_core_for_dram_view(dram_channel);
 }
 
-uint32_t Device::dram_channel_from_logical_core(const CoreCoord& logical_core) const {
+std::uint32_t Device::dram_channel_from_logical_core(const CoreCoord& logical_core) const {
     return MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(id_).get_dram_channel_from_logical_core(
         logical_core);
 }
 
-uint32_t Device::dram_channel_from_virtual_core(const CoreCoord& virtual_core) const {
+std::uint32_t Device::dram_channel_from_virtual_core(const CoreCoord& virtual_core) const {
     const metal_SocDescriptor& soc_desc = MetalEnvAccessor(*env_).impl().get_cluster().get_soc_desc(this->id_);
-    uint32_t num_nocs = MetalEnvAccessor(*env_).impl().get_hal().get_num_nocs();
-    for (uint32_t noc = 0; noc < num_nocs; noc++) {
-        for (uint32_t channel = 0; channel < this->num_dram_channels(); ++channel) {
+    std::uint32_t num_nocs = MetalEnvAccessor(*env_).impl().get_hal().get_num_nocs();
+    for (std::uint32_t noc = 0; noc < num_nocs; noc++) {
+        for (std::uint32_t channel = 0; channel < this->num_dram_channels(); ++channel) {
             if (soc_desc.get_preferred_worker_core_for_dram_view(channel, noc) == virtual_core) {
                 return channel;
             }
@@ -727,7 +754,7 @@ std::optional<DeviceAddr> Device::lowest_occupied_compute_l1_address(
     return default_allocator_->get_lowest_occupied_l1_address(0);
 }
 
-HWCommandQueue& Device::command_queue(std::optional<uint8_t> cq_id) {
+HWCommandQueue& Device::command_queue(std::optional<std::uint8_t> cq_id) {
     detail::DispatchStateCheck(using_fast_dispatch_);
     TT_FATAL(using_fast_dispatch_, "Fast dispatch must be enabled to use command_queue");
     auto actual_cq_id = cq_id.value_or(GetCurrentCommandQueueIdForThread());
@@ -774,19 +801,19 @@ bool Device::has_noc_mcast_txns(SubDeviceId /*sub_device_id*/) const {
     return false;
 }
 
-uint8_t Device::num_noc_unicast_txns(SubDeviceId /*sub_device_id*/) const {
+std::uint8_t Device::num_noc_unicast_txns(SubDeviceId /*sub_device_id*/) const {
     TT_FATAL(false, "num_noc_unicast_txns is deprecated for device");
     return 0U;
 }
 
-uint8_t Device::noc_data_start_index(SubDeviceId /*sub_device_id*/, bool unicast_data) const {
+std::uint8_t Device::noc_data_start_index(SubDeviceId /*sub_device_id*/, bool unicast_data) const {
     if (unicast_data) {
         TT_FATAL(false, "noc_data_start_index is deprecated for unicast mode for device");
     }
     return 0U;
 }
 
-CoreCoord Device::virtual_program_dispatch_core(uint8_t cq_id) const {
+CoreCoord Device::virtual_program_dispatch_core(std::uint8_t cq_id) const {
     if (cq_id >= this->command_queues_.size() || !this->command_queues_[cq_id]) {
         return CoreCoord{0, 0};  // Return default for mock devices
     }
@@ -848,14 +875,14 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
     // and passes them to logic in core_assignment.cpp to derive the most optimal core placement
     // based on architecture specific logic and Physical Grid configuration.
     if (this->optimal_dram_bank_to_logical_worker_assignment_.empty()) {
-        uint32_t full_grid_size_x = this->grid_size().x;
-        uint32_t full_grid_size_y = this->grid_size().y;
+        std::uint32_t full_grid_size_x = this->grid_size().x;
+        std::uint32_t full_grid_size_y = this->grid_size().y;
 
         auto compute_with_storage_grid_size = this->compute_with_storage_grid_size();
-        uint32_t num_cores_x = compute_with_storage_grid_size.x;
-        uint32_t num_cores_y = compute_with_storage_grid_size.y;
+        std::uint32_t num_cores_x = compute_with_storage_grid_size.x;
+        std::uint32_t num_cores_y = compute_with_storage_grid_size.y;
         // Get physical coordinates of DRAM Controller NOC end-points
-        uint32_t num_dram_banks = this->num_dram_channels();
+        std::uint32_t num_dram_banks = this->num_dram_channels();
 
         const auto& hal = MetalEnvAccessor(*env_).impl().get_hal();
         bool noc_translation_enabled = true;
@@ -885,13 +912,13 @@ std::vector<CoreCoord> Device::get_optimal_dram_bank_to_logical_worker_assignmen
             }
         }
         // Get the physical rows and cols  (y, x) in the worker grid
-        std::vector<uint32_t> worker_phy_y;
+        std::vector<std::uint32_t> worker_phy_y;
         worker_phy_y.reserve(num_cores_y);
         for (int i = 0; i < num_cores_y; ++i) {
             auto core_phy = this->physical_worker_core_from_logical_core(CoreCoord(0, i));
             worker_phy_y.push_back(core_phy.y);
         }
-        std::vector<uint32_t> worker_phy_x;
+        std::vector<std::uint32_t> worker_phy_x;
         worker_phy_x.reserve(num_cores_x);
         for (int i = 0; i < num_cores_x; ++i) {
             auto core_phy = this->physical_worker_core_from_logical_core(CoreCoord(i, 0));
@@ -953,14 +980,14 @@ void Device::unregister_program(detail::ProgramImpl* program) {
     active_programs_.erase(program);
 }
 
-uint64_t Device::get_total_cb_allocated() const {
+std::uint64_t Device::get_total_cb_allocated() const {
     std::lock_guard<std::mutex> lock(active_programs_mutex_);
 
     // For PHYSICAL CB tracking accounting for address reuse:
     // Collect L1 regions per core and merge overlapping addresses
     // This handles cached/traced programs that share the same physical L1 addresses on the same core
 
-    std::map<CoreCoord, std::vector<std::pair<uint64_t, uint64_t>>> device_regions_per_core;
+    std::map<CoreCoord, std::vector<std::pair<std::uint64_t, std::uint64_t>>> device_regions_per_core;
 
     for (const auto* program : active_programs_) {
         size_t num_devices = program->get_num_cb_devices();
@@ -976,7 +1003,7 @@ uint64_t Device::get_total_cb_allocated() const {
     }
 
     // Merge overlapping regions per core to get actual physical usage
-    uint64_t total_physical = 0;
+    std::uint64_t total_physical = 0;
 
     for (auto& [core, regions] : device_regions_per_core) {
         if (regions.empty()) {
@@ -987,7 +1014,7 @@ uint64_t Device::get_total_cb_allocated() const {
         std::sort(regions.begin(), regions.end());
 
         // Merge overlapping ranges
-        std::vector<std::pair<uint64_t, uint64_t>> merged;
+        std::vector<std::pair<std::uint64_t, std::uint64_t>> merged;
         merged.push_back(regions[0]);
 
         for (size_t i = 1; i < regions.size(); i++) {

--- a/tt_metal/impl/device/device_manager.cpp
+++ b/tt_metal/impl/device/device_manager.cpp
@@ -8,6 +8,8 @@
 #include <pthread.h>
 #include <tracy/Tracy.hpp>
 #include <unistd.h>  // Warning Linux Only, needed for _SC_NPROCESSORS_ONLN
+#include <cstdio>
+#include <ctime>
 
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -32,6 +34,7 @@
 #include "dispatch/system_memory_manager.hpp"
 
 #include <device.hpp>
+#include <cstdint>
 #include "device_impl.hpp"
 
 using namespace tt::tt_metal;
@@ -39,8 +42,9 @@ using namespace tt::tt_metal;
 namespace tt {
 
 namespace device_cpu_allocator {
-std::unordered_map<int, std::vector<uint32_t>> get_cpu_cores_per_numa_node(std::unordered_set<uint32_t>& free_cores) {
-    std::unordered_map<int, std::vector<uint32_t>> cpu_cores_per_numa_node = {};
+std::unordered_map<int, std::vector<std::uint32_t>> get_cpu_cores_per_numa_node(
+    std::unordered_set<std::uint32_t>& free_cores) {
+    std::unordered_map<int, std::vector<std::uint32_t>> cpu_cores_per_numa_node = {};
     if (numa_available() != -1) {
         // Host has NUMA enabled. Group CPU IDs by the NUMA nodes they belong to.
         for (int cpu = 0; cpu < numa_num_configured_cpus(); ++cpu) {
@@ -64,13 +68,13 @@ std::unordered_map<int, std::vector<uint32_t>> get_cpu_cores_per_numa_node(std::
 std::pair<int, int> get_cpu_cores_for_dispatch_threads(
     ContextId context_id,
     int mmio_controlled_device_id,
-    const std::unordered_map<int, std::vector<uint32_t>>& cpu_cores_per_numa_node,
-    std::unordered_set<uint32_t>& free_cores,
-    uint32_t num_devices,
+    const std::unordered_map<int, std::vector<std::uint32_t>>& cpu_cores_per_numa_node,
+    std::unordered_set<std::uint32_t>& free_cores,
+    std::uint32_t num_devices,
     bool use_separate_procs) {
     int core_assigned_to_device_worker_thread = 0;
     int core_assigned_to_device_completion_queue_reader = 0;
-    uint32_t num_online_processors = sysconf(_SC_NPROCESSORS_ONLN);
+    std::uint32_t num_online_processors = sysconf(_SC_NPROCESSORS_ONLN);
     // Get NUMA node that the current device is mapped to through UMD
     int numa_node_for_device = tt::tt_metal::MetalContext::instance(context_id)
                                    .get_cluster()
@@ -111,7 +115,7 @@ std::pair<int, int> get_cpu_cores_for_dispatch_threads(
     return std::make_pair(core_assigned_to_device_worker_thread, core_assigned_to_device_completion_queue_reader);
 }
 
-void bind_current_thread_to_free_cores(const std::unordered_set<uint32_t>& free_cores) {
+void bind_current_thread_to_free_cores(const std::unordered_set<std::uint32_t>& free_cores) {
     cpu_set_t cpuset;
     pthread_t current_thread = pthread_self();
     CPU_ZERO(&cpuset);
@@ -128,24 +132,24 @@ void bind_current_thread_to_free_cores(const std::unordered_set<uint32_t>& free_
     }
 }
 
-std::unordered_map<uint32_t, uint32_t> get_device_id_to_core_map(
+std::unordered_map<std::uint32_t, std::uint32_t> get_device_id_to_core_map(
     ContextId context_id,
-    const uint8_t num_hw_cqs,
-    std::unordered_map<uint32_t, uint32_t>& completion_queue_reader_to_cpu_core_map) {
+    const std::uint8_t num_hw_cqs,
+    std::unordered_map<std::uint32_t, std::uint32_t>& completion_queue_reader_to_cpu_core_map) {
     std::vector<ChipId> device_ids;
     for (ChipId device_id : tt::tt_metal::MetalContext::instance(context_id).get_cluster().all_chip_ids()) {
         device_ids.emplace_back(device_id);
     }
     bool use_numa_node_based_thread_binding =
         tt::tt_metal::MetalContext::instance(context_id).rtoptions().get_numa_based_affinity();
-    std::unordered_set<uint32_t> free_cores = {};
-    uint32_t num_online_processors = sysconf(_SC_NPROCESSORS_ONLN);
-    constexpr uint32_t max_num_procs_per_device = 2;
+    std::unordered_set<std::uint32_t> free_cores = {};
+    std::uint32_t num_online_processors = sysconf(_SC_NPROCESSORS_ONLN);
+    constexpr std::uint32_t max_num_procs_per_device = 2;
     // When using multiple command queues, assign separate CPU cores to worker and completion queue reader threads,
     // if enough processors exist on host. At least one core is given to the main thread.
     bool separate_procs_for_worker_and_reader =
         (num_hw_cqs > 1) && (max_num_procs_per_device * device_ids.size() <= num_online_processors - 1);
-    std::unordered_map<uint32_t, uint32_t> worker_thread_to_cpu_core_map = {};
+    std::unordered_map<std::uint32_t, std::uint32_t> worker_thread_to_cpu_core_map = {};
     if (use_numa_node_based_thread_binding) {
         auto cpu_cores_per_numa_node = device_cpu_allocator::get_cpu_cores_per_numa_node(free_cores);
         for (const auto& device_id : device_ids) {
@@ -163,10 +167,10 @@ std::unordered_map<uint32_t, uint32_t> get_device_id_to_core_map(
     } else {
         // Round Robin CPU assignment for worker and completion queue reader threads
         for (const auto& device_id : device_ids) {
-            uint32_t worker_thread_proc = device_id % num_online_processors;
+            std::uint32_t worker_thread_proc = device_id % num_online_processors;
             worker_thread_to_cpu_core_map.insert({device_id, worker_thread_proc});
             if (separate_procs_for_worker_and_reader) {
-                uint32_t completion_queue_reader_proc = (device_id + device_ids.size()) % num_online_processors;
+                std::uint32_t completion_queue_reader_proc = (device_id + device_ids.size()) % num_online_processors;
                 completion_queue_reader_to_cpu_core_map.insert({device_id, completion_queue_reader_proc});
             } else {
                 completion_queue_reader_to_cpu_core_map.insert({device_id, worker_thread_proc});
@@ -235,9 +239,28 @@ void DeviceManager::open_devices(const std::vector<ChipId>& device_ids) {
         // Must open all devices in cluster to use fabric
         if (any_remote_devices) {
             device_ids_to_open.clear();
-            for (int id = 0; id < env_impl_.get_cluster().number_of_devices(); ++id) {
+            // With TT_METAL_NO_CHIP_ID_REMAP (simulator multi-rank), chip IDs are not
+            // necessarily 0..N-1 — use the cluster's actual target set.
+            for (ChipId id : ctx_.get_cluster().all_chip_ids()) {
                 device_ids_to_open.push_back(id);
             }
+            // #region agent log
+            {
+                std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+                if (f) {
+                    std::fprintf(
+                        f,
+                        "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_NONCONSEC_CHIP_IDS\","
+                        "\"location\":\"device_manager.cpp:open_devices\","
+                        "\"message\":\"fabric_open_all_target_chips\",\"data\":{\"pid\":%d,"
+                        "\"num_devices\":%zu},\"timestamp\":%ld}\n",
+                        (int)getpid(),
+                        device_ids_to_open.size(),
+                        (long)std::time(nullptr));
+                    std::fclose(f);
+                }
+            }
+            // #endregion
         }
     }
 
@@ -445,7 +468,7 @@ void DeviceManager::add_devices_to_pool(const std::vector<ChipId>& device_ids) {
         this,
         [this]() -> tt::tt_fabric::ControlPlane& { return env_impl_.get_control_plane(); },
         [this]() -> const tt::tt_metal::DispatchQueryManager& { return ctx_.get_dispatch_query_manager(); },
-        [this]() { return static_cast<uint32_t>(this->get_max_num_eth_cores_across_all_devices()); },
+        [this]() { return static_cast<std::uint32_t>(this->get_max_num_eth_cores_across_all_devices()); },
         [this](ChipId id) {
             auto& s = ctx_.dprint_server();
             return s && s.get() && s->reads_dispatch_cores(id);
@@ -507,7 +530,7 @@ void DeviceManager::initialize_dispatch_firmware(bool force_recreate_topology) {
             this,
             [this]() -> tt::tt_fabric::ControlPlane& { return env_impl_.get_control_plane(); },
             [this]() -> const tt::tt_metal::DispatchQueryManager& { return ctx_.get_dispatch_query_manager(); },
-            [this]() { return static_cast<uint32_t>(this->get_max_num_eth_cores_across_all_devices()); },
+            [this]() { return static_cast<std::uint32_t>(this->get_max_num_eth_cores_across_all_devices()); },
             [this](ChipId id) {
                 auto& s = ctx_.dprint_server();
                 return s && s.get() && s->reads_dispatch_cores(id);
@@ -616,8 +639,8 @@ std::vector<ChipId> DeviceManager::get_all_active_device_ids() const {
 // Get all command queue event infos for all active devices
 // The key is the device id and the value is a vector of event ids for each command queue
 // This function needs to be thread-safe as its called in inspector::data on a different thread
-std::unordered_map<ChipId, std::vector<uint32_t>> DeviceManager::get_all_command_queue_event_infos() const {
-    std::unordered_map<ChipId, std::vector<uint32_t>> cq_to_event_by_device;
+std::unordered_map<ChipId, std::vector<std::uint32_t>> DeviceManager::get_all_command_queue_event_infos() const {
+    std::unordered_map<ChipId, std::vector<std::uint32_t>> cq_to_event_by_device;
     std::lock_guard<std::mutex> lock(lock_);
     cq_to_event_by_device.reserve(devices_.size());
     for (const auto& device : devices_) {
@@ -626,7 +649,7 @@ std::unordered_map<ChipId, std::vector<uint32_t>> DeviceManager::get_all_command
             const auto num_hw_cqs = device->num_hw_cqs();
             vec.resize(num_hw_cqs);
             for (size_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-                const auto event_id = device->sysmem_manager().get_last_event(static_cast<uint8_t>(cq_id));
+                const auto event_id = device->sysmem_manager().get_last_event(static_cast<std::uint8_t>(cq_id));
                 vec[cq_id] = event_id;
             }
         }
@@ -689,7 +712,7 @@ bool DeviceManager::close_devices(const std::vector<IDevice*>& devices, bool /*s
         // iterate over all tunnels origination from this mmio device
         for (auto t : tunnels_from_mmio) {
             // iterate over all tunneled devices (tunnel stops) in this tunnel
-            for (uint32_t ts = t.size() - 1; ts > 0; ts--) {
+            for (std::uint32_t ts = t.size() - 1; ts > 0; ts--) {
                 if (this->is_device_active(t[ts])) {
                     devices_to_close.push_back(t[ts]);
                 }

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -15,7 +15,8 @@
 
 namespace tt::tt_metal {
 
-uint32_t calculate_max_prefetch_data_size_bytes(const CoreType& /*dispatch_core_type*/, uint32_t num_subdevices) {
+std::uint32_t calculate_max_prefetch_data_size_bytes(
+    const CoreType& /*dispatch_core_type*/, std::uint32_t num_subdevices) {
     // CQ capacity would be reduced by the commands and alignment padding.
     // prefetch_relay_inline, dispatch_wait (x #workers), and dispatch_write_linear would add alignment padding
     const auto host_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::HOST);
@@ -32,7 +33,7 @@ struct CoreWriteDispatchParams : public CoreDispatchParams {
 };
 
 void validate_core_read_write_bounds(
-    IDevice* device, const CoreCoord& virtual_core, DeviceAddr address, uint32_t size_bytes) {
+    IDevice* device, const CoreCoord& virtual_core, DeviceAddr address, std::uint32_t size_bytes) {
     const HalMemType mem_type = device->get_mem_type_of_core(virtual_core);
     if (mem_type == HalMemType::L1) {
         const auto& hal = tt::tt_metal::MetalContext::instance(extract_context_id(device)).hal();
@@ -46,7 +47,7 @@ void validate_core_read_write_bounds(
         TT_ASSERT(mem_type == HalMemType::DRAM);
 
         const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
-        const uint32_t dram_channel = device->dram_channel_from_virtual_core(virtual_core);
+        const std::uint32_t dram_channel = device->dram_channel_from_virtual_core(virtual_core);
         const DeviceAddr dram_base_address = soc_desc.get_address_offset(dram_channel);
 
         const DeviceAddr dram_channel_size = device->dram_size_per_channel();
@@ -60,29 +61,29 @@ DeviceAddr add_bank_offset_to_address(IDevice* device, const CoreCoord& virtual_
     const HalMemType mem_type = device->get_mem_type_of_core(virtual_core);
     if (mem_type == HalMemType::DRAM) {
         const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
-        const uint32_t dram_channel = device->dram_channel_from_virtual_core(virtual_core);
+        const std::uint32_t dram_channel = device->dram_channel_from_virtual_core(virtual_core);
         address += soc_desc.get_address_offset(dram_channel);
     }
     return address;
 }
 
 void issue_core_write_command_sequence(const CoreWriteDispatchParams& dispatch_params) {
-    const uint32_t num_worker_counters = dispatch_params.sub_device_ids.size();
+    const std::uint32_t num_worker_counters = dispatch_params.sub_device_ids.size();
 
     DeviceCommandCalculator calculator;
-    for (uint32_t i = 0; i < num_worker_counters; ++i) {
+    for (std::uint32_t i = 0; i < num_worker_counters; ++i) {
         calculator.add_dispatch_wait();
     }
     calculator.add_dispatch_write_linear<true, true>(dispatch_params.size_bytes);
 
-    const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
+    const std::uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
-    for (uint32_t i = 0; i < num_worker_counters; ++i) {
-        const uint8_t offset_index = *dispatch_params.sub_device_ids[i];
+    for (std::uint32_t i = 0; i < num_worker_counters; ++i) {
+        const std::uint8_t offset_index = *dispatch_params.sub_device_ids[i];
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
             0,
@@ -95,7 +96,7 @@ void issue_core_write_command_sequence(const CoreWriteDispatchParams& dispatch_p
         dispatch_params.device->get_noc_unicast_encoding(k_dispatch_downstream_noc, dispatch_params.virtual_core),
         dispatch_params.address,
         dispatch_params.size_bytes,
-        (uint8_t*)dispatch_params.src);
+        (std::uint8_t*)dispatch_params.src);
 
     sysmem_manager.issue_queue_push_back(cmd_sequence_sizeB, dispatch_params.cq_id);
     sysmem_manager.fetch_queue_reserve_back(dispatch_params.cq_id);
@@ -107,16 +108,16 @@ void write_to_core(
     const CoreCoord& virtual_core,
     const void* src,
     DeviceAddr address,
-    uint32_t size_bytes,
-    uint32_t cq_id,
-    tt::stl::Span<const uint32_t> expected_num_workers_completed,
+    std::uint32_t size_bytes,
+    std::uint32_t cq_id,
+    tt::stl::Span<const std::uint32_t> expected_num_workers_completed,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     validate_core_read_write_bounds(device, virtual_core, address, size_bytes);
 
     while (size_bytes > 0) {
         const CoreType dispatch_core_type =
             MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-        const uint32_t size_bytes_to_write =
+        const std::uint32_t size_bytes_to_write =
             std::min(size_bytes, calculate_max_prefetch_data_size_bytes(dispatch_core_type, sub_device_ids.size()));
 
         CoreWriteDispatchParams dispatch_params{
@@ -133,36 +134,36 @@ void write_to_core(
 
         size_bytes -= size_bytes_to_write;
         address += size_bytes_to_write;
-        src = (uint8_t*)src + size_bytes_to_write;
+        src = (std::uint8_t*)src + size_bytes_to_write;
     }
 }
 
 void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_params) {
-    const uint32_t num_worker_counters = dispatch_params.sub_device_ids.size();
+    const std::uint32_t num_worker_counters = dispatch_params.sub_device_ids.size();
     DeviceCommandCalculator calculator;
-    for (uint32_t i = 0; i < num_worker_counters - 1; ++i) {
+    for (std::uint32_t i = 0; i < num_worker_counters - 1; ++i) {
         calculator.add_dispatch_wait();
     }
     calculator.add_dispatch_wait_with_prefetch_stall();
     calculator.add_dispatch_write_linear_host();
     calculator.add_prefetch_relay_linear();
-    const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
+    const std::uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
     // We only need the write barrier + prefetch stall for the last wait cmd
-    const uint32_t last_index = num_worker_counters - 1;
-    for (uint32_t i = 0; i < last_index; ++i) {
-        const uint8_t offset_index = *dispatch_params.sub_device_ids[i];
+    const std::uint32_t last_index = num_worker_counters - 1;
+    for (std::uint32_t i = 0; i < last_index; ++i) {
+        const std::uint8_t offset_index = *dispatch_params.sub_device_ids[i];
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
             0,
             tt::tt_metal::MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
             dispatch_params.expected_num_workers_completed[offset_index]);
     }
-    const uint8_t offset_index = *dispatch_params.sub_device_ids[last_index];
+    const std::uint8_t offset_index = *dispatch_params.sub_device_ids[last_index];
     command_sequence.add_dispatch_wait_with_prefetch_stall(
         CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER,
         0,
@@ -183,19 +184,26 @@ void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_par
 
 void read_completion_queue(
     void* dst,
-    uint32_t size_bytes,
+    std::uint32_t size_bytes,
     ChipId device_id,
-    uint16_t channel,
-    uint32_t addr,
+    std::uint16_t channel,
+    std::uint32_t addr,
     const SystemMemoryManager& sysmem_manager) {
     if (sysmem_manager.is_dram_backed()) {
-        const uint32_t dram_channel = tt::tt_metal::MetalContext::instance()
-                                          .device_manager()
-                                          ->get_active_device(device_id)
-                                          ->allocator_impl()
-                                          ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
+        // Caller passes mmio_device_id (correct for the hugepage / read_sysmem
+        // path), but DRAM-backed CQs live in the dispatch chip's OWN DRAM, not
+        // the local MMIO chip's. Use the SystemMemoryManager's actual device_id
+        // so tunnel/remote-chip event completions read from the chip whose
+        // dispatch kernel produced them, not from chip 0.
+        const ChipId actual_device_id = sysmem_manager.get_device_id();
+        const std::uint32_t dram_channel =
+            tt::tt_metal::MetalContext::instance()
+                .device_manager()
+                ->get_active_device(actual_device_id)
+                ->allocator_impl()
+                ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
         tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
-            dst, size_bytes, device_id, dram_channel, addr);
+            dst, size_bytes, actual_device_id, dram_channel, addr);
     } else {
         tt::tt_metal::MetalContext::instance().get_cluster().read_sysmem(dst, size_bytes, addr, device_id, channel);
     }
@@ -204,27 +212,27 @@ void read_completion_queue(
 void read_core_data_from_completion_queue(
     const ReadCoreDataDescriptor& read_descriptor,
     ChipId mmio_device_id,
-    uint16_t channel,
-    uint8_t cq_id,
+    std::uint16_t channel,
+    std::uint8_t cq_id,
     SystemMemoryManager& sysmem_manager,
     std::atomic<bool>& exit_condition) {
-    uint32_t completion_queue_read_offset = sizeof(CQDispatchCmd);
-    const uint32_t num_bytes_to_read = read_descriptor.size_bytes;
-    uint32_t num_bytes_read = 0;
+    std::uint32_t completion_queue_read_offset = sizeof(CQDispatchCmd);
+    const std::uint32_t num_bytes_to_read = read_descriptor.size_bytes;
+    std::uint32_t num_bytes_read = 0;
     while (num_bytes_read < num_bytes_to_read) {
-        const uint32_t completion_queue_write_ptr_and_toggle =
+        const std::uint32_t completion_queue_write_ptr_and_toggle =
             sysmem_manager.completion_queue_wait_front(cq_id, exit_condition);
 
         if (exit_condition) {
             break;
         }
 
-        const uint32_t completion_q_write_ptr = (completion_queue_write_ptr_and_toggle & 0x7fffffff) << 4;
-        const uint32_t completion_q_write_toggle = completion_queue_write_ptr_and_toggle >> (31);
-        const uint32_t completion_q_read_ptr = sysmem_manager.get_completion_queue_read_ptr(cq_id);
-        const uint32_t completion_q_read_toggle = sysmem_manager.get_completion_queue_read_toggle(cq_id);
+        const std::uint32_t completion_q_write_ptr = (completion_queue_write_ptr_and_toggle & 0x7fffffff) << 4;
+        const std::uint32_t completion_q_write_toggle = completion_queue_write_ptr_and_toggle >> (31);
+        const std::uint32_t completion_q_read_ptr = sysmem_manager.get_completion_queue_read_ptr(cq_id);
+        const std::uint32_t completion_q_read_toggle = sysmem_manager.get_completion_queue_read_toggle(cq_id);
 
-        uint32_t num_bytes_available_in_completion_queue;
+        std::uint32_t num_bytes_available_in_completion_queue;
         if (completion_q_write_ptr > completion_q_read_ptr and completion_q_write_toggle == completion_q_read_toggle) {
             num_bytes_available_in_completion_queue = completion_q_write_ptr - completion_q_read_ptr;
         } else {
@@ -234,11 +242,11 @@ void read_core_data_from_completion_queue(
                 sysmem_manager.get_completion_queue_limit(cq_id) - completion_q_read_ptr;
         }
 
-        const uint32_t num_bytes_to_copy = std::min(
+        const std::uint32_t num_bytes_to_copy = std::min(
             num_bytes_to_read - num_bytes_read, num_bytes_available_in_completion_queue - completion_queue_read_offset);
 
         read_completion_queue(
-            (char*)(uint64_t(read_descriptor.dst) + num_bytes_read),
+            (char*)(std::uint64_t(read_descriptor.dst) + num_bytes_read),
             num_bytes_to_copy,
             mmio_device_id,
             channel,
@@ -246,7 +254,7 @@ void read_core_data_from_completion_queue(
             sysmem_manager);
 
         num_bytes_read += num_bytes_to_copy;
-        const uint32_t num_pages_read =
+        const std::uint32_t num_pages_read =
             tt::div_up(num_bytes_to_copy + completion_queue_read_offset, DispatchSettings::TRANSFER_PAGE_SIZE);
         sysmem_manager.completion_queue_pop_front(num_pages_read, cq_id);
         completion_queue_read_offset = 0;

--- a/tt_metal/impl/device/dispatch.cpp
+++ b/tt_metal/impl/device/dispatch.cpp
@@ -15,8 +15,7 @@
 
 namespace tt::tt_metal {
 
-std::uint32_t calculate_max_prefetch_data_size_bytes(
-    const CoreType& /*dispatch_core_type*/, std::uint32_t num_subdevices) {
+uint32_t calculate_max_prefetch_data_size_bytes(const CoreType& /*dispatch_core_type*/, uint32_t num_subdevices) {
     // CQ capacity would be reduced by the commands and alignment padding.
     // prefetch_relay_inline, dispatch_wait (x #workers), and dispatch_write_linear would add alignment padding
     const auto host_alignment = tt::tt_metal::MetalContext::instance().hal().get_alignment(HalMemType::HOST);
@@ -33,7 +32,7 @@ struct CoreWriteDispatchParams : public CoreDispatchParams {
 };
 
 void validate_core_read_write_bounds(
-    IDevice* device, const CoreCoord& virtual_core, DeviceAddr address, std::uint32_t size_bytes) {
+    IDevice* device, const CoreCoord& virtual_core, DeviceAddr address, uint32_t size_bytes) {
     const HalMemType mem_type = device->get_mem_type_of_core(virtual_core);
     if (mem_type == HalMemType::L1) {
         const auto& hal = tt::tt_metal::MetalContext::instance(extract_context_id(device)).hal();
@@ -47,7 +46,7 @@ void validate_core_read_write_bounds(
         TT_ASSERT(mem_type == HalMemType::DRAM);
 
         const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
-        const std::uint32_t dram_channel = device->dram_channel_from_virtual_core(virtual_core);
+        const uint32_t dram_channel = device->dram_channel_from_virtual_core(virtual_core);
         const DeviceAddr dram_base_address = soc_desc.get_address_offset(dram_channel);
 
         const DeviceAddr dram_channel_size = device->dram_size_per_channel();
@@ -61,29 +60,29 @@ DeviceAddr add_bank_offset_to_address(IDevice* device, const CoreCoord& virtual_
     const HalMemType mem_type = device->get_mem_type_of_core(virtual_core);
     if (mem_type == HalMemType::DRAM) {
         const auto& soc_desc = tt::tt_metal::MetalContext::instance().get_cluster().get_soc_desc(device->id());
-        const std::uint32_t dram_channel = device->dram_channel_from_virtual_core(virtual_core);
+        const uint32_t dram_channel = device->dram_channel_from_virtual_core(virtual_core);
         address += soc_desc.get_address_offset(dram_channel);
     }
     return address;
 }
 
 void issue_core_write_command_sequence(const CoreWriteDispatchParams& dispatch_params) {
-    const std::uint32_t num_worker_counters = dispatch_params.sub_device_ids.size();
+    const uint32_t num_worker_counters = dispatch_params.sub_device_ids.size();
 
     DeviceCommandCalculator calculator;
-    for (std::uint32_t i = 0; i < num_worker_counters; ++i) {
+    for (uint32_t i = 0; i < num_worker_counters; ++i) {
         calculator.add_dispatch_wait();
     }
     calculator.add_dispatch_write_linear<true, true>(dispatch_params.size_bytes);
 
-    const std::uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
+    const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
-    for (std::uint32_t i = 0; i < num_worker_counters; ++i) {
-        const std::uint8_t offset_index = *dispatch_params.sub_device_ids[i];
+    for (uint32_t i = 0; i < num_worker_counters; ++i) {
+        const uint8_t offset_index = *dispatch_params.sub_device_ids[i];
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
             0,
@@ -96,7 +95,7 @@ void issue_core_write_command_sequence(const CoreWriteDispatchParams& dispatch_p
         dispatch_params.device->get_noc_unicast_encoding(k_dispatch_downstream_noc, dispatch_params.virtual_core),
         dispatch_params.address,
         dispatch_params.size_bytes,
-        (std::uint8_t*)dispatch_params.src);
+        (uint8_t*)dispatch_params.src);
 
     sysmem_manager.issue_queue_push_back(cmd_sequence_sizeB, dispatch_params.cq_id);
     sysmem_manager.fetch_queue_reserve_back(dispatch_params.cq_id);
@@ -108,16 +107,16 @@ void write_to_core(
     const CoreCoord& virtual_core,
     const void* src,
     DeviceAddr address,
-    std::uint32_t size_bytes,
-    std::uint32_t cq_id,
-    tt::stl::Span<const std::uint32_t> expected_num_workers_completed,
+    uint32_t size_bytes,
+    uint32_t cq_id,
+    tt::stl::Span<const uint32_t> expected_num_workers_completed,
     tt::stl::Span<const SubDeviceId> sub_device_ids) {
     validate_core_read_write_bounds(device, virtual_core, address, size_bytes);
 
     while (size_bytes > 0) {
         const CoreType dispatch_core_type =
             MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-        const std::uint32_t size_bytes_to_write =
+        const uint32_t size_bytes_to_write =
             std::min(size_bytes, calculate_max_prefetch_data_size_bytes(dispatch_core_type, sub_device_ids.size()));
 
         CoreWriteDispatchParams dispatch_params{
@@ -134,36 +133,36 @@ void write_to_core(
 
         size_bytes -= size_bytes_to_write;
         address += size_bytes_to_write;
-        src = (std::uint8_t*)src + size_bytes_to_write;
+        src = (uint8_t*)src + size_bytes_to_write;
     }
 }
 
 void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_params) {
-    const std::uint32_t num_worker_counters = dispatch_params.sub_device_ids.size();
+    const uint32_t num_worker_counters = dispatch_params.sub_device_ids.size();
     DeviceCommandCalculator calculator;
-    for (std::uint32_t i = 0; i < num_worker_counters - 1; ++i) {
+    for (uint32_t i = 0; i < num_worker_counters - 1; ++i) {
         calculator.add_dispatch_wait();
     }
     calculator.add_dispatch_wait_with_prefetch_stall();
     calculator.add_dispatch_write_linear_host();
     calculator.add_prefetch_relay_linear();
-    const std::uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
+    const uint32_t cmd_sequence_sizeB = calculator.write_offset_bytes();
 
     SystemMemoryManager& sysmem_manager = dispatch_params.device->sysmem_manager();
     void* cmd_region = sysmem_manager.issue_queue_reserve(cmd_sequence_sizeB, dispatch_params.cq_id);
     HugepageDeviceCommand command_sequence(cmd_region, cmd_sequence_sizeB);
 
     // We only need the write barrier + prefetch stall for the last wait cmd
-    const std::uint32_t last_index = num_worker_counters - 1;
-    for (std::uint32_t i = 0; i < last_index; ++i) {
-        const std::uint8_t offset_index = *dispatch_params.sub_device_ids[i];
+    const uint32_t last_index = num_worker_counters - 1;
+    for (uint32_t i = 0; i < last_index; ++i) {
+        const uint8_t offset_index = *dispatch_params.sub_device_ids[i];
         command_sequence.add_dispatch_wait(
             CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM,
             0,
             tt::tt_metal::MetalContext::instance().dispatch_mem_map().get_dispatch_stream_index(offset_index),
             dispatch_params.expected_num_workers_completed[offset_index]);
     }
-    const std::uint8_t offset_index = *dispatch_params.sub_device_ids[last_index];
+    const uint8_t offset_index = *dispatch_params.sub_device_ids[last_index];
     command_sequence.add_dispatch_wait_with_prefetch_stall(
         CQ_DISPATCH_CMD_WAIT_FLAG_WAIT_STREAM | CQ_DISPATCH_CMD_WAIT_FLAG_BARRIER,
         0,
@@ -184,10 +183,10 @@ void issue_core_read_command_sequence(const CoreReadDispatchParams& dispatch_par
 
 void read_completion_queue(
     void* dst,
-    std::uint32_t size_bytes,
+    uint32_t size_bytes,
     ChipId device_id,
-    std::uint16_t channel,
-    std::uint32_t addr,
+    uint16_t channel,
+    uint32_t addr,
     const SystemMemoryManager& sysmem_manager) {
     if (sysmem_manager.is_dram_backed()) {
         // Caller passes mmio_device_id (correct for the hugepage / read_sysmem
@@ -196,12 +195,11 @@ void read_completion_queue(
         // so tunnel/remote-chip event completions read from the chip whose
         // dispatch kernel produced them, not from chip 0.
         const ChipId actual_device_id = sysmem_manager.get_device_id();
-        const std::uint32_t dram_channel =
-            tt::tt_metal::MetalContext::instance()
-                .device_manager()
-                ->get_active_device(actual_device_id)
-                ->allocator_impl()
-                ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
+        const uint32_t dram_channel = tt::tt_metal::MetalContext::instance()
+                                          .device_manager()
+                                          ->get_active_device(actual_device_id)
+                                          ->allocator_impl()
+                                          ->get_dram_channel_from_bank_id(sysmem_manager.get_dram_region_bank_id());
         tt::tt_metal::MetalContext::instance().get_cluster().read_dram_vec(
             dst, size_bytes, actual_device_id, dram_channel, addr);
     } else {
@@ -212,27 +210,27 @@ void read_completion_queue(
 void read_core_data_from_completion_queue(
     const ReadCoreDataDescriptor& read_descriptor,
     ChipId mmio_device_id,
-    std::uint16_t channel,
-    std::uint8_t cq_id,
+    uint16_t channel,
+    uint8_t cq_id,
     SystemMemoryManager& sysmem_manager,
     std::atomic<bool>& exit_condition) {
-    std::uint32_t completion_queue_read_offset = sizeof(CQDispatchCmd);
-    const std::uint32_t num_bytes_to_read = read_descriptor.size_bytes;
-    std::uint32_t num_bytes_read = 0;
+    uint32_t completion_queue_read_offset = sizeof(CQDispatchCmd);
+    const uint32_t num_bytes_to_read = read_descriptor.size_bytes;
+    uint32_t num_bytes_read = 0;
     while (num_bytes_read < num_bytes_to_read) {
-        const std::uint32_t completion_queue_write_ptr_and_toggle =
+        const uint32_t completion_queue_write_ptr_and_toggle =
             sysmem_manager.completion_queue_wait_front(cq_id, exit_condition);
 
         if (exit_condition) {
             break;
         }
 
-        const std::uint32_t completion_q_write_ptr = (completion_queue_write_ptr_and_toggle & 0x7fffffff) << 4;
-        const std::uint32_t completion_q_write_toggle = completion_queue_write_ptr_and_toggle >> (31);
-        const std::uint32_t completion_q_read_ptr = sysmem_manager.get_completion_queue_read_ptr(cq_id);
-        const std::uint32_t completion_q_read_toggle = sysmem_manager.get_completion_queue_read_toggle(cq_id);
+        const uint32_t completion_q_write_ptr = (completion_queue_write_ptr_and_toggle & 0x7fffffff) << 4;
+        const uint32_t completion_q_write_toggle = completion_queue_write_ptr_and_toggle >> (31);
+        const uint32_t completion_q_read_ptr = sysmem_manager.get_completion_queue_read_ptr(cq_id);
+        const uint32_t completion_q_read_toggle = sysmem_manager.get_completion_queue_read_toggle(cq_id);
 
-        std::uint32_t num_bytes_available_in_completion_queue;
+        uint32_t num_bytes_available_in_completion_queue;
         if (completion_q_write_ptr > completion_q_read_ptr and completion_q_write_toggle == completion_q_read_toggle) {
             num_bytes_available_in_completion_queue = completion_q_write_ptr - completion_q_read_ptr;
         } else {
@@ -242,11 +240,11 @@ void read_core_data_from_completion_queue(
                 sysmem_manager.get_completion_queue_limit(cq_id) - completion_q_read_ptr;
         }
 
-        const std::uint32_t num_bytes_to_copy = std::min(
+        const uint32_t num_bytes_to_copy = std::min(
             num_bytes_to_read - num_bytes_read, num_bytes_available_in_completion_queue - completion_queue_read_offset);
 
         read_completion_queue(
-            (char*)(std::uint64_t(read_descriptor.dst) + num_bytes_read),
+            (char*)(uint64_t(read_descriptor.dst) + num_bytes_read),
             num_bytes_to_copy,
             mmio_device_id,
             channel,
@@ -254,7 +252,7 @@ void read_core_data_from_completion_queue(
             sysmem_manager);
 
         num_bytes_read += num_bytes_to_copy;
-        const std::uint32_t num_pages_read =
+        const uint32_t num_pages_read =
             tt::div_up(num_bytes_to_copy + completion_queue_read_offset, DispatchSettings::TRANSFER_PAGE_SIZE);
         sysmem_manager.completion_queue_pop_front(num_pages_read, cq_id);
         completion_queue_read_offset = 0;

--- a/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
+++ b/tt_metal/impl/device/firmware/dispatch_kernel_initializer.cpp
@@ -4,10 +4,15 @@
 
 #include "dispatch_kernel_initializer.hpp"
 
+#include <cstdio>
+#include <ctime>
+#include <string>
+#include <unistd.h>
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
 #include <llrt/tt_cluster.hpp>
 #include <tt_metal.hpp>
+#include <cstdint>
 #include "common/executor.hpp"
 #include "device/firmware/firmware_initializer.hpp"
 #include "impl/context/context_descriptor.hpp"
@@ -145,8 +150,8 @@ void DispatchKernelInitializer::compile_dispatch_kernels() {
         auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
         dispatch_topology_->populate_cq_static_args(dev);
         for (const auto& tunnel : tunnels_from_mmio) {
-            for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
-                uint32_t mmio_controlled_device_id = tunnel[ts];
+            for (std::uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                std::uint32_t mmio_controlled_device_id = tunnel[ts];
                 auto it = std::find_if(
                     devices_.begin(), devices_.end(), [&](IDevice* d) { return d->id() == mmio_controlled_device_id; });
                 if (it != devices_.end()) {
@@ -165,8 +170,8 @@ void DispatchKernelInitializer::compile_dispatch_kernels() {
         dispatch_topology_->create_cq_program(dev);
         auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(dev->id());
         for (const auto& tunnel : tunnels_from_mmio) {
-            for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
-                uint32_t mmio_controlled_device_id = tunnel[ts];
+            for (std::uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                std::uint32_t mmio_controlled_device_id = tunnel[ts];
                 auto it = std::find_if(
                     devices_.begin(), devices_.end(), [&](IDevice* d) { return d->id() == mmio_controlled_device_id; });
                 if (it != devices_.end()) {
@@ -186,6 +191,34 @@ void DispatchKernelInitializer::init_device_command_queues() {
     if (descriptor_->is_mock_device()) {
         return;
     }
+    // #region agent log
+    {
+        std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+        if (f) {
+            std::string visible_ids;
+            for (auto* d : devices_) {
+                visible_ids += std::to_string(d->id()) + ",";
+            }
+            const char* env_visible = std::getenv("TT_VISIBLE_DEVICES");
+            const char* env_mesh_id = std::getenv("TT_MESH_ID");
+            const char* env_mesh_rank = std::getenv("TT_MESH_HOST_RANK");
+            std::fprintf(
+                f,
+                "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_DUAL_INIT_CONFLICT\","
+                "\"location\":\"dispatch_kernel_initializer.cpp:init_device_command_queues\","
+                "\"message\":\"INIT_DCQ_START\",\"data\":{\"pid\":%d,\"visible_devices_actual\":\"%s\","
+                "\"TT_VISIBLE_DEVICES_env\":\"%s\",\"TT_MESH_ID\":\"%s\",\"TT_MESH_HOST_RANK\":\"%s\"},\"timestamp\":%"
+                "ld}\n",
+                (int)getpid(),
+                visible_ids.c_str(),
+                env_visible ? env_visible : "(unset)",
+                env_mesh_id ? env_mesh_id : "(unset)",
+                env_mesh_rank ? env_mesh_rank : "(unset)",
+                (long)std::time(nullptr));
+            std::fclose(f);
+        }
+    }
+    // #endregion
 
     std::vector<std::shared_future<void>> events;
     for (auto* dev : devices_) {
@@ -196,15 +229,69 @@ void DispatchKernelInitializer::init_device_command_queues() {
         events.emplace_back(detail::async([this, dev, mmio_device_id]() {
             auto tunnels_from_mmio = cluster_.get_tunnels_from_mmio_device(mmio_device_id);
             dev->init_command_queue_device_with_topology(dispatch_topology_.get());
+            // #region agent log
+            {
+                std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+                if (f) {
+                    std::fprintf(
+                        f,
+                        "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_DISPATCH_NOT_LAUNCHED_TUNNEL\","
+                        "\"location\":\"dispatch_kernel_initializer.cpp:init_device_command_queues\","
+                        "\"message\":\"INIT_DCQ_MMIO\",\"data\":{\"pid\":%d,\"device_id\":%u,\"is_tunnel\":0},"
+                        "\"timestamp\":%ld}\n",
+                        (int)getpid(),
+                        (unsigned)dev->id(),
+                        (long)std::time(nullptr));
+                    std::fclose(f);
+                }
+            }
+            // #endregion
             log_debug(tt::LogMetal, "Command Queue initialized on Device {}", dev->id());
             for (const auto& tunnel : tunnels_from_mmio) {
-                for (uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
-                    uint32_t mmio_controlled_device_id = tunnel[ts];
+                for (std::uint32_t ts = tunnel.size() - 1; ts > 0; ts--) {
+                    std::uint32_t mmio_controlled_device_id = tunnel[ts];
                     auto it = std::find_if(devices_.begin(), devices_.end(), [&](IDevice* d) {
                         return d->id() == mmio_controlled_device_id;
                     });
+                    // #region agent log
+                    {
+                        std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+                        if (f) {
+                            std::fprintf(
+                                f,
+                                "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_DISPATCH_NOT_LAUNCHED_TUNNEL\","
+                                "\"location\":\"dispatch_kernel_initializer.cpp:init_device_command_queues\","
+                                "\"message\":\"TUNNEL_CHECK\",\"data\":{\"pid\":%d,\"mmio_device_id\":%u,"
+                                "\"tunnel_chip\":%u,\"found_in_devices_\":%d},\"timestamp\":%ld}\n",
+                                (int)getpid(),
+                                (unsigned)mmio_device_id,
+                                (unsigned)mmio_controlled_device_id,
+                                (int)(it != devices_.end()),
+                                (long)std::time(nullptr));
+                            std::fclose(f);
+                        }
+                    }
+                    // #endregion
                     if (it != devices_.end()) {
                         (*it)->init_command_queue_device_with_topology(dispatch_topology_.get());
+                        // #region agent log
+                        {
+                            std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+                            if (f) {
+                                std::fprintf(
+                                    f,
+                                    "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_DISPATCH_NOT_LAUNCHED_TUNNEL\","
+                                    "\"location\":\"dispatch_kernel_initializer.cpp:init_device_command_queues\","
+                                    "\"message\":\"INIT_DCQ_TUNNEL\",\"data\":{\"pid\":%d,\"device_id\":%u,\"mmio_"
+                                    "device_id\":%u,\"is_tunnel\":1},\"timestamp\":%ld}\n",
+                                    (int)getpid(),
+                                    (unsigned)mmio_controlled_device_id,
+                                    (unsigned)mmio_device_id,
+                                    (long)std::time(nullptr));
+                                std::fclose(f);
+                            }
+                        }
+                        // #endregion
                         log_debug(tt::LogMetal, "Command Queue initialized on Device {}", (*it)->id());
                     }
                 }
@@ -267,7 +354,7 @@ void DispatchKernelInitializer::process_termination_signals() const {
     for (auto* dev : devices_) {
         const auto& info = dispatch_topology_->get_registered_termination_cores(dev->id());
         for (const auto& core_to_terminate : info) {
-            std::vector<uint32_t> val{core_to_terminate.val};
+            std::vector<std::uint32_t> val{core_to_terminate.val};
             detail::WriteToDeviceL1(
                 dev, core_to_terminate.logical_core, core_to_terminate.address, val, core_to_terminate.core_type);
         }

--- a/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/fabric_firmware_initializer.cpp
@@ -6,9 +6,13 @@
 #include "fabric_firmware_initializer.hpp"
 
 #include <algorithm>
+#include <atomic>
 #include <chrono>
+#include <cstdio>
+#include <ctime>
 #include <optional>
 #include <string_view>
+#include <unistd.h>
 
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>
@@ -454,8 +458,34 @@ void FabricFirmwareInitializer::wait_for_fabric_router_sync(uint32_t timeout_ms)
         std::vector<std::uint32_t> master_router_status{0};
         auto start_time = std::chrono::steady_clock::now();
         while (master_router_status[0] != expected_status) {
+            cluster_.advance_device_execution(dev->id());
             detail::ReadFromDeviceL1(
                 dev, master_router_logical_core, router_sync_address, 4, master_router_status, CoreType::ETH);
+            // #region agent log
+            {
+                static std::atomic<int> fab_poll_log{0};
+                const int n = fab_poll_log.fetch_add(1);
+                if (n == 0 || (n % 2000) == 0) {
+                    std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+                    if (f) {
+                        std::fprintf(
+                            f,
+                            "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_FAB_ROUTER_SYNC\","
+                            "\"location\":\"fabric_firmware_initializer.cpp:wait_for_handshake\","
+                            "\"message\":\"POLL\",\"data\":{\"device_id\":%u,\"master_chan\":%u,"
+                            "\"status\":%u,\"expected\":%u,\"poll\":%d,\"pid\":%d},\"timestamp\":%ld}\n",
+                            (unsigned)dev->id(),
+                            (unsigned)master_router_chan,
+                            (unsigned)master_router_status[0],
+                            (unsigned)expected_status,
+                            n,
+                            (int)getpid(),
+                            (long)std::time(nullptr));
+                        std::fclose(f);
+                    }
+                }
+            }
+            // #endregion
             if (master_router_status[0] == expected_status) {
                 break;
             }

--- a/tt_metal/impl/dispatch/command_queue_common.cpp
+++ b/tt_metal/impl/dispatch/command_queue_common.cpp
@@ -14,6 +14,8 @@
 #include <llrt/tt_cluster.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include <impl/dispatch/dispatch_core_manager.hpp>
+#include <cstdint>
+#include <llrt/hal.hpp>
 
 namespace tt::tt_metal {
 
@@ -159,6 +161,29 @@ uint32_t get_cq_dispatch_progress(ChipId chip_id, uint8_t cq_id) {
         &progress, sizeof(uint32_t), dispatcher_core_virtual, dev_dispatch_progress_ptr);
 
     return progress;
+}
+
+uint32_t get_cq_dispatch_go_signal(ChipId chip_id, uint8_t cq_id) {
+    uint32_t go_msg_word = 0;
+    uint16_t channel =
+        tt::tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(chip_id);
+    auto& dispatch_core_manager = MetalContext::instance().get_dispatch_core_manager();
+    const tt_cxy_pair& dispatcher_core_logical =
+        dispatch_core_manager.is_dispatcher_d_core_allocated(chip_id, channel, cq_id)
+            ? dispatch_core_manager.dispatcher_d_core(chip_id, channel, cq_id)
+            : dispatch_core_manager.dispatcher_core(chip_id, channel, cq_id);
+    CoreType dispatch_core_type = dispatch_core_manager.get_dispatch_core_type();
+    tt_cxy_pair dispatcher_core_virtual =
+        MetalContext::instance().get_cluster().get_virtual_coordinate_from_logical_coordinates(
+            dispatcher_core_logical, dispatch_core_type);
+    const auto programmable_core_type = dispatch_core_type == CoreType::ETH
+                                            ? tt::tt_metal::HalProgrammableCoreType::ACTIVE_ETH
+                                            : tt::tt_metal::HalProgrammableCoreType::TENSIX;
+    uint64_t go_msg_addr =
+        MetalContext::instance().hal().get_dev_noc_addr(programmable_core_type, tt::tt_metal::HalL1MemAddrType::GO_MSG);
+    tt::tt_metal::MetalContext::instance().get_cluster().read_core(
+        &go_msg_word, sizeof(uint32_t), dispatcher_core_virtual, go_msg_addr);
+    return go_msg_word & 0xffu;
 }
 
 uint32_t calculate_expected_workers_to_finish(

--- a/tt_metal/impl/dispatch/command_queue_common.hpp
+++ b/tt_metal/impl/dispatch/command_queue_common.hpp
@@ -78,6 +78,9 @@ uint32_t get_cq_completion_rd_ptr(ChipId chip_id, uint8_t cq_id, uint32_t cq_siz
 
 uint32_t get_cq_dispatch_progress(ChipId chip_id, uint8_t cq_id);
 
+// Low byte of go_msg.signal on the dispatch core (RUN_MSG_* constants in dev_msgs.h).
+uint32_t get_cq_dispatch_go_signal(ChipId chip_id, uint8_t cq_id);
+
 // Return the expected number of workers to be in the finished state
 uint32_t calculate_expected_workers_to_finish(const tt::tt_metal::IDevice* device, const SubDeviceId& sub_device_id, tt::tt_metal::HalProgrammableCoreType core_type);
 

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -646,6 +646,29 @@ void SystemMemoryManager::issue_queue_push_back(std::uint32_t push_size_B, const
         const std::uint32_t dram_channel =
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id());
         if (dram_backed_cq_dirty_flush_enabled()) {
+            // #region agent log
+            {
+                static std::atomic<int> dirty_flush_log_count{0};
+                if (dirty_flush_log_count.fetch_add(1) < 20) {
+                    std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+                    if (f) {
+                        std::fprintf(
+                            f,
+                            "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_DIRTY_FLUSH\","
+                            "\"location\":\"system_memory_manager.cpp:issue_queue_push_back\","
+                            "\"message\":\"DIRTY_FLUSH\",\"data\":{\"device_id\":%u,\"cq_id\":%u,"
+                            "\"dram_target_addr\":%u,\"push_size_B\":%u,\"pid\":%d},\"timestamp\":%ld}\n",
+                            (unsigned)this->device_id,
+                            (unsigned)cq_id,
+                            (unsigned)(wr_ptr_bytes - this->channel_offset),
+                            (unsigned)push_size_B,
+                            (int)getpid(),
+                            (long)std::time(nullptr));
+                        std::fclose(f);
+                    }
+                }
+            }
+            // #endregion
             const std::uint32_t dram_target_addr = wr_ptr_bytes - this->channel_offset;
             ctx.get_cluster().write_dram_vec(
                 this->cq_sysmem_start + (dram_target_addr - this->get_dram_region_base_addr()),
@@ -833,14 +856,10 @@ std::uint32_t SystemMemoryManager::completion_queue_wait_front(
         // #region agent log
         // Log first poll and every 5000th poll to track wr_ptr from device + rd_ptr expectation.
         if (poll_count == 0 || (poll_count % 5000) == 0) {
-            std::uint32_t issue_rd = 0;
-            std::uint32_t issue_wr = 0;
-            std::uint32_t dispatch_progress = 0;
-            if (poll_count == 0) {
-                issue_rd = get_cq_issue_rd_ptr<true>(this->device_id, cq_id, this->cq_size);
-                issue_wr = get_cq_issue_wr_ptr<true>(this->device_id, cq_id, this->cq_size);
-                dispatch_progress = get_cq_dispatch_progress(this->device_id, cq_id);
-            }
+            std::uint32_t issue_rd = get_cq_issue_rd_ptr<true>(this->device_id, cq_id, this->cq_size);
+            std::uint32_t issue_wr = get_cq_issue_wr_ptr<true>(this->device_id, cq_id, this->cq_size);
+            std::uint32_t dispatch_progress = get_cq_dispatch_progress(this->device_id, cq_id);
+            std::uint32_t dispatch_go_signal = get_cq_dispatch_go_signal(this->device_id, cq_id);
             std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
             if (f) {
                 std::fprintf(
@@ -850,7 +869,7 @@ std::uint32_t SystemMemoryManager::completion_queue_wait_front(
                     "\"message\":\"POLL\",\"data\":{\"device_id\":%u,\"cq_id\":%u,"
                     "\"poll_count\":%d,\"wr_ptr_raw\":%u,\"wr_ptr\":%u,\"wr_toggle\":%u,"
                     "\"rd_ptr\":%u,\"rd_toggle\":%u,\"issue_rd\":%u,\"issue_wr\":%u,"
-                    "\"dispatch_progress\":%u,\"pid\":%d},\"timestamp\":%ld}\n",
+                    "\"dispatch_progress\":%u,\"dispatch_go_signal\":%u,\"pid\":%d},\"timestamp\":%ld}\n",
                     (unsigned)this->device_id,
                     (unsigned)cq_id,
                     poll_count,
@@ -862,6 +881,7 @@ std::uint32_t SystemMemoryManager::completion_queue_wait_front(
                     (unsigned)issue_rd,
                     (unsigned)issue_wr,
                     (unsigned)dispatch_progress,
+                    (unsigned)dispatch_go_signal,
                     (int)getpid(),
                     (long)std::time(nullptr));
                 std::fclose(f);
@@ -1016,6 +1036,31 @@ void SystemMemoryManager::fetch_queue_write(
         this->prefetch_q_windows[cq_id]->write32(this->prefetch_q_dev_ptrs[cq_id], entry_val);
     }
     this->prefetch_q_dev_ptrs[cq_id] += entry_bytes;
+    // #region agent log
+    {
+        static std::atomic<int> fetch_q_log_count{0};
+        if (fetch_q_log_count.fetch_add(1) < 30) {
+            std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+            if (f) {
+                std::fprintf(
+                    f,
+                    "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_FETCH_Q\","
+                    "\"location\":\"system_memory_manager.cpp:fetch_queue_write\","
+                    "\"message\":\"FETCH_Q_WRITE\",\"data\":{\"device_id\":%u,\"cq_id\":%u,"
+                    "\"command_size_B\":%u,\"prefetch_q_dev_ptr\":%u,\"stall\":%u,\"pid\":%d},"
+                    "\"timestamp\":%ld}\n",
+                    (unsigned)this->device_id,
+                    (unsigned)cq_id,
+                    (unsigned)command_size_B,
+                    (unsigned)this->prefetch_q_dev_ptrs[cq_id],
+                    (unsigned)stall_prefetcher,
+                    (int)getpid(),
+                    (long)std::time(nullptr));
+                std::fclose(f);
+            }
+        }
+    }
+    // #endregion
 }
 
 bool SystemMemoryManager::is_dram_backed() const {

--- a/tt_metal/impl/dispatch/system_memory_manager.cpp
+++ b/tt_metal/impl/dispatch/system_memory_manager.cpp
@@ -10,7 +10,10 @@
 #include <array>
 #include <atomic>
 #include <cstring>
+#include <cstdio>
+#include <ctime>
 #include <chrono>
+#include <unistd.h>
 #include <cstdlib>
 #include <optional>
 #include <thread>
@@ -36,6 +39,7 @@
 #include <llrt/tt_cluster.hpp>
 #include <impl/dispatch/dispatch_mem_map.hpp>
 #include <impl/device/device_manager.hpp>
+#include <cstdint>
 
 namespace tt::tt_metal {
 
@@ -43,10 +47,25 @@ void on_dispatch_timeout_detected();
 
 namespace {
 
-bool wrap_ge(uint32_t a, uint32_t b) {
+bool dram_backed_cq_dirty_flush_enabled() {
+    static const bool enabled = [] {
+        const char* env = std::getenv("TT_METAL_DRAM_BACKED_CQ_DIRTY_FLUSH");
+        if (env == nullptr) {
+            return false;
+        }
+        const std::string value(env);
+        if (value == "auto") {
+            return std::getenv("TT_METAL_SIMULATOR") != nullptr || std::getenv("TT_UMD_SIMULATOR") != nullptr;
+        }
+        return value == "1" || value == "true" || value == "TRUE" || value == "on" || value == "ON";
+    }();
+    return enabled;
+}
+
+bool wrap_ge(std::uint32_t a, std::uint32_t b) {
     // Signed Diff uses 2's Complement to handle wrap
     // Works as long as a and b are 2^31 apart
-    int32_t diff = a - b;
+    std::int32_t diff = a - b;
     return diff >= 0;
 }
 
@@ -62,7 +81,7 @@ void loop_and_wait_with_timeout(
     const GetProgress& get_progress) {
     if (timeout_duration.count() > 0.0f) {
         auto last_progress_time = std::chrono::high_resolution_clock::now();
-        uint32_t last_progress_value = 0;
+        std::uint32_t last_progress_value = 0;
         // We won't read progress value initially as most of the waits are expected to be shorter than progress update
         // interval. Only long running operations will read progress value updates.
         auto last_progress_update_time = std::chrono::high_resolution_clock::now();
@@ -79,7 +98,7 @@ void loop_and_wait_with_timeout(
 
             // Check if progress should be updated
             if (std::chrono::high_resolution_clock::now() - last_progress_update_time >= progress_update_interval) {
-                uint32_t current_progress = get_progress();
+                std::uint32_t current_progress = get_progress();
 
                 last_progress_update_time = std::chrono::high_resolution_clock::now();
                 if (current_progress != last_progress_value) {
@@ -107,7 +126,7 @@ void loop_and_wait_with_timeout(
 }
 }  // namespace
 
-SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id, uint8_t num_hw_cqs) :
+SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id, std::uint8_t num_hw_cqs) :
     context_id(context_id),
     device_id(device_id),
     completion_byte_addrs(num_hw_cqs),
@@ -124,8 +143,8 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
         this->channel_offset = 0;
         this->cq_to_event.resize(num_hw_cqs, 0);
         this->cq_to_last_completed_event.resize(num_hw_cqs, 0);
-        const uint32_t alignment = MetalContext::instance(context_id).hal().get_alignment(HalMemType::HOST);
-        for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+        const std::uint32_t alignment = MetalContext::instance(context_id).hal().get_alignment(HalMemType::HOST);
+        for (std::uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
             this->cq_interfaces.emplace_back(0, cq_id, this->cq_size, 0, alignment);
         }
         log_debug(tt::LogMetal, "SystemMemoryManager: Initialized with stubs for mock device");
@@ -140,7 +159,7 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
             "DRAM-backed CQs are enabled; this feature is intended for niche use-cases such as simulator "
             "environments, may not work in all configurations, and will result in significantly slower fast dispatch "
             "performance due to DRAM read/write latency replacing direct host memory access.");
-        const uint32_t dram_backed_command_queues_size =
+        const std::uint32_t dram_backed_command_queues_size =
             ctx.hal().get_dev_size(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES);
         TT_ASSERT(dram_backed_command_queues_size > 0);
         TT_FATAL(
@@ -151,27 +170,35 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
         this->cq_size = dram_backed_command_queues_size / num_hw_cqs;
         TT_ASSERT((this->cq_size % ctx.hal().get_alignment(tt::tt_metal::HalMemType::DRAM)) == 0);
         const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
+        // DRAM-backed CQ originally required this chip to be MMIO because host
+        // staging is delivered into the chip's own DRAM via a PCIe BAR write.
+        // In multi-process simulator runs every rank loads a constrained
+        // cluster descriptor whose chips_with_mmio only covers its local
+        // visible chips, but the dispatch CQ initializer still drives
+        // initialize_host on tunnel (peer-rank) chips. Those host writes do
+        // not go through PCIe; they go through the ttsim RPC layer, which can
+        // reach any chip's DRAM regardless of MMIO. Without this relaxation
+        // every MP suite trips a fatal on the first tunnel chip
+        // (e.g. rank 0 on t3k 2x2: chip 2). Real silicon still asserts MMIO.
         TT_FATAL(
             device->is_mmio_capable() || ctx.get_cluster().get_target_device_type() == tt::TargetDevice::Simulator,
             "Device {} is not an MMIO device",
             this->device_id);
-        // Host mirror of the DRAM-backed CQ sysmem region: the host edits this buffer and
-        // write_dram_vec/read_dram_vec sync it to each chip's DRAM (no PCIe hugepage).
         this->dram_region_staging_buffer = std::make_unique<char[]>(dram_backed_command_queues_size);
         this->cq_sysmem_start = this->dram_region_staging_buffer.get();
         this->channel_offset = 0;
-
-        // Carve out the hugepage "auxiliary" tail (same layout as the MMIO path below).
-        // Per HW CQ we reserve two TRANSFER_PAGE_SIZE (4 KiB) pages outside the issue/completion
-        // fifo layout; they are pooled after all CQ slots in free_region_* and allocated via
-        // allocate_region() when host code needs extra device-visible sysmem (e.g. D2H socket
-        // hugepage fallback for fifo data and bytes-sent counters).
-        static constexpr uint32_t AUX_PAGES_PER_CQ_SIM = 2;
-        uint32_t per_cq_reduction_sim = AUX_PAGES_PER_CQ_SIM * DispatchSettings::TRANSFER_PAGE_SIZE;
+        // Mirror the hardware path's free_region carveout. Without this, D2HSocket
+        // (and any other consumer of SystemMemoryManager::allocate_region) gets
+        // {nullptr, 0} back, then memsets the null pointer and segfaults. Reserve
+        // the same AUX_PAGES_PER_CQ pages per CQ that real hardware reserves at
+        // the tail of the per-CQ hugepage region, but inside the DRAM staging
+        // buffer instead of the hugepage.
+        static constexpr std::uint32_t AUX_PAGES_PER_CQ_SIM = 2;
+        std::uint32_t per_cq_reduction_sim = AUX_PAGES_PER_CQ_SIM * DispatchSettings::TRANSFER_PAGE_SIZE;
         this->cq_size -= per_cq_reduction_sim;
-        uint32_t total_cq_space_sim = static_cast<uint32_t>(num_hw_cqs) * this->cq_size;
+        std::uint32_t total_cq_space_sim = static_cast<std::uint32_t>(num_hw_cqs) * this->cq_size;
         this->free_region_start_ = this->channel_offset + total_cq_space_sim;
-        this->free_region_size_ = static_cast<uint32_t>(num_hw_cqs) * per_cq_reduction_sim;
+        this->free_region_size_ = static_cast<std::uint32_t>(num_hw_cqs) * per_cq_reduction_sim;
         this->free_region_host_ptr_ = this->cq_sysmem_start + total_cq_space_sim;
         this->free_region_bump_ = 0;
         this->init_dispatch_core_interfaces(num_hw_cqs, 0);
@@ -180,7 +207,7 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
 
     // Real hardware initialization below
     ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(device_id);
-    uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(device_id);
+    std::uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(device_id);
     char* hugepage_start = static_cast<char*>(ctx.get_cluster().host_dma_address(0, mmio_device_id, channel));
     hugepage_start += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
     this->cq_sysmem_start = hugepage_start;
@@ -188,7 +215,7 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
     // TODO(abhullar): Remove env var and expose sizing at the API level
     char* cq_size_override_env = std::getenv("TT_METAL_CQ_SIZE_OVERRIDE");
     if (cq_size_override_env != nullptr) {
-        uint32_t cq_size_override = std::stoi(std::string(cq_size_override_env));
+        std::uint32_t cq_size_override = std::stoi(std::string(cq_size_override_env));
         this->cq_size = cq_size_override;
     } else {
         this->cq_size = ctx.get_cluster().get_host_channel_size(mmio_device_id, channel) / num_hw_cqs;
@@ -201,38 +228,34 @@ SystemMemoryManager::SystemMemoryManager(ContextId context_id, ChipId device_id,
     this->channel_offset = DispatchSettings::MAX_HUGEPAGE_SIZE * get_umd_channel(channel) +
                            (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
 
-    // Two TRANSFER_PAGE_SIZE pages per HW CQ reserved for free_region_* (see DRAM-backed path above).
-    static constexpr uint32_t AUX_PAGES_PER_CQ = 2;
-    uint32_t per_cq_reduction = AUX_PAGES_PER_CQ * DispatchSettings::TRANSFER_PAGE_SIZE;
+    static constexpr std::uint32_t AUX_PAGES_PER_CQ = 2;
+    std::uint32_t per_cq_reduction = AUX_PAGES_PER_CQ * DispatchSettings::TRANSFER_PAGE_SIZE;
     this->cq_size -= per_cq_reduction;
 
-    uint32_t total_cq_space = static_cast<uint32_t>(num_hw_cqs) * this->cq_size;
+    std::uint32_t total_cq_space = static_cast<std::uint32_t>(num_hw_cqs) * this->cq_size;
     this->free_region_start_ = this->channel_offset + total_cq_space;
-    this->free_region_size_ = static_cast<uint32_t>(num_hw_cqs) * per_cq_reduction;
+    this->free_region_size_ = static_cast<std::uint32_t>(num_hw_cqs) * per_cq_reduction;
     this->free_region_host_ptr_ = this->cq_sysmem_start + total_cq_space;
     this->free_region_bump_ = 0;
 
     this->init_dispatch_core_interfaces(num_hw_cqs, channel);
 }
 
-void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint16_t channel) {
+void SystemMemoryManager::init_dispatch_core_interfaces(std::uint8_t num_hw_cqs, std::uint16_t channel) {
     auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
-    const CoreType core_type =
-        ctx.get_dispatch_core_manager().get_dispatch_core_type();
-    const uint32_t completion_q_rd_ptr = ctx.dispatch_mem_map().get_device_command_queue_addr(
-        CommandQueueDeviceAddrType::COMPLETION_Q_RD);
-    const uint32_t prefetch_q_base = ctx.dispatch_mem_map().get_device_command_queue_addr(
-        CommandQueueDeviceAddrType::UNRESERVED);
-    const uint32_t cq_start =
+    const CoreType core_type = ctx.get_dispatch_core_manager().get_dispatch_core_type();
+    const std::uint32_t completion_q_rd_ptr =
+        ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
+    const std::uint32_t prefetch_q_base =
+        ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
+    const std::uint32_t cq_start =
         ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
-    for (uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
-        tt_cxy_pair prefetcher_core =
-            ctx.get_dispatch_core_manager().prefetcher_core(device_id, channel, cq_id);
+    for (std::uint8_t cq_id = 0; cq_id < num_hw_cqs; cq_id++) {
+        tt_cxy_pair prefetcher_core = ctx.get_dispatch_core_manager().prefetcher_core(device_id, channel, cq_id);
         auto prefetcher_virtual = ctx.get_cluster().get_virtual_coordinate_from_logical_coordinates(
             prefetcher_core.chip, CoreCoord(prefetcher_core.x, prefetcher_core.y), core_type);
         this->prefetcher_cores[cq_id] = tt_cxy_pair(prefetcher_core.chip, prefetcher_virtual.x, prefetcher_virtual.y);
-        this->prefetch_q_windows.emplace_back(
-            ctx.get_cluster().get_static_tlb_window(this->prefetcher_cores[cq_id]));
+        this->prefetch_q_windows.emplace_back(ctx.get_cluster().get_static_tlb_window(this->prefetcher_cores[cq_id]));
 
         tt_cxy_pair completion_queue_writer_core =
             ctx.get_dispatch_core_manager().completion_queue_writer_core(this->device_id, channel, cq_id);
@@ -241,24 +264,22 @@ void SystemMemoryManager::init_dispatch_core_interfaces(uint8_t num_hw_cqs, uint
             CoreCoord(completion_queue_writer_core.x, completion_queue_writer_core.y),
             core_type);
 
-        const std::tuple<uint32_t, uint32_t> completion_interface_tlb_data = ctx.get_cluster()
-                                                                                 .get_tlb_data(tt_cxy_pair(
-                                                                                     completion_queue_writer_core.chip,
-                                                                                     completion_queue_writer_virtual.x,
-                                                                                     completion_queue_writer_virtual.y))
-                                                                                 .value();
+        const std::tuple<std::uint32_t, std::uint32_t> completion_interface_tlb_data =
+            ctx.get_cluster()
+                .get_tlb_data(tt_cxy_pair(
+                    completion_queue_writer_core.chip,
+                    completion_queue_writer_virtual.x,
+                    completion_queue_writer_virtual.y))
+                .value();
         auto [completion_tlb_offset, completion_tlb_size] = completion_interface_tlb_data;
 
         this->completion_byte_addrs[cq_id] = completion_q_rd_ptr % completion_tlb_size;
-        this->completion_q_windows.emplace_back(
-            ctx.get_cluster().get_static_tlb_window(tt_cxy_pair(
-                completion_queue_writer_core.chip,
-                completion_queue_writer_virtual.x,
-                completion_queue_writer_virtual.y)));
+        this->completion_q_windows.emplace_back(ctx.get_cluster().get_static_tlb_window(tt_cxy_pair(
+            completion_queue_writer_core.chip, completion_queue_writer_virtual.x, completion_queue_writer_virtual.y)));
 
-        const uint32_t alignment =
+        const std::uint32_t alignment =
             is_dram_backed() ? ctx.hal().get_alignment(HalMemType::DRAM) : ctx.hal().get_alignment(HalMemType::HOST);
-        const uint32_t base = is_dram_backed() ? this->get_dram_region_base_addr() : 0;
+        const std::uint32_t base = is_dram_backed() ? this->get_dram_region_base_addr() : 0;
         this->cq_interfaces.emplace_back(channel, cq_id, this->cq_size, cq_start, alignment, base);
         // Prefetch queue acts as the sync mechanism to ensure that issue queue has space to write, so issue queue
         // must be as large as the max amount of space the prefetch queue can specify Plus 1 to handle wrapping plus
@@ -284,25 +305,25 @@ bool SystemMemoryManager::is_mock_device() const {
     return tt::tt_metal::MetalContext::instance(this->context_id).get_cluster().is_mock_or_emulated();
 }
 
-uint32_t SystemMemoryManager::get_next_event(const uint8_t cq_id) {
+std::uint32_t SystemMemoryManager::get_next_event(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return ++this->cq_to_event[cq_id];
     }
     cq_to_event_locks[cq_id].lock();
-    uint32_t next_event = ++this->cq_to_event[cq_id];  // Event ids start at 1
+    std::uint32_t next_event = ++this->cq_to_event[cq_id];  // Event ids start at 1
 
     cq_to_event_locks[cq_id].unlock();
     return next_event;
 }
 
 // Get last issued event to Command Queue
-uint32_t SystemMemoryManager::get_last_event(const uint8_t cq_id) {
+std::uint32_t SystemMemoryManager::get_last_event(const std::uint8_t cq_id) {
     std::lock_guard<std::mutex> lock(cq_to_event_locks[cq_id]);
     return this->cq_to_event[cq_id];
 }
 
 void SystemMemoryManager::set_current_and_last_completed_event(
-    const uint8_t cq_id, const uint32_t current_event_id, const uint32_t last_completed_event_id) {
+    const std::uint8_t cq_id, const std::uint32_t current_event_id, const std::uint32_t last_completed_event_id) {
     cq_to_event_locks[cq_id].lock();
 
     this->cq_to_event[cq_id] = current_event_id;
@@ -310,7 +331,7 @@ void SystemMemoryManager::set_current_and_last_completed_event(
     cq_to_event_locks[cq_id].unlock();
 }
 
-void SystemMemoryManager::reset_event_id(const uint8_t cq_id) {
+void SystemMemoryManager::reset_event_id(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         this->cq_to_event[cq_id] = 0;
         return;
@@ -320,7 +341,7 @@ void SystemMemoryManager::reset_event_id(const uint8_t cq_id) {
     cq_to_event_locks[cq_id].unlock();
 }
 
-void SystemMemoryManager::increment_event_id(const uint8_t cq_id, const uint32_t val) {
+void SystemMemoryManager::increment_event_id(const std::uint8_t cq_id, const std::uint32_t val) {
     if (is_mock_device()) {
         this->cq_to_event[cq_id] += val;
         return;
@@ -330,7 +351,7 @@ void SystemMemoryManager::increment_event_id(const uint8_t cq_id, const uint32_t
     cq_to_event_locks[cq_id].unlock();
 }
 
-void SystemMemoryManager::set_last_completed_event(const uint8_t cq_id, const uint32_t event_id) {
+void SystemMemoryManager::set_last_completed_event(const std::uint8_t cq_id, const std::uint32_t event_id) {
     if (is_mock_device()) {
         this->cq_to_last_completed_event[cq_id] = event_id;
         return;
@@ -348,24 +369,24 @@ void SystemMemoryManager::set_last_completed_event(const uint8_t cq_id, const ui
     cq_to_event_locks[cq_id].unlock();
 }
 
-uint32_t SystemMemoryManager::get_current_event(const uint8_t cq_id) {
+std::uint32_t SystemMemoryManager::get_current_event(const std::uint8_t cq_id) {
     cq_to_event_locks[cq_id].lock();
-    uint32_t current_event = this->cq_to_event[cq_id];
+    std::uint32_t current_event = this->cq_to_event[cq_id];
     cq_to_event_locks[cq_id].unlock();
     return current_event;
 }
 
-uint32_t SystemMemoryManager::get_last_completed_event(const uint8_t cq_id) {
+std::uint32_t SystemMemoryManager::get_last_completed_event(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return this->cq_to_last_completed_event[cq_id];
     }
     cq_to_event_locks[cq_id].lock();
-    uint32_t last_completed_event = this->cq_to_last_completed_event[cq_id];
+    std::uint32_t last_completed_event = this->cq_to_last_completed_event[cq_id];
     cq_to_event_locks[cq_id].unlock();
     return last_completed_event;
 }
 
-void SystemMemoryManager::reset(const uint8_t cq_id) {
+void SystemMemoryManager::reset(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return;
     }
@@ -377,7 +398,7 @@ void SystemMemoryManager::reset(const uint8_t cq_id) {
     cq_interface.completion_fifo_rd_toggle = false;
 }
 
-void SystemMemoryManager::set_issue_queue_size(const uint8_t cq_id, const uint32_t issue_queue_size) {
+void SystemMemoryManager::set_issue_queue_size(const std::uint8_t cq_id, const std::uint32_t issue_queue_size) {
     if (is_mock_device()) {
         return;
     }
@@ -397,37 +418,37 @@ void SystemMemoryManager::set_bypass_mode(const bool enable, const bool clear) {
 
 bool SystemMemoryManager::get_bypass_mode() const { return this->bypass_enable; }
 
-std::vector<uint32_t>& SystemMemoryManager::get_bypass_data() { return this->bypass_buffer; }
+std::vector<std::uint32_t>& SystemMemoryManager::get_bypass_data() { return this->bypass_buffer; }
 
-uint32_t SystemMemoryManager::get_issue_queue_size(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_issue_queue_size(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 65536;
     }
     return this->cq_interfaces[cq_id].issue_fifo_size << 4;
 }
 
-uint32_t SystemMemoryManager::get_issue_queue_limit(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_issue_queue_limit(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 65536;
     }
     return this->cq_interfaces[cq_id].issue_fifo_limit << 4;
 }
 
-uint32_t SystemMemoryManager::get_completion_queue_size(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_completion_queue_size(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 65536;
     }
     return this->cq_interfaces[cq_id].completion_fifo_size << 4;
 }
 
-uint32_t SystemMemoryManager::get_completion_queue_limit(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_completion_queue_limit(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 65536;
     }
     return this->cq_interfaces[cq_id].completion_fifo_limit << 4;
 }
 
-uint32_t SystemMemoryManager::get_issue_queue_write_ptr(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_issue_queue_write_ptr(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 0;
     }
@@ -437,18 +458,18 @@ uint32_t SystemMemoryManager::get_issue_queue_write_ptr(const uint8_t cq_id) con
     return this->cq_interfaces[cq_id].issue_fifo_wr_ptr << 4;
 }
 
-uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_completion_queue_read_ptr(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 0;
     }
     return this->cq_interfaces[cq_id].completion_fifo_rd_ptr << 4;
 }
 
-void* SystemMemoryManager::get_completion_queue_ptr(uint8_t cq_id) const {
+void* SystemMemoryManager::get_completion_queue_ptr(std::uint8_t cq_id) const {
     if (is_dram_backed()) {
         auto& ctx = tt::tt_metal::MetalContext::instance(this->context_id);
         const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
-        const uint32_t dram_channel =
+        const std::uint32_t dram_channel =
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id());
         ctx.get_cluster().read_dram_vec(
             this->cq_sysmem_start +
@@ -468,14 +489,14 @@ void* SystemMemoryManager::get_completion_queue_ptr(uint8_t cq_id) const {
     return (void*)(this->cq_sysmem_start + (this->get_issue_queue_limit(cq_id) - this->channel_offset));
 }
 
-uint32_t SystemMemoryManager::get_completion_queue_read_toggle(const uint8_t cq_id) const {
+std::uint32_t SystemMemoryManager::get_completion_queue_read_toggle(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return 0;
     }
     return this->cq_interfaces[cq_id].completion_fifo_rd_toggle;
 }
 
-uint32_t SystemMemoryManager::get_cq_size() const {
+std::uint32_t SystemMemoryManager::get_cq_size() const {
     if (is_mock_device()) {
         return 65536;
     }
@@ -488,23 +509,23 @@ ContextId SystemMemoryManager::get_context_id() const { return this->context_id;
 
 std::vector<SystemMemoryCQInterface>& SystemMemoryManager::get_cq_interfaces() { return this->cq_interfaces; }
 
-void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_t cq_id) {
+void* SystemMemoryManager::issue_queue_reserve(std::uint32_t cmd_size_B, const std::uint8_t cq_id) {
     if (is_mock_device()) {
         thread_local std::array<char, 65536> dummy_buffer{};
         return dummy_buffer.data();
     }
 
     if (this->bypass_enable) {
-        uint32_t curr_size = this->bypass_buffer.size();
-        uint32_t new_size = curr_size + (cmd_size_B / sizeof(uint32_t));
+        std::uint32_t curr_size = this->bypass_buffer.size();
+        std::uint32_t new_size = curr_size + (cmd_size_B / sizeof(std::uint32_t));
         this->bypass_buffer.resize(new_size);
         return (void*)((char*)this->bypass_buffer.data() + this->bypass_buffer_write_offset);
     }
 
-    uint32_t issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
+    std::uint32_t issue_q_write_ptr = this->get_issue_queue_write_ptr(cq_id);
 
-    const uint32_t command_issue_limit = this->get_issue_queue_limit(cq_id);
-    const uint32_t alignment =
+    const std::uint32_t command_issue_limit = this->get_issue_queue_limit(cq_id);
+    const std::uint32_t alignment =
         is_dram_backed()
             ? tt::tt_metal::MetalContext::instance(this->context_id).hal().get_alignment(tt::tt_metal::HalMemType::DRAM)
             : tt::tt_metal::MetalContext::instance(this->context_id)
@@ -535,7 +556,7 @@ void* SystemMemoryManager::issue_queue_reserve(uint32_t cmd_size_B, const uint8_
     return issue_q_region;
 }
 
-void SystemMemoryManager::cq_write(const void* data, uint32_t size_in_bytes, uint32_t write_ptr) {
+void SystemMemoryManager::cq_write(const void* data, std::uint32_t size_in_bytes, std::uint32_t write_ptr) {
     if (is_mock_device()) {
         return;
     }
@@ -551,7 +572,10 @@ void SystemMemoryManager::cq_write(const void* data, uint32_t size_in_bytes, uin
     // https://github.com/tenstorrent/tt-metal/issues/4757
 
     if (this->bypass_enable) {
-        std::copy((uint8_t*)data, (uint8_t*)data + size_in_bytes, (uint8_t*)this->bypass_buffer.data() + write_ptr);
+        std::copy(
+            (std::uint8_t*)data,
+            (std::uint8_t*)data + size_in_bytes,
+            (std::uint8_t*)this->bypass_buffer.data() + write_ptr);
     } else if (is_dram_backed()) {
         void* user_scratchspace =
             this->cq_sysmem_start + (write_ptr - this->get_dram_region_base_addr() - this->channel_offset);
@@ -563,7 +587,7 @@ void SystemMemoryManager::cq_write(const void* data, uint32_t size_in_bytes, uin
 }
 
 // TODO: RENAME issue_queue_stride ?
-void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint8_t cq_id) {
+void SystemMemoryManager::issue_queue_push_back(std::uint32_t push_size_B, const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return;
     }
@@ -574,20 +598,21 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
     }
 
     auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
-    const uint32_t alignment =
+    const std::uint32_t alignment =
         is_dram_backed()
             ? tt::tt_metal::MetalContext::instance(this->context_id).hal().get_alignment(tt::tt_metal::HalMemType::DRAM)
             : tt::tt_metal::MetalContext::instance(this->context_id)
                   .hal()
                   .get_alignment(tt::tt_metal::HalMemType::HOST);
-    const uint32_t push_size_16B = align(push_size_B, alignment) >> 4;
+    const std::uint32_t push_size_16B = align(push_size_B, alignment) >> 4;
 
     SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
-    uint32_t issue_q_wr_ptr = ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
+    std::uint32_t issue_q_wr_ptr =
+        ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::ISSUE_Q_WR);
 
     // Capture before advancing: issue_fifo_wr_ptr points to the slot just written; after the advance below it points to
     // the next slot.
-    const uint32_t wr_ptr_bytes = cq_interface.issue_fifo_wr_ptr << 4;
+    const std::uint32_t wr_ptr_bytes = cq_interface.issue_fifo_wr_ptr << 4;
 
     if (cq_interface.issue_fifo_wr_ptr + push_size_16B >= cq_interface.issue_fifo_limit) {
         cq_interface.issue_fifo_wr_ptr = (cq_interface.cq_start + cq_interface.offset) >> 4;  // In 16B words
@@ -595,21 +620,53 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
     } else {
         cq_interface.issue_fifo_wr_ptr += push_size_16B;
     }
+    // #region agent log
+    {
+        std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+        if (f) {
+            std::fprintf(
+                f,
+                "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_DISPATCH_STUCK\","
+                "\"location\":\"system_memory_manager.cpp:issue_queue_push_back\","
+                "\"message\":\"PUSH\",\"data\":{\"device_id\":%u,\"cq_id\":%u,"
+                "\"push_size_B\":%u,\"issue_fifo_wr_ptr_after\":%u,\"pid\":%d},\"timestamp\":%ld}\n",
+                (unsigned)this->device_id,
+                (unsigned)cq_id,
+                (unsigned)push_size_B,
+                (unsigned)cq_interface.issue_fifo_wr_ptr,
+                (int)getpid(),
+                (long)std::time(nullptr));
+            std::fclose(f);
+        }
+    }
+    // #endregion
 
     if (is_dram_backed()) {
         const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
-        const uint32_t dram_channel =
+        const std::uint32_t dram_channel =
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id());
-        const uint32_t dram_target_addr = wr_ptr_bytes - this->channel_offset;
-        ctx.get_cluster().write_dram_vec(
-            this->cq_sysmem_start + (dram_target_addr - this->get_dram_region_base_addr()),
-            push_size_16B << 4,
-            this->device_id,
-            dram_channel,
-            dram_target_addr);
+        if (dram_backed_cq_dirty_flush_enabled()) {
+            const std::uint32_t dram_target_addr = wr_ptr_bytes - this->channel_offset;
+            ctx.get_cluster().write_dram_vec(
+                this->cq_sysmem_start + (dram_target_addr - this->get_dram_region_base_addr()),
+                push_size_16B << 4,
+                this->device_id,
+                dram_channel,
+                dram_target_addr);
+        } else {
+            ctx.get_cluster().write_dram_vec(
+                this->cq_sysmem_start +
+                    (cq_interface.offset - this->get_dram_region_base_addr() - this->channel_offset) +
+                    cq_interface.cq_start,
+                this->get_issue_queue_size(cq_id),
+                this->device_id,
+                dram_channel,
+                this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) +
+                    cq_interface.cq_start);
+        }
         ctx.get_cluster().write_dram_vec(
             &cq_interface.issue_fifo_wr_ptr,
-            sizeof(uint32_t),
+            sizeof(std::uint32_t),
             this->device_id,
             dram_channel,
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + issue_q_wr_ptr);
@@ -618,33 +675,34 @@ void SystemMemoryManager::issue_queue_push_back(uint32_t push_size_B, const uint
 
     // Also store this data in hugepages, so if a hang happens we can see what was written by host.
     ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(this->device_id);
-    uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
+    std::uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
     ctx.get_cluster().write_sysmem(
         &cq_interface.issue_fifo_wr_ptr,
-        sizeof(uint32_t),
+        sizeof(std::uint32_t),
         issue_q_wr_ptr + get_relative_cq_offset(cq_id, this->cq_size),
         mmio_device_id,
         channel);
 }
 
-void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) const {
+void SystemMemoryManager::send_completion_queue_read_ptr(const std::uint8_t cq_id) const {
     if (is_mock_device()) {
         return;
     }
 
     const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
 
-    uint32_t read_ptr_and_toggle = cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
+    std::uint32_t read_ptr_and_toggle =
+        cq_interface.completion_fifo_rd_ptr | (cq_interface.completion_fifo_rd_toggle << 31);
     this->completion_q_windows[cq_id]->write32(this->completion_byte_addrs[cq_id], read_ptr_and_toggle);
     auto& ctx = tt::tt_metal::MetalContext::instance(this->context_id);
-    const uint32_t completion_q_rd_ptr =
+    const std::uint32_t completion_q_rd_ptr =
         ctx.dispatch_mem_map().get_host_command_queue_addr(CommandQueueHostAddrType::COMPLETION_Q_RD);
 
     if (is_dram_backed()) {
         const IDevice* device = ctx.device_manager()->get_active_device(this->device_id);
         ctx.get_cluster().write_dram_vec(
             &read_ptr_and_toggle,
-            sizeof(uint32_t),
+            sizeof(std::uint32_t),
             this->device_id,
             device->allocator_impl()->get_dram_channel_from_bank_id(this->get_dram_region_bank_id()),
             this->get_dram_region_base_addr() + get_relative_cq_offset(cq_id, this->cq_size) + completion_q_rd_ptr);
@@ -653,16 +711,16 @@ void SystemMemoryManager::send_completion_queue_read_ptr(const uint8_t cq_id) co
 
     // Also store this data in hugepages in case we hang and can't get it from the device.
     ChipId mmio_device_id = ctx.get_cluster().get_associated_mmio_device(this->device_id);
-    uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
+    std::uint16_t channel = ctx.get_cluster().get_assigned_channel_for_device(this->device_id);
     ctx.get_cluster().write_sysmem(
         &read_ptr_and_toggle,
-        sizeof(uint32_t),
+        sizeof(std::uint32_t),
         completion_q_rd_ptr + get_relative_cq_offset(cq_id, this->cq_size),
         mmio_device_id,
         channel);
 }
 
-void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
+void SystemMemoryManager::fetch_queue_reserve_back(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return;
     }
@@ -672,11 +730,11 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
     }
 
     auto& ctx = tt::tt_metal::MetalContext::instance(context_id);
-    const uint32_t prefetch_q_rd_ptr =
+    const std::uint32_t prefetch_q_rd_ptr =
         ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::PREFETCH_Q_RD);
 
     // Helper to wait for fetch queue space, if needed
-    uint32_t fence;
+    std::uint32_t fence;
     auto wait_for_fetch_q_space = [&]() {
         if (this->prefetch_q_dev_ptrs[cq_id] != this->prefetch_q_dev_fences[cq_id]) {
             return;
@@ -685,8 +743,11 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
 
         // Body of the operation
         auto fetch_operation_body = [&]() {
-            ctx.get_cluster().read_core(&fence, sizeof(uint32_t), this->prefetcher_cores[cq_id], prefetch_q_rd_ptr);
+            ctx.get_cluster().read_core(
+                &fence, sizeof(std::uint32_t), this->prefetcher_cores[cq_id], prefetch_q_rd_ptr);
             this->prefetch_q_dev_fences[cq_id] = fence;
+            // Yield to clock the simulator when running on TTSim; no-op on real hardware.
+            ctx.get_cluster().advance_device_execution(this->device_id);
         };
 
         // Condition to check if should continue waiting
@@ -701,7 +762,9 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
         };
 
         // Get dispatch progress for timeout detection
-        auto get_dispatch_progress = [&]() -> uint32_t { return get_cq_dispatch_progress(this->device_id, cq_id); };
+        auto get_dispatch_progress = [&]() -> std::uint32_t {
+            return get_cq_dispatch_progress(this->device_id, cq_id);
+        };
 
         auto timeout_duration = ctx.rtoptions().get_timeout_duration_for_operations();
 
@@ -711,32 +774,101 @@ void SystemMemoryManager::fetch_queue_reserve_back(const uint8_t cq_id) {
 
     wait_for_fetch_q_space();
     // Wrap FetchQ if possible
-    uint32_t prefetch_q_base =
+    std::uint32_t prefetch_q_base =
         ctx.dispatch_mem_map().get_device_command_queue_addr(CommandQueueDeviceAddrType::UNRESERVED);
-    uint32_t prefetch_q_limit = prefetch_q_base + (ctx.dispatch_mem_map().prefetch_q_entries() *
-                                                   ctx.dispatch_mem_map().prefetch_q_entry_size_bytes());
+    std::uint32_t prefetch_q_limit = prefetch_q_base + (ctx.dispatch_mem_map().prefetch_q_entries() *
+                                                        ctx.dispatch_mem_map().prefetch_q_entry_size_bytes());
     if (this->prefetch_q_dev_ptrs[cq_id] == prefetch_q_limit) {
         this->prefetch_q_dev_ptrs[cq_id] = prefetch_q_base;
         wait_for_fetch_q_space();
     }
 }
 
-uint32_t SystemMemoryManager::completion_queue_wait_front(
-    const uint8_t cq_id, std::atomic<bool>& exit_condition) const {
+std::uint32_t SystemMemoryManager::completion_queue_wait_front(
+    const std::uint8_t cq_id, std::atomic<bool>& exit_condition) const {
     if (is_mock_device()) {
         return 0;
     }
 
-    uint32_t write_ptr_and_toggle;
-    uint32_t write_ptr;
-    uint32_t write_toggle;
+    std::uint32_t write_ptr_and_toggle;
+    std::uint32_t write_ptr;
+    std::uint32_t write_toggle;
     const SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
+    // #region agent log
+    {
+        std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+        if (f) {
+            std::fprintf(
+                f,
+                "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_WAIT_FRONT_ENTRY\","
+                "\"location\":\"system_memory_manager.cpp:completion_queue_wait_front\","
+                "\"message\":\"WAIT_FRONT_ENTRY\",\"data\":{\"device_id\":%u,\"cq_id\":%u,"
+                "\"is_dram_backed\":%u,\"rd_ptr_16B\":%u,\"rd_toggle\":%u,\"pid\":%d},\"timestamp\":%ld}\n",
+                (unsigned)this->device_id,
+                (unsigned)cq_id,
+                (unsigned)this->is_dram_backed(),
+                (unsigned)cq_interface.completion_fifo_rd_ptr,
+                (unsigned)cq_interface.completion_fifo_rd_toggle,
+                (int)getpid(),
+                (long)std::time(nullptr));
+            std::fclose(f);
+        }
+    }
+    // #endregion
 
     // Body of the operation to be timed out
-    auto wait_operation_body = [this, cq_id, &write_ptr_and_toggle, &write_ptr, &write_toggle]() {
+    int poll_count = 0;
+    auto wait_operation_body = [this,
+                                cq_id,
+                                &write_ptr_and_toggle,
+                                &write_ptr,
+                                &write_toggle,
+                                &cq_interface,
+                                &poll_count]() {
         write_ptr_and_toggle = get_cq_completion_wr_ptr<true>(this->device_id, cq_id, this->cq_size);
         write_ptr = write_ptr_and_toggle & 0x7fffffff;
         write_toggle = write_ptr_and_toggle >> 31;
+        // Yield to clock the simulator when running on TTSim; no-op on real hardware.
+        tt::tt_metal::MetalContext::instance(this->context_id).get_cluster().advance_device_execution(this->device_id);
+        // #region agent log
+        // Log first poll and every 5000th poll to track wr_ptr from device + rd_ptr expectation.
+        if (poll_count == 0 || (poll_count % 5000) == 0) {
+            std::uint32_t issue_rd = 0;
+            std::uint32_t issue_wr = 0;
+            std::uint32_t dispatch_progress = 0;
+            if (poll_count == 0) {
+                issue_rd = get_cq_issue_rd_ptr<true>(this->device_id, cq_id, this->cq_size);
+                issue_wr = get_cq_issue_wr_ptr<true>(this->device_id, cq_id, this->cq_size);
+                dispatch_progress = get_cq_dispatch_progress(this->device_id, cq_id);
+            }
+            std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+            if (f) {
+                std::fprintf(
+                    f,
+                    "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_CQ_STALL_DIAG\","
+                    "\"location\":\"system_memory_manager.cpp:wait_operation_body\","
+                    "\"message\":\"POLL\",\"data\":{\"device_id\":%u,\"cq_id\":%u,"
+                    "\"poll_count\":%d,\"wr_ptr_raw\":%u,\"wr_ptr\":%u,\"wr_toggle\":%u,"
+                    "\"rd_ptr\":%u,\"rd_toggle\":%u,\"issue_rd\":%u,\"issue_wr\":%u,"
+                    "\"dispatch_progress\":%u,\"pid\":%d},\"timestamp\":%ld}\n",
+                    (unsigned)this->device_id,
+                    (unsigned)cq_id,
+                    poll_count,
+                    (unsigned)write_ptr_and_toggle,
+                    (unsigned)write_ptr,
+                    (unsigned)write_toggle,
+                    (unsigned)cq_interface.completion_fifo_rd_ptr,
+                    (unsigned)cq_interface.completion_fifo_rd_toggle,
+                    (unsigned)issue_rd,
+                    (unsigned)issue_wr,
+                    (unsigned)dispatch_progress,
+                    (int)getpid(),
+                    (long)std::time(nullptr));
+                std::fclose(f);
+            }
+        }
+        poll_count++;
+        // #endregion
     };
 
     // Condition to check if the operation should continue
@@ -754,7 +886,7 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
     };
 
     // Get dispatch progress for timeout detection
-    auto get_dispatch_progress = [this, cq_id]() -> uint32_t {
+    auto get_dispatch_progress = [this, cq_id]() -> std::uint32_t {
         return get_cq_dispatch_progress(this->device_id, cq_id);
     };
 
@@ -765,10 +897,41 @@ uint32_t SystemMemoryManager::completion_queue_wait_front(
         tt::tt_metal::MetalContext::instance().rtoptions().get_timeout_duration_for_operations(),
         get_dispatch_progress);
 
+    // #region agent log
+    {
+        FILE* f = fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+        if (f) {
+            fprintf(
+                f,
+                "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_wait_front\",\"location\":\"system_memory_manager.cpp:"
+                "completion_queue_wait_front\","
+                "\"message\":\"WAIT_FRONT_DONE\",\"data\":{\"device_id\":%u,\"cq_id\":%u,\"is_dram_backed\":%u,"
+                "\"write_ptr_raw\":%u,\"write_ptr\":%u,\"write_toggle\":%u,"
+                "\"rd_ptr_16B\":%u,\"rd_toggle\":%u,"
+                "\"completion_fifo_size_16B\":%u,\"completion_fifo_limit_16B\":%u,"
+                "\"issue_fifo_limit_16B\":%u,\"cq_start\":%u,\"cq_size\":%u},\"timestamp\":%lu}\n",
+                (unsigned)this->device_id,
+                (unsigned)cq_id,
+                (unsigned)this->is_dram_backed(),
+                (unsigned)write_ptr_and_toggle,
+                (unsigned)write_ptr,
+                (unsigned)write_toggle,
+                (unsigned)cq_interface.completion_fifo_rd_ptr,
+                (unsigned)cq_interface.completion_fifo_rd_toggle,
+                (unsigned)cq_interface.completion_fifo_size,
+                (unsigned)cq_interface.completion_fifo_limit,
+                (unsigned)cq_interface.issue_fifo_limit,
+                (unsigned)cq_interface.cq_start,
+                (unsigned)this->cq_size,
+                (unsigned long)time(nullptr));
+            fclose(f);
+        }
+    }
+    // #endregion
     return write_ptr_and_toggle;
 }
 
-void SystemMemoryManager::wrap_issue_queue_wr_ptr(const uint8_t cq_id) {
+void SystemMemoryManager::wrap_issue_queue_wr_ptr(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return;
     }
@@ -781,7 +944,7 @@ void SystemMemoryManager::wrap_issue_queue_wr_ptr(const uint8_t cq_id) {
     cq_interface.issue_fifo_wr_toggle = not cq_interface.issue_fifo_wr_toggle;
 }
 
-void SystemMemoryManager::wrap_completion_queue_rd_ptr(const uint8_t cq_id) {
+void SystemMemoryManager::wrap_completion_queue_rd_ptr(const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return;
     }
@@ -791,13 +954,13 @@ void SystemMemoryManager::wrap_completion_queue_rd_ptr(const uint8_t cq_id) {
     cq_interface.completion_fifo_rd_toggle = not cq_interface.completion_fifo_rd_toggle;
 }
 
-void SystemMemoryManager::completion_queue_pop_front(uint32_t num_pages_read, const uint8_t cq_id) {
+void SystemMemoryManager::completion_queue_pop_front(std::uint32_t num_pages_read, const std::uint8_t cq_id) {
     if (is_mock_device()) {
         return;
     }
 
-    uint32_t data_read_B = num_pages_read * DispatchSettings::TRANSFER_PAGE_SIZE;
-    uint32_t data_read_16B = data_read_B >> 4;
+    std::uint32_t data_read_B = num_pages_read * DispatchSettings::TRANSFER_PAGE_SIZE;
+    std::uint32_t data_read_16B = data_read_B >> 4;
 
     SystemMemoryCQInterface& cq_interface = this->cq_interfaces[cq_id];
     cq_interface.completion_fifo_rd_ptr += data_read_16B;
@@ -810,22 +973,23 @@ void SystemMemoryManager::completion_queue_pop_front(uint32_t num_pages_read, co
     this->send_completion_queue_read_ptr(cq_id);
 }
 
-void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8_t cq_id, bool stall_prefetcher) {
+void SystemMemoryManager::fetch_queue_write(
+    std::uint32_t command_size_B, const std::uint8_t cq_id, bool stall_prefetcher) {
     if (is_mock_device()) {
         return;
     }
 
     const DispatchMemMap& dispatch_mem_map = MetalContext::instance(this->context_id).dispatch_mem_map();
-    const uint32_t max_command_size_B = dispatch_mem_map.max_prefetch_command_size();
+    const std::uint32_t max_command_size_B = dispatch_mem_map.max_prefetch_command_size();
     TT_ASSERT(
         command_size_B <= max_command_size_B,
         "Generated prefetcher command of size {} B exceeds max command size {} B",
         command_size_B,
         max_command_size_B);
 
-    const uint32_t entry_bytes = dispatch_mem_map.prefetch_q_entry_size_bytes();
-    const uint32_t shift_for_msb = entry_bytes * 8 - 1;
-    const uint32_t max_encodable = 1u << shift_for_msb;
+    const std::uint32_t entry_bytes = dispatch_mem_map.prefetch_q_entry_size_bytes();
+    const std::uint32_t shift_for_msb = entry_bytes * 8 - 1;
+    const std::uint32_t max_encodable = 1u << shift_for_msb;
     TT_ASSERT(
         (command_size_B >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE) < max_encodable,
         "FetchQ command too large to represent");
@@ -834,7 +998,7 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
         return;
     }
     tt_driver_atomics::sfence();
-    uint32_t entry_val = command_size_B >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE;
+    std::uint32_t entry_val = command_size_B >> DispatchSettings::PREFETCH_Q_LOG_MINSIZE;
 
     // stall_prefetcher is used for enqueuing traces, as replaying a trace will hijack the cmd_data_q
     // so prefetcher fetches multiple cmds that include the trace cmd, they will be corrupted by trace pulling data
@@ -845,7 +1009,8 @@ void SystemMemoryManager::fetch_queue_write(uint32_t command_size_B, const uint8
     }
 
     if (entry_bytes == 2) {
-        this->prefetch_q_windows[cq_id]->write16(this->prefetch_q_dev_ptrs[cq_id], static_cast<uint16_t>(entry_val));
+        this->prefetch_q_windows[cq_id]->write16(
+            this->prefetch_q_dev_ptrs[cq_id], static_cast<std::uint16_t>(entry_val));
     } else {
         TT_ASSERT(entry_bytes == 4);
         this->prefetch_q_windows[cq_id]->write32(this->prefetch_q_dev_ptrs[cq_id], entry_val);
@@ -857,25 +1022,25 @@ bool SystemMemoryManager::is_dram_backed() const {
     return tt::tt_metal::MetalContext::instance(this->context_id).rtoptions().get_dram_backed_cq();
 }
 
-uint32_t SystemMemoryManager::get_dram_region_base_addr() const {
+std::uint32_t SystemMemoryManager::get_dram_region_base_addr() const {
     TT_FATAL(this->is_dram_backed(), "CQs are not DRAM backed");
     return tt::tt_metal::MetalContext::instance(this->context_id)
         .hal()
         .get_dev_addr(HalDramMemAddrType::DRAM_BACKED_COMMAND_QUEUES);
 }
 
-uint32_t SystemMemoryManager::get_dram_region_bank_id() const {
+std::uint32_t SystemMemoryManager::get_dram_region_bank_id() const {
     TT_FATAL(this->is_dram_backed(), "CQs are not DRAM backed");
     return 0;
 }
 
-std::pair<void*, uint32_t> SystemMemoryManager::allocate_region(uint32_t size) {
+std::pair<void*, std::uint32_t> SystemMemoryManager::allocate_region(std::uint32_t size) {
     if (free_region_host_ptr_ == nullptr || free_region_size_ == 0) {
         return {nullptr, 0};
     }
 
-    static constexpr uint32_t kMinAlignment = 64;
-    uint32_t aligned_size = tt::align(size, kMinAlignment);
+    static constexpr std::uint32_t kMinAlignment = 64;
+    std::uint32_t aligned_size = tt::align(size, kMinAlignment);
     TT_FATAL(
         free_region_bump_ + aligned_size <= free_region_size_,
         "Hugepage auxiliary region exhausted: requested {} bytes ({} aligned), {} of {} used",
@@ -885,7 +1050,7 @@ std::pair<void*, uint32_t> SystemMemoryManager::allocate_region(uint32_t size) {
         free_region_size_);
 
     void* host_ptr = free_region_host_ptr_ + free_region_bump_;
-    uint32_t device_addr = free_region_start_ + free_region_bump_;
+    std::uint32_t device_addr = free_region_start_ + free_region_bump_;
     free_region_bump_ += aligned_size;
 
     std::memset(host_ptr, 0, aligned_size);

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -39,7 +39,7 @@ namespace tt::tt_metal {
 // For readablity, unset = x = -1
 constexpr int x = -1;
 
-void increment_node_ids(DispatchKernelNode& node, uint32_t inc) {
+void increment_node_ids(DispatchKernelNode& node, std::uint32_t inc) {
     node.id += inc;
     for (int& id : node.upstream_ids) {
         if (id != x) {
@@ -425,15 +425,15 @@ DispatchTopology::~DispatchTopology() { reset(); }
 
 // Helper to automatically generate dispatch nodes given devices + num hw CQs + detection of card type.
 std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
-    const std::set<ChipId>& device_ids, uint32_t num_hw_cqs) const {
+    const std::set<ChipId>& device_ids, std::uint32_t num_hw_cqs) const {
     // Select/generate the right input table, depends on (1) board [detected from total # of devices], and (2) number
     // of active devices. TODO: read this out of YAML instead of the structs above?
-    uint32_t total_devices = descriptor_.cluster().number_of_devices();
+    std::uint32_t total_devices = descriptor_.cluster().number_of_devices();
     TT_ASSERT(
         total_devices == 1 or total_devices == 2 or total_devices == 4 or total_devices == 8 or total_devices == 32 or
             total_devices == 36,
         "Unexpected target.");
-    uint32_t num_devices = device_ids.size();
+    std::uint32_t num_devices = device_ids.size();
     TT_ASSERT(num_devices > 0, "Can't determine dispatch architecture with no active devices.");
     TT_ASSERT(num_devices <= total_devices);
     std::vector<DispatchKernelNode> nodes;
@@ -462,7 +462,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
     if (remote_devices.empty()) {
         // MMIO devices only, just replicate a single chip arch for each
         std::vector<DispatchKernelNode> nodes_for_one_mmio = populate_single_device();
-        uint32_t index_offset = 0;
+        std::uint32_t index_offset = 0;
         for (auto id : mmio_devices) {
             for (auto node : nodes_for_one_mmio) {
                 node.device_id = id;
@@ -479,7 +479,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
             // For Galaxy, we always init all remote devices associated with an mmio device.
             std::vector<DispatchKernelNode> nodes_for_one_mmio =
                 (num_hw_cqs == 1) ? galaxy_nine_chip_arch_1cq_fabric : galaxy_nine_chip_arch_2cq_fabric;
-            uint32_t index_offset = 0;
+            std::uint32_t index_offset = 0;
             for (auto mmio_device_id : mmio_devices) {
                 // Need a mapping from templated device id (1-8) to actual device id (from the tunnel)
                 std::vector<ChipId> template_id_to_device_id;
@@ -495,7 +495,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
 
                 // Pull nodes from the template, updating their index and device id
                 for (DispatchKernelNode node : nodes_for_one_mmio) {
-                    int32_t num_devices = template_id_to_device_id.size();
+                    std::int32_t num_devices = template_id_to_device_id.size();
                     TT_ASSERT(
                         node.device_id < num_devices,
                         "Device id {} out of bounds (max = {})",
@@ -521,7 +521,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
             std::vector<DispatchKernelNode> nodes_for_one_mmio =
                 (num_hw_cqs == 1) ? two_chip_arch_1cq_fabric : two_chip_arch_2cq_fabric;
 
-            uint32_t index_offset = 0;
+            std::uint32_t index_offset = 0;
             for (auto mmio_device_id : mmio_devices) {
                 // Find the corresponding remote chip
                 ChipId remote_device_id{};
@@ -541,8 +541,8 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
 
                 // Add dispatch kernels for the mmio/remote pair
                 for (DispatchKernelNode node : nodes_for_one_mmio) {
-                    constexpr uint32_t k_MMIO = 0;
-                    constexpr uint32_t k_Remote = 1;
+                    constexpr std::uint32_t k_MMIO = 0;
+                    constexpr std::uint32_t k_Remote = 1;
                     TT_ASSERT(node.device_id == k_MMIO || node.device_id == k_Remote);
                     TT_ASSERT(
                         node.servicing_device_id == k_MMIO || node.servicing_device_id == k_Remote ||
@@ -571,7 +571,7 @@ std::vector<DispatchKernelNode> DispatchTopology::generate_nodes(
     return nodes;
 }
 
-void DispatchTopology::populate_fd_kernels(const std::vector<Device*>& devices, uint32_t num_hw_cqs) {
+void DispatchTopology::populate_fd_kernels(const std::vector<Device*>& devices, std::uint32_t num_hw_cqs) {
     std::set<ChipId> device_ids;
     for (const auto& device : devices) {
         device_ids.insert(device->id());
@@ -579,7 +579,7 @@ void DispatchTopology::populate_fd_kernels(const std::vector<Device*>& devices, 
     populate_fd_kernels(generate_nodes(device_ids, num_hw_cqs));
 }
 
-void DispatchTopology::populate_fd_kernels(const std::set<ChipId>& device_ids, uint32_t num_hw_cqs) {
+void DispatchTopology::populate_fd_kernels(const std::set<ChipId>& device_ids, std::uint32_t num_hw_cqs) {
     populate_fd_kernels(generate_nodes(device_ids, num_hw_cqs));
 }
 
@@ -595,7 +595,7 @@ void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>
 
     // Read the input table, create configs for each node + track mmio devices and number of cqs.
     std::unordered_set<ChipId> mmio_device_ids;
-    std::unordered_set<uint8_t> hw_cq_ids;
+    std::unordered_set<std::uint8_t> hw_cq_ids;
     node_id_to_kernel_.reserve(nodes.size());
     for (const auto& node : nodes) {
         TT_ASSERT(node_id_to_kernel_.size() == node.id);
@@ -618,7 +618,7 @@ void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>
         }
         hw_cq_ids.insert(node.cq_id);
     }
-    uint32_t num_hw_cqs = hw_cq_ids.size();
+    std::uint32_t num_hw_cqs = hw_cq_ids.size();
 
     // Connect the graph with upstream/downstream kernels
     for (const auto& node : nodes) {
@@ -645,7 +645,7 @@ void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>
     }
 
     // For kernels on mmio chip, need to confirm which remote device each is servicing
-    std::map<ChipId, uint32_t> device_id_to_tunnel_stop;
+    std::map<ChipId, std::uint32_t> device_id_to_tunnel_stop;
     std::map<ChipId, std::vector<ChipId>> mmio_device_id_to_serviced_devices;
     for (auto mmio_device_id : mmio_device_ids) {
         if (descriptor_.cluster().get_associated_mmio_device(mmio_device_id) != mmio_device_id) {
@@ -658,7 +658,7 @@ void DispatchTopology::populate_fd_kernels(const std::vector<DispatchKernelNode>
         }
         std::vector<ChipId> remote_devices;
         for (auto tunnel : descriptor_.cluster().get_tunnels_from_mmio_device(mmio_device_id)) {
-            for (uint32_t tunnel_stop = 0; tunnel_stop < tunnel.size(); tunnel_stop++) {
+            for (std::uint32_t tunnel_stop = 0; tunnel_stop < tunnel.size(); tunnel_stop++) {
                 ChipId remote_device_id = tunnel[tunnel_stop];
                 device_id_to_tunnel_stop[remote_device_id] = tunnel_stop;
                 if (remote_device_id != mmio_device_id) {
@@ -762,30 +762,46 @@ void DispatchTopology::configure_dispatch_cores(Device* device) {
     // it here. TODO: should this be in the struct?
     CoreType dispatch_core_type = this->dispatch_core_manager_.get_dispatch_core_type();
     const auto& my_dispatch_constants = *dispatch_mem_map_[enchantum::to_underlying(dispatch_core_type)];
-    uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
-    uint32_t cq_size = device->sysmem_manager().get_cq_size();
-    std::vector<uint32_t> zero = {0x0};
+    std::uint32_t cq_start = my_dispatch_constants.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
+    std::uint32_t cq_size = device->sysmem_manager().get_cq_size();
+    std::vector<std::uint32_t> zero = {0x0};
 
-    // Need to set up for all devices serviced by an mmio chip
+    // Need to set up for all devices serviced by an mmio chip.
+    //
+    // In dram-backed simulator mode each chip (MMIO or tunnel) owns its own
+    // dram_region and dispatch core L1; the MMIO chip's PCIe loop cannot stage
+    // pointer storage for tunnel chips. Mirror the same dram_backed_sim fanout
+    // we use in Device::configure_command_queue_programs so the tunnel-chip
+    // dispatch FW finds initialized completion_q_wr/rd pointers and actually
+    // services WRITE_LINEAR_H_HOST commands instead of silently doing nothing.
     TT_ASSERT(device_manager_ != nullptr, "DeviceManager required for configure_dispatch_cores");
-    if (device->is_mmio_capable()) {
-        for (ChipId serviced_device_id : descriptor_.cluster().get_devices_controlled_by_mmio_device(device->id())) {
-            uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(serviced_device_id);
-            for (uint8_t cq_id = 0; cq_id < device->num_hw_cqs(); cq_id++) {
+    const bool dram_backed_sim = device->sysmem_manager().is_dram_backed();
+    const bool init_dispatch_ptrs = device->is_mmio_capable() || dram_backed_sim;
+    if (init_dispatch_ptrs) {
+        std::vector<ChipId> serviced_for_init;
+        if (dram_backed_sim) {
+            serviced_for_init = {device->id()};
+        } else {
+            const auto& mmio_serviced = descriptor_.cluster().get_devices_controlled_by_mmio_device(device->id());
+            serviced_for_init.assign(mmio_serviced.begin(), mmio_serviced.end());
+        }
+        for (ChipId serviced_device_id : serviced_for_init) {
+            std::uint16_t channel = descriptor_.cluster().get_assigned_channel_for_device(serviced_device_id);
+            for (std::uint8_t cq_id = 0; cq_id < device->num_hw_cqs(); cq_id++) {
                 tt_cxy_pair completion_q_writer_location =
                     this->dispatch_core_manager_.completion_queue_writer_core(serviced_device_id, channel, cq_id);
                 IDevice* mmio_device = device_manager_->get_active_device(completion_q_writer_location.chip);
-                uint32_t completion_q_wr_ptr =
+                std::uint32_t completion_q_wr_ptr =
                     my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR);
-                uint32_t completion_q_rd_ptr =
+                std::uint32_t completion_q_rd_ptr =
                     my_dispatch_constants.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_RD);
-                uint32_t completion_q0_last_event_ptr = my_dispatch_constants.get_device_command_queue_addr(
+                std::uint32_t completion_q0_last_event_ptr = my_dispatch_constants.get_device_command_queue_addr(
                     CommandQueueDeviceAddrType::COMPLETION_Q0_LAST_EVENT);
-                uint32_t completion_q1_last_event_ptr = my_dispatch_constants.get_device_command_queue_addr(
+                std::uint32_t completion_q1_last_event_ptr = my_dispatch_constants.get_device_command_queue_addr(
                     CommandQueueDeviceAddrType::COMPLETION_Q1_LAST_EVENT);
                 // Initialize completion queue write pointer and read pointer copy
-                uint32_t issue_queue_size = device->sysmem_manager().get_issue_queue_size(cq_id);
-                uint32_t completion_queue_start_addr;
+                std::uint32_t issue_queue_size = device->sysmem_manager().get_issue_queue_size(cq_id);
+                std::uint32_t completion_queue_start_addr;
                 if (device->sysmem_manager().is_dram_backed()) {
                     completion_queue_start_addr =
                         cq_start + issue_queue_size +
@@ -795,8 +811,8 @@ void DispatchTopology::configure_dispatch_cores(Device* device) {
                     completion_queue_start_addr =
                         cq_start + issue_queue_size + get_absolute_cq_offset(channel, cq_id, cq_size);
                 }
-                uint32_t completion_queue_start_addr_16B = completion_queue_start_addr >> 4;
-                std::vector<uint32_t> completion_queue_wr_ptr = {completion_queue_start_addr_16B};
+                std::uint32_t completion_queue_start_addr_16B = completion_queue_start_addr >> 4;
+                std::vector<std::uint32_t> completion_queue_wr_ptr = {completion_queue_start_addr_16B};
                 detail::WriteToDeviceL1(
                     mmio_device,
                     completion_q_writer_location,

--- a/tt_metal/llrt/llrt.cpp
+++ b/tt_metal/llrt/llrt.cpp
@@ -148,6 +148,11 @@ void write_launch_msg_to_core(
     tt_driver_atomics::sfence();
     if (send_go) {
         cluster.write_core_immediate(go_msg.data(), go_msg.size(), {static_cast<size_t>(chip), core}, go_addr);
+        if (tt::tt_metal::MetalContext::instance().rtoptions().get_simulator_enabled()) {
+            const bool is_eth = dispatch_core_type == tt_metal::HalProgrammableCoreType::ACTIVE_ETH ||
+                                dispatch_core_type == tt_metal::HalProgrammableCoreType::IDLE_ETH;
+            cluster.sim_arm_launch_watcher(chip, core, is_eth);
+        }
     }
 }
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1629,6 +1629,14 @@ void Cluster::register_sim_fabric_endpoint_direction(
 #endif
 }
 
+void Cluster::sim_arm_launch_watcher(ChipId chip_id, CoreCoord virtual_core, bool is_eth) const {
+    if (this->target_type_ != tt::TargetDevice::Simulator) {
+        return;
+    }
+    tt::umd::CoreCoord core_coord(virtual_core.x, virtual_core.y);
+    this->get_driver()->sim_arm_launch_watcher(chip_id, core_coord, is_eth);
+}
+
 }  // namespace tt
 
 std::ostream& operator<<(std::ostream& os, const tt_target_dram& dram) {

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -1629,13 +1629,11 @@ void Cluster::register_sim_fabric_endpoint_direction(
 #endif
 }
 
-void Cluster::sim_arm_launch_watcher(ChipId chip_id, CoreCoord virtual_core, bool is_eth) const {
-    if (this->target_type_ != tt::TargetDevice::Simulator) {
-        return;
-    }
-    tt::umd::CoreCoord core_coord(virtual_core.x, virtual_core.y);
-    this->get_driver()->sim_arm_launch_watcher(chip_id, core_coord, is_eth);
+void Cluster::sim_arm_launch_watcher(ChipId /*chip_id*/, CoreCoord /*virtual_core*/, bool /*is_eth*/) const {
+    // WIP debug hook for sim watcher; UMD/craq-sim do not expose this API on blaze-metal-main yet.
 }
+
+void Cluster::advance_device_execution(ChipId chip_id) const { this->get_driver()->advance_device_execution(chip_id); }
 
 }  // namespace tt
 

--- a/tt_metal/llrt/tt_cluster.cpp
+++ b/tt_metal/llrt/tt_cluster.cpp
@@ -15,11 +15,13 @@
 #include <cstdio>
 #include <cstdint>
 #include <cstdlib>
+#include <ctime>
 #include <iostream>
 #include <memory>
 #include <stdexcept>
 #include <string>
 #include <tuple>  // for get
+#include <unistd.h>
 #include <unordered_map>
 #include <unordered_set>
 #include <utility>
@@ -345,6 +347,45 @@ void Cluster::initialize_device_drivers() {
             }
         }
     }
+    // #region agent log H_RANK_CHIP_COLLISION
+    {
+        std::FILE* f = std::fopen("/data/rsong/tt-metal-fork/.cursor/debug-ae7d0a.log", "a");
+        if (f) {
+            std::string driver_ids;
+            for (const auto& id : this->driver_->get_target_device_ids()) {
+                driver_ids += std::to_string(id) + ",";
+            }
+            std::string mmio_ids;
+            for (const auto& id : this->driver_->get_target_mmio_device_ids()) {
+                mmio_ids += std::to_string(id) + ",";
+            }
+            std::string desc_ids;
+            for (const auto& id : this->cluster_desc_->get_all_chips()) {
+                desc_ids += std::to_string(id) + ",";
+            }
+            const char* env_visible = std::getenv("TT_VISIBLE_DEVICES");
+            const char* env_mesh = std::getenv("TT_MESH_ID");
+            std::fprintf(
+                f,
+                "{\"sessionId\":\"ae7d0a\",\"hypothesisId\":\"H_RANK_CHIP_COLLISION\","
+                "\"location\":\"tt_cluster.cpp:initialize_device_drivers\","
+                "\"message\":\"CLUSTER_INIT_DONE\",\"data\":{\"pid\":%d,"
+                "\"target_type\":%d,\"driver_target_device_ids\":\"%s\","
+                "\"driver_target_mmio_device_ids\":\"%s\","
+                "\"cluster_desc_all_chips\":\"%s\","
+                "\"TT_VISIBLE_DEVICES\":\"%s\",\"TT_MESH_ID\":\"%s\"},\"timestamp\":%ld}\n",
+                (int)getpid(),
+                (int)this->target_type_,
+                driver_ids.c_str(),
+                mmio_ids.c_str(),
+                desc_ids.c_str(),
+                env_visible ? env_visible : "(unset)",
+                env_mesh ? env_mesh : "(unset)",
+                (long)std::time(nullptr));
+            std::fclose(f);
+        }
+    }
+    // #endregion
 }
 
 void Cluster::assert_risc_reset() { this->driver_->assert_risc_reset(); }
@@ -390,6 +431,21 @@ const std::unordered_map<CoreCoord, int32_t>& Cluster::get_virtual_routing_to_pr
 
 void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
     std::unique_ptr<tt::umd::Cluster> device_driver;
+    // Shared-daemon simulator/mock: skip chip-id remapping so each MPI rank keeps
+    // disjoint physical chip IDs from TT_VISIBLE_DEVICES (see cluster_descriptor.cpp).
+    const bool needs_no_remap =
+        (this->target_type_ == TargetDevice::Simulator || this->target_type_ == TargetDevice::Mock ||
+         this->target_type_ == TargetDevice::Emule) &&
+        rtoptions_.get_mock_enabled();
+    bool prev_no_remap_was_set = false;
+    std::string prev_no_remap_value;
+    if (needs_no_remap) {
+        if (const char* v = std::getenv("TT_METAL_NO_CHIP_ID_REMAP")) {
+            prev_no_remap_was_set = true;
+            prev_no_remap_value = v;
+        }
+        setenv("TT_METAL_NO_CHIP_ID_REMAP", "1", /*overwrite=*/1);
+    }
     if (this->target_type_ == TargetDevice::Silicon) {
         device_driver = std::make_unique<tt::umd::Cluster>(tt::umd::ClusterOptions{
             .num_host_mem_ch_per_mmio_device = std::nullopt,  // Automatically determine number of host mem channels.
@@ -439,6 +495,13 @@ void Cluster::open_driver(const bool& /*skip_driver_allocs*/) {
     }
 
     this->driver_ = std::move(device_driver);
+    if (needs_no_remap) {
+        if (prev_no_remap_was_set) {
+            setenv("TT_METAL_NO_CHIP_ID_REMAP", prev_no_remap_value.c_str(), /*overwrite=*/1);
+        } else {
+            unsetenv("TT_METAL_NO_CHIP_ID_REMAP");
+        }
+    }
 }
 
 void Cluster::set_hal(const tt_metal::Hal* hal) {

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -373,6 +373,7 @@ public:
     void register_sim_fabric_endpoint_direction(
         ChipId chip_id, tt_fabric::chan_id_t eth_chan_id, tt_fabric::eth_chan_directions direction) const;
     void sim_arm_launch_watcher(ChipId chip_id, CoreCoord virtual_core, bool is_eth) const;
+    void advance_device_execution(ChipId chip_id) const;
 
     // Get all fabric ethernet cores
     std::set<tt_fabric::chan_id_t> get_fabric_ethernet_channels(

--- a/tt_metal/llrt/tt_cluster.hpp
+++ b/tt_metal/llrt/tt_cluster.hpp
@@ -368,10 +368,11 @@ public:
         return this->target_type_ == tt::TargetDevice::Mock || this->target_type_ == tt::TargetDevice::Emule;
     }
 
+    bool is_base_routing_fw_enabled() const;
+
     void register_sim_fabric_endpoint_direction(
         ChipId chip_id, tt_fabric::chan_id_t eth_chan_id, tt_fabric::eth_chan_directions direction) const;
-
-    bool is_base_routing_fw_enabled() const;
+    void sim_arm_launch_watcher(ChipId chip_id, CoreCoord virtual_core, bool is_eth) const;
 
     // Get all fabric ethernet cores
     std::set<tt_fabric::chan_id_t> get_fabric_ethernet_channels(

--- a/tt_metal/llrt/tunnels_from_mmio_device.cpp
+++ b/tt_metal/llrt/tunnels_from_mmio_device.cpp
@@ -26,9 +26,17 @@ std::map<ChipId, std::vector<std::vector<ChipId>>> discover_tunnels_from_mmio_de
     std::map<ChipId, std::vector<std::vector<tt::ChipId>>> tunnels_from_mmio_device = {};
 
     for (const auto& mmio_chip_id : cluster.get_target_mmio_device_ids()) {
+        // In simulation every chip is created as a directly-addressable SimulationChip,
+        // so UMD reports all of them as "target MMIO devices" even when the cluster
+        // descriptor models some chips as topologically remote (e.g. the remote chip of
+        // an N300, which is reached over an ethernet tunnel on real hardware). Tunnel
+        // discovery must only root tunnels at chips that are genuinely MMIO-capable per
+        // the cluster descriptor; remote chips are discovered as tunnel stops below.
+        if (!cluster.get_cluster_description()->is_chip_mmio_capable(mmio_chip_id)) {
+            continue;
+        }
         std::vector<std::vector<ChipId>> tunnels_from_mmio = {};
         const auto& all_eth_connections = cluster.get_cluster_description()->get_ethernet_connections();
-        TT_ASSERT(cluster.get_cluster_description()->is_chip_mmio_capable(mmio_chip_id));
 
         if (!all_eth_connections.contains(mmio_chip_id)) {
             tunnels_from_mmio_device.insert({mmio_chip_id, {}});


### PR DESCRIPTION
## Summary
- Rebases `nkapre/multichip-mp-ttsim-mock-cluster-rank-binding-20260527` (formerly PR #45379) onto `blaze-metal-main`.
- Brings host-side MP ttsimd fixes: TT_VISIBLE_DEVICES filtering, TT_METAL_NO_CHIP_ID_REMAP, DRAM-backed per-chip CQ init, mock-cluster-rank-binding sweep scripts, and debug helpers.
- Keeps blaze-metal-main Cluster& physical_system_discovery API and UMD pin (`cb0be91a`); skipped upstream ClusterDescriptor-only restore commit as incompatible with blaze-metal-main.

## Test plan
- [ ] `./build_metal.sh --build-type RelWithDebInfo --build-tests` on compute node
- [ ] N300/P300 fabric smoke tests (TopologyMapper, ControlPlane, Fabric1DFixture, SimpleUnicastWriteLinear)


Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rsong/multichip-mp-ttsim-rebased-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rsong/multichip-mp-ttsim-rebased-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rsong/multichip-mp-ttsim-rebased-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rsong/multichip-mp-ttsim-rebased-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rsong/multichip-mp-ttsim-rebased-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rsong/multichip-mp-ttsim-rebased-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rsong/multichip-mp-ttsim-rebased-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rsong/multichip-mp-ttsim-rebased-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rsong/multichip-mp-ttsim-rebased-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rsong/multichip-mp-ttsim-rebased-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rsong/multichip-mp-ttsim-rebased-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rsong/multichip-mp-ttsim-rebased-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rsong/multichip-mp-ttsim-rebased-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rsong/multichip-mp-ttsim-rebased-blaze-metal-main)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rsong/multichip-mp-ttsim-rebased-blaze-metal-main)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rsong/multichip-mp-ttsim-rebased-blaze-metal-main)