### PR TITLE
[Cleanup] Migrate concat interleaved readers to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_interleaved_start_id.cpp
@@ -4,7 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 // Make n reads defined by num_reads
 // Writes to Specified Circular Buffers in L1
@@ -40,15 +43,20 @@ void kernel_main() {
     }
 
     CircularBuffer cb_in(cb_id_in);
+    Noc noc;
 
     uint32_t curr_tensor = start_tensor;
     uint32_t curr_tensor_id = start_tensor_id;
     for (uint32_t i = 0; i < num_tiles; ++i) {
         cb_in.reserve_back(ublock_size_tiles);
         uint32_t l1_write_addr = cb_in.get_write_ptr();
-        auto read_addr = abstract_tensor_accessor_wrappers[curr_tensor].get_noc_addr(tile_id_per_tensor[curr_tensor]);
-        noc_async_read(read_addr, l1_write_addr, tile_size_bytes);
-        noc_async_read_barrier();
+        noc.async_read(
+            abstract_tensor_accessor_wrappers[curr_tensor],
+            CoreLocalMem<uint8_t>(l1_write_addr),
+            tile_size_bytes,
+            {.page_id = tile_id_per_tensor[curr_tensor]},
+            {});
+        noc.async_read_barrier();
         cb_in.push_back(ublock_size_tiles);
 
         tile_id_per_tensor[curr_tensor]++;

--- a/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/concat/device/kernels/dataflow/reader_concat_stick_layout_interleaved_start_id.cpp
@@ -4,7 +4,10 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 // Make n reads defined by num_reads
 // Writes to Specified Circular Buffers in L1
@@ -39,6 +42,7 @@ void kernel_main() {
     }
 
     CircularBuffer cb_in(cb_id_in);
+    Noc noc;
 
     uint32_t curr_tensor = start_tensor;
     uint32_t curr_tensor_id = start_tensor_id;
@@ -50,19 +54,26 @@ void kernel_main() {
         // For width concat we know we start at curr_tensor=0
         // num_pages_per_block[curr_tensor] is always one for width concat
         for (uint32_t j = 0; j < num_tensors; ++j) {
-            auto read_addr =
-                abstract_tensor_accessor_wrappers[curr_tensor].get_noc_addr(page_id_per_tensor[curr_tensor]);
             auto page_size = kernel_compile_time_args[page_size_base_idx + curr_tensor];
-            noc_async_read(read_addr, l1_write_addr, page_size);
+            noc.async_read(
+                abstract_tensor_accessor_wrappers[curr_tensor],
+                CoreLocalMem<uint8_t>(l1_write_addr),
+                page_size,
+                {.page_id = page_id_per_tensor[curr_tensor]},
+                {});
             l1_write_addr += page_size;
             page_id_per_tensor[curr_tensor]++;
             curr_tensor++;
         }
         curr_tensor = 0;
 #else
-        auto read_addr = abstract_tensor_accessor_wrappers[curr_tensor].get_noc_addr(page_id_per_tensor[curr_tensor]);
         auto page_size = kernel_compile_time_args[page_size_base_idx + curr_tensor];
-        noc_async_read(read_addr, l1_write_addr, page_size);
+        noc.async_read(
+            abstract_tensor_accessor_wrappers[curr_tensor],
+            CoreLocalMem<uint8_t>(l1_write_addr),
+            page_size,
+            {.page_id = page_id_per_tensor[curr_tensor]},
+            {});
 
         page_id_per_tensor[curr_tensor]++;
         curr_tensor_id++;
@@ -75,7 +86,7 @@ void kernel_main() {
             }
         }
 #endif
-        noc_async_read_barrier();
+        noc.async_read_barrier();
         cb_in.push_back(ublock_size_pages);
     }
 }


### PR DESCRIPTION
### PR Category
  Cleanup

### Summary
  Relates to https://github.com/tenstorrent/tt-metal/issues/45003.

  Migrate the two remaining dataflow readers under `data_movement/concat/device/kernels/dataflow/` that use free-function `noc_async_read` / `noc_async_read_barrier` to use the Device 2.0 counterpart: `Noc::async_read`. 

  The approach matches the migrated `writer_height_sharded_width_concat_two_tensors_tiled.cpp` and `ring_attention_all_gather_reader.cpp` idioms already in the tree.

  ### Notes for reviewers
  - Both readers add the same include set as the sibling migrated writer: `api/dataflow/noc.h`, `api/core_local_mem.h`, `api/tensor/noc_traits.h`.
  - `CoreLocalMem<uint8_t>` is used for the destination since the L1 write address is a byte address;
 
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/concat_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/concat_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/concat_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/concat_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/concat_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/concat_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/concat_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/concat_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/concat_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/concat_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/concat_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/concat_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/concat_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/concat_device_2_0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/concat_device_2_0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/concat_device_2_0)