### PR TITLE
fix(llk fuser): avoid mutable default for tile_shape field

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/fused_operand.py
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 
 import torch
@@ -28,8 +28,10 @@ class Operand:
     name: str
     dimensions: Tuple[int, int]
     data_format: DataFormat
-    tile_shape: TileShape = construct_tile_shape(
-        (DEFAULT_TILE_R_DIM, DEFAULT_TILE_C_DIM)
+    tile_shape: TileShape = field(
+        default_factory=lambda: construct_tile_shape(
+            (DEFAULT_TILE_R_DIM, DEFAULT_TILE_C_DIM)
+        )
     )
     l1_address: Optional[int] = None
     is_output: bool = False


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
I kept getting this error when trying to run tests using Python 3.12:
```
perf_fused.py:7: in <module>
    from fuser.fuser_config_parser import FUSER_CONFIG_DIR, FuserConfigSchema
fuser/fuser_config_parser.py:23: in <module>
    from .fused_operand import OperandRegistry
<frozen importlib._bootstrap>:1360: in _find_and_load
    ???
<frozen importlib._bootstrap>:1331: in _find_and_load_unlocked
    ???
<frozen importlib._bootstrap>:935: in _load_unlocked
    ???
../.venv/lib/python3.12/site-packages/_pytest/assertion/rewrite.py:197: in exec_module
    exec(co, module.__dict__)
fuser/fused_operand.py:26: in <module>
    @dataclass
     ^^^^^^^^^
/usr/lib/python3.12/dataclasses.py:1268: in dataclass
    return wrap(cls)
           ^^^^^^^^^
/usr/lib/python3.12/dataclasses.py:1258: in wrap
    return _process_class(cls, init, repr, eq, order, unsafe_hash,
/usr/lib/python3.12/dataclasses.py:994: in _process_class
    cls_fields.append(_get_field(cls, name, type, kw_only))
                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
/usr/lib/python3.12/dataclasses.py:852: in _get_field
    raise ValueError(f'mutable default {type(f.default)} for field '
E   ValueError: mutable default <class 'helpers.tile_shape.TileShape'> for field tile_shape is not allowed: use default_factory
```

`Operand.tile_shape` was declared with a mutable default value (`construct_tile_shape(...)` returns a `TileShape` instance). Python's `@dataclass` forbids mutable defaults and raised `ValueError` at import time, which broke importing `fused_operand.py` (and anything downstream, e.g. `perf_fused.py`).

#### Proposed fix
Use `field(default_factory=...)` so each `Operand` instance gets a fresh `TileShape` default.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fvranicTT-patch-1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fvranicTT-patch-1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fvranicTT-patch-1)