### PR TITLE
[Test Only]Widen clamp inputs for eltwise integer typecast tests

### DIFF
--- a/tests/ttnn/python_api_testing/typecast_test_helpers.py
+++ b/tests/ttnn/python_api_testing/typecast_test_helpers.py
@@ -8,33 +8,90 @@ import ttnn
 from tests.ttnn.utils_for_testing import assert_equal
 
 FLOAT_INPUT_DTYPES = {ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b, ttnn.bfloat4_b}
+_INTEGER_OUTPUT_DTYPES = {ttnn.uint8, ttnn.uint16, ttnn.uint32, ttnn.int32}
+_UNSIGNED_INPUT_DTYPES = {ttnn.uint8, ttnn.uint16, ttnn.uint32}
+_SIGNED_OR_FLOAT_INPUT = {ttnn.int32} | FLOAT_INPUT_DTYPES
+
+# Signed 32-bit extrema: min = -2^(32-1), max = 2^(32-1) - 1 (exponent is 31, not 32).
+_INT32_MIN = -(2**31)
+_INT32_MAX = 2**31 - 1
+
+_UNSIGNED_INPUT_MAX = {
+    ttnn.uint8: 255,
+    ttnn.uint16: 65535,
+    # uint32 inputs are stored as int32 in tests; clamp_high fits without wrap.
+    ttnn.uint32: _INT32_MAX,
+}
+# Representable limits per dtype (uint32 output capped to uint16-scale for practical randint).
+_DTYPE_MIN = {
+    ttnn.uint8: 0,
+    ttnn.uint16: 0,
+    ttnn.uint32: 0,
+    ttnn.int32: _INT32_MIN,
+}
+_DTYPE_MAX = {
+    ttnn.uint8: 255,
+    ttnn.uint16: 65535,
+    ttnn.uint32: 65535,
+    ttnn.int32: _INT32_MAX,
+}
+
+# Extend ~14465 above uint16 max → 80000 (clamp headroom without full uint32 range).
+_CLAMP_HIGH = _DTYPE_MAX[ttnn.uint16] + 14465
+# Practical negative magnitude for signed/float inputs (beyond output min, randint-friendly).
+_CLAMP_LOW_MAGNITUDE = 1000
+
+
+def _output_allows_negative(tt_output_dtype):
+    return tt_output_dtype == ttnn.int32
+
+
+def _input_allows_negative(tt_input_dtype):
+    return tt_input_dtype in _SIGNED_OR_FLOAT_INPUT
 
 
 def typecast_test_input_bounds(tt_input_dtype, tt_output_dtype):
-    """Out-of-range inputs for integer typecast: clamp (→uint16), wrap (→uint8).
+    """Derive out-of-range input bounds from dtype limits for integer typecast tests.
 
-    int32 inputs may be negative; uint16/uint32 inputs stay >= 0 to avoid reinterpretation
+    Extends below/above the output dtype range so clamp (→uint16), wrap (→uint8), and
+    saturation paths are exercised. Unsigned inputs stay >= 0 to avoid reinterpretation
     on device (e.g. -1 as uint32 → 4294967295) that would mismatch clamp-aware golden.
