### PR TITLE
prefill runner: create LayerAck channel only on the request-loop path

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
@@ -289,16 +289,6 @@ def main() -> None:
         )
         send_kv_chunk_table(table_path)
 
-        # Per-layer LayerAck: the runner bumps a counter once per layer; the scheduler
-        # reads the delta (the ack carries no payload) and drives the migration worker.
-        # ttnn.InterProcessCounterChannel owns a named POSIX shm segment the scheduler
-        # connects to via shm_layer_ack_name(service_id).
-        service_id = os.environ.get("PREFILL_H2D_SERVICE_ID", "ds_prefill")
-        ack_shm_name = f"/tt_prefill_layer_acks_{service_id}"
-        ack_channel = ttnn.InterProcessCounterChannel(ack_shm_name)
-        pipeline.set_layer_ack_channel(ack_channel)
-        logger.info(f"[migration] LayerAck channel ready at {ack_shm_name}; runner emits one ack per layer")
-
     if os.environ.get("PREFILL_STANDALONE", "0") == "1":
         # Truly standalone: file input, no H2D socket service at all.
         logger.info("Setup complete, running standalone loop (file input, no socket)")
@@ -328,6 +318,15 @@ def main() -> None:
             f"[h2d] exported descriptor service_id={service_id!r} -> {descriptor_path}; "
             f"run prefill_h2d_producer.py (or the scheduler) in another process to drive token pushes."
         )
+
+        # Per-layer LayerAck: the runner bumps a counter once per layer; the scheduler
+        # reads the delta (the ack carries no payload) and drives the migration worker.
+        # ttnn.InterProcessCounterChannel owns a named POSIX shm segment the scheduler
+        # connects to via shm_layer_ack_name(service_id).
+        ack_shm_name = f"/tt_prefill_layer_acks_{service_id}"
+        ack_channel = ttnn.InterProcessCounterChannel(ack_shm_name)
+        pipeline.set_layer_ack_channel(ack_channel)
+        logger.info(f"[migration] LayerAck channel ready at {ack_shm_name}; runner emits one ack per layer")
 
         logger.info("Setup complete, entering request loop")
         run_request_loop(pipeline, h2d_service)


### PR DESCRIPTION
The LayerAck InterProcessCounterChannel is consumed only by the scheduler, which exists only on the request-loop (production) path. Creating it in the shared `enable_migration` block also allocated the POSIX shm on the standalone path and made the runner inject acks no consumer reads. Move the channel creation + set_layer_ack_channel() into the request-loop branch (reusing the service_id already derived there for the H2D descriptor) so standalone runs neither allocate the shm nor emit acks.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jjovicic/layerack-ack-request-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jjovicic/layerack-ack-request-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jjovicic/layerack-ack-request-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jjovicic/layerack-ack-request-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jjovicic/layerack-ack-request-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jjovicic/layerack-ack-request-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jjovicic/layerack-ack-request-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jjovicic/layerack-ack-request-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jjovicic/layerack-ack-request-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jjovicic/layerack-ack-request-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jjovicic/layerack-ack-request-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jjovicic/layerack-ack-request-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jjovicic/layerack-ack-request-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jjovicic/layerack-ack-request-loop)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jjovicic/layerack-ack-request-loop)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jjovicic/layerack-ack-request-loop)