### PR TITLE
Enable fabric2d on chunked mla test

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
@@ -20,7 +20,7 @@ _CMD_8X4 = f"pytest {_TEST_PATH} -k 'balanced-skip_check-seq100k-scaled_sl-rando
 # 640 matmul/SDPA configs. Functional reference (no PCC) keeps the measured region to the single
 # forward (the 50k prefix is preloaded host->device before the MLA_START signpost, so it is not timed).
 _CHUNKED_TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill"
-_CMD_CHUNKED_8X4 = f"pytest {_CHUNKED_TEST_PATH} -k 'deep-50k+5k and kimi and func and 8x4 and ring'"
+_CMD_CHUNKED_8X4 = f"pytest {_CHUNKED_TEST_PATH} -k 'deep-50k+5k and kimi and func and 8x4 and fabric2d'"
 
 
 @pytest.mark.timeout(0)
@@ -64,11 +64,14 @@ def test_kimi_mla_chunked_perf_galaxy():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
     run_model_device_perf_test_with_merge(
         command=_CMD_CHUNKED_8X4,
-        expected_device_perf_ns_per_iteration=6_740_968,
+        expected_device_perf_ns_per_iteration=7_118_649,
         subdir="deepseek_v3_mla",
         model_name="kimi_mla_chunked_glx_8x4",
         num_iterations=1,
         batch_size=1,
         margin=0.03,
+        # Time only the forward: ops between the MLA_START/MLA_END signposts, excluding one-time
+        # weight-load tilize/typecast at construction (dispatched before MLA_START).
+        between_signposts=("MLA_START", "MLA_END"),
         comments="kimi_chunked_50k+5k_glx_8x4_ground_truth",
     )

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -769,43 +769,52 @@ _CHUNKED_SCENARIOS = (
     [(f"rot-{rid}", dict(iters_isl=lst)) for rid, lst in zip(ROTATED_VALID_IDS, ROTATED_VALID_LISTS)]
     # One representative case packing the most sp=8 edges: iter0 aligned partial, iter1 rotated
     # chip-aligned (offset=0) partial, iter2 rotated mid-chip straddle (offset=32) + multi-slab + full.
-    + [("maxedge", dict(iters_isl=[2560, 2592, 5120]))]
+    # NOTE: ids must not nest as substrings, else `-k <id>` can't isolate one (pytest -k is substring).
+    # Convention: "-Nu" = N users. "maxedge"/"deep" are intentional families (single- + multi-user).
+    + [("maxedge-1u", dict(iters_isl=[2560, 2592, 5120]))]
     + [
         ("production-50k+5k", dict(iters_isl=[5120] * 11)),
-        ("multiuser-U2", dict(iters_isl=[5120] * 4, num_users=2)),
+        ("fullchunk-2u", dict(iters_isl=[5120] * 4, num_users=2)),
         # Multi-user WITH padding/rotation: each user runs the full maxedge pattern in its own slot
         # (partition splits [..]*2 into one maxedge per user), exercising rotation + cross-user isolation.
-        ("maxedge-multiuser-U2", dict(iters_isl=[2560, 2592, 5120] * 2, num_users=2)),
+        ("maxedge-2u", dict(iters_isl=[2560, 2592, 5120] * 2, num_users=2)),
         ("deep-50k+5k", dict(iters_isl=[5120], prefill_len=50 * 1024)),
-        ("deep-multiuser-U2", dict(iters_isl=[5120, 5120], prefill_len=50 * 1024, num_users=2)),
+        ("deep-2u", dict(iters_isl=[5120, 5120], prefill_len=50 * 1024, num_users=2)),
     ]
 )
 
 
-# TODO(FABRIC_2D): the BH Galaxy 8x4 prefill target moved to FABRIC_2D (#45595, which fixed the MLA
-# ring all-gather writer this path uses). Add a fabric2d device_params variant (router config +
-# RELAXED_INIT + per-mesh num_links, via conftest's FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS) in a
-# follow-up, validated on BH Galaxy. This test currently covers FABRIC_1D (line + ring) only.
 @pytest.mark.parametrize(
     "device_params",
     [
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
-        {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+        },
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
+            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+        },
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+        },
     ],
-    ids=["line", "ring"],
+    ids=["line", "ring", "fabric2d"],
     indirect=True,
 )
 @pytest.mark.parametrize("mesh_device", [(2, 2), (2, 4), (8, 4)], ids=["2x2", "2x4", "8x4"], indirect=True)
 @pytest.mark.parametrize("reference", ["cpu", "trace", None], ids=["cpu", "trace", "func"])
 @pytest.mark.parametrize("kwargs", [kw for _, kw in _CHUNKED_SCENARIOS], ids=[sid for sid, _ in _CHUNKED_SCENARIOS])
