### PR TITLE
[Performance] keep descriptor fast path for safe inplace aliasing

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
+++ b/tests/tt_metal/tt_metal/api/test_descriptor_patching.cpp
@@ -170,6 +170,24 @@ TEST(DescriptorPatching, ResolvedBindings_EmptyAfterAddingCb_IsFalse) {
     EXPECT_FALSE(b.empty());
 }
 
+TEST(DescriptorPatching, TensorBufferIndexMap_DuplicateInputReturnsNullopt) {
+    Buffer* buf_a = reinterpret_cast<Buffer*>(0x1000);
+
+    auto index_map = detail::build_tensor_buffer_index_map(std::vector<Buffer*>{buf_a, buf_a}, 2u);
+
+    EXPECT_FALSE(index_map.has_value());
+}
+
+TEST(DescriptorPatching, TensorBufferIndexMap_OutputAliasingInputKeepsInputSlot) {
+    Buffer* buf_a = reinterpret_cast<Buffer*>(0x1000);
+
+    auto index_map = detail::build_tensor_buffer_index_map(std::vector<Buffer*>{buf_a, buf_a}, 1u);
+
+    ASSERT_TRUE(index_map.has_value());
+    ASSERT_EQ(index_map->size(), 1u);
+    EXPECT_EQ(index_map->at(buf_a), 0u);
+}
+
 // ============================================================================
 // SECTION 2: Device integration tests
 // ============================================================================
@@ -608,6 +626,27 @@ TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_DuplicateBuffer_Retu
 
     EXPECT_TRUE(resolved.empty());
     EXPECT_TRUE(resolved.rt_args.empty());
+    EXPECT_TRUE(resolved.cbs.empty());
+}
+
+// Regression: an output tensor aliasing an input tensor is the safe in-place
+// case, not the ambiguous "same input passed twice" case. The resolver should
+// preserve the input-slot mapping and keep the cache-hit fast path alive.
+TEST_F(DescriptorPatchingDeviceTest, Tensix_ResolveBindings_OutputAliasingInput_KeepsFastPath) {
+    auto buf_a = MakeDramBuffer(device());
+
+    KernelDescriptor kd = MakeBlankReaderKernel({0, 0});
+    kd.emplace_runtime_args({0, 0}, {buf_a.get()});
+
+    ProgramDescriptor desc;
+    desc.kernels = {kd};
+
+    Program program{desc};
+    ResolvedBindings resolved = resolve_bindings(program, desc, std::vector<Buffer*>{buf_a.get(), buf_a.get()}, 1u);
+
+    ASSERT_FALSE(resolved.empty());
+    ASSERT_EQ(resolved.rt_args.size(), 1u);
+    EXPECT_EQ(resolved.rt_args[0].tensor_buffer_idx, 0u);
     EXPECT_TRUE(resolved.cbs.empty());
 }
 

--- a/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
+++ b/tt_metal/api/tt-metalium/experimental/program_descriptor_patching.hpp
@@ -39,7 +39,10 @@
 
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <span>
+#include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace tt::tt_metal {
@@ -80,6 +83,41 @@ struct ResolvedBindings {
     std::vector<ResolvedCbBinding> cbs;
     bool empty() const noexcept { return rt_args.empty() && cbs.empty(); }
 };
+
+namespace detail {
+
+inline std::optional<std::unordered_map<Buffer*, uint32_t>> build_tensor_buffer_index_map(
+    std::span<Buffer* const> tensor_buffers,
+    size_t num_input_buffers) {
+    std::unordered_map<Buffer*, uint32_t> tensor_buffer_to_idx;
+    tensor_buffer_to_idx.reserve(tensor_buffers.size());
+
+    std::unordered_set<Buffer*> input_buffers;   // buffers seen in the input region
+    std::unordered_set<Buffer*> output_buffers;  // buffers seen in the output/workload region
+    input_buffers.reserve(num_input_buffers);
+    output_buffers.reserve(tensor_buffers.size() >= num_input_buffers ? tensor_buffers.size() - num_input_buffers : 0);
+    for (uint32_t i = 0; i < tensor_buffers.size(); ++i) {
+        Buffer* buf = tensor_buffers[i];
+        if (!buf) {
+            continue;
+        }
+        const bool is_input = i < num_input_buffers;
+        // An output/workload buffer that aliases an input is the safe in-place case — keep
+        // the first input slot mapping so all bindings patch the shared address consistently.
+        if (!is_input && input_buffers.contains(buf)) {
+            continue;
+        }
+        // Otherwise a repeat is ambiguous (matmul(X, X), or a repeated output) — bail to slow path.
+        auto& seen = is_input ? input_buffers : output_buffers;
+        if (!seen.insert(buf).second) {
+            return std::nullopt;
+        }
+        tensor_buffer_to_idx.emplace(buf, i);
+    }
+    return tensor_buffer_to_idx;
+}
+
+}  // namespace detail
 
 // ---------------------------------------------------------------------------
 // resolve / apply

