### PR TITLE
[Bug fix] Validate contradictory MemoryConfig shard metadata

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_sharding.cpp
@@ -151,6 +151,33 @@ TEST_F(MemoryConfigEqualityTest, DifferentMemoryLayout) {
     EXPECT_NE(interleaved, height_sharded);
 }
 
+TEST_F(MemoryConfigEqualityTest, InterleavedRejectsLegacyShardSpec) {
+    EXPECT_THAT(
+        std::function<void()>([this]() {
+            [[maybe_unused]] auto config =
+                MemoryConfig(TensorMemoryLayout::INTERLEAVED, BufferType::L1, shard_spec_a_);
+        }),
+        ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("Interleaved MemoryConfig must not contain a legacy ShardSpec")));
+}
+
+TEST_F(MemoryConfigEqualityTest, LegacyShardedLayoutAllowsDeferredShardSpec) {
+    auto config = MemoryConfig(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1);
+
+    EXPECT_EQ(config.memory_layout(), TensorMemoryLayout::HEIGHT_SHARDED);
+    EXPECT_EQ(config.buffer_type(), BufferType::L1);
+    EXPECT_FALSE(config.shard_spec().has_value());
+}
+
+TEST_F(MemoryConfigEqualityTest, NdShardedRejectsLegacyShardSpecConstructor) {
+    EXPECT_THAT(
+        std::function<void()>([this]() {
+            [[maybe_unused]] auto config = MemoryConfig(TensorMemoryLayout::ND_SHARDED, BufferType::L1, shard_spec_a_);
+        }),
+        ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("ND_SHARDED MemoryConfig must be constructed from NdShardSpec")));
+}
+
 TEST_F(MemoryConfigEqualityTest, BothLegacyShardSpec_Equal) {
     MemoryConfig a(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1, shard_spec_a_);
     MemoryConfig b(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1, shard_spec_a_);

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_sharding.cpp
@@ -178,6 +178,14 @@ TEST_F(MemoryConfigEqualityTest, NdShardedRejectsLegacyShardSpecConstructor) {
             ::testing::HasSubstr("ND_SHARDED MemoryConfig must be constructed from NdShardSpec")));
 }
 
+TEST_F(MemoryConfigEqualityTest, NdShardedRejectsLegacyConstructorWithoutShardSpec) {
+    EXPECT_THAT(
+        std::function<void()>(
+            []() { [[maybe_unused]] auto config = MemoryConfig(TensorMemoryLayout::ND_SHARDED, BufferType::L1); }),
+        ThrowsMessage<std::runtime_error>(
+            ::testing::HasSubstr("ND_SHARDED MemoryConfig must be constructed from NdShardSpec")));
+}
+
 TEST_F(MemoryConfigEqualityTest, BothLegacyShardSpec_Equal) {
     MemoryConfig a(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1, shard_spec_a_);
     MemoryConfig b(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1, shard_spec_a_);

--- a/tt_metal/impl/tensor/spec/memory_config/memory_config.cpp
+++ b/tt_metal/impl/tensor/spec/memory_config/memory_config.cpp
@@ -33,8 +33,9 @@ void validate_memory_layout_and_shard_spec_consistency(
             break;
         case TensorMemoryLayout::ND_SHARDED:
             TT_FATAL(
-                !has_legacy_shard_spec,
-                "ND_SHARDED MemoryConfig must be constructed from NdShardSpec, not legacy ShardSpec.");
+                false,
+                "ND_SHARDED MemoryConfig must be constructed from NdShardSpec, not the legacy ShardSpec constructor "
+                "path.");
             break;
         default: break;
     }

--- a/tt_metal/impl/tensor/spec/memory_config/memory_config.cpp
+++ b/tt_metal/impl/tensor/spec/memory_config/memory_config.cpp
@@ -4,15 +4,50 @@
 #include <cstdint>
 
 #include <tt_stl/reflection.hpp>
