### PR TITLE
Pinned interleaved buffer write: fix command sequence size mismatch assert

### DIFF
--- a/tt_metal/impl/buffers/dispatch.cpp
+++ b/tt_metal/impl/buffers/dispatch.cpp
@@ -604,8 +604,8 @@ void populate_interleaved_buffer_write_dispatch_cmds(
                     data_size_bytes);
             }
         }
-        command_sequence.align_write_offset();
     }
+    command_sequence.align_write_offset();
 }
 
 void populate_sharded_buffer_write_dispatch_cmds(


### PR DESCRIPTION
### Ticket
[#46532](https://github.com/tenstorrent/tt-metal/issues/46532)

### Problem description
Writing to an interleaved buffer from pinned host memory trips a command-sequence size assert:

```
TT_ASSERT: Command sequence size mismatch, calculator: 128, command sequence: 96
@ tt_metal/impl/buffers/dispatch.cpp: command_sequence.write_offset_bytes() == cmd_sequence_sizeB
```

The size calculator and the command populator disagree on trailing alignment for the pinned path. On a pinned write the payload is relayed out-of-line, so the next entry in the issue queue is a command that must start aligned; the calculator in `issue_buffer_dispatch_command_sequence` accounts for this by calling `add_alignment()` in the pinned case. The populator `populate_interleaved_buffer_write_dispatch_cmds` does not match it: its `align_write_offset()` call sits inside the `if (not use_pinned_transfer)` block, so the pinned path leaves the write offset unaligned at 96 B while the calculator has already reserved 128 B. The mismatch trips the assert.

### What's changed
- **`tt_metal/impl/buffers/dispatch.cpp`**: moved `command_sequence.align_write_offset()` out of the `if (not use_pinned_transfer)` block in `populate_interleaved_buffer_write_dispatch_cmds` so it runs unconditionally, matching the size calculator and every other populate path.

### Validation
Validated on a Blackhole LoudBox (8x p150b) with full Debug builds (Debug required for `TT_ASSERT` to be active), A/B on both latest `main` and the deepseek hang-fix branch. Without the fix the assert fires (calculator: 128, command sequence: 96); with the fix the write completes with no assert. Reproduced via `ttnn.from_torch` of a `[3200, 7168]` bf16 ROW_MAJOR tensor to DRAM, which routes through `FDMeshCommandQueue::write_shard_to_device` and supplies a `PinnedMemory` so the pinned path is taken.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ianastasijevic/pinned_write_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ianastasijevic/pinned_write_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ianastasijevic/pinned_write_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ianastasijevic/pinned_write_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ianastasijevic/pinned_write_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ianastasijevic/pinned_write_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ianastasijevic/pinned_write_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ianastasijevic/pinned_write_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ianastasijevic/pinned_write_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ianastasijevic/pinned_write_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ianastasijevic/pinned_write_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ianastasijevic/pinned_write_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ianastasijevic/pinned_write_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ianastasijevic/pinned_write_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ianastasijevic/pinned_write_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ianastasijevic/pinned_write_fix)