### PR TITLE
[Feature] Bring up prefetcher side of fast dispatch on Quasar

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -935,29 +935,28 @@ static constexpr uint32_t SD_PREFETCH_CMDDAT_PAGE_SIZE = 1u << SD_PREFETCH_CMDDA
 static constexpr uint32_t SD_PREFETCH_CMDDAT_BLOCKS = DispatchSettings::PREFETCH_D_BUFFER_BLOCKS;
 inline constexpr CoreCoord sd_prefetch_core = {0, 0};  // combined prefetch_hd
 
-// Quasar simulation exposes only the low 26 address bits of each DRAM bank as backing physical
-// memory (64 MB); addresses above this alias back into the same physical space even though the
-// bank is configured as 1 GB. Code that places buffers in DRAM on Quasar must keep them within
-// this window to avoid aliasing collisions.
+// Quasar simulator exposes only 64 MB as physical DRAM memory; addresses above this alias back into the same physical
+// space even though the bank is configured as 1 GB. Code that places data in DRAM on Quasar must keep it within this 64
+// MB window to avoid aliasing collisions.
 static constexpr uint32_t QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE = 1u << 26;  // 64 MB
 
-// True when running on the Quasar RTL/behavioral simulator. Used to select DRAM-backed CQ paths
-// and scale down data sizes / iteration counts to fit within the simulator's memory window.
+// DRAM addresses and sizes for the command queue on the Quasar simulator. Issue queue (8 MB) and completion queue (8
+// MB) sit at [48, 56) and [56, 64) MB respectively, exactly reaching the physical DRAM window size limit.
+static constexpr uint32_t QUASAR_SIMULATION_ISSUE_QUEUE_BASE = 0x3000000u;  // 48 MB
+static constexpr uint32_t QUASAR_SIMULATION_ISSUE_QUEUE_SIZE = 0x800000;    // 8 MB
+static constexpr uint32_t QUASAR_SIMULATION_COMPLETION_QUEUE_BASE =
+    QUASAR_SIMULATION_ISSUE_QUEUE_BASE + QUASAR_SIMULATION_ISSUE_QUEUE_SIZE;   // 56 MB
+static constexpr uint32_t QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE = 0x800000;  // 8 MB
+static_assert(
+    QUASAR_SIMULATION_COMPLETION_QUEUE_BASE + QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE <=
+        QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE,
+    "CQ overruns Quasar simulator physical DRAM window");
+
 inline bool is_quasar_sim() {
     const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
     return rtoptions.get_simulator_enabled() &&
            tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::QUASAR;
 }
-
-// DRAM addresses for the SD (slow-dispatch) command queue on the Quasar simulator.
-// Bank 0 decodes only 64 MB; issue (8 MB) and completion (8 MB) sit at [48, 56) and [56, 64) MB
-// respectively, exactly filling the decoded window without aliasing into the low-memory region.
-static constexpr uint32_t kSdQuasarIssueBase = 0x3000000u;                                    // 48 MB
-static constexpr uint32_t kSdQuasarIssueSize = DispatchSettings::MAX_DEV_CHANNEL_SIZE / 32;   // 8 MB
-static constexpr uint32_t kSdQuasarCompletionBase = kSdQuasarIssueBase + kSdQuasarIssueSize;  // 56 MB
-static_assert(
-    kSdQuasarCompletionBase + kSdQuasarIssueSize <= QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE,
-    "SD CQ overruns Quasar DRAM bank-0 window");
 
 // BaseTestFixture forms the basis for prefetch and dispatcher tests.
 // Inherits from GenericMeshDeviceFixture which determines the mesh device type automatically
@@ -1039,29 +1038,29 @@ protected:
         return true;
     }
 
