### PR TITLE
Feature: MoE: Dynamically adjust mux buffers in order to handle more experts

### DIFF
--- a/models/common/modules/moe/configs/deepseek_v3_single_glx.yaml
+++ b/models/common/modules/moe/configs/deepseek_v3_single_glx.yaml
@@ -1,0 +1,20 @@
+# deepseek_v3
+mesh_shape: [8, 4]
+cluster_axis: 0
+batch_per_device: 32
+hidden_size: 7168
+select_experts_k: 8
+num_routed_experts: 256
+num_shared_experts: 1
+has_bias: false
+
+compute:
+  intermediate_size: 2048
+  activation_type: SILU
+
+reduce:
+  shared_expert_scale: 1.0
+
+experts:
+  expert_mapping: sequential
+  shared_expert_ids_to_devices: fully_replicated

--- a/models/common/modules/moe/tt_moe_decode.py
+++ b/models/common/modules/moe/tt_moe_decode.py
@@ -325,6 +325,11 @@ class _TTMoEDecodeExpertState:
             torch_b2,
         )
 
+        # An empty mapping ({} when num_shared_experts==0) means "no shared experts" —
+        # normalize to None so the shared-expert paths below are skipped entirely.
+        if not shared_expert_ids_to_devices:
+            shared_expert_ids_to_devices = None
+
         num_routed = torch_w0.shape[1]
         logger.info(
             f"Initializing expert state: routed_experts={num_routed} num_shared={num_shared_experts} "

--- a/models/common/modules/moe/tt_moe_decode.py
+++ b/models/common/modules/moe/tt_moe_decode.py
@@ -33,16 +33,7 @@ from __future__ import annotations
 
 import torch
 from loguru import logger
-from ttnn.experimental.moe_compute_utils import (
-    add_shared_expert_weights,
-    get_weight_core_shard_maps,
-    get_weight_mem_configs,
-    map_shared_experts,
-    prepare_w0_w1_tensor_for_moe_compute,
-    prepare_w0_w1_tensor_with_bias,
-    prepare_w2_tensor_for_moe_compute,
-    prepare_w2_tensor_with_bias,
-)
+from ttnn.experimental.moe_compute_utils import map_shared_experts
 
 import ttnn
 from models.common.modules.moe.tt_moe_decode_config import TTMoEDecodeConfig
@@ -298,11 +289,13 @@ class _TTMoEDecodeExpertState:
     ):
         """Prepare and upload all expert state to the mesh.
 
-        Pipeline: argsort-permute routed weights to match the device assignment
-        (`_device_reorder_weights`), optionally splice in shared expert weights so each
-        device holds `routed_per_device + shared_per_device` slots (`add_shared_expert_weights`),
-        then run the prepared tensors through the bf4-tile reordering preparers and
-        upload sharded along the expert dim.
+        Pipeline: argsort-permute routed weights on host to match the device assignment
+        (`_device_reorder_weights`), upload them to the mesh sharded on the experts dim
+        (dim 1) as bf16, optionally splice in shared experts on-device so each device holds
+        `routed_per_device + shared_per_device` slots (`ttnn.experimental.add_shared_expert_weights`),
+        then run the C++ on-device packers (`ttnn.experimental.prepare_*`) and quantize to
+        `bfloat4_b` (`ttnn.experimental.quantize_weights_via_host`) — see
+        `_init_total_expert_weights_impl`.
 
         Routed weight shapes (host, post-permute): `w0/w1 = [L, num_routed, H, N]`,
         `w2 = [L, num_routed, N, H]`. Shared weights are dicts keyed by global expert id;
@@ -310,8 +303,7 @@ class _TTMoEDecodeExpertState:
 
         Biases match the routed shape minus the matmul-output dim (`[L, num_routed, N]`
         for `b0/b1`, `[L, num_routed, H]` for `b2`). Shared experts + bias is not yet
-        supported because `add_shared_expert_weights` doesn't take a bias dict — would
-        need a parallel API.
+        supported because the shared splice doesn't carry bias rows — would need a parallel API.
         """
         self._validate(
             torch_w0,
@@ -352,6 +344,28 @@ class _TTMoEDecodeExpertState:
             torch_expert_mapping, torch_w0, torch_w1, torch_w2, torch_b0, torch_b1, torch_b2
         )
 