+#include <tt_stl/assert.hpp>
 
 #include <tt-metalium/experimental/tensor/tensor_types.hpp>
 #include <tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp>
 
 namespace tt::tt_metal {
 
+namespace {
+namespace CMAKE_UNIQUE_NAMESPACE {
+
+void validate_memory_layout_and_shard_spec_consistency(
+    TensorMemoryLayout memory_layout, const std::optional<ShardSpec>& shard_spec) {
+    const bool has_legacy_shard_spec = shard_spec.has_value();
+
+    switch (memory_layout) {
+        case TensorMemoryLayout::INTERLEAVED:
+            TT_FATAL(
+                !has_legacy_shard_spec,
+                "Interleaved MemoryConfig must not contain a legacy ShardSpec. Use a sharded TensorMemoryLayout when "
+                "providing shard metadata.");
+            break;
+        case TensorMemoryLayout::HEIGHT_SHARDED:
+        case TensorMemoryLayout::WIDTH_SHARDED:
+        case TensorMemoryLayout::BLOCK_SHARDED:
+            // Legacy sharded layouts can be created without a shard spec when a later stage
+            // synthesizes the concrete shard geometry.
+            break;
+        case TensorMemoryLayout::ND_SHARDED:
+            TT_FATAL(
+                !has_legacy_shard_spec,
+                "ND_SHARDED MemoryConfig must be constructed from NdShardSpec, not legacy ShardSpec.");
+            break;
+        default: break;
+    }
+}
+
+}  // namespace CMAKE_UNIQUE_NAMESPACE
+}  // namespace
+
 MemoryConfig::MemoryConfig(
     TensorMemoryLayout memory_layout, BufferType buffer_type, std::optional<ShardSpec> shard_spec) :
-    memory_layout_(memory_layout), buffer_type_(buffer_type), shard_spec_(std::move(shard_spec)) {}
+    memory_layout_(memory_layout), buffer_type_(buffer_type), shard_spec_(std::move(shard_spec)) {
+    CMAKE_UNIQUE_NAMESPACE::validate_memory_layout_and_shard_spec_consistency(memory_layout_, shard_spec_);
+}
 
 MemoryConfig::MemoryConfig(BufferType buffer_type, std::optional<NdShardSpec> nd_shard_spec) :
     memory_layout_(nd_shard_spec.has_value() ? TensorMemoryLayout::ND_SHARDED : TensorMemoryLayout::INTERLEAVED),


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Relates to #46436

`MemoryConfig(TensorMemoryLayout, BufferType, std::optional<ShardSpec>)` currently accepts some metadata combinations that are contradictory before any tensor shape enters the picture.

This change keeps the fix at the constructor boundary the constructor actually owns:
- reject `INTERLEAVED` configs that carry a legacy `ShardSpec`
- reject the legacy `ShardSpec` constructor path for `ND_SHARDED`, with or without an immediate legacy `ShardSpec`

The patch does not move the shape-dependent shard-fit checks out of `TensorSpec`. Those checks still depend on tensor shape, physical shape, and physical shard geometry.

The patch also preserves the deferred-synthesis path for legacy sharded layouts with no immediate `ShardSpec`. That path is still used by transpose code that seeds a sharded `MemoryConfig` first and fills in the concrete shard geometry later.

### Notes for reviewers
The semantic change is in `tt_metal/impl/tensor/spec/memory_config/memory_config.cpp`.

The regression coverage in `tests/tt_metal/tt_metal/api/tensor/test_tensor_sharding.cpp` now checks four constructor-local cases:
- `INTERLEAVED` rejects legacy `ShardSpec`
- legacy sharded layouts still allow deferred shard-spec synthesis
- `ND_SHARDED` rejects a legacy `ShardSpec`
- `ND_SHARDED` also rejects the legacy constructor path when no shard spec is passed

Validation
- `git diff --check`
- fresh WSL configure succeeded with:
  - `cmake -S . -B .build-46581-api -G Ninja -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=OFF -DWITH_PYTHON_BINDINGS=OFF -DENABLE_DISTRIBUTED=OFF -DTT_UMD_BUILD_SIMULATION=OFF -DBUILD_PROGRAMMING_EXAMPLES=OFF`
- a follow-up local `ninja` build in that clean verification checkout hit an unrelated googletest source-layout problem on this machine, so I kept the public claim at constructor-local semantics plus focused regression coverage