-    CoreCoord worker_start() const {
-        return (device_->arch() == tt::ARCH::QUASAR) ? CoreCoord{1, 0} : default_worker_start;
-    }
+    CoreCoord worker_start() const { return Common::is_quasar_sim() ? CoreCoord{1, 0} : default_worker_start; }
 
     CoreRange worker_range(const CoreCoord& first_worker, bool multi_core = true) const {
-        if (device_->arch() == tt::ARCH::QUASAR) {
+        if (Common::is_quasar_sim()) {
             return CoreRange{first_worker, first_worker};
         }
         const CoreCoord last_worker = multi_core ? CoreCoord{first_worker.x + 1, first_worker.y + 1} : first_worker;
         return CoreRange{first_worker, last_worker};
     }
 
-    // SD (slow dispatch) issue + completion buffer sizes. Must fit in one device's hugepage slot
+    // SD (slow dispatch) issue + completion queue sizes. Must fit in one device's hugepage slot
     // (MAX_DEV_CHANNEL_SIZE = 256 MB) on WH/BH; an even 50/50 split gives 128 MB each. On Quasar simulation, command
     // queues must be stored in DRAM due to limitations, and only 64 MB of physical DRAM space
     // (QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE) is available even though the bank size is 1 GB. The remaining addresses
     // alias this physical space. The SD command queue must therefore fit in a single 64-MB window, so each half is
-    // capped at 8 MB on Quasar (matching kSdQuasarIssueSize so the host and kernel agree on the CQ wrap boundary).
-    uint32_t sd_hugepage_issue_buffer_size() const {
-        return (device_->arch() == tt::ARCH::QUASAR) ? kSdQuasarIssueSize : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
+    // capped at 8 MB on Quasar.
+    uint32_t sd_issue_queue_size() const {
+        return Common::is_quasar_sim() ? QUASAR_SIMULATION_ISSUE_QUEUE_SIZE
+                                       : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
     }
     uint32_t sd_completion_queue_size() const {
-        return (device_->arch() == tt::ARCH::QUASAR) ? kSdQuasarIssueSize : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
+        return Common::is_quasar_sim() ? QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE
+                                       : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
     }
 
     // Helper function that polls completion queue until expected data is written into by dispatcher
@@ -1258,7 +1257,6 @@ inline std::map<std::string, std::string> make_sd_dispatch_defines(
     uint32_t dispatch_cb_base,
     uint32_t completion_queue_base = 0,
     uint32_t completion_queue_size = 0) {
-    const bool is_cq_dram_backed = (device_->arch() == tt::ARCH::QUASAR);
     const uint32_t num_compute_cores =
         device_->compute_with_storage_grid_size().x * device_->compute_with_storage_grid_size().y;
     const auto my_virtual = device_->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, phys_disp);
@@ -1268,7 +1266,7 @@ inline std::map<std::string, std::string> make_sd_dispatch_defines(
     const auto downstream_virtual = device_->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, CoreCoord{0, 0});
 
     return {
-        {"IS_CQ_DRAM_BACKED", is_cq_dram_backed ? "1" : "0"},
+        {"IS_CQ_DRAM_BACKED", Common::is_quasar_sim() ? "1" : "0"},
         {"DRAM_BACKED_CQ_BANK_ID", "0"},
         {"DISPATCH_CB_BASE", std::to_string(dispatch_cb_base)},
         {"DISPATCH_CB_LOG_PAGE_SIZE", std::to_string(DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE)},
@@ -1382,7 +1380,6 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
     uint32_t entry_size,
     const CoreCoord& phys_prefetch,
     const CoreCoord& phys_dispatch) {
-    const bool is_cq_dram_backed = (device->arch() == tt::ARCH::QUASAR);
     const auto my_virtual = device->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, phys_prefetch);
     const auto downstream_virtual = device->virtual_noc0_coordinate(tt_metal::NOC::NOC_0, phys_dispatch);
     return {
@@ -1403,7 +1400,7 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
         // these share a slot id; on Quasar (prefetch+dispatch same core) they are distinct slots.
         {"MY_DOWNSTREAM_CB_SEM_ID", std::to_string(dispatch_cb_sem_id)},
         {"DOWNSTREAM_CB_SEM_ID", std::to_string(downstream_cb_sem_id)},
-        {"IS_CQ_DRAM_BACKED", is_cq_dram_backed ? "1" : "0"},
+        {"IS_CQ_DRAM_BACKED", Common::is_quasar_sim() ? "1" : "0"},
         {"DRAM_BACKED_CQ_BANK_ID", "0"},
         {"PCIE_BASE", std::to_string(pcie_base)},
         {"PCIE_SIZE", std::to_string(pcie_size)},

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -1377,6 +1377,7 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
     uint32_t dispatch_cb_base,
     uint32_t dispatch_cb_pages,
     uint32_t dispatch_cb_sem_id,
+    uint32_t downstream_cb_sem_id,
     uint32_t downstream_sync_sem_id,
     uint32_t entry_size,
     const CoreCoord& phys_prefetch,
@@ -1397,8 +1398,11 @@ inline std::map<std::string, std::string> make_sd_prefetch_defines(
         {"DOWNSTREAM_CB_BASE", std::to_string(dispatch_cb_base)},
         {"DOWNSTREAM_CB_LOG_PAGE_SIZE", std::to_string(DispatchSettings::DISPATCH_BUFFER_LOG_PAGE_SIZE)},
         {"DOWNSTREAM_CB_PAGES", std::to_string(dispatch_cb_pages)},
+        // MY_DOWNSTREAM_CB_SEM_ID: prefetch's own downstream credit pool (waited on locally).
+        // DOWNSTREAM_CB_SEM_ID: the dispatcher's received-pages sem the prefetcher signals. On WH/BH
+        // these share a slot id; on Quasar (prefetch+dispatch same core) they are distinct slots.
         {"MY_DOWNSTREAM_CB_SEM_ID", std::to_string(dispatch_cb_sem_id)},
-        {"DOWNSTREAM_CB_SEM_ID", std::to_string(dispatch_cb_sem_id)},
+        {"DOWNSTREAM_CB_SEM_ID", std::to_string(downstream_cb_sem_id)},
         {"IS_CQ_DRAM_BACKED", is_cq_dram_backed ? "1" : "0"},
         {"DRAM_BACKED_CQ_BANK_ID", "0"},
         {"PCIE_BASE", std::to_string(pcie_base)},

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -941,6 +941,24 @@ inline constexpr CoreCoord sd_prefetch_core = {0, 0};  // combined prefetch_hd
 // this window to avoid aliasing collisions.
 static constexpr uint32_t QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE = 1u << 26;  // 64 MB
 
+// True when running on the Quasar RTL/behavioral simulator. Used to select DRAM-backed CQ paths
+// and scale down data sizes / iteration counts to fit within the simulator's memory window.
+inline bool is_quasar_sim() {
+    const auto& rtoptions = tt::tt_metal::MetalContext::instance().rtoptions();
+    return rtoptions.get_simulator_enabled() &&
+           tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::QUASAR;
+}
+
+// DRAM addresses for the SD (slow-dispatch) command queue on the Quasar simulator.
+// Bank 0 decodes only 64 MB; issue (8 MB) and completion (8 MB) sit at [48, 56) and [56, 64) MB
+// respectively, exactly filling the decoded window without aliasing into the low-memory region.
+static constexpr uint32_t kSdQuasarIssueBase = 0x3000000u;                                    // 48 MB
+static constexpr uint32_t kSdQuasarIssueSize = DispatchSettings::MAX_DEV_CHANNEL_SIZE / 32;   // 8 MB
+static constexpr uint32_t kSdQuasarCompletionBase = kSdQuasarIssueBase + kSdQuasarIssueSize;  // 56 MB
+static_assert(
+    kSdQuasarCompletionBase + kSdQuasarIssueSize <= QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE,
+    "SD CQ overruns Quasar DRAM bank-0 window");
+
 // BaseTestFixture forms the basis for prefetch and dispatcher tests.
 // Inherits from GenericMeshDeviceFixture which determines the mesh device type automatically
 class BaseTestFixture : public tt_metal::GenericMeshDeviceFixture {
@@ -975,6 +993,9 @@ protected:
     void SetUp() override {
         if (!validate_dispatch_mode()) {
             GTEST_SKIP();
+        }
+        if (is_quasar_sim()) {
+            GTEST_SKIP() << "FD unsupported on Quasar simulator: 256 MB DRAM-backed CQ overflows the 64 MB window";
         }
         tt_metal::GenericMeshDeviceFixture::SetUp();
 
@@ -1035,14 +1056,12 @@ protected:
     // queues must be stored in DRAM due to limitations, and only 64 MB of physical DRAM space
     // (QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE) is available even though the bank size is 1 GB. The remaining addresses
     // alias this physical space. The SD command queue must therefore fit in a single 64-MB window, so each half is
-    // capped at 16 MB on Quasar.
+    // capped at 8 MB on Quasar (matching kSdQuasarIssueSize so the host and kernel agree on the CQ wrap boundary).
     uint32_t sd_hugepage_issue_buffer_size() const {
-        return (device_->arch() == tt::ARCH::QUASAR) ? QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE / 4
-                                                     : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
+        return (device_->arch() == tt::ARCH::QUASAR) ? kSdQuasarIssueSize : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
     }
     uint32_t sd_completion_queue_size() const {
-        return (device_->arch() == tt::ARCH::QUASAR) ? QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE / 4
-                                                     : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
+        return (device_->arch() == tt::ARCH::QUASAR) ? kSdQuasarIssueSize : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
     }
 
     // Helper function that polls completion queue until expected data is written into by dispatcher

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -1238,7 +1238,7 @@ inline CoreCoord dispatch_core(const tt_metal::IDevice* device) {
 // SD drives only the core dispatch fields; all fabric-mux, multi-CQ, go-signal, and downstream
 // fields are zeroed since the spoof path never uses them.
 //
-// completion_queue_{base,size} default to 0 for SD dispatcher tests (no host-text writeback).
+// completion_queue_{base,size} default to 0 for SD dispatcher tests (no host-test writeback).
 // SD prefetcher tests that exercise host writeback must pass real values - cq_dispatch.cpp
 // computes the host PCIe destination from COMPLETION_QUEUE_BASE_ADDR.
 //

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -495,7 +495,7 @@ protected:
     }
 
     // Hooks that differ between FD and SD execution. Overridden in SDPrefetchTestBase /
-    // SDPrefetchHostTextFixture so the test bodies can be written once.
+    // SDPrefetchHostTestFixture so the test bodies can be written once.
     virtual void append_terminate_commands(std::vector<HostMemDeviceCommand>& cmds) {
         cmds.push_back(CommandBuilder::build_dispatch_terminate());
         cmds.push_back(CommandBuilder::build_prefetch_terminate());
@@ -1160,7 +1160,7 @@ public:
     }
 };
 
-class PrefetcherHostTextFixture : virtual public BasePrefetcherTestFixture {
+class PrefetcherHostTestFixture : virtual public BasePrefetcherTestFixture {
 protected:
     void pad_host_data(Common::DeviceData& device_data) {
         Common::one_core_data_t& host_data = device_data.get_data()[device_data.get_host_core()][0];
@@ -1310,7 +1310,7 @@ public:
         SmokeTestHelper helper(device_, device_data, commands_per_iteration, info);
 
         auto add_host_write_func = [this](Common::DeviceData& device_data) {
-            PrefetcherHostTextFixture::pad_host_data(device_data);
+            PrefetcherHostTestFixture::pad_host_data(device_data);
         };
 
         for (uint32_t multiplier = 1; multiplier < 3; multiplier++) {
@@ -2921,7 +2921,7 @@ class SDPrefetchDRAMToL1TestFixture : public SDPrefetchTestBase<BasePrefetcherTe
 class SDPrefetchPackedReadTestFixture : public SDPrefetchTestBase<PrefetcherPackedReadTestFixture> {};
 class SDPrefetchRandomTestFixture : public SDPrefetchTestBase<RandomTestFixture> {};
 
-class SDPrefetchHostTextFixture : public SDPrefetchTestBase<PrefetcherHostTextFixture> {
+class SDPrefetchHostTestFixture : public SDPrefetchTestBase<PrefetcherHostTestFixture> {
 public:
     // Completion-buffer hooks: in SD mode the dispatch kernel writes to the hugepage region
     // we set up ourselves (dev_hugepage_base + sd_hugepage_issue_buffer_size()), not to a
@@ -3009,8 +3009,8 @@ TEST_P(BasePrefetcherTestFixture, DRAMToL1PagedRead) {
 // In this test, the prefetcher reads from L1 and relays it to dispatcher. Dispatcher then
 // writes the data to the host completion queue.
 // Note: Since we're writing into completion queue, we skip distributed::Finish
-TEST_P(PrefetcherHostTextFixture, HostTest) {
-    log_info(tt::LogTest, "PrefetcherHostTextFixture - HostTest (Fast Dispatch) - Test Start");
+TEST_P(PrefetcherHostTestFixture, HostTest) {
+    log_info(tt::LogTest, "PrefetcherHostTestFixture - HostTest (Fast Dispatch) - Test Start");
     run_host_test();
 }
 
@@ -3180,8 +3180,8 @@ TEST_P(PrefetcherPackedReadTestFixture, SmokeTest) {
 // Smoke test for writes to Host from dispatcher
 // This needed to be separate since it executes differently than others
 // (we skip distributed::Finish)
-TEST_P(PrefetcherHostTextFixture, HostSmokeTest) {
-    log_info(tt::LogTest, "PrefetcherHostTextFixture - HostSmokeTest (Fast Dispatch) - Test Start");
+TEST_P(PrefetcherHostTestFixture, HostSmokeTest) {
+    log_info(tt::LogTest, "PrefetcherHostTestFixture - HostSmokeTest (Fast Dispatch) - Test Start");
     run_host_smoke_test();
 }
 
@@ -3391,13 +3391,13 @@ TEST_P(SDPrefetchPagedReadWriteTestFixture, PagedReadWriteTest) {
     run_paged_read_write_test();
 }
 
-TEST_P(SDPrefetchHostTextFixture, HostTest) {
-    log_info(tt::LogTest, "SDPrefetchHostTextFixture - HostTest (Slow Dispatch) - Test Start");
+TEST_P(SDPrefetchHostTestFixture, HostTest) {
+    log_info(tt::LogTest, "SDPrefetchHostTestFixture - HostTest (Slow Dispatch) - Test Start");
     run_host_test();
 }
 
-TEST_P(SDPrefetchHostTextFixture, HostSmokeTest) {
-    log_info(tt::LogTest, "SDPrefetchHostTextFixture - HostSmokeTest (Slow Dispatch) - Test Start");
+TEST_P(SDPrefetchHostTestFixture, HostSmokeTest) {
+    log_info(tt::LogTest, "SDPrefetchHostTestFixture - HostSmokeTest (Slow Dispatch) - Test Start");
     run_host_smoke_test();
 }
 
@@ -3486,10 +3486,10 @@ INSTANTIATE_TEST_SUITE_P(
                "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
     });
 
-// PrefetcherHostTextFixture test with exec buff enabled / disabled
+// PrefetcherHostTestFixture test with exec buff enabled / disabled
 INSTANTIATE_TEST_SUITE_P(
     PrefetcherTests,
-    PrefetcherHostTextFixture,
+    PrefetcherHostTestFixture,
     ::testing::Values(
         // With exec buf disabled
         PagedReadParams{
@@ -3701,7 +3701,7 @@ INSTANTIATE_TEST_SUITE_P(
 
 INSTANTIATE_TEST_SUITE_P(
     SlowDispatch,
-    SDPrefetchHostTextFixture,
+    SDPrefetchHostTestFixture,
     ::testing::Values(
         PagedReadParams{
             DRAM_PAGE_SIZE_DEFAULT,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -68,6 +68,7 @@ constexpr uint32_t DEFAULT_ITERATIONS = 5;
 constexpr uint32_t DEFAULT_ITERATIONS_SMOKE_RANDOM = 1000;
 constexpr uint32_t DEVICE_DATA_SIZE = 768 * 1024;
 constexpr uint32_t DEVICE_DATA_SIZE_LARGE = 20 * 1024 * 1024;
+constexpr uint32_t QUASAR_SIMULATION_DEVICE_DATA_SIZE = 96 * 1024;
 constexpr uint32_t DRAM_PAGE_SIZE_DEFAULT = 1024;
 constexpr uint32_t DRAM_PAGES_TO_READ_DEFAULT = 16;
 constexpr uint32_t DEFAULT_SCRATCH_DB_SIZE = 16 * 1024;
@@ -771,7 +772,7 @@ public:
         std::vector<HostMemDeviceCommand> commands_per_iteration;
         uint32_t absolute_start_page = 0;
         const uint32_t page_size_words = page_size_bytes / sizeof(uint32_t);
-        uint32_t remaining_bytes = DEVICE_DATA_SIZE;
+        uint32_t remaining_bytes = Common::is_quasar_sim() ? QUASAR_SIMULATION_DEVICE_DATA_SIZE : DEVICE_DATA_SIZE;
         const auto first_worker = worker_range.start_coord;
 
         // Compute NOC encoding once
@@ -832,7 +833,7 @@ public:
         const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
         std::vector<HostMemDeviceCommand> commands_per_iteration;
 
-        uint32_t remaining_bytes = DEVICE_DATA_SIZE;
+        uint32_t remaining_bytes = Common::is_quasar_sim() ? QUASAR_SIMULATION_DEVICE_DATA_SIZE : DEVICE_DATA_SIZE;
         uint32_t absolute_start_page = 0;
 
         while (remaining_bytes > 0) {
@@ -1209,7 +1210,8 @@ protected:
         uint32_t max_limit = max_data_size_words / 100;
 
         // Vary host write sizes up to 1% - 100% of max_data_size_words
-        for (uint32_t count = 1; count < 100; count++) {
+        const uint32_t max_count = Common::is_quasar_sim() ? 10 : 100;
+        for (uint32_t count = 1; count < max_count; count++) {
             uint32_t data_size_words = payload_generator_->get_rand<uint32_t>(0, max_limit - 1) * count + 1;
             uint32_t data_size_bytes = data_size_words * sizeof(uint32_t);
 
@@ -1236,7 +1238,7 @@ public:
     // Note: Since we're writing into completion queue, we skip distributed::Finish
     void run_host_test() {
         // Scale down data size on the Quasar simulator to avoid exceeding the 64 MB DRAM window.
-        const uint32_t max_data_size = Common::is_quasar_sim() ? (DEVICE_DATA_SIZE / 25) : DEVICE_DATA_SIZE;
+        const uint32_t max_data_size = Common::is_quasar_sim() ? QUASAR_SIMULATION_DEVICE_DATA_SIZE : DEVICE_DATA_SIZE;
         const uint32_t max_data_size_words = max_data_size / sizeof(uint32_t);
         const uint32_t dram_data_size_words = this->get_dram_data_size_words();
         const uint32_t num_iterations = this->get_num_iterations();
@@ -1405,14 +1407,18 @@ protected:
 
         std::vector<HostMemDeviceCommand> commands_per_iteration;
 
-        uint32_t remaining_bytes = DEVICE_DATA_SIZE;
+        const uint32_t device_data_size_bytes =
+            Common::is_quasar_sim() ? QUASAR_SIMULATION_DEVICE_DATA_SIZE : DEVICE_DATA_SIZE;
+        uint32_t remaining_bytes = device_data_size_bytes;
 
         constexpr uint32_t max_size128b = (DEFAULT_SCRATCH_DB_SIZE / 2) >> 7;
         while (remaining_bytes > 0) {
             uint32_t packed_read_page_size =
                 payload_generator_->get_rand<uint32_t>(0, 2) + 9;  // log2 values. i.e., 512, 1024, 2048
-            uint32_t n_sub_cmds = relay_max_packed_paged_submcds ? CQ_PREFETCH_CMD_RELAY_PAGED_PACKED_MAX_SUB_CMDS
-                                                                 : payload_generator_->get_rand<uint32_t>(0, 6) + 1;
+            const uint32_t max_n_sub_cmds =
+                Common::is_quasar_sim() ? 10 : CQ_PREFETCH_CMD_RELAY_PAGED_PACKED_MAX_SUB_CMDS;
+            uint32_t n_sub_cmds =
+                relay_max_packed_paged_submcds ? max_n_sub_cmds : payload_generator_->get_rand<uint32_t>(0, 6) + 1;
             uint32_t max_read_size = std::min((1 << packed_read_page_size) * num_banks_, remaining_bytes);
 
             std::vector<uint32_t> lengths;
@@ -1428,7 +1434,7 @@ protected:
             }
 
             // If we're about to exceed DEVICE_DATA_SIZE, then exit
-            if (device_data.size() * sizeof(uint32_t) + total_length > DEVICE_DATA_SIZE) {
+            if (device_data.size() * sizeof(uint32_t) + total_length > device_data_size_bytes) {
                 break;
             }
 
@@ -1653,8 +1659,9 @@ protected:
             device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, dest_dram_physical_core);
         const CoreCoord dest_dram_logical = device_->logical_core_from_dram_channel(dest_dram_channel);
 
-        // On Quasar, scale down from 20 MB to DEVICE_DATA_SIZE (768 KB) so the simulator finishes.
-        uint32_t remaining_bytes = Common::is_quasar_sim() ? DEVICE_DATA_SIZE : DEVICE_DATA_SIZE_LARGE;
+        const uint32_t device_data_size_bytes =
+            Common::is_quasar_sim() ? QUASAR_SIMULATION_DEVICE_DATA_SIZE : DEVICE_DATA_SIZE_LARGE;
+        uint32_t remaining_bytes = device_data_size_bytes;
         const uint32_t MAX_SUB_CMD_SIZE = tt::align(DEVICE_DATA_SIZE, l1_alignment);
 
         while (remaining_bytes >= MIN_READ_SIZE) {
@@ -1686,7 +1693,7 @@ protected:
             }
             EXPECT_GT(lengths.size(), 0u);
 
-            EXPECT_LE(total_length + (device_data.size() * sizeof(uint32_t)), DEVICE_DATA_SIZE_LARGE);
+            EXPECT_LE(total_length + (device_data.size() * sizeof(uint32_t)), device_data_size_bytes);
 
             const uint32_t dram_dest_addr = device_data.get_result_data_addr(dest_dram_logical, dest_bank_id);
 
@@ -1839,12 +1846,15 @@ public:
         const uint32_t noc_xy = device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, first_virt_worker);
         std::vector<HostMemDeviceCommand> commands_per_iteration;
 
-        uint32_t remaining_bytes = DEVICE_DATA_SIZE;
+        const uint32_t device_data_size_bytes =
+            Common::is_quasar_sim() ? QUASAR_SIMULATION_DEVICE_DATA_SIZE : DEVICE_DATA_SIZE;
+        uint32_t remaining_bytes = device_data_size_bytes;
 
         while (remaining_bytes > 0) {
             uint32_t ringbuffer_read_page_size_log2 =
                 payload_generator_->get_rand<uint32_t>(0, 2) + 9;  // log2 values. i.e., 512, 1024, 2048
-            uint32_t n_sub_cmds = payload_generator_->get_rand<uint32_t>(0, 6) + 1;
+            const uint32_t max_n_sub_cmds = Common::is_quasar_sim() ? 3 : 7;
+            uint32_t n_sub_cmds = payload_generator_->get_rand<uint32_t>(1, max_n_sub_cmds);
             uint32_t max_read_size = std::min((1 << ringbuffer_read_page_size_log2) * num_banks_, remaining_bytes);
 
             std::vector<uint32_t> lengths;
@@ -1861,7 +1871,7 @@ public:
             }
 
             // If we're about to exceed DEVICE_DATA_SIZE, then exit
-            if (device_data.size() * sizeof(uint32_t) + total_length > DEVICE_DATA_SIZE) {
+            if (device_data.size() * sizeof(uint32_t) + total_length > device_data_size_bytes) {
                 break;
             }
 
@@ -2496,7 +2506,7 @@ public:
         // PHASE 1: Generate random command metadata
         std::vector<HostMemDeviceCommand> commands_per_iteration;
 
-        uint32_t remaining_bytes = DEVICE_DATA_SIZE;
+        uint32_t remaining_bytes = Common::is_quasar_sim() ? QUASAR_SIMULATION_DEVICE_DATA_SIZE : DEVICE_DATA_SIZE;
 
         while (remaining_bytes > 0) {
             // Assumes terminate is the last command...

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -516,7 +516,7 @@ protected:
         const uint32_t num_pages = get_num_pages();
 
         // Setup target worker cores
-        const CoreRange worker_range(default_worker_start, default_worker_start);
+        const CoreRange worker_range = this->worker_range(this->worker_start(), /*multi_core=*/false);
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
@@ -546,7 +546,7 @@ protected:
         const uint32_t num_pages = get_num_pages();
 
         // Setup target worker cores
-        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord first_worker = this->worker_start();
         const CoreCoord last_worker = first_worker;  // {first_worker.x + 1, first_worker.y + 1};
         const CoreRange worker_range = {first_worker, last_worker};
 
@@ -575,7 +575,7 @@ protected:
         const uint32_t num_iterations = get_num_iterations();
         const uint32_t dram_data_size_words = get_dram_data_size_words();
 
-        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord first_worker = this->worker_start();
         const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
         const CoreRange worker_range = {first_worker, last_worker};
 
@@ -1225,7 +1225,8 @@ public:
     // writes the data to the host completion queue.
     // Note: Since we're writing into completion queue, we skip distributed::Finish
     void run_host_test() {
-        const uint32_t max_data_size = DEVICE_DATA_SIZE;
+        // Scale down data size on the Quasar simulator to avoid exceeding the 64 MB DRAM window.
+        const uint32_t max_data_size = Common::is_quasar_sim() ? (DEVICE_DATA_SIZE / 25) : DEVICE_DATA_SIZE;
         const uint32_t max_data_size_words = max_data_size / sizeof(uint32_t);
         const uint32_t dram_data_size_words = this->get_dram_data_size_words();
         const uint32_t num_iterations = this->get_num_iterations();
@@ -1236,7 +1237,7 @@ public:
         }
 
         // Setup target worker cores
-        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord first_worker = this->worker_start();
         const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
         const CoreRange worker_range = {first_worker, last_worker};
 
@@ -1283,7 +1284,7 @@ public:
         const uint32_t dram_data_size_words = get_dram_data_size_words();
 
         // Setup target worker cores
-        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord first_worker = this->worker_start();
         const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
         const CoreRange worker_range = {first_worker, last_worker};
 
@@ -1379,7 +1380,7 @@ protected:
                 uint32_t words = (page_size_words > length_words - i) ? length_words - i : page_size_words;
 
                 DeviceDataUpdater::update_read(
-                    default_worker_start, device_data, bank_core, dram_bank_id, bank_offset, words);
+                    this->worker_start(), device_data, bank_core, dram_bank_id, bank_offset, words);
 
                 page_idx++;
             }
@@ -1447,7 +1448,7 @@ public:
         const uint32_t dram_data_size_words = Common::DRAM_DATA_SIZE_WORDS;
 
         // Setup target worker cores
-        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord first_worker = this->worker_start();
         const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
         const CoreRange worker_range = {first_worker, last_worker};
 
@@ -1470,7 +1471,7 @@ public:
         const uint32_t dram_data_size_words = get_dram_data_size_words();
 
         // Setup target worker cores
-        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord first_worker = this->worker_start();
         const CoreCoord last_worker = first_worker;
         const CoreRange worker_range = {first_worker, last_worker};
 
@@ -1559,7 +1560,7 @@ public:
         helper.add_paged_dram_read(worker_range, 3, 128, page_size, length / page_size, 160);
 
         // Section 5: Inline packed writes
-        const CoreCoord first_worker_2x2 = default_worker_start;
+        const CoreCoord first_worker_2x2 = this->worker_start();
         const CoreCoord last_worker_2x2 = {first_worker_2x2.x + 1, first_worker_2x2.y + 1};
         const CoreRange worker_range_2x2 = {first_worker_2x2, last_worker_2x2};
         // Pick worker cores once for all commands
@@ -1645,7 +1646,8 @@ protected:
             device_->get_noc_unicast_encoding(k_dispatch_downstream_noc, dest_dram_physical_core);
         const CoreCoord dest_dram_logical = device_->logical_core_from_dram_channel(dest_dram_channel);
 
-        uint32_t remaining_bytes = DEVICE_DATA_SIZE_LARGE;
+        // On Quasar, scale down from 20 MB to DEVICE_DATA_SIZE (768 KB) so the simulator finishes.
+        uint32_t remaining_bytes = Common::is_quasar_sim() ? DEVICE_DATA_SIZE : DEVICE_DATA_SIZE_LARGE;
         const uint32_t MAX_SUB_CMD_SIZE = tt::align(DEVICE_DATA_SIZE, l1_alignment);
 
         while (remaining_bytes >= MIN_READ_SIZE) {
@@ -1712,7 +1714,7 @@ public:
     void run_linear_packed_read_test() {
         const uint32_t num_iterations = 1;
 
-        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord first_worker = this->worker_start();
         const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
         const CoreRange worker_range = {first_worker, last_worker};
 
@@ -1799,7 +1801,7 @@ public:
 
                 uint32_t words = (page_size_words > length_words - i) ? length_words - i : page_size_words;
                 DeviceDataUpdater::update_read(
-                    default_worker_start, device_data, bank_core, dram_bank_id, bank_offset, words);
+                    this->worker_start(), device_data, bank_core, dram_bank_id, bank_offset, words);
 
                 page_idx++;
             }
@@ -1881,7 +1883,7 @@ public:
         const uint32_t dram_data_size_words = get_dram_data_size_words();
 
         // Setup target worker cores
-        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord first_worker = this->worker_start();
         const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
         const CoreRange worker_range = {first_worker, last_worker};
 
@@ -2133,7 +2135,7 @@ public:
         std::vector<HostMemDeviceCommand> commands_per_iteration;
 
         // Source: L1 on MMIO device worker core (pre-populated with data)
-        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord first_worker = this->worker_start();
         const CoreCoord first_virt_worker =
             mmio_device_->virtual_core_from_logical_core(first_worker, CoreType::WORKER);
         const uint32_t src_noc_xy =
@@ -2413,7 +2415,7 @@ protected:
                     }
 
                     if (worker_cores.empty()) {
-                        worker_cores.push_back(default_worker_start);
+                        worker_cores.push_back(this->worker_start());
                     }
                     const uint32_t num_sub_cmds = static_cast<uint32_t>(worker_cores.size());
                     const uint32_t sub_cmds_bytes =
@@ -2478,7 +2480,7 @@ public:
         const uint32_t dram_data_size_words = get_dram_data_size_words();
 
         // Setup target worker cores
-        const CoreCoord first_worker = default_worker_start;
+        const CoreCoord first_worker = this->worker_start();
         const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
         const CoreRange worker_range = {first_worker, last_worker};
 
@@ -2599,6 +2601,14 @@ public:
             this->device_->compute_with_storage_grid_size().x * this->device_->compute_with_storage_grid_size().y;
 
         this->init_params(this->GetParam());
+
+        // On Quasar, the SD issue queue is fixed at kSdQuasarIssueBase. If the exec_buf base
+        // address (derived from the allocator) would overlap the issue queue, skip rather than
+        // overrun the CQ region and produce spurious command data.
+        if (Common::is_quasar_sim() && this->DRAM_EXEC_BUF_DEFAULT_BASE_ADDR >= Common::kSdQuasarIssueBase) {
+            GTEST_SKIP() << "SD exec_buf base " << this->DRAM_EXEC_BUF_DEFAULT_BASE_ADDR
+                         << " reaches the Quasar-sim SD issue queue at " << Common::kSdQuasarIssueBase;
+        }
     }
 
     void TearDown() override {
@@ -2644,23 +2654,29 @@ public:
         const uint32_t scratch_db_size = memmap.scratch_db_size();
 
         // Hugepage addressing
-        // Use the same hugepage region that the FD runtime uses for the issue queue
-        // (safe since SD mode never runs the FD runtime concurrently).
-        // Assumption: SD always runs on device 0 / cq_id 0 (see SetUp's CreateDevice(0)).
-        // For that configuration, get_absolute_cq_offset(channel, cq_id, cq_size) = 0, so
-        // dev_hugepage_base == get_host_command_queue_addr(UNRESERVED) lands in the same
-        // PCIe region the FD runtime would use.  If SD is ever extended to non-zero channel/
-        // cq_id, switch to get_absolute_cq_offset(...) + cq_start (mirroring topology.cpp).
-        const uint32_t dev_hugepage_base = memmap.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
-
-        const ChipId mmio_id =
-            tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_->id());
-        const uint16_t channel =
-            tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(this->device_->id());
-        char* hugepage_bar_base =
-            static_cast<char*>(tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_id, channel));
-        hugepage_bar_base += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
-        void* const host_hugepage_base = hugepage_bar_base + dev_hugepage_base;
+        // WH/BH stage commands in the PCIe hugepage (same region the FD runtime uses for the issue
+        // queue; safe since SD mode never runs the FD runtime concurrently). Quasar has no PCIe
+        // hugepage — commands are staged in DRAM bank 0 at Common::kSdQuasarIssueBase instead.
+        uint32_t dev_hugepage_base = 0;
+        void* host_hugepage_base = nullptr;
+        if (this->device_->arch() != tt::ARCH::QUASAR) {
+            dev_hugepage_base = memmap.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
+            const ChipId mmio_id =
+                tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_->id());
+            const uint16_t channel =
+                tt_metal::MetalContext::instance().get_cluster().get_assigned_channel_for_device(this->device_->id());
+            char* hugepage_bar_base = static_cast<char*>(
+                tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_id, channel));
+            hugepage_bar_base += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
+            host_hugepage_base = hugepage_bar_base + dev_hugepage_base;
+        } else {
+            TT_FATAL(
+                Common::kSdQuasarIssueBase >= this->dram_base_,
+                "SD DRAM command buffer ({:#x}) overlaps allocator region (base {:#x})",
+                Common::kSdQuasarIssueBase,
+                this->dram_base_);
+            dev_hugepage_base = Common::kSdQuasarIssueBase;
+        }
 
         // Physical cores
         const CoreCoord phys_prefetch = this->device_->worker_core_from_logical_core(Common::sd_prefetch_core);
@@ -2687,23 +2703,36 @@ public:
         const uint32_t prefetch_q_dev_fence = prefetch_q_base + prefetch_q_size;
 
         uint32_t* host_mem_ptr = static_cast<uint32_t*>(host_hugepage_base);
+        uint32_t dram_write_offset = 0;
 
         const uint32_t host_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
 
-        // write_prefetcher_cmd: streaming-store cmd to hugepage + write one FetchQ entry via TLB.
+        // write_prefetcher_cmd: streaming-store cmd to hugepage (WH/BH) or DRAM bank 0 (Quasar),
+        // then write one FetchQ entry via TLB.
         // cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the
         // pre-computed FetchQ value (may have MSB stall flag set for exec_buf).
         auto write_prefetcher_cmd = [&](const uint32_t* src, uint32_t cmd_size_bytes, uint32_t cmd_size_entry) {
-            const uint64_t host_offset =
-                static_cast<uint64_t>(reinterpret_cast<char*>(host_mem_ptr) - static_cast<char*>(host_hugepage_base));
-            TT_FATAL(
-                host_offset + cmd_size_bytes <= this->sd_hugepage_issue_buffer_size(),
-                "SD prefetch: command stream exceeds sd_hugepage_issue_buffer_size()");
-            tt::tt_metal::memcpy_to_device<true>(host_mem_ptr, src, cmd_size_bytes);
-            host_mem_ptr += cmd_size_bytes / sizeof(uint32_t);
-
+            if (Common::is_quasar_sim()) {
+                // DRAM path: write commands to DRAM bank 0 at kSdQuasarIssueBase. Wrap to base on overflow.
+                if (dram_write_offset + cmd_size_bytes > Common::kSdQuasarIssueSize) {
+                    dram_write_offset = 0;
+                }
+                tt::tt_metal::detail::WriteToDeviceDRAMChannel(
+                    this->device_,
+                    0,
+                    Common::kSdQuasarIssueBase + dram_write_offset,
+                    std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(src), cmd_size_bytes));
+                dram_write_offset += cmd_size_bytes;
+            } else {
+                const uint64_t host_offset = static_cast<uint64_t>(
+                    reinterpret_cast<char*>(host_mem_ptr) - static_cast<char*>(host_hugepage_base));
+                TT_FATAL(
+                    host_offset + cmd_size_bytes <= this->sd_hugepage_issue_buffer_size(),
+                    "SD prefetch: command stream exceeds sd_hugepage_issue_buffer_size()");
+                tt::tt_metal::memcpy_to_device<true>(host_mem_ptr, src, cmd_size_bytes);
+                host_mem_ptr += cmd_size_bytes / sizeof(uint32_t);
+            }
             prefetch_q_tlb->write32(prefetch_q_dev_ptr, cmd_size_entry);
-            // this->prefetch_q_windows[cq_id]->write32(this->prefetch_q_dev_ptrs[cq_id], entry_val);
             prefetch_q_dev_ptr += entry_size;
             if (prefetch_q_dev_ptr >= prefetch_q_dev_fence) {
                 prefetch_q_dev_ptr = prefetch_q_base;
@@ -2737,6 +2766,24 @@ public:
         // Terminate: dispatch_wait + dispatch_terminate + prefetch_terminate (shared by both paths).
         write_cmd(CommandBuilder::build_dispatch_terminate(/*include_dispatch_s*/ false));
         write_cmd(CommandBuilder::build_prefetch_terminate());
+
+        if (Common::is_quasar_sim()) {
+            // Flush all DRAM command writes so the kernel sees them when it starts.
+            cluster.dram_barrier(this->device_->id());
+            // Pre-fill the completion DRAM with the dirty pattern so page padding matches
+            // HOST_DATA_DIRTY_PATTERN validation in DeviceData::validate().
+            static constexpr uint32_t kChunkBytes = 64 * 1024;
+            std::vector<uint32_t> chunk(kChunkBytes / sizeof(uint32_t), this->HOST_DATA_DIRTY_PATTERN);
+            for (uint32_t offset = 0; offset < Common::kSdQuasarIssueSize; offset += kChunkBytes) {
+                const uint32_t chunk_bytes = std::min(kChunkBytes, Common::kSdQuasarIssueSize - offset);
+                tt::tt_metal::detail::WriteToDeviceDRAMChannel(
+                    this->device_,
+                    0,
+                    Common::kSdQuasarCompletionBase + offset,
+                    std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(chunk.data()), chunk_bytes));
+            }
+            cluster.dram_barrier(this->device_->id());
+        }
 
         // Semaphores
         tt_metal::Program program = tt_metal::CreateProgram();
@@ -2835,6 +2882,9 @@ public:
         tt_metal::detail::LaunchProgram(this->device_, program);
         // Ensure host CPU sees any PCIe-written completion queue data before validating.
         tt_driver_atomics::mfence();
+        // On Quasar the completion queue lives in DRAM; read it back into the host staging buffer
+        // before validate() (which reads from get_completion_queue_buffer()).
+        this->refresh_completion_data();
         EXPECT_TRUE(device_data.validate(this->device_)) << "SD prefetch test failed validation";
     }
 
@@ -2842,6 +2892,11 @@ public:
     // prefetch_terminate so LaunchProgram can return. The unified test bodies must not
     // re-append them, so this hook becomes a no-op in SD.
     void append_terminate_commands(std::vector<HostMemDeviceCommand>& /*cmds*/) override {}
+
+    // Called after LaunchProgram and before device_data.validate(). On Quasar the completion queue
+    // lives in DRAM bank 0 and must be read back into the host staging buffer before validation.
+    // Default no-op (WH/BH completion queue is in PCIe-mapped host memory — already visible).
+    virtual void refresh_completion_data() {}
 
 private:
     // Orchestrates exec_buf execution: builds DRAM payload, writes to DRAM, then issues the
@@ -2871,7 +2926,15 @@ public:
     // Completion-buffer hooks: in SD mode the dispatch kernel writes to the hugepage region
     // we set up ourselves (dev_hugepage_base + sd_hugepage_issue_buffer_size()), not to a
     // runtime-managed FDMeshCommandQueue completion queue.
+    //
+    // WH/BH: points into the host-mapped hugepage at dev_hugepage_base + issue_buffer_size.
+    // Quasar: points into a host-side staging buffer; refresh_completion_data() fills it from DRAM
+    //         at Common::kSdQuasarCompletionBase before validate() is called.
     void* get_completion_queue_buffer() override {
+        if (this->device_->arch() == tt::ARCH::QUASAR) {
+            quasar_completion_buf_.resize(Common::kSdQuasarIssueSize);
+            return quasar_completion_buf_.data();
+        }
         const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
         const uint32_t dev_hugepage_base = memmap.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
         const ChipId mmio_id =
@@ -2884,6 +2947,46 @@ public:
         return hugepage_bar_base + dev_hugepage_base + this->sd_hugepage_issue_buffer_size();
     }
     uint32_t get_completion_queue_buffer_size() override { return this->sd_completion_queue_size(); }
+
+    void refresh_completion_data() override {
+        if (this->device_->arch() == tt::ARCH::QUASAR) {
+            // Read the dispatch kernel's DRAM completion writes into the host staging buffer so
+            // device_data.validate() sees the correct data.
+            const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
+            const CoreCoord phys_disp =
+                this->device_->worker_core_from_logical_core(Common::dispatch_core(this->device_));
+            const tt_cxy_pair dispatch_cxy(this->device_->id(), phys_disp);
+            const uint32_t completion_q_wr_l1 =
+                memmap.get_device_command_queue_addr(CommandQueueDeviceAddrType::COMPLETION_Q_WR);
+
+            uint32_t wr_ptr_and_toggle = 0;
+            tt_metal::MetalContext::instance().get_cluster().read_core(
+                &wr_ptr_and_toggle, sizeof(wr_ptr_and_toggle), dispatch_cxy, completion_q_wr_l1);
+
+            // The write pointer is stored in 16-byte units; strip the toggle bit.
+            constexpr uint32_t toggle_mask = ~(1u << 31);
+            const uint32_t wr_ptr_16B = wr_ptr_and_toggle & toggle_mask;
+            const uint32_t completion_base_16B = Common::kSdQuasarCompletionBase >> 4;
+            if (wr_ptr_16B <= completion_base_16B) {
+                return;
+            }
+            const uint32_t bytes_written = (wr_ptr_16B - completion_base_16B) * 16;
+            TT_FATAL(
+                bytes_written <= Common::kSdQuasarIssueSize,
+                "Quasar SD completion readback exceeds queue size ({} > {})",
+                bytes_written,
+                Common::kSdQuasarIssueSize);
+
+            tt::tt_metal::detail::ReadFromDeviceDRAMChannel(
+                this->device_,
+                0,
+                Common::kSdQuasarCompletionBase,
+                std::span<uint8_t>(quasar_completion_buf_.data(), bytes_written));
+        }
+    }
+
+private:
+    std::vector<uint8_t> quasar_completion_buf_;
 };
 
 class SDPrefetchLinearPackedReadTestFixture : public SDPrefetchTestBase<PrefetcherLinearPackedReadTestFixture> {};
@@ -2963,7 +3066,7 @@ TEST_P(PrefetchRelayLinearHTestFixture, RelayLinearHTest) {
     const uint32_t dram_data_size_words = get_dram_data_size_words();
 
     // Setup dummy worker cores (not actually used for writes, but needed for DeviceData init)
-    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord first_worker = this->worker_start();
     const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
@@ -3014,7 +3117,7 @@ TEST_P(PrefetcherLinearPackedHTestFixture, RelayLinearPackedHTest) {
     const uint32_t dram_data_size_words = get_dram_data_size_words();
 
     // Setup worker cores
-    const CoreCoord first_worker = default_worker_start;
+    const CoreCoord first_worker = this->worker_start();
     const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
@@ -3096,8 +3199,8 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
     TT_FATAL(page_size_bytes % sizeof(uint32_t) == 0U, "page_size_bytes must be a multiple of 4");
 
     // Dummy worker range (not the destination of this test) for DeviceData init.
-    constexpr CoreCoord first_worker = default_worker_start;
-    constexpr CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
+    const CoreCoord first_worker = this->worker_start();
+    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
     const CoreRange worker_range = {first_worker, last_worker};
 
     const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -16,6 +16,7 @@
 #include "tt_metal/impl/context/metal_context.hpp"
 #include <tt-metalium/tt_align.hpp>
 #include "tt_metal/impl/dispatch/topology.hpp"
+#include "tt_metal/impl/host_api/temp_quasar_api.hpp"
 #include "tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h"
 #include <impl/dispatch/dispatch_query_manager.hpp>
 #include "tt_metal/impl/dispatch/memcpy.hpp"
@@ -2799,21 +2800,35 @@ public:
         // Semaphores
         tt_metal::Program program = tt_metal::CreateProgram();
 
-        // Slot 0: prefetch_sync_sem - dispatch signals prefetch when a stall round-trip is done.
-        const uint32_t pf_sync_sem = tt_metal::CreateSemaphore(program, {Common::sd_prefetch_core}, 0u);
-        const uint32_t di_sync_sem = tt_metal::CreateSemaphore(program, {Common::dispatch_core(this->device_)}, 0u);
-        TT_FATAL(pf_sync_sem == di_sync_sem, "prefetch_sync_sem slot mismatch ({} vs {})", pf_sync_sem, di_sync_sem);
+        // Semaphore slots. On WH/BH prefetch and dispatch are on different cores, so each pair of sems
+        // lands at the same per-core slot id (the equality asserts below hold). On Quasar both kernels
+        // share core {0,0}, so every CreateSemaphore consumes a distinct slot: create a single sync sem
+        // (used by both kernels) and let the two CB sems take their own slots. The distinct ids are
+        // threaded into each kernel's defines, which is correct on both arches (ids are equal on WH/BH).
+        const bool fd_kernels_on_same_core = (phys_prefetch == phys_disp);
 
-        // Slot 1: downstream_cb_sem on prefetch (init=dispatch_buffer_pages); dispatch_cb_sem on dispatch (init=0).
+        // prefetch_sync_sem: dispatch signals prefetch when a stall round-trip is done.
+        const uint32_t pf_sync_sem = tt_metal::CreateSemaphore(program, {Common::sd_prefetch_core}, 0u);
+        uint32_t di_sync_sem = pf_sync_sem;
+        if (!fd_kernels_on_same_core) {
+            di_sync_sem = tt_metal::CreateSemaphore(program, {Common::dispatch_core(this->device_)}, 0u);
+            TT_FATAL(
+                pf_sync_sem == di_sync_sem, "prefetch_sync_sem slot mismatch ({} vs {})", pf_sync_sem, di_sync_sem);
+        }
+
+        // downstream_cb_sem on prefetch (init=dispatch_buffer_pages, the credit pool); dispatch_cb_sem on
+        // dispatch (init=0, the received-pages count).
         const uint32_t pf_downstream_cb_sem =
             tt_metal::CreateSemaphore(program, {Common::sd_prefetch_core}, dispatch_buffer_pages);
         const uint32_t di_dispatch_cb_sem =
             tt_metal::CreateSemaphore(program, {Common::dispatch_core(this->device_)}, 0u);
-        TT_FATAL(
-            pf_downstream_cb_sem == di_dispatch_cb_sem,
-            "dispatch_cb sem slot mismatch ({} vs {})",
-            pf_downstream_cb_sem,
-            di_dispatch_cb_sem);
+        if (!fd_kernels_on_same_core) {
+            TT_FATAL(
+                pf_downstream_cb_sem == di_dispatch_cb_sem,
+                "dispatch_cb sem slot mismatch ({} vs {})",
+                pf_downstream_cb_sem,
+                di_dispatch_cb_sem);
+        }
 
         // Kernel defines and creation
         auto prefetch_defines = Common::make_sd_prefetch_defines(
@@ -2831,18 +2846,32 @@ public:
             dispatch_cb_base,
             dispatch_buffer_pages,
             pf_downstream_cb_sem,
+            di_dispatch_cb_sem,
             pf_sync_sem,
             entry_size,
             phys_prefetch,
             phys_disp);
-        auto prefetch_kernel = tt_metal::CreateKernel(
-            program,
-            "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
-            {Common::sd_prefetch_core},
-            tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_0,
-                .noc = tt_metal::NOC::NOC_0,
-                .defines = prefetch_defines});
+        // On Quasar prefetch and dispatch share core {0,0}; the experimental API auto-assigns DM
+        // cores, so prefetch must be created before dispatch to land on DM0 (dispatch then gets DM1),
+        // mirroring the merged SD dispatcher test. is_legacy_kernel ports the WH/BH kernel unchanged.
+        tt_metal::KernelHandle prefetch_kernel;
+        if (this->device_->arch() == tt::ARCH::QUASAR) {
+            prefetch_kernel = tt::tt_metal::experimental::quasar::CreateKernel(
+                program,
+                "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
+                Common::sd_prefetch_core,
+                tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                    .num_threads_per_cluster = 1, .defines = prefetch_defines, .is_legacy_kernel = true});
+        } else {
+            prefetch_kernel = tt_metal::CreateKernel(
+                program,
+                "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
+                {Common::sd_prefetch_core},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::NOC_0,
+                    .defines = prefetch_defines});
+        }
         tt_metal::SetRuntimeArgs(program, prefetch_kernel, Common::sd_prefetch_core, {0u, 0u, 0u});
 
         const uint32_t dev_completion_base = dev_hugepage_base + this->sd_hugepage_issue_buffer_size();
@@ -2850,7 +2879,7 @@ public:
             this->device_,
             dispatch_buffer_pages,
             di_dispatch_cb_sem,
-            di_dispatch_cb_sem,
+            pf_downstream_cb_sem,
             di_sync_sem,
             phys_prefetch,
             phys_disp,
@@ -2858,14 +2887,25 @@ public:
             memmap.dispatch_buffer_base(),
             dev_completion_base,
             this->sd_completion_queue_size());
-        auto dispatch_kernel = tt_metal::CreateKernel(
-            program,
-            "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
-            {Common::dispatch_core(this->device_)},
-            tt_metal::DataMovementConfig{
-                .processor = tt_metal::DataMovementProcessor::RISCV_0,
-                .noc = tt_metal::NOC::NOC_0,
-                .defines = dispatch_defines});
+        tt_metal::KernelHandle dispatch_kernel;
+        if (this->device_->arch() == tt::ARCH::QUASAR) {
+            // prefetch already occupies DM0 on this shared core, so dispatch auto-assigns to DM1.
+            dispatch_kernel = tt::tt_metal::experimental::quasar::CreateKernel(
+                program,
+                "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
+                Common::dispatch_core(this->device_),
+                tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                    .num_threads_per_cluster = 1, .defines = dispatch_defines, .is_legacy_kernel = true});
+        } else {
+            dispatch_kernel = tt_metal::CreateKernel(
+                program,
+                "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
+                {Common::dispatch_core(this->device_)},
+                tt_metal::DataMovementConfig{
+                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
+                    .noc = tt_metal::NOC::NOC_0,
+                    .defines = dispatch_defines});
+        }
         tt_metal::SetRuntimeArgs(program, dispatch_kernel, Common::dispatch_core(this->device_), {0u, 0u, 0u});
 
         // Initialize the dispatcher's completion queue write/read pointers in L1, mirroring
@@ -3711,18 +3751,8 @@ INSTANTIATE_TEST_SUITE_P(
     SlowDispatch,
     SDPrefetchHostTestFixture,
     ::testing::Values(
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            false},
-        PagedReadParams{
-            DRAM_PAGE_SIZE_DEFAULT,
-            DRAM_PAGES_TO_READ_DEFAULT,
-            DEFAULT_ITERATIONS,
-            Common::DRAM_DATA_SIZE_WORDS,
-            true}),
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
     [](const testing::TestParamInfo<PagedReadParams>& info) {
         return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
                std::to_string(info.param.num_iterations) + "iter_" +

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -427,6 +427,18 @@ protected:
     static constexpr uint32_t DRAM_EXEC_BUF_DEFAULT_BASE_ADDR = 0x1f400000;  // Magic, half of dram
     static constexpr uint32_t DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE = 10;
 
+    // Exec buffer DRAM base: on the Quasar simulator, place it just above THIS test's bank-0 data
+    // (per-bank prepopulate + DRAM-result headroom) so it stays below the fixed SD issue queue;
+    // elsewhere keep the default. Tests whose data alone reaches the issue queue are skipped in
+    // SetUp, so any test that runs has room left for its (small) exec buffer.
+    uint32_t compute_exec_buf_base_addr() const {
+        if (!Common::is_quasar_sim()) {
+            return DRAM_EXEC_BUF_DEFAULT_BASE_ADDR;
+        }
+        const uint32_t bank0_data_bytes = dram_data_size_words_ * sizeof(uint32_t) + DEVICE_DATA_SIZE;
+        return tt::align(dram_base_ + bank0_data_bytes, 1u << DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE);
+    }
+
     // Default values for inline data and flush prefetch for prefetcher tests
     static constexpr bool inline_data_ = false;
     static constexpr bool flush_prefetch_ = false;
@@ -668,7 +680,7 @@ public:
         exec_buf_data.insert(exec_buf_data.end(), tptr, tptr + exec_terminate.size_bytes());
 
         const uint32_t page_size = 1u << DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE;
-        const uint32_t exec_buf_base_addr = DRAM_EXEC_BUF_DEFAULT_BASE_ADDR;
+        const uint32_t exec_buf_base_addr = compute_exec_buf_base_addr();
         const size_t size_bytes = exec_buf_data.size();
         const size_t padded_size_bytes = tt::align(size_bytes, static_cast<size_t>(page_size));
         exec_buf_data.resize(padded_size_bytes, 0u);
@@ -716,7 +728,7 @@ private:
         // Use DeviceCommand helper (HugepageDeviceCommand) to write to the issue queue memory
         HugepageDeviceCommand exec_cmd(cmd_buffer_base, cmd_size);
         exec_cmd.add_prefetch_exec_buf(
-            fixture.DRAM_EXEC_BUF_DEFAULT_BASE_ADDR, fixture.DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
+            fixture.compute_exec_buf_base_addr(), fixture.DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
 
         // Verifies destination memory bounds
         device_data.overflow_check(device_);
@@ -2597,8 +2609,8 @@ public:
         // On Quasar, the SD issue queue is fixed at kSdQuasarIssueBase. If the exec_buf base
         // address (derived from the allocator) would overlap the issue queue, skip rather than
         // overrun the CQ region and produce spurious command data.
-        if (Common::is_quasar_sim() && this->DRAM_EXEC_BUF_DEFAULT_BASE_ADDR >= Common::kSdQuasarIssueBase) {
-            GTEST_SKIP() << "SD exec_buf base " << this->DRAM_EXEC_BUF_DEFAULT_BASE_ADDR
+        if (Common::is_quasar_sim() && this->compute_exec_buf_base_addr() >= Common::kSdQuasarIssueBase) {
+            GTEST_SKIP() << "SD exec_buf base " << this->compute_exec_buf_base_addr()
                          << " reaches the Quasar-sim SD issue queue at " << Common::kSdQuasarIssueBase;
         }
     }
@@ -2904,7 +2916,7 @@ private:
         exec_buf_calc.add_prefetch_exec_buf();
         HostMemDeviceCommand exec_cmd(exec_buf_calc.write_offset_bytes());
         exec_cmd.add_prefetch_exec_buf(
-            this->DRAM_EXEC_BUF_DEFAULT_BASE_ADDR, this->DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
+            this->compute_exec_buf_base_addr(), this->DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE, num_pages);
         write_cmd(exec_cmd, /*stall*/ true);
     }
 };

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -436,7 +436,7 @@ protected:
         // On the Quasar simulator, place the exec buffer just above the test's bank data so it stays below the issue
         // queue. Tests whose data alone reaches the issue queue are skipped, so any test that runs has room left for
         // its exec buffer.
-        const uint32_t bank_data_bytes = dram_data_size_words_ * sizeof(uint32_t) + DEVICE_DATA_SIZE;
+        const uint32_t bank_data_bytes = dram_data_size_words_ * sizeof(uint32_t) + QUASAR_SIMULATION_DEVICE_DATA_SIZE;
         return tt::align(dram_base_ + bank_data_bytes, 1u << DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE);
     }
 
@@ -2726,16 +2726,14 @@ public:
 
         const uint32_t host_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
 
-        // write_prefetcher_cmd: streaming-store cmd to hugepage (WH/BH) or DRAM bank 0 (Quasar),
-        // then write one FetchQ entry via TLB.
-        // cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the
-        // pre-computed FetchQ value (may have MSB stall flag set for exec_buf).
+        // write_prefetcher_cmd: streaming-store cmd to hugepage (WH/BH) or DRAM (Quasar), then write one FetchQ entry
+        // via TLB. cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the pre-computed
+        // FetchQ value (may have MSB stall flag set for exec_buf).
         auto write_prefetcher_cmd = [&](const uint32_t* src, uint32_t cmd_size_bytes, uint32_t cmd_size_entry) {
             if (Common::is_quasar_sim()) {
-                // DRAM path: write commands to DRAM at QUASAR_SIMULATION_ISSUE_QUEUE_BASE. Wrap to base on overflow.
-                if (dram_write_offset + cmd_size_bytes > Common::QUASAR_SIMULATION_ISSUE_QUEUE_SIZE) {
-                    dram_write_offset = 0;
-                }
+                TT_FATAL(
+                    dram_write_offset + cmd_size_bytes <= Common::QUASAR_SIMULATION_ISSUE_QUEUE_SIZE,
+                    "SD prefetch: command stream exceeds QUASAR_SIMULATION_ISSUE_QUEUE_SIZE");
                 tt::tt_metal::detail::WriteToDeviceDRAMChannel(
                     this->device_,
                     0,

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -428,16 +428,15 @@ protected:
     static constexpr uint32_t DRAM_EXEC_BUF_DEFAULT_BASE_ADDR = 0x1f400000;  // Magic, half of dram
     static constexpr uint32_t DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE = 10;
 
-    // Exec buffer DRAM base: on the Quasar simulator, place it just above THIS test's bank-0 data
-    // (per-bank prepopulate + DRAM-result headroom) so it stays below the fixed SD issue queue;
-    // elsewhere keep the default. Tests whose data alone reaches the issue queue are skipped in
-    // SetUp, so any test that runs has room left for its (small) exec buffer.
     uint32_t compute_exec_buf_base_addr() const {
         if (!Common::is_quasar_sim()) {
             return DRAM_EXEC_BUF_DEFAULT_BASE_ADDR;
         }
-        const uint32_t bank0_data_bytes = dram_data_size_words_ * sizeof(uint32_t) + DEVICE_DATA_SIZE;
-        return tt::align(dram_base_ + bank0_data_bytes, 1u << DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE);
+        // On the Quasar simulator, place the exec buffer just above the test's bank data so it stays below the issue
+        // queue. Tests whose data alone reaches the issue queue are skipped, so any test that runs has room left for
+        // its exec buffer.
+        const uint32_t bank_data_bytes = dram_data_size_words_ * sizeof(uint32_t) + DEVICE_DATA_SIZE;
+        return tt::align(dram_base_ + bank_data_bytes, 1u << DRAM_EXEC_BUF_DEFAULT_LOG_PAGE_SIZE);
     }
 
     // Default values for inline data and flush prefetch for prefetcher tests
@@ -2611,12 +2610,13 @@ public:
 
         this->init_params(this->GetParam());
 
-        // On Quasar, the SD issue queue is fixed at kSdQuasarIssueBase. If the exec_buf base
-        // address (derived from the allocator) would overlap the issue queue, skip rather than
-        // overrun the CQ region and produce spurious command data.
-        if (Common::is_quasar_sim() && this->compute_exec_buf_base_addr() >= Common::kSdQuasarIssueBase) {
-            GTEST_SKIP() << "SD exec_buf base " << this->compute_exec_buf_base_addr()
-                         << " reaches the Quasar-sim SD issue queue at " << Common::kSdQuasarIssueBase;
+        // On Quasar simulator, the issue queue is fixed at QUASAR_SIMULATION_ISSUE_QUEUE_BASE. If the exec_buf base
+        // address would overlap the issue queue, skip the test rather than overrun the CQ region.
+        if (Common::is_quasar_sim() &&
+            this->compute_exec_buf_base_addr() >= Common::QUASAR_SIMULATION_ISSUE_QUEUE_BASE) {
+            GTEST_SKIP() << "exec_buf base " << this->compute_exec_buf_base_addr()
+                         << " reaches the Quasar simulator issue queue at "
+                         << Common::QUASAR_SIMULATION_ISSUE_QUEUE_BASE;
         }
     }
 
@@ -2664,11 +2664,11 @@ public:
 
         // Hugepage addressing
         // WH/BH stage commands in the PCIe hugepage (same region the FD runtime uses for the issue
-        // queue; safe since SD mode never runs the FD runtime concurrently). Quasar has no PCIe
-        // hugepage — commands are staged in DRAM bank 0 at Common::kSdQuasarIssueBase instead.
+        // queue; safe since SD mode never runs the FD runtime concurrently). Quasar simulator has no PCIe
+        // hugepage — commands are staged in DRAM at QUASAR_SIMULATION_ISSUE_QUEUE_BASE instead.
         uint32_t dev_hugepage_base = 0;
         void* host_hugepage_base = nullptr;
-        if (this->device_->arch() != tt::ARCH::QUASAR) {
+        if (!Common::is_quasar_sim()) {
             dev_hugepage_base = memmap.get_host_command_queue_addr(CommandQueueHostAddrType::UNRESERVED);
             const ChipId mmio_id =
                 tt_metal::MetalContext::instance().get_cluster().get_associated_mmio_device(this->device_->id());
@@ -2680,11 +2680,11 @@ public:
             host_hugepage_base = hugepage_bar_base + dev_hugepage_base;
         } else {
             TT_FATAL(
-                Common::kSdQuasarIssueBase >= this->dram_base_,
+                Common::QUASAR_SIMULATION_ISSUE_QUEUE_BASE >= this->dram_base_,
                 "SD DRAM command buffer ({:#x}) overlaps allocator region (base {:#x})",
-                Common::kSdQuasarIssueBase,
+                Common::QUASAR_SIMULATION_ISSUE_QUEUE_BASE,
                 this->dram_base_);
-            dev_hugepage_base = Common::kSdQuasarIssueBase;
+            dev_hugepage_base = Common::QUASAR_SIMULATION_ISSUE_QUEUE_BASE;
         }
 
         // Physical cores
@@ -2722,22 +2722,22 @@ public:
         // pre-computed FetchQ value (may have MSB stall flag set for exec_buf).
         auto write_prefetcher_cmd = [&](const uint32_t* src, uint32_t cmd_size_bytes, uint32_t cmd_size_entry) {
             if (Common::is_quasar_sim()) {
-                // DRAM path: write commands to DRAM bank 0 at kSdQuasarIssueBase. Wrap to base on overflow.
-                if (dram_write_offset + cmd_size_bytes > Common::kSdQuasarIssueSize) {
+                // DRAM path: write commands to DRAM at QUASAR_SIMULATION_ISSUE_QUEUE_BASE. Wrap to base on overflow.
+                if (dram_write_offset + cmd_size_bytes > Common::QUASAR_SIMULATION_ISSUE_QUEUE_SIZE) {
                     dram_write_offset = 0;
                 }
                 tt::tt_metal::detail::WriteToDeviceDRAMChannel(
                     this->device_,
                     0,
-                    Common::kSdQuasarIssueBase + dram_write_offset,
+                    Common::QUASAR_SIMULATION_ISSUE_QUEUE_BASE + dram_write_offset,
                     std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(src), cmd_size_bytes));
                 dram_write_offset += cmd_size_bytes;
             } else {
                 const uint64_t host_offset = static_cast<uint64_t>(
                     reinterpret_cast<char*>(host_mem_ptr) - static_cast<char*>(host_hugepage_base));
                 TT_FATAL(
-                    host_offset + cmd_size_bytes <= this->sd_hugepage_issue_buffer_size(),
-                    "SD prefetch: command stream exceeds sd_hugepage_issue_buffer_size()");
+                    host_offset + cmd_size_bytes <= this->sd_issue_queue_size(),
+                    "SD prefetch: command stream exceeds sd_issue_queue_size()");
                 tt::tt_metal::memcpy_to_device<true>(host_mem_ptr, src, cmd_size_bytes);
                 host_mem_ptr += cmd_size_bytes / sizeof(uint32_t);
             }
@@ -2783,12 +2783,13 @@ public:
             // HOST_DATA_DIRTY_PATTERN validation in DeviceData::validate().
             static constexpr uint32_t kChunkBytes = 64 * 1024;
             std::vector<uint32_t> chunk(kChunkBytes / sizeof(uint32_t), this->HOST_DATA_DIRTY_PATTERN);
-            for (uint32_t offset = 0; offset < Common::kSdQuasarIssueSize; offset += kChunkBytes) {
-                const uint32_t chunk_bytes = std::min(kChunkBytes, Common::kSdQuasarIssueSize - offset);
+            for (uint32_t offset = 0; offset < Common::QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE; offset += kChunkBytes) {
+                const uint32_t chunk_bytes =
+                    std::min(kChunkBytes, Common::QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE - offset);
                 tt::tt_metal::detail::WriteToDeviceDRAMChannel(
                     this->device_,
                     0,
-                    Common::kSdQuasarCompletionBase + offset,
+                    Common::QUASAR_SIMULATION_COMPLETION_QUEUE_BASE + offset,
                     std::span<const uint8_t>(reinterpret_cast<const uint8_t*>(chunk.data()), chunk_bytes));
             }
             cluster.dram_barrier(this->device_->id());
@@ -2831,7 +2832,7 @@ public:
         auto prefetch_defines = Common::make_sd_prefetch_defines(
             this->device_,
             dev_hugepage_base,
-            this->sd_hugepage_issue_buffer_size(),
+            this->sd_issue_queue_size(),
             prefetch_q_base,
             prefetch_q_size,
             prefetch_q_rd_ptr_addr,
@@ -2875,7 +2876,7 @@ public:
             "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp", Common::sd_prefetch_core, prefetch_defines);
         tt_metal::SetRuntimeArgs(program, prefetch_kernel, Common::sd_prefetch_core, {0u, 0u, 0u});
 
-        const uint32_t dev_completion_base = dev_hugepage_base + this->sd_hugepage_issue_buffer_size();
+        const uint32_t dev_completion_base = dev_hugepage_base + this->sd_issue_queue_size();
         auto dispatch_defines = Common::make_sd_dispatch_defines(
             this->device_,
             dispatch_buffer_pages,
@@ -2960,15 +2961,15 @@ class SDPrefetchRandomTestFixture : public SDPrefetchTestBase<RandomTestFixture>
 class SDPrefetchHostTestFixture : public SDPrefetchTestBase<PrefetcherHostTestFixture> {
 public:
     // Completion-buffer hooks: in SD mode the dispatch kernel writes to the hugepage region
-    // we set up ourselves (dev_hugepage_base + sd_hugepage_issue_buffer_size()), not to a
+    // we set up ourselves (dev_hugepage_base + sd_issue_queue_size()), not to a
     // runtime-managed FDMeshCommandQueue completion queue.
     //
-    // WH/BH: points into the host-mapped hugepage at dev_hugepage_base + issue_buffer_size.
-    // Quasar: points into a host-side staging buffer; refresh_completion_data() fills it from DRAM
-    //         at Common::kSdQuasarCompletionBase before validate() is called.
+    // WH/BH: points into the host-mapped hugepage at dev_hugepage_base + issue_queue_size.
+    // Quasar simulator: points into a host-side staging buffer; refresh_completion_data() fills it from DRAM at
+    // QUASAR_SIMULATION_COMPLETION_QUEUE_BASE before validate() is called.
     void* get_completion_queue_buffer() override {
-        if (this->device_->arch() == tt::ARCH::QUASAR) {
-            quasar_completion_buf_.resize(Common::kSdQuasarIssueSize);
+        if (Common::is_quasar_sim()) {
+            quasar_completion_buf_.resize(Common::QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE);
             return quasar_completion_buf_.data();
         }
         const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
@@ -2980,12 +2981,12 @@ public:
         char* hugepage_bar_base =
             static_cast<char*>(tt_metal::MetalContext::instance().get_cluster().host_dma_address(0, mmio_id, channel));
         hugepage_bar_base += (channel >> 2) * DispatchSettings::MAX_DEV_CHANNEL_SIZE;
-        return hugepage_bar_base + dev_hugepage_base + this->sd_hugepage_issue_buffer_size();
+        return hugepage_bar_base + dev_hugepage_base + this->sd_issue_queue_size();
     }
     uint32_t get_completion_queue_buffer_size() override { return this->sd_completion_queue_size(); }
 
     void refresh_completion_data() override {
-        if (this->device_->arch() == tt::ARCH::QUASAR) {
+        if (Common::is_quasar_sim()) {
             // Read the dispatch kernel's DRAM completion writes into the host staging buffer so
             // device_data.validate() sees the correct data.
             const auto& memmap = tt_metal::MetalContext::instance().dispatch_mem_map(CoreType::WORKER);
@@ -3002,21 +3003,21 @@ public:
             // The write pointer is stored in 16-byte units; strip the toggle bit.
             constexpr uint32_t toggle_mask = ~(1u << 31);
             const uint32_t wr_ptr_16B = wr_ptr_and_toggle & toggle_mask;
-            const uint32_t completion_base_16B = Common::kSdQuasarCompletionBase >> 4;
+            const uint32_t completion_base_16B = Common::QUASAR_SIMULATION_COMPLETION_QUEUE_BASE >> 4;
             if (wr_ptr_16B <= completion_base_16B) {
                 return;
             }
             const uint32_t bytes_written = (wr_ptr_16B - completion_base_16B) * 16;
             TT_FATAL(
-                bytes_written <= Common::kSdQuasarIssueSize,
-                "Quasar SD completion readback exceeds queue size ({} > {})",
+                bytes_written <= Common::QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE,
+                "Quasar simulator completion readback exceeds queue size ({} > {})",
                 bytes_written,
-                Common::kSdQuasarIssueSize);
+                Common::QUASAR_SIMULATION_COMPLETION_QUEUE_SIZE);
 
             tt::tt_metal::detail::ReadFromDeviceDRAMChannel(
                 this->device_,
                 0,
-                Common::kSdQuasarCompletionBase,
+                Common::QUASAR_SIMULATION_COMPLETION_QUEUE_BASE,
                 std::span<uint8_t>(quasar_completion_buf_.data(), bytes_written));
         }
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2501,8 +2501,12 @@ public:
         while (remaining_bytes > 0) {
             // Assumes terminate is the last command...
             uint32_t cmd = payload_generator_->get_rand<uint32_t>(0, CQ_PREFETCH_CMD_TERMINATE - 1);
-            const uint32_t limit_x = (worker_range.end_coord.x - first_worker.x - 1);
-            const uint32_t limit_y = (worker_range.end_coord.y - first_worker.y - 1);
+            // Underflow-safe: on a collapsed single-core range (Quasar) end_coord == first_worker, so the
+            // span is 0 and the limit stays 0. WH/BH is unchanged (end_coord.x == first_worker.x + 1 -> 0).
+            const uint32_t limit_x =
+                worker_range.end_coord.x > first_worker.x ? worker_range.end_coord.x - first_worker.x - 1 : 0;
+            const uint32_t limit_y =
+                worker_range.end_coord.y > first_worker.y ? worker_range.end_coord.y - first_worker.y - 1 : 0;
             uint32_t x = payload_generator_->get_rand<uint32_t>(0, limit_x);
             uint32_t y = payload_generator_->get_rand<uint32_t>(0, limit_y);
 
@@ -2539,7 +2543,10 @@ public:
                     break;
                 }
                 case CQ_PREFETCH_CMD_RELAY_INLINE: {
-                    const CoreCoord last_worker = {worker_core.x + 1, worker_core.y + 1};
+                    // On single-core arches (Quasar) collapse mcast to unicast to stay within grid.
+                    const CoreCoord last_worker = (device_->arch() == tt::ARCH::QUASAR)
+                                                      ? worker_core
+                                                      : CoreCoord{worker_core.x + 1, worker_core.y + 1};
                     CoreRange multi_worker_range = {worker_core, last_worker};
                     auto result = gen_random_inline_cmd(device_data, multi_worker_range, noc_xy, remaining_bytes);
                     if (result.has_value()) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -2544,11 +2544,8 @@ public:
                     break;
                 }
                 case CQ_PREFETCH_CMD_RELAY_INLINE: {
-                    // On single-core arches (Quasar) collapse mcast to unicast to stay within grid.
-                    const CoreCoord last_worker = (device_->arch() == tt::ARCH::QUASAR)
-                                                      ? worker_core
-                                                      : CoreCoord{worker_core.x + 1, worker_core.y + 1};
-                    CoreRange multi_worker_range = {worker_core, last_worker};
+                    // worker_range() collapses mcast to unicast on single-core arches (Quasar) to stay within grid.
+                    const CoreRange multi_worker_range = this->worker_range(worker_core, /*multi_core=*/true);
                     auto result = gen_random_inline_cmd(device_data, multi_worker_range, noc_xy, remaining_bytes);
                     if (result.has_value()) {
                         HostMemDeviceCommand& cmd = *result;
@@ -2851,27 +2848,31 @@ public:
             entry_size,
             phys_prefetch,
             phys_disp);
-        // On Quasar prefetch and dispatch share core {0,0}; the experimental API auto-assigns DM
-        // cores, so prefetch must be created before dispatch to land on DM0 (dispatch then gets DM1),
-        // mirroring the merged SD dispatcher test. is_legacy_kernel ports the WH/BH kernel unchanged.
-        tt_metal::KernelHandle prefetch_kernel;
-        if (this->device_->arch() == tt::ARCH::QUASAR) {
-            prefetch_kernel = tt::tt_metal::experimental::quasar::CreateKernel(
+        // On Quasar the experimental API auto-assigns DM cores in creation order, so prefetch must be
+        // created before dispatch to land on DM0 (dispatch then gets DM1). is_legacy_kernel ports the
+        // WH/BH kernel unchanged.
+        auto create_fd_kernel = [&](const std::string& kernel_path,
+                                    const CoreCoord& core,
+                                    const std::map<std::string, std::string>& defines) -> tt_metal::KernelHandle {
+            if (this->device_->arch() == tt::ARCH::QUASAR) {
+                return tt::tt_metal::experimental::quasar::CreateKernel(
+                    program,
+                    kernel_path,
+                    core,
+                    tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
+                        .num_threads_per_cluster = 1, .defines = defines, .is_legacy_kernel = true});
+            }
+            return tt_metal::CreateKernel(
                 program,
-                "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
-                Common::sd_prefetch_core,
-                tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                    .num_threads_per_cluster = 1, .defines = prefetch_defines, .is_legacy_kernel = true});
-        } else {
-            prefetch_kernel = tt_metal::CreateKernel(
-                program,
-                "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp",
-                {Common::sd_prefetch_core},
+                kernel_path,
+                {core},
                 tt_metal::DataMovementConfig{
                     .processor = tt_metal::DataMovementProcessor::RISCV_0,
                     .noc = tt_metal::NOC::NOC_0,
-                    .defines = prefetch_defines});
-        }
+                    .defines = defines});
+        };
+        const tt_metal::KernelHandle prefetch_kernel = create_fd_kernel(
+            "tt_metal/impl/dispatch/kernels/cq_prefetch.cpp", Common::sd_prefetch_core, prefetch_defines);
         tt_metal::SetRuntimeArgs(program, prefetch_kernel, Common::sd_prefetch_core, {0u, 0u, 0u});
 
         const uint32_t dev_completion_base = dev_hugepage_base + this->sd_hugepage_issue_buffer_size();
@@ -2887,25 +2888,9 @@ public:
             memmap.dispatch_buffer_base(),
             dev_completion_base,
             this->sd_completion_queue_size());
-        tt_metal::KernelHandle dispatch_kernel;
-        if (this->device_->arch() == tt::ARCH::QUASAR) {
-            // prefetch already occupies DM0 on this shared core, so dispatch auto-assigns to DM1.
-            dispatch_kernel = tt::tt_metal::experimental::quasar::CreateKernel(
-                program,
-                "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
-                Common::dispatch_core(this->device_),
-                tt::tt_metal::experimental::quasar::QuasarDataMovementConfig{
-                    .num_threads_per_cluster = 1, .defines = dispatch_defines, .is_legacy_kernel = true});
-        } else {
-            dispatch_kernel = tt_metal::CreateKernel(
-                program,
-                "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp",
-                {Common::dispatch_core(this->device_)},
-                tt_metal::DataMovementConfig{
-                    .processor = tt_metal::DataMovementProcessor::RISCV_0,
-                    .noc = tt_metal::NOC::NOC_0,
-                    .defines = dispatch_defines});
-        }
+        // prefetch already occupies DM0 on this shared core, so dispatch auto-assigns to DM1.
+        const tt_metal::KernelHandle dispatch_kernel = create_fd_kernel(
+            "tt_metal/impl/dispatch/kernels/cq_dispatch.cpp", Common::dispatch_core(this->device_), dispatch_defines);
         tt_metal::SetRuntimeArgs(program, dispatch_kernel, Common::dispatch_core(this->device_), {0u, 0u, 0u});
 
         // Initialize the dispatcher's completion queue write/read pointers in L1, mirroring

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -547,8 +547,7 @@ protected:
 
         // Setup target worker cores
         const CoreCoord first_worker = this->worker_start();
-        const CoreCoord last_worker = first_worker;  // {first_worker.x + 1, first_worker.y + 1};
-        const CoreRange worker_range = {first_worker, last_worker};
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/false);
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
@@ -576,8 +575,7 @@ protected:
         const uint32_t dram_data_size_words = get_dram_data_size_words();
 
         const CoreCoord first_worker = this->worker_start();
-        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-        const CoreRange worker_range = {first_worker, last_worker};
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
@@ -1238,8 +1236,7 @@ public:
 
         // Setup target worker cores
         const CoreCoord first_worker = this->worker_start();
-        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-        const CoreRange worker_range = {first_worker, last_worker};
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
         const CoreCoord phys_worker_core = device_->worker_core_from_logical_core(first_worker);
@@ -1285,8 +1282,7 @@ public:
 
         // Setup target worker cores
         const CoreCoord first_worker = this->worker_start();
-        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-        const CoreRange worker_range = {first_worker, last_worker};
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
@@ -1449,8 +1445,7 @@ public:
 
         // Setup target worker cores
         const CoreCoord first_worker = this->worker_start();
-        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-        const CoreRange worker_range = {first_worker, last_worker};
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
         const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
@@ -1472,8 +1467,7 @@ public:
 
         // Setup target worker cores
         const CoreCoord first_worker = this->worker_start();
-        const CoreCoord last_worker = first_worker;
-        const CoreRange worker_range = {first_worker, last_worker};
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/false);
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
@@ -1561,8 +1555,7 @@ public:
 
         // Section 5: Inline packed writes
         const CoreCoord first_worker_2x2 = this->worker_start();
-        const CoreCoord last_worker_2x2 = {first_worker_2x2.x + 1, first_worker_2x2.y + 1};
-        const CoreRange worker_range_2x2 = {first_worker_2x2, last_worker_2x2};
+        const CoreRange worker_range_2x2 = this->worker_range(first_worker_2x2, /*multi_core=*/true);
         // Pick worker cores once for all commands
         std::vector<CoreCoord> worker_cores{first_worker_2x2};
         helper.add_packed_write(worker_cores, 4);
@@ -1576,7 +1569,9 @@ public:
         helper.add_packed_write(worker_cores, 12, true);
         worker_cores.clear();
         worker_cores.push_back(first_worker_2x2);
-        worker_cores.push_back(last_worker_2x2);
+        if (worker_range_2x2.end_coord != worker_range_2x2.start_coord) {
+            worker_cores.push_back(worker_range_2x2.end_coord);
+        }
         helper.add_packed_write(worker_cores, 156);
 
         // Section 6: Linear read -> Linear write test
@@ -1715,8 +1710,7 @@ public:
         const uint32_t num_iterations = 1;
 
         const CoreCoord first_worker = this->worker_start();
-        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-        const CoreRange worker_range = {first_worker, last_worker};
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
         const auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
@@ -1884,8 +1878,7 @@ public:
 
         // Setup target worker cores
         const CoreCoord first_worker = this->worker_start();
-        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-        const CoreRange worker_range = {first_worker, last_worker};
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
         const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
@@ -2481,8 +2474,7 @@ public:
 
         // Setup target worker cores
         const CoreCoord first_worker = this->worker_start();
-        const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-        const CoreRange worker_range = {first_worker, last_worker};
+        const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
 
         const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
 
@@ -3067,8 +3059,7 @@ TEST_P(PrefetchRelayLinearHTestFixture, RelayLinearHTest) {
 
     // Setup dummy worker cores (not actually used for writes, but needed for DeviceData init)
     const CoreCoord first_worker = this->worker_start();
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
+    const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
 
     const uint32_t l1_base = remote_device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
     const auto dram_alignment = MetalContext::instance().hal().get_alignment(HalMemType::DRAM);
@@ -3118,8 +3109,7 @@ TEST_P(PrefetcherLinearPackedHTestFixture, RelayLinearPackedHTest) {
 
     // Setup worker cores
     const CoreCoord first_worker = this->worker_start();
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
+    const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
 
     const uint32_t l1_base = mmio_device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
     const auto l1_alignment = MetalContext::instance().hal().get_alignment(HalMemType::L1);
@@ -3200,8 +3190,7 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
 
     // Dummy worker range (not the destination of this test) for DeviceData init.
     const CoreCoord first_worker = this->worker_start();
-    const CoreCoord last_worker = {first_worker.x + 1, first_worker.y + 1};
-    const CoreRange worker_range = {first_worker, last_worker};
+    const CoreRange worker_range = this->worker_range(first_worker, /*multi_core=*/true);
 
     const uint32_t l1_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::L1);
     const uint32_t dram_base = device_->allocator_impl()->get_base_allocator_addr(HalMemType::DRAM);

--- a/tt_metal/hw/firmware/src/tt-2xx/dm.cc
+++ b/tt_metal/hw/firmware/src/tt-2xx/dm.cc
@@ -314,7 +314,8 @@ extern "C" uint32_t _start1() {
                 WAYPOINT("R");
                 if (enables & (1u << index)) {
                     uintptr_t kernel_lma =
-                        (kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index]);
+                        (kernel_config_base + launch_msg_address->kernel_config.kernel_text_offset[index] +
+                         MEM_L1_UNCACHED_BASE);
                     // Invalidate the i$ now the kernels have loaded and before running
                     invalidate_l1_icache();
                     uint32_t* kernel_ptr = reinterpret_cast<uint32_t*>(kernel_lma);
@@ -391,7 +392,8 @@ extern "C" uint32_t _start1() {
         uintptr_t kernel_config_base = firmware_config_init(mailboxes, ProgrammableCoreType::TENSIX, hartid);
         int index = hartid;
 
-        uintptr_t kernel_lma = kernel_config_base + launch_msg->kernel_config.kernel_text_offset[index];
+        uintptr_t kernel_lma =
+            kernel_config_base + launch_msg->kernel_config.kernel_text_offset[index] + MEM_L1_UNCACHED_BASE;
 
         uint32_t tt_l1_ptr* dfb_l1_base = (uint32_t tt_l1_ptr*)(MEM_L1_UNCACHED_BASE + kernel_config_base +
                                                                 launch_msg->kernel_config.local_cb_offset);

--- a/tt_metal/impl/dispatch/kernels/cq_common.hpp
+++ b/tt_metal/impl/dispatch/kernels/cq_common.hpp
@@ -90,6 +90,17 @@ constexpr FORCE_INLINE uintptr_t l1_uncached_addr(uintptr_t addr) {
 #endif
 }
 
+// Inverse of l1_uncached_addr: maps an uncached-alias address back to its cached form.
+// Identity on non-Quasar. Used to store the host-visible (cached-form) prefetch_q_rd_ptr value.
+constexpr FORCE_INLINE uintptr_t l1_cached_addr(uintptr_t addr) {
+#ifdef ARCH_QUASAR
+    ASSERT(addr >= MEM_L1_UNCACHED_BASE);
+    return addr - MEM_L1_UNCACHED_BASE;
+#else
+    return addr;
+#endif
+}
+
 template <typename T>
 FORCE_INLINE volatile T tt_l1_ptr* uncached_l1_ptr(uintptr_t addr) {
     return reinterpret_cast<volatile T tt_l1_ptr*>(l1_uncached_addr(addr));

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1044,9 +1044,7 @@ static void process_wait() {
     }
     if (notify_prefetch) {
 #ifdef ARCH_QUASAR
-        volatile tt_l1_ptr uint32_t* upstream_sync_sem_addr =
-            uncached_l1_ptr<uint32_t>(get_semaphore<fd_core_type>(upstream_sync_sem));
-        *upstream_sync_sem_addr += 1;
+        Semaphore<fd_core_type>(upstream_sync_sem).up(1);
 #else
         noc_semaphore_inc(
             get_noc_addr_helper(upstream_noc_xy, get_semaphore<fd_core_type>(upstream_sync_sem)),
@@ -1471,9 +1469,7 @@ void publish_dispatch_d_noc_count(const NocCounterSnapshot& snapshot) {
     set_noc_counter_val<proc_type, NocBarrierType::POSTED_WRITES_NUM_ISSUED>(
         upstream_noc_index, posted_writes_delta);
 
-    volatile tt_l1_ptr uint32_t* shutdown_sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-        l1_uncached_addr(get_semaphore<fd_core_type>(dispatch_d_shutdown_sem_id)));
-    *shutdown_sem_addr = 1;
+    Semaphore<fd_core_type>(dispatch_d_shutdown_sem_id).set(1);
 }
 
 void kernel_main() {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1044,10 +1044,8 @@ static void process_wait() {
     }
     if (notify_prefetch) {
 #ifdef ARCH_QUASAR
-        // Same-core (prefetch+dispatch colocated): increment the sync sem in local L1 instead of
-        // a NOC self-loopback. Sole writer, so a plain RMW through the uncached alias is safe.
-        volatile tt_l1_ptr uint32_t* upstream_sync_sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-            l1_uncached_addr(get_semaphore<fd_core_type>(upstream_sync_sem)));
+        volatile tt_l1_ptr uint32_t* upstream_sync_sem_addr =
+            uncached_l1_ptr<uint32_t>(get_semaphore<fd_core_type>(upstream_sync_sem));
         *upstream_sync_sem_addr += 1;
 #else
         noc_semaphore_inc(

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1043,11 +1043,18 @@ static void process_wait() {
             neg_sem_val << REMOTE_DEST_BUF_WORDS_FREE_INC);
     }
     if (notify_prefetch) {
+#ifdef ARCH_QUASAR
         // Same-core (prefetch+dispatch colocated): increment the sync sem in local L1 instead of
         // a NOC self-loopback. Sole writer, so a plain RMW through the uncached alias is safe.
         volatile tt_l1_ptr uint32_t* upstream_sync_sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
             l1_uncached_addr(get_semaphore<fd_core_type>(upstream_sync_sem)));
         *upstream_sync_sem_addr += 1;
+#else
+        noc_semaphore_inc(
+            get_noc_addr_helper(upstream_noc_xy, get_semaphore<fd_core_type>(upstream_sync_sem)),
+            1,
+            upstream_noc_index);
+#endif
     }
 
     cmd_ptr += sizeof(CQDispatchCmd);

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1043,10 +1043,11 @@ static void process_wait() {
             neg_sem_val << REMOTE_DEST_BUF_WORDS_FREE_INC);
     }
     if (notify_prefetch) {
-        noc_semaphore_inc(
-            get_noc_addr_helper(upstream_noc_xy, get_semaphore<fd_core_type>(upstream_sync_sem)),
-            1,
-            upstream_noc_index);
+        // Same-core (prefetch+dispatch colocated): increment the sync sem in local L1 instead of
+        // a NOC self-loopback. Sole writer, so a plain RMW through the uncached alias is safe.
+        volatile tt_l1_ptr uint32_t* upstream_sync_sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+            l1_uncached_addr(get_semaphore<fd_core_type>(upstream_sync_sem)));
+        *upstream_sync_sem_addr += 1;
     }
 
     cmd_ptr += sizeof(CQDispatchCmd);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -1790,7 +1790,7 @@ uint32_t process_exec_buf_cmd(
     // dispatch on eth cores is memory constrained, so exec_buf reuses the cmddat_q
     // prefetch_h stalls upon issuing an exec_buf to prevent conflicting use of the cmddat_q,
     // the exec_buf contains the release commands
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr) _outer;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr_outer);
 
     // setup exec_buf_state the first time
     exec_buf_state.page_id = 0;

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -286,6 +286,23 @@ bool process_cmd(
     uint32_t* l1_cache,
     PrefetchExecBufState& exec_buf_state);
 
+#ifdef ARCH_QUASAR
+// Same-core copy: word-by-word L1->L1 memcpy through the L1 uncached alias, used when prefetcher and dispatcher are on
+// the same core.
+FORCE_INLINE void local_copy_words(uintptr_t dst_addr, uintptr_t src_addr, uint32_t num_bytes, uint32_t dst_end) {
+    ASSERT((num_bytes & 0x3u) == 0);
+    ASSERT((src_addr & 0x3u) == 0);
+    ASSERT((dst_addr & 0x3u) == 0);
+    ASSERT(dst_addr + num_bytes <= dst_end);
+    volatile uint32_t tt_l1_ptr* dst_ptr = uncached_l1_ptr<uint32_t>(dst_addr);
+    volatile uint32_t tt_l1_ptr* src_ptr = uncached_l1_ptr<uint32_t>(src_addr);
+    const uint32_t words = num_bytes >> 2;
+    for (uint32_t i = 0; i < words; ++i) {
+        dst_ptr[i] = src_ptr[i];
+    }
+}
+#endif
+
 template <uint32_t downstream_cb_base_addr, uint32_t downstream_cmd_buf>
 FORCE_INLINE void write_downstream(
     uintptr_t& data_ptr,
@@ -302,20 +319,7 @@ FORCE_INLINE void write_downstream(
                 get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
                 remaining);
 #elif defined(ARCH_QUASAR)
-            // Same-core dispatch: word-by-word uncached memcpy into the dispatcher's CB.
-            ASSERT((remaining & 0x3u) == 0);
-            ASSERT((data_ptr & 0x3u) == 0);
-            ASSERT((local_downstream_data_ptr & 0x3u) == 0);
-            ASSERT(local_downstream_data_ptr + remaining <= downstream_end);
-            {
-                auto* dst_ptr =
-                    reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(local_downstream_data_ptr));
-                auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr));
-                const uint32_t words = remaining >> 2;
-                for (uint32_t i = 0; i < words; ++i) {
-                    dst_ptr[i] = src_ptr[i];
-                }
-            }
+            local_copy_words(local_downstream_data_ptr, data_ptr, remaining, downstream_end);
 #else
             cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
                 static_cast<uint32_t>(data_ptr),
@@ -334,19 +338,7 @@ FORCE_INLINE void write_downstream(
         get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
         length);
 #elif defined(ARCH_QUASAR)
-    // Same-core dispatch: word-by-word uncached memcpy into the dispatcher's CB.
-    ASSERT((length & 0x3u) == 0);
-    ASSERT((data_ptr & 0x3u) == 0);
-    ASSERT((local_downstream_data_ptr & 0x3u) == 0);
-    ASSERT(local_downstream_data_ptr + length <= downstream_end);
-    {
-        auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(local_downstream_data_ptr));
-        auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr));
-        const uint32_t words = length >> 2;
-        for (uint32_t i = 0; i < words; ++i) {
-            dst_ptr[i] = src_ptr[i];
-        }
-    }
+    local_copy_words(local_downstream_data_ptr, data_ptr, length, downstream_end);
 #else
     cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
         static_cast<uint32_t>(data_ptr),
@@ -497,17 +489,15 @@ FORCE_INLINE uint32_t read_from_pcie(
     // prefetch_q_dev_ptrs (which are cached offsets) match. Write through the uncached L1 alias
     // so the value lands in L1 SRAM directly (otherwise it sits in DM0's L1 D$ and the host's
     // NOC poll reads stale). l1_uncached_addr/l1_cached_addr are identity on WH/BH.
-    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(prefetch_q_rd_ptr_addr)) =
-        l1_cached_addr(reinterpret_cast<uintptr_t>(prefetch_q_rd_ptr));
-    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(prefetch_q_pcie_rd_ptr_addr)) = pcie_read_ptr;
+    *uncached_l1_ptr<uint32_t>(prefetch_q_rd_ptr_addr) = l1_cached_addr(reinterpret_cast<uintptr_t>(prefetch_q_rd_ptr));
+    *uncached_l1_ptr<uint32_t>(prefetch_q_pcie_rd_ptr_addr) = pcie_read_ptr;
 
     ++prefetch_q_rd_ptr;
 
     // Wrap prefetch_q. prefetch_q_rd_ptr lives in the uncached alias on Quasar, so compare and
     // reset via l1_uncached_addr (identity on WH/BH, so no change there).
     if (reinterpret_cast<uintptr_t>(prefetch_q_rd_ptr) == l1_uncached_addr(prefetch_q_end)) {
-        prefetch_q_rd_ptr =
-            reinterpret_cast<volatile tt_l1_ptr prefetch_q_entry_type*>(l1_uncached_addr(prefetch_q_base));
+        prefetch_q_rd_ptr = uncached_l1_ptr<prefetch_q_entry_type>(prefetch_q_base);
     }
     return pending_read_size;
 }
@@ -565,7 +555,9 @@ void fetch_q_get_cmds(uintptr_t& fence, uintptr_t& cmd_ptr, uint32_t& pcie_read_
     // `fence` remains the committed boundary used for cmd_ready checks.
     static uintptr_t issue_fence = cmddat_q_base;
     // On Quasar prefetch_q_rd_ptr lives in the uncached L1 alias so every deref bypasses the DM core's
-    // L1 D$/L2. l1_uncached_addr is identity on non-Quasar, so this is unchanged on WH/BH.
+    // L1 D$/L2. l1_uncached_addr is identity on non-Quasar, so this is unchanged on WH/BH. The bare
+    // reinterpret_cast (rather than uncached_l1_ptr) keeps this a constant initializer; the kernel
+    // environment disallows dynamic initialization of static storage.
     static volatile tt_l1_ptr prefetch_q_entry_type* prefetch_q_rd_ptr =
         reinterpret_cast<volatile tt_l1_ptr prefetch_q_entry_type*>(l1_uncached_addr(prefetch_q_base));
     static constexpr uint32_t prefetch_q_msb_mask = 1u << (sizeof(prefetch_q_entry_type) * CHAR_BIT - 1U);
@@ -867,18 +859,7 @@ static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& di
     if (cmddat_wrap_enable && length > remaining) {
         // wrap cmddat
 #if defined(ARCH_QUASAR)
-        ASSERT((remaining & 0x3u) == 0);
-        ASSERT((data_ptr & 0x3u) == 0);
-        ASSERT((dispatch_data_ptr & 0x3u) == 0);
-        ASSERT(dispatch_data_ptr + remaining <= downstream_cb_end);
-        {
-            auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(dispatch_data_ptr));
-            auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr));
-            const uint32_t words = remaining >> 2;
-            for (uint32_t i = 0; i < words; ++i) {
-                dst_ptr[i] = src_ptr[i];
-            }
-        }
+        local_copy_words(dispatch_data_ptr, data_ptr, remaining, downstream_cb_end);
 #else
         noc_async_write(
             static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
@@ -888,18 +869,7 @@ static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& di
         data_ptr = cmddat_q_base;
     }
 #if defined(ARCH_QUASAR)
-    ASSERT((length & 0x3u) == 0);
-    ASSERT((data_ptr & 0x3u) == 0);
-    ASSERT((dispatch_data_ptr & 0x3u) == 0);
-    ASSERT(dispatch_data_ptr + length <= downstream_cb_end);
-    {
-        auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(dispatch_data_ptr));
-        auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr));
-        const uint32_t words = length >> 2;
-        for (uint32_t i = 0; i < words; ++i) {
-            dst_ptr[i] = src_ptr[i];
-        }
-    }
+    local_copy_words(dispatch_data_ptr, data_ptr, length, downstream_cb_end);
 #else
     noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
 #endif
@@ -923,9 +893,7 @@ static uint32_t write_pages_to_dispatcher(
         DispatchRelayInlineState::cb_writer.acquire_pages(npages);
     }
 
-#if defined(FABRIC_RELAY) || !defined(ARCH_QUASAR)
-    uint64_t noc_addr;
-#endif
+    [[maybe_unused]] uint64_t noc_addr;
     if (downstream_data_ptr == downstream_cb_end) {
         downstream_data_ptr = downstream_cb_base;
     } else if (downstream_data_ptr + amt_to_write > downstream_cb_end) {  // wrap
@@ -936,18 +904,7 @@ static uint32_t write_pages_to_dispatcher(
 #if defined(FABRIC_RELAY)
         noc_async_write(scratch_write_addr, noc_addr, last_chunk_size);
 #elif defined(ARCH_QUASAR)
-        ASSERT((last_chunk_size & 0x3u) == 0);
-        ASSERT((scratch_write_addr & 0x3u) == 0);
-        ASSERT((downstream_data_ptr & 0x3u) == 0);
-        ASSERT(downstream_data_ptr + last_chunk_size <= downstream_cb_end);
-        {
-            auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(downstream_data_ptr));
-            auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(scratch_write_addr));
-            const uint32_t words = last_chunk_size >> 2;
-            for (uint32_t i = 0; i < words; ++i) {
-                dst_ptr[i] = src_ptr[i];
-            }
-        }
+        local_copy_words(downstream_data_ptr, scratch_write_addr, last_chunk_size, downstream_cb_end);
 #else
         cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, last_chunk_size);
 #endif
@@ -962,18 +919,7 @@ static uint32_t write_pages_to_dispatcher(
 #if defined(FABRIC_RELAY)
     noc_async_write(scratch_write_addr, noc_addr, amt_to_write);
 #elif defined(ARCH_QUASAR)
-    ASSERT((amt_to_write & 0x3u) == 0);
-    ASSERT((scratch_write_addr & 0x3u) == 0);
-    ASSERT((downstream_data_ptr & 0x3u) == 0);
-    ASSERT(downstream_data_ptr + amt_to_write <= downstream_cb_end);
-    {
-        auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(downstream_data_ptr));
-        auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(scratch_write_addr));
-        const uint32_t words = amt_to_write >> 2;
-        for (uint32_t i = 0; i < words; ++i) {
-            dst_ptr[i] = src_ptr[i];
-        }
-    }
+    local_copy_words(downstream_data_ptr, scratch_write_addr, amt_to_write, downstream_cb_end);
 #else
     cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, amt_to_write);
 #endif
@@ -1466,8 +1412,8 @@ uint32_t process_stall(uintptr_t cmd_ptr) {
     count++;
 
     WAYPOINT("PSW");
-    volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-        l1_uncached_addr(get_semaphore<fd_core_type>(my_downstream_sync_sem_id)));
+    volatile tt_l1_ptr uint32_t* sem_addr =
+        uncached_l1_ptr<uint32_t>(get_semaphore<fd_core_type>(my_downstream_sync_sem_id));
     uint32_t heartbeat = 0;
     do {
         invalidate_l1_cache();
@@ -1671,18 +1617,7 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
         noc_async_write(
             static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
 #elif defined(ARCH_QUASAR)
-        ASSERT((remaining & 0x3u) == 0);
-        ASSERT((data_ptr & 0x3u) == 0);
-        ASSERT((dispatch_data_ptr & 0x3u) == 0);
-        ASSERT(dispatch_data_ptr + remaining <= downstream_cb_end);
-        {
-            auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(dispatch_data_ptr));
-            auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr));
-            const uint32_t words = remaining >> 2;
-            for (uint32_t i = 0; i < words; ++i) {
-                dst_ptr[i] = src_ptr[i];
-            }
-        }
+        local_copy_words(dispatch_data_ptr, data_ptr, remaining, downstream_cb_end);
 #else
         cq_noc_async_write_with_state_any_len<true, true>(
             static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
@@ -1704,18 +1639,7 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
 #if defined(FABRIC_RELAY)
     noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
 #elif defined(ARCH_QUASAR)
-    ASSERT((length & 0x3u) == 0);
-    ASSERT((data_ptr & 0x3u) == 0);
-    ASSERT((dispatch_data_ptr & 0x3u) == 0);
-    ASSERT(dispatch_data_ptr + length <= downstream_cb_end);
-    {
-        auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(dispatch_data_ptr));
-        auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr));
-        const uint32_t words = length >> 2;
-        for (uint32_t i = 0; i < words; ++i) {
-            dst_ptr[i] = src_ptr[i];
-        }
-    }
+    local_copy_words(dispatch_data_ptr, data_ptr, length, downstream_cb_end);
 #else
     cq_noc_async_write_with_state_any_len<true, true>(
         static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -301,6 +301,21 @@ FORCE_INLINE void write_downstream(
                 static_cast<uint32_t>(data_ptr),
                 get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
                 remaining);
+#elif defined(ARCH_QUASAR)
+            // Same-core dispatch: word-by-word uncached memcpy into the dispatcher's CB.
+            ASSERT((remaining & 0x3u) == 0);
+            ASSERT((data_ptr & 0x3u) == 0);
+            ASSERT((local_downstream_data_ptr & 0x3u) == 0);
+            ASSERT(local_downstream_data_ptr + remaining <= downstream_end);
+            {
+                auto* dst_ptr =
+                    reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(local_downstream_data_ptr));
+                auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr));
+                const uint32_t words = remaining >> 2;
+                for (uint32_t i = 0; i < words; ++i) {
+                    dst_ptr[i] = src_ptr[i];
+                }
+            }
 #else
             cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
                 static_cast<uint32_t>(data_ptr),
@@ -318,6 +333,20 @@ FORCE_INLINE void write_downstream(
         static_cast<uint32_t>(data_ptr),
         get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
         length);
+#elif defined(ARCH_QUASAR)
+    // Same-core dispatch: word-by-word uncached memcpy into the dispatcher's CB.
+    ASSERT((length & 0x3u) == 0);
+    ASSERT((data_ptr & 0x3u) == 0);
+    ASSERT((local_downstream_data_ptr & 0x3u) == 0);
+    ASSERT(local_downstream_data_ptr + length <= downstream_end);
+    {
+        auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(local_downstream_data_ptr));
+        auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr));
+        const uint32_t words = length >> 2;
+        for (uint32_t i = 0; i < words; ++i) {
+            dst_ptr[i] = src_ptr[i];
+        }
+    }
 #else
     cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
         static_cast<uint32_t>(data_ptr),