--- a/tt_metal/impl/program/program_descriptor_patching.cpp
+++ b/tt_metal/impl/program/program_descriptor_patching.cpp
@@ -31,7 +31,6 @@
 #include <cstdint>
 #include <span>
 #include <string_view>
-#include <unordered_set>
 #include <vector>
 
 namespace tt::tt_metal {
@@ -57,37 +56,21 @@ ResolvedBindings resolve_bindings(
     //     mapping them to the one shared address is always correct.  Keep the fast path.
     //
     // tensor_buffers is ordered inputs-first; the first num_input_buffers entries are inputs.
-    {
-        std::unordered_set<Buffer*> input_buffers;   // buffers seen in the input region
-        std::unordered_set<Buffer*> output_buffers;  // buffers seen in the output/workload region
-        for (size_t i = 0; i < tensor_buffers.size(); ++i) {
-            Buffer* buf = tensor_buffers[i];
-            if (!buf) {
-                continue;
-            }
-            const bool is_input = i < num_input_buffers;
-            // An output/workload buffer that aliases an input is the safe in-place case — skip it.
-            if (!is_input && input_buffers.contains(buf)) {
-                continue;
-            }
-            // Otherwise a repeat is ambiguous (matmul(X, X), or a repeated output) — bail to slow path.
-            auto& seen = is_input ? input_buffers : output_buffers;
-            if (!seen.insert(buf).second) {
-                return ResolvedBindings{};
-            }
-        }
+    auto tensor_buffer_to_idx = detail::build_tensor_buffer_index_map(tensor_buffers, num_input_buffers);
+    if (!tensor_buffer_to_idx.has_value()) {
+        return ResolvedBindings{};
     }
 
     // Map each Buffer* to its index in tensor_buffers.  Every binding Buffer* must be
     // present; TT_FATAL fires if a factory used a non-tensor buffer in emplace_runtime_args.
     auto find_idx = [&](Buffer* buf, std::string_view context) -> uint32_t {
-        auto it = std::find(tensor_buffers.begin(), tensor_buffers.end(), buf);
+        auto it = tensor_buffer_to_idx->find(buf);
         TT_FATAL(
-            it != tensor_buffers.end(),
+            it != tensor_buffer_to_idx->end(),
             "Buffer* in {} not found in tensor_args/tensor_return_value enumeration. "
             "All buffer bindings must come directly from input/output tensors.",
             context);
-        return static_cast<uint32_t>(it - tensor_buffers.begin());
+        return it->second;
     };
 
     for (uint32_t k = 0; k < static_cast<uint32_t>(desc.kernels.size()); ++k) {
@@ -166,10 +149,9 @@ ResolvedBindings resolve_bindings(
                 cb_buffer = cb_desc.tensor->mesh_buffer().get_reference_buffer();
             }
             if (cb_buffer) {
-                auto it = std::find(tensor_buffers.begin(), tensor_buffers.end(), cb_buffer);
-                if (it != tensor_buffers.end()) {
-                    result.cbs.push_back(
-                        {program_cbs[ci]->id(), static_cast<uint32_t>(it - tensor_buffers.begin()), cb_desc.address_offset});
+                auto it = tensor_buffer_to_idx->find(cb_buffer);
+                if (it != tensor_buffer_to_idx->end()) {
+                    result.cbs.push_back({program_cbs[ci]->id(), it->second, cb_desc.address_offset});
                 }
                 // else: stable, non-tensor buffer; pegged at create time, no patching needed.
             }


### PR DESCRIPTION
PR Category
Performance

Summary
resolve_bindings currently falls back whenever the collected tensor-buffer list contains the same Buffer* more than once.

That fallback is required for repeated input slots such as matmul(X, X). Those slots are logically distinct inputs that only share an address on one call, so a later same-shape call with distinct tensors would need different patching.

The same rule is too broad for inplace aliasing. When an output or workload buffer aliases an input buffer, both slots refer to the same buffer by construction on every dispatch. In that case the resolver can keep the first input-slot mapping and preserve the descriptor cache-hit fast path.

This change:
- keeps the slow-path bailout for duplicate inputs
- keeps the fast path for output- or workload-alias-input bindings
- reuses one Buffer* to slot map for both rt-arg and CB patching

Relates to #46506.

Notes for reviewers
Please focus on build_tensor_buffer_index_map(...) and on the new duplicate-input vs output-alias-input regression coverage in test_descriptor_patching.cpp.

Local validation on 2026-06-10:
- rebuilt unit_tests_api_lib after the change
- ran git diff --check
- retried linking unit_tests_api

The local proof is still compile-level plus focused regression coverage, not a full device-gtest runtime pass in this environment. The unit_tests_api link still fails on unrelated baseline symbol resolution for tt::umd::SimulationChip::get_soc_descriptor_path_from_simulator_path(...) and MPI C++ symbols such as MPI::Datatype::Free().
