### PR TITLE
[CI Disable] single-card-demo-tests: skip sdxl test_demo on wormhole_b0 with trace+device_encoders

### DIFF
--- a/models/demos/stable_diffusion_xl_base/demo/demo.py
+++ b/models/demos/stable_diffusion_xl_base/demo/demo.py
@@ -11,7 +11,7 @@ from diffusers import DiffusionPipeline
 from loguru import logger
 from transformers import CLIPTextModel, CLIPTextModelWithProjection
 
-from models.common.utility_functions import is_blackhole, profiler
+from models.common.utility_functions import is_blackhole, is_wormhole_b0, profiler
 from models.demos.stable_diffusion_xl_base.conftest import is_galaxy
 from models.demos.stable_diffusion_xl_base.tests.test_common import (
     CONCATENATED_TEXT_EMBEDINGS_SIZE,
@@ -310,6 +310,9 @@ def test_demo(
 ):
     if image_resolution == (512, 512) and is_blackhole():
         pytest.skip("512x512 not supported on Blackhole")
+
+    if capture_trace and encoders_on_device and not use_cfg_parallel and is_wormhole_b0():
+        pytest.skip("Disabled on wormhole_b0 with trace+device_encoders (no cfg_parallel): see #46550")
 
     prepare_device(mesh_device, use_cfg_parallel)
     return run_demo_inference(


### PR DESCRIPTION
Disable removed — all previously disabled tests are now passing on main.

Original disable: skip `test_demo[wormhole_b0-...-with_trace-device_encoders-...-no_cfg_parallel-1024x1024]` and `test_demo[...512x512]` due to `CLIPEncoder.forward() takes 2 positional arguments but 3 were given`.

Verification run [27244284837](https://github.com/tenstorrent/tt-metal/actions/runs/27244284837) concluded `success` (verified-pass). Tests subsequently started passing on main (run [27257893975](https://github.com/tenstorrent/tt-metal/actions/runs/27257893975/job/80497556116), 2026-06-10 07:17 UTC) — disable no longer needed. PR closed with no tests disabled.

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| _(all disables removed — see PR comment)_ | | | |