@@ -464,16 +493,21 @@ FORCE_INLINE uint32_t read_from_pcie(
 
     *prefetch_q_rd_ptr = 0U;
 
-    // Tell host we read
-    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(prefetch_q_rd_ptr_addr) =
-        reinterpret_cast<uintptr_t>(prefetch_q_rd_ptr);
-    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(prefetch_q_pcie_rd_ptr_addr) = pcie_read_ptr;
+    // Tell host we read. Store the cached-form pointer value so host comparisons against
+    // prefetch_q_dev_ptrs (which are cached offsets) match. Write through the uncached L1 alias
+    // so the value lands in L1 SRAM directly (otherwise it sits in DM0's L1 D$ and the host's
+    // NOC poll reads stale). l1_uncached_addr/l1_cached_addr are identity on WH/BH.
+    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(prefetch_q_rd_ptr_addr)) =
+        l1_cached_addr(reinterpret_cast<uintptr_t>(prefetch_q_rd_ptr));
+    *reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(prefetch_q_pcie_rd_ptr_addr)) = pcie_read_ptr;
 
     ++prefetch_q_rd_ptr;
 
-    // Wrap prefetch_q
-    if (reinterpret_cast<uintptr_t>(prefetch_q_rd_ptr) == prefetch_q_end) {
-        prefetch_q_rd_ptr = reinterpret_cast<volatile tt_l1_ptr prefetch_q_entry_type*>(prefetch_q_base);
+    // Wrap prefetch_q. prefetch_q_rd_ptr lives in the uncached alias on Quasar, so compare and
+    // reset via l1_uncached_addr (identity on WH/BH, so no change there).
+    if (reinterpret_cast<uintptr_t>(prefetch_q_rd_ptr) == l1_uncached_addr(prefetch_q_end)) {
+        prefetch_q_rd_ptr =
+            reinterpret_cast<volatile tt_l1_ptr prefetch_q_entry_type*>(l1_uncached_addr(prefetch_q_base));
     }
     return pending_read_size;
 }
