### PR TITLE
#46449: Routed Expert Kimi PCC

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -140,6 +140,13 @@ void kernel_main() {
     // Look up active token count for this expert from device-side buffers.
     // Reserve+read+push so the compute kernel (TRISC) and writer kernel
     // (NCRISC) can cb_wait_front on these CBs and read the same L1 data.
+    //
+    // Each scratch CB is a single page sized (host-side) to hold up to
+    // MAX_GLOBAL_EXPERTS UINT32 entries, so `1` here is the whole buffer and a
+    // single noc_async_read_page lands the entire counts / idx vector. The
+    // later counts_ptr[global_expert_id] / idx_ptr[local_expert_id] indexing
+    // therefore stays in-bounds for any model up to MAX_GLOBAL_EXPERTS experts
+    // (DeepSeek V3 256, Kimi 384, ... up to 1024).
     cb_reserve_back(cb_counts_scratch, 1);
     cb_reserve_back(cb_idx_scratch, 1);
     const uint32_t counts_l1 = get_write_ptr(cb_counts_scratch);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -75,9 +75,12 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
     // Aux tensors: counts / global_expert_idx_table are small UINT32 vectors
     // the reader fetches via DRAM accessor. The reader does a single
     // noc_async_read_page(page=0, ...) and then indexes anywhere in
-    // [0, num_experts), so the full vector must fit in one page (= one tile
-    // for TILE layout, 1024 uint32 entries). Validate here so larger expert
-    // counts produce a clean assertion instead of silent OOB reads at runtime.
+    // [0, num_global_experts), so the full vector must fit in one page. The
+    // L1 scratch CB is sized to hold MAX_GLOBAL_EXPERTS UINT32 entries (see
+    // the program factory), which covers DeepSeek V3 (256), Kimi (384) and any
+    // model up to MAX_GLOBAL_EXPERTS routed experts. Validate the length here
+    // so larger expert counts produce a clean assertion instead of silent OOB
+    // reads at runtime.
     for (const auto& [name, a] : std::initializer_list<std::pair<const char*, const ttnn::Tensor&>>{
              {"counts", t.counts}, {"global_expert_idx_table", t.global_expert_idx_table}}) {
         TT_FATAL(a.storage_type() == tt::tt_metal::StorageType::DEVICE, "{} must be on device", name);
@@ -85,12 +88,12 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
         TT_FATAL(is_dram_interleaved(a), "{} must be DRAM-interleaved", name);
         const uint32_t num_entries = a.logical_shape()[-1];
         TT_FATAL(
-            num_entries <= tt::constants::TILE_HW,
-            "{} length ({}) must fit in one tile ({} entries) — reader fetches "
-            "only page 0 of this tensor",
+            num_entries <= MAX_GLOBAL_EXPERTS,
+            "{} length ({}) exceeds the maximum supported number of experts ({}) — "
+            "the reader fetches only page 0 of this tensor into a fixed-size L1 scratch",
             name,
             num_entries,
-            tt::constants::TILE_HW);
+            MAX_GLOBAL_EXPERTS);
     }
     TT_FATAL(
         op.local_expert_id < t.global_expert_idx_table.logical_shape()[-1],

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -4,6 +4,7 @@
 
 #include "unified_routed_expert_ffn_program_factory.hpp"
 
+#include <algorithm>
 #include <cstdint>
 #include <map>
 #include <unordered_map>
@@ -289,22 +290,38 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         /*tiles=*/d_in0_block_num_tiles * 2,
         intermed_tile_size);
 
-    // Scratch CBs for the device-side count lookup. One page each, sized to
-    // the corresponding tensor's aligned page size so noc_async_read_page
-    // can land them.
-    const uint32_t counts_page_size = counts_buffer->aligned_page_size();
-    const uint32_t idx_page_size = idx_buffer->aligned_page_size();
+    // Scratch CBs for the device-side count lookup. The reader does a single
+    // noc_async_read_page(page=0, ...) of each tensor and then indexes
+    // counts[global_expert_id] for global_expert_id in
+    // [0, num_global_experts). The scratch must therefore be large enough to
+    // both (a) land the tensor's page and (b) hold up to MAX_GLOBAL_EXPERTS
+    // UINT32 entries so indexing the largest global id stays in-bounds.
+    //
+    // Size to max(aligned_page_size, MAX_GLOBAL_EXPERTS * 4B). For the
+    // supported range (<= MAX_GLOBAL_EXPERTS experts) the page never exceeds
+    // MAX_GLOBAL_EXPERTS * 4B, so this fixes the scratch at 4 KB ("4 tiles" of
+    // 1 KB) — enough for DeepSeek V3 (256), Kimi (384) and up to 1024 routed
+    // experts. Decoupling the capacity from the incidental input page size
+    // (which scales with num_experts) keeps the buffer correct for the design
+    // maximum regardless of how few experts a given call passes. ~4 KB/core of
+    // the ~250 KB L1 headroom — negligible.
+    constexpr uint32_t kScratchMinBytes = MAX_GLOBAL_EXPERTS * static_cast<uint32_t>(sizeof(uint32_t));
+    const uint32_t counts_scratch_bytes =
+        std::max<uint32_t>(static_cast<uint32_t>(counts_buffer->aligned_page_size()), kScratchMinBytes);
+    const uint32_t idx_scratch_bytes =
+        std::max<uint32_t>(static_cast<uint32_t>(idx_buffer->aligned_page_size()), kScratchMinBytes);
     tt::tt_metal::CircularBufferConfig counts_cb_cfg =