+        num_devices = mesh_device.get_num_devices()
+        num_layers = torch_w0.shape[0]
+        hidden_size = torch_w0.shape[-2]
+        intermediate_size = torch_w0.shape[-1]
+        routed_per_device = num_routed // num_devices
+
+        # Upload the (reordered) routed weights to the mesh sharded on the experts dim (dim 1),
+        # bf16 / ROW_MAJOR, so the C++ `ttnn.experimental.prepare_*` helpers can do the layout
+        # transform on-device. Each device receives its assigned contiguous expert chunk.
+        def _shard_experts(t):
+            return ttnn.from_torch(
+                t,
+                device=mesh_device,
+                layout=ttnn.ROW_MAJOR_LAYOUT,
+                dtype=ttnn.bfloat16,
+                mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=1),
+            )
+
+        tt_w0 = _shard_experts(mapped_torch_w0)
+        tt_w1 = _shard_experts(mapped_torch_w1)
+        tt_w2 = _shard_experts(mapped_torch_w2)
+
         if shared_expert_ids_to_devices is not None:
             if has_bias:
                 # add_shared_expert_weights only handles weights; extending it to bias
@@ -359,21 +373,35 @@ class _TTMoEDecodeExpertState:
                 raise NotImplementedError("bias + shared experts is not yet supported")
 
             logger.info(f"Adding shared expert weights for {len(shared_expert_ids_to_devices)} shared experts")