@@ -530,8 +564,10 @@ void fetch_q_get_cmds(uintptr_t& fence, uintptr_t& cmd_ptr, uint32_t& pcie_read_
     // End of reserved (possibly-not-yet-committed) region in cmddat_q for issued reads.
     // `fence` remains the committed boundary used for cmd_ready checks.
     static uintptr_t issue_fence = cmddat_q_base;
+    // On Quasar prefetch_q_rd_ptr lives in the uncached L1 alias so every deref bypasses the DM core's
+    // L1 D$/L2. l1_uncached_addr is identity on non-Quasar, so this is unchanged on WH/BH.
     static volatile tt_l1_ptr prefetch_q_entry_type* prefetch_q_rd_ptr =
-        (volatile tt_l1_ptr prefetch_q_entry_type*)prefetch_q_base;
+        reinterpret_cast<volatile tt_l1_ptr prefetch_q_entry_type*>(l1_uncached_addr(prefetch_q_base));
     static constexpr uint32_t prefetch_q_msb_mask = 1u << (sizeof(prefetch_q_entry_type) * CHAR_BIT - 1U);
 
     if (stall_state == StallState::STALLED) {
@@ -769,13 +805,13 @@ void fetch_q_get_cmds(uintptr_t& fence, uintptr_t& cmd_ptr, uint32_t& pcie_read_
 }
 
 uint32_t process_debug_cmd(uintptr_t cmd_ptr) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     return cmd->debug.stride;
 }
 
 template <bool cmddat_wrap_enable, typename RelayInlineState>
 static uint32_t process_relay_inline_cmd(uintptr_t cmd_ptr, uint32_t& local_downstream_data_ptr) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     uint32_t length = cmd->relay_inline.length;
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
@@ -818,7 +854,7 @@ static uint32_t process_relay_inline_cmd(uintptr_t cmd_ptr, uint32_t& local_down
 // NOTE: this routine assumes we're sending a command header and that is LESS THAN A PAGE
 template <bool cmddat_wrap_enable>
 static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& dispatch_data_ptr) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
 
     uint32_t length = cmd->relay_inline.length;
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
@@ -830,13 +866,43 @@ static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& di
     uint32_t remaining = cmddat_q_end - data_ptr;
     if (cmddat_wrap_enable && length > remaining) {
         // wrap cmddat
+#if defined(ARCH_QUASAR)
+        ASSERT((remaining & 0x3u) == 0);
+        ASSERT((data_ptr & 0x3u) == 0);
+        ASSERT((dispatch_data_ptr & 0x3u) == 0);
+        ASSERT(dispatch_data_ptr + remaining <= downstream_cb_end);
+        {
+            auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(dispatch_data_ptr));
+            auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr));
+            const uint32_t words = remaining >> 2;
+            for (uint32_t i = 0; i < words; ++i) {
+                dst_ptr[i] = src_ptr[i];
+            }
+        }
+#else
         noc_async_write(
             static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
+#endif
         dispatch_data_ptr += remaining;
         length -= remaining;
         data_ptr = cmddat_q_base;
     }
