### PR TITLE
[Feature] Partial ProgramRunArgs update and enqueue-invariant arguments for Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -162,7 +162,7 @@ inline ProgramRunArgs MakeRunArgsForMinimalSpec(
 }
 
 // ============================================================================
-// SECTION 1: Validation Tests (expect failure)
+// SECTION: Validation Tests (expect failure)
 // ============================================================================
 
 TEST_F(ProgramRunArgsTestQuasar, UnknownKernelNameFails) {
@@ -340,7 +340,7 @@ TEST_F(ProgramRunArgsTestQuasar, DFBNumEntriesOverrideFails) {
 }
 
 // ============================================================================
-// SECTION 1b: Uniqueness Tests (duplicate detection)
+// SECTION: Uniqueness Tests (duplicate detection)
 // ============================================================================
 
 TEST_F(ProgramRunArgsTestQuasar, DuplicateKernelParamsFails) {
@@ -398,7 +398,7 @@ TEST_F(ProgramRunArgsTestQuasar, DuplicateNodeCoordInRuntimeArgsFails) {
 }
 
 // ============================================================================
-// SECTION 2: Success Tests (basic functionality)
+// SECTION: Success Tests (basic functionality)
 // ============================================================================
 
 TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_ZeroRTAs) {
@@ -478,7 +478,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_DFBRunOverridesWithNoOverrid
 }
 
 // ============================================================================
-// SECTION 3: Repeated Call Tests
+// SECTION: Repeated Call Tests
 // ============================================================================
 
 TEST_F(ProgramRunArgsTestQuasar, SetRunArgsTwice_SameValuesSucceeds) {
@@ -544,7 +544,7 @@ TEST_F(ProgramRunArgsTestQuasar, SetRunArgsMultipleTimes_Succeeds) {
 }
 
 // ============================================================================
-// SECTION 4: Multi-Node Tests
+// SECTION: Multi-Node Tests
 // ============================================================================
 
 TEST_F(ProgramRunArgsTestQuasar, SetRunArgsSucceeds_MultiNodeKernel) {
@@ -653,7 +653,7 @@ TEST_F(ProgramRunArgsTestQuasar, MultiNode_MissingOneNodeFails) {
 }
 
 // ============================================================================
-// SECTION 5: Gen1 (WH/BH) Tests
+// SECTION: Gen1 (WH/BH) Tests
 // ============================================================================
 // The RTA validation logic in SetProgramRunArgs is arch-agnostic; these
 // tests verify the full roundtrip works on gen1 programs and that validation
@@ -661,7 +661,7 @@ TEST_F(ProgramRunArgsTestQuasar, MultiNode_MissingOneNodeFails) {
 
 // Test fixture for ProgramRunArgs on Wormhole - uses WORMHOLE_B0 mock device
 // ============================================================================
-// SECTION 4: Named RTA / CRTA Tests (Quasar)
+// SECTION: Named RTA / CRTA Tests (Quasar)
 // ============================================================================
 
 // Make a ProgramSpec where the DM kernel has a named-RTA / named-CRTA schema.
@@ -768,12 +768,8 @@ TEST_F(ProgramRunArgsTestQuasar, NamedCRTACountMismatchFails) {
 // Vararg-only regression tests
 // ============================================================================
 //
-// These document the "legacy kernel migrated to Metal 2.0" pattern: all args as positional
-// varargs, no named RTAs/CRTAs/CTAs. This is expected to be the dominant migration shape —
-// users who port existing kernels will default to leaving everything as positional args
-// because that's how the old kernel source reads them. These tests are deliberately the
-// strongest regression canaries in this file; breaking them will break migration.
-
+// These document the "legacy kernel migrated lazily to Metal 2.0" pattern: all args as
+// positional varargs, no named RTAs/CRTAs/CTAs.
 TEST_F(ProgramRunArgsTestQuasar, VarargOnlyMultiNodeDifferingCountsSucceeds) {
     // A kernel on two nodes with DIFFERENT vararg counts per node. Exercises the advanced
     // num_runtime_varargs_per_node override path. The RTA dispatch buffer must be sized
@@ -1891,6 +1887,248 @@ TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_DynamicWinsWhenBothSet) {
         {TensorParamName{"input_tensor"}, TensorArgument{tensor}},
     };
     EXPECT_NO_THROW(SetProgramRunArgs(program, params));
+}
+
+// ============================================================================
+// SECTION: Enqueue-loop invariance + UpdateProgramRunArgs + MergeProgramRunArgs
+// ============================================================================
+
+// --- Spec-time legality: an invariant name must reference a declared named arg ---
+
+TEST_F(ProgramRunArgsTestQuasar, InvariantRuntimeArgNameMustBeDeclaredFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, /*rtas=*/{"real_rta"}, /*crtas=*/{});
+    spec.kernels[0].advanced_options.enqueue_invariant_runtime_args = {"not_declared"};
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("is not a declared named")));
+}
+
+TEST_F(ProgramRunArgsTestQuasar, InvariantCommonRuntimeArgNameMustBeDeclaredFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, /*rtas=*/{}, /*crtas=*/{"real_crta"});
+    spec.kernels[0].advanced_options.enqueue_invariant_common_runtime_args = {"not_declared"};
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("is not a declared named")));
+}
+
+// --- The core contract: invariant args are retained, regular args are updated ---
+
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsInvariantCRTA) {
+    NodeCoord node{0, 0};
+    // Declaration order: keep @ slot 0 (invariant), change @ slot 1 (regular).
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"keep", "change"});
+    spec.kernels[0].advanced_options.enqueue_invariant_common_runtime_args = {"keep"};
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    ProgramRunArgs params;
+    params.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .common_runtime_arg_values = {{"keep", 10}, {"change", 20}},
+    });
+    params.kernel_run_args.push_back(MakeKernelRunArgs(KernelSpecName{"compute_kernel"}, node, {}, {}));
+    SetProgramRunArgs(program, params);
+
+    // Supply only the regular "change"; omit invariant "keep" and the all-empty compute_kernel.
+    ProgramRunArgs upd;
+    upd.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .common_runtime_arg_values = {{"change", 99}},
+    });
+    EXPECT_NO_THROW(UpdateProgramRunArgs(program, upd));
+
+    const auto* crta = program.impl().get_kernel_by_spec_name("dm_kernel")->common_runtime_args_data().data();
+    EXPECT_EQ(crta[0], 10u) << "invariant 'keep' must retain its value across a partial update";
+    EXPECT_EQ(crta[1], 99u) << "regular 'change' must be updated";
+}
+
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_RetainsInvariantPerNodeRTA) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, {"keep", "change"}, {});
+    spec.kernels[0].advanced_options.enqueue_invariant_runtime_args = {"keep"};
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    ProgramRunArgs params;
+    params.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .runtime_arg_values = {{node, {{"keep", 1}, {"change", 2}}}},
+    });
+    params.kernel_run_args.push_back(MakeKernelRunArgs(KernelSpecName{"compute_kernel"}, node, {}, {}));
+    SetProgramRunArgs(program, params);
+
+    ProgramRunArgs upd;
+    upd.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .runtime_arg_values = {{node, {{"change", 99}}}},
+    });
+    EXPECT_NO_THROW(UpdateProgramRunArgs(program, upd));
+
+    const auto& rta = program.impl().get_kernel_by_spec_name("dm_kernel")->runtime_args(node);
+    ASSERT_GE(rta.size(), 2u);
+    EXPECT_EQ(rta[0], 1u) << "invariant 'keep' must retain its value";
+    EXPECT_EQ(rta[1], 99u) << "regular 'change' must be updated";
+}
+
+// --- Completeness: a regular (non-invariant) arg may not be omitted ---
+
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_MissingRegularCRTAFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"keep", "change"});
+    spec.kernels[0].advanced_options.enqueue_invariant_common_runtime_args = {"keep"};
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    ProgramRunArgs full;
+    full.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .common_runtime_arg_values = {{"keep", 10}, {"change", 20}},
+    });
+    full.kernel_run_args.push_back(MakeKernelRunArgs(KernelSpecName{"compute_kernel"}, node, {}, {}));
+    SetProgramRunArgs(program, full);
+
+    // Supply only the invariant "keep"; omit the regular "change" → error.
+    ProgramRunArgs upd;
+    upd.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .common_runtime_arg_values = {{"keep", 11}},
+    });
+    EXPECT_THAT(
+        [&] { UpdateProgramRunArgs(program, upd); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("is missing named CRTA 'change'")));
+}
+
+// --- Precondition: a partial update before any full set fails ---
+
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_BeforeSetFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"keep", "change"});
+    spec.kernels[0].advanced_options.enqueue_invariant_common_runtime_args = {"keep"};
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    ProgramRunArgs upd;
+    upd.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .common_runtime_arg_values = {{"change", 99}},
+    });
+    EXPECT_THAT(
+        [&] { UpdateProgramRunArgs(program, upd); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("CRTA buffer not allocated")));
+}
+
+// --- Kernel-omission rule ---
+
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_OmittingKernelWithRegularArgsFails) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"change"});  // regular CRTA, nothing invariant
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    ProgramRunArgs full;
+    full.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .common_runtime_arg_values = {{"change", 20}},
+    });
+    full.kernel_run_args.push_back(MakeKernelRunArgs(KernelSpecName{"compute_kernel"}, node, {}, {}));
+    SetProgramRunArgs(program, full);
+
+    // Omit dm_kernel entirely though it has a regular CRTA → error.
+    ProgramRunArgs upd;
+    EXPECT_THAT(
+        [&] { UpdateProgramRunArgs(program, upd); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("was omitted from UpdateProgramRunArgs")));
+}
+
+TEST_F(ProgramRunArgsTestQuasar, UpdateProgramRunArgs_OmittingAllInvariantKernelSucceeds) {
+    NodeCoord node{0, 0};
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, {}, {"keep"});  // single CRTA, invariant
+    spec.kernels[0].advanced_options.enqueue_invariant_common_runtime_args = {"keep"};
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    ProgramRunArgs full;
+    full.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .common_runtime_arg_values = {{"keep", 7}},
+    });
+    full.kernel_run_args.push_back(MakeKernelRunArgs(KernelSpecName{"compute_kernel"}, node, {}, {}));
+    SetProgramRunArgs(program, full);
+
+    // Both kernels may be omitted: dm_kernel's only arg is invariant, compute_kernel is empty.
+    ProgramRunArgs upd;
+    EXPECT_NO_THROW(UpdateProgramRunArgs(program, upd));
+    EXPECT_EQ(program.impl().get_kernel_by_spec_name("dm_kernel")->common_runtime_args_data().data()[0], 7u)
+        << "invariant CRTA retained even when its kernel is omitted entirely";
+}
+
+// --- MergeProgramRunArgs (pure data helper; no device needed) ---
+
+const ProgramRunArgs::KernelRunArgs* FindKernel(const ProgramRunArgs& p, const std::string& name) {
+    for (const auto& kra : p.kernel_run_args) {
+        if (kra.kernel == KernelSpecName{name}) {
+            return &kra;
+        }
+    }
+    return nullptr;
+}
+
+TEST(MergeProgramRunArgs, UnionsDisjointCRTAsForSameKernel) {
+    // The motivating pattern: an invariant-args piece + a volatile-args piece for the SAME kernel
+    // with disjoint named CRTAs merge into one kernel entry holding both.
+    ProgramRunArgs invariant_piece;
+    invariant_piece.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .common_runtime_arg_values = {{"keep", 10}},
+    });
+    ProgramRunArgs volatile_piece;
+    volatile_piece.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .common_runtime_arg_values = {{"change", 20}},
+    });
+
+    std::vector<ProgramRunArgs> rest{volatile_piece};
+    ProgramRunArgs merged = MergeProgramRunArgs(std::move(invariant_piece), rest);
+
+    const auto* dm = FindKernel(merged, "dm_kernel");
+    ASSERT_NE(dm, nullptr);
+    auto keep = dm->common_runtime_arg_values.get("keep");
+    auto change = dm->common_runtime_arg_values.get("change");
+    ASSERT_TRUE(keep.has_value());
+    ASSERT_TRUE(change.has_value());
+    EXPECT_EQ(*keep, 10u);
+    EXPECT_EQ(*change, 20u);
+}
+
+TEST(MergeProgramRunArgs, ConflictingArgFails) {
+    ProgramRunArgs a;
+    a.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .common_runtime_arg_values = {{"x", 1}},
+    });
+    ProgramRunArgs b;
+    b.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .common_runtime_arg_values = {{"x", 2}},  // same arg in both inputs → conflict
+    });
+    std::vector<ProgramRunArgs> rest{b};
+    EXPECT_THAT(
+        [&] { MergeProgramRunArgs(std::move(a), rest); },
+        ::testing::ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("specified in more than one ProgramRunArgs")));
+}
+
+TEST(MergeProgramRunArgs, AppendsDistinctKernel) {
+    ProgramRunArgs a;
+    a.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"dm_kernel"},
+        .common_runtime_arg_values = {{"x", 1}},
+    });
+    ProgramRunArgs b;
+    b.kernel_run_args.push_back(ProgramRunArgs::KernelRunArgs{
+        .kernel = KernelSpecName{"compute_kernel"},
+        .common_runtime_arg_values = {{"y", 2}},
+    });
+    std::vector<ProgramRunArgs> rest{b};
+    ProgramRunArgs merged = MergeProgramRunArgs(std::move(a), rest);
+    EXPECT_NE(FindKernel(merged, "dm_kernel"), nullptr);
+    EXPECT_NE(FindKernel(merged, "compute_kernel"), nullptr);
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -1553,7 +1553,7 @@ TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_InterleavedAcceptsDifferentSha
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");  // shape {1, 32}
-    binding.relaxations = TensorParameterRelaxations{.dynamic_tensor_shape = true};
+    binding.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -1576,7 +1576,7 @@ TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_DTypeMismatchStillFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");  // BFLOAT16
-    binding.relaxations = TensorParameterRelaxations{.dynamic_tensor_shape = true};
+    binding.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -1605,7 +1605,7 @@ TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_RankMismatchFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");  // rank-2 shape {1, 32}
-    binding.relaxations = TensorParameterRelaxations{.dynamic_tensor_shape = true};
+    binding.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -1671,7 +1671,7 @@ TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_ShardedSetWritesShapeIntoCRTAs
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding =
         MakeShardedTensorParameter("input_tensor", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, /*num_cores=*/2);