+
+    Rules (per review on #46574):
+    - Unsigned input → low = 0.
+    - Signed/float input + uint8 output → ±2×(max+1) for wrap/clamp (±512).
+    - Signed/float input + wider unsigned/signed output → low = -min(1000, out_max+1),
+      high = out_max + slack (80000 for uint16-scale outputs).
+    - Unsigned input + uint8 output → [0, min(512, input_max)]; wider outputs → [0, min(80000, input_max)].
     """
-    if tt_output_dtype == ttnn.uint16 and tt_input_dtype == ttnn.int32:
-        return -1000, 80000
-    if tt_output_dtype == ttnn.uint16 and tt_input_dtype == ttnn.uint32:
-        return 0, 80000
-    if tt_output_dtype == ttnn.uint32 and tt_input_dtype == ttnn.int32:
-        return -1000, 80000
-    if tt_output_dtype == ttnn.uint8 and tt_input_dtype == ttnn.int32:
-        return -512, 512
-    if tt_output_dtype == ttnn.uint8 and tt_input_dtype in (ttnn.uint16, ttnn.uint32):
-        return 0, 512
-    if tt_output_dtype == ttnn.uint8 and tt_input_dtype in FLOAT_INPUT_DTYPES:
-        return -512, 512
-    if tt_output_dtype == ttnn.uint16 and tt_input_dtype in FLOAT_INPUT_DTYPES:
-        return -1000, 80000
-    if tt_output_dtype == ttnn.uint32 and tt_input_dtype in FLOAT_INPUT_DTYPES:
-        return -1000, 80000
-    if tt_output_dtype == ttnn.int32 and tt_input_dtype in FLOAT_INPUT_DTYPES:
-        return -1000, 80000
-    return 0, 100
+    if tt_output_dtype not in _INTEGER_OUTPUT_DTYPES:
+        return 0, 100
+
+    out_min = _DTYPE_MIN[tt_output_dtype]
+    out_max = _DTYPE_MAX[tt_output_dtype]
+
+    if tt_input_dtype in _UNSIGNED_INPUT_DTYPES:
+        low = 0
+    elif tt_output_dtype == ttnn.uint8:
+        span = out_max + 1
+        low = -2 * span
+    elif not _output_allows_negative(tt_output_dtype):
+        low = -min(_CLAMP_LOW_MAGNITUDE, out_max + 1)
+    else:
+        low = -min(_CLAMP_LOW_MAGNITUDE, abs(out_min) if out_min < 0 else _CLAMP_LOW_MAGNITUDE)
+
+    if tt_output_dtype == ttnn.uint8:
+        high = 2 * (out_max + 1)
+    elif tt_output_dtype in (ttnn.uint16, ttnn.uint32, ttnn.int32):
+        high = _CLAMP_HIGH
+    else:
+        high = out_max + 100
+
+    # Unsigned inputs cannot represent values above their dtype max (wrap on device).
+    if tt_input_dtype in _UNSIGNED_INPUT_DTYPES:
+        high = min(high, _UNSIGNED_INPUT_MAX[tt_input_dtype])
+
+    return low, high
 
 
 def make_typecast_test_input(shape, pt_input_dtype, in_low, in_high):

--- a/tests/ttnn/python_api_testing/typecast_test_helpers.py
+++ b/tests/ttnn/python_api_testing/typecast_test_helpers.py
@@ -1,0 +1,60 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_equal
+
+FLOAT_INPUT_DTYPES = {ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b, ttnn.bfloat4_b}
+
+
+def typecast_test_input_bounds(tt_input_dtype, tt_output_dtype):
+    """Out-of-range inputs for integer typecast: clamp (→uint16), wrap (→uint8).
+
+    int32 inputs may be negative; uint16/uint32 inputs stay >= 0 to avoid reinterpretation
+    on device (e.g. -1 as uint32 → 4294967295) that would mismatch clamp-aware golden.
+    """
+    if tt_output_dtype == ttnn.uint16 and tt_input_dtype == ttnn.int32:
+        return -1000, 80000
+    if tt_output_dtype == ttnn.uint16 and tt_input_dtype == ttnn.uint32:
+        return 0, 80000
+    if tt_output_dtype == ttnn.uint32 and tt_input_dtype == ttnn.int32:
+        return -1000, 80000
+    if tt_output_dtype == ttnn.uint8 and tt_input_dtype == ttnn.int32:
+        return -512, 512
+    if tt_output_dtype == ttnn.uint8 and tt_input_dtype in (ttnn.uint16, ttnn.uint32):
+        return 0, 512
+    if tt_output_dtype == ttnn.uint8 and tt_input_dtype in FLOAT_INPUT_DTYPES:
+        return -512, 512
+    if tt_output_dtype == ttnn.uint16 and tt_input_dtype in FLOAT_INPUT_DTYPES:
+        return -1000, 80000
+    if tt_output_dtype == ttnn.uint32 and tt_input_dtype in FLOAT_INPUT_DTYPES:
+        return -1000, 80000
+    if tt_output_dtype == ttnn.int32 and tt_input_dtype in FLOAT_INPUT_DTYPES:
+        return -1000, 80000
+    return 0, 100
+
+
+def make_typecast_test_input(shape, pt_input_dtype, in_low, in_high):
+    if pt_input_dtype == torch.uint8:
+        return torch.randint(0, 256, shape, dtype=torch.uint8)
+    if pt_input_dtype in (torch.int, torch.int32):
+        return torch.randint(in_low, in_high + 1, shape, dtype=torch.int32)
+    return (torch.rand(shape) * (in_high - in_low) + in_low).to(pt_input_dtype)
+
+
+def assert_integer_typecast_equal(expected, actual):
+    assert_equal(expected.to(torch.int64), actual.to(torch.int64))
+
+
+def uses_exact_integer_typecast_check(tt_input_dtype, tt_output_dtype):
+    if tt_output_dtype in (ttnn.int32, ttnn.uint32, ttnn.uint8):
+        return True
+    return tt_output_dtype == ttnn.uint16 and tt_input_dtype in (
+        ttnn.int32,
+        ttnn.uint16,
+        ttnn.uint32,
+        ttnn.uint8,
+    )

--- a/tests/ttnn/python_api_testing/typecast_test_helpers.py
+++ b/tests/ttnn/python_api_testing/typecast_test_helpers.py
@@ -7,10 +7,8 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_equal
 
-FLOAT_INPUT_DTYPES = {ttnn.bfloat16, ttnn.float32, ttnn.bfloat8_b, ttnn.bfloat4_b}
 _INTEGER_OUTPUT_DTYPES = {ttnn.uint8, ttnn.uint16, ttnn.uint32, ttnn.int32}
 _UNSIGNED_INPUT_DTYPES = {ttnn.uint8, ttnn.uint16, ttnn.uint32}
-_SIGNED_OR_FLOAT_INPUT = {ttnn.int32} | FLOAT_INPUT_DTYPES
 
 # Signed 32-bit extrema: min = -2^(32-1), max = 2^(32-1) - 1 (exponent is 31, not 32).
 _INT32_MIN = -(2**31)
@@ -44,10 +42,6 @@ _CLAMP_LOW_MAGNITUDE = 1000
 
 def _output_allows_negative(tt_output_dtype):
     return tt_output_dtype == ttnn.int32
-
-
-def _input_allows_negative(tt_input_dtype):
-    return tt_input_dtype in _SIGNED_OR_FLOAT_INPUT
 
 
 def typecast_test_input_bounds(tt_input_dtype, tt_output_dtype):

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -7,6 +7,12 @@ import torch
 import ttnn
 
 from tests.ttnn.python_api_testing.sweep_tests.ttnn_pytorch_ops import eltwise_typecast
+from tests.ttnn.python_api_testing.typecast_test_helpers import (
+    assert_integer_typecast_equal,
+    make_typecast_test_input,
+    typecast_test_input_bounds,
+    uses_exact_integer_typecast_check,
+)
 from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
 
 mem_configs = [
@@ -21,31 +27,9 @@ cpu_layout = ttnn.Layout.ROW_MAJOR
 npu_layout = ttnn.Layout.TILE
 
 
-def _typecast_test_input_bounds(tt_input_dtype, tt_output_dtype):
-    """Out-of-range inputs for integer typecast: clamp (→uint16), wrap (→uint8).
-
-    int32 inputs may be negative; uint16/uint32 inputs stay >= 0 to avoid reinterpretation
-    on device (e.g. -1 as uint32 → 4294967295) that would mismatch clamp-aware golden.
-    """
-    if tt_output_dtype == ttnn.uint16 and tt_input_dtype == ttnn.int32:
-        return -1000, 80000  # signed: negatives clamp to 0, >65535 clamp to 65535
-    if tt_output_dtype == ttnn.uint16 and tt_input_dtype == ttnn.uint32:
-        return 0, 80000  # unsigned: no negatives; >65535 values will be clamped
-    if tt_output_dtype == ttnn.uint32 and tt_input_dtype == ttnn.int32:
-        return -1000, 80000
-    if tt_output_dtype == ttnn.uint8 and tt_input_dtype == ttnn.int32:
-        return -512, 512  # wrap/truncate to uint8 (not clamp); wide range ensures out-of-[0,255] values
-    if tt_output_dtype == ttnn.uint8 and tt_input_dtype in (ttnn.uint16, ttnn.uint32):
-        return 0, 512  # values >255 exercise truncation; wide enough to guarantee hits
-    return 0, 100
-
-
-def _make_typecast_test_input(shape, pt_input_dtype, in_low, in_high):
-    if pt_input_dtype == torch.uint8:
-        return torch.randint(0, 256, shape, dtype=torch.uint8)
-    if pt_input_dtype in (torch.int, torch.int32):
-        return torch.randint(in_low, in_high + 1, shape, dtype=torch.int32)
-    return (torch.rand(shape) * (in_high - in_low) + in_low).to(pt_input_dtype)
+def _make_fp32_to_int32_input(shape):
+    in_low, in_high = typecast_test_input_bounds(ttnn.float32, ttnn.int32)
+    return make_typecast_test_input(shape, torch.float32, in_low, in_high)
 
 
 @pytest.mark.parametrize(
@@ -137,9 +121,9 @@ class TestTypecast:
     ):
         if tt_input_dtype == tt_output_dtype:
             pytest.skip("Same I/O data types. Skip.")
-        in_low, in_high = _typecast_test_input_bounds(tt_input_dtype, tt_output_dtype)
+        in_low, in_high = typecast_test_input_bounds(tt_input_dtype, tt_output_dtype)
         shape = input_shapes[0]
-        torch_input = _make_typecast_test_input(shape, pt_input_dtype, in_low, in_high)
+        torch_input = make_typecast_test_input(shape, pt_input_dtype, in_low, in_high)
 
         tt_input = ttnn.from_torch(
             torch_input, dtype=tt_input_dtype, layout=ttnn.TILE_LAYOUT, device=device, memory_config=input_mem_config
@@ -151,11 +135,8 @@ class TestTypecast:
 
         if tt_output_dtype in (ttnn.float32, ttnn.bfloat16):
             assert_equal(torch_golden, torch_output)
-        # Integer outputs (and uint16 from integer inputs): compare elementwise via assert_equal.
-        elif tt_output_dtype in (ttnn.int32, ttnn.uint32, ttnn.uint8) or (
-            tt_output_dtype == ttnn.uint16 and tt_input_dtype in (ttnn.int32, ttnn.uint16, ttnn.uint32, ttnn.uint8)
-        ):
-            assert_equal(torch_golden.to(torch.int64), torch_output.to(torch.int64))
+        elif uses_exact_integer_typecast_check(tt_input_dtype, tt_output_dtype):
+            assert_integer_typecast_equal(torch_golden, torch_output)
         else:
             pcc = 0.98 if tt_input_dtype == ttnn.bfloat4_b or tt_output_dtype == ttnn.bfloat4_b else 0.99
             assert_with_pcc(torch_golden, torch_output, pcc=pcc)
@@ -377,7 +358,7 @@ def test_typecast_legacy_sharded(device, shard_layout, core_grid, shard_shape):
     shard_spec = ttnn.ShardSpec(core_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     mem_config = ttnn.MemoryConfig(shard_layout, ttnn.BufferType.L1, shard_spec)
 
-    torch_input = torch.randint(0, 100, shape, dtype=torch.int32).float()
+    torch_input = _make_fp32_to_int32_input(shape)
     input_tensor = ttnn.from_torch(
         torch_input, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem_config
     )
@@ -385,8 +366,8 @@ def test_typecast_legacy_sharded(device, shard_layout, core_grid, shard_shape):
     assert output_tensor.dtype == ttnn.int32
 
     result = ttnn.to_torch(output_tensor)
-    expected = torch_input.int()
-    assert torch.equal(result, expected)
+    expected = eltwise_typecast(torch_input, tt_input_dtype=ttnn.float32, tt_output_dtype=ttnn.int32)
+    assert_integer_typecast_equal(expected, result)
 
 
 @pytest.mark.parametrize(
@@ -435,7 +416,7 @@ def test_typecast_nd_sharded_int(device, tensor_shape, nd_shard_shape, shard_gri
     nd_shard_spec = ttnn.NdShardSpec(shard_shape=nd_shard_shape, grid=shard_grid, orientation=shard_orientation)
     mem_config = ttnn.MemoryConfig(buffer_type=ttnn.BufferType.L1, nd_shard_spec=nd_shard_spec)
 
-    torch_input = torch.randint(0, 100, tensor_shape, dtype=torch.int32).float()
+    torch_input = _make_fp32_to_int32_input(tensor_shape)
     input_tensor = ttnn.from_torch(
         torch_input, dtype=ttnn.float32, layout=layout, device=device, memory_config=mem_config
     )
@@ -443,8 +424,8 @@ def test_typecast_nd_sharded_int(device, tensor_shape, nd_shard_shape, shard_gri
     assert output_tensor.dtype == ttnn.int32
 
     result = ttnn.to_torch(output_tensor)
-    expected = torch_input.int()
-    assert torch.equal(result, expected)
+    expected = eltwise_typecast(torch_input, tt_input_dtype=ttnn.float32, tt_output_dtype=ttnn.int32)
+    assert_integer_typecast_equal(expected, result)
 
 
 @pytest.mark.parametrize(
@@ -592,7 +573,7 @@ def test_typecast_legacy_sharded_dram_buffer(device, shard_layout):
     shard_spec = ttnn.ShardSpec(core_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     mem_config = ttnn.MemoryConfig(shard_layout, ttnn.BufferType.DRAM, shard_spec)
 
-    torch_input = torch.randint(0, 100, shape, dtype=torch.int32).float()
+    torch_input = _make_fp32_to_int32_input(shape)
 
     input_tensor = ttnn.from_torch(
         torch_input, dtype=ttnn.float32, layout=ttnn.TILE_LAYOUT, device=device, memory_config=mem_config
@@ -601,8 +582,8 @@ def test_typecast_legacy_sharded_dram_buffer(device, shard_layout):
     assert output_tensor.dtype == ttnn.int32
 
     npu_result = ttnn.to_torch(output_tensor)
-    expected = torch_input.int()
-    assert torch.equal(npu_result, expected)
+    expected = eltwise_typecast(torch_input, tt_input_dtype=ttnn.float32, tt_output_dtype=ttnn.int32)
+    assert_integer_typecast_equal(expected, npu_result)
 
 
 def test_typecast_legacy_sharded_shard_size_not_tile_aligned(device):
@@ -621,7 +602,7 @@ def test_typecast_legacy_sharded_shard_size_not_tile_aligned(device):
 
     shard_spec = ttnn.ShardSpec(core_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
     mem_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, shard_spec)
-    torch_input = torch.randint(0, 100, shape, dtype=torch.int32).float()
+    torch_input = _make_fp32_to_int32_input(shape)
 
     input_tensor = ttnn.from_torch(
         torch_input, dtype=ttnn.float32, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=mem_config
@@ -630,8 +611,8 @@ def test_typecast_legacy_sharded_shard_size_not_tile_aligned(device):
     assert output_tensor.dtype == ttnn.int32
 
     npu_result = ttnn.to_torch(output_tensor)
-    expected = torch_input.int()
-    assert torch.equal(npu_result, expected)
+    expected = eltwise_typecast(torch_input, tt_input_dtype=ttnn.float32, tt_output_dtype=ttnn.int32)
+    assert_integer_typecast_equal(expected, npu_result)
 
 
 @pytest.mark.parametrize(
@@ -648,8 +629,9 @@ def test_typecast_legacy_sharded_shard_size_not_tile_aligned(device):
 def test_typecast_rm_non_aligned_width(shape, device):
     """ROW_MAJOR bfloat16→uint8 typecast with width not divisible by 32."""
     torch.manual_seed(42)
-    torch_input = (torch.rand(shape) * 200).to(torch.bfloat16)
-    expected = torch_input.to(torch.uint8)
+    in_low, in_high = typecast_test_input_bounds(ttnn.bfloat16, ttnn.uint8)
+    torch_input = make_typecast_test_input(shape, torch.bfloat16, in_low, in_high)
+    expected = eltwise_typecast(torch_input, tt_input_dtype=ttnn.bfloat16, tt_output_dtype=ttnn.uint8)
 
     input_tensor = ttnn.from_torch(
         torch_input,
@@ -659,7 +641,7 @@ def test_typecast_rm_non_aligned_width(shape, device):
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     result = ttnn.to_torch(ttnn.typecast(input_tensor, ttnn.uint8))
-    assert torch.equal(result, expected), f"mismatch for shape {shape}"
+    assert_integer_typecast_equal(expected, result)
 
 
 def test_typecast_rm_chunked_program_cache(device):
@@ -670,8 +652,9 @@ def test_typecast_rm_chunked_program_cache(device):
     num_cores = grid.x * grid.y
     shape = [num_cores + 1, 64]
 
-    torch_input = (torch.rand(shape) * 100).to(torch.bfloat16)
-    expected = torch_input.to(torch.uint8)
+    in_low, in_high = typecast_test_input_bounds(ttnn.bfloat16, ttnn.uint8)
+    torch_input = make_typecast_test_input(shape, torch.bfloat16, in_low, in_high)
+    expected = eltwise_typecast(torch_input, tt_input_dtype=ttnn.bfloat16, tt_output_dtype=ttnn.uint8)
 
     for i in range(2):
         input_tensor = ttnn.from_torch(
@@ -683,4 +666,4 @@ def test_typecast_rm_chunked_program_cache(device):
         )
         output_tensor = ttnn.typecast(input_tensor, ttnn.uint8)
         result = ttnn.to_torch(output_tensor)
-        assert torch.equal(result, expected), f"typecast correctness check failed on call {i + 1}"
+        assert_integer_typecast_equal(expected, result)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_eltwise_typecast.py
@@ -33,6 +33,33 @@ def _make_fp32_to_int32_input(shape):
 
 
 @pytest.mark.parametrize(
+    "tt_input_dtype, tt_output_dtype, expected",
+    [
+        (ttnn.int32, ttnn.uint16, (-1000, 80000)),
+        (ttnn.uint32, ttnn.uint16, (0, 80000)),
+        (ttnn.int32, ttnn.uint32, (-1000, 80000)),
+        (ttnn.int32, ttnn.uint8, (-512, 512)),
+        (ttnn.uint16, ttnn.uint8, (0, 512)),
+        (ttnn.uint32, ttnn.uint8, (0, 512)),
+        (ttnn.uint16, ttnn.uint32, (0, 65535)),
+        (ttnn.uint16, ttnn.int32, (0, 65535)),
+        (ttnn.bfloat16, ttnn.uint8, (-512, 512)),
+        (ttnn.bfloat16, ttnn.uint16, (-1000, 80000)),
+        (ttnn.bfloat16, ttnn.bfloat16, (0, 100)),
+    ],
+)
+def test_typecast_test_input_bounds(tt_input_dtype, tt_output_dtype, expected):
+    assert typecast_test_input_bounds(tt_input_dtype, tt_output_dtype) == expected
+
+
+def test_typecast_test_input_bounds_unsigned_high_never_exceeds_input_max():
+    for tt_output_dtype in (ttnn.uint32, ttnn.int32, ttnn.uint16, ttnn.uint8):
+        low, high = typecast_test_input_bounds(ttnn.uint16, tt_output_dtype)
+        assert low == 0
+        assert high <= 65535
+
+
+@pytest.mark.parametrize(
     "pt_input_dtype, tt_input_dtype, tt_output_dtype",
     (
         (torch.bfloat16, ttnn.bfloat16, ttnn.float32),

--- a/tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
@@ -93,8 +93,8 @@ def test_typecast_uint16(device):
 def test_typecast_subcore_grid(device, shape, sub_core_grid):
     torch.manual_seed(0)
 
-    in_data1 = torch.randint(0, 65500, (shape), dtype=torch.int32)
-    in_data2 = torch.randint(0, 128000, (shape), dtype=torch.int32)
+    in_data1 = torch.randint(0, 65536, (shape), dtype=torch.int32)
+    in_data2 = torch.randint(-1000, 128001, (shape), dtype=torch.int32)
 
     input_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
@@ -165,7 +165,7 @@ def test_typecast_subcore_grid_large_tensor(device, shape, sub_core_grid):
     """Regression test: large tensors with sub_core_grids must not overflow L1."""
     torch.manual_seed(0)
 
-    in_data = torch.randint(0, 65500, shape, dtype=torch.int32)
+    in_data = torch.randint(0, 65536, shape, dtype=torch.int32)
     input_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     input_tensor = ttnn.from_torch(

--- a/tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_typecast_int.py
@@ -6,6 +6,11 @@ import torch
 import ttnn
 import pytest
 
+from tests.ttnn.python_api_testing.typecast_test_helpers import (
+    make_typecast_test_input,
+    typecast_test_input_bounds,
+)
+
 
 # use case for TG Llama : need to achieve (int32 + int32) addition with (uint16 + int32) inputs
 def test_typecast_uint16(device):
@@ -93,8 +98,8 @@ def test_typecast_uint16(device):
 def test_typecast_subcore_grid(device, shape, sub_core_grid):
     torch.manual_seed(0)
 
-    in_data1 = torch.randint(0, 65536, (shape), dtype=torch.int32)
-    in_data2 = torch.randint(-1000, 128001, (shape), dtype=torch.int32)
+    in_data1 = make_typecast_test_input(shape, torch.int32, *typecast_test_input_bounds(ttnn.uint16, ttnn.uint32))
+    in_data2 = make_typecast_test_input(shape, torch.int32, *typecast_test_input_bounds(ttnn.int32, ttnn.int32))
 
     input_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
@@ -165,7 +170,7 @@ def test_typecast_subcore_grid_large_tensor(device, shape, sub_core_grid):
     """Regression test: large tensors with sub_core_grids must not overflow L1."""
     torch.manual_seed(0)
 
-    in_data = torch.randint(0, 65536, shape, dtype=torch.int32)
+    in_data = make_typecast_test_input(shape, torch.int32, *typecast_test_input_bounds(ttnn.uint16, ttnn.uint32))
     input_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     input_tensor = ttnn.from_torch(


### PR DESCRIPTION
### PR Category
Test Only

### Issue
https://github.com/tenstorrent/tt-metal/issues/46237

## Summary

Follow-up to #46118 for remaining **eltwise** integer typecast tests. Widens inputs and uses clamp-aware `eltwise_typecast` goldens on sharded, legacy, and row-major paths that still used in-range inputs or naive `.int()` / `.to(uint8)` references.

Also extracts shared helpers used by `test_run_eltwise_typecast_op` and the updated sharded/RM tests.

**Note:** Moving helpers to `typecast_test_helpers.py` also widens float→integer input ranges in `test_run_eltwise_typecast_op` (e.g. `fp32→int32`, `bf16→uint8` now use `[-1000, 80000]` / `[-512, 512]` instead of default `0..100`). Integer-input bounds are unchanged vs #46118.

## What changed

### `typecast_test_helpers.py` (new)

* `typecast_test_input_bounds()` — derives `(low, high)` from output dtype limits plus margin:
  * signed/float → `uint8`: ±2×(max+1) (wrap/truncation)
  * signed/float → `uint16`/`uint32`/`int32`: below 0 and above 65535 (clamp/saturation)
  * unsigned inputs: `low = 0`; `high` capped by `_UNSIGNED_INPUT_MAX` (e.g. `uint16` → `[0, 65535]`)
* `make_typecast_test_input()` — integer vs float input generation
* `uses_exact_integer_typecast_check()` — integer exact-equality predicate
* `assert_integer_typecast_equal()` — int64 comparison via `assert_equal`

**Note:** Explicit paths from #46118 (`int32/uint32 → uint16`, `int32 → uint8`, etc.) are preserved. Additional integer combos that previously defaulted to `(0, 100)` now get widened bounds where appropriate. Float→integer paths in `test_run_eltwise_typecast_op` also use the derived ranges.

### `test_eltwise_typecast.py`
- Refactor `test_run_eltwise_typecast_op` to shared helpers; float→integer combos now get widened bounds
- Sharded fp32→int32 (4 tests): `[-1000, 80000]` + `eltwise_typecast` golden
- RM bf16→uint8 (2 tests): `[-512, 512]` + wrap-aware golden

### `test_typecast_int.py`
- `test_typecast_subcore_grid`: full uint16 range for `in_data1`; signed negatives in `in_data2`
- `test_typecast_subcore_grid_large_tensor`: full uint16 range

###Pipeline status

- [x] Sanity test
- [x] (Runtime) Sanity Tests
- [x] BHPC

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchani/typecast_test_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchani/typecast_test_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchani/typecast_test_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchani/typecast_test_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchani/typecast_test_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchani/typecast_test_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchani/typecast_test_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchani/typecast_test_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchani/typecast_test_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchani/typecast_test_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchani/typecast_test_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchani/typecast_test_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchani/typecast_test_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchani/typecast_test_2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchani/typecast_test_2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchani/typecast_test_2)