+#if defined(ARCH_QUASAR)
+    ASSERT((length & 0x3u) == 0);
+    ASSERT((data_ptr & 0x3u) == 0);
+    ASSERT((dispatch_data_ptr & 0x3u) == 0);
+    ASSERT(dispatch_data_ptr + length <= downstream_cb_end);
+    {
+        auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(dispatch_data_ptr));
+        auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr));
+        const uint32_t words = length >> 2;
+        for (uint32_t i = 0; i < words; ++i) {
+            dst_ptr[i] = src_ptr[i];
+        }
+    }
+#else
     noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
+#endif
     dispatch_data_ptr += length;
 
     return cmd->relay_inline.stride;
@@ -857,14 +923,31 @@ static uint32_t write_pages_to_dispatcher(
         DispatchRelayInlineState::cb_writer.acquire_pages(npages);
     }
 
+#if defined(FABRIC_RELAY) || !defined(ARCH_QUASAR)
     uint64_t noc_addr;
+#endif
     if (downstream_data_ptr == downstream_cb_end) {
         downstream_data_ptr = downstream_cb_base;
     } else if (downstream_data_ptr + amt_to_write > downstream_cb_end) {  // wrap
         uint32_t last_chunk_size = downstream_cb_end - downstream_data_ptr;
+#if defined(FABRIC_RELAY) || !defined(ARCH_QUASAR)
         noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
+#endif
 #if defined(FABRIC_RELAY)
         noc_async_write(scratch_write_addr, noc_addr, last_chunk_size);
+#elif defined(ARCH_QUASAR)
+        ASSERT((last_chunk_size & 0x3u) == 0);
+        ASSERT((scratch_write_addr & 0x3u) == 0);
+        ASSERT((downstream_data_ptr & 0x3u) == 0);
+        ASSERT(downstream_data_ptr + last_chunk_size <= downstream_cb_end);
+        {
+            auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(downstream_data_ptr));
+            auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(scratch_write_addr));
+            const uint32_t words = last_chunk_size >> 2;
+            for (uint32_t i = 0; i < words; ++i) {
+                dst_ptr[i] = src_ptr[i];
+            }
+        }
 #else
         cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, last_chunk_size);
 #endif