-            total_torch_w0, total_torch_w1, total_torch_w2 = add_shared_expert_weights(
-                mapped_torch_w0,
-                mapped_torch_w1,
-                mapped_torch_w2,
-                shared_id_to_torch_w0,
-                shared_id_to_torch_w1,
-                shared_id_to_torch_w2,
-                shared_expert_ids_to_devices,
-                mesh_device.get_num_devices(),
+            # The C++ add_shared_expert_weights consumes pre-arranged shared *device* tensors
+            # (per device: its assigned shared experts in sorted-id order; then concatenated
+            # across devices). Arrange on host, upload sharded on dim 1, splice on-device.
+            tt_shared_w0 = _shard_experts(
+                self._arrange_shared(shared_id_to_torch_w0, shared_expert_ids_to_devices, num_devices)
             )
-            total_torch_b0 = total_torch_b1 = total_torch_b2 = None
+            tt_shared_w1 = _shard_experts(
+                self._arrange_shared(shared_id_to_torch_w1, shared_expert_ids_to_devices, num_devices)
+            )
+            tt_shared_w2 = _shard_experts(
+                self._arrange_shared(shared_id_to_torch_w2, shared_expert_ids_to_devices, num_devices)
+            )
+            routed_w0, routed_w1, routed_w2 = tt_w0, tt_w1, tt_w2
+            tt_w0, tt_w1, tt_w2 = ttnn.experimental.add_shared_expert_weights(
+                routed_w0, routed_w1, routed_w2, tt_shared_w0, tt_shared_w1, tt_shared_w2
+            )
+            for t in (routed_w0, routed_w1, routed_w2, tt_shared_w0, tt_shared_w1, tt_shared_w2):
+                ttnn.deallocate(t)
 
+            total_shared_slots = sum(len(devs) for devs in shared_expert_ids_to_devices.values())
+            experts_per_device = (num_routed + total_shared_slots) // num_devices
         else:
-            total_torch_w0, total_torch_w1, total_torch_w2 = mapped_torch_w0, mapped_torch_w1, mapped_torch_w2
-            total_torch_b0, total_torch_b1, total_torch_b2 = mapped_torch_b0, mapped_torch_b1, mapped_torch_b2
+            experts_per_device = routed_per_device
+
+        tt_b0 = tt_b1 = tt_b2 = None
+        if has_bias:
+            tt_b0 = _shard_experts(mapped_torch_b0)
+            tt_b1 = _shard_experts(mapped_torch_b1)
+            tt_b2 = _shard_experts(mapped_torch_b2)
 
         self.tt_expert_mapping = self._init_expert_mapping(
             torch_expert_mapping, shared_expert_ids_to_devices, mesh_device, mesh_shape, cluster_axis
@@ -381,133 +409,114 @@ class _TTMoEDecodeExpertState:
         logger.info("Uploaded expert mapping to mesh")
 
         self.tt_w0_w1, self.tt_w2 = self._init_total_expert_weights_impl(
-            total_torch_w0,
-            total_torch_w1,
-            total_torch_w2,
-            cluster_axis,
+            tt_w0,
+            tt_w1,
+            tt_w2,
             mesh_device,
-            has_bias,
-            total_torch_b0,
-            total_torch_b1,
-            total_torch_b2,
-        )
-
-    @staticmethod
-    def _init_total_expert_weights_impl(
-        torch_w0: "torch.Tensor",
-        torch_w1: "torch.Tensor",
-        torch_w2: "torch.Tensor",
-        cluster_axis: int,
-        mesh_device: ttnn.MeshDevice,
-        has_bias: bool,
-        torch_b0: "torch.Tensor" | None = None,
-        torch_b1: "torch.Tensor" | None = None,
-        torch_b2: "torch.Tensor" | None = None,
-    ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
-        """Tile-reorder and upload the routed+shared weight tensors as `bfloat4_b`.
-
-        Calls the `prepare_*_for_moe_compute` helpers (with the `_with_bias` variants
-        when bias rows are folded in), gets the per-device DRAM shard configs from
-        `get_weight_mem_configs`, then `from_torch` uploads with `ShardTensorToMesh(dim=2)`
-        — dim 2 is the expert axis after the preparers' permutations, so each device
-        receives its assigned slice of experts.
-
-        Returns the two device tensors `(tt_w0_w1, tt_w2)` ready to feed `moe_compute`.
-        """
-        # TODO validate these be comparing to explicit values in the config
-        num_layers = torch_w0.shape[0]
-        # torch_w0 holds all experts globally [L, num_devices * experts_per_device, K, N];
-        # ShardTensorToMesh(dim=2) below splits the experts dim across mesh devices, so the
-        # `E` we feed prepare_* must match the tensor's actual experts dim, not the per-device count.
-        num_experts_total = torch_w0.shape[1]
-        experts_per_device = num_experts_total // mesh_device.get_num_devices()
-        hidden_size = torch_w0.shape[-2]
-        intermediate_size = torch_w0.shape[-1]
-
-        logger.info(
-            f"Preparing expert weights: total_experts={num_experts_total} per_device={experts_per_device} "
-            f"hidden={hidden_size} intermediate={intermediate_size} has_bias={has_bias}"
-        )
-
-        w0_w1_shard_map, w2_shard_map, dram_core_range_set = get_weight_core_shard_maps(
-            mesh_device, hidden_size, intermediate_size
-        )
-
-        if has_bias:
-            torch_w0_w1_reordered = prepare_w0_w1_tensor_with_bias(
-                torch_w0,
-                torch_w1,
-                torch_b0,
-                torch_b1,
-                num_layers,
-                num_experts_total,
-                hidden_size,
-                intermediate_size,
-                w0_w1_shard_map,
-            )
-            torch_w2_reordered = prepare_w2_tensor_with_bias(
-                torch_w2,
-                torch_b2,
-                num_layers,
-                num_experts_total,
-                intermediate_size,
-                hidden_size,
-                w2_shard_map,
-                w0_w1_shard_map,
-            )
-
-        else:
-            torch_w0_w1_reordered = prepare_w0_w1_tensor_for_moe_compute(
-                torch_w0,
-                torch_w1,
-                num_layers,
-                num_experts_total,
-                hidden_size,
-                intermediate_size,
-                w0_w1_shard_map,
-            )
-            torch_w2_reordered = prepare_w2_tensor_for_moe_compute(
-                torch_w2,
-                num_layers,
-                num_experts_total,
-                intermediate_size,
-                hidden_size,
-                w2_shard_map,
-                w0_w1_shard_map,
-            )
-
-        # get_weight_mem_configs sizes per-device shard footprints, so it wants the per-device count.
-        # has_bias is passed so K_for_shard / w2_N_total grow by a tile to accommodate the bias row.
-        w0_w1_mem_config, w2_mem_config, K_for_shard, w2_N_total = get_weight_mem_configs(
             num_layers,
             experts_per_device,
             hidden_size,
             intermediate_size,
-            w0_w1_shard_map,
-            w2_shard_map,
-            dram_core_range_set,
+            has_bias,
+            tt_b0,
+            tt_b1,
+            tt_b2,
+        )
+
+    @staticmethod
+    def _arrange_shared(
+        shared_dict: dict[int, "torch.Tensor"],
+        shared_expert_ids_to_devices: dict[int, list[int]],
+        num_devices: int,
+    ) -> "torch.Tensor":
+        """Arrange a `{shared_expert_id: tensor}` dict into the per-device-stacked layout the
+        C++ `add_shared_expert_weights` expects.
+
+        For each device (in order), concatenate its assigned shared experts (in sorted global-id
+        order) along the experts dim (dim 1), then concatenate across devices. Sharding the
+        result on dim 1 then lands each device's shared experts on it, in slot order — matching
+        how the device-side splice appends shared experts after routed ones per device.
+        """
+        device_to_shared: list[list[int]] = [[] for _ in range(num_devices)]
+        for sid in sorted(shared_expert_ids_to_devices):
+            for d in shared_expert_ids_to_devices[sid]:
+                device_to_shared[d].append(sid)
+        per_device = [torch.cat([shared_dict[sid] for sid in device_to_shared[d]], dim=1) for d in range(num_devices)]
+        return torch.cat(per_device, dim=1)
+
+    @staticmethod
+    def _init_total_expert_weights_impl(
+        tt_w0: ttnn.Tensor,
+        tt_w1: ttnn.Tensor,
+        tt_w2: ttnn.Tensor,
+        mesh_device: ttnn.MeshDevice,
+        num_layers: int,
+        experts_per_device: int,
+        hidden_size: int,
+        intermediate_size: int,
+        has_bias: bool,
+        tt_b0: ttnn.Tensor | None = None,
+        tt_b1: ttnn.Tensor | None = None,
+        tt_b2: ttnn.Tensor | None = None,
+    ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        """Pack and quantize the combined routed+shared weight device tensors to `bfloat4_b`.
+
+        Inputs are multi-device tensors sharded on the experts dim (dim 1), bf16 / ROW_MAJOR.
+        Runs the C++ on-device packers (`ttnn.experimental.prepare_*`, with the `_with_bias`
+        variants when bias rows are folded in), fetches the DRAM-sharded mem configs from
+        `ttnn.experimental.get_weight_mem_configs`, then quantizes to `bfloat4_b` onto those
+        configs via `ttnn.experimental.quantize_weights_via_host` (host round-trip).
+
+        `experts_per_device` is the *combined* (routed + shared) per-device expert count — the
+        experts dim of the inputs, divided across the mesh. Returns the two device tensors
+        `(tt_w0_w1, tt_w2)` ready to feed `moe_compute`.
+        """
+        logger.info(
+            f"Preparing expert weights on device: per_device={experts_per_device} "
+            f"hidden={hidden_size} intermediate={intermediate_size} has_bias={has_bias}"
+        )
+
+        if has_bias:
+            tt_w0_w1_prepped = ttnn.experimental.prepare_w0_w1_tensor_with_bias(
+                tt_w0, tt_w1, tt_b0, tt_b1, L=num_layers, E=experts_per_device, K=hidden_size, N=intermediate_size
+            )
+            tt_w2_prepped = ttnn.experimental.prepare_w2_tensor_with_bias(
+                tt_w2, tt_b2, L=num_layers, E=experts_per_device, N=intermediate_size, K=hidden_size
+            )
+        else:
+            tt_w0_w1_prepped = ttnn.experimental.prepare_w0_w1_tensor_for_moe_compute(
+                tt_w0, tt_w1, L=num_layers, E=experts_per_device, K=hidden_size, N=intermediate_size
+            )
+            tt_w2_prepped = ttnn.experimental.prepare_w2_tensor_for_moe_compute(
+                tt_w2, L=num_layers, E=experts_per_device, N=intermediate_size, K=hidden_size
+            )
+
+        # Raw uploaded inputs are consumed by the packers; free them before the host round-trip.
+        for t in (tt_w0, tt_w1, tt_w2):
+            ttnn.deallocate(t)
+        if has_bias:
+            for t in (tt_b0, tt_b1, tt_b2):
+                ttnn.deallocate(t)
+
+        # has_bias grows the padded K / N by a tile to accommodate the bias row.
+        weight_mem_configs = ttnn.experimental.get_weight_mem_configs(
+            mesh_device,
+            num_layers=num_layers,
+            experts_per_device=experts_per_device,
+            hidden_size=hidden_size,
+            intermediate_size=intermediate_size,
             has_bias=has_bias,
         )
 
-        # Prepared tensors are shape (num_cores, L, E_total, groups_per_core, ..., 4*TILE).
-        # Shard along E (dim=2) so each device receives its assigned experts.
-        tt_w0_w1 = ttnn.from_torch(
-            torch_w0_w1_reordered,
-            dtype=ttnn.bfloat4_b,
-            device=mesh_device,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=w0_w1_mem_config,
-            mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=2),
+        tt_w0_w1 = ttnn.experimental.quantize_weights_via_host(
+            tt_w0_w1_prepped, dtype=ttnn.bfloat4_b, memory_config=weight_mem_configs.w0_w1
         )
-        tt_w2 = ttnn.from_torch(
-            torch_w2_reordered,
-            dtype=ttnn.bfloat4_b,
-            device=mesh_device,
-            layout=ttnn.TILE_LAYOUT,
-            memory_config=w2_mem_config,
-            mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=2),
+        ttnn.deallocate(tt_w0_w1_prepped)
+        tt_w2 = ttnn.experimental.quantize_weights_via_host(
+            tt_w2_prepped, dtype=ttnn.bfloat4_b, memory_config=weight_mem_configs.w2
         )
-        logger.info("Uploaded w0/w1 and w2 to mesh")
+        ttnn.deallocate(tt_w2_prepped)
+        logger.info("Prepared and quantized w0/w1 and w2 to bfloat4_b on mesh")
 
         return tt_w0_w1, tt_w2
 

--- a/models/common/tests/modules/moe/test_tt_moe_decode.py
+++ b/models/common/tests/modules/moe/test_tt_moe_decode.py
@@ -86,6 +86,10 @@ def is_mesh_graph_descriptor_set(expected_path):
 # ---------------------------------------------------------------------------
 
 
+torch.set_num_threads(os.cpu_count())
+
+
+@torch.no_grad()
 def _matmul_golden(
     token: torch.Tensor,
     w0: torch.Tensor,
@@ -107,12 +111,19 @@ def _matmul_golden(
     Per-expert bias shapes: `b0`/`b1` are `[num_layers, 1, N]`, `b2` is
     `[num_layers, 1, hidden_size]`. `unsqueeze(-2)` broadcasts over the token dim.
     """
+
+    _orig_dtype = token.dtype
+    token = token.float()
+    w0 = w0.float()
+    w1 = w1.float()
+    w2 = w2.float()
+
     gate = token @ w0
     if b0 is not None:
-        gate = gate + b0.unsqueeze(-2)
+        gate = gate + b0.float().unsqueeze(-2)
     up = token @ w1
     if b1 is not None:
-        up = up + b1.unsqueeze(-2)
+        up = up + b1.float().unsqueeze(-2)
 
     if activation_type == MoEActivationFunction.SILU:
         intermediate = torch.nn.functional.silu(gate) * up
@@ -125,8 +136,8 @@ def _matmul_golden(
 
     output = intermediate @ w2
     if b2 is not None:
-        output = output + b2.unsqueeze(-2)
-    return output
+        output = output + b2.float().unsqueeze(-2)
+    return output.to(_orig_dtype)
 
 
 def _create_per_expert_weights(num_layers: int, num_experts: int, h: int, n: int) -> torch.Tensor:
@@ -186,6 +197,7 @@ def _create_expert_indices(batch: int, num_experts: int, select_k: int) -> torch
     return out
 
 
+@torch.no_grad()
 def _gen_output_golden(
     tokens: torch.Tensor,
     expert_indices: torch.Tensor,
@@ -253,6 +265,7 @@ def _create_shared_expert_weights(
     return shared_w0, shared_w1, shared_w2
 
 
+@torch.no_grad()
 def _add_shared_experts_to_golden(
     out: torch.Tensor,
     tokens: torch.Tensor,
@@ -338,6 +351,7 @@ SKIP_LIST = [
 )
 @pytest.mark.parametrize("num_iterations", [3])
 @pytest.mark.parametrize("config_path", CONFIG_PATHS, ids=_config_id)
+@pytest.mark.timeout(900)
 @torch.no_grad()
 def test_tt_moe_decode(
     mesh_device: ttnn.MeshDevice,

--- a/models/common/tests/modules/moe/test_tt_moe_decode.py
+++ b/models/common/tests/modules/moe/test_tt_moe_decode.py
@@ -86,7 +86,7 @@ def is_mesh_graph_descriptor_set(expected_path):
 # ---------------------------------------------------------------------------
 
 
-torch.set_num_threads(os.cpu_count())
+torch.set_num_threads(max(1, os.cpu_count() or 1))
 
 
 @torch.no_grad()

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -87,8 +87,6 @@ tt::tt_fabric::FabricMuxConfig get_fabric_mux_config(
         l1_unreserved_base_address);
 
     if (occupied_l1_tensor_addr.has_value() && config.get_memory_map_end_address() >= *occupied_l1_tensor_addr) {
-        std::cout << "Reducing mux channels num_buffers_full_size_channels:" << num_buffers_full_size_channels - 1
-                  << " num_buffers_header_only_channels: " << num_buffers_header_only_channels - 1 << std::endl;
         return get_fabric_mux_config(
             num_full_size_channels,
             num_header_only_channels,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -86,7 +86,7 @@ tt::tt_fabric::FabricMuxConfig get_fabric_mux_config(
         buffer_size_bytes_full_size_channel,
         l1_unreserved_base_address);
 
-    if (occupied_l1_tensor_addr.has_value() && config.get_memory_map_end_address() >= *occupied_l1_tensor_addr) {
+    if (occupied_l1_tensor_addr.has_value() && config.get_memory_map_end_address() > *occupied_l1_tensor_addr) {
         return get_fabric_mux_config(
             num_full_size_channels,
             num_header_only_channels,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe/selective_reduce_combine/device/selective_reduce_combine_program_factory.cpp
@@ -64,6 +64,44 @@ SelectiveReduceCombineWorkerLayout compute_worker_layout(
     };
 }
 
+
+tt::tt_fabric::FabricMuxConfig get_fabric_mux_config(
+    const uint32_t num_full_size_channels,
+    const uint32_t num_header_only_channels,
+    uint8_t num_buffers_full_size_channels,
+    uint8_t num_buffers_header_only_channels,
+    const size_t buffer_size_bytes_full_size_channel,
+    const uint32_t l1_unreserved_base_address,
+    const std::optional<uint32_t>& occupied_l1_tensor_addr) {
+    TT_FATAL(
+        num_buffers_full_size_channels > 0 && num_buffers_header_only_channels > 0,
+        "Not enough L1 space for mux core memory requirements given current occupancy. Likely too many experts per "
+        "device");
+
+    const auto config = tt::tt_fabric::FabricMuxConfig(
+        num_full_size_channels,
+        num_header_only_channels,
+        num_buffers_full_size_channels,
+        num_buffers_header_only_channels,
+        buffer_size_bytes_full_size_channel,
+        l1_unreserved_base_address);
+
+    if (occupied_l1_tensor_addr.has_value() && config.get_memory_map_end_address() >= *occupied_l1_tensor_addr) {
+        std::cout << "Reducing mux channels num_buffers_full_size_channels:" << num_buffers_full_size_channels - 1
+                  << " num_buffers_header_only_channels: " << num_buffers_header_only_channels - 1 << std::endl;
+        return get_fabric_mux_config(
+            num_full_size_channels,
+            num_header_only_channels,
+            --num_buffers_full_size_channels,
+            --num_buffers_header_only_channels,
+            buffer_size_bytes_full_size_channel,
+            l1_unreserved_base_address,
+            occupied_l1_tensor_addr);
+    }
+
+    return config;
+}
+
 auto launch_mux_workers(
     const MeshDevice& mesh_device,
     const CoreRangeSet& mux_core_range_set,
@@ -74,46 +112,24 @@ auto launch_mux_workers(
     Program& program) {
     const auto num_header_only_channels = tt::div_up(num_workers, num_links);
     const auto num_full_size_channels = tt::div_up(num_workers, num_links);
-    // BH single-LB has 2 ethernet channels per inter-chip link (vs 4 on WH 6U), so its mux
-    // cores host 2x the channels per link at the same num_workers. At full-size num_buffers=15
-    // the resulting per-mux-core L1 (~520 KB at DeepSeek hidden=7168) collides with the
-    // tilize_output shared shard by ~11 KB. Trimming by 1 buffer on BH only (1/15 = 6.7%
-    // burst-tolerance reduction) recovers ~32 KB per mux core — ~3x the overflow — with zero
-    // impact on WH.
-    //
-    // Calibration: BH=14 was sized against deepseek_v3 (hidden=7168), the LARGEST MoE shape
-    // currently fitting on WH at epd=2. Per-core mux+tilize_output sums:
-    //   hidden=2880 (GPT-OSS):   448 + 360 = 808 KB    (~590 KB headroom)
-    //   hidden=7168 (DeepSeek):  448 + 896 = 1344 KB   (~ 21 KB headroom)  ← binding
-    //   hidden=8192 (Ling):      448 + 1024 = 1472 KB  (~ 75 KB overflow — future fix needed)
-    // tilize_output scales 1:1 with hidden, mux is shape-independent. Any future MoE shape
-    // with hidden ≤ 7168 fits with equal or wider margin. If hidden > 7168 (or some new
-    // shape variant pushes per-core L1 differently), the TT_FATAL just below will fire with
-    // a clear "mux L1 overlaps tensor" message — at that point either drop the buffer count
-    // further (e.g. 13) or revisit the L1 layout to free more headroom for tilize_output.
-    const uint8_t num_buffers_full_size_channels = (mesh_device.arch() == tt::ARCH::BLACKHOLE) ? 14 : 15;
-    const uint8_t num_buffers_header_only_channels = (mesh_device.arch() == tt::ARCH::BLACKHOLE) ? 14 : 15;
+
+    constexpr uint8_t num_buffers_full_size_channels = 15;
+    constexpr uint8_t num_buffers_header_only_channels = 15;
 
     const size_t buffer_size_bytes_full_size_channel = tt::tt_fabric::get_tt_fabric_channel_buffer_size_bytes();
     const auto l1_unreserved_base_address =
         mesh_device.allocator()->get_base_allocator_addr(tt::tt_metal::HalMemType::L1);
-    auto mux_kernel_config = tt::tt_fabric::FabricMuxConfig(
+
+    const auto occupied_l1_tensor_addr = mesh_device.lowest_occupied_compute_l1_address();
+
+    auto mux_kernel_config = get_fabric_mux_config(
         num_full_size_channels,
         num_header_only_channels,
         num_buffers_full_size_channels,
         num_buffers_header_only_channels,
         buffer_size_bytes_full_size_channel,
-        l1_unreserved_base_address);
-
-    const auto occupied_l1_tensor_addr = mesh_device.lowest_occupied_compute_l1_address();
-    if (occupied_l1_tensor_addr.has_value()) {
-        TT_FATAL(
-            mux_kernel_config.get_memory_map_end_address() <= *occupied_l1_tensor_addr,
-            "Mux L1 memory [base={:#x}, end={:#x}] overlaps with L1 tensor {:#x} and is in danger of being clobbered.",
-            l1_unreserved_base_address,
-            mux_kernel_config.get_memory_map_end_address(),
-            *occupied_l1_tensor_addr);
-    }
+        l1_unreserved_base_address,
+        occupied_l1_tensor_addr);
 
     // Calculate required vs available mux cores for fabric communication (one core per link per neighbor)
     const uint32_t needed_cores = num_links * neighbors.size();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
@@ -368,15 +368,9 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
     const ttnn::Tensor& shared_w1,
     const ttnn::Tensor& shared_w2) {
     auto output_w0 = ttnn::concat({routed_w0, shared_w0}, 1);
-    auto tile_w0 = ttnn::to_layout(output_w0, ttnn::Layout::TILE);
-    output_w0.deallocate(/*force=*/true);
     auto output_w1 = ttnn::concat({routed_w1, shared_w1}, 1);
-    auto tile_w1 = ttnn::to_layout(output_w1, ttnn::Layout::TILE);
-    output_w1.deallocate(/*force=*/true);
     auto output_w2 = ttnn::concat({routed_w2, shared_w2}, 1);
-    auto tile_w2 = ttnn::to_layout(output_w2, ttnn::Layout::TILE);
-    output_w2.deallocate(/*force=*/true);
-    return {tile_w0, tile_w1, tile_w2};
+    return {output_w0, output_w1, output_w2};
 }
 
 ttnn::Tensor prepare_w0_w1_tensor_for_moe_compute(
@@ -553,11 +547,11 @@ ttnn::Tensor prepare_w2_tensor_for_moe_compute(
         n_reordered_no_pad.deallocate(/*force=*/true);
         pad.deallocate(/*force=*/true);
         auto result = ttnn::to_layout(padded, ttnn::Layout::TILE);
-        padded.deallocate(/*force=*/true);
+        padded.deallocate(/*force=*/false);
         return result;
     }
     auto result = ttnn::to_layout(n_reordered_no_pad, ttnn::Layout::TILE);
-    n_reordered_no_pad.deallocate(/*force=*/true);
+    n_reordered_no_pad.deallocate(/*force=*/false);
     return result;
 }
 
@@ -691,7 +685,7 @@ ttnn::Tensor prepare_w2_tensor_with_bias(
         n_with_bias = padded;
     }
     auto result = ttnn::to_layout(n_with_bias, ttnn::Layout::TILE);
-    n_with_bias.deallocate(/*force=*/true);
+    n_with_bias.deallocate(/*force=*/false);
     return result;
 }
 


### PR DESCRIPTION
### Summary
- Port `tt_mode_decode`over to new C++ weight prep functions
- Reduce mux buffers slots until there are no clashes with resident L1

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/moe-compute-mux-conflict)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/moe-compute-mux-conflict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/moe-compute-mux-conflict)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/moe-compute-mux-conflict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amorrison/moe-compute-mux-conflict)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/moe-compute-mux-conflict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/moe-compute-mux-conflict)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/moe-compute-mux-conflict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/moe-compute-mux-conflict)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/moe-compute-mux-conflict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/moe-compute-mux-conflict)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/moe-compute-mux-conflict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/moe-compute-mux-conflict)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/moe-compute-mux-conflict)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/moe-compute-mux-conflict)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/moe-compute-mux-conflict)