### PR TITLE
sdpa: fix ncrisc build of zero_fill_block for sharded TensorAccessor

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -1089,8 +1089,12 @@ inline void zero_fill_block(
     uint32_t dst_addr,
     uint32_t outer_stride,
     uint32_t inner_stride) {
-    const uint32_t page_size =
-        has_get_aligned_page_size_v<ReaderType> ? reader.get_aligned_page_size() : reader.page_size;
+    uint32_t page_size;
+    if constexpr (has_get_aligned_page_size_v<ReaderType>) {
+        page_size = reader.get_aligned_page_size();
+    } else {
+        page_size = reader.page_size;
+    }
     Noc noc;
     for (uint32_t r = 0; r < num_rows; ++r) {
         uint32_t dst = dst_addr + (dst_row_origin + r) * outer_stride;


### PR DESCRIPTION
## Summary
Fix ncrisc build failure of `ring_joint_reader` on the indexed-KV-cache SDPA path.

## Reason
`zero_fill_block` picked the page size with a runtime ternary, which forces both arms to compile. The `TensorAccessor<DistributionSpec<...>>` reader has `get_aligned_page_size()` but no `.page_size`, so the dead `reader.page_size` arm failed to compile. Regression from #45450 (refactored an `if constexpr` into the ternary).

## Solution
Restore `if constexpr` so the unused branch is not instantiated — behaviorally identical to pre-#45450. `test_ring_joint_attention_chunked_nd_sharded_indexed_kv_cache_accuracy` passes (PCC ≈ 0.9998).

## Additional CI
- (Blackhole) e2e tests — SDPA only: https://github.com/tenstorrent/tt-metal/actions/runs/27261256227

🤖 Generated with [Claude Code](https://claude.com/claude-code)