### PR TITLE
Bug fix: remove width-only untilize cache heuristic

### DIFF
--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -24,6 +24,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_levelized_graph.cpp
     test_graph_capture_arguments_morehdot.cpp
     test_graph_capture_arguments_transpose.cpp
+    test_graph_capture_arguments_untilize_with_unpadding.cpp
     test_graph_query_op_constraints.cpp
     test_graph_query_op_runtime.cpp
     test_launch_operation.cpp

--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_untilize_with_unpadding.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_untilize_with_unpadding.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <nlohmann/json.hpp>
+#include "ttnn/tensor/tensor_ops.hpp"
+#include <algorithm>
+#include <vector>
+
+#include <tt-metalium/graph_tracking.hpp>
+#include "gtest/gtest.h"
+#include <tt-metalium/shape.hpp>
+#include "ttnn/graph/graph_processor.hpp"
+#include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.hpp"
+#include "ttnn/tensor/layout/page_config.hpp"
+#include "ttnn/tensor/layout/tensor_layout.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn_test_fixtures.hpp"
+
+namespace ttnn::graph::arguments::test {
+namespace {
+
+using TestGraphCaptureArgumentsUntilizeWithUnpadding = TTNNFixtureWithDevice;
+
+TEST_F(TestGraphCaptureArgumentsUntilizeWithUnpadding, UntilizeWithUnpadding) {
+    TensorSpec tensor_spec(
+        ttnn::Shape({1, 10240, 32}),
+        TensorLayout(tt::tt_metal::DataType::BFLOAT16, PageConfig(tt::tt_metal::Layout::TILE), DRAM_MEMORY_CONFIG));
+    auto input_tensor = create_device_tensor(tensor_spec, device_);
+
+    ttnn::graph::GraphProcessor::begin_graph_capture(tt::tt_metal::IGraphProcessor::RunMode::NORMAL);
+    ttnn::untilize_with_unpadding(
+        input_tensor,
+        ttnn::Shape({0, 10239, 31}),
+        ttnn::DRAM_MEMORY_CONFIG,
+        true,
+        std::nullopt);
+    auto trace = ttnn::graph::GraphProcessor::end_graph_capture();
+    auto operations = ttnn::graph::extract_arguments(trace);
+
+    const auto it = std::find_if(operations.begin(), operations.end(), [](const auto& op) {
+        return op.operation_name == "UntilizeWithUnpaddingDeviceOperation";
+    });
+    ASSERT_NE(it, operations.end()) << "UntilizeWithUnpaddingDeviceOperation not found";
+
+    const auto& operation = *it;
+    ASSERT_EQ(operation.arguments.size(), 2u);
+
+    const auto& op_attrs = operation.arguments[0];
+    EXPECT_TRUE(op_attrs.find("UntilizeWithUnpaddingParams(") != std::string::npos);
+    EXPECT_TRUE(op_attrs.find("Shape([0, 10239, 31])") != std::string::npos);
+    EXPECT_TRUE(op_attrs.find("TensorMemoryLayout::INTERLEAVED") != std::string::npos);
+    EXPECT_TRUE(op_attrs.find("BufferType::DRAM") != std::string::npos);
+
+    // The host-side op identity now carries one space heuristic bit (height) instead of
+    // separate width and height bits.
+    EXPECT_TRUE(op_attrs.find(", 1, 0, 1, std::nullopt)") != std::string::npos);
+    EXPECT_TRUE(op_attrs.find(", 1, 0, 0, 1, std::nullopt)") == std::string::npos);
+
+    const auto& tensor_args = operation.arguments[1];
+    EXPECT_TRUE(tensor_args.find("Tensor(") != std::string::npos);
+    EXPECT_TRUE(tensor_args.find("Shape([1, 10240, 32])") != std::string::npos);
+    EXPECT_TRUE(tensor_args.find("DataType::BFLOAT16") != std::string::npos);
+    EXPECT_TRUE(tensor_args.find("TilePageConfig") != std::string::npos);
+    EXPECT_TRUE(tensor_args.find("DeviceStorage()") != std::string::npos);
+}
+
+}  // namespace
+}  // namespace ttnn::graph::arguments::test

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
@@ -15,6 +15,15 @@ TTNN_TO_TORCH_DTYPE = {
 }
 
 
+@pytest.fixture
+def isolate_program_cache(device):
+    """Ensure each test starts with an empty program cache and cleans up after."""
+    device.disable_and_clear_program_cache()
+    device.enable_program_cache()
+    yield
+    device.disable_and_clear_program_cache()
+
+
 @pytest.mark.parametrize("dtype", [ttnn.float32, ttnn.bfloat16])
 @pytest.mark.parametrize(
     "shape_output_end",
@@ -51,6 +60,59 @@ def test_untilize_with_unpadding_fp32(device, dtype, shape_output_end, input_buf
     torch_result = torch_tensor[slices]
 
     assert torch.equal(result, torch_result), f"untilize_with_unpadding lost {dtype} precision"
+
+
+def test_untilize_with_unpadding_reuses_cache_when_only_width_l1_heuristic_changes(device, isolate_program_cache):
+    """
+    Regression test for issue #46533 first-shot fix.
+
+    This shape keeps the height-side CB estimate tiny (1 tile row) while making the
+    width-side estimate large enough to react to unrelated resident L1 buffers.
+    enough_space_width is not consumed by factory selection or descriptor creation,
+    so changing only that heuristic must not fork the program cache.
+    """
+    torch.manual_seed(0)
+
+    input_shape = [1, 10240, 32]
+    output_end = [0, 10239, 31]
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    assert device.num_program_cache_entries() == 0, "Program cache should be empty before the test"
+
+    with device.cache_entries_counter.measure():
+        output_tensor = ttnn.untilize_with_unpadding(
+            input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+
+    assert_equal(ttnn.to_torch(output_tensor), torch_input)
+    assert device.cache_entries_counter.total == 1
+
+    ttnn.synchronize_device(device)
+
+    hog_shape = [1, 1, 32, 16384]
+    hog_tensors = [
+        ttnn.allocate_tensor_on_device(
+            ttnn.Shape(hog_shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device, ttnn.L1_MEMORY_CONFIG
+        )
+        for _ in range(3)
+    ]
+    assert len(hog_tensors) == 3
+
+    with device.cache_entries_counter.measure():
+        output_tensor = ttnn.untilize_with_unpadding(
+            input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
+        )
+
+    assert_equal(ttnn.to_torch(output_tensor), torch_input)
+    assert device.cache_entries_counter.total == 1
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -289,7 +289,6 @@ Tensor untilize_with_unpadding(
     const std::optional<tt::tt_metal::MemoryConfig>& output_mem_config,
     bool use_multicore,
     bool fp32_dest_acc_en,
-    bool enough_space_width,
     bool enough_space_height,
     const std::optional<CoreRangeSet>& sub_core_grids) {
     return ttnn::device_operation::launch<UntilizeWithUnpaddingDeviceOperation>(
@@ -298,7 +297,6 @@ Tensor untilize_with_unpadding(
             .output_mem_config = output_mem_config.value_or(input_tensor.memory_config()),
             .use_multicore = use_multicore,
             .fp32_dest_acc_en = fp32_dest_acc_en,
-            .enough_space_width = enough_space_width,
             .enough_space_height = enough_space_height,
             .sub_core_grids = sub_core_grids},
         input_tensor);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.hpp
@@ -51,7 +51,6 @@ Tensor untilize_with_unpadding(
     const std::optional<MemoryConfig>& output_mem_config,
     bool use_multicore,
     bool fp32_dest_acc_en,
-    bool enough_space_width,
     bool enough_space_height,
     const std::optional<CoreRangeSet>& sub_core_grids);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp
@@ -13,7 +13,6 @@ struct UntilizeWithUnpaddingParams {
     tt::tt_metal::MemoryConfig output_mem_config;
     bool use_multicore = false;
     bool fp32_dest_acc_en = false;
-    bool enough_space_width = false;
     bool enough_space_height = false;
     std::optional<CoreRangeSet> sub_core_grids = std::nullopt;
 };

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
@@ -91,10 +91,7 @@ Tensor untilize_with_unpadding(
     uint32_t output_single_tile_size = input_single_tile_size;
 
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / tt::constants::TILE_WIDTH;
-    uint32_t num_tiles_per_col = input_tensor.padded_shape()[-2] / tt::constants::TILE_HEIGHT;
 
-    bool enough_space_width = operations::data_movement::is_enough_space(
-        input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_col);
     bool enough_space_height = operations::data_movement::is_enough_space(
         input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
 
@@ -105,7 +102,6 @@ Tensor untilize_with_unpadding(
             memory_config,
             use_multicore,
             fp32_dest_acc_en,
-            enough_space_width,
             enough_space_height,
             sub_core_grids);
     };


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Relates to #46533.

untilize_with_unpadding was folding enough_space_width into the device op attributes even though program-factory selection only consumes enough_space_height.

That made the program-cache key depend on transient free L1 for a width-side heuristic that does not change the selected program factory. The same tensor spec could therefore fork the cache when unrelated resident L1 allocations changed enough_space_width.

This change removes enough_space_width from the host-side untilize_with_unpadding attribute surface.

The regression coverage now checks that boundary from two sides:
1. a Python cache-entry test keeps the op shape fixed, changes unrelated resident L1 pressure, and checks that the cache entry count stays stable
2. a graph-capture gtest pins the UntilizeWithUnpaddingDeviceOperation argument surface so the width-side heuristic no longer contributes to the captured host-side op identity

### Notes for reviewers
I left enough_space_height in place because select_program_factory still branches on it for the interleaved multicore path.

The code-path argument is:
- untilize_with_unpadding computes both heuristics from current free L1
- select_program_factory only reads enough_space_height
- enough_space_width therefore changed op identity without changing factory selection

This PR is intentionally narrower than full issue closure. I could validate the host-side width-heuristic path and the new regression surfaces locally, but I could not rerun the original trace-capture repro end to end on this machine because the local hardware-free path uses slow dispatch and trace capture is not supported there.
