### PR TITLE
Remove hardcoded DS env variables from prefill_transformer

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
@@ -70,16 +70,7 @@ def _handle_sigterm(signum, frame):
     _shutdown = True
 
 
-DEFAULT_HOST_REF_CACHE = "/tmp/prefill_ref_cache"
-
-# Default the variant's TTNN-cache env so resolve_weight_cache_path works
-# without the caller exporting anything. TtPrefillTransformer additionally
-# *guards* on TT_DS_PREFILL_{TTNN,HOST_REF}_CACHE being set (it only validates
-# they're non-None — the real weights come from `weight_cache_path`), so seed
-# those too. For DeepSeek the variant env IS TT_DS_PREFILL_TTNN_CACHE.
 os.environ.setdefault(VARIANT.ttnn_cache_env, VARIANT.ttnn_cache_default)
-os.environ.setdefault("TT_DS_PREFILL_TTNN_CACHE", VARIANT.ttnn_cache_default)
-os.environ.setdefault("TT_DS_PREFILL_HOST_REF_CACHE", DEFAULT_HOST_REF_CACHE)
 
 
 def run_standalone_loop(pipeline: TtDeepSeekPrefillPipeline) -> None:

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -11,7 +11,6 @@ Equivalent to the reference Transformer class (models/demos/deepseek_v3/referenc
 but targeting the TT prefill path with SP+TP parallelism.
 """
 
-import os
 from pathlib import Path
 from typing import Callable, Optional, Union
 
@@ -122,19 +121,10 @@ class TtPrefillTransformer(LightweightModule):
         self.seq_len = seq_len
         self.padding_side = padding_side
 
-        # Log environment variables that define reference output cache and TTNN weights cache.
-        # This is to prevent accidental cache creation at unusual places and fill disk space.
-        TT_DS_PREFILL_TTNN_CACHE = os.getenv("TT_DS_PREFILL_TTNN_CACHE", None)
-        TT_DS_PREFILL_HOST_REF_CACHE = os.getenv("TT_DS_PREFILL_HOST_REF_CACHE", None)
-        logger.debug(f"{TT_DS_PREFILL_TTNN_CACHE=}")
-        logger.debug(f"{TT_DS_PREFILL_HOST_REF_CACHE=}")
-        if TT_DS_PREFILL_TTNN_CACHE is None:
-            raise RuntimeError(
-                "TT_DS_PREFILL_TTNN_CACHE environment variable is not set; export TT_DS_PREFILL_TTNN_CACHE=<path>"
-            )
-        if TT_DS_PREFILL_HOST_REF_CACHE is None:
-            raise RuntimeError(
-                "TT_DS_PREFILL_HOST_REF_CACHE environment variable is not set; export TT_DS_PREFILL_HOST_REF_CACHE=<path>"
+        if not state_dict and not (weight_cache_path and weight_cache_path.exists()):
+            raise ValueError(
+                "TtPrefillTransformer requires weights: pass a non-empty state_dict "
+                f"or a weight_cache_path to an existing cache (got {weight_cache_path=})."
             )
 
         logger.info(f"Building TtPrefillTransformer with {num_layers} layers, seq_len={seq_len}")


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`TtPrefillTransformer.__init__` read `TT_DS_PREFILL_TTNN_CACHE` and `TT_DS_PREFILL_HOST_REF_CACHE` via `os.getenv` and raised if either was unset unconditionally, for every model variant. This DeepSeek code is now shared by Kimi, which resolves its weight cache through `TT_KIMI_*` env vars. So a correctly-configured Kimi prefill run aborted at construction demanding the DS-named vars it never uses:

`RuntimeError: TT_DS_PREFILL_TTNN_CACHE environment variable is not set; export TT_DS_PREFILL_TTNN_CACHE=<path>`

The prefill transformer was validating the environment variables instead of its own inputs. The cache location is already resolved by the `test_prefill_transformer.py` and passed in as the `weight_cache_path` argument, so the env reads were both redundant and bound to one variant's naming.

This PR removes the env vars check in prefill transformer and checks if a weight source exists — a non-empty `state_dict` (in-memory weights) or an existing `weight_cache_path` (on-disk TTNN cache) — otherwise it raises `ValueError`.


### DeepSeek Prefill CI

- [ ] [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/fix_ds_env_vars)
- [ ] [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nbabin/fix_ds_env_vars)
- [ ] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:nbabin/fix_ds_env_vars)
- [ ] [![(T3K) T3000 e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:nbabin/fix_ds_env_vars)
- [ ] [![(Release) Model Status for Console Deployment](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nbabin/fix_ds_env_vars)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/fix_ds_env_vars)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nbabin/fix_ds_env_vars)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nbabin/fix_ds_env_vars)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nbabin/fix_ds_env_vars)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nbabin/fix_ds_env_vars)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nbabin/fix_ds_env_vars)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nbabin/fix_ds_env_vars)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nbabin/fix_ds_env_vars)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nbabin/fix_ds_env_vars)