-        tt::tt_metal::CircularBufferConfig(counts_page_size, {{CB_COUNTS_SCRATCH, tt::DataFormat::UInt32}})
-            .set_page_size(CB_COUNTS_SCRATCH, counts_page_size);
+        tt::tt_metal::CircularBufferConfig(counts_scratch_bytes, {{CB_COUNTS_SCRATCH, tt::DataFormat::UInt32}})
+            .set_page_size(CB_COUNTS_SCRATCH, counts_scratch_bytes);
     tt::tt_metal::CreateCircularBuffer(program, core_range_set, counts_cb_cfg);
     // CB_IDX_SCRATCH holds the device-side global_expert_idx_table page so
     // reader/compute/writer can resolve `global_expert_id =
-    // idx_table[local_expert_id]` without re-reading DRAM. One page sized
-    // to the table's aligned page size.
+    // idx_table[local_expert_id]` without re-reading DRAM. Sized the same way:
+    // a single-chip deployment can place all experts locally, so the idx table
+    // may itself be up to MAX_GLOBAL_EXPERTS entries.
     tt::tt_metal::CircularBufferConfig idx_cb_cfg =
-        tt::tt_metal::CircularBufferConfig(idx_page_size, {{CB_IDX_SCRATCH, tt::DataFormat::UInt32}})
-            .set_page_size(CB_IDX_SCRATCH, idx_page_size);
+        tt::tt_metal::CircularBufferConfig(idx_scratch_bytes, {{CB_IDX_SCRATCH, tt::DataFormat::UInt32}})
+            .set_page_size(CB_IDX_SCRATCH, idx_scratch_bytes);
     tt::tt_metal::CreateCircularBuffer(program, core_range_set, idx_cb_cfg);
 
     // -------------------------- kernel build ------------------------------

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
@@ -8,11 +8,27 @@
 #include <optional>
 #include <tuple>
 
+#include <tt-metalium/constants.hpp>
+
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn {
+
+// Maximum number of global experts the op supports.
+//
+// The reader fetches the per-global-expert `counts` vector (and the
+// local->global `global_expert_idx_table`) into an L1 scratch CB with a
+// single noc_async_read_page, then indexes counts[global_expert_id] for
+// global_expert_id in [0, num_global_experts). The L1 scratch is sized to
+// hold this many UINT32 entries — 1024 entries = 4 KB ("4 tiles" of 1 KB) —
+// which covers DeepSeek V3 (256 experts), Kimi (384 experts) and any model up
+// to 1024 routed experts with headroom. A single ROW_MAJOR DRAM page already
+// holds the whole vector, so the read stays a single page fetch; bumping this
+// past TILE_HW would additionally require widening the device-op validation
+// below and re-checking the per-core L1 budget.
+inline constexpr uint32_t MAX_GLOBAL_EXPERTS = tt::constants::TILE_HW;  // 1024
 
 // Attributes (the constants known at host time).
 struct UnifiedRoutedExpertFfnParams {


### PR DESCRIPTION
The reader fetches the per-global-expert `counts` vector (and the local->global `global_expert_idx_table`) into an L1 scratch CB, then indexes counts[global_expert_id]. The scratch was sized to the input tensor's incidental page size, which scales with num_experts — fine for DeepSeek V3 (256) but coupling the L1 capacity to the input layout.

Size both scratch CBs explicitly to hold up to MAX_GLOBAL_EXPERTS (= 1024) UINT32 entries (4 KB), decoupled from the input page size, so the op robustly supports models with larger expert counts (e.g. Kimi = 384) up to the 1024 maximum. ~4 KB/core of the ~250 KB L1 headroom — negligible.

- types.hpp: add shared MAX_GLOBAL_EXPERTS constant (= TILE_HW).
- program_factory: size counts/idx scratch to max(page_size, 1024 * 4B).
- device_operation: validate num_entries <= MAX_GLOBAL_EXPERTS (clearer message; behavior unchanged — TILE_HW was already 1024).
- reader: clarify the single-page read covers the whole vector.

### CIs
- [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=kgrujcic%2Frexpert_l1_scratch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml)