### PR TITLE
[Bug Fix] Fix run_validation for non-default volume inputs

### DIFF
--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -224,6 +224,67 @@ if [[ "$TEST_CONFIG_EXPLICIT" == false && ( "$CONFIG" == "4x8z" || "$CONFIG" == 
     TEST_CONFIG="$TEST_CONFIG_Z"
 fi
 
+# ---------------------------------------------------------------------------
+# Canonical host ordering (snake/zigzag) for the multi-host quad configs.
+#
+# Mirrors generate_blitz_decode_pipeline_configs.py:sort_hosts_canonical so the
+# operator does not have to pass --hosts in physical ring order. Hosts are
+# grouped by the <rack> number in r<rack>u<unit>; within each group <unit> is
+# sorted descending for even-indexed groups and ascending for odd-indexed
+# groups, producing the serpentine order that matches the physical Z-ring
+# cabling. Unrecognised hostnames (no r<rack>u<unit> pattern) are appended last
+# in input order. Echoes the reordered comma-separated list.
+sort_hosts_canonical() {
+    local csv="$1"
+    local -a in_hosts
+    IFS=',' read -ra in_hosts <<< "$csv"
+
+    local -a unrecognised=()
+    local -A group_units=()
+    local h
+    for h in "${in_hosts[@]}"; do
+        if [[ "$h" =~ ([0-9]+)u([0-9]{2}) ]]; then
+            group_units["${BASH_REMATCH[1]}"]+="${BASH_REMATCH[2]}:${h} "
+        else
+            unrecognised+=("$h")
+        fi
+    done
+
+    local -a racks=()
+    mapfile -t racks < <(printf '%s\n' "${!group_units[@]}" | sort -n)
+
+    local -a out=()
+    local idx=0 r sort_flag entry
+    for r in "${racks[@]}"; do
+        # Even-indexed groups descend by unit, odd-indexed ascend (serpentine).
+        if (( idx % 2 == 0 )); then sort_flag="-rn"; else sort_flag="-n"; fi
+        while IFS= read -r entry; do
+            [[ -n "$entry" ]] && out+=("${entry#*:}")
+        done < <(printf '%s\n' ${group_units[$r]} | sort -t: -k1,1 "$sort_flag")
+        ((idx++))
+    done
+
+    if [[ ${#unrecognised[@]} -gt 0 ]]; then
+        out+=("${unrecognised[@]}")
+    fi
+
+    local joined
+    printf -v joined '%s,' "${out[@]}"
+    echo "${joined%,}"
+}
+
+# Only the multi-host quad configs need deterministic ring order; smaller and
+# single-host configs keep the user's --hosts order untouched.
+if [[ "$CONFIG" == "8x4x4z" || "$CONFIG" == "4x32z" ]]; then
+    HOSTS_ORIG="$HOSTS"
+    HOSTS="$(sort_hosts_canonical "$HOSTS")"
+    if [[ "$HOSTS" != "$HOSTS_ORIG" ]]; then
+        echo "Reordered hosts into canonical ring order for $CONFIG:"
+        echo "  before: $HOSTS_ORIG"
+        echo "  after:  $HOSTS"
+    fi
+fi
+
 # Create output directory if it doesn't exist
 mkdir -p "$OUTPUT_DIR"
 

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -23,8 +23,9 @@ Optional:
                                             (if provided, cabling and deployment descriptors are ignored)
     --output <directory>                    Output directory for log files (default: validation_output)
     --volume <host-path>                    Additional volume mount for Docker containers (can be repeated)
-                                            /data/scaleout_configs is mounted by default; each host path
-                                            is mounted at the same path inside the container
+                                            /data/scaleout_configs is mounted by default when it exists on
+                                            the host; each host path is mounted at the same path inside
+                                            the container
     --mpi-if <interface>                    Network interface for MPI TCP transport (default: ens5f0np0)
     --mpi-args <args>                       Extra arguments passed directly to mpirun (quoted string)
                                             e.g. --mpi-args "--tag-output"
@@ -57,7 +58,13 @@ ITERATIONS=50
 
 FACTORY_DESCRIPTOR_PATH=""
 OUTPUT_DIR="validation_output"
-EXTRA_VOLUMES=(/data/scaleout_configs)
+# /data/scaleout_configs is a Markham-cluster convention. Only mount it when it
+# actually exists locally; otherwise Docker fails trying to auto-create the
+# missing bind-mount source path (mkdir: permission denied) and every rank dies
+# before run_cluster_validation starts. Sites that keep configs elsewhere just
+# pass them via --volume / the descriptor path flags.
+EXTRA_VOLUMES=()
+[[ -d /data/scaleout_configs ]] && EXTRA_VOLUMES+=(/data/scaleout_configs)
 MPI_IF="ens5f0np0"
 MPI_EXTRA_ARGS=()
 VALIDATION_EXTRA_ARGS=()
@@ -365,6 +372,14 @@ for ((i=1; i<=ITERATIONS; i++)); do
             echo ""
             echo "Running cluster validation..."
             run_cluster_validation "$OUTPUT_DIR/iteration_${i}"
+            VALIDATION_EXIT_CODE=$?
+            # Surface validation failures explicitly. Without this, a container
+            # that dies before run_cluster_validation starts (e.g. a bad bind
+            # mount -> docker exit 126) produces no output yet the loop still
+            # prints "completed", masking the failure.
+            if [[ $VALIDATION_EXIT_CODE -ne 0 ]]; then
+                echo "ERROR: cluster validation FAILED (exit code $VALIDATION_EXIT_CODE)"
+            fi
         else
             echo "Skipping validation due to mpirun failure"
         fi


### PR DESCRIPTION
### PR Category
[Bug Fix]

### Summary
run_validation always passes in /data/scaleout_configs as an input regardless of what environment its running on. This fails in any other environment when no such directory exists. 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nnyamagoudar/fix-run-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nnyamagoudar/fix-run-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nnyamagoudar/fix-run-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nnyamagoudar/fix-run-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nnyamagoudar/fix-run-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nnyamagoudar/fix-run-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nnyamagoudar/fix-run-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nnyamagoudar/fix-run-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nnyamagoudar/fix-run-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nnyamagoudar/fix-run-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nnyamagoudar/fix-run-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nnyamagoudar/fix-run-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nnyamagoudar/fix-run-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nnyamagoudar/fix-run-validation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nnyamagoudar/fix-run-validation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nnyamagoudar/fix-run-validation)