### PR TITLE
conv1d: enable DRAM width slicing via slice_config

### DIFF
--- a/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
+++ b/tests/ttnn/unit_tests/operations/conv/test_conv1d.py
@@ -676,3 +676,188 @@ def test_conv1d_replicate_pad(
         dilation=dilation,
         groups=groups,
     )
+
+
+# ---------------------------------------------------------------------------
+# DRAM slicing
+#
+# conv1d reshapes its 1D input to a [N, 1, input_length, C] 4D tensor and delegates to
+# conv2d. Because the height dimension is always 1, only width slicing (slicing along
+# input_length) is meaningful. The tests below cover the L1_FULL OOM baseline, manual and
+# auto DRAM width slicing, the channel-bound case width slicing cannot relieve, and
+# DRAM_HEIGHT slicing being rejected (degenerate for conv1d).
+# ---------------------------------------------------------------------------
+
+
+def run_conv1d_slice(
+    device,
+    batch_size,
+    in_channels,
+    out_channels,
+    input_length,
+    kernel_size,
+    stride,
+    padding,
+    slice_config,
+    pcc=0.99,
+    weights_dtype=ttnn.bfloat16,
+    activations_dtype=ttnn.bfloat16,
+    output_dtype=ttnn.bfloat16,
+):
+    torch.manual_seed(0)
+    torch_input_ncl = torch.randn(batch_size, in_channels, input_length, dtype=torch.bfloat16).float()
+    torch_weight = torch.randn(out_channels, in_channels, kernel_size, dtype=torch.bfloat16).float()
+
+    golden = torch.nn.functional.conv1d(
+        torch_input_ncl,
+        torch_weight,
+        bias=None,
+        stride=stride,
+        padding=padding,
+    )
+
+    # DRAM slicing requires the input to live in DRAM (interleaved). Layout is NLC for conv1d.
+    input_tt = ttnn.from_torch(
+        torch_input_ncl.permute(0, 2, 1),
+        dtype=activations_dtype,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    weight_tt = ttnn.from_torch(torch_weight, dtype=weights_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    # DRAM slicing requires an explicit shard layout (no auto-shard).
+    conv_config = ttnn.Conv1dConfig(
+        weights_dtype=weights_dtype,
+        shard_layout=ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        deallocate_activation=False,
+    )
+
+    tt_out, out_length = ttnn.conv1d(
+        input_tensor=input_tt,
+        weight_tensor=weight_tt,
+        device=device,
+        in_channels=in_channels,
+        out_channels=out_channels,
+        batch_size=batch_size,
+        input_length=input_length,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        conv_config=conv_config,
+        slice_config=slice_config,
+        dtype=output_dtype,
+        return_output_dim=True,
+    )
+
+    out = ttnn.to_torch(tt_out).reshape(batch_size, out_length, out_channels).permute(0, 2, 1)
+    passing, pcc_msg = check_with_pcc_without_tensor_printout(out, golden, pcc=pcc)
+    assert passing, pcc_msg
+    return out
+
+
+# A 1D conv whose L1 footprint is dominated by the (long) sequence dimension, so it
+# overflows L1 in the L1_FULL path but is relieved by slicing along input_length (width).
+# input_length=32768 with 256 channels: the width-independent weight block is small enough
+# that width slicing brings the per-slice footprint under the L1 budget.
+_SLICE_OOM_SHAPE = dict(
+    batch_size=1,
+    in_channels=256,
+    out_channels=256,
+    input_length=32768,
+    kernel_size=3,
+    stride=1,
+    padding=1,
+)
+
+# A 1D conv whose L1 footprint is dominated by the channel dimension (the weight block does
+# not shrink with width slicing). Width slicing - the only kind conv1d supports - cannot
+# relieve this, so even the auto-slicer (up to one tile per slice) fails to find a fit.
+_SLICE_CHANNEL_BOUND_SHAPE = dict(
+    batch_size=1,
+    in_channels=512,
+    out_channels=512,
+    input_length=32768,
+    kernel_size=3,
+    stride=1,
+    padding=1,
+)
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
+def test_conv1d_no_slicing_oom(device):
+    """Baseline: the large conv1d should run out of L1 when forced into the L1_FULL path."""
+    with pytest.raises(RuntimeError) as excinfo:
+        run_conv1d_slice(
+            device,
+            **_SLICE_OOM_SHAPE,
+            slice_config=ttnn.Conv2dL1FullSliceConfig,
+        )
+    # Sanity-check the failure is an allocation/L1 capacity error and not something unrelated.
+    msg = str(excinfo.value).lower()
+    assert any(k in msg for k in ("memory", "allocat", "l1", "circular buffer", "out of")), excinfo.value
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
+@pytest.mark.parametrize("num_slices", [4, 8])
+def test_conv1d_manual_dram_width_slicing(device, num_slices):
+    """The same conv1d should succeed with manual DRAM width slicing."""
+    run_conv1d_slice(
+        device,
+        **_SLICE_OOM_SHAPE,
+        slice_config=ttnn.Conv2dSliceConfig(
+            slice_type=ttnn.Conv2dDRAMSliceWidth,
+            num_slices=num_slices,
+        ),
+    )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
+def test_conv1d_auto_dram_width_slicing(device):
+    """The same conv1d should succeed with auto-determined DRAM width slicing (num_slices=0)."""
+    run_conv1d_slice(
+        device,
+        **_SLICE_OOM_SHAPE,
+        slice_config=ttnn.Conv2dSliceConfig(
+            slice_type=ttnn.Conv2dDRAMSliceWidth,
+            num_slices=0,
+        ),
+    )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
+def test_conv1d_channel_bound_slicing_insufficient(device):
+    """Width slicing cannot relieve a channel-bound OOM (the weight block is width-independent).
+
+    Documents the boundary of conv1d DRAM slicing: when L1 pressure comes from the channel
+    dimension rather than the sequence length, even maximal width slicing fails to find a fit.
+    """
+    with pytest.raises(RuntimeError, match="could not find valid slice configuration"):
+        run_conv1d_slice(
+            device,
+            **_SLICE_CHANNEL_BOUND_SHAPE,
+            slice_config=ttnn.Conv2dSliceConfig(
+                slice_type=ttnn.Conv2dDRAMSliceWidth,
+                num_slices=0,
+            ),
+        )
+
+
+@pytest.mark.parametrize("device_params", [{"l1_small_size": 1 << 15}], indirect=True)
+def test_conv1d_dram_height_slicing_rejected(device):
+    """DRAM_HEIGHT slicing is degenerate for conv1d (height==1) and must be rejected."""
+    with pytest.raises(RuntimeError, match="DRAM_HEIGHT"):
+        run_conv1d_slice(
+            device,
+            batch_size=1,
+            in_channels=64,
+            out_channels=64,
+            input_length=1024,
+            kernel_size=3,
+            stride=1,
+            padding=1,
+            slice_config=ttnn.Conv2dSliceConfig(
+                slice_type=ttnn.Conv2dDRAMSliceHeight,
+                num_slices=4,
+            ),
+        )

--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.cpp
@@ -7,6 +7,7 @@
 #include <array>
 #include <variant>
 
+#include <tt_stl/assert.hpp>
 #include "ttnn/operations/conv/conv_types.hpp"
 #include "ttnn/operations/conv/conv2d/conv2d.hpp"
 #include "ttnn/operations/core/core.hpp"
@@ -31,6 +32,7 @@ Conv1dResult conv1d(
     const std::optional<const Conv1dConfig>& conv_config,
     const std::optional<const DeviceComputeKernelConfig>& compute_config,
     const std::optional<const MemoryConfig>& memory_config,
+    const std::optional<const Conv1dSliceConfig>& slice_config,
     bool return_output_dim,
     bool return_weights_and_bias) {
     // reshape input tensor to 4D, if it is not already
@@ -54,6 +56,20 @@ Conv1dResult conv1d(
         };
     };
 
+    // Conv1d reshapes the input to [N, 1, input_length, C], so the height dimension is always 1.
+    // DRAM slicing is therefore only meaningful along the width dimension (DRAM_WIDTH, i.e. input_length);
+    // DRAM_HEIGHT would produce a single degenerate slice and silently collapse back to L1.
+    // When no slice config is provided, preserve the historical conv1d behaviour of forcing L1_FULL.
+    // Forwarding nullopt instead would route by input location (conv2d's default), sending DRAM/host
+    // inputs through the DRAM slicing path - which breaks existing auto_shard / shard_layout=None
+    // callers (the slicing path requires a shard layout). So conv1d opts in to DRAM slicing explicitly.
+    const ttnn::prim::Conv2dSliceConfig effective_slice_config = slice_config.value_or(
+        ttnn::prim::Conv2dSliceConfig{.slice_type = ttnn::prim::Conv2dSliceConfig::SliceType::L1_FULL});
+    TT_FATAL(
+        effective_slice_config.slice_type != ttnn::prim::Conv2dSliceConfig::SliceType::DRAM_HEIGHT,
+        "Conv1D does not support DRAM_HEIGHT slicing because the convolution height is always 1. "
+        "Use DRAM_WIDTH slicing (slices along input_length) or L1_FULL.");
+
     auto [output_tensor, output_dimensions, weights_and_bias] =
         std::get<static_cast<int>(ConvResultType::OUTPUT_DIM_WEIGHTS_AND_BIAS)>(ttnn::conv2d(
             input_tensor_4d,
@@ -74,9 +90,7 @@ Conv1dResult conv1d(
             conv_config,
             compute_config,
             memory_config,
-            ttnn::prim::Conv2dSliceConfig{
-                .slice_type =
-                    ttnn::prim::Conv2dSliceConfig::SliceType::L1_FULL},  // Conv1D doesn't support DRAM Slicing. Only L1
+            effective_slice_config,
             true,
             true));
 

--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d.hpp
@@ -15,6 +15,7 @@
 namespace ttnn {
 
 using Conv1dConfig = ttnn::prim::Conv2dConfig;
+using Conv1dSliceConfig = ttnn::prim::Conv2dSliceConfig;
 
 using OutputLength = uint32_t;
 using Conv1dResult = std::variant<
@@ -44,6 +45,7 @@ Conv1dResult conv1d(
     const std::optional<const Conv1dConfig>& conv_config = std::nullopt,
     const std::optional<const DeviceComputeKernelConfig>& compute_config = std::nullopt,
     const std::optional<const MemoryConfig>& memory_config = std::nullopt,
+    const std::optional<const Conv1dSliceConfig>& slice_config = std::nullopt,
     bool return_output_dim = true,
     bool return_weights_and_bias = true);
 

--- a/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv1d/conv1d_nanobind.cpp
@@ -47,6 +47,7 @@ void bind_conv1d(nb::module_& mod) {
             conv_config (ttnn.Conv2dConfig, optional): Configuration for convolution. Default: None
             compute_config (ttnn.DeviceComputeKernelConfig, optional): Configuration for compute kernel. Default: None
             memory_config (ttnn.MemoryConfig, optional): Output Tensor's Memory Configuration. Default: None
+            slice_config (ttnn.Conv2dSliceConfig, optional): Configuration for slicing the input & output tensors in DRAM along the input_length (width) dimension. Use slice_type=Conv2dDRAMSliceWidth with num_slices=0 to auto-determine the number of slices, or num_slices=N to slice manually. DRAM_HEIGHT slicing is not supported because the conv1d height is always 1. If None, the op runs fully in L1 (L1_FULL). Default: None
             return_output_dim (bool, optional): If true, the op also returns the length of the output tensor. Default: False
             return_weights_and_bias (bool, optional): If true, the op also returns the preprocessed weight and bias on device. Default: False
 
@@ -81,6 +82,7 @@ void bind_conv1d(nb::module_& mod) {
         nb::arg("conv_config") = nb::none(),
         nb::arg("compute_config") = nb::none(),
         nb::arg("memory_config") = nb::none(),
+        nb::arg("slice_config") = nb::none(),
         nb::arg("return_output_dim") = false,
         nb::arg("return_weights_and_bias") = false);
 }


### PR DESCRIPTION
### Ticket
N/A

### Problem description
`ttnn.conv1d` always forced the underlying conv2d into the `L1_FULL` path, so large 1D convolutions that exceed L1 capacity had no way to run. conv2d already supports DRAM slicing, but conv1d hard-coded `L1_FULL` and exposed no way to opt in.

### What's changed
conv1d reshapes its input to `[N, 1, input_length, C]` and delegates to conv2d, so only **width** slicing (along `input_length`) is meaningful — `DRAM_HEIGHT` would collapse to a single degenerate slice.

- Add an optional `slice_config` parameter (`Conv1dSliceConfig` = `Conv2dSliceConfig`) plumbed through `conv1d()` and the nanobind binding.
- When omitted, conv1d preserves its historical `L1_FULL` behaviour rather than forwarding `nullopt` (which would route DRAM/host inputs through the slicing path and break existing `auto_shard` / `shard_layout=None` callers).
- `DRAM_HEIGHT` is explicitly rejected via `TT_FATAL`.
- New tests covering: the `L1_FULL` OOM baseline, manual and auto DRAM width slicing, the channel-bound case width slicing cannot relieve, and `DRAM_HEIGHT` rejection.

### Checklist
- [ ] New/existing tests provide coverage for changes

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/conv1d-dram-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/conv1d-dram-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/conv1d-dram-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/conv1d-dram-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/conv1d-dram-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/conv1d-dram-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/conv1d-dram-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/conv1d-dram-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/conv1d-dram-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/conv1d-dram-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/conv1d-dram-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/conv1d-dram-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/conv1d-dram-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/conv1d-dram-slice)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/conv1d-dram-slice)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/conv1d-dram-slice)

### Manually triggered runs (mstaletovic/conv1d-dram-slice)
Dispatched 2026-06-11 against this branch:
- All post-commit (Sanity tests): https://github.com/tenstorrent/tt-metal/actions/runs/27338992825
- Blackhole post-commit tests: https://github.com/tenstorrent/tt-metal/actions/runs/27338994799
- Conv nightly (Nightly tt-metal L2, `conv` category): https://github.com/tenstorrent/tt-metal/actions/runs/27338996535

- Device perf regressions (Single-card): https://github.com/tenstorrent/tt-metal/actions/runs/27340708515
