### PR TITLE
[QSR] Remove unused unpack_A_init variant

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_unpack_A_api.h
@@ -13,24 +13,6 @@
 
 /**
  *
- * @brief Initialize selected unpacker to unpack a single tile
- *
- * @tparam TRANSPOSE_EN: Enables transpose of a tile, supported for SrcA and SrcB
- * @tparam IS_32b_DEST_EN: Enable using Math destination Register in 32-bit mode
- * @param operand: The input operand circular buffer
- *
- * This function initializes unpacker0 to unpack a single tile
- * from the input circular buffer to srcA/dest register.
- */
-template <bool TRANSPOSE_EN, bool IS_32b_DEST_EN>
-inline void llk_unpack_A_init(const std::uint32_t operand) {
-    const std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
-    _llk_unpack_unary_operand_init_<p_unpacr::UNP_A, TRANSPOSE_EN, IS_32b_DEST_EN>(operand_id, NUM_TILES, num_faces);
-}
-
-/**
- *
  * @brief Initialize unpacker for unary / unary-broadcast / binary-dest-reuse paths.
  *
  * Overload matching Blackhole/Wormhole API signature `(transpose_of_faces, within_face_16x16_transpose, operand)`.


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
There used to be two `unpack_A_init` llk api functions. One had Quasar only parameters and the other one had a WH/BH compatible signature. In favor of having an api that will be as similar as possible for all architectures the first variant was deleted in PR https://github.com/tenstorrent/tt-metal/pull/44876.

However, this variant of the function reappeared through a mistake in a rebase inside of some other commit. Deleting the function now. 

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amokan/remove_dead_unp_A_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amokan/remove_dead_unp_A_init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amokan/remove_dead_unp_A_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amokan/remove_dead_unp_A_init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amokan/remove_dead_unp_A_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amokan/remove_dead_unp_A_init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amokan/remove_dead_unp_A_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amokan/remove_dead_unp_A_init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amokan/remove_dead_unp_A_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amokan/remove_dead_unp_A_init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amokan/remove_dead_unp_A_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amokan/remove_dead_unp_A_init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amokan/remove_dead_unp_A_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amokan/remove_dead_unp_A_init)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amokan/remove_dead_unp_A_init)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amokan/remove_dead_unp_A_init)