### PR TITLE
Bug fix: Add Int8 support to `transpose_wh_tile` on Wormhole (#36800)

### DIFF
--- a/tt_metal/hw/inc/api/compute/transpose_wh.h
+++ b/tt_metal/hw/inc/api/compute/transpose_wh.h
@@ -38,6 +38,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
 
 #ifndef ARCH_QUASAR
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
+    const bool is_int8 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int8;
     const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
                                        (dst_format == (std::uint32_t)DataFormat::UInt32) ||
                                        (dst_format == (std::uint32_t)DataFormat::Int32);
@@ -52,6 +53,13 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
+    } else if (is_int8) {
+        UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
+        MATH((llk_math_eltwise_unary_datacopy_init<
+              DataCopyType::A2D,
+              DST_ACCUM_MODE,
+              BroadcastType::NONE,
+              true /*is_int_fpu_en*/>(icb)));
     } else {
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
@@ -92,9 +100,11 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
 ALWI void transpose_wh_init_short(uint32_t icb, uint32_t call_line = __builtin_LINE()) {
     state_configure(icb, call_line);
 #if defined(TRISC_MATH) || defined(TRISC_UNPACK)
+    const std::uint32_t src_format = get_operand_src_format(icb);
     const std::uint32_t dst_format = get_operand_dst_format(icb);
 
 #ifndef ARCH_QUASAR
+    const bool is_int8 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int8;
     const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
                                        (dst_format == (std::uint32_t)DataFormat::UInt32) ||
                                        (dst_format == (std::uint32_t)DataFormat::Int32);
@@ -103,6 +113,13 @@ ALWI void transpose_wh_init_short(uint32_t icb, uint32_t call_line = __builtin_L
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
+    } else if (is_int8) {
+        UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
+        MATH((llk_math_eltwise_unary_datacopy_init<
+              DataCopyType::A2D,
+              DST_ACCUM_MODE,
+              BroadcastType::NONE,
+              true /*is_int_fpu_en*/>(icb)));
     } else {
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));

--- a/tt_metal/hw/inc/api/compute/transpose_wh.h
+++ b/tt_metal/hw/inc/api/compute/transpose_wh.h
@@ -38,7 +38,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
 
 #ifndef ARCH_QUASAR
     const bool is_int32 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int32;
-    const bool is_int8 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int8;
+    const bool is_8bit_int = (src_format & 0xf) == (std::uint32_t)DataFormat::Int8;
     const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
                                        (dst_format == (std::uint32_t)DataFormat::UInt32) ||
                                        (dst_format == (std::uint32_t)DataFormat::Int32);
@@ -53,7 +53,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
-    } else if (is_int8) {
+    } else if (is_8bit_int) {
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<
               DataCopyType::A2D,
@@ -104,7 +104,10 @@ ALWI void transpose_wh_init_short(uint32_t icb, uint32_t call_line = __builtin_L
     const std::uint32_t dst_format = get_operand_dst_format(icb);
 
 #ifndef ARCH_QUASAR
-    const bool is_int8 = (src_format & 0xf) == (std::uint32_t)DataFormat::Int8;
+    // Low-nibble compare intentionally matches both signed Int8 (14) and unsigned UInt8
+    // (30 -> low nibble 0xE): both 8-bit integer formats need the int-FPU (ELWADD) A2D
+    // reconstruct path.
+    const bool is_8bit_int = (src_format & 0xf) == (std::uint32_t)DataFormat::Int8;
     const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
                                        (dst_format == (std::uint32_t)DataFormat::UInt32) ||
                                        (dst_format == (std::uint32_t)DataFormat::Int32);
@@ -113,7 +116,7 @@ ALWI void transpose_wh_init_short(uint32_t icb, uint32_t call_line = __builtin_L
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
-    } else if (is_int8) {
+    } else if (is_8bit_int) {
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<
               DataCopyType::A2D,

--- a/tt_metal/hw/inc/api/compute/transpose_wh.h
+++ b/tt_metal/hw/inc/api/compute/transpose_wh.h
@@ -54,6 +54,10 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
         MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else if (is_8bit_int) {
+        // 8-bit integer (Int8/UInt8) transpose needs the int-FPU (ELWADD) A2D reconstruct path,
+        // selected here via is_int_fpu_en. Ideally the LLK layer would infer this path from the
+        // data format instead of selecting it here in the Compute API layer.
+        // TODO: #46832.
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<
               DataCopyType::A2D,
@@ -117,6 +121,10 @@ ALWI void transpose_wh_init_short(uint32_t icb, uint32_t call_line = __builtin_L
         MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
     } else if (is_8bit_int) {
+        // 8-bit integer (Int8/UInt8) transpose needs the int-FPU (ELWADD) A2D reconstruct path,
+        // selected here via is_int_fpu_en. Ideally the LLK layer would infer this path from the
+        // data format instead of selecting it here in the Compute API layer.
+        // TODO: #46832.
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<
               DataCopyType::A2D,

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_transpose_dest.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_transpose_dest.py
@@ -222,7 +222,10 @@ def transpose_dest_int8(
         formats,
         templates=[MATH_TRANSPOSE_FACES(math_transpose_faces)],
         runtimes=[
-            UNPACK_TRANS_FACES(Transpose.No),
+            # The kernel hard-codes transpose_of_faces=1 (the haloize path); this
+            # param is currently unused by transpose_wh_int8_test.cpp but is set to
+            # Yes to stay aligned with the kernel's actual behavior.
+            UNPACK_TRANS_FACES(Transpose.Yes),
             TILE_COUNT(tile_cnt_A),
             NUM_FACES(),
         ],

--- a/tt_metal/tt-llk/tests/python_tests/test_zzz_transpose_dest.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_zzz_transpose_dest.py
@@ -129,6 +129,129 @@ def test_transpose_dest_int(
     transpose_dest(formats, dest_acc, math_transpose_faces, unpack_to_dest)
 
 
+@parametrize(
+    formats=input_output_formats([DataFormat.Int8], same=True),
+    dest_acc=[DestAccumulation.Yes],
+    math_transpose_faces=[Transpose.Yes],
+    unpack_to_dest=[False],
+)
+def test_transpose_dest_int8(
+    formats,
+    dest_acc,
+    math_transpose_faces,
+    unpack_to_dest,
+):
+    """
+    Test transpose_wh_tile with Int8 format using the haloize unpack path.
+
+    Int8 uses the non-unpack-to-dest path in transpose_wh_init/tile:
+    the unpacker performs transpose_of_faces + within_face_16x16_transpose (haloize), and
+    the math thread uses A2D datacopy with is_int_fpu_en=true to reconstruct Int8 in DEST.
+    No _llk_math_transpose_dest_ call is made — the unpacker already produced the transposed tile.
+    """
+    transpose_dest_int8(formats, dest_acc, math_transpose_faces, unpack_to_dest)
+
+
+@parametrize(
+    formats=input_output_formats([DataFormat.Int8], same=True),
+    dest_acc=[DestAccumulation.Yes],
+    math_transpose_faces=[Transpose.Yes],
+    unpack_to_dest=[False],
+)
+def test_transpose_dest_int8_single_tile(
+    formats,
+    dest_acc,
+    math_transpose_faces,
+    unpack_to_dest,
+):
+    """
+    Single-tile (32x32) variant of test_transpose_dest_int8.
+
+    Exercises the Int8 haloize unpack path on a single tile (tile_cnt == 1),
+    covering the face / within-face 16x16 transpose edge case where the whole
+    transpose fits in one tile rather than spanning a multi-tile grid.
+    """
+    transpose_dest_int8(
+        formats,
+        dest_acc,
+        math_transpose_faces,
+        unpack_to_dest,
+        input_dimensions=[32, 32],
+    )
+
+
+def transpose_dest_int8(
+    formats, dest_acc, math_transpose_faces, unpack_to_dest, input_dimensions=None
+):
+
+    if input_dimensions is None:
+        input_dimensions = [64, 64]
+
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+    )
+
+    if TestConfig.BUILD_MODE != BuildMode.PRODUCE:
+        t_matrix = get_golden_generator(TransposeGolden)
+        # The haloize unpack path performs transpose_of_faces + within_face_16x16_transpose.
+        # There is no DataCopy golden step (the A2D datacopy only moves data to DEST; it does
+        # not change the transpose already done by the unpacker). Generate the golden by
+        # applying both transpose steps directly to the raw input.
+        golden_faces = t_matrix.transpose_faces_multi_tile(
+            src_A,
+            formats.output_format,
+            num_tiles=tile_cnt_A,
+            tilize=False,
+            input_dimensions=input_dimensions,
+        )
+        golden_tensor = t_matrix.transpose_within_faces_multi_tile(
+            golden_faces,
+            formats.output_format,
+            num_tiles=tile_cnt_A,
+            untilize=False,
+            input_dimensions=input_dimensions,
+        )
+    else:
+        golden_tensor = []
+
+    configuration = TestConfig(
+        "sources/transpose_wh_int8_test.cpp",
+        formats,
+        templates=[MATH_TRANSPOSE_FACES(math_transpose_faces)],
+        runtimes=[
+            UNPACK_TRANS_FACES(Transpose.No),
+            TILE_COUNT(tile_cnt_A),
+            NUM_FACES(),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+        ),
+        dest_acc=dest_acc,
+        unpack_to_dest=unpack_to_dest,
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    torch_format = format_dict[formats.output_format]
+    res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
+
+    assert torch.equal(res_tensor, golden_tensor), "Assert against golden failed"
+
+
 def transpose_dest(formats, dest_acc, math_transpose_faces, unpack_to_dest):
 
     input_dimensions = [64, 64]

--- a/tt_metal/tt-llk/tests/sources/transpose_wh_int8_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_wh_int8_test.cpp
@@ -1,0 +1,125 @@
+
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Faithful reproduction of the compute-API transpose_wh_tile i8 path
+// (tt_metal/hw/inc/api/compute/transpose_wh.h, the float/int8 `else` branch):
+// the full 32x32 transpose is performed in the UNPACKER (transpose_of_faces +
+// within_face_16x16_transpose / haloize), and the math thread only does the
+// A2D datacopy that reconstructs the Int8 register datum into DEST. There is no
+// _llk_math_transpose_dest_ call here, unlike transpose_dest_test.cpp.
+
+#include <cstdint>
+
+#include "ckernel.h"
+#include "llk_defs.h"
+#include "params.h"
+
+// Globals
+std::uint32_t unp_cfg_context          = 0;
+std::uint32_t pack_sync_tile_dst_ptr   = 0;
+std::uint32_t math_sync_tile_dst_index = 0;
+
+#ifdef LLK_TRISC_UNPACK
+
+#include "llk_unpack_A.h"
+#include "llk_unpack_common.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
+        formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
+    // Mirror transpose_wh_init i8 branch: acc_to_dest=true, transpose_of_faces=1, within_face_16x16_transpose=1.
+    _llk_unpack_A_init_<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE, false /* unpack_to_dest */>(
+        1 /* transpose_of_faces */, 1 /* within_face_16x16_transpose */, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        // Mirror transpose_wh_tile execute else branch: acc_to_dest=false.
+        _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false /* unpack_to_dest */>(
+            L1_ADDRESS(params.buffer_A[i]), formats.unpack_A_src, formats.unpack_A_dst);
+    }
+}
+
+#endif
+
+#ifdef LLK_TRISC_MATH
+
+#include "llk_lib_math_wrappers.h"
+
+using namespace ckernel;
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+
+    // Int8/UInt8 both unpack into the Int8 register format and need the integer FPU datapath
+    // (is_int_fpu_en => ELWADD move) to reconstruct the integer value in DEST under FP32 dest mode.
+    const bool is_int8 = (masked_data_format(formats.math) == to_underlying(DataFormat::Int8));
+    if (is_int8)
+    {
+        _llk_math_eltwise_unary_datacopy_init_wrapper_<
+            DataCopyType::A2D,
+            is_fp32_dest_acc_en,
+            BroadcastType::NONE,
+            true /* is_int_fpu_en */,
+            PackMode::Default>(params.num_faces, formats.math);
+    }
+    else
+    {
+        _llk_math_eltwise_unary_datacopy_init_wrapper_<
+            DataCopyType::A2D,
+            is_fp32_dest_acc_en,
+            BroadcastType::NONE,
+            false /* is_int_fpu_en */,
+            PackMode::Default>(params.num_faces, formats.math);
+    }
+
+    _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+    _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
+
+    _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        LLK_ASSERT(
+            (i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Block tile index exceeds maximum destination tiles");
+        // No math transpose_dest: the unpacker already produced the transposed tile.
+        _llk_math_eltwise_unary_datacopy_wrapper_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en, BroadcastType::NONE, false /* unpack_to_dest */>(
+            i, formats.math, formats.math);
+    }
+    _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+
+#endif
+
+#ifdef LLK_TRISC_PACK
+
+#include "llk_lib_pack_wrappers.h"
+#include "llk_pack_common.h"
+
+void run_kernel(RUNTIME_PARAMETERS params)
+{
+#if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
+    const FormatConfig& formats = params.formats;
+#endif
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+
+    _llk_packer_wait_for_math_done_();
+    for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
+    {
+        LLK_ASSERT(
+            (i < get_dest_max_tiles<DstSync::SyncHalf, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()), "Block tile index exceeds maximum destination tiles");
+        _llk_pack_<DstSync::SyncHalf, is_fp32_dest_acc_en, ckernel::PackMode::Default>(i, L1_ADDRESS(params.buffer_Res[i]));
+    }
+    _llk_pack_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
+}
+#endif

--- a/tt_metal/tt-llk/tests/sources/transpose_wh_int8_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_wh_int8_test.cpp
@@ -4,7 +4,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Faithful reproduction of the compute-API transpose_wh_tile i8 path
-// (tt_metal/hw/inc/api/compute/transpose_wh.h, the float/int8 `else` branch):
+// (tt_metal/hw/inc/api/compute/transpose_wh.h, the dedicated `else if (is_8bit_int)`
+// branch in transpose_wh_init / transpose_wh_init_short):
 // the full 32x32 transpose is performed in the UNPACKER (transpose_of_faces +
 // within_face_16x16_transpose / haloize), and the math thread only does the
 // A2D datacopy that reconstructs the Int8 register datum into DEST. There is no


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`transpose_wh_tile` produced incorrect results (failed validation) for the `Int8`
datatype on Wormhole, while `Float32`, `Int32`, and `bfloat16` worked. Fixes #36800.

Root cause: `transpose_wh_init` / `transpose_wh_init_short` ran the Int8 path through
`llk_math_eltwise_unary_datacopy_init` **without `is_int_fpu_en=true`**. As a result
`eltwise_unary_configure_mop` programmed the MOP to use `MOVA2D` instead of `ELWADD`,
which mis-reconstructs the Int8 datum in DEST under FP32 accumulation.

Fix: add an `is_int8` branch to both init functions that enables `is_int_fpu_en` on the
A2D datacopy init, so the math thread reconstructs the integer value correctly via the
integer-FPU (`ELWADD`) datapath. The unpacker haloize path (`transpose_of_faces` +
`within_face_16x16_transpose`) was already correct, so the per-tile execute path is
unchanged and simply replays the corrected MOP. This deliberately keeps Int8 on the
haloize path rather than `transpose_dest`, sidestepping the known latent signed-Int8
issue in the 32-bit `transpose_dest` overlay.

Production change is confined to `tt_metal/hw/inc/api/compute/transpose_wh.h`
(`#ifndef ARCH_QUASAR` only — Quasar behavior is untouched). The rest is test-only.

### Notes for reviewers
- **Where to focus:** the new `else if (is_int8)` branch in `transpose_wh_init` and
  `transpose_wh_init_short`. Note `transpose_wh_init_short` now also reads `src_format`
  (previously it only read `dst_format`) to compute `is_int8`.
- **Why init-only:** in the LLK model the datatype-dependent MOP is programmed at init
  time; the per-tile execute call just replays it. So the fix belongs in init and the
  execute path needs no change.
- **Tests added** (`tests/python_tests/test_zzz_transpose_dest.py`, new source
  `tests/sources/transpose_wh_int8_test.cpp`):
  - `test_transpose_dest_int8` — 64×64, 4-tile
  - `test_transpose_dest_int8_single_tile` — 32×32, 1-tile (single-tile face / within-face
    16×16 transpose edge case)
- **Verification:** both Int8 tests pass on Wormhole n150 silicon (exact `torch.equal`
  against the golden built from the two haloize transpose steps). The existing
  `test_transpose_dest_int` (Int32) and `test_transpose_dest_float` (26 combos) remain
  green on silicon — no regression on the neighboring float/int32 paths.
- **Scope:** Wormhole only, matching the issue. BH/Quasar paths are unaffected.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nstamatovic/issue-36800-i8-transpose-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nstamatovic/issue-36800-i8-transpose-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nstamatovic/issue-36800-i8-transpose-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nstamatovic/issue-36800-i8-transpose-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nstamatovic/issue-36800-i8-transpose-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nstamatovic/issue-36800-i8-transpose-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nstamatovic/issue-36800-i8-transpose-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nstamatovic/issue-36800-i8-transpose-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nstamatovic/issue-36800-i8-transpose-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nstamatovic/issue-36800-i8-transpose-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nstamatovic/issue-36800-i8-transpose-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nstamatovic/issue-36800-i8-transpose-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nstamatovic/issue-36800-i8-transpose-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nstamatovic/issue-36800-i8-transpose-wh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nstamatovic/issue-36800-i8-transpose-wh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nstamatovic/issue-36800-i8-transpose-wh)