### PR TITLE
[skip ci] move time budgets for tiered models pipelines into their own category

### DIFF
--- a/.github/scripts/utils/query_time_budget.py
+++ b/.github/scripts/utils/query_time_budget.py
@@ -19,14 +19,11 @@ Key conventions
 * Owner is the entry's `team:` field, not the file name. One file may hold
   several teams' entries, so all files of a test type are scanned and filtered.
 * A file's "test type" is the workflow_name passed to verify_time_budget.py by
-  the workflow that runs it -- NOT the file name. It is read live from
-  .github/workflows, because names can differ: release_tests.yaml and
-  galaxy_deepseek_prefill_tests.yaml both map to `demo`, and
-  demo_sp_multihost_tests.yaml maps to `e2e`.
+  the workflow that runs it.
 * The models unit/e2e/sweep budgets are tier-split: the plain key covers the
   non-tiered pipelines, while unit_tier<n>/e2e_tier<n>/sweep_tier<n> cover
   models_<testtype>_tests.yaml. Pass --tier to target a tiered budget.
-* Cron frequency is parsed live from .github/workflows by following the test
+* Cron frequency is parsed from .github/workflows by following the test
   file -> running workflow -> scheduled caller(s). Only cron schedules count;
   manual workflow_dispatch runs are excluded from the estimate.
 
@@ -49,6 +46,20 @@ Example
     Est. machine-hours/week: 11.0 h  (47 min x 14 runs/wk / 60)
     Note: estimate uses cron schedules only; manual workflow_dispatch runs are NOT counted.
     [OK] Within budget (7 min headroom).
+
+
+  $ query_time_budget.py --team runtime --testtype unit --machine wh_n150_civ2
+  Team 'runtime' / test type 'unit' / machine 'wh_n150_civ2'
+    Files scanned: 5
+    Tests matched: 20
+    Allocated:     222 min
+    Budget:        222 min
+    Scheduled pipelines (cron):
+          7 runs/wk  code-coverage.yaml
+          7 runs/wk  runtime-unit-tests.yaml
+    Est. machine-hours/week: 51.8 h  (222 min x 14 runs/wk / 60)
+    Note: estimate uses cron schedules only; manual workflow_dispatch runs are NOT counted.
+    [OK] Within budget (0 min headroom).
 """
 
 import argparse

--- a/.github/scripts/utils/query_time_budget.py
+++ b/.github/scripts/utils/query_time_budget.py
@@ -4,7 +4,7 @@ the budget declared in .github/time_budget.yaml.
 The companion script verify_time_budget.py checks one tests file against the
 budget during CI. This tool answers the inverse question: "How much time does
 team X currently allocate for test type Y on machine Z?" by summing the
-per-SKU timeouts across every tests file of that test type.
+per-SKU timeouts across the tests files covered by that budget key.
 
 Notes on the data model (see tests/pipeline_reorg/*_tests.yaml):
   * Each entry has a `team:` field. This field -- not the file name -- is the
@@ -15,6 +15,9 @@ Notes on the data model (see tests/pipeline_reorg/*_tests.yaml):
     (unit, e2e, sanity, stress, perf, integration, l2, device_perf, smoke,
     profiler, sweep, health, demo). `device_perf` and `perf` are distinct.
   * Per entry: skus: { <machine>: { timeout: <minutes>, tier: <n> } }.
+  * The models unit/e2e/sweep budgets are split. The plain keys cover non-tiered
+    pipelines; the unit_tier<n>/e2e_tier<n>/sweep_tier<n> keys cover
+    models_<testtype>_tests.yaml.
 
 Usage:
   query_time_budget.py --team models --testtype unit --machine wh_n150 [--tier 1] [-v]
@@ -30,6 +33,7 @@ import yaml
 REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
 TESTS_DIR = os.path.join(REPO_ROOT, "tests", "pipeline_reorg")
 DEFAULT_BUDGET_FILE = os.path.join(REPO_ROOT, ".github", "time_budget.yaml")
+TIERED_MODEL_TESTTYPES = {"unit", "e2e", "sweep"}
 
 
 def testtype_of_file(filename):
@@ -56,6 +60,26 @@ def testtype_of_file(filename):
 def find_test_files(tests_dir, testtype):
     """All *_tests.yaml files in tests_dir whose test type equals `testtype`."""
     return sorted(f for f in glob.glob(os.path.join(tests_dir, "*_tests.yaml")) if testtype_of_file(f) == testtype)
+
+
+def uses_tiered_model_budget(team, testtype):
+    """Whether this query should use the models-specific tiered budget split."""
+    return team == "models" and testtype in TIERED_MODEL_TESTTYPES
+
+
+def select_files_for_budget(files, team, testtype, tier):
+    """Return the files that correspond to the budget key being queried.
+
+    The models unit/e2e/sweep budgets are split: the plain keys cover non-tiered
+    pipelines, while the <testtype>_tier<n> keys cover models_<testtype>_tests.yaml.
+    """
+    if not uses_tiered_model_budget(team, testtype):
+        return files
+
+    tiered_filename = f"models_{testtype}_tests.yaml"
+    if tier is not None:
+        return [f for f in files if os.path.basename(f) == tiered_filename]
+    return [f for f in files if os.path.basename(f) != tiered_filename]
 
 
 def collect_allocations(files, team, machine, tier=None):
@@ -86,12 +110,17 @@ def collect_allocations(files, team, machine, tier=None):
     return total, breakdown
 
 
-def lookup_budget(budget_file, team, testtype, machine):
+def lookup_budget(budget_file, team, testtype, machine, tier=None):
     """Return the declared budget, or None if not present."""
     with open(budget_file, "r") as f:
         budgets = yaml.safe_load(f) or {}
     try:
-        return budgets[team][testtype][machine]
+        team_budgets = budgets[team]
+        if tier is not None and uses_tiered_model_budget(team, testtype):
+            return team_budgets[f"{testtype}_tier{tier}"][machine]
+        if tier is not None and f"{testtype}_tier{tier}" in team_budgets:
+            return team_budgets[f"{testtype}_tier{tier}"][machine]
+        return team_budgets[testtype][machine]
     except (KeyError, TypeError):
         return None
 
@@ -101,18 +130,23 @@ def main():
     parser.add_argument("--team", required=True, help="Team name, e.g. models, llk, runtime")
     parser.add_argument("--testtype", required=True, help="Test type, e.g. unit, sanity, stress, e2e")
     parser.add_argument("--machine", required=True, help="SKU/machine name, e.g. wh_n150, wh_llmbox")
-    parser.add_argument("--tier", type=int, default=None, help="Optional: only sum entries of this tier")
+    parser.add_argument(
+        "--tier", type=int, choices=(1, 2, 3), default=None, help="Optional: only sum entries of this tier"
+    )
     parser.add_argument("--tests-dir", default=TESTS_DIR, help="Directory of *_tests.yaml files")
     parser.add_argument("--budget-file", default=DEFAULT_BUDGET_FILE, help="Path to time_budget.yaml")
     parser.add_argument("-v", "--verbose", action="store_true", help="Print per-test breakdown")
     args = parser.parse_args()
 
-    files = find_test_files(args.tests_dir, args.testtype)
-    if not files:
+    matching_files = find_test_files(args.tests_dir, args.testtype)
+    files = select_files_for_budget(matching_files, args.team, args.testtype, args.tier)
+    if not matching_files:
         print(f"[WARN] No '*_{args.testtype}_tests.yaml' files found in {args.tests_dir}")
+    elif not files:
+        print(f"[WARN] No files correspond to this budget key after applying model tier split rules")
 
     total, breakdown = collect_allocations(files, args.team, args.machine, args.tier)
-    budget = lookup_budget(args.budget_file, args.team, args.testtype, args.machine)
+    budget = lookup_budget(args.budget_file, args.team, args.testtype, args.machine, args.tier)
 
     tier_note = f", tier {args.tier}" if args.tier is not None else ""
     print(f"Team '{args.team}' / test type '{args.testtype}' / machine '{args.machine}'{tier_note}")

--- a/.github/scripts/utils/query_time_budget.py
+++ b/.github/scripts/utils/query_time_budget.py
@@ -92,7 +92,8 @@ def build_testtype_map(workflows_dir):
     mapping = {}
     for path in glob.glob(os.path.join(workflows_dir, "*.y*ml")):
         try:
-            lines = open(path, "r").read().splitlines()
+            with open(path, "r") as f:
+                lines = f.read().splitlines()
         except OSError:
             continue
 

--- a/.github/scripts/utils/query_time_budget.py
+++ b/.github/scripts/utils/query_time_budget.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3
+
 """Report how much CI test time a (team, test type, machine[, tier]) uses, and
 compare it against the budget declared in .github/time_budget.yaml.
 

