### PR TITLE
runtime-integration-tests: disable test_indexed_slice (device hang)

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py
@@ -30,7 +30,7 @@ from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
 )
 @pytest.mark.parametrize(
     "D",
-    [pytest.param(4, marks=pytest.mark.skip(reason="Disabled: see #45989")), 16, 1024, 4096],
+    [4, 16, 1024, 4096],
 )
 @pytest.mark.parametrize(
     "tt_dtype",
@@ -38,6 +38,7 @@ from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
         ttnn.bfloat16,
     ],
 )
+@pytest.mark.skip(reason="Disabled: indexed_fill ProgramDescriptor migration (#43840) regressed factory — see #45989")
 def test_indexed_slice(seed, B, b, D, tt_dtype, device):
     torch.manual_seed(seed)
 

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py
@@ -38,7 +38,9 @@ from tests.ttnn.utils_for_testing import tt_dtype_to_torch_dtype
         ttnn.bfloat16,
     ],
 )
-@pytest.mark.skip(reason="Disabled: indexed_fill ProgramDescriptor migration (#43840) regressed factory — see #45989")
+@pytest.mark.skip(
+    reason="Disabled: device hang; tracked in https://github.com/tenstorrent/tt-metal/issues/45989 (regression from #43840)"
+)
 def test_indexed_slice(seed, B, b, D, tt_dtype, device):
     torch.manual_seed(seed)
 


### PR DESCRIPTION
## Summary
- Disable all `test_indexed_slice` parametrizations in `tests/tt_eager/python_api_testing/unit_testing/misc/test_indexed_fill.py` that hang the device in `runtime-integration-tests`.
- Replaces the partial `D=4` skip from #45991 with a test-level skip until `IndexedFillProgramFactory` is restored.
- Root cause: #43840 ProgramDescriptor migration regressed the generic indexed_fill path (missing `kernel_mode`, wrong writer, incomplete runtime args). Tracks #45989.

## Test plan
- [x] `runtime-integration-tests` completes without device timeout on BH/WH - https://github.com/tenstorrent/tt-metal/actions/runs/27244809141
- [x] pytest reports `test_indexed_slice` as skipped (not failed)
- [ ] Re-enable once #43840 factory logic is restored and verified locally

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/ci-disable-indexed-fill-45989)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/ci-disable-indexed-fill-45989)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/ci-disable-indexed-fill-45989)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/ci-disable-indexed-fill-45989)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=msudumbrekar/ci-disable-indexed-fill-45989)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:msudumbrekar/ci-disable-indexed-fill-45989)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/ci-disable-indexed-fill-45989)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/ci-disable-indexed-fill-45989)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/ci-disable-indexed-fill-45989)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/ci-disable-indexed-fill-45989)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/ci-disable-indexed-fill-45989)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/ci-disable-indexed-fill-45989)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/ci-disable-indexed-fill-45989)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/ci-disable-indexed-fill-45989)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/ci-disable-indexed-fill-45989)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/ci-disable-indexed-fill-45989)