@@ -872,10 +955,25 @@ static uint32_t write_pages_to_dispatcher(
         scratch_write_addr += last_chunk_size;
         amt_to_write -= last_chunk_size;
     }
+#if defined(FABRIC_RELAY) || !defined(ARCH_QUASAR)
     noc_addr = get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr);
+#endif
 
 #if defined(FABRIC_RELAY)
     noc_async_write(scratch_write_addr, noc_addr, amt_to_write);
+#elif defined(ARCH_QUASAR)
+    ASSERT((amt_to_write & 0x3u) == 0);
+    ASSERT((scratch_write_addr & 0x3u) == 0);
+    ASSERT((downstream_data_ptr & 0x3u) == 0);
+    ASSERT(downstream_data_ptr + amt_to_write <= downstream_cb_end);
+    {
+        auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(downstream_data_ptr));
+        auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(scratch_write_addr));
+        const uint32_t words = amt_to_write >> 2;
+        for (uint32_t i = 0; i < words; ++i) {
+            dst_ptr[i] = src_ptr[i];
+        }
+    }
 #else
     cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, amt_to_write);
 #endif
@@ -1014,7 +1112,7 @@ uint32_t process_relay_paged_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_p
     // This ensures that a previous cmd using the scratch buf has finished
     noc_async_writes_flushed();
 
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     uint32_t base_addr = cmd->relay_paged.base_addr;
     uint32_t page_size = cmd->relay_paged.page_size;
     uint32_t pages = cmd->relay_paged.pages;
