### PR TITLE
Fix dispatch packet tag cleanup on idle ERISC

### DIFF
--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1562,7 +1562,15 @@ void kernel_main() {
         dispatch_cb_reader.wait_for_available_data_and_release_old_pages<DispatchTelemetryBlockGuard>(cmd_ptr);
 
         DeviceZoneScopedN("CQ-DISPATCH");
-        IDLE_ERISC_HEARTBEAT_AND_RETURN(heartbeat);
+#if defined(COMPILE_FOR_IDLE_ERISC)
+        RISC_POST_HEARTBEAT(heartbeat);
+        if (early_exit()) {
+            noc_async_full_barrier();
+            noc_clear_packet_tags(my_noc_index);
+            set_l1_data_cache<false>();
+            return;
+        }
+#endif
 
         done = is_d_variant ? process_cmd_d(cmd_ptr, l1_cache) : process_cmd_h(cmd_ptr);
 
@@ -1590,6 +1598,8 @@ void kernel_main() {
     if (is_h_variant && !is_d_variant) {
         relay_client.template teardown<upstream_noc_index, upstream_noc_xy, upstream_dispatch_cb_sem_id>();
     }
+    noc_async_full_barrier();
+    noc_clear_packet_tags(my_noc_index);
     // DPRINT("dispatch_{}{}: out\n", is_h_variant, is_d_variant);
     set_l1_data_cache<false>();
 }

--- a/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
@@ -2727,12 +2727,20 @@ void kernel_main() {
     } else {
         ASSERT(0);
     }
-    IDLE_ERISC_RETURN();
+#if defined(COMPILE_FOR_IDLE_ERISC)
+    if (early_exit()) {
+        noc_async_full_barrier();
+        noc_clear_packet_tags(my_noc_index);
+        set_l1_data_cache<false>();
+        return;
+    }
+#endif
 
     // Confirm expected number of pages, spinning here is a leak
     DispatchRelayInlineState::cb_writer.wait_all_pages(downstream_cb_pages);
 
     noc_async_full_barrier();
+    noc_clear_packet_tags(my_noc_index);
 
     DPRINT("prefetcher_{}{}: out\n", is_h_variant, is_d_variant);
     set_l1_data_cache<false>();


### PR DESCRIPTION
## Summary
- AutoFix-generated fix from the Llama 3.1 8B multichip RMSNorm1D watcher investigation.
- Clear sticky write-capable NOC packet tags from idle ERISC `cq_prefetch` and `cq_dispatch` cleanup paths after full barriers.
- Ensure idle close-path early returns also drain and clear packet tags before kernel handoff.
- Fixes watcher packet-tag asserts seen when closing a `FABRIC_1D_RING` mesh and in the local direct RMSNorm1D distributed prefill repro.

## Root Cause
Watcher was failing before the next dispatch kernel started because the previous idle Ethernet dispatch kernel left write-capable NOC packet tags nonzero. `noc_async_full_barrier()` drains outstanding transactions, but it does not clear the sticky `NOC_PACKET_TAG` registers checked by watcher.

The original model repro surfaced as an RMSNorm1D watcher failure. AutoFix reduced it to a smaller repro: opening and closing a `(1, 8)` `FABRIC_1D_RING` mesh was enough to reproduce the same `cq_prefetch.cpp` packet-tag assert, so the failure was below RMSNorm/CCL model code.

## Minimal Reproducer
This is the self-contained reproducer used by AutoFix on the PR branch:

```bash
TT_METAL_LOGS_PATH=/tmp/watcher_open_close_only \
TT_METAL_WATCHER=10 TT_METAL_WATCHER_APPEND=1 TT_METAL_WATCHER_NOINLINE=1 \
PYTHONFAULTHANDLER=1 timeout 180s python - <<'PY'
import ttnn
print("open-close-only start")
ttnn.set_fabric_config(ttnn.FabricConfig.FABRIC_1D_RING)
mesh = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(1, 8), trace_region_size=0)
print("mesh opened")
ttnn.close_mesh_device(mesh)
ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
print("mesh closed")
PY
```

Before this fix, that aborted during `close_mesh_device` with:

```text
Device 0 idleth core ... ierisc detected invalid NOC command buffer state before starting the next kernel ... Current kernel: tt_metal/impl/dispatch/kernels/cq_prefetch.cpp
```

After fixing `cq_prefetch` only, the same fresh-cache repro moved to `cq_dispatch.cpp`, so this PR clears packet tags in both dispatch kernels.

## Local Model Reproducer
This model repro is from the repo-local Llama autoport branch used during bringup; it is included here as provenance/evidence for the original user-visible failure, not as a main-branch CI target:

```bash
TT_METAL_LOGS_PATH=/tmp/watcher_common_rmsnorm_1d \
TT_METAL_WATCHER=10 TT_METAL_WATCHER_APPEND=1 TT_METAL_WATCHER_NOINLINE=1 \
TT_AUTOPORT_RUN_WATCHER_REPRO=1 PYTHONFAULTHANDLER=1 timeout 300s pytest \
  --confcutdir=models/autoports/meta_llama/Llama_3_1_8B_Instruct -q -s \
  models/autoports/meta_llama/Llama_3_1_8B_Instruct/tests/test_multichip_decoder.py::test_common_rmsnorm_1d_distributed_prefill_watcher_repro
```

## AutoFix Evidence
- Refuted RMSNorm worker-count theory: setting RMSNorm stats `num_workers_per_link=1` still failed watcher with the same `cq_prefetch.cpp` packet-tag assert.
- Open/close-only repro before fix failed with the `cq_prefetch.cpp` packet-tag assert.
- Fresh-cache repro after the `cq_prefetch`-only fix moved failure to `cq_dispatch.cpp`.
- Open/close-only repro after both fixes passed with watcher clean detach.
- Direct RMSNorm1D distributed prefill repro passed with watcher clean detach.
- Repeated direct RMSNorm1D watcher repro using default cache after invalidating stale `cq_prefetch`/`cq_dispatch` cache entries also passed.

Local evidence artifacts from the AutoFix run:

```text
models/autoports/meta_llama/Llama_3_1_8B_Instruct/doc/multichip_decoder/watcher_open_close_only/open_close_watcher.log
models/autoports/meta_llama/Llama_3_1_8B_Instruct/doc/multichip_decoder/watcher_open_close_prefetch_clear_tags_fresh_cache/open_close_watcher.log
models/autoports/meta_llama/Llama_3_1_8B_Instruct/doc/multichip_decoder/watcher_open_close_dispatch_clear_tags_fresh_cache/open_close_watcher.log
models/autoports/meta_llama/Llama_3_1_8B_Instruct/doc/multichip_decoder/watcher_common_rmsnorm_1d_dispatch_clear_tags/common_rmsnorm_1d_watcher.log
models/autoports/meta_llama/Llama_3_1_8B_Instruct/doc/multichip_decoder/watcher_common_rmsnorm_1d_dispatch_clear_tags_default_cache/common_rmsnorm_1d_watcher.log
```

## Testing
- `git diff --check`
- `cmake --build build_Release --target install -j 16`
- Open/close-only watcher repro above, with `TT_METAL_CACHE=/tmp/tt-metal-cache-codex-dispatch-tags`: PASS
- Direct RMSNorm1D watcher repro above, with fresh dispatch cache: PASS
- Direct RMSNorm1D watcher repro above, with default cache after targeted dispatch cache invalidation: PASS

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=codex/fix-dispatch-packet-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:codex/fix-dispatch-packet-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=codex/fix-dispatch-packet-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:codex/fix-dispatch-packet-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=codex/fix-dispatch-packet-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:codex/fix-dispatch-packet-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=codex/fix-dispatch-packet-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:codex/fix-dispatch-packet-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=codex/fix-dispatch-packet-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:codex/fix-dispatch-packet-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=codex/fix-dispatch-packet-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:codex/fix-dispatch-packet-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=codex/fix-dispatch-packet-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:codex/fix-dispatch-packet-tags)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=codex/fix-dispatch-packet-tags)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:codex/fix-dispatch-packet-tags)