-@pytest.mark.parametrize("variant", ["deepseek_v3_d_p", "kimi_k2_6"], indirect=True, ids=["deepseek_v3", "kimi"])
+@pytest.mark.parametrize("variant", ["deepseek_v3_d_p", "kimi_k2_6"], indirect=True, ids=["dsv3", "kimi"])
 @pytest.mark.timeout(0)
 def test_mla_chunked_prefill(request, mesh_device, kwargs, reference, device_params, variant):
     """Unified chunked-prefill driver crossed with independent mesh and reference axes. Each
     functionality scenario (rotation edges, production depth, multi-user, deep prefix) runs on any mesh
     and is validated against the CPU torch reference ('cpu'), the GPU trace ('trace', skips without
     DEEPSEEK_MLA_TRACE_DIR), or run with no reference ('func'). Select with e.g.
-    -k 'maxedge and trace and 8x4'. See _run_chunked_prefill.
+    -k 'maxedge-1u and trace and 8x4'. See _run_chunked_prefill.
 
     Real weights on the CPU-reference path: point the variant's HF env var (DEEPSEEK_V3_HF_MODEL /
     KIMI_K2_6_HF_MODEL) at a checkpoint to validate the chunked path against the CPU torch reference

--- a/models/demos/deepseek_v3_d_p/utils/perf_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/perf_utils.py
@@ -181,6 +181,7 @@ def run_model_device_perf_test_with_merge(
     margin: float = 0.015,
     comments: str = "",
     op_filter: str = "",
+    between_signposts: tuple[str, str] | None = None,
     extra_env: dict | None = None,
 ):
     """
@@ -203,6 +204,12 @@ def run_model_device_perf_test_with_merge(
         op_filter: If set, restricts the measurement to rows whose OP CODE
             contains the given substring — useful when the worker emits multiple
             ops and only one is under test.
+        between_signposts: If set to (start_header, stop_header), restricts the
+            measurement to device ops emitted between those two tracy signposts
+            (e.g. ("MLA_START", "MLA_END")), excluding everything dispatched before
+            the first start / after the last stop — such as one-time weight-load
+            tilize/typecast at construction. Handles repeated/nested pairs (only ops
+            inside an open region are kept).
         extra_env: If set, applied to os.environ for the duration of the subprocess
             invocation. Use for vars the worker reads directly (e.g. TT_DS_CAPTURED_LAYER)
             — prefixing them into the command doesn't work because tracy's -m flag
@@ -234,6 +241,25 @@ def run_model_device_perf_test_with_merge(
     device_rows = len(df[df["OP TYPE"] == "tt_dnn_device"])
 
     logger.debug(f"CSV total rows: {total_rows}, signposts: {signpost_rows}, device ops: {device_rows}")
+
+    if between_signposts is not None:
+        start_header, stop_header = between_signposts
+        sp = df["OP TYPE"] == "signpost"
+        is_start = sp & (df["OP CODE"] == start_header)
+        is_stop = sp & (df["OP CODE"] == stop_header)
+        if not is_start.any() or not is_stop.any():
+            pytest.fail(
+                f"between_signposts={between_signposts!r}: signpost(s) not found in {filename} "
+                f"(found starts={int(is_start.sum())}, stops={int(is_stop.sum())})"
+            )
+        # CSV rows are in host-dispatch order; +1 at each start, -1 at each stop. A row is "inside"
+        # an open region when the running depth is > 0. The start row itself raises depth to 1, so it
+        # is excluded only by ~sp (signpost rows are never device ops); the stop row drops depth to 0.
+        depth = (is_start.astype(int) - is_stop.astype(int)).cumsum()
+        df = df[(depth > 0) & ~sp]
+        if df.empty:
+            pytest.fail(f"between_signposts={between_signposts!r} matched no device rows in {filename}")
+        logger.debug(f"Rows between signposts {between_signposts}: {len(df)}")
 
     df = df[df["OP TYPE"].isin(["tt_dnn_device"])]
 

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -219,7 +219,7 @@
     exit_code=0
     pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64 and not fabric2d-" --timeout 1800 || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short || exit_code=$?
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge and cpu and 2x4 and line and not multiuser" -vvv --tb=short || exit_code=$?
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge-1u and cpu and 2x4 and fabric2d" -vvv --tb=short || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "balanced and not non_balanced and fabric2d" -vvv --tb=short --timeout=900 || exit_code=$?
     pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py -k "2x4 and layer0 and device and not fabric2d-" -vvv --tb=short || exit_code=$?
     exit $exit_code

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -43,7 +43,7 @@
   cmd: |
     export MESH_DEVICE=TG
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge and cpu and 8x4 and line and not multiuser" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge-1u and cpu and 8x4 and fabric2d" -vvv --tb=short
   test_type: mla_chunked
   test_group: module
   skus:

--- a/tests/pipeline_reorg/t3k_e2e_tests.yaml
+++ b/tests/pipeline_reorg/t3k_e2e_tests.yaml
@@ -126,7 +126,7 @@
   cmd: |
     pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -vvv --tb=short -k "mesh-4x2" --timeout 900
     pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge and cpu and 2x4 and line and not multiuser" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "maxedge-1u and cpu and 2x4 and line" -vvv --tb=short
   skus:
     wh_llmbox:
       timeout: 25


### PR DESCRIPTION
## What

Resolves #46444. Adds option to run chunked MLA with fabric2d.

2x4 mesh tests passed along with padded cases from the CI on 8x4. PCC remains unchanged from line configuration. 

## Testing

- [x] [![galaxy-deepseek-prefill-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ipotkonjak/chunked_fabric_2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ipotkonjak/chunked_fabric_2d) 
- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ipotkonjak/chunked_fabric_2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ipotkonjak/chunked_fabric_2d)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/chunked_fabric_2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/chunked_fabric_2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/chunked_fabric_2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/chunked_fabric_2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/chunked_fabric_2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/chunked_fabric_2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/chunked_fabric_2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/chunked_fabric_2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/chunked_fabric_2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/chunked_fabric_2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/chunked_fabric_2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/chunked_fabric_2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/chunked_fabric_2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/chunked_fabric_2d)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/chunked_fabric_2d)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/chunked_fabric_2d)