### PR TITLE
fix(llk): set pack_reads_per_xy_plane on all BH packer sections in reduce

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -245,7 +245,13 @@ inline void _llk_pack_reduce_mask_config_(const std::uint32_t face_r_dim = FACE_
     // Wait for packer to finish to avoid breaking its current configuration
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
 
+    // Reduce can engage packers 0-3 (REDUCE_ROW uses all four, REDUCE_COL uses 0/1), so the
+    // per-packer pack_reads_per_xy_plane counter must be set in every section, not just SEC0.
+    // Leaving SEC1-3 at the default of 1 corrupts the reduce pack on those packers (matches WH).
     cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(face_r_dim);
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC1_pack_reads_per_xy_plane_RMW>(face_r_dim);
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC2_pack_reads_per_xy_plane_RMW>(face_r_dim);
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC3_pack_reads_per_xy_plane_RMW>(face_r_dim);
 
     // Configure packer
     TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PCK_EDGE_OFFSET_SEC0_mask_ADDR32);
@@ -278,7 +284,11 @@ inline void _llk_pack_reduce_mask_clear_()
     // Wait for packer to finish to avoid breaking its current configuration
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
 
+    // Symmetric to _llk_pack_reduce_mask_config_: reset the counter on every packer section.
     cfg_reg_rmw_tensix<PACK_COUNTERS_SEC0_pack_reads_per_xy_plane_RMW>(1);
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC1_pack_reads_per_xy_plane_RMW>(1);
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC2_pack_reads_per_xy_plane_RMW>(1);
+    cfg_reg_rmw_tensix<PACK_COUNTERS_SEC3_pack_reads_per_xy_plane_RMW>(1);
 
     // Clear out packer configuration for reduce
     TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, PCK_EDGE_OFFSET_SEC0_mask_ADDR32);


### PR DESCRIPTION
### Summary

Follow-up fix to #43096 (`pack_reads_per_xy_plane` default + reduce ownership).

That PR moved the `pack_reads_per_xy_plane` packer counter into the reduce layer:
default `1`, set to `face_r_dim` on `_llk_pack_reduce_mask_config_`, reset to `1`
on `_llk_pack_reduce_mask_clear_`. On **Blackhole** the counter was written to
**`SEC0` only**, but a reduce engages multiple packers:

- `REDUCE_ROW` uses packers **0–3** (`tile_row_set_select_pack0..3 = 1`)
- `REDUCE_COL` uses packers **0 and 1**

Packers 1–3 were left at the new default of `1` instead of `face_r_dim`, so the
reduce pack on those packers is misconfigured. **Wormhole B0 already writes
`SEC0–SEC3`** in both the config and clear paths; this brings BH to parity.

### Symptom this fixes

`blackhole nightly debug run (Ubuntu 22.04) / ops-unit-tests (P150b) / blackhole
deepseek blitz op tests` → `test_sampling_topk_single_device[test_4]`:

> p_scores not allclose: kernel produces all overflow values [9.917e+35, ...]
> instead of golden [1.0, 0.0, 0.0, ...]

The overflow comes from the `REDUCE_COL` sum step of the DeepSeek-V3 top-p
sampling softmax, where packer 1's counter was stuck at `1`.

### Change

`tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h`:
- `_llk_pack_reduce_mask_config_`: write `pack_reads_per_xy_plane = face_r_dim`
  to `SEC0–SEC3` (was `SEC0` only).
- `_llk_pack_reduce_mask_clear_`: reset `SEC0–SEC3` to `1` (was `SEC0` only).

### Testing

Triggering the `Sanity tests nightly debug run` workflow on this branch
(Blackhole only) to confirm the deepseek blitz op tests pass. We only have
Wormhole hardware locally, hence the CI dispatch.

> Note: this same fix should be mirrored into the upstream `tt-llk` repo
> (BH `llk_pack_common.h`), since `tt_metal/tt-llk` is the vendored copy.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ncvetkovic/fix-bh-reduce-pack-counter-sections)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ncvetkovic/fix-bh-reduce-pack-counter-sections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ncvetkovic/fix-bh-reduce-pack-counter-sections)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ncvetkovic/fix-bh-reduce-pack-counter-sections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ncvetkovic/fix-bh-reduce-pack-counter-sections)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ncvetkovic/fix-bh-reduce-pack-counter-sections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ncvetkovic/fix-bh-reduce-pack-counter-sections)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ncvetkovic/fix-bh-reduce-pack-counter-sections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ncvetkovic/fix-bh-reduce-pack-counter-sections)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ncvetkovic/fix-bh-reduce-pack-counter-sections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ncvetkovic/fix-bh-reduce-pack-counter-sections)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ncvetkovic/fix-bh-reduce-pack-counter-sections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ncvetkovic/fix-bh-reduce-pack-counter-sections)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ncvetkovic/fix-bh-reduce-pack-counter-sections)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ncvetkovic/fix-bh-reduce-pack-counter-sections)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ncvetkovic/fix-bh-reduce-pack-counter-sections)