-    binding.relaxations = TensorParameterRelaxations{.dynamic_tensor_shape = true};
+    binding.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -1697,7 +1697,7 @@ TEST_F(ProgramRunArgsTestGen1, DynamicTensorShape_ShardedUpdateRefreshesShape) {
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding =
         MakeShardedTensorParameter("input_tensor", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, /*num_cores=*/2);
-    binding.relaxations = TensorParameterRelaxations{.dynamic_tensor_shape = true};
+    binding.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -1750,7 +1750,7 @@ TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_AcceptsDifferentLogicalShape
     TensorParameter binding{
         .unique_id = TensorParamName{"input_tensor"},
         .spec = declared_spec,
-        .relaxations = TensorParameterRelaxations{.match_padded_shape_only = true},
+        .advanced_options = TensorParameterAdvancedOptions{.match_padded_shape_only = true},
     };
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
@@ -1782,7 +1782,7 @@ TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_PaddedShapeMismatchFails) {
     TensorParameter binding{
         .unique_id = TensorParamName{"input_tensor"},
         .spec = declared_spec,
-        .relaxations = TensorParameterRelaxations{.match_padded_shape_only = true},
+        .advanced_options = TensorParameterAdvancedOptions{.match_padded_shape_only = true},
     };
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
@@ -1811,7 +1811,7 @@ TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_DTypeMismatchStillFails) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");  // BFLOAT16
-    binding.relaxations = TensorParameterRelaxations{.match_padded_shape_only = true};
+    binding.advanced_options = TensorParameterAdvancedOptions{.match_padded_shape_only = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -1874,8 +1874,8 @@ TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_DynamicWinsWhenBothSet) {
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");  // shape {1, 32}
-    binding.relaxations =
-        TensorParameterRelaxations{.match_padded_shape_only = true, .dynamic_tensor_shape = true};
+    binding.advanced_options =
+        TensorParameterAdvancedOptions{.match_padded_shape_only = true, .dynamic_tensor_shape = true};
     spec.tensor_parameters = {binding};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -1897,7 +1897,7 @@ TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_DynamicWinsWhenBothSet) {
 
 TEST_F(ProgramRunArgsTestQuasar, InvariantRuntimeArgNameMustBeDeclaredFails) {
     NodeCoord node{0, 0};
-    ProgramSpec spec = MakeSpecWithNamedArgs(node, /*rtas=*/{"real_rta"}, /*crtas=*/{});
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, /*named_rtas=*/{"real_rta"}, /*named_crtas=*/{});
     spec.kernels[0].advanced_options.enqueue_invariant_runtime_args = {"not_declared"};
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
@@ -1906,7 +1906,7 @@ TEST_F(ProgramRunArgsTestQuasar, InvariantRuntimeArgNameMustBeDeclaredFails) {
 
 TEST_F(ProgramRunArgsTestQuasar, InvariantCommonRuntimeArgNameMustBeDeclaredFails) {
     NodeCoord node{0, 0};
-    ProgramSpec spec = MakeSpecWithNamedArgs(node, /*rtas=*/{}, /*crtas=*/{"real_crta"});
+    ProgramSpec spec = MakeSpecWithNamedArgs(node, /*named_rtas=*/{}, /*named_crtas=*/{"real_crta"});
     spec.kernels[0].advanced_options.enqueue_invariant_common_runtime_args = {"not_declared"};
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3094,7 +3094,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedKernelHashStableAcross
         TensorParameter tp{
             .unique_id = TensorParamName{"input_tensor"},
             .spec = tt::tt_metal::TensorSpec(std::move(shape), std::move(tensor_layout)),
-            .relaxations = TensorParameterRelaxations{.dynamic_tensor_shape = true},
+            .advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true},
         };
         spec.tensor_parameters = {tp};
         BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
@@ -3120,7 +3120,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedKernelHashStableAcrossShap
     auto make_spec = [](const tt::tt_metal::Shape& shape, bool dynamic) {
         ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
         auto tp = MakeShardedTensorParameter("input_tensor", shape, {32, 32}, /*num_cores=*/2);
-        tp.relaxations = TensorParameterRelaxations{.dynamic_tensor_shape = dynamic};
+        tp.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = dynamic};
         spec.tensor_parameters = {tp};
         BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
         return spec;
@@ -3154,7 +3154,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedBindingTracksShapeCRTASlot
     // directly to be robust against BDS-internal flattening conventions.
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto tp = MakeShardedTensorParameter("input_tensor", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, 2);
-    tp.relaxations = TensorParameterRelaxations{.dynamic_tensor_shape = true};
+    tp.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {tp};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -3176,7 +3176,7 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedBindingHasNoRuntimeFie
     // demotion, so num_runtime_field_crta_words should remain zero.
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto tp = MakeMinimalTensorParameter("input_tensor");
-    tp.relaxations = TensorParameterRelaxations{.dynamic_tensor_shape = true};
+    tp.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {tp};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -3215,7 +3215,7 @@ TEST_F(ProgramSpecTestGen1, KernelCrtaLayout_AllThreeSectionsConsistent) {
     auto plain_tp = MakeMinimalTensorParameter("plain_tensor");
     auto dyn_tp =
         MakeShardedTensorParameter("dyn_tensor", tt::tt_metal::Shape{1, 1, 64, 32}, {32, 32}, /*num_cores=*/2);
-    dyn_tp.relaxations = TensorParameterRelaxations{.dynamic_tensor_shape = true};
+    dyn_tp.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
     spec.tensor_parameters = {plain_tp, dyn_tp};
     BindTensorParameterToKernel(spec.kernels[0], "plain_tensor", "plain_ta");
     BindTensorParameterToKernel(spec.kernels[0], "dyn_tensor", "dyn_ta");

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -56,6 +56,21 @@ struct KernelAdvancedOptions {
     Table<Nodes, /* num_threads */ uint32_t> node_specific_thread_counts;
 
     ////////////////////////////////////////////////////////////////////////////////
+    // Enqueue-loop invariant kernel arguments
+    ////////////////////////////////////////////////////////////////////////////////
+
+    // Designate certain runtime arguments and common runtime arguments as enqueue-loop
+    // invariant. This permits the same argument value to be reused across multiple Program
+    // enqueues via UpdateProgramRunArgs, which can improve performance in enqueue loops.
+    // By default, every runtime argument and common runtime argument is expected to be
+    // re-specified (via SetProgramRunArgs) on every enqueue.
+    //
+    // CAUTION: This feature is unsafe if used incorrectly! The onus is on the programmer
+    // to ensure that the designated arguments remain valid across enqueues.
+    Group<std::string> enqueue_invariant_runtime_args;
+    Group<std::string> enqueue_invariant_common_runtime_args;
+
+    ////////////////////////////////////////////////////////////////////////////////
     // Varargs
     ////////////////////////////////////////////////////////////////////////////////
 
@@ -176,7 +191,23 @@ struct SemaphoreAdvancedOptions {
     uint32_t initial_value = 0;
 };
 
-struct TensorParameterRelaxations {
+struct TensorParameterAdvancedOptions {
+    ////////////////////////////////////////////////////////////////////////////////
+    // Enqueue-loop invariance
+    ////////////////////////////////////////////////////////////////////////////////
+
+    // Designate this TensorParameter as enqueue-loop invariant.
+    // Permits the same MeshTensor argument to be reused across multiple Program
+    // enqueues via UpdateProgramRunArgs. By default, a TensorParameter is expected to
+    // be re-specified on every enqueue.
+    //
+    // CAUTION:
+    // The user is responsible for managing the MeshTensor argument's lifetime and
+    // ensuring that it remains valid across enqueues. Undefined behavior will result
+    // if the MeshTensor goes out of scope (and its device memory is deallocated),
+    // and you try to re-enqueue the Program with the now-stale MeshTensor argument.
+    bool enqueue_invariant = false;
+
     ////////////////////////////////////////////////////////////////////////////////
     // TensorSpec match relaxation options
     ////////////////////////////////////////////////////////////////////////////////

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -32,7 +32,7 @@ Program MakeProgramFromSpec(
 //
 // For high-performance inner loops, prefer the power user APIs below.
 // If stateful behavior of parameters is required, use the power user APIs.
-void SetProgramRunArgs(Program& program, const ProgramRunArgs& params);
+void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip_validation = false);
 
 // Fast-path partial update: refresh ONLY the TensorArgs of an existing Program.
 // All other ProgramRunArgs (named/vararg RTAs and CRTAs, DFB params) retain their values

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp
@@ -23,7 +23,7 @@ namespace tt::tt_metal::experimental {
 Program MakeProgramFromSpec(
     const distributed::MeshDevice& mesh_device, const ProgramSpec& spec, bool skip_validation = false);
 
-// Configure the mutable parameters of an existing Program
+// Configure the arguments (mutable parameters) of an existing Program
 // (This will become a member function for the Program class)
 // This performs a copy from the ProgramRunArgs to the Program's internal data structures.
 //
@@ -33,6 +33,33 @@ Program MakeProgramFromSpec(
 // For high-performance inner loops, prefer the power user APIs below.
 // If stateful behavior of parameters is required, use the power user APIs.
 void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip_validation = false);
+
+// Fast-path partial update: refresh ONLY a subset of arguments for an existing Program.
+// All other arguments exhibit STATEFUL behavior: they retain their values from whatever they
+// were most recently set to.
+//
+// PRE-CONDITION: SetProgramRunArgs must have been called previously.
+//
+// CAUTION: It is the caller's responsibility to ensure that the stateful, enqueue-invariant
+// tensor and runtime arguments being retained are still valid in the new execution context.
+//
+// COMPLETENESS: Only those tensor and runtime arguments that have been specified in the
+// ProgramSpec as enqueue-loop invariant (via the AdvancedOptions fields) may be omitted
+// when calling UpdateProgramRunArgs. All regular arguments must be specified. This is enforced
+// by runtime validation checks.
+//
+// USE CASE: Program re-enqueue loops where only a subset of ProgramRunArgs need to be mutated
+// per iteration. This saves the host overhead of re-computing, re-specifying and re-validating
+// the full ProgramRunArgs if only a few arguments change per iteration. The onus is on the
+// programmer to ensure that the retained arguments remain valid across iterations.
+//
+// NOTE: If DFB size overrides are unspecified, they revert to the ProgramSpec-defined defaults.
+void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip_validation = false);
+
+//////////////////////////////////////////////////////////////////////////////////////
+// NOTE: UpdateProgramRunArgs supersedes UpdateTensorArgs. I plan to remove it.
+//       (or require that all non-tensor args are enqueue-loop invariant.)
+//////////////////////////////////////////////////////////////////////////////////////
 
 // Fast-path partial update: refresh ONLY the TensorArgs of an existing Program.
 // All other ProgramRunArgs (named/vararg RTAs and CRTAs, DFB params) retain their values

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
@@ -112,11 +112,17 @@ using KernelRunArgs = ProgramRunArgs::KernelRunArgs;
 using DFBRunOverrides = ProgramRunArgs::DFBRunOverrides;
 using TensorArgument = ProgramRunArgs::TensorArgument;
 
-// Resolve a TensorArgument to its MeshTensor. (One alternative today; switch to
-// std::visit once MeshTensorView is added as a second variant alternative.)
+// Resolve a TensorArgument to its MeshTensor.
+// (Switch to std::visit once MeshTensorView is added as a second variant alternative.)
 inline const MeshTensor& mesh_tensor_of(const TensorArgument& arg) {
     return std::get<std::reference_wrapper<const MeshTensor>>(arg).get();
 }
+
+// Helper function to merge two or more ProgramRunArgs objects into one.
+// Validates that the provided ProgramRunArgs objects specify mutually disjoint arguments.
+ProgramRunArgs MergeProgramRunArgs(
+    ProgramRunArgs base, std::span<const ProgramRunArgs> rest, bool skip_validation = false);
+// Invocation: auto full = MergeProgramRunArgs(std::move(base_run_args), {appended_run_args});
 
 //------------------------------------------------
 // ProgramRunArgsView (for advanced users)

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp
@@ -42,7 +42,7 @@ struct TensorParameter {
     ////////////////////////////////////////////////
     // Advanced options (see advanced_options.hpp)
     ////////////////////////////////////////////////
-    TensorParameterRelaxations relaxations;
+    TensorParameterAdvancedOptions advanced_options;
 };
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -1074,7 +1074,7 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
             }
             bool any_supplied = false;
             for (const auto& handle : binding_handles) {
-                if (tensor_by_param.count(handle.tensor_parameter_name) > 0) {
+                if (tensor_by_param.contains(handle.tensor_parameter_name)) {
                     any_supplied = true;
                     break;
                 }

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -446,11 +446,14 @@ void AttachBorrowedDFBBuffers(
 // PUBLIC ENTRY POINTS: SetProgramRunArgs + UpdateTensorArgs + GetProgramRunArgsView
 // ============================================================================
 
-void SetProgramRunArgs(Program& program, const ProgramRunArgs& params) {
+void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip_validation) {
     log_debug(tt::LogMetal, "Setting ProgramRunArgs");
 
-    // Validate parameters against the schema
-    ValidateProgramRunArgs(program, params);
+    // Validate parameters against the schema (can be skipped for trusted inputs, e.g. cached-program
+    // re-enqueue inner loops where the args have already been validated once).
+    if (!skip_validation) {
+        ValidateProgramRunArgs(program, params);
+    }
 
     detail::ProgramImpl& program_impl = program.impl();
 

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -683,18 +683,6 @@ void UpdateTensorArgs(Program& program, const Table<TensorParamName, ProgramRunA
     AttachBorrowedDFBBuffers(program_impl, tensor_args);
 }
 
-// Build a name -> slot-index map from a declaration-ordered name list. The slot index is the
-// arg's position within its section of the dispatch buffer (named RTAs / named CRTAs are laid
-// out in declaration order; see the layout comment in SetProgramRunArgs).
-std::unordered_map<std::string, size_t> BuildArgNameToSlotIndex(const std::vector<std::string>& ordered_names) {
-    std::unordered_map<std::string, size_t> index;
-    index.reserve(ordered_names.size());
-    for (size_t i = 0; i < ordered_names.size(); ++i) {
-        index.emplace(ordered_names[i], i);
-    }
-    return index;
-}
-
 // Union the args of `src` into `dst` for a single kernel (same kernel name). Used by
 // MergeProgramRunArgs. Named RTAs (per node) and named CRTAs union by name; a given name may
 // appear in at most one input (disjoint), else error unless skip_validation. Positional varargs
@@ -993,7 +981,7 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
 
         // ---- Per-node RTA buffer: patch supplied named RTAs at their declaration-order slot ----
         if (!kernel_params.runtime_arg_values.empty()) {
-            const auto rta_index = BuildArgNameToSlotIndex(schema->runtime_arg_names);
+            const auto& rta_index = schema->runtime_arg_name_to_slot;
             for (const auto& [node, args] : kernel_params.runtime_arg_values) {
                 TT_FATAL(
                     kernel->cores_with_runtime_args().contains(node),
@@ -1043,7 +1031,7 @@ void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool s
             RuntimeArgsData& crta = kernel->common_runtime_args_data();
 
             if (!kernel_params.common_runtime_arg_values.empty()) {
-                const auto crta_index = BuildArgNameToSlotIndex(schema->common_runtime_arg_names);
+                const auto& crta_index = schema->common_runtime_arg_name_to_slot;
                 for (const auto& [name, value] : kernel_params.common_runtime_arg_values) {
                     const auto it = crta_index.find(name);
                     TT_FATAL(

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -48,8 +48,13 @@ const AdvancedKernelRunArgs::Varargs& kernel_common_runtime_varargs(const Progra
 //         rank must match. Both logical_shape and padded_shape per-dim values may differ.
 //     See the field doc comments in tensor_parameter.hpp for the full contracts.
 //   - Every declared TensorParameter must be set
+//   - Every declared TensorParameter must be set, UNLESS require_all is false (partial update),
+//     in which case TensorParameters declared enqueue-loop invariant may be omitted (their
+//     previously-bound MeshTensor is retained).
 void ValidateTensorArgs(
-    const Program& program, const Table<TensorParamName, ProgramRunArgs::TensorArgument>& tensor_args) {
+    const Program& program,
+    const Table<TensorParamName, ProgramRunArgs::TensorArgument>& tensor_args,
+    bool require_all = true) {
     const detail::ProgramImpl& program_impl = program.impl();
 
     std::unordered_set<std::string> tensor_parameters_with_params;
@@ -108,6 +113,11 @@ void ValidateTensorArgs(
         }
     }
     for (const std::string& declared : program_impl.get_registered_tensor_parameter_names()) {
+        if (!require_all && program_impl.get_tensor_parameter_enqueue_invariant(declared)) {
+            // Partial update: an enqueue-invariant TensorParameter may be omitted; its previously
+            // bound MeshTensor is retained.
+            continue;
+        }
         TT_FATAL(
             tensor_parameters_with_params.contains(declared),
             "TensorParameter '{}' is declared in the Program but has no TensorArgument entry.",
@@ -383,7 +393,9 @@ std::vector<uint32_t> ComputeBindingCrtaValues(const TensorBindingHandle& handle
 // Pre-condition: ValidateTensorArgs has enforced that every declared TensorParameter
 // has a corresponding TensorArgument, so the lookup below cannot miss for any registered binding.
 void AttachBorrowedDFBBuffers(
-    detail::ProgramImpl& program_impl, const Table<TensorParamName, ProgramRunArgs::TensorArgument>& tensor_args) {
+    detail::ProgramImpl& program_impl,
+    const Table<TensorParamName, ProgramRunArgs::TensorArgument>& tensor_args,
+    bool require_all = true) {
     const auto& borrowed_bindings = program_impl.get_dfb_borrowed_bindings();
     if (borrowed_bindings.empty()) {
         return;
@@ -397,12 +409,18 @@ void AttachBorrowedDFBBuffers(
 
     for (const auto& [dfb_id, tp_name] : borrowed_bindings) {
         auto it = tensor_by_param.find(tp_name);
-        TT_FATAL(
-            it != tensor_by_param.end(),
-            "Internal error: DFB id {} borrows from TensorParameter '{}' but no TensorArgument supplied it (validation "
-            "should have caught this).",
-            dfb_id,
-            tp_name);
+        if (it == tensor_by_param.end()) {
+            // Partial update (require_all=false): the borrowed TensorParameter is enqueue-invariant
+            // and was omitted; the DFB keeps its previously-attached backing buffer. On the full
+            // path (require_all=true) every borrowed binding must have been supplied.
+            TT_FATAL(
+                !require_all,
+                "Internal error: DFB id {} borrows from TensorParameter '{}' but no TensorArgument supplied it "
+                "(validation should have caught this).",
+                dfb_id,
+                tp_name);
+            continue;
+        }
         const MeshTensor& tensor = *it->second;
         const tt::tt_metal::Buffer* buffer = tensor.mesh_buffer().get_reference_buffer();
 
@@ -663,6 +681,492 @@ void UpdateTensorArgs(Program& program, const Table<TensorParamName, ProgramRunA
 
     // Process DFB runtime parameters to update borrowed-memory DFB backing L1 Buffer*s.
     AttachBorrowedDFBBuffers(program_impl, tensor_args);
+}
+
+// Build a name -> slot-index map from a declaration-ordered name list. The slot index is the
+// arg's position within its section of the dispatch buffer (named RTAs / named CRTAs are laid
+// out in declaration order; see the layout comment in SetProgramRunArgs).
+std::unordered_map<std::string, size_t> BuildArgNameToSlotIndex(const std::vector<std::string>& ordered_names) {
+    std::unordered_map<std::string, size_t> index;
+    index.reserve(ordered_names.size());
+    for (size_t i = 0; i < ordered_names.size(); ++i) {
+        index.emplace(ordered_names[i], i);
+    }
+    return index;
+}
+
+// Union the args of `src` into `dst` for a single kernel (same kernel name). Used by
+// MergeProgramRunArgs. Named RTAs (per node) and named CRTAs union by name; a given name may
+// appear in at most one input (disjoint), else error unless skip_validation. Positional varargs
+// cannot be name-merged: at most one input may supply them for a given node / for common varargs.
+void MergeKernelRunArgsInto(
+    ProgramRunArgs::KernelRunArgs& dst, const ProgramRunArgs::KernelRunArgs& src, bool skip_validation) {
+    const auto& kernel_name = dst.kernel;
+
+    // Named CRTAs.
+    for (const auto& [name, value] : src.common_runtime_arg_values) {
+        if (!skip_validation) {
+            TT_FATAL(
+                !dst.common_runtime_arg_values.get(name).has_value(),
+                "MergeProgramRunArgs: kernel '{}' common runtime arg '{}' is specified in more than one "
+                "ProgramRunArgs.",
+                kernel_name,
+                name);
+        }
+        dst.common_runtime_arg_values[name] = value;
+    }
+
+    // Per-node named RTAs.
+    for (const auto& src_node : src.runtime_arg_values) {
+        ProgramRunArgs::KernelRunArgs::NodeRuntimeArgs* dst_node = nullptr;
+        for (auto& dn : dst.runtime_arg_values) {
+            if (dn.node == src_node.node) {
+                dst_node = &dn;
+                break;
+            }
+        }
+        if (dst_node == nullptr) {
+            dst.runtime_arg_values.push_back(src_node);
+            continue;
+        }
+        for (const auto& [name, value] : src_node.args) {
+            if (!skip_validation) {
+                TT_FATAL(
+                    !dst_node->args.get(name).has_value(),
+                    "MergeProgramRunArgs: kernel '{}' node {} runtime arg '{}' is specified in more than one "
+                    "ProgramRunArgs.",
+                    kernel_name,
+                    src_node.node.str(),
+                    name);
+            }
+            dst_node->args[name] = value;
+        }
+    }
+
+    // Positional RTA varargs (per node): cannot be merged; at most one input may supply them.
+    for (const auto& [node, vals] : src.advanced_options.runtime_varargs) {
+        if (dst.advanced_options.runtime_varargs.get(node).has_value()) {
+            if (!skip_validation) {
+                TT_FATAL(
+                    false,
+                    "MergeProgramRunArgs: kernel '{}' node {} runtime varargs are specified in more than one "
+                    "ProgramRunArgs (positional varargs cannot be merged).",
+                    kernel_name,
+                    node.str());
+            }
+            continue;  // skip_validation: keep dst's existing varargs.
+        }
+        dst.advanced_options.runtime_varargs[node] = vals;
+    }
+
+    // Positional common varargs: at most one input may be non-empty.
+    if (!src.advanced_options.common_runtime_varargs.empty()) {
+        if (!dst.advanced_options.common_runtime_varargs.empty()) {
+            if (!skip_validation) {
+                TT_FATAL(
+                    false,
+                    "MergeProgramRunArgs: kernel '{}' common runtime varargs are specified in more than one "
+                    "ProgramRunArgs (positional varargs cannot be merged).",
+                    kernel_name);
+            }
+        } else {
+            dst.advanced_options.common_runtime_varargs = src.advanced_options.common_runtime_varargs;
+        }
+    }
+}
+
+// Validation for the partial fast-path UpdateProgramRunArgs.
+//
+// Differs from ValidateProgramRunArgs in exactly one dimension: named RTAs/CRTAs and tensor
+// parameters declared enqueue-loop invariant MAY be omitted — the value installed by the prior
+// SetProgramRunArgs is retained. All other ("regular") args must still be fully specified.
+// Varargs are positional and can never be invariant, so they must always be supplied when the
+// schema declares them.
+void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& params) {
+    const detail::ProgramImpl& program_impl = program.impl();
+
+    std::unordered_set<KernelSpecName> kernels_with_params;
+    for (const auto& kernel_params : params.kernel_run_args) {
+        const auto& kernel_name = kernel_params.kernel;
+        auto [it, inserted] = kernels_with_params.insert(kernel_name);
+        TT_FATAL(
+            inserted,
+            "Duplicate kernel '{}' in ProgramRunArgs.kernel_run_args. Each kernel must appear exactly once.",
+            kernel_name);
+
+        const KernelRTASchema* schema = program_impl.get_kernel_rta_schema(kernel_name.get());
+        TT_FATAL(
+            schema != nullptr,
+            "Kernel '{}' has no RTA schema registered. Was the Program created from a ProgramSpec?",
+            kernel_name);
+
+        const std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name.get());
+        const std::set<CoreCoord>& kernel_nodes = kernel->logical_cores();
+
+        // --- Vararg RTA counts per node (varargs are never invariant; identical to the full path) ---
+        std::unordered_set<NodeCoord> nodes_with_vararg_params;
+        for (const auto& [node_coord, args] : kernel_runtime_varargs(kernel_params)) {
+            nodes_with_vararg_params.insert(node_coord);
+            TT_FATAL(
+                kernel_nodes.contains(node_coord),
+                "Kernel '{}' is setting runtime_varargs for node {}, but the kernel does not run on that node.",
+                kernel_name,
+                node_coord.str());
+            auto it_schema = schema->num_runtime_varargs_per_node.find(node_coord);
+            const size_t expected_varargs =
+                (it_schema != schema->num_runtime_varargs_per_node.end()) ? it_schema->second : 0;
+            TT_FATAL(
+                args.size() == expected_varargs,
+                "Kernel '{}' node {} expects {} vararg runtime args, but {} were provided",
+                kernel_name,
+                node_coord.str(),
+                expected_varargs,
+                args.size());
+        }
+        for (const auto& [node_coord, expected_count] : schema->num_runtime_varargs_per_node) {
+            if (expected_count == 0) {
+                continue;
+            }
+            TT_FATAL(
+                nodes_with_vararg_params.contains(node_coord),
+                "Kernel '{}' is missing vararg runtime args for node {} (expected {}). Varargs cannot be "
+                "enqueue-invariant and must be supplied to UpdateProgramRunArgs.",
+                kernel_name,
+                node_coord.str(),
+                expected_count);
+        }
+
+        // --- Common vararg count (never invariant) ---
+        TT_FATAL(
+            kernel_common_runtime_varargs(kernel_params).size() == schema->num_common_runtime_varargs,
+            "Kernel '{}' expects {} vararg common runtime args, but {} were provided",
+            kernel_name,
+            schema->num_common_runtime_varargs,
+            kernel_common_runtime_varargs(kernel_params).size());
+
+        // --- Named RTAs: supplied names must be declared (no extras); every non-invariant name
+        //     must be supplied for every node; invariant names may be omitted. ---
+        const auto& named_rta_names = schema->runtime_arg_names;
+        const std::unordered_set<std::string> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
+        std::vector<std::string> regular_rta_names;
+        for (const auto& n : named_rta_names) {
+            if (!schema->enqueue_invariant_runtime_arg_names.contains(n)) {
+                regular_rta_names.push_back(n);
+            }
+        }
+        std::unordered_set<NodeCoord> nodes_with_named_params;
+        for (const auto& [node, args] : kernel_params.runtime_arg_values) {
+            auto [it_node, inserted_node] = nodes_with_named_params.insert(node);
+            TT_FATAL(
+                inserted_node,
+                "Duplicate node_coord {} in runtime_arg_values for kernel '{}'.",
+                node.str(),
+                kernel_name);
+            TT_FATAL(
+                kernel_nodes.contains(node),
+                "Kernel '{}' is setting runtime_arg_values for node {}, but the kernel does not run on that node.",
+                kernel_name,
+                node.str());
+            for (const auto& [name, _value] : args) {
+                (void)_value;
+                TT_FATAL(
+                    named_rta_name_set.contains(name),
+                    "Kernel '{}' node {} sets named RTA '{}' which is not declared in the schema.",
+                    kernel_name,
+                    node.str(),
+                    name);
+            }
+            for (const auto& rname : regular_rta_names) {
+                TT_FATAL(
+                    args.get(rname).has_value(),
+                    "Kernel '{}' node {} is missing named RTA '{}', which is not declared enqueue-invariant and so "
+                    "must be supplied to UpdateProgramRunArgs.",
+                    kernel_name,
+                    node.str(),
+                    rname);
+            }
+        }
+        if (!regular_rta_names.empty()) {
+            for (const auto& node : kernel_nodes) {
+                TT_FATAL(
+                    nodes_with_named_params.contains(node),
+                    "Kernel '{}' has non-invariant named RTAs but no runtime_arg_values provided for node {}.",
+                    kernel_name,
+                    node.str());
+            }
+        }
+
+        // --- Named CRTAs: regular ones must be supplied; invariant may be omitted; no extras. ---
+        const auto& named_crta_names = schema->common_runtime_arg_names;
+        const std::unordered_set<std::string> named_crta_name_set(named_crta_names.begin(), named_crta_names.end());
+        for (const auto& [name, _value] : kernel_params.common_runtime_arg_values) {
+            (void)_value;
+            TT_FATAL(
+                named_crta_name_set.contains(name),
+                "Kernel '{}' sets named CRTA '{}' which is not declared in the schema.",
+                kernel_name,
+                name);
+        }
+        for (const auto& name : named_crta_names) {
+            if (schema->enqueue_invariant_common_runtime_arg_names.contains(name)) {
+                continue;
+            }
+            TT_FATAL(
+                kernel_params.common_runtime_arg_values.get(name).has_value(),
+                "Kernel '{}' is missing named CRTA '{}', which is not declared enqueue-invariant and so must be "
+                "supplied to UpdateProgramRunArgs.",
+                kernel_name,
+                name);
+        }
+    }
+
+    // A registered kernel may be omitted from kernel_run_args only if it has nothing regular to
+    // supply: no non-invariant named RTAs, no non-invariant named CRTAs, and no varargs.
+    for (const auto& name : program_impl.get_registered_kernel_names()) {
+        if (kernels_with_params.contains(KernelSpecName{name})) {
+            continue;
+        }
+        const KernelRTASchema* schema = program_impl.get_kernel_rta_schema(name);
+        if (schema == nullptr) {
+            continue;
+        }
+        bool has_regular_rta = false;
+        for (const auto& n : schema->runtime_arg_names) {
+            if (!schema->enqueue_invariant_runtime_arg_names.contains(n)) {
+                has_regular_rta = true;
+                break;
+            }
+        }
+        bool has_regular_crta = false;
+        for (const auto& n : schema->common_runtime_arg_names) {
+            if (!schema->enqueue_invariant_common_runtime_arg_names.contains(n)) {
+                has_regular_crta = true;
+                break;
+            }
+        }
+        const bool has_varargs =
+            !schema->num_runtime_varargs_per_node.empty() || schema->num_common_runtime_varargs > 0;
+        TT_FATAL(
+            !(has_regular_rta || has_regular_crta || has_varargs),
+            "Kernel '{}' has non-invariant runtime args (or varargs) but was omitted from UpdateProgramRunArgs. Only "
+            "kernels whose every runtime arg is enqueue-invariant — and which have no varargs — may be omitted.",
+            name);
+    }
+
+    // DFB run overrides: same checks as the full path (duplicates; size overrides unimplemented).
+    std::unordered_set<DFBSpecName> dfbs_with_params;
+    for (const auto& dfb_params : params.dfb_run_overrides) {
+        auto [it, inserted] = dfbs_with_params.insert(dfb_params.dfb);
+        TT_FATAL(
+            inserted,
+            "Duplicate DFB '{}' in ProgramRunArgs.dfb_run_overrides. Each DFB must appear at most once.",
+            dfb_params.dfb);
+        TT_FATAL(
+            !dfb_params.entry_size.has_value() && !dfb_params.num_entries.has_value(),
+            "DFB size overrides are not yet implemented for DFB '{}'.",
+            dfb_params.dfb);
+    }
+
+    // Tensor args: non-invariant TensorParameters must be supplied; invariant ones may be omitted.
+    ValidateTensorArgs(program, params.tensor_args, /*require_all=*/false);
+}
+
+void UpdateProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip_validation) {
+    log_debug(tt::LogMetal, "Updating ProgramRunArgs (partial fast-path)");
+
+    if (!skip_validation) {
+        ValidateUpdateProgramRunArgs(program, params);
+    }
+
+    detail::ProgramImpl& program_impl = program.impl();
+
+    // Patch the supplied args in place. Omitted (enqueue-invariant) named args and tensor params
+    // are left untouched, retaining the value installed by the most recent SetProgramRunArgs.
+    // Positional varargs are never invariant, so a supplied vararg section refreshes wholesale.
+    for (const auto& kernel_params : params.kernel_run_args) {
+        const auto& kernel_name = kernel_params.kernel;
+        std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name.get());
+        const KernelRTASchema* schema = program_impl.get_kernel_rta_schema(kernel_name.get());
+        TT_FATAL(schema != nullptr, "Kernel '{}' has no RTA schema registered.", kernel_name);
+
+        const size_t num_named_rtas = schema->runtime_arg_names.size();
+
+        // ---- Per-node RTA buffer: patch supplied named RTAs at their declaration-order slot ----
+        if (!kernel_params.runtime_arg_values.empty()) {
+            const auto rta_index = BuildArgNameToSlotIndex(schema->runtime_arg_names);
+            for (const auto& [node, args] : kernel_params.runtime_arg_values) {
+                TT_FATAL(
+                    kernel->cores_with_runtime_args().contains(node),
+                    "UpdateProgramRunArgs: kernel '{}' has no runtime-arg buffer for node {}. Call SetProgramRunArgs "
+                    "at least once before a partial update.",
+                    kernel_name,
+                    node.str());
+                RuntimeArgsData& rta = kernel->runtime_args_data(node);
+                for (const auto& [name, value] : args) {
+                    const auto it = rta_index.find(name);
+                    TT_FATAL(
+                        it != rta_index.end(),
+                        "Internal error: named RTA '{}' not in schema for kernel '{}'.",
+                        name,
+                        kernel_name);
+                    rta.data()[it->second] = value;
+                }
+            }
+        }
+
+        // ---- Per-node RTA buffer: patch supplied varargs (positional, after the named section) ----
+        for (const auto& [node, vals] : kernel_runtime_varargs(kernel_params)) {
+            if (vals.empty()) {
+                continue;
+            }
+            TT_FATAL(
+                kernel->cores_with_runtime_args().contains(node),
+                "UpdateProgramRunArgs: kernel '{}' has no runtime-arg buffer for node {}. Call SetProgramRunArgs at "
+                "least once before a partial update.",
+                kernel_name,
+                node.str());
+            RuntimeArgsData& rta = kernel->runtime_args_data(node);
+            for (size_t j = 0; j < vals.size(); ++j) {
+                rta.data()[num_named_rtas + j] = vals[j];
+            }
+        }
+
+        // ---- CRTA buffer: patch supplied named CRTAs + supplied common varargs ----
+        const auto& cvarargs = kernel_common_runtime_varargs(kernel_params);
+        const bool touches_crta = !kernel_params.common_runtime_arg_values.empty() || !cvarargs.empty();
+        if (touches_crta) {
+            TT_FATAL(
+                !kernel->common_runtime_args().empty(),
+                "UpdateProgramRunArgs: kernel '{}' CRTA buffer not allocated. Call SetProgramRunArgs at least once "
+                "before a partial update.",
+                kernel_name);
+            RuntimeArgsData& crta = kernel->common_runtime_args_data();
+
+            if (!kernel_params.common_runtime_arg_values.empty()) {
+                const auto crta_index = BuildArgNameToSlotIndex(schema->common_runtime_arg_names);
+                for (const auto& [name, value] : kernel_params.common_runtime_arg_values) {
+                    const auto it = crta_index.find(name);
+                    TT_FATAL(
+                        it != crta_index.end(),
+                        "Internal error: named CRTA '{}' not in schema for kernel '{}'.",
+                        name,
+                        kernel_name);
+                    crta.data()[it->second] = value;
+                }
+            }
+            if (!cvarargs.empty()) {
+                // Common varargs live after the named CRTAs and the tensor-binding address section.
+                const auto& binding_handles = kernel->tensor_binding_handles();
+                size_t binding_section_words = 0;
+                for (const auto& h : binding_handles) {
+                    binding_section_words += 1u + h.num_runtime_field_crta_words;
+                }
+                const size_t crta_vararg_base = schema->common_runtime_arg_names.size() + binding_section_words;
+                for (size_t j = 0; j < cvarargs.size(); ++j) {
+                    crta.data()[crta_vararg_base + j] = cvarargs[j];
+                }
+            }
+        }
+    }
+
+    // ---- Tensor bindings: patch CRTA address slots for SUPPLIED tensors only ----
+    // (Invariant tensors omitted from params keep their previously-patched binding slots.)
+    if (!params.tensor_args.empty()) {
+        std::unordered_map<std::string, const MeshTensor*> tensor_by_param;
+        tensor_by_param.reserve(params.tensor_args.size());
+        for (const auto& [param_name, tensor_arg] : params.tensor_args) {
+            tensor_by_param.emplace(param_name.get(), &mesh_tensor_of(tensor_arg));
+        }
+
+        for (const auto& kernel_name : program_impl.get_registered_kernel_names()) {
+            std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name);
+            const auto& binding_handles = kernel->tensor_binding_handles();
+            if (binding_handles.empty()) {
+                continue;
+            }
+            bool any_supplied = false;
+            for (const auto& handle : binding_handles) {
+                if (tensor_by_param.count(handle.tensor_parameter_name) > 0) {
+                    any_supplied = true;
+                    break;
+                }
+            }
+            if (!any_supplied) {
+                continue;  // none of this kernel's bindings are being updated.
+            }
+            TT_FATAL(
+                !kernel->common_runtime_args().empty(),
+                "UpdateProgramRunArgs: kernel '{}' CRTA buffer not allocated; cannot patch tensor bindings. Call "
+                "SetProgramRunArgs at least once before a partial update.",
+                kernel_name);
+            RuntimeArgsData& crta = kernel->common_runtime_args_data();
+            for (const auto& handle : binding_handles) {
+                auto t_it = tensor_by_param.find(handle.tensor_parameter_name);
+                if (t_it == tensor_by_param.end()) {
+                    continue;  // invariant tensor omitted → binding slot retained.
+                }
+                const auto values = ComputeBindingCrtaValues(handle, *t_it->second);
+                const uint32_t base_word = handle.addr_crta_offset / sizeof(uint32_t);
+                for (size_t i = 0; i < values.size(); ++i) {
+                    crta.data()[base_word + i] = values[i];
+                }
+            }
+        }
+
+        // Re-attach borrowed-memory DFBs for the supplied tensors (skip omitted invariant ones).
+        AttachBorrowedDFBBuffers(program_impl, params.tensor_args, /*require_all=*/false);
+    }
+}
+
+ProgramRunArgs MergeProgramRunArgs(ProgramRunArgs base, std::span<const ProgramRunArgs> rest, bool skip_validation) {
+    for (const ProgramRunArgs& other : rest) {
+        // Tensor args: union by TensorParameter name (disjoint).
+        for (const auto& [name, arg] : other.tensor_args) {
+            if (!skip_validation) {
+                TT_FATAL(
+                    base.tensor_args.find(name) == base.tensor_args.end(),
+                    "MergeProgramRunArgs: TensorParameter '{}' is specified in more than one ProgramRunArgs.",
+                    name);
+            }
+            // Table::operator[] default-constructs its value; TensorArgument (a variant over a
+            // reference_wrapper) is not default-constructible, so insert the pair directly. After
+            // the disjoint check the key is absent, so insert takes effect (under skip_validation a
+            // collision keeps base's existing entry).
+            base.tensor_args.insert({name, arg});
+        }
+
+        // DFB run overrides: union by DFB name (disjoint).
+        for (const auto& dfb : other.dfb_run_overrides) {
+            if (!skip_validation) {
+                for (const auto& existing : base.dfb_run_overrides) {
+                    TT_FATAL(
+                        existing.dfb != dfb.dfb,
+                        "MergeProgramRunArgs: DFB '{}' overrides are specified in more than one ProgramRunArgs.",
+                        dfb.dfb);
+                }
+            }
+            base.dfb_run_overrides.push_back(dfb);
+        }
+
+        // Kernel run args: union per kernel (a kernel may appear in multiple inputs as long as
+        // the actual args it carries are disjoint — e.g. one input's invariant args, another's
+        // volatile args for the same kernel).
+        for (const auto& kra : other.kernel_run_args) {
+            ProgramRunArgs::KernelRunArgs* dst = nullptr;
+            for (auto& existing : base.kernel_run_args) {
+                if (existing.kernel == kra.kernel) {
+                    dst = &existing;
+                    break;
+                }
+            }
+            if (dst == nullptr) {
+                base.kernel_run_args.push_back(kra);
+                continue;
+            }
+            MergeKernelRunArgsInto(*dst, kra, skip_validation);
+        }
+    }
+    return base;
 }
 
 ProgramRunArgsView& GetProgramRunArgsView(Program& program) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -657,7 +657,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             kernel.runtime_arg_schema.runtime_arg_names.begin(), kernel.runtime_arg_schema.runtime_arg_names.end());
         for (const auto& name : kernel.advanced_options.enqueue_invariant_runtime_args) {
             TT_FATAL(
-                declared_rtas.count(name) > 0,
+                declared_rtas.contains(name),
                 "KernelSpec '{}' marks runtime arg '{}' enqueue-loop invariant, but it is not a declared named runtime "
                 "arg (runtime_arg_schema.runtime_arg_names). Only named runtime args can be marked invariant; "
                 "positional varargs cannot.",
@@ -669,7 +669,7 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             kernel.runtime_arg_schema.common_runtime_arg_names.end());
         for (const auto& name : kernel.advanced_options.enqueue_invariant_common_runtime_args) {
             TT_FATAL(
-                declared_crtas.count(name) > 0,
+                declared_crtas.contains(name),
                 "KernelSpec '{}' marks common runtime arg '{}' enqueue-loop invariant, but it is not a declared named "
                 "common runtime arg (runtime_arg_schema.common_runtime_arg_names). Only named common runtime args can "
                 "be marked invariant; positional varargs cannot.",

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -649,6 +649,35 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         }
     }
 
+    // Validate enqueue-loop-invariant named-arg declarations: each invariant name must reference a
+    // declared named RTA / CRTA. Invariance requires naming the argument, so positional varargs
+    // cannot be marked invariant.
+    for (const auto& kernel : spec.kernels) {
+        const std::unordered_set<std::string> declared_rtas(
+            kernel.runtime_arg_schema.runtime_arg_names.begin(), kernel.runtime_arg_schema.runtime_arg_names.end());
+        for (const auto& name : kernel.advanced_options.enqueue_invariant_runtime_args) {
+            TT_FATAL(
+                declared_rtas.count(name) > 0,
+                "KernelSpec '{}' marks runtime arg '{}' enqueue-loop invariant, but it is not a declared named runtime "
+                "arg (runtime_arg_schema.runtime_arg_names). Only named runtime args can be marked invariant; "
+                "positional varargs cannot.",
+                kernel.unique_id,
+                name);
+        }
+        const std::unordered_set<std::string> declared_crtas(
+            kernel.runtime_arg_schema.common_runtime_arg_names.begin(),
+            kernel.runtime_arg_schema.common_runtime_arg_names.end());
+        for (const auto& name : kernel.advanced_options.enqueue_invariant_common_runtime_args) {
+            TT_FATAL(
+                declared_crtas.count(name) > 0,
+                "KernelSpec '{}' marks common runtime arg '{}' enqueue-loop invariant, but it is not a declared named "
+                "common runtime arg (runtime_arg_schema.common_runtime_arg_names). Only named common runtime args can "
+                "be marked invariant; positional varargs cannot.",
+                kernel.unique_id,
+                name);
+        }
+    }
+
     // Validate kernel thread counts
     for (const auto& kernel : spec.kernels) {
         TT_FATAL(kernel.num_threads > 0, "KernelSpec '{}' has no threads!", kernel.unique_id);
@@ -2566,8 +2595,9 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     for (const auto& tensor_parameter : spec.tensor_parameters) {
         const bool dyn_shape = tensor_parameter.advanced_options.dynamic_tensor_shape;
         const bool match_padded_only = tensor_parameter.advanced_options.match_padded_shape_only;
+        const bool enqueue_invariant = tensor_parameter.advanced_options.enqueue_invariant;
         program_impl->register_tensor_parameter(
-            tensor_parameter.unique_id.get(), tensor_parameter.spec, dyn_shape, match_padded_only);
+            tensor_parameter.unique_id.get(), tensor_parameter.spec, dyn_shape, match_padded_only, enqueue_invariant);
     }
 
     // Create DataflowBuffers and build name -> ID map.
@@ -2761,6 +2791,16 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // (via tensor_binding_handles) and its slot offsets are baked into each binding handle's
         // addr_crta_offset; SetProgramRunArgs uses BOTH to assemble the per-enqueue CRTA buffer.
         runtime_schema.common_runtime_arg_names = user_named_crtas;
+
+        // Enqueue-loop-invariant named args. Each is a subset of the declared named RTAs/CRTAs and
+        // may be omitted from a partial UpdateProgramRunArgs call (retaining its value). Legality
+        // (each invariant name actually names a declared arg) is checked in ValidateProgramSpec.
+        for (const auto& name : kernel_spec.advanced_options.enqueue_invariant_runtime_args) {
+            runtime_schema.enqueue_invariant_runtime_arg_names.insert(name);
+        }
+        for (const auto& name : kernel_spec.advanced_options.enqueue_invariant_common_runtime_args) {
+            runtime_schema.enqueue_invariant_common_runtime_arg_names.insert(name);
+        }
 
         // Varargs schema now lives on KernelAdvancedOptions.
         const uint32_t num_runtime_varargs = kernel_spec.advanced_options.num_runtime_varargs;

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1960,7 +1960,7 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
     // tensors the CTA payload never carried tensor_shape in the first place (and
     // the device-side accessor doesn't read it), so the flag is a pure host-side
     // validation loosening and has no effect on the CTA/CRTA layout.
-    const bool dyn_shape = tensor_parameter.relaxations.dynamic_tensor_shape && is_sharded;
+    const bool dyn_shape = tensor_parameter.advanced_options.dynamic_tensor_shape && is_sharded;
 
     tensor_accessor::ArgsConfig args_config;
     if (is_sharded) {
@@ -2564,8 +2564,8 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
 
     // Register TensorParameters with the program for ValidateProgramRunArgs to consult at enqueue.
     for (const auto& tensor_parameter : spec.tensor_parameters) {
-        const bool dyn_shape = tensor_parameter.relaxations.dynamic_tensor_shape;
-        const bool match_padded_only = tensor_parameter.relaxations.match_padded_shape_only;
+        const bool dyn_shape = tensor_parameter.advanced_options.dynamic_tensor_shape;
+        const bool match_padded_only = tensor_parameter.advanced_options.match_padded_shape_only;
         program_impl->register_tensor_parameter(
             tensor_parameter.unique_id.get(), tensor_parameter.spec, dyn_shape, match_padded_only);
     }

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2792,6 +2792,15 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
         // addr_crta_offset; SetProgramRunArgs uses BOTH to assemble the per-enqueue CRTA buffer.
         runtime_schema.common_runtime_arg_names = user_named_crtas;
 
+        // Precompute the name -> slot-index maps so the hot UpdateProgramRunArgs path does O(1)
+        // lookups rather than rebuilding a map per call.
+        for (size_t i = 0; i < runtime_schema.runtime_arg_names.size(); ++i) {
+            runtime_schema.runtime_arg_name_to_slot.emplace(runtime_schema.runtime_arg_names[i], i);
+        }
+        for (size_t i = 0; i < runtime_schema.common_runtime_arg_names.size(); ++i) {
+            runtime_schema.common_runtime_arg_name_to_slot.emplace(runtime_schema.common_runtime_arg_names[i], i);
+        }
+
         // Enqueue-loop-invariant named args. Each is a subset of the declared named RTAs/CRTAs and
         // may be omitted from a partial UpdateProgramRunArgs call (retaining its value). Legality
         // (each invariant name actually names a declared arg) is checked in ValidateProgramSpec.

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -579,12 +579,18 @@ std::vector<std::string> ProgramImpl::get_registered_kernel_names() const {
 }
 
 void ProgramImpl::register_tensor_parameter(
-    const std::string& name, const TensorSpec& spec, bool dynamic_tensor_shape, bool match_padded_shape_only) {
+    const std::string& name,
+    const TensorSpec& spec,
+    bool dynamic_tensor_shape,
+    bool match_padded_shape_only,
+    bool enqueue_invariant) {
     if (!metal2_registry_) {
         metal2_registry_ = Metal2NameRegistry{};
     }
     auto [it, inserted] = metal2_registry_->tensor_parameter_layouts.try_emplace(
-        name, Metal2NameRegistry::RegisteredTensorParameter{spec, dynamic_tensor_shape, match_padded_shape_only});
+        name,
+        Metal2NameRegistry::RegisteredTensorParameter{
+            spec, dynamic_tensor_shape, match_padded_shape_only, enqueue_invariant});
     TT_FATAL(inserted, "Duplicate tensor parameter name: {}", name);
 }
 
@@ -619,6 +625,17 @@ bool ProgramImpl::get_tensor_parameter_match_padded_shape_only(const std::string
         return false;
     }
     return it->second.match_padded_shape_only;
+}
+
+bool ProgramImpl::get_tensor_parameter_enqueue_invariant(const std::string& name) const {
+    if (!metal2_registry_) {
+        return false;
+    }
+    auto it = metal2_registry_->tensor_parameter_layouts.find(name);
+    if (it == metal2_registry_->tensor_parameter_layouts.end()) {
+        return false;
+    }
+    return it->second.enqueue_invariant;
 }
 
 std::vector<std::string> ProgramImpl::get_registered_tensor_parameter_names() const {

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -339,7 +339,11 @@ public:
     void register_dfb_spec_name(const std::string& name, uint32_t dfb_id);
     void register_semaphore_spec_name(const std::string& name, uint32_t sem_id);
     void register_tensor_parameter(
-        const std::string& name, const TensorSpec& spec, bool dynamic_tensor_shape, bool match_padded_shape_only);
+        const std::string& name,
+        const TensorSpec& spec,
+        bool dynamic_tensor_shape,
+        bool match_padded_shape_only,
+        bool enqueue_invariant);
 
     // Metal 2.0: Get handle from name (TT_FATAL if not found)
     KernelHandle get_kernel_handle(const std::string& name) const;
@@ -353,6 +357,9 @@ public:
     // Returns false if the parameter was not registered with match_padded_shape_only=true,
     // or if the name is unknown. (The caller validates known-ness separately.)
     bool get_tensor_parameter_match_padded_shape_only(const std::string& name) const;
+    // Returns false if the parameter was not registered enqueue-invariant, or if the name is
+    // unknown. (The caller validates known-ness separately.)
+    bool get_tensor_parameter_enqueue_invariant(const std::string& name) const;
     std::vector<std::string> get_registered_tensor_parameter_names() const;
 
     // Metal 2.0: register that DFB `dfb_id` borrows its backing L1 memory from the MeshTensor
@@ -378,6 +385,13 @@ public:
         // broadcast count.
         std::unordered_map<CoreCoord, size_t> num_runtime_varargs_per_node;
         size_t num_common_runtime_varargs = 0;
+
+        // Names (each a subset of runtime_arg_names / common_runtime_arg_names) declared
+        // enqueue-loop invariant via KernelAdvancedOptions. These named args may be omitted
+        // from a partial UpdateProgramRunArgs call, in which case the value installed by the
+        // most recent SetProgramRunArgs is retained. (Varargs cannot be marked invariant.)
+        std::unordered_set<std::string> enqueue_invariant_runtime_arg_names;
+        std::unordered_set<std::string> enqueue_invariant_common_runtime_arg_names;
     };
 
     // Metal 2.0: Runtime argument schema registration and lookup
@@ -475,6 +489,9 @@ private:
             TensorSpec spec;
             bool dynamic_tensor_shape = false;
             bool match_padded_shape_only = false;
+            // Declared enqueue-loop invariant: the TensorArgument may be omitted from a partial
+            // UpdateProgramRunArgs call (the previously-bound MeshTensor is retained).
+            bool enqueue_invariant = false;
         };
         std::unordered_map<std::string, RegisteredTensorParameter> tensor_parameter_layouts;
 

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -380,6 +380,14 @@ public:
         std::vector<std::string> runtime_arg_names;
         std::vector<std::string> common_runtime_arg_names;
 
+        // Precomputed name -> slot-index maps mirroring the *_names vectors above (slot = the arg's
+        // position within its dispatch-buffer section). Built once at Program construction so the
+        // hot UpdateProgramRunArgs path does O(1) lookups instead of rebuilding a map per call —
+        // that path is not bypassable via skip_validation, so per-call construction would be pure
+        // host overhead on the inner re-enqueue loop.
+        std::unordered_map<std::string, size_t> runtime_arg_name_to_slot;
+        std::unordered_map<std::string, size_t> common_runtime_arg_name_to_slot;
+
         // Vararg counts. RTA vararg count is per-node (stored post-expansion from the
         // user-facing schema, which groups nodes that share a count); CRTA vararg is a single
         // broadcast count.


### PR DESCRIPTION
## PR Category
Feature

## Summary
This PR adds a new "advanced" concept to the Metal 2.0 APIs: enqueue-loop invariant arguments, and partial `ProgramRunArgs` updates.

### Background
Currently `SetProgramRunArgs` requires that _all_ the Program's arguments must be set with every invocation. This is by design. It conceals the stateful nature of arguments, which has historically been a significant bug generator. The thinking was: "a `Program` is like a compiled function that you can invoke again and again; `ProgramRunArgs` is the arguments you pass it on invocation".

However, in performance-sensitive contexts, the full arg update can impose too much host overhead. 

However... partial args update need not be a capitulation of our safe-by-construction ambitions. The key insight is that RTAs actually serve two distinct purposes:
 - Pass per-node info to a compiled kernel (the binaries for which are broadcast to a large set of nodes)
 - Pass per-enqueue (per-node) information

In many cases, a Program wants only the former property for many of its RTAs. It should not be forced to pay the cost of the latter at each enqueue. This advanced feature enables structurally distinguishing against these two RTA use cases.

### Changes

To enable fast-path args updates without compromising safety, use the new `UpdateProgramRunArgs`. It conditionally supports argument "patching". However, arguments that are statefully retained from the previous enqueue must be explicitly designated as `enqueue_invariant` in the `ProgramSpec`. The user must pre-declare those arguments that are safe to omit; the runtime legality checks enforce this.

Other supporting changes:
 - Renames (the recently renamed) `TensorParameterRelaxations` back to `TensorParameterAdvancedOptions`.
 - Adds a convenience helper `MergeProgramRunArgs` to manage the "outer loop" full args update
 - Adds the missing `skip_validation` argument to `SetProgramRunArgs` (small slow-path production speedup), 

## Notes for reviewers
This change resolves challenges we've having porting ops to Metal 2.0 with strict safe-by-construction guarantees. The previous "safe" programming model insisted on full fast-path args update. The insight above that RTAs have two distinct "flavors" opens the door to safe-by-construction, strictly validated fast path updates that preserve performance.

## CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/partial-run-args-update)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/partial-run-args-update)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/partial-run-args-update)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/partial-run-args-update)