### PR TITLE
[Bug fix] Fix CCL watcher cleanup for all-gather and fabric mux

### DIFF
--- a/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
+++ b/tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp
@@ -270,8 +270,8 @@ void kernel_main() {
     }
 
     fabric_connection.close();
-    noc_async_write_barrier();
-    noc_async_atomic_barrier();
+    noc_async_full_barrier();
+    noc_clear_packet_tags(noc_index);
 
     status_ptr[0] = tt::tt_fabric::FabricMuxStatus::TERMINATED;
     set_l1_data_cache<false>();

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp
@@ -390,4 +390,5 @@ void kernel_main() {
     }
 
     noc_semaphore_set(reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_ready_sem), 0);
+    noc_async_atomic_barrier();
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This is an AutoFix-generated follow-up to #46602. It fixes the next two watcher failures exposed after idle dispatch packet tags were cleaned up:

- `minimal_default_reader.cpp` could complete with pending non-posted semaphore atomics, tripping watcher on the traced all-gather reader path.
- `tt_fabric_mux.cpp` could terminate with write-capable NOC packet tags still set, tripping watcher during fabric close/teardown.

The patch is intentionally small:

- add `noc_async_atomic_barrier()` after the final all-gather reader semaphore reset;
- use `noc_async_full_barrier()` plus `noc_clear_packet_tags(noc_index)` before fabric mux termination.

This PR is stacked on #46602 so the diff contains only the CCL/fabric cleanup changes. Once #46602 merges, this can be retargeted/rebased onto `main`.

### Reproducer and AutoFix evidence
Target hardware: T3K, 8 Wormhole B0 devices, `ttnn.FabricConfig.FABRIC_1D_RING`, mesh `(1, 8)`.

Failing evidence before this PR, with #46602 applied:

- Full traced multichip decode watcher failed in `ttnn/cpp/ttnn/operations/experimental/ccl/all_gather_async/device/kernels/minimal_default_reader.cpp`:
  - local artifact: `models/autoports/meta_llama/Llama_3_1_8B_Instruct/doc/multichip_decoder/watcher_full_traced_after_dispatch/traced_decode_watcher.log`
  - watcher message: `NCRISC detected an inter-kernel data race due to kernel completing with pending NOC transactions (missing NOC non-posted atomics flushed barrier)`.
- After adding the reader atomic barrier, the same full traced decode test passed its pytest body but failed during close in `tt_metal/fabric/impl/kernels/tt_fabric_mux.cpp`:
  - local artifact: `models/autoports/meta_llama/Llama_3_1_8B_Instruct/doc/multichip_decoder/watcher_full_traced_after_reader_atomic/traced_decode_watcher.log`
  - watcher message: `write-capable NOC packet tags must be zero so implicit transaction ID users start with transaction ID 0`.

Focused all-gather repro used for the CCL/fabric path:

```bash
TT_METAL_CACHE=/tmp/tt-metal-cache-codex-ag-reader-mux-cleanup-v2 \
TT_METAL_LOGS_PATH=models/autoports/meta_llama/Llama_3_1_8B_Instruct/doc/multichip_decoder/watcher_ag_reader_mux_cleanup \
TT_METAL_WATCHER=10 TT_METAL_WATCHER_APPEND=1 TT_METAL_WATCHER_NOINLINE=1 \
PYTHONFAULTHANDLER=1 timeout 420s python - <<'PY'
import ttnn
from tests.nightly.t3000.ccl.test_minimal_all_gather_async import run_all_gather_impl

ttnn.set_fabric_config(ttnn.FabricConfig.FABRIC_1D_RING)
mesh = ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(1, 8), trace_region_size=90112)
try:
    run_all_gather_impl(
        mesh, mesh.get_num_devices(), [1, 1, 1024, 5120], 3, 1,
        ttnn.bfloat16, ttnn.TILE_LAYOUT,
        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM),
        all_gather_topology=ttnn.Topology.Ring,
        enable_trace=True,
        num_iters=10,
        use_barrier=True,
        use_persistent_buffers=True,
        use_semaphore_free_all_gather_impl=False,
        allowed_pcc=1.0,
    )
    ttnn.synchronize_device(mesh)
finally:
    ttnn.close_mesh_device(mesh)
    ttnn.set_fabric_config(ttnn.FabricConfig.DISABLED)
PY
```

Result after this PR:

- focused traced `all_gather_async`: 10 iterations passed with PCC 1.0; watcher detached cleanly from devices 0 through 7;
- full traced multichip decode watcher: `1 passed in 131.57s`; watcher detached cleanly from devices 0 through 7.

Full traced decode command:

```bash
TT_METAL_CACHE=/tmp/tt-metal-cache-codex-fulltrace-after-dispatch \
TT_METAL_LOGS_PATH=models/autoports/meta_llama/Llama_3_1_8B_Instruct/doc/multichip_decoder/watcher_full_traced_after_mux_cleanup \
TT_METAL_WATCHER=10 TT_METAL_WATCHER_APPEND=1 TT_METAL_WATCHER_NOINLINE=1 \
TT_AUTOPORT_RUN_PERF=1 PYTHONFAULTHANDLER=1 timeout 900s pytest --timeout=600 \
  --confcutdir=models/autoports/meta_llama/Llama_3_1_8B_Instruct -q -s \
  models/autoports/meta_llama/Llama_3_1_8B_Instruct/tests/test_multichip_decoder.py::test_multichip_decoder_perf_traced_decode_synthetic
```

### Notes for reviewers
This patch was generated by AutoFix from watcher evidence during Llama 3.1 8B multichip decoder bringup. Please focus review on whether these are the right cleanup boundaries:

- reader-side non-posted semaphore atomics should be flushed before `minimal_default_reader.cpp` exits;
- fabric mux close should leave both outstanding NOC work drained and packet tags zeroed before `TERMINATED` is published.

`git diff --check` passed locally, and the commit hook passed formatting/include checks during commit.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=codex/fix-ccl-fabric-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:codex/fix-ccl-fabric-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=codex/fix-ccl-fabric-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:codex/fix-ccl-fabric-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=codex/fix-ccl-fabric-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:codex/fix-ccl-fabric-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=codex/fix-ccl-fabric-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:codex/fix-ccl-fabric-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=codex/fix-ccl-fabric-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:codex/fix-ccl-fabric-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=codex/fix-ccl-fabric-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:codex/fix-ccl-fabric-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=codex/fix-ccl-fabric-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:codex/fix-ccl-fabric-watcher-cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=codex/fix-ccl-fabric-watcher-cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:codex/fix-ccl-fabric-watcher-cleanup)