### PR TITLE
[Bug fix] Gate top-level GTest dependency on test build flags

### DIFF
--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -146,16 +146,18 @@ CPMAddPackage(
 # googletest
 ############################################################################################################################
 
-CPMAddPackage(
-    NAME GTest
-    GITHUB_REPOSITORY google/googletest
-    GIT_TAG v1.13.0
-    VERSION 1.13.0
-    OPTIONS
-        "INSTALL_GTEST OFF"
-        "BUILD_SHARED_LIBS OFF"
-)
-CPMRegisterPackage("googletest" "1.13.0")
+if(TT_METAL_BUILD_TESTS OR TTNN_BUILD_TESTS)
+    CPMAddPackage(
+        NAME GTest
+        GITHUB_REPOSITORY google/googletest
+        GIT_TAG v1.13.0
+        VERSION 1.13.0
+        OPTIONS
+            "INSTALL_GTEST OFF"
+            "BUILD_SHARED_LIBS OFF"
+    )
+    CPMRegisterPackage("googletest" "1.13.0")
+endif()
 
 ############################################################################################################################
 # boost-ext reflect : https://github.com/boost-ext/reflect

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -146,7 +146,7 @@ CPMAddPackage(
 # googletest
 ############################################################################################################################
 
-if(TT_METAL_BUILD_TESTS OR TTNN_BUILD_TESTS)
+if(TT_METAL_BUILD_TESTS OR TTNN_BUILD_TESTS OR BUILD_TT_TRAIN)
     CPMAddPackage(
         NAME GTest
         GITHUB_REPOSITORY google/googletest


### PR DESCRIPTION
PR Category
Bug fix

Summary
Gate top-level googletest registration in `third_party/CMakeLists.txt` behind `TT_METAL_BUILD_TESTS || TTNN_BUILD_TESTS`.

Before this change, runtime-only configurations still registered googletest before the existing top-level `tests/` gate in `CMakeLists.txt`, so `_deps/gtest` entered the default build graph even when both test flags were off. This change aligns the dependency-registration boundary with the existing test-subtree gate. Tests-on builds still register googletest.

Closes #46510.

Notes for reviewers
The only code change is in `third_party/CMakeLists.txt`.

Validation
- `cmake -S . -B .build-46510-off -G Ninja -DTT_METAL_BUILD_TESTS=OFF -DTTNN_BUILD_TESTS=OFF -DWITH_PYTHON_BINDINGS=OFF -DENABLE_DISTRIBUTED=OFF -DTT_UMD_BUILD_SIMULATION=OFF -DBUILD_PROGRAMMING_EXAMPLES=OFF`
  - configure succeeds
  - the generated build graph does not contain `_deps/gtest`, `gtest-all.cc`, or `gmock-all.cc`
- `cmake -S . -B .build-46510-on -G Ninja -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=OFF -DWITH_PYTHON_BINDINGS=OFF -DENABLE_DISTRIBUTED=OFF -DTT_UMD_BUILD_SIMULATION=OFF -DBUILD_PROGRAMMING_EXAMPLES=OFF`
  - configure succeeds
  - the configure log still registers `GTest`
  - the generated build graph still contains the googletest objects
