### PR TITLE
Widen SDPA perf-check margins to +/-1.0%

### DIFF
--- a/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py
@@ -785,7 +785,7 @@ def test_exp_ring_joint_attention_create_perf_table(b, nh, total_seq, d, q_chunk
 
 # === TEST 5: PERFORMANCE CHECK (CI-gated by SDPA_PERF_CHECKS=1) ===
 # Symmetric +/- band — catches both regressions and unexpected speedups.
-EXP_RING_JOINT_PERF_MARGIN = 0.005
+EXP_RING_JOINT_PERF_MARGIN = 0.01
 
 EXP_RING_JOINT_PERF_CHECK_CONFIGS = [
     # (ring_size_expected, max_payload_size, payload_id, expected_util)

--- a/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
+++ b/tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py
@@ -3310,7 +3310,7 @@ def test_ring_joint_attention_create_perf_table(model_name):
 
 # === TEST 5: PERFORMANCE CHECK (CI-gated by SDPA_PERF_CHECKS=1) ===
 # Symmetric +/- band — catches both regressions and unexpected speedups.
-RING_JOINT_PERF_MARGIN = 0.005
+RING_JOINT_PERF_MARGIN = 0.01
 
 RING_JOINT_PERF_CHECK_CONFIGS = [
     # (model_name, q_chunk_size, k_chunk_size, ring_size, expected_util)

--- a/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
+++ b/tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py
@@ -418,7 +418,7 @@ def test_sdpa_create_perf_table(b, nh, s, d):
 
 # === TEST 5: PERFORMANCE CHECK (CI-gated by SDPA_PERF_CHECKS=1) ===
 # Symmetric +/- band — catches both regressions and unexpected speedups.
-SDPA_PERF_MARGIN = 0.007
+SDPA_PERF_MARGIN = 0.01
 
 SDPA_PERF_CHECK_CONFIGS = [
     # (shape_id, q_chunk_size, k_chunk_size, expected_util)


### PR DESCRIPTION
### What's changed
The SDPA perf checks (`SDPA_PERF_CHECKS=1`) are sometimes flaky in CI because the margins are really tight — narrower than the ~0.6%+ run-to-run/cross-machine duration jitter, causing marginal boundary failures (e.g. q224-k512 at 57.04% vs a [57.10, 57.90] band).

Widen all three margin constants to +/-1.0%:
- `SDPA_PERF_MARGIN`: 0.007 → 0.01
- `EXP_RING_JOINT_PERF_MARGIN`: 0.005 → 0.01
- `RING_JOINT_PERF_MARGIN`: 0.005 → 0.01 (also covers ring-MLA chunked)

Still flags any genuine >1% regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/widen-sdpa-perf-margins)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/widen-sdpa-perf-margins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/widen-sdpa-perf-margins)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/widen-sdpa-perf-margins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/widen-sdpa-perf-margins)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/widen-sdpa-perf-margins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/widen-sdpa-perf-margins)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/widen-sdpa-perf-margins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/widen-sdpa-perf-margins)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/widen-sdpa-perf-margins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/widen-sdpa-perf-margins)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/widen-sdpa-perf-margins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/widen-sdpa-perf-margins)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/widen-sdpa-perf-margins)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/widen-sdpa-perf-margins)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/widen-sdpa-perf-margins)