### PR TITLE
Fix: Raise runtime_llk WH timeout from 8 to 12 minutes

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -153,7 +153,7 @@ runtime:
     bh_quietbox: 5
     bh_loudbox: 5
   unit:
-    wh_n150_civ2: 222
+    wh_n150_civ2: 226
     wh_n300_civ2: 74
     bh_p150b_civ2: 210
     bh_p150b_civ2_viommu: 5

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -88,6 +88,7 @@
   team: runtime
 
 # --- LLK + SFPI Tests ---
+# WH timeout raised from 8→12 min: full LLK+SFPI suite exceeds 8 min wall clock on wh_n150_civ2.
 - name: runtime_llk
   # 4 tests disabled by #44767.
   disabled_llk_filter: &disabled_llk 'LLKBlackholeSingleCardFixture.TensixComputePackUntilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixComputeUnpackTilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixFp8e4m3ToFp8e4m3:MeshDeviceFixture.Top32RmDevPipelineCompletes'
@@ -96,7 +97,7 @@
     ./build/test/tt_metal/unit_tests_sfpi
   skus:
     wh_n150_civ2:
-      timeout: 8
+      timeout: 12
     bh_p150b_civ2:
       timeout: 8
   owner_id: U099A7FMKL2 # Manish Sudumbrekar


### PR DESCRIPTION

## Summary
- Increase `runtime_llk` timeout for `wh_n150_civ2` from 8 to 12 minutes.
- The job was timing out while tests were still passing (not a test failure).
- BH stays at 8 minutes (passes today).
- Runtime unit budget for `wh_n150_civ2` increased by 4 minutes (222 → 226).

## Test plan
- [x] `runtime_llk [wh_n150_civ2]` completes within 12 minutes on CI
- [x] `runtime_llk [bh_p150b_civ2]` still passes at 8 minutes
- [ ] If WH still times out, follow up by removing WH from `runtime_llk` (covered by `llk_unit_tests.yaml`)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-runtime-llk-wh-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/fix-runtime-llk-wh-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/fix-runtime-llk-wh-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/fix-runtime-llk-wh-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=msudumbrekar/fix-runtime-llk-wh-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:msudumbrekar/fix-runtime-llk-wh-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/fix-runtime-llk-wh-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/fix-runtime-llk-wh-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/fix-runtime-llk-wh-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/fix-runtime-llk-wh-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/fix-runtime-llk-wh-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/fix-runtime-llk-wh-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/fix-runtime-llk-wh-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/fix-runtime-llk-wh-timeout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/fix-runtime-llk-wh-timeout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/fix-runtime-llk-wh-timeout)