@@ -1222,7 +1320,7 @@ void process_relay_paged_packed_sub_cmds(uint32_t total_length, uint32_t* l1_cac
 
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_paged_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     uint32_t total_length = cmd->relay_paged_packed.total_length;
     uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
     uint32_t stride = cmd->relay_paged_packed.stride;
@@ -1236,7 +1334,7 @@ uint32_t process_relay_paged_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream_
         // wrap cmddat
         uint32_t amt = remaining / sizeof(uint32_t);
         careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-            (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+            uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache_pos);
         sub_cmds_length -= remaining;
         data_ptr = cmddat_q_base;
         l1_cache_pos += amt;
@@ -1251,7 +1349,7 @@ uint32_t process_relay_paged_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream_
                        l1_to_local_cache_copy_chunk -
                    l1_cache) < l1_cache_elements_rounded);
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+        uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache_pos);
     // Store a sentinel non 0 value at the end to save a test/branch in read path
     ((CQPrefetchRelayPagedPackedSubCmd*)&l1_cache_pos[amt])->length = 1;
 
@@ -1293,7 +1391,7 @@ uint32_t process_relay_linear_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_p
     // This ensures that a previous cmd using the scratch buf has finished
     noc_async_writes_flushed();
 
-    volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = (volatile CQPrefetchCmdLarge tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmdLarge>(cmd_ptr);
     uint32_t noc_xy_addr = cmd->relay_linear.noc_xy_addr;
     uint64_t read_addr = cmd->relay_linear.addr;
     uint64_t wlength = cmd->relay_linear.length;
@@ -1368,8 +1466,8 @@ uint32_t process_stall(uintptr_t cmd_ptr) {
     count++;
 
     WAYPOINT("PSW");
-    volatile tt_l1_ptr uint32_t* sem_addr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore<fd_core_type>(my_downstream_sync_sem_id));
+    volatile tt_l1_ptr uint32_t* sem_addr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
+        l1_uncached_addr(get_semaphore<fd_core_type>(my_downstream_sync_sem_id)));
     uint32_t heartbeat = 0;
     do {
         invalidate_l1_cache();
@@ -1497,7 +1595,7 @@ void paged_read_into_cmddat_q(uintptr_t& cmd_ptr, PrefetchExecBufState& exec_buf
 template <typename RelayInlineState>
 FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
     uintptr_t& cmd_ptr, uint32_t& local_downstream_data_ptr, PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     uint32_t length = cmd->relay_inline.length;
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
 
@@ -1554,7 +1652,7 @@ FORCE_INLINE static uint32_t process_exec_buf_relay_inline_cmd(
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_inline_noflush_cmd(
     uintptr_t& cmd_ptr, uint32_t& dispatch_data_ptr, PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
 
     uint32_t length = cmd->relay_inline.length;
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchCmd);
@@ -1572,6 +1670,19 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
 #if defined(FABRIC_RELAY)
         noc_async_write(
             static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
+#elif defined(ARCH_QUASAR)
+        ASSERT((remaining & 0x3u) == 0);
+        ASSERT((data_ptr & 0x3u) == 0);
+        ASSERT((dispatch_data_ptr & 0x3u) == 0);
+        ASSERT(dispatch_data_ptr + remaining <= downstream_cb_end);
+        {
+            auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(dispatch_data_ptr));
+            auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr));
+            const uint32_t words = remaining >> 2;
+            for (uint32_t i = 0; i < words; ++i) {
+                dst_ptr[i] = src_ptr[i];
+            }
+        }
 #else
         cq_noc_async_write_with_state_any_len<true, true>(
             static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
@@ -1592,6 +1703,19 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
 
 #if defined(FABRIC_RELAY)
     noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
+#elif defined(ARCH_QUASAR)
+    ASSERT((length & 0x3u) == 0);
+    ASSERT((data_ptr & 0x3u) == 0);
+    ASSERT((dispatch_data_ptr & 0x3u) == 0);
+    ASSERT(dispatch_data_ptr + length <= downstream_cb_end);
+    {
+        auto* dst_ptr = reinterpret_cast<volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(dispatch_data_ptr));
+        auto* src_ptr = reinterpret_cast<const volatile uint32_t tt_l1_ptr*>(l1_uncached_addr(data_ptr));
+        const uint32_t words = length >> 2;
+        for (uint32_t i = 0; i < words; ++i) {
+            dst_ptr[i] = src_ptr[i];
+        }
+    }
 #else
     cq_noc_async_write_with_state_any_len<true, true>(
         static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
@@ -1610,7 +1734,7 @@ void* copy_into_l1_cache(
     uint32_t& stride) {
     uint32_t remaining_stride = exec_buf_state.length;
     uint32_t remaining = (exec_buf_state.length - cmd_header_size);
-    volatile uint32_t tt_l1_ptr* l1_ptr = (volatile uint32_t tt_l1_ptr*)(cmd_ptr + cmd_header_size);
+    volatile uint32_t tt_l1_ptr* l1_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + cmd_header_size);
     uint32_t* l1_cache_pos = l1_cache;
     while (sub_cmds_length > remaining) {
         uint32_t amt = remaining / sizeof(uint32_t);
@@ -1623,7 +1747,7 @@ void* copy_into_l1_cache(
         exec_buf_state.length = 0;
         cmd_ptr += remaining_stride;
         paged_read_into_cmddat_q(cmd_ptr, exec_buf_state);
-        l1_ptr = (volatile uint32_t tt_l1_ptr*)(cmd_ptr);
+        l1_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr);
         remaining = exec_buf_state.length;
         remaining_stride = exec_buf_state.length;
     }
@@ -1645,7 +1769,7 @@ void* copy_into_l1_cache(
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_paged_packed_cmd(
     uintptr_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     uint32_t total_length = cmd->relay_paged_packed.total_length;
     uint32_t sub_cmds_length = cmd->relay_paged_packed.count * sizeof(CQPrefetchRelayPagedPackedSubCmd);
     uint32_t stride = cmd->relay_paged_packed.stride;
@@ -1666,7 +1790,7 @@ uint32_t process_exec_buf_cmd(
     // dispatch on eth cores is memory constrained, so exec_buf reuses the cmddat_q
     // prefetch_h stalls upon issuing an exec_buf to prevent conflicting use of the cmddat_q,
     // the exec_buf contains the release commands
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr_outer;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr) _outer;
 
     // setup exec_buf_state the first time
     exec_buf_state.page_id = 0;
@@ -1702,7 +1826,7 @@ uint32_t process_paged_to_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream
     // This ensures that a previous cmd using the ringbuffer have completed.
     noc_async_writes_flushed();
 
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     uint32_t start_page = cmd->paged_to_ringbuffer.start_page;
     uint32_t base_addr = cmd->paged_to_ringbuffer.base_addr;
     uint8_t log2_page_size = cmd->paged_to_ringbuffer.log2_page_size;
@@ -1748,7 +1872,7 @@ uint32_t process_paged_to_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream
 }
 
 uint32_t process_set_ringbuffer_offset(uintptr_t cmd_ptr) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     uint32_t offset = cmd->set_ringbuffer_offset.offset;
 
     if (cmd->set_ringbuffer_offset.update_wp) {
@@ -1788,7 +1912,7 @@ void process_relay_ringbuffer_sub_cmds(uint32_t count, uint32_t* l1_cache) {
 
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     uint32_t count = cmd->relay_ringbuffer.count;
     uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
     uint32_t stride = cmd->relay_ringbuffer.stride;
@@ -1801,7 +1925,7 @@ uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__d
         // wrap cmddat
         uint32_t amt = remaining / sizeof(uint32_t);
         careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-            (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+            uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache_pos);
         sub_cmds_length -= remaining;
         data_ptr = cmddat_q_base;
         l1_cache_pos += amt;
@@ -1816,7 +1940,7 @@ uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__d
                        l1_to_local_cache_copy_chunk -
                    l1_cache) < l1_cache_elements_rounded);
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+        uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache_pos);
 
     process_relay_ringbuffer_sub_cmds(count, l1_cache);
     return stride;
@@ -1825,7 +1949,7 @@ uint32_t process_relay_ringbuffer_cmd(uintptr_t cmd_ptr, uint32_t& downstream__d
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_ringbuffer_cmd(
     uintptr_t& cmd_ptr, uint32_t& downstream__data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     uint32_t count = cmd->relay_ringbuffer.count;
     uint32_t sub_cmds_length = count * sizeof(CQPrefetchRelayRingbufferSubCmd);
     uint32_t stride = cmd->relay_ringbuffer.stride;
@@ -1920,7 +2044,7 @@ void process_relay_linear_packed_sub_cmds(uint32_t noc_xy_addr, uint32_t total_l
 
 template <bool cmddat_wrap_enable>
 uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
     uint32_t total_length = cmd->relay_linear_packed.total_length;
     uint32_t sub_cmds_length = cmd->relay_linear_packed.count * sizeof(CQPrefetchRelayLinearPackedSubCmd);
@@ -1935,7 +2059,7 @@ uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream
         // wrap cmddat
         uint32_t amt = remaining / sizeof(uint32_t);
         careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-            (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+            uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache_pos);
         sub_cmds_length -= remaining;
         data_ptr = cmddat_q_base;
         l1_cache_pos += amt;
@@ -1950,7 +2074,7 @@ uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream
                        l1_to_local_cache_copy_chunk -
                    l1_cache) < l1_cache_elements_rounded);
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache_pos);
+        uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache_pos);
 
     process_relay_linear_packed_sub_cmds(noc_xy_addr, total_length, l1_cache);
     return stride;
@@ -1959,7 +2083,7 @@ uint32_t process_relay_linear_packed_cmd(uintptr_t cmd_ptr, uint32_t& downstream
 // Separate implementation that fetches more data from exec buf when cmd has been split
 static uint32_t process_exec_buf_relay_linear_packed_cmd(
     uintptr_t& cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache, PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
     uint32_t total_length = cmd->relay_linear_packed.total_length;
     uint32_t sub_cmds_length = cmd->relay_linear_packed.count * sizeof(CQPrefetchRelayLinearPackedSubCmd);
@@ -1977,7 +2101,7 @@ bool process_cmd(
     uint32_t& stride,
     uint32_t* l1_cache,
     PrefetchExecBufState& exec_buf_state) {
-    volatile CQPrefetchCmd tt_l1_ptr* cmd = (volatile CQPrefetchCmd tt_l1_ptr*)cmd_ptr;
+    volatile CQPrefetchCmd tt_l1_ptr* cmd = uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr);
     bool done = false;
 
     switch (cmd->base.cmd_id) {
@@ -2173,7 +2297,7 @@ static void relay_linear_to_downstream(
 // Used in prefetch_h upstream of a CQ_PREFETCH_CMD_RELAY_LINEAR_H command.
 uint32_t process_relay_linear_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr) {
     volatile CQPrefetchCmdLarge tt_l1_ptr* cmd = nullptr;
-    cmd = (volatile CQPrefetchCmdLarge tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
+    cmd = uncached_l1_ptr<CQPrefetchCmdLarge>(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
     uint64_t wlength = cmd->relay_linear_h.length;
     uint32_t scratch_read_addr = scratch_db_top[0];
     constexpr uint32_t start_offset = sizeof(CQPrefetchHToPrefetchDHeader);
@@ -2255,7 +2379,7 @@ uint32_t process_relay_linear_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data
 // Combines packed linear reads (multiple sub-commands) with H-variant relay to remote device.
 uint32_t process_relay_linear_packed_h_cmd(uintptr_t cmd_ptr, uint32_t& downstream_data_ptr, uint32_t* l1_cache) {
     volatile CQPrefetchCmd tt_l1_ptr* cmd =
-        (volatile CQPrefetchCmd tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
+        uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
     uint32_t noc_xy_addr = cmd->relay_linear_packed.noc_xy_addr;
     uint32_t total_length = cmd->relay_linear_packed.total_length;
     uint32_t sub_cmds_length = cmd->relay_linear_packed.count * sizeof(CQPrefetchRelayLinearPackedSubCmd);
@@ -2266,7 +2390,7 @@ uint32_t process_relay_linear_packed_h_cmd(uintptr_t cmd_ptr, uint32_t& downstre
     uintptr_t data_ptr = cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader) + sizeof(CQPrefetchCmd);
     uint32_t amt = sub_cmds_length / sizeof(uint32_t);
     careful_copy_from_l1_to_local_cache<l1_to_local_cache_copy_chunk, l1_cache_elements_rounded>(
-        (volatile uint32_t tt_l1_ptr*)(data_ptr), amt, l1_cache);
+        uncached_l1_ptr<uint32_t>(data_ptr), amt, l1_cache);
 
     // Setup scratch buffer for relay
     uint32_t scratch_read_addr = scratch_db_top[0];
@@ -2571,7 +2695,7 @@ void kernel_main_h() {
         IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
 
         volatile CQPrefetchCmd tt_l1_ptr* cmd =
-            (volatile CQPrefetchCmd tt_l1_ptr*)(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
+            uncached_l1_ptr<CQPrefetchCmd>(cmd_ptr + sizeof(CQPrefetchHToPrefetchDHeader));
         uint32_t cmd_id = cmd->base.cmd_id;
         // Infer that an exec_buf command is to be executed based on the stall state.
         const bool is_exec_buf = (stall_state == StallState::STALLED);
@@ -2630,10 +2754,13 @@ void kernel_main_d() {
         num_hops,
         NCRISC_WR_CMD_BUF>(get_noc_addr_helper(downstream_noc_xy, 0), my_dev_id, to_dev_id, router_direction);
 #else
+#if !defined(ARCH_QUASAR)
+    // On Quasar, relay to the dispatcher is a same-core uncached memcpy; no NOC init-state needed.
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchRelayInlineState::downstream_write_cmd_buf>(
         0, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), 0, my_noc_index);
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchSRelayInlineState::downstream_write_cmd_buf>(
         0, get_noc_addr_helper(dispatch_s_noc_xy, downstream_data_ptr_s), 0, my_noc_index);
+#endif
 #endif
 
     // Initialize cmd_ptr tracking for release_pages synchronization assertions
@@ -2685,10 +2812,13 @@ void kernel_main_hd() {
     uint32_t l1_cache[l1_cache_elements_rounded];
     PrefetchExecBufState exec_buf_state;
 
+#if !defined(ARCH_QUASAR)
+    // On Quasar, relay to the dispatcher is a same-core uncached memcpy; no NOC init-state needed.
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchRelayInlineState::downstream_write_cmd_buf>(
         0, get_noc_addr_helper(downstream_noc_xy, downstream_data_ptr), 0);
     cq_noc_async_write_init_state<CQ_NOC_sNdl, false, false, DispatchSRelayInlineState::downstream_write_cmd_buf>(
         0, get_noc_addr_helper(dispatch_s_noc_xy, downstream_data_ptr_s), 0);
+#endif
 
     while (!done) {
         DeviceZoneScopedN("CQ-PREFETCH");

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -287,10 +287,9 @@ bool process_cmd(
     PrefetchExecBufState& exec_buf_state);
 
 #ifdef ARCH_QUASAR
-// Same-core copy: word-by-word L1->L1 memcpy through the L1 uncached alias, used when prefetcher and dispatcher are on
+// Same-core copy: L1->L1 memcpy through the L1 uncached alias, used when prefetcher and dispatcher are on
 // the same core.
-FORCE_INLINE void local_copy_words(uintptr_t dst_addr, uintptr_t src_addr, uint32_t num_bytes, uint32_t dst_end) {
-    ASSERT((num_bytes & 0x3u) == 0);
+FORCE_INLINE void local_copy_bytes(uintptr_t dst_addr, uintptr_t src_addr, uint32_t num_bytes, uint32_t dst_end) {
     ASSERT((src_addr & 0x3u) == 0);
     ASSERT((dst_addr & 0x3u) == 0);
     ASSERT(dst_addr + num_bytes <= dst_end);
@@ -299,6 +298,14 @@ FORCE_INLINE void local_copy_words(uintptr_t dst_addr, uintptr_t src_addr, uint3
     const uint32_t words = num_bytes >> 2;
     for (uint32_t i = 0; i < words; ++i) {
         dst_ptr[i] = src_ptr[i];
+    }
+    const uint32_t tail_bytes = num_bytes & 0x3u;
+    if (tail_bytes != 0) {
+        volatile uint8_t tt_l1_ptr* dst_tail = uncached_l1_ptr<uint8_t>(dst_addr + (words << 2));
+        volatile uint8_t tt_l1_ptr* src_tail = uncached_l1_ptr<uint8_t>(src_addr + (words << 2));
+        for (uint32_t i = 0; i < tail_bytes; ++i) {
+            dst_tail[i] = src_tail[i];
+        }
     }
 }
 #endif
@@ -319,7 +326,7 @@ FORCE_INLINE void write_downstream(
                 get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
                 remaining);
 #elif defined(ARCH_QUASAR)
-            local_copy_words(local_downstream_data_ptr, data_ptr, remaining, downstream_end);
+            local_copy_bytes(local_downstream_data_ptr, data_ptr, remaining, downstream_end);
 #else
             cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
                 static_cast<uint32_t>(data_ptr),
@@ -338,7 +345,7 @@ FORCE_INLINE void write_downstream(
         get_noc_addr_helper(downstream_noc_encoding, local_downstream_data_ptr),
         length);
 #elif defined(ARCH_QUASAR)
-    local_copy_words(local_downstream_data_ptr, data_ptr, length, downstream_end);
+    local_copy_bytes(local_downstream_data_ptr, data_ptr, length, downstream_end);
 #else
     cq_noc_async_write_with_state_any_len<true, true, CQNocWait::CQ_NOC_WAIT, downstream_cmd_buf>(
         static_cast<uint32_t>(data_ptr),
@@ -859,7 +866,7 @@ static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& di
     if (cmddat_wrap_enable && length > remaining) {
         // wrap cmddat
 #if defined(ARCH_QUASAR)
-        local_copy_words(dispatch_data_ptr, data_ptr, remaining, downstream_cb_end);
+        local_copy_bytes(dispatch_data_ptr, data_ptr, remaining, downstream_cb_end);
 #else
         noc_async_write(
             static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
@@ -869,7 +876,7 @@ static uint32_t process_relay_inline_noflush_cmd(uintptr_t cmd_ptr, uint32_t& di
         data_ptr = cmddat_q_base;
     }
 #if defined(ARCH_QUASAR)
-    local_copy_words(dispatch_data_ptr, data_ptr, length, downstream_cb_end);
+    local_copy_bytes(dispatch_data_ptr, data_ptr, length, downstream_cb_end);
 #else
     noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
 #endif
@@ -904,7 +911,7 @@ static uint32_t write_pages_to_dispatcher(
 #if defined(FABRIC_RELAY)
         noc_async_write(scratch_write_addr, noc_addr, last_chunk_size);
 #elif defined(ARCH_QUASAR)
-        local_copy_words(downstream_data_ptr, scratch_write_addr, last_chunk_size, downstream_cb_end);
+        local_copy_bytes(downstream_data_ptr, scratch_write_addr, last_chunk_size, downstream_cb_end);
 #else
         cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, last_chunk_size);
 #endif
@@ -919,7 +926,7 @@ static uint32_t write_pages_to_dispatcher(
 #if defined(FABRIC_RELAY)
     noc_async_write(scratch_write_addr, noc_addr, amt_to_write);
 #elif defined(ARCH_QUASAR)
-    local_copy_words(downstream_data_ptr, scratch_write_addr, amt_to_write, downstream_cb_end);
+    local_copy_bytes(downstream_data_ptr, scratch_write_addr, amt_to_write, downstream_cb_end);
 #else
     cq_noc_async_write_with_state_any_len<true, true>(scratch_write_addr, noc_addr, amt_to_write);
 #endif
@@ -1617,7 +1624,7 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
         noc_async_write(
             static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
 #elif defined(ARCH_QUASAR)
-        local_copy_words(dispatch_data_ptr, data_ptr, remaining, downstream_cb_end);
+        local_copy_bytes(dispatch_data_ptr, data_ptr, remaining, downstream_cb_end);
 #else
         cq_noc_async_write_with_state_any_len<true, true>(
             static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), remaining);
@@ -1639,7 +1646,7 @@ static uint32_t process_exec_buf_relay_inline_noflush_cmd(
 #if defined(FABRIC_RELAY)
     noc_async_write(static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);
 #elif defined(ARCH_QUASAR)
-    local_copy_words(dispatch_data_ptr, data_ptr, length, downstream_cb_end);
+    local_copy_bytes(dispatch_data_ptr, data_ptr, length, downstream_cb_end);
 #else
     cq_noc_async_write_with_state_any_len<true, true>(
         static_cast<uint32_t>(data_ptr), get_noc_addr_helper(downstream_noc_xy, dispatch_data_ptr), length);


### PR DESCRIPTION
### PR Category
Feature

### Summary
This branch brings up the prefetcher side of fast dispatch on Quasar with a single CQ, building on the dispatcher-side work in #45055. Fast dispatch will not work end-to-end with this PR alone because further work is needed to run the prefetcher and dispatcher kernels in fast dispatch.

The key device-side changes are:
 - `cq_prefetch.cpp` and `cq_common.hpp` are updated to route all L1 reads through the L1 uncached address to avoid cache staleness or cache coherency issues
 - data is moved from the prefetcher to the dispatcher with a local L1-to-L1 copy on Quasar instead of using the NOC
 - the dispatcher's upstream sync semaphore increment on Quasar uses the local increment path instead of using the NOC

For testing, the slow dispatch tests in `test_prefetcher.cpp` have been updated to be compatible with Quasar. The changes in this branch have only been tested with the slow dispatch tests in `test_prefetcher.cpp`.

Remaining work:
 - getting the prefetcher and dispatcher kernels to run end-to-end in fast dispatch
 - moving the fast dispatch kernels to a Dispatch Engine instead of a regular core
 - using host hugepages instead of DRAM for CQs for Quasar fast dispatch
 - supporting 2CQ fast dispatch

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_fd_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_fd_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/qsr_fd_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/qsr_fd_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_fd_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_fd_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_fd_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_fd_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_fd_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_fd_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_fd_prefetcher)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_fd_prefetcher)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_fd_prefetcher)