### PR TITLE
Fix SDPA zero_fill_block page-size: if constexpr instead of runtime ternary

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -1089,8 +1089,14 @@ inline void zero_fill_block(
     uint32_t dst_addr,
     uint32_t outer_stride,
     uint32_t inner_stride) {
-    const uint32_t page_size =
-        has_get_aligned_page_size_v<ReaderType> ? reader.get_aligned_page_size() : reader.page_size;
+    // if constexpr (not a runtime ?:): TensorAccessor dropped its `page_size` member in favor of
+    // `get_aligned_page_size()` (#38958), so the fallback branch must not be instantiated for it.
+    uint32_t page_size;
+    if constexpr (has_get_aligned_page_size_v<ReaderType>) {
+        page_size = reader.get_aligned_page_size();
+    } else {
+        page_size = reader.page_size;
+    }
     Noc noc;
     for (uint32_t r = 0; r < num_rows; ++r) {
         uint32_t dst = dst_addr + (dst_row_origin + r) * outer_stride;


### PR DESCRIPTION
## Problem

`zero_fill_block()` in the SDPA dataflow kernel selected its page size with a **runtime** ternary:

```cpp
const uint32_t page_size =
    has_get_aligned_page_size_v<ReaderType> ? reader.get_aligned_page_size() : reader.page_size;
```

In a runtime `?:`, **both** branches are always instantiated, so this required `ReaderType` to expose *both* `get_aligned_page_size()` **and** a `.page_size` member.

`TensorAccessor` dropped its `.page_size` member in favor of `get_aligned_page_size()` in #38958 ("Setting the buffer aligned_page_size as default page size for TensorAccessor"). As a result the dead fallback branch no longer compiles, and `ring_joint_reader` — and any other SDPA kernel using a `TensorAccessor` reader — fails to JIT-build:

```
dataflow_common.hpp: error: 'const class TensorAccessor<...>' has no member named 'page_size'
```

This blocks the chunked-prefill ring-joint SDPA path.

## Fix

Switch to an `if constexpr` cascade (matching the canonical helper already in `dataflow_api.h`) so only the branch valid for the actual `ReaderType` is instantiated:

- `TensorAccessor` → `get_aligned_page_size()`
- legacy address generators that still carry `.page_size` → `.page_size`

This is strictly more permissive than the original (the old `?:` required *both* members on *every* reader type) and unbreaks the path.

## Verification

`models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill` (deepseek, 2x4, FABRIC_1D, CPU reference): 9 chunked-prefill scenarios (rotation edges, maxedge, multi-user) all pass, output PCC ~0.998, KV-cache PCC ~0.9999.

🤖 Generated with [Claude Code](https://claude.com/claude-code)