### PR TITLE
[Bug fix] Preserve ND provenance in with_shard_spec

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_sharding.cpp
@@ -227,6 +227,17 @@ TEST_F(MemoryConfigEqualityTest, WithShardSpecUpdatesLegacyFieldWithoutDroppingN
     EXPECT_EQ(updated, expected);
 }
 
+TEST_F(MemoryConfigEqualityTest, WithShardSpecPreservesPerCoreAllocation) {
+    MemoryConfig legacy_config(TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1, shard_spec_a_);
+    experimental::per_core_allocation::set_per_core_allocation(legacy_config, true);
+
+    auto updated = legacy_config.with_shard_spec(shard_spec_b_);
+
+    EXPECT_FALSE(updated.created_with_nd_shard_spec());
+    EXPECT_TRUE(experimental::per_core_allocation::is_per_core_allocation(updated));
+    EXPECT_EQ(updated.shard_spec(), std::optional<ShardSpec>(shard_spec_b_));
+}
+
 TEST_F(MemoryConfigEqualityTest, LegacyShardCreatedIgnoresNdField) {
     // Two configs both created with legacy shard_spec should compare equal on shard_spec alone,
     // even if one has an nd_shard_spec prepopulated and the other does not.

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_sharding.cpp
@@ -194,6 +194,39 @@ TEST_F(MemoryConfigEqualityTest, NdShardCreatedIgnoresLegacyField) {
     EXPECT_EQ(user_config, tensor_config);
 }
 
+TEST_F(MemoryConfigEqualityTest, WithShardSpecPreservesNdCreationPath) {
+    MemoryConfig nd_config(BufferType::L1, nd_shard_spec_a_);
+
+    auto updated = nd_config.with_shard_spec(shard_spec_a_);
+
+    EXPECT_TRUE(updated.created_with_nd_shard_spec());
+    EXPECT_EQ(updated.nd_shard_spec(), nd_config.nd_shard_spec());
+    EXPECT_EQ(updated.shard_spec(), std::optional<ShardSpec>(shard_spec_a_));
+    EXPECT_EQ(updated, nd_config);
+}
+
+TEST_F(MemoryConfigEqualityTest, WithShardSpecUpdatesLegacyFieldWithoutDroppingNdProvenance) {
+    MemoryConfig nd_config = MemoryConfig::create_with_prepopulated_shard_specs(
+        TensorMemoryLayout::ND_SHARDED,
+        BufferType::L1,
+        shard_spec_a_,
+        nd_shard_spec_a_,
+        /*created_with_nd_shard_spec=*/true);
+
+    auto updated = nd_config.with_shard_spec(shard_spec_b_);
+    auto expected = MemoryConfig::create_with_prepopulated_shard_specs(
+        TensorMemoryLayout::ND_SHARDED,
+        BufferType::L1,
+        shard_spec_b_,
+        nd_shard_spec_a_,
+        /*created_with_nd_shard_spec=*/true);
+
+    EXPECT_TRUE(updated.created_with_nd_shard_spec());
+    EXPECT_EQ(updated.nd_shard_spec(), expected.nd_shard_spec());
+    EXPECT_EQ(updated.shard_spec(), expected.shard_spec());
+    EXPECT_EQ(updated, expected);
+}
+
 TEST_F(MemoryConfigEqualityTest, LegacyShardCreatedIgnoresNdField) {
     // Two configs both created with legacy shard_spec should compare equal on shard_spec alone,
     // even if one has an nd_shard_spec prepopulated and the other does not.

--- a/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp
@@ -56,7 +56,10 @@ public:
     friend void experimental::per_core_allocation::set_per_core_allocation(MemoryConfig&, bool);
 
     MemoryConfig with_shard_spec(std::optional<ShardSpec> shard_spec) const {
-        return MemoryConfig(memory_layout_, buffer_type_, std::move(shard_spec));
+        auto result = create_with_prepopulated_shard_specs(
+            memory_layout_, buffer_type_, std::move(shard_spec), nd_shard_spec_, created_with_nd_shard_spec_);
+        result.per_core_allocation_ = per_core_allocation_;
+        return result;
     }
 
     bool is_sharded() const;


### PR DESCRIPTION
PR Category
Bug fix

Summary
Fixes #46585

MemoryConfig::with_shard_spec(...) rebuilt a new MemoryConfig from only memory_layout, buffer_type, and the replacement legacy ShardSpec.

That preserved the legacy companion spec update, but it dropped semantic sharding state from the original config:
- nd_shard_spec
- created_with_nd_shard_spec
- per_core_allocation

This patch keeps with_shard_spec(...) as a narrow helper that only replaces the legacy companion spec while preserving the config's existing ND provenance and per-core allocation state.

The regression coverage now pins the three preserved invariants:
- adding a legacy ShardSpec to an ND-created config keeps created_with_nd_shard_spec
- replacing the legacy ShardSpec on an ND-created config keeps nd_shard_spec
- replacing the legacy ShardSpec on a legacy-created sharded config keeps per_core_allocation

Notes for reviewers
The core change is in tt_metal/api/tt-metalium/experimental/tensor/spec/memory_config/memory_config.hpp.

The focused regressions are in tests/tt_metal/tt_metal/api/tensor/test_tensor_sharding.cpp.

Validation notes:
- git diff --check
- fresh WSL configure of a minimal test build:
  cmake -S . -B .build/pr-46586-api -G Ninja -DCMAKE_C_COMPILER=/usr/bin/cc -DCMAKE_CXX_COMPILER=/usr/bin/c++ -DTT_METAL_BUILD_TESTS=ON -DTTNN_BUILD_TESTS=OFF -DWITH_PYTHON_BINDINGS=OFF -DENABLE_DISTRIBUTED=OFF -DTT_UMD_BUILD_SIMULATION=OFF -DBUILD_PROGRAMMING_EXAMPLES=OFF
- compile-level validation of the touched test target:
  cmake --build .build/pr-46586-api --target unit_tests_api_lib -j4