--- a/.github/scripts/utils/query_time_budget.py
+++ b/.github/scripts/utils/query_time_budget.py
@@ -11,9 +11,12 @@ Notes on the data model (see tests/pipeline_reorg/*_tests.yaml):
     authoritative owner. A single file (e.g. galaxy_unit_tests.yaml) mixes
     entries from several teams, so we scan every file of the test type and
     filter by `team:`.
-  * A file's test type is the underscore-delimited token before `_tests.yaml`
-    (unit, e2e, sanity, stress, perf, integration, l2, device_perf, smoke,
-    profiler, sweep, health, demo). `device_perf` and `perf` are distinct.
+  * A file's test type is NOT its file name. It is the workflow_name argument
+    passed to verify_time_budget.py by the workflow that runs the file (the same
+    key used in time_budget.yaml). This is discovered live from .github/workflows,
+    because the file name can differ from the budget key -- e.g. release_tests.yaml
+    and galaxy_deepseek_prefill_tests.yaml both map to `demo`, and
+    demo_sp_multihost_tests.yaml maps to `e2e`.
   * Per entry: skus: { <machine>: { timeout: <minutes>, tier: <n> } }.
   * The models unit/e2e/sweep budgets are split. The plain keys cover non-tiered
     pipelines; the unit_tier<n>/e2e_tier<n>/sweep_tier<n> keys cover
@@ -33,6 +36,7 @@ Usage:
 import argparse
 import glob
 import os
+import re
 import sys
 
 import yaml
@@ -44,30 +48,61 @@ TIERED_MODEL_TESTTYPES = {"unit", "e2e", "sweep"}
 WORKFLOWS_DIR = os.path.join(REPO_ROOT, ".github", "workflows")
 
 
-def testtype_of_file(filename):
-    """Return the test-type token of a `*_tests.yaml` file, or None.
+_TESTS_YAML_RE = re.compile(r"TESTS_YAML_PATH:\s*\S*?([A-Za-z0-9_]+_tests\.yaml)")
 
-    e.g. models_unit_tests.yaml      -> "unit"
-         models_device_perf_tests.yaml -> "device_perf"
-         galaxy_perf_tests.yaml      -> "perf"
+
+def build_testtype_map(workflows_dir):
+    """Map each tests YAML (basename) to its budget test type, parsed from workflows.
+
+    The authoritative test type for a tests YAML is the workflow_name argument
+    passed to verify_time_budget.py in the workflow that runs it -- NOT the file
+    name. We read it live so the mapping tracks pipeline changes (and handles
+    cases where the file name differs from the budget key, e.g. release_tests.yaml
+    -> 'demo', demo_sp_multihost_tests.yaml -> 'e2e').
     """
-    base = os.path.basename(filename)
-    if not base.endswith("_tests.yaml"):
-        return None
-    stem = base[: -len("_tests.yaml")]  # e.g. "models_device_perf"
-    parts = stem.split("_")
-    if len(parts) < 2:
-        return None
-    # The test type is the trailing token(s). Treat "device_perf" specially so it
-    # is not confused with "perf"; everything else is the single last token.
-    if len(parts) >= 2 and parts[-2] == "device" and parts[-1] == "perf":
-        return "device_perf"
-    return parts[-1]
+    mapping = {}
+    for path in glob.glob(os.path.join(workflows_dir, "*.y*ml")):
+        try:
+            lines = open(path, "r").read().splitlines()
+        except OSError:
+            continue
+
+        test_files = {m.group(1) for line in lines for m in [_TESTS_YAML_RE.search(line)] if m}
+        if not test_files:
+            continue
+
+        # The workflow_name is the 3rd positional arg to verify_time_budget.py:
+        # the first literal token following the time_budget.yaml path argument.
+        workflow_name = None
+        for i, line in enumerate(lines):
+            if "verify_time_budget.py" not in line:
+                continue
+            for j in range(i + 1, min(i + 8, len(lines))):
+                if "time_budget.yaml" not in lines[j]:
+                    continue
+                for k in range(j + 1, min(j + 4, len(lines))):
+                    arg = lines[k].strip().rstrip("\\").strip().strip("\"'")
+                    if arg and not arg.startswith("${{"):
+                        workflow_name = arg
+                        break
+                break
+            if workflow_name:
+                break
+        if not workflow_name:
+            continue
+
+        for test_file in test_files:
+            mapping[test_file] = workflow_name
+    return mapping
 
 
-def find_test_files(tests_dir, testtype):
-    """All *_tests.yaml files in tests_dir whose test type equals `testtype`."""
-    return sorted(f for f in glob.glob(os.path.join(tests_dir, "*_tests.yaml")) if testtype_of_file(f) == testtype)
+def find_test_files(tests_dir, testtype, testtype_map):
+    """Tests YAML paths in tests_dir whose budget test type equals `testtype`."""
+    return sorted(
+        path
+        for path in glob.glob(os.path.join(tests_dir, "*_tests.yaml"))
+        if testtype_map.get(os.path.basename(path)) == testtype
+    )
 
 
 def uses_tiered_model_budget(team, testtype):
@@ -267,12 +302,13 @@ def main():
     parser.add_argument("-v", "--verbose", action="store_true", help="Print per-test breakdown")
     args = parser.parse_args()
 
-    matching_files = find_test_files(args.tests_dir, args.testtype)
+    testtype_map = build_testtype_map(args.workflows_dir)
+    matching_files = find_test_files(args.tests_dir, args.testtype, testtype_map)
     files = select_files_for_budget(matching_files, args.team, args.testtype, args.tier)
     if not matching_files:
-        print(f"[WARN] No '*_{args.testtype}_tests.yaml' files found in {args.tests_dir}")
+        print(f"[WARN] No tests files map to budget test type '{args.testtype}' (checked {args.workflows_dir})")
     elif not files:
-        print(f"[WARN] No files correspond to this budget key after applying model tier split rules")
+        print("[WARN] No files correspond to this budget key after applying model tier split rules")
 
     total, breakdown = collect_allocations(files, args.team, args.machine, args.tier)
     budget = lookup_budget(args.budget_file, args.team, args.testtype, args.machine, args.tier)

--- a/.github/scripts/utils/query_time_budget.py
+++ b/.github/scripts/utils/query_time_budget.py
@@ -1,36 +1,54 @@
-"""Query allocated test time for a (team, test type, machine) and compare it to
-the budget declared in .github/time_budget.yaml.
+"""Report how much CI test time a (team, test type, machine[, tier]) uses, and
+compare it against the budget declared in .github/time_budget.yaml.
 
-The companion script verify_time_budget.py checks one tests file against the
-budget during CI. This tool answers the inverse question: "How much time does
-team X currently allocate for test type Y on machine Z?" by summing the
-per-SKU timeouts across the tests files covered by that budget key.
+verify_time_budget.py runs in CI to fail a pipeline whose timeouts exceed budget.
+This script is the interactive companion: it answers "how much time does team X
+allocate for test type Y on machine Z, how does that compare to budget, and how
+many machine-hours/week does it cost?"
 
-Notes on the data model (see tests/pipeline_reorg/*_tests.yaml):
-  * Each entry has a `team:` field. This field -- not the file name -- is the
-    authoritative owner. A single file (e.g. galaxy_unit_tests.yaml) mixes
-    entries from several teams, so we scan every file of the test type and
-    filter by `team:`.
-  * A file's test type is NOT its file name. It is the workflow_name argument
-    passed to verify_time_budget.py by the workflow that runs the file (the same
-    key used in time_budget.yaml). This is discovered live from .github/workflows,
-    because the file name can differ from the budget key -- e.g. release_tests.yaml
-    and galaxy_deepseek_prefill_tests.yaml both map to `demo`, and
-    demo_sp_multihost_tests.yaml maps to `e2e`.
-  * Per entry: skus: { <machine>: { timeout: <minutes>, tier: <n> } }.
-  * The models unit/e2e/sweep budgets are split. The plain keys cover non-tiered
-    pipelines; the unit_tier<n>/e2e_tier<n>/sweep_tier<n> keys cover
-    models_<testtype>_tests.yaml.
+How it works
+------------
+1. Allocated time: sum the per-SKU `timeout` values from the relevant
+   tests/pipeline_reorg/*_tests.yaml entries, filtered by team, machine and
+   (optionally) tier.
+2. Budget: look up budgets[team][test type][machine] in time_budget.yaml.
+3. Machine-hours/week: budget x (cron runs/week) / 60.
 
-It also estimates weekly machine-hours = budget x (cron runs/week) / 60. The
-cron frequency is discovered live by parsing .github/workflows at query time
-(so it tracks schedule changes): the workflow that runs each contributing test
-file is found via its TESTS_YAML_PATH, then the scheduled workflow(s) that
-trigger it are read for their cron schedules. Only cron triggers are counted;
-manual workflow_dispatch runs are intentionally excluded from the estimate.
+Key conventions
+---------------
+* Owner is the entry's `team:` field, not the file name. One file may hold
+  several teams' entries, so all files of a test type are scanned and filtered.
+* A file's "test type" is the workflow_name passed to verify_time_budget.py by
+  the workflow that runs it -- NOT the file name. It is read live from
+  .github/workflows, because names can differ: release_tests.yaml and
+  galaxy_deepseek_prefill_tests.yaml both map to `demo`, and
+  demo_sp_multihost_tests.yaml maps to `e2e`.
+* The models unit/e2e/sweep budgets are tier-split: the plain key covers the
+  non-tiered pipelines, while unit_tier<n>/e2e_tier<n>/sweep_tier<n> cover
+  models_<testtype>_tests.yaml. Pass --tier to target a tiered budget.
+* Cron frequency is parsed live from .github/workflows by following the test
+  file -> running workflow -> scheduled caller(s). Only cron schedules count;
+  manual workflow_dispatch runs are excluded from the estimate.
 
-Usage:
-  query_time_budget.py --team models --testtype unit --machine wh_n150 [--tier 1] [-v]
+Usage
+-----
+  query_time_budget.py --team <team> --testtype <type> --machine <sku> [--tier N] [-v]
+
+Example
+-------
+  $ query_time_budget.py --team models --testtype unit --machine wh_n150 --tier 1 -v
+  Team 'models' / test type 'unit' / machine 'wh_n150', tier 1
+    Files scanned: 1
+         30 min  models_unit_tests.yaml: Llama 3.1-8B unit tests (tier 1)
+         10 min  models_unit_tests.yaml: Whisper unit tests (tier 1)
+    Tests matched: 2
+    Allocated:     40 min
+    Budget:        47 min
+    Scheduled pipelines (cron):
+         14 runs/wk  models-t1-unit-tests.yaml
+    Est. machine-hours/week: 11.0 h  (47 min x 14 runs/wk / 60)
+    Note: estimate uses cron schedules only; manual workflow_dispatch runs are NOT counted.
+    [OK] Within budget (7 min headroom).
 """
 
 import argparse

--- a/.github/scripts/utils/query_time_budget.py
+++ b/.github/scripts/utils/query_time_budget.py
@@ -1,0 +1,142 @@
+"""Query allocated test time for a (team, test type, machine) and compare it to
+the budget declared in .github/time_budget.yaml.
+
+The companion script verify_time_budget.py checks one tests file against the
+budget during CI. This tool answers the inverse question: "How much time does
+team X currently allocate for test type Y on machine Z?" by summing the
+per-SKU timeouts across every tests file of that test type.
+
+Notes on the data model (see tests/pipeline_reorg/*_tests.yaml):
+  * Each entry has a `team:` field. This field -- not the file name -- is the
+    authoritative owner. A single file (e.g. galaxy_unit_tests.yaml) mixes
+    entries from several teams, so we scan every file of the test type and
+    filter by `team:`.
+  * A file's test type is the underscore-delimited token before `_tests.yaml`
+    (unit, e2e, sanity, stress, perf, integration, l2, device_perf, smoke,
+    profiler, sweep, health, demo). `device_perf` and `perf` are distinct.
+  * Per entry: skus: { <machine>: { timeout: <minutes>, tier: <n> } }.
+
+Usage:
+  query_time_budget.py --team models --testtype unit --machine wh_n150 [--tier 1] [-v]
+"""
+
+import argparse
+import glob
+import os
+import sys
+
+import yaml
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+TESTS_DIR = os.path.join(REPO_ROOT, "tests", "pipeline_reorg")
+DEFAULT_BUDGET_FILE = os.path.join(REPO_ROOT, ".github", "time_budget.yaml")
+
+
+def testtype_of_file(filename):
+    """Return the test-type token of a `*_tests.yaml` file, or None.
+
+    e.g. models_unit_tests.yaml      -> "unit"
+         models_device_perf_tests.yaml -> "device_perf"
+         galaxy_perf_tests.yaml      -> "perf"
+    """
+    base = os.path.basename(filename)
+    if not base.endswith("_tests.yaml"):
+        return None
+    stem = base[: -len("_tests.yaml")]  # e.g. "models_device_perf"
+    parts = stem.split("_")
+    if len(parts) < 2:
+        return None
+    # The test type is the trailing token(s). Treat "device_perf" specially so it
+    # is not confused with "perf"; everything else is the single last token.
+    if len(parts) >= 2 and parts[-2] == "device" and parts[-1] == "perf":
+        return "device_perf"
+    return parts[-1]
+
+
+def find_test_files(tests_dir, testtype):
+    """All *_tests.yaml files in tests_dir whose test type equals `testtype`."""
+    return sorted(f for f in glob.glob(os.path.join(tests_dir, "*_tests.yaml")) if testtype_of_file(f) == testtype)
+
+
+def collect_allocations(files, team, machine, tier=None):
+    """Return (total_minutes, breakdown) for entries matching team/machine.
+
+    breakdown is a list of (file_basename, test_name, timeout, tier) tuples.
+    """
+    total = 0
+    breakdown = []
+    for path in files:
+        with open(path, "r") as f:
+            entries = yaml.safe_load(f) or []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("team") != team:
+                continue
+            skus = entry.get("skus") or {}
+            sku_cfg = skus.get(machine)
+            if not isinstance(sku_cfg, dict) or "timeout" not in sku_cfg:
+                continue
+            entry_tier = sku_cfg.get("tier")
+            if tier is not None and entry_tier != tier:
+                continue
+            timeout = sku_cfg["timeout"]
+            total += timeout
+            breakdown.append((os.path.basename(path), entry.get("name", "Unnamed"), timeout, entry_tier))
+    return total, breakdown
+
+
+def lookup_budget(budget_file, team, testtype, machine):
+    """Return the declared budget, or None if not present."""
+    with open(budget_file, "r") as f:
+        budgets = yaml.safe_load(f) or {}
+    try:
+        return budgets[team][testtype][machine]
+    except (KeyError, TypeError):
+        return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--team", required=True, help="Team name, e.g. models, llk, runtime")
+    parser.add_argument("--testtype", required=True, help="Test type, e.g. unit, sanity, stress, e2e")
+    parser.add_argument("--machine", required=True, help="SKU/machine name, e.g. wh_n150, wh_llmbox")
+    parser.add_argument("--tier", type=int, default=None, help="Optional: only sum entries of this tier")
+    parser.add_argument("--tests-dir", default=TESTS_DIR, help="Directory of *_tests.yaml files")
+    parser.add_argument("--budget-file", default=DEFAULT_BUDGET_FILE, help="Path to time_budget.yaml")
+    parser.add_argument("-v", "--verbose", action="store_true", help="Print per-test breakdown")
+    args = parser.parse_args()
+
+    files = find_test_files(args.tests_dir, args.testtype)
+    if not files:
+        print(f"[WARN] No '*_{args.testtype}_tests.yaml' files found in {args.tests_dir}")
+
+    total, breakdown = collect_allocations(files, args.team, args.machine, args.tier)
+    budget = lookup_budget(args.budget_file, args.team, args.testtype, args.machine)
+
+    tier_note = f", tier {args.tier}" if args.tier is not None else ""
+    print(f"Team '{args.team}' / test type '{args.testtype}' / machine '{args.machine}'{tier_note}")
+    print(f"  Files scanned: {len(files)}")
+    if args.verbose:
+        for fname, name, timeout, etier in breakdown:
+            tlabel = f" (tier {etier})" if etier is not None else ""
+            print(f"    {timeout:>5} min  {fname}: {name}{tlabel}")
+    print(f"  Tests matched: {len(breakdown)}")
+    print(f"  Allocated:     {total} min")
+
+    if budget is None:
+        print(f"  Budget:        (not declared in {os.path.basename(args.budget_file)})")
+        # No budget to compare against; allocation is informational only.
+        return 0
+
+    headroom = budget - total
+    print(f"  Budget:        {budget} min")
+    if headroom >= 0:
+        print(f"  [OK] Within budget ({headroom} min headroom).")
+        return 0
+    print(f"  [OVER] Exceeds budget by {-headroom} min.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/utils/query_time_budget.py
+++ b/.github/scripts/utils/query_time_budget.py
@@ -19,6 +19,13 @@ Notes on the data model (see tests/pipeline_reorg/*_tests.yaml):
     pipelines; the unit_tier<n>/e2e_tier<n>/sweep_tier<n> keys cover
     models_<testtype>_tests.yaml.
 
+It also estimates weekly machine-hours = budget x (cron runs/week) / 60. The
+cron frequency is discovered live by parsing .github/workflows at query time
+(so it tracks schedule changes): the workflow that runs each contributing test
+file is found via its TESTS_YAML_PATH, then the scheduled workflow(s) that
+trigger it are read for their cron schedules. Only cron triggers are counted;
+manual workflow_dispatch runs are intentionally excluded from the estimate.
+
 Usage:
   query_time_budget.py --team models --testtype unit --machine wh_n150 [--tier 1] [-v]
 """
@@ -34,6 +41,7 @@ REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "..", 
 TESTS_DIR = os.path.join(REPO_ROOT, "tests", "pipeline_reorg")
 DEFAULT_BUDGET_FILE = os.path.join(REPO_ROOT, ".github", "time_budget.yaml")
 TIERED_MODEL_TESTTYPES = {"unit", "e2e", "sweep"}
+WORKFLOWS_DIR = os.path.join(REPO_ROOT, ".github", "workflows")
 
 
 def testtype_of_file(filename):
@@ -116,13 +124,131 @@ def lookup_budget(budget_file, team, testtype, machine, tier=None):
         budgets = yaml.safe_load(f) or {}
     try:
         team_budgets = budgets[team]
-        if tier is not None and uses_tiered_model_budget(team, testtype):
-            return team_budgets[f"{testtype}_tier{tier}"][machine]
-        if tier is not None and f"{testtype}_tier{tier}" in team_budgets:
-            return team_budgets[f"{testtype}_tier{tier}"][machine]
+        tiered_key = f"{testtype}_tier{tier}"
+        if tier is not None and tiered_key in team_budgets:
+            return team_budgets[tiered_key][machine]
         return team_budgets[testtype][machine]
     except (KeyError, TypeError):
         return None
+
+
+def _expand_cron_field(field, lo, hi):
+    """Expand a single cron field, supporting '*', comma lists, ranges and steps."""
+    values = set()
+    for part in field.split(","):
+        step = 1
+        token = part
+        if "/" in token:
+            token, step_str = token.split("/", 1)
+            step = int(step_str)
+        if token == "*":
+            start, end = lo, hi
+        elif "-" in token:
+            a, b = token.split("-", 1)
+            start, end = int(a), int(b)
+        else:
+            start = end = int(token)
+        values.update(range(start, end + 1, step))
+    return values
+
+
+def cron_runs_per_week(cron):
+    """Approximate how many times a 5-field cron expression fires per week.
+
+    Handles '*', comma lists, ranges and steps in the minute, hour and
+    day-of-week fields. Day-of-month / month restrictions are not modelled
+    (assumed '*'); such schedules are rare for these pipelines.
+    """
+    fields = cron.split()
+    if len(fields) != 5:
+        return 0
+    minute, hour, _dom, _month, dow = fields
+    per_day = len(_expand_cron_field(minute, 0, 59)) * len(_expand_cron_field(hour, 0, 23))
+    if dow.strip() == "*":
+        days = 7
+    else:
+        # cron allows 7 as Sunday; normalise to 0-6 before counting distinct days.
+        days = len({0 if d == 7 else d for d in _expand_cron_field(dow, 0, 7)})
+    return per_day * days
+
+
+def _workflow_call(job):
+    """Return (impl_basename, tier_value) for a reusable-workflow job, else None."""
+    uses = job.get("uses")
+    if not isinstance(uses, str) or ".github/workflows/" not in uses:
+        return None
+    impl = uses.split(".github/workflows/", 1)[1].split("@", 1)[0].strip()
+    tier = (job.get("with") or {}).get("tier")
+    return os.path.basename(impl), tier
+
+
+def build_workflow_index(workflows_dir):
+    """Parse every workflow once, capturing schedule / test-file / reuse metadata.
+
+    Returns a list of dicts: {name, crons, tests_yaml (set), calls [(impl, tier)]}.
+    """
+    index = []
+    for path in sorted(glob.glob(os.path.join(workflows_dir, "*.y*ml"))):
+        try:
+            with open(path, "r") as f:
+                data = yaml.safe_load(f)
+        except (yaml.YAMLError, OSError):
+            continue
+        if not isinstance(data, dict):
+            continue
+
+        # PyYAML parses the `on:` trigger key as the boolean True (YAML 1.1).
+        triggers = data.get("on", data.get(True)) or {}
+        crons = []
+        if isinstance(triggers, dict) and isinstance(triggers.get("schedule"), list):
+            crons = [s["cron"] for s in triggers["schedule"] if isinstance(s, dict) and "cron" in s]
+
+        jobs = data.get("jobs") or {}
+        env_dicts = [data["env"]] if isinstance(data.get("env"), dict) else []
+        calls = []
+        for job in jobs.values():
+            if not isinstance(job, dict):
+                continue
+            if isinstance(job.get("env"), dict):
+                env_dicts.append(job["env"])
+            call = _workflow_call(job)
+            if call:
+                calls.append(call)
+
+        tests_yaml = set()
+        for env in env_dicts:
+            value = env.get("TESTS_YAML_PATH")
+            if isinstance(value, str) and value.endswith("_tests.yaml"):
+                tests_yaml.add(os.path.basename(value))
+
+        index.append({"name": os.path.basename(path), "crons": crons, "tests_yaml": tests_yaml, "calls": calls})
+    return index
+
+
+def discover_scheduled_runs(workflow_index, test_file, tier):
+    """Map a test file to {scheduled_workflow_basename: runs_per_week}.
+
+    Walks the reuse graph: a test file is run by the impl whose TESTS_YAML_PATH
+    references it, and that impl is triggered by scheduled caller workflows. When
+    a tier is queried, callers that pass a non-matching `tier:` input are skipped.
+    """
+    runner_names = {w["name"] for w in workflow_index if test_file in w["tests_yaml"]}
+    runs = {}
+    for w in workflow_index:
+        if not w["crons"]:
+            continue
+        weekly = sum(cron_runs_per_week(c) for c in w["crons"])
+        # A workflow that directly declares the test file and is itself scheduled.
+        if w["name"] in runner_names:
+            runs[w["name"]] = weekly
+        # A scheduled workflow that calls the impl which runs the test file.
+        for impl, tier_val in w["calls"]:
+            if impl not in runner_names:
+                continue
+            if tier is not None and tier_val is not None and str(tier_val) != str(tier):
+                continue
+            runs[w["name"]] = weekly
+    return runs
 
 
 def main():
@@ -135,6 +261,9 @@ def main():
     )
     parser.add_argument("--tests-dir", default=TESTS_DIR, help="Directory of *_tests.yaml files")
     parser.add_argument("--budget-file", default=DEFAULT_BUDGET_FILE, help="Path to time_budget.yaml")
+    parser.add_argument(
+        "--workflows-dir", default=WORKFLOWS_DIR, help="Directory of workflow YAMLs (for cron frequency)"
+    )
     parser.add_argument("-v", "--verbose", action="store_true", help="Print per-test breakdown")
     args = parser.parse_args()
 
@@ -160,11 +289,36 @@ def main():
 
     if budget is None:
         print(f"  Budget:        (not declared in {os.path.basename(args.budget_file)})")
+    else:
+        print(f"  Budget:        {budget} min")
+
+    # --- Estimated weekly machine-hours (cron-scheduled runs only) ---
+    workflow_index = build_workflow_index(args.workflows_dir)
+    contributing_files = sorted({fname for fname, _, _, _ in breakdown})
+    runs_by_workflow = {}
+    for fname in contributing_files:
+        for workflow, weekly in discover_scheduled_runs(workflow_index, fname, args.tier).items():
+            runs_by_workflow[workflow] = weekly
+    total_runs = sum(runs_by_workflow.values())
+
+    print("  Scheduled pipelines (cron):")
+    if runs_by_workflow:
+        for workflow in sorted(runs_by_workflow):
+            print(f"      {runs_by_workflow[workflow]:>3} runs/wk  {workflow}")
+    else:
+        print("      (none found -- manual workflow_dispatch only)")
+
+    if budget is not None:
+        machine_hours = budget * total_runs / 60.0
+        print(f"  Est. machine-hours/week: {machine_hours:.1f} h  ({budget} min x {total_runs} runs/wk / 60)")
+    else:
+        print("  Est. machine-hours/week: n/a (no budget declared)")
+    print("  Note: estimate uses cron schedules only; manual workflow_dispatch runs are NOT counted.")
+
+    if budget is None:
         # No budget to compare against; allocation is informational only.
         return 0
-
     headroom = budget - total
-    print(f"  Budget:        {budget} min")
     if headroom >= 0:
         print(f"  [OK] Within budget ({headroom} min headroom).")
         return 0

--- a/.github/scripts/utils/verify_time_budget.py
+++ b/.github/scripts/utils/verify_time_budget.py
@@ -4,11 +4,18 @@ import os
 from collections import defaultdict
 
 
-def verify_timeouts(tests_file, time_budget_file, workflow_name):
+def verify_timeouts(tests_file, time_budget_file, workflow_name, tier=None):
     """
     Verifies that the SUM of all test timeouts for each (Team, SKU) pair in tests_file
     is within the total time budget defined in time_budget_file for the given workflow.
+
+    When `tier` is provided, only the SKU entries whose `tier` matches are summed, and
+    the budget is looked up under the per-tier key "<workflow_name>_tier<tier>" (e.g.
+    "unit_tier1"). When `tier` is None the behaviour is unchanged: every SKU entry is
+    summed and the budget is looked up under the plain "<workflow_name>" key.
     """
+    budget_workflow = workflow_name if tier is None else f"{workflow_name}_tier{tier}"
+
     print(f"Loading time budgets from: {time_budget_file}")
     with open(time_budget_file, "r") as f:
         budgets = yaml.safe_load(f)
@@ -16,6 +23,9 @@ def verify_timeouts(tests_file, time_budget_file, workflow_name):
     print(f"Loading tests from: {tests_file}")
     with open(tests_file, "r") as f:
         tests = yaml.safe_load(f)
+
+    if tier is not None:
+        print(f"Filtering tests to tier '{tier}'; budgets looked up under workflow key '{budget_workflow}'.")
 
     errors_found = False
 
@@ -56,6 +66,10 @@ def verify_timeouts(tests_file, time_budget_file, workflow_name):
                 errors_found = True
                 continue
 
+            # When verifying a specific tier, only count SKU entries belonging to it.
+            if tier is not None and str(sku_config.get("tier")) != str(tier):
+                continue
+
             test_timeout = sku_config["timeout"]
 
             # Use a tuple (team, sku) as the key for summation
@@ -72,8 +86,8 @@ def verify_timeouts(tests_file, time_budget_file, workflow_name):
 
     for (team, sku), total_time_requested in budget_totals.items():
         try:
-            # Navigate the budgets config using team, workflow, and sku
-            total_time_budget = budgets[team][workflow_name][sku]
+            # Navigate the budgets config using team, workflow (or per-tier key), and sku
+            total_time_budget = budgets[team][budget_workflow][sku]
 
             print(
                 f"Checking total for Team '{team}', SKU '{sku}': Requested = {total_time_requested} min, Budget = {total_time_budget} min"
@@ -90,7 +104,7 @@ def verify_timeouts(tests_file, time_budget_file, workflow_name):
 
         except (KeyError, TypeError):
             print(
-                f"  [ERROR] Configuration FAILED! Could not find a 'time_budget' for Team '{team}', Workflow '{workflow_name}', SKU '{sku}' in {time_budget_file}."
+                f"  [ERROR] Configuration FAILED! Could not find a 'time_budget' for Team '{team}', Workflow '{budget_workflow}', SKU '{sku}' in {time_budget_file}."
             )
             errors_found = True
             continue
@@ -105,8 +119,15 @@ def verify_timeouts(tests_file, time_budget_file, workflow_name):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) != 4:
-        print("Usage: python verify_time_budget.py <path_to_tests.yaml> <path_to_time_budget.yaml> <workflow_name>")
+    if len(sys.argv) not in (4, 5):
+        print(
+            "Usage: python verify_time_budget.py <path_to_tests.yaml> <path_to_time_budget.yaml> "
+            "<workflow_name> [<tier>]"
+        )
         sys.exit(1)
 
-    verify_timeouts(sys.argv[1], sys.argv[2], sys.argv[3])
+    # Optional tier arg: when given (and non-empty) budgets are checked per tier
+    # under the "<workflow_name>_tier<tier>" key.
+    tier_arg = sys.argv[4].strip() if len(sys.argv) == 5 and sys.argv[4].strip() else None
+
+    verify_timeouts(sys.argv[1], sys.argv[2], sys.argv[3], tier_arg)

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -195,19 +195,16 @@ models:
     wh_n150: 90
     wh_n300: 115
     bh_p150b_civ2: 70
+  # Plain `e2e` budget for the non-tiered pipelines that share the models team
+  # (blackhole-e2e, t3000-e2e). SKUs that are only exercised by the tiered model
+  # pipeline have moved to the e2e_tier* keys below.
   e2e:
     wh_llmbox: 198
-    wh_llmbox_perf: 330
-    wh_n150: 100
-    wh_n300: 15
-    wh_galaxy_perf: 120
     bh_p150b_civ2: 63
-    bh_p150: 60
     bh_p300: 50
     bh_loudbox: 160
     bh_llmbox: 50
     bh_quietbox_2: 251
-    bh_galaxy: 78
   # Per-tier e2e budgets, consumed by the tiered model pipelines
   # (all-model-tests.yaml + models-t{1,2,3}-e2e-tests.yaml via
   # models-e2e-tests-impl.yaml, which passes the leg's tier to
@@ -234,17 +231,12 @@ models:
     bh_p150: 7
     bh_p300: 8
     bh_quietbox_2: 30
+  # Plain `unit` budget for the non-tiered pipelines that share the models team
+  # (galaxy-unit, t3000-unit). SKUs that are only exercised by the tiered model
+  # pipeline have moved to the unit_tier* keys below.
   unit:
     wh_llmbox: 175
-    wh_llmbox_perf: 230
-    wh_n150: 135
-    wh_n300: 15
-    wh_galaxy: 45
     wh_galaxy_perf: 45
-    bh_p150: 60
-    bh_p300: 30
-    bh_quietbox_2: 85
-    bh_galaxy: 70
   # Per-tier unit budgets — split of the plain `unit` budget above (see the
   # e2e_tier* note). Consumed by the tiered model pipelines; the plain `unit`
   # key is kept for the non-tiered pipelines (galaxy-unit, t3000-unit).
@@ -301,12 +293,8 @@ models:
     bh_loudbox: 1200
     bh_p300: 800
     bh_quietbox_2: 280
-  sweep:
-    wh_n150: 10
-    wh_llmbox_perf: 30
-    wh_galaxy: 30
-  # Per-tier sweep budgets — split of the plain `sweep` budget above (see the
-  # e2e_tier* note). Consumed by the tiered model pipelines. No tier 3 sweep
+  # No plain `sweep` key: sweep tests run only through the tiered model pipeline,
+  # so the budget lives entirely in the sweep_tier* keys below. No tier 3 sweep
   # tests exist today, so there is no sweep_tier3 key.
   sweep_tier1:
     wh_n150: 10

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -8,8 +8,6 @@
 
 # Team names are currently assigned to tests by best guess.
 #   Please message #tt-metal-infra if there are any concerns.
-# Sku names do not make the distinction between baremetal/vm, or viommu/non-viommu.
-#   This will be determined per pipeline based on need.
 
 # Example:
 metal_infra:
@@ -18,7 +16,7 @@ metal_infra:
     N150: 0
     N300: 0
     wh_llmbox: 0
-  sanity: # APC will be renamed to sanity
+  sanity: # APC and BHPC will be renamed to sanity
     CPU: 0
     N150: 0
     N300: 0
@@ -84,8 +82,8 @@ ttnn:
     bh_p300: 145
     bh_quietbox_2: 145
   integration:
-    wh_llmbox: 30   # t3k_integration_tests.yaml (ttnn entries)
-    wh_galaxy: 340  # galaxy_integration_tests.yaml
+    wh_llmbox: 30
+    wh_galaxy: 340
   l2:
     wh_n150: 970
     wh_n300: 970
@@ -99,11 +97,9 @@ ttnn:
   # test-framework assignment is being settled. Tracked in
   # https://github.com/tenstorrent/tt-metal/issues/44285
   profiler:
-    # Budgets sized against the per-test decomposition of the umbrella
-    # run_profiling_test (each unique test now has its own matrix entry).
-    wh_llmbox: 150              # t3k_profiler_tests.yaml (~141m actual + headroom)
-    wh_galaxy: 50               # galaxy_profiler_tests.yaml (~45m actual + headroom)
-    wh_n150_civ2: 60            # single_card_profiler_tests.yaml (~53m actual + headroom)
+    wh_llmbox: 150
+    wh_galaxy: 50
+    wh_n150_civ2: 60
     wh_n300_civ2: 60
     bh_p100a_civ2_viommu: 60
     bh_p150b_civ2_viommu: 60
@@ -195,9 +191,6 @@ models:
     wh_n150: 90
     wh_n300: 115
     bh_p150b_civ2: 70
-  # Plain `e2e` budget for the non-tiered pipelines that share the models team
-  # (blackhole-e2e, t3000-e2e). SKUs that are only exercised by the tiered model
-  # pipeline have moved to the e2e_tier* keys below.
   e2e:
     wh_llmbox: 198
     bh_p150b_civ2: 63
@@ -205,13 +198,8 @@ models:
     bh_loudbox: 160
     bh_llmbox: 30
     bh_quietbox_2: 30
-  # Per-tier e2e budgets, consumed by the tiered model pipelines
-  # (all-model-tests.yaml + models-t{1,2,3}-e2e-tests.yaml via
-  # models-e2e-tests-impl.yaml, which passes the leg's tier to
-  # verify_time_budget.py). These are a split of the plain `e2e` budget above,
-  # apportioned across tiers in proportion to each SKU's current per-tier usage.
-  # The plain `e2e` key is kept for the non-tiered pipelines that still rely on
-  # it (blackhole-e2e, t3000-e2e).
+  # Per-tier e2e budgets, consumed by the tiered model pipelines;
+  # The plain `e2e` key is used for the non-tiered pipelines (blackhole-e2e, t3000-e2e).
   e2e_tier1:
     wh_n150: 28
     wh_galaxy_perf: 120
@@ -231,15 +219,11 @@ models:
     bh_p150: 7
     bh_p300: 8
     bh_quietbox_2: 30
-  # Plain `unit` budget for the non-tiered pipelines that share the models team
-  # (galaxy-unit, t3000-unit). SKUs that are only exercised by the tiered model
-  # pipeline have moved to the unit_tier* keys below.
   unit:
     wh_llmbox: 100
     wh_galaxy_perf: 10
-  # Per-tier unit budgets — split of the plain `unit` budget above (see the
-  # e2e_tier* note). Consumed by the tiered model pipelines; the plain `unit`
-  # key is kept for the non-tiered pipelines (galaxy-unit, t3000-unit).
+  # Per-tier unit budgets. Consumed by the tiered model pipelines; the plain `unit`
+  # key is used for the non-tiered pipelines (galaxy-unit, t3000-unit).
   unit_tier1:
     wh_llmbox: 61
     wh_n150: 47
@@ -272,7 +256,6 @@ models:
     bh_p150: 20
     bh_p300: 20
     bh_quietbox_2: 80
-
   demo:
     wh_llmbox_perf: 200
     wh_llmbox_perf_release: 1090
@@ -293,9 +276,6 @@ models:
     bh_loudbox: 1200
     bh_p300: 800
     bh_quietbox_2: 280
-  # No plain `sweep` key: sweep tests run only through the tiered model pipeline,
-  # so the budget lives entirely in the sweep_tier* keys below. No tier 3 sweep
-  # tests exist today, so there is no sweep_tier3 key.
   sweep_tier1:
     wh_n150: 10
     wh_galaxy: 30

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -208,6 +208,32 @@ models:
     bh_llmbox: 50
     bh_quietbox_2: 251
     bh_galaxy: 78
+  # Per-tier e2e budgets, consumed by the tiered model pipelines
+  # (all-model-tests.yaml + models-t{1,2,3}-e2e-tests.yaml via
+  # models-e2e-tests-impl.yaml, which passes the leg's tier to
+  # verify_time_budget.py). These are a split of the plain `e2e` budget above,
+  # apportioned across tiers in proportion to each SKU's current per-tier usage.
+  # The plain `e2e` key is kept for the non-tiered pipelines that still rely on
+  # it (blackhole-e2e, t3000-e2e).
+  e2e_tier1:
+    wh_n150: 28
+    wh_galaxy_perf: 120
+    bh_p150: 27
+    bh_quietbox_2: 35
+    bh_galaxy: 78
+  e2e_tier2:
+    wh_llmbox_perf: 266
+    wh_n150: 30
+    bh_p150: 26
+    bh_p300: 42
+    bh_quietbox_2: 186
+  e2e_tier3:
+    wh_llmbox_perf: 64
+    wh_n150: 42
+    wh_n300: 15
+    bh_p150: 7
+    bh_p300: 8
+    bh_quietbox_2: 30
   unit:
     wh_llmbox: 175
     wh_llmbox_perf: 230
@@ -219,6 +245,30 @@ models:
     bh_p300: 30
     bh_quietbox_2: 85
     bh_galaxy: 70
+  # Per-tier unit budgets — split of the plain `unit` budget above (see the
+  # e2e_tier* note). Consumed by the tiered model pipelines; the plain `unit`
+  # key is kept for the non-tiered pipelines (galaxy-unit, t3000-unit).
+  unit_tier1:
+    wh_llmbox: 61
+    wh_n150: 47
+    wh_galaxy: 45
+    wh_galaxy_perf: 45
+    bh_p150: 20
+    bh_quietbox_2: 14
+    bh_galaxy: 70
+  unit_tier2:
+    wh_llmbox: 114
+    wh_llmbox_perf: 172
+    wh_n150: 55
+    bh_p150: 20
+    bh_quietbox_2: 50
+  unit_tier3:
+    wh_llmbox_perf: 58
+    wh_n150: 33
+    wh_n300: 15
+    bh_p150: 20
+    bh_p300: 30
+    bh_quietbox_2: 21
   integration:
     wh_llmbox: 422
   perf:
@@ -255,6 +305,14 @@ models:
     wh_n150: 10
     wh_llmbox_perf: 30
     wh_galaxy: 30
+  # Per-tier sweep budgets — split of the plain `sweep` budget above (see the
+  # e2e_tier* note). Consumed by the tiered model pipelines. No tier 3 sweep
+  # tests exist today, so there is no sweep_tier3 key.
+  sweep_tier1:
+    wh_n150: 10
+    wh_galaxy: 30
+  sweep_tier2:
+    wh_llmbox_perf: 30
 
 umd:
   unit:

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -201,10 +201,10 @@ models:
   e2e:
     wh_llmbox: 198
     bh_p150b_civ2: 63
-    bh_p300: 50
+    bh_p300: 20
     bh_loudbox: 160
-    bh_llmbox: 50
-    bh_quietbox_2: 251
+    bh_llmbox: 30
+    bh_quietbox_2: 30
   # Per-tier e2e budgets, consumed by the tiered model pipelines
   # (all-model-tests.yaml + models-t{1,2,3}-e2e-tests.yaml via
   # models-e2e-tests-impl.yaml, which passes the leg's tier to
@@ -235,8 +235,8 @@ models:
   # (galaxy-unit, t3000-unit). SKUs that are only exercised by the tiered model
   # pipeline have moved to the unit_tier* keys below.
   unit:
-    wh_llmbox: 175
-    wh_galaxy_perf: 45
+    wh_llmbox: 100
+    wh_galaxy_perf: 10
   # Per-tier unit budgets — split of the plain `unit` budget above (see the
   # e2e_tier* note). Consumed by the tiered model pipelines; the plain `unit`
   # key is kept for the non-tiered pipelines (galaxy-unit, t3000-unit).

--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -58,7 +58,8 @@ jobs:
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "e2e"
+            "e2e" \
+            "${{ inputs.tier }}"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/models-sweep-tests-impl.yaml
+++ b/.github/workflows/models-sweep-tests-impl.yaml
@@ -58,7 +58,8 @@ jobs:
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "sweep"
+            "sweep" \
+            "${{ inputs.tier }}"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |

--- a/.github/workflows/models-unit-tests-impl.yaml
+++ b/.github/workflows/models-unit-tests-impl.yaml
@@ -58,7 +58,8 @@ jobs:
           python3 .github/scripts/utils/verify_time_budget.py \
             ${{ env.TESTS_YAML_PATH }} \
             ./.github/time_budget.yaml \
-            "unit"
+            "unit" \
+            "${{ inputs.tier }}"
       - name: Build unified test matrix based on enabled SKUs
         id: build-matrix
         run: |


### PR DESCRIPTION
### PR Category
Infra

### Summary
Currently the tiered models pipelines use `unit`, `e2e`, and `sweep` keys in `time_budget.yaml`. These keys are shared between tiers and other pipelines and were not intended to be used that way due to these separate pipelines having different frequencies. This PR splits keys to better represent the budget per pipeline.

Also add a budget query script co authored with @jamesleeTT. Example usage:
```
  $ query_time_budget.py --team models --testtype unit --machine wh_n150 --tier 1 -v
  Team 'models' / test type 'unit' / machine 'wh_n150', tier 1
    Files scanned: 1
         30 min  models_unit_tests.yaml: Llama 3.1-8B unit tests (tier 1)
         10 min  models_unit_tests.yaml: Whisper unit tests (tier 1)
    Tests matched: 2
    Allocated:     40 min
    Budget:        47 min
    Scheduled pipelines (cron):
         14 runs/wk  models-t1-unit-tests.yaml
    Est. machine-hours/week: 11.0 h  (47 min x 14 runs/wk / 60)
    Note: estimate uses cron schedules only; manual workflow_dispatch runs are NOT counted.
    [OK] Within budget (7 min headroom).

  $ query_time_budget.py --team models --testtype unit --machine wh_n150 --tier 2 -v
Team 'models' / test type 'unit' / machine 'wh_n150', tier 2
  Files scanned: 1
       20 min  models_unit_tests.yaml: Mistral-7B unit tests (tier 2)
       22 min  models_unit_tests.yaml: Gemma-3-4B unit tests (tier 2)
        5 min  models_unit_tests.yaml: Shallow UNet unit tests (tier 2)
  Tests matched: 3
  Allocated:     47 min
  Budget:        55 min
  Scheduled pipelines (cron):
       21 runs/wk  models-t2-unit-tests.yaml
  Est. machine-hours/week: 19.2 h  (55 min x 21 runs/wk / 60)
  Note: estimate uses cron schedules only; manual workflow_dispatch runs are NOT counted.
  [OK] Within budget (8 min headroom).
```

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:roseli/0-reimplement-time-budget-verif-tiered-models-pipeline)