### PR TITLE
ttnn: up-front parallel precompile (collect + parallel CompileProgram)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -513,6 +513,7 @@ tools/tests/triage/ @tenstorrent/metalium-developers-triage @tenstorrent/codeown
 tools/tests/triage/**/CMakeLists.txt @tenstorrent/metalium-developers-triage @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 scripts/install_debugger.sh @tenstorrent/metalium-developers-triage @tenstorrent/codeowner-bypass
 scripts/run_safe_pytest.sh @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
+tests/plugins/up_front_collect.py @tenstorrent/metalium-developers-convolutions @tenstorrent/codeowner-bypass
 
 # docs
 docs/realtime_profiler_architecture.md @mo-tenstorrent @akerteszTT @tenstorrent/codeowner-bypass

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -183,30 +183,7 @@ else
     echo "SAFE_PYTEST: WARNING: python_env not found; using system Python" >&2
 fi
 
-# --- Precompile warm phase (opt-in, hardware only; never aborts the real run) ---
-if [[ "$PRECOMPILE" == true ]]; then
-    if [[ "$SIM_MODE" == true ]]; then
-        echo "PRECOMPILE: skipped under simulator (no warm benefit)" >&2
-    else
-        precompile_warm
-    fi
-fi
-
-# --- Hang detection setup (hardware only) ---
-# On timeout, the dispatch layer runs tt-triage. Fires only on actual hang —
-# zero overhead for passing tests. On sim there is no hang detection because
-# wall-clock timeouts are meaningless at kHz clock speeds.
-rm -f "$TRIAGE_LOG"
-if [[ "$SIM_MODE" == false ]]; then
-    export TT_METAL_OPERATION_TIMEOUT_SECONDS="$DISPATCH_TIMEOUT"
-    # Requires tt-exalens: uv pip install -r tools/triage/requirements.txt
-    if ! python3 -c "import ttexalens" 2>/dev/null; then
-        echo "SAFE_PYTEST: WARNING: tt-exalens not installed — triage on hang will be unavailable." >&2
-        echo "SAFE_PYTEST: Install with: uv pip install -r tools/triage/requirements.txt" >&2
-    fi
-    export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress > ${TRIAGE_LOG} 2>&1"
-fi
-
+# --- Dev-mode build flags (must precede the warm phase: they feed the JIT build_key) ---
 if [[ "$DEV_MODE" == true ]]; then
     # Lightweight asserts: compiles ASSERT() as ebreak, halting the core at the
     # exact instruction. The dispatch timeout then fires and runs triage, which
@@ -232,7 +209,34 @@ if [[ "$DEV_MODE" == true ]]; then
     export TT_METAL_WATCHER_NOINLINE=1
     export TT_METAL_WATCHER_DISABLE_ASSERT=1
     export TT_METAL_WATCHER_DISABLE_DISPATCH=1
+fi
 
+# --- Precompile warm phase (opt-in, hardware only; never aborts the real run) ---
+if [[ "$PRECOMPILE" == true ]]; then
+    if [[ "$SIM_MODE" == true ]]; then
+        echo "PRECOMPILE: skipped under simulator (no warm benefit)" >&2
+    else
+        precompile_warm
+    fi
+fi
+
+# --- Hang detection setup (hardware only) ---
+# On timeout, the dispatch layer runs tt-triage. Fires only on actual hang —
+# zero overhead for passing tests. On sim there is no hang detection because
+# wall-clock timeouts are meaningless at kHz clock speeds.
+rm -f "$TRIAGE_LOG"
+if [[ "$SIM_MODE" == false ]]; then
+    export TT_METAL_OPERATION_TIMEOUT_SECONDS="$DISPATCH_TIMEOUT"
+    # Requires tt-exalens: uv pip install -r tools/triage/requirements.txt
+    if ! python3 -c "import ttexalens" 2>/dev/null; then
+        echo "SAFE_PYTEST: WARNING: tt-exalens not installed — triage on hang will be unavailable." >&2
+        echo "SAFE_PYTEST: Install with: uv pip install -r tools/triage/requirements.txt" >&2
+    fi
+    export TT_METAL_DISPATCH_TIMEOUT_COMMAND_TO_EXECUTE="python3 ${TRIAGE_SCRIPT} --disable-progress > ${TRIAGE_LOG} 2>&1"
+fi
+
+# Dev-mode banner (flags exported above).
+if [[ "$DEV_MODE" == true ]]; then
     if [[ "$SIM_MODE" == true ]]; then
         echo "SAFE_PYTEST: [sim+dev] asserts=ebreak llk_asserts=ON watcher=polling (no hang detection on sim)" >&2
     else

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -20,12 +20,9 @@
 #               on hang with full triage + watcher log dump.
 #   --run-all   Run all tests instead of stopping on first failure (-x).
 #               Useful for eval scoring where you need full pass/fail counts.
-#   --precompile  Before the real run, transparently warm the JIT cache on the real
-#               device and in parallel (no env vars, no second command), so kernels
-#               compile up-front in parallel instead of inline & serial. ALWAYS falls
-#               back to a normal cold run if anything goes wrong — it can only make a
-#               run slower, never broken or wrong. Prints a one-line diagnostic. Hardware
-#               only. Tune parallelism with --precompile-workers N (default: nproc).
+#   --precompile  Warm the JIT cache on the real device, in parallel, before the run, so kernels
+#               compile up-front instead of inline & serial. No env vars; always falls back to a
+#               cold run on any failure. Hardware only. --precompile-workers N (default: nproc).
 #
 # Modes:
 #   default  - Dispatch timeout only. Lean, no debug overhead.
@@ -38,11 +35,8 @@
 #   3 - Setup error (missing args, etc.)
 #
 # Total runtime:
-#   Always prints SAFE_PYTEST_TOTAL_RUNTIME as the very last line (on every exit path).
-#   It is the wall-clock time from "device lock acquired" (idle lock-wait queueing is
-#   deliberately excluded) to script exit, so it covers the whole run — device reset,
-#   precompile warm phase, and the pytest run itself — not just pytest. Under simulator
-#   there is no lock, so the clock starts at the equivalent point.
+#   SAFE_PYTEST_TOTAL_RUNTIME is printed last on every exit path — wall time from device-lock
+#   acquired (idle lock-wait excluded) to exit, covering reset + warmup + pytest. Sim: from start.
 
 set -o pipefail
 
@@ -78,10 +72,8 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --precompile)
-            # Opt-in: transparently warm the JIT cache (real-device, parallel) before the
-            # real run, so kernels compile up-front in parallel instead of inline & serial.
-            # Everything is internal — no env vars, no second command. Always falls back to a
-            # normal cold run if anything goes wrong (see precompile_warm). Hardware only.
+            # Warm the JIT cache (real device, parallel) before the real run. Internal only;
+            # always falls back to a cold run on failure (see precompile_warm). Hardware only.
             PRECOMPILE=true
             shift
             ;;
@@ -107,31 +99,21 @@ shift
 # Remaining args are extra pytest args — the precompile collect must use the SAME selection.
 EXTRA_ARGS=("$@")
 
-# Precompile uses WHATEVER cache the user already has (TT_METAL_CACHE if set, else tt-metal's
-# default) — both the warm-collect and the real run inherit the same value (incl. ccache state), so
-# they share it and a pre-warmed cache is transparently reused. We never override it.
+# Both the warmup and the real run inherit whatever TT_METAL_CACHE / ccache the user has (we never
+# override), so they share one cache and a pre-warmed one is reused.
 PRECOMPILE_PLUGIN_DIR="$REPO_DIR"
 
-# ============================================================================
-# Precompile (opt-in --precompile): warm the JIT cache on the REAL device, then
-# let the normal run below hit it. We open the same device the tests use, so the
-# build_key matches by construction — no mock / fingerprint / pre-flight needed.
-# Every failure path degrades to a normal cold run — slower at worst, never wrong.
-# ============================================================================
+# Precompile (--precompile): warm the JIT cache on the SAME device the tests use (so the build_key
+# matches by construction), then let the normal run below hit it. Any failure degrades to a cold run.
 
 precompile_warm() {
     [[ "$SIM_MODE" == false ]] && touch "$DIRTY_FLAG"
     echo "PRECOMPILE: ===== warmup (collect + precompile, real device) =====" >&2
-    # Real-device collect over the SAME selection -> warms the shared cache. We open the same device the
-    # real run uses, so the build_key matches by construction (no mock / fingerprint / pre-flight needed).
-    # SINGLE-PROCESS by design: the heavy kernel COMPILE is parallelized by the plugin's in-process C++
-    # thread pool via ttnn.graph.up_front_compile(device, UP_FRONT_COLLECT_WORKERS=N). xdist (-n) would
-    # only parallelize the cheap COLLECT body-run and, measured, LOSES ~half the cache (concurrent writers
-    # + per-worker dedup: full conv2d 47.6% xdist vs 99.8% single-process). FAST collect (default) keeps
-    # real torch tensors with cheap host stand-ins + a SHAPE-ONLY ttnn.from_torch (skips the weight-prep
-    # tilize/convert) — works on model tests where storage-free collect collapses on weight prep. REAL_ALLOC
-    # gives real buffer addresses so address-baked kernels (pool/move/conv) warm too. ccache state is
-    # INHERITED (untouched) so it matches the real run below — a mismatch would silently miss the warm cache.
+    # Single-process by design: the heavy kernel COMPILE is parallelized in-process by
+    # up_front_compile's thread pool; xdist (-n) would only parallelize the cheap collect and
+    # measurably loses ~half the cache (concurrent writers + per-worker dedup). REAL_ALLOC gives real
+    # addresses so address-baked kernels (pool/move/conv) warm too. ccache state is inherited so it
+    # matches the real run — a mismatch would silently miss the cache.
     local clog="/tmp/precompile_collect_$$.log" t0 t1 cstatus
     echo "PRECOMPILE: warming (single proc x ${PRECOMPILE_WORKERS} compile-threads) over: ${TEST_PATH} ${EXTRA_ARGS[*]}" >&2
     t0=$(date +%s)
@@ -140,9 +122,8 @@ precompile_warm() {
         pytest "${TEST_PATH}" "${EXTRA_ARGS[@]}" -p tests.plugins.up_front_collect > "$clog" 2>&1
     cstatus=$?
     t1=$(date +%s)
-    # Don't pretend it warmed if the collect failed. A non-zero exit (pytest usage/collection error,
-    # plugin failure, OOM, etc.) means we warmed nothing -> say so plainly; the real run still runs COLD
-    # and CORRECT, just without the speedup. (pytest exit 5 = "no tests collected" counts as a failure.)
+    # A non-zero exit (collection error, plugin failure, OOM, pytest-5 "no tests") means nothing
+    # warmed -> say so; the real run still runs cold and correct, just without the speedup.
     if [[ $cstatus -ne 0 ]]; then
         echo "PRECOMPILE: ✗ warmup FAILED (pytest exit $cstatus) after $((t1-t0))s -> warmed NOTHING; running COLD." >&2
         grep -iE "error|unrecognized|no tests ran|no tests collected" "$clog" 2>/dev/null | head -3 | sed 's/^/PRECOMPILE:   /' >&2
@@ -153,10 +134,8 @@ precompile_warm() {
 }
 
 # --- Total-run timer ---
-# Reports wall-clock time from "device lock acquired" to script exit. Registered as an
-# EXIT trap so it ALWAYS prints last, on every exit path (pass, fail, hang, error). The
-# RUN_START guard means nothing is printed for exits that happen before testing begins
-# (e.g. missing args), since no run took place.
+# EXIT trap so it always prints last on every path; the RUN_START guard suppresses it for exits
+# before testing begins (e.g. missing args).
 _print_total_runtime() {
     [[ -z "${RUN_START:-}" ]] && return 0
     local run_end elapsed
@@ -176,8 +155,7 @@ if [[ "$SIM_MODE" == false ]]; then
     flock 9
     echo "SAFE_PYTEST: Device lock acquired" >&2
 
-    # Start the total-run clock the moment we own the device. The lock-wait above is
-    # idle queueing behind other runners and is deliberately excluded.
+    # Start the clock once we own the device; the idle lock-wait above is excluded.
     RUN_START=$(date +%s)
 
     # --- Check if device needs reset from previous hang ---
@@ -191,8 +169,7 @@ if [[ "$SIM_MODE" == false ]]; then
         echo "SAFE_PYTEST: Device reset complete" >&2
     fi
 else
-    # Simulator: no device lock to acquire, so start the total-run clock here (the
-    # equivalent "start of testing" point).
+    # Simulator: no lock, so start the clock here.
     RUN_START=$(date +%s)
 fi
 

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -135,7 +135,7 @@ precompile_warm() {
     local clog="/tmp/precompile_collect_$$.log" t0 t1 cstatus
     echo "PRECOMPILE: warming (single proc x ${PRECOMPILE_WORKERS} compile-threads) over: ${TEST_PATH} ${EXTRA_ARGS[*]}" >&2
     t0=$(date +%s)
-    UP_FRONT_COLLECT=1 UP_FRONT_REAL_ALLOC=1 UP_FRONT_COLLECT_WORKERS="$PRECOMPILE_WORKERS" \
+    UP_FRONT_REAL_ALLOC=1 UP_FRONT_COLLECT_WORKERS="$PRECOMPILE_WORKERS" \
     LOGURU_LEVEL=ERROR PYTHONPATH="$PRECOMPILE_PLUGIN_DIR" \
         pytest "${TEST_PATH}" "${EXTRA_ARGS[@]}" -p tests.plugins.up_front_collect > "$clog" 2>&1
     cstatus=$?

--- a/scripts/run_safe_pytest.sh
+++ b/scripts/run_safe_pytest.sh
@@ -12,7 +12,7 @@
 #   Skips flock, device resets, and triage (these require real hardware).
 #   No hang protection — sim runs at kHz, so wall-clock timeouts are meaningless.
 #
-# Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] <test_path> [extra_pytest_args...]
+# Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] [--precompile] <test_path> [extra_pytest_args...]
 #
 # Options:
 #   --dev       Enables polling watcher (NoC sanitizer, waypoints, CB
@@ -20,6 +20,12 @@
 #               on hang with full triage + watcher log dump.
 #   --run-all   Run all tests instead of stopping on first failure (-x).
 #               Useful for eval scoring where you need full pass/fail counts.
+#   --precompile  Before the real run, transparently warm the JIT cache on the real
+#               device and in parallel (no env vars, no second command), so kernels
+#               compile up-front in parallel instead of inline & serial. ALWAYS falls
+#               back to a normal cold run if anything goes wrong — it can only make a
+#               run slower, never broken or wrong. Prints a one-line diagnostic. Hardware
+#               only. Tune parallelism with --precompile-workers N (default: nproc).
 #
 # Modes:
 #   default  - Dispatch timeout only. Lean, no debug overhead.
@@ -30,11 +36,18 @@
 #   1 - Test failure (normal pytest failure, no hang)
 #   2 - Hang detected (dispatch timeout fired)
 #   3 - Setup error (missing args, etc.)
+#
+# Total runtime:
+#   Always prints SAFE_PYTEST_TOTAL_RUNTIME as the very last line (on every exit path).
+#   It is the wall-clock time from "device lock acquired" (idle lock-wait queueing is
+#   deliberately excluded) to script exit, so it covers the whole run — device reset,
+#   precompile warm phase, and the pytest run itself — not just pytest. Under simulator
+#   there is no lock, so the clock starts at the equivalent point.
 
 set -o pipefail
 
 REPO_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-DISPATCH_TIMEOUT=5
+DISPATCH_TIMEOUT="${SAFE_PYTEST_DISPATCH_TIMEOUT:-5}"
 TRIAGE_SCRIPT="${REPO_DIR}/tools/tt-triage.py"
 WATCHER_LOG="${REPO_DIR}/generated/watcher/watcher.log"
 LOCK_FILE="/tmp/tt-device.lock"
@@ -52,6 +65,8 @@ fi
 # --- Parse flags ---
 DEV_MODE=false
 FAIL_FAST=true
+PRECOMPILE=false
+PRECOMPILE_WORKERS="${PRECOMPILE_WORKERS:-$(nproc 2>/dev/null || echo 8)}"
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --dev)
@@ -62,6 +77,18 @@ while [[ $# -gt 0 ]]; do
             FAIL_FAST=false
             shift
             ;;
+        --precompile)
+            # Opt-in: transparently warm the JIT cache (real-device, parallel) before the
+            # real run, so kernels compile up-front in parallel instead of inline & serial.
+            # Everything is internal — no env vars, no second command. Always falls back to a
+            # normal cold run if anything goes wrong (see precompile_warm). Hardware only.
+            PRECOMPILE=true
+            shift
+            ;;
+        --precompile-workers)
+            PRECOMPILE_WORKERS="$2"
+            shift 2
+            ;;
         *)
             break
             ;;
@@ -71,12 +98,75 @@ done
 # --- Argument validation ---
 if [[ $# -eq 0 ]]; then
     echo "SAFE_PYTEST_ERROR: No test path provided" >&2
-    echo "Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] <test_path> [extra_pytest_args...]" >&2
+    echo "Usage: scripts/run_safe_pytest.sh [--dev] [--run-all] [--precompile] <test_path> [extra_pytest_args...]" >&2
     exit 3
 fi
 
 TEST_PATH="$1"
 shift
+# Remaining args are extra pytest args — the precompile collect must use the SAME selection.
+EXTRA_ARGS=("$@")
+
+# Precompile uses WHATEVER cache the user already has (TT_METAL_CACHE if set, else tt-metal's
+# default) — both the warm-collect and the real run inherit the same value (incl. ccache state), so
+# they share it and a pre-warmed cache is transparently reused. We never override it.
+PRECOMPILE_PLUGIN_DIR="$REPO_DIR"
+
+# ============================================================================
+# Precompile (opt-in --precompile): warm the JIT cache on the REAL device, then
+# let the normal run below hit it. We open the same device the tests use, so the
+# build_key matches by construction — no mock / fingerprint / pre-flight needed.
+# Every failure path degrades to a normal cold run — slower at worst, never wrong.
+# ============================================================================
+
+precompile_warm() {
+    [[ "$SIM_MODE" == false ]] && touch "$DIRTY_FLAG"
+    echo "PRECOMPILE: ===== warmup (collect + precompile, real device) =====" >&2
+    # Real-device collect over the SAME selection -> warms the shared cache. We open the same device the
+    # real run uses, so the build_key matches by construction (no mock / fingerprint / pre-flight needed).
+    # SINGLE-PROCESS by design: the heavy kernel COMPILE is parallelized by the plugin's in-process C++
+    # thread pool via ttnn.graph.up_front_compile(device, UP_FRONT_COLLECT_WORKERS=N). xdist (-n) would
+    # only parallelize the cheap COLLECT body-run and, measured, LOSES ~half the cache (concurrent writers
+    # + per-worker dedup: full conv2d 47.6% xdist vs 99.8% single-process). FAST collect (default) keeps
+    # real torch tensors with cheap host stand-ins + a SHAPE-ONLY ttnn.from_torch (skips the weight-prep
+    # tilize/convert) — works on model tests where storage-free collect collapses on weight prep. REAL_ALLOC
+    # gives real buffer addresses so address-baked kernels (pool/move/conv) warm too. ccache state is
+    # INHERITED (untouched) so it matches the real run below — a mismatch would silently miss the warm cache.
+    local clog="/tmp/precompile_collect_$$.log" t0 t1 cstatus
+    echo "PRECOMPILE: warming (single proc x ${PRECOMPILE_WORKERS} compile-threads) over: ${TEST_PATH} ${EXTRA_ARGS[*]}" >&2
+    t0=$(date +%s)
+    UP_FRONT_COLLECT=1 UP_FRONT_REAL_ALLOC=1 UP_FRONT_COLLECT_WORKERS="$PRECOMPILE_WORKERS" \
+    LOGURU_LEVEL=ERROR PYTHONPATH="$PRECOMPILE_PLUGIN_DIR" \
+        pytest "${TEST_PATH}" "${EXTRA_ARGS[@]}" -p tests.plugins.up_front_collect > "$clog" 2>&1
+    cstatus=$?
+    t1=$(date +%s)
+    # Don't pretend it warmed if the collect failed. A non-zero exit (pytest usage/collection error,
+    # plugin failure, OOM, etc.) means we warmed nothing -> say so plainly; the real run still runs COLD
+    # and CORRECT, just without the speedup. (pytest exit 5 = "no tests collected" counts as a failure.)
+    if [[ $cstatus -ne 0 ]]; then
+        echo "PRECOMPILE: ✗ warmup FAILED (pytest exit $cstatus) after $((t1-t0))s -> warmed NOTHING; running COLD." >&2
+        grep -iE "error|unrecognized|no tests ran|no tests collected" "$clog" 2>/dev/null | head -3 | sed 's/^/PRECOMPILE:   /' >&2
+        echo "PRECOMPILE:   (full collect log: $clog)" >&2
+        return 0
+    fi
+    echo "PRECOMPILE: ✓ warmup complete in $((t1-t0))s — the real run below reuses it. Log: $clog" >&2
+}
+
+# --- Total-run timer ---
+# Reports wall-clock time from "device lock acquired" to script exit. Registered as an
+# EXIT trap so it ALWAYS prints last, on every exit path (pass, fail, hang, error). The
+# RUN_START guard means nothing is printed for exits that happen before testing begins
+# (e.g. missing args), since no run took place.
+_print_total_runtime() {
+    [[ -z "${RUN_START:-}" ]] && return 0
+    local run_end elapsed
+    run_end=$(date +%s)
+    elapsed=$((run_end - RUN_START))
+    echo "========================================" >&2
+    printf 'SAFE_PYTEST_TOTAL_RUNTIME: %dm%02ds (%ds total, device-lock-acquired -> exit)\n' \
+        $((elapsed / 60)) $((elapsed % 60)) "$elapsed" >&2
+}
+trap _print_total_runtime EXIT
 
 # --- Acquire flock (hardware only) ---
 if [[ "$SIM_MODE" == false ]]; then
@@ -85,6 +175,10 @@ if [[ "$SIM_MODE" == false ]]; then
     echo "SAFE_PYTEST: Waiting for device lock..." >&2
     flock 9
     echo "SAFE_PYTEST: Device lock acquired" >&2
+
+    # Start the total-run clock the moment we own the device. The lock-wait above is
+    # idle queueing behind other runners and is deliberately excluded.
+    RUN_START=$(date +%s)
 
     # --- Check if device needs reset from previous hang ---
     if [[ -f "$DIRTY_FLAG" ]]; then
@@ -96,6 +190,10 @@ if [[ "$SIM_MODE" == false ]]; then
         rm -f "$DIRTY_FLAG"
         echo "SAFE_PYTEST: Device reset complete" >&2
     fi
+else
+    # Simulator: no device lock to acquire, so start the total-run clock here (the
+    # equivalent "start of testing" point).
+    RUN_START=$(date +%s)
 fi
 
 # --- Setup environment ---
@@ -106,6 +204,15 @@ if [[ -f python_env/bin/activate ]]; then
     fi
 else
     echo "SAFE_PYTEST: WARNING: python_env not found; using system Python" >&2
+fi
+
+# --- Precompile warm phase (opt-in, hardware only; never aborts the real run) ---
+if [[ "$PRECOMPILE" == true ]]; then
+    if [[ "$SIM_MODE" == true ]]; then
+        echo "PRECOMPILE: skipped under simulator (no warm benefit)" >&2
+    else
+        precompile_warm
+    fi
 fi
 
 # --- Hang detection setup (hardware only) ---

--- a/tests/plugins/up_front_collect.py
+++ b/tests/plugins/up_front_collect.py
@@ -3,14 +3,14 @@
 
 """Up-front precompile collector for any ttnn pytest suite.
 
-A call-phase hookwrapper runs every test body under NO_DISPATCH, stashing and deduping
-its ops via the C++ collector (``ttnn.graph.up_front_*``), then JIT-compiles the distinct
-set once, in parallel, at session end — warming the on-disk cache (``TT_METAL_CACHE``).
-A hookwrapper (vs re-invoking tests) reuses each test's own fixtures, so any suite works.
-``begin_collect(clear=False)`` wraps only the call phase (device setup stays real) and
-accumulates across tests.
+A call-phase hookwrapper runs every test body with dispatch blocked but buffers allocated
+at REAL addresses (nothing executes), stashing and deduping its ops via the C++ collector
+(``ttnn.graph.up_front_*``), then JIT-compiles the distinct set once, in parallel, at session
+end — warming the on-disk cache (``TT_METAL_CACHE``). A hookwrapper (vs re-invoking tests)
+reuses each test's own fixtures, so any suite works. ``begin_collect(clear=False)`` wraps only
+the call phase (device setup stays real) and accumulates across tests.
 
-TWO PASSES: under NO_DISPATCH each body runs neutered (addr-0 buffers), so its asserts
+TWO PASSES: with dispatch blocked the body's outputs are never computed, so its asserts
 fail and are swallowed — pass 1 only collects + compiles. Re-run for the real, warm results:
 
     # pass 1 — collect + parallel-compile (warms the cache). Loading the plugin IS the opt-in.
@@ -22,9 +22,9 @@ fail and are swallowed — pass 1 only collects + compiles. Re-run for the real,
 Knobs:  UP_FRONT_COLLECT_WORKERS=N (0 => hardware_concurrency) ·
         UP_FRONT_COLLECT_DEVICE_ID=N (device for the session-end compile, default 0)
 
-Cold-compiled in pass 2 instead (NO_DISPATCH can't capture them faithfully): tests driving
-trace/graph capture (skipped); ops after a mid-body tensor readback; ops whose program is
-chosen from live allocator state (they see empty L1 and may collect a different variant).
+Cold-compiled in pass 2 instead (collect can't capture them faithfully): tests driving
+trace/graph capture (skipped); ops after a mid-body tensor readback. (Real allocation means
+ops that bake/branch on a buffer address now collect the same program the real run builds.)
 
 Every collect-time substitution is one of two reversible primitives (_AttrPatch /
 _RebindPatch), grouped into declarative sets and entered under one ExitStack — see
@@ -45,9 +45,6 @@ import pytest
 # own -p no:up_front_collect.
 _WORKERS = int(os.environ.get("UP_FRONT_COLLECT_WORKERS", "0"))  # 0 => hardware_concurrency
 _DEVICE_ID = int(os.environ.get("UP_FRONT_COLLECT_DEVICE_ID", "0"))
-# Collect with REAL buffer addresses (dispatch still blocked) instead of addr-0 mocking, so
-# address-baked kernels (pool reader, move) warm. Costs ~the real run's peak memory; use when it fits.
-_REAL_ALLOC = os.environ.get("UP_FRONT_REAL_ALLOC") == "1"
 # Fast collect (default): swap host reference work for shape-correct stand-ins (randn/conv/matmul/
 # layer_norm -> zeros, comp_pcc -> no-op) and allocate ttnn.from_torch shape-only. Values are
 # irrelevant under NO_DISPATCH and programs depend only on op shapes/config, so collection is
@@ -391,7 +388,7 @@ def pytest_runtest_call(item):
     n_before = ttnn.graph.up_front_num_collected() if _log else 0
     swallowed = False
     exc_info = ""
-    ttnn.graph.up_front_begin_collect(clear=False, real_alloc=_REAL_ALLOC)  # accumulate; wraps ONLY the body
+    ttnn.graph.up_front_begin_collect(clear=False)  # accumulate; wraps ONLY the body
     try:
         with _collect_window(_STATS):
             return (yield)  # ops stash into the collector as the body runs

--- a/tests/plugins/up_front_collect.py
+++ b/tests/plugins/up_front_collect.py
@@ -143,6 +143,7 @@ class _RebindPatch:
                     self._patched.append(m)
                     setattr(m, self._attr, replacement)
             except Exception:
+                # Some modules/proxies raise on getattr/setattr; skip them, rebinding is best-effort.
                 pass
         return self
 
@@ -447,6 +448,7 @@ def pytest_sessionfinish(session, exitstatus):
         try:
             device.enable_program_cache()
         except Exception:
+            # Cache may already be enabled or unsupported here; compile still warms the on-disk cache.
             pass
         n_prog, n_err, used, wall = ttnn.graph.up_front_compile(device, _WORKERS)
         print(
@@ -461,4 +463,5 @@ def pytest_sessionfinish(session, exitstatus):
             try:
                 ttnn.close_device(device)
             except Exception:
+                # Teardown is best-effort: a close failure must not fail the pytest session.
                 pass

--- a/tests/plugins/up_front_collect.py
+++ b/tests/plugins/up_front_collect.py
@@ -448,7 +448,7 @@ def pytest_sessionfinish(session, exitstatus):
             device.enable_program_cache()
         except Exception:
             pass
-        n_prog, n_err, used, wall = ttnn.graph.up_front_compile(device, _WORKERS, True)
+        n_prog, n_err, used, wall = ttnn.graph.up_front_compile(device, _WORKERS)
         print(
             f"UP_FRONT_COLLECT: compiled {n_prog} programs in {wall:.1f}s "
             f"(workers={used}, errors={n_err}) -> on-disk JIT cache warm",

--- a/tests/plugins/up_front_collect.py
+++ b/tests/plugins/up_front_collect.py
@@ -1,0 +1,429 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Up-front precompile collector for any ttnn pytest suite.
+
+Drives the op-agnostic C++ collector (``ttnn.graph.up_front_*``) across a whole
+pytest session via a call-phase hookwrapper: every op of every test body is
+stashed and deduped, then the distinct set is JIT-compiled once, in parallel, at
+session end — warming the on-disk JIT cache (``TT_METAL_CACHE``) so a subsequent
+real run finds its kernels already built.
+
+A hookwrapper is used (rather than re-invoking each test) because pytest runs each
+body through its own fixture machinery, so this works for arbitrary tests without
+knowing their signatures. ``begin_collect(clear=False)`` wraps ONLY the call phase,
+so NO_DISPATCH never spans fixture setup/teardown (the device is created for real in
+setup); ``clear=False`` makes the collector ACCUMULATE across tests.
+
+TWO PASSES: under NO_DISPATCH each body runs "neutered" (mocked addr-0 buffers,
+nothing dispatched), so its asserts fail and are swallowed — pass 1 only collects +
+compiles. Re-run the SAME suite over the SAME on-disk cache for the real, now-warm
+results:
+
+    # pass 1 — collect every op + parallel-compile the distinct set (warms the cache)
+    # (run from the repo root; PYTHONPATH=$PWD ensures the local `tests` package wins
+    #  over any foreign tt-metal checkout on an inherited PYTHONPATH)
+    UP_FRONT_COLLECT=1 TT_METAL_CACHE=/tmp/c  PYTHONPATH="$PWD" pytest -p tests.plugins.up_front_collect <tests>
+    # pass 2 — real run, warm (plugin off)
+    TT_METAL_CACHE=/tmp/c  pytest <tests>
+
+Knobs:  UP_FRONT_COLLECT=1 (enable; no-op otherwise) ·
+        UP_FRONT_COLLECT_WORKERS=N (0 => hardware_concurrency) ·
+        UP_FRONT_COLLECT_DEVICE_ID=N (device for the session-end compile, default 0)
+
+Limitations:
+  * Tests that drive trace/graph capture are SKIPPED — NO_DISPATCH blocks the real
+    dispatch + buffer allocation that recording needs. They cold-compile in pass 2.
+  * A body that reads a tensor back / branches on values mid-body breaks on addr-0:
+    we capture the ops before that point; the rest cold-compile in pass 2.
+  * Ops that pick their program from live allocator state see empty L1 under
+    NO_DISPATCH and may collect a different variant than the real run uses.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import inspect
+import os
+
+import pytest
+
+_ACTIVE = os.environ.get("UP_FRONT_COLLECT") == "1"
+_WORKERS = int(os.environ.get("UP_FRONT_COLLECT_WORKERS", "0"))  # 0 => hardware_concurrency
+_DEVICE_ID = int(os.environ.get("UP_FRONT_COLLECT_DEVICE_ID", "0"))
+# UP_FRONT_REAL_ALLOC=1: collect with REAL buffer addresses (dispatch still blocked) instead of
+# addr-0 mocking, so address-baked / address-branched kernels (pool reader, move fwd/bwd) warm.
+# Costs real device memory (~the real run's peak) — only use when the model fits.
+_REAL_ALLOC = os.environ.get("UP_FRONT_REAL_ALLOC") == "1"
+# UP_FRONT_FAST_COLLECT=1 (default): in the collect window (results thrown away under NO_DISPATCH),
+# replace expensive HOST-side torch work — torch.randn -> zeros, the torch *reference* conv
+# (torch.nn.functional.conv2d) -> shape-correct zeros, comp_pcc -> no-op. Values are irrelevant
+# under NO_DISPATCH and collected programs depend only on ttnn op shapes/config, so this does NOT
+# change what is collected — it stops pass 1 paying for the golden reference + PCC + RNG.
+# Set =0 to run the body with real torch (full-fidelity, slower collect).
+_FAST_COLLECT = os.environ.get("UP_FRONT_FAST_COLLECT", "1") == "1"
+# UP_FRONT_FAST_COLLECT_SHALLOW=1 (default): within fast collect, make ttnn.from_torch allocate the
+# ttnn tensor SHAPE-ONLY (skip the host tilize/convert/copy) — program build needs only the spec, not
+# values. Removes the dominant collect cost on weight-heavy models (e.g. SDXL UNet weight prep, ~35s
+# of from_torch). Keeps REAL torch tensors so host-side weight prep value reads still work. Set =0 to
+# restore the original full from_torch inside fast collect.
+_FAST_SHALLOW = os.environ.get("UP_FRONT_FAST_COLLECT_SHALLOW", "1") == "1"
+# UP_FRONT_COLLECT_NO_COMPILE=1: collect/dedup only, skip the session-end parallel compile. Used to
+# isolate the body-run cost from the compile floor when benchmarking.
+_NO_COMPILE = os.environ.get("UP_FRONT_COLLECT_NO_COMPILE") == "1"
+
+# Bodies that drive trace/graph capture can't run under NO_DISPATCH (it blocks the
+# dispatch + alloc that recording needs). Heuristic: scan the test function source.
+_CAPTURE_MARKERS = (
+    "begin_trace_capture",
+    "capture_trace",
+    "execute_trace",
+    "begin_graph_capture",
+    "begin_mesh_trace_capture",
+)
+
+_stats = {"bodies": 0, "swallowed": 0, "skipped_capture": 0}
+_fast_stats = {"shallow": 0, "fallback": 0}
+
+
+def _torch_to_ttnn_dtype(torch_dtype):
+    import torch
+    import ttnn
+
+    return {
+        torch.float32: ttnn.float32,
+        torch.float64: ttnn.float32,
+        torch.bfloat16: ttnn.bfloat16,
+        torch.float16: ttnn.bfloat16,
+        torch.int32: ttnn.uint32,
+        torch.int64: ttnn.uint32,
+        torch.int16: ttnn.uint16,
+        torch.uint8: ttnn.uint8,
+        torch.bool: ttnn.uint8,
+    }.get(torch_dtype, ttnn.bfloat16)
+
+
+@contextlib.contextmanager
+def _shape_only_boundary(stats):
+    """Patch the ttnn<->torch boundary to allocate device tensors SHAPE-ONLY during collect.
+
+    Program build needs only the spec, so ttnn.from_torch and torch2tt_tensor (incl. their
+    `from ... import` bindings) skip the host tilize/convert/copy — the dominant collect cost on
+    weight-heavy bodies. Falls back to the real path for anything not safely shape-only
+    (mesh_mapper, custom tile, host tensors, meta tensors). `stats` gets shallow/fallback counts.
+    """
+    import sys
+
+    import ttnn
+
+    real_from_torch = ttnn.from_torch
+
+    def _shallow_from_torch(
+        tensor,
+        dtype=None,
+        *,
+        spec=None,
+        tile=None,
+        layout=None,
+        device=None,
+        memory_config=None,
+        mesh_mapper=None,
+        **kw,
+    ):
+        if (
+            tensor is not None
+            and device is not None
+            and mesh_mapper is None
+            and tile is None
+            and not getattr(tensor, "is_meta", False)
+        ):
+            try:
+                if spec is not None:
+                    dt, lay, mc = spec.dtype, spec.layout, spec.memory_config
+                    shp = ttnn.Shape(tuple(spec.shape))
+                else:
+                    dt = dtype or _torch_to_ttnn_dtype(tensor.dtype)
+                    lay = layout or ttnn.ROW_MAJOR_LAYOUT
+                    mc = memory_config or ttnn.DRAM_MEMORY_CONFIG
+                    shp = ttnn.Shape(tuple(tensor.shape))
+                t = ttnn.allocate_tensor_on_device(shp, dt, lay, device, mc)
+                stats["shallow"] += 1
+                return t
+            except Exception:
+                stats["fallback"] += 1
+        return real_from_torch(
+            tensor,
+            dtype,
+            spec=spec,
+            tile=tile,
+            layout=layout,
+            device=device,
+            memory_config=memory_config,
+            mesh_mapper=mesh_mapper,
+            **kw,
+        )
+
+    # torch2tt_tensor builds device tensors outside from_torch (ttnn.Tensor(t).to(...)); same lever.
+    t2tt_modules = []
+    _ucf = sys.modules.get("models.common.utility_functions")
+    real_t2tt = getattr(_ucf, "torch2tt_tensor", None) if _ucf is not None else None
+    if real_t2tt is not None:
+        _interleaved_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED)
+
+        def _shallow_torch2tt(
+            py_tensor, tt_device, tt_layout=ttnn.TILE_LAYOUT, tt_memory_config=_interleaved_mc, tt_dtype=ttnn.bfloat16
+        ):
+            if tt_device is not None and not getattr(py_tensor, "is_meta", False):
+                try:
+                    size = list(py_tensor.size())
+                    while len(size) < 4:
+                        size.insert(0, 1)
+                    t = ttnn.allocate_tensor_on_device(
+                        ttnn.Shape(tuple(size)), tt_dtype, tt_layout, tt_device, tt_memory_config
+                    )
+                    stats["shallow"] += 1
+                    return t
+                except Exception:
+                    stats["fallback"] += 1
+            return real_t2tt(py_tensor, tt_device, tt_layout, tt_memory_config, tt_dtype)
+
+        for m in list(sys.modules.values()):
+            try:
+                if getattr(m, "torch2tt_tensor", None) is real_t2tt:
+                    t2tt_modules.append(m)
+                    m.torch2tt_tensor = _shallow_torch2tt
+            except Exception:
+                pass
+
+    ttnn.from_torch = _shallow_from_torch
+    try:
+        yield
+    finally:
+        ttnn.from_torch = real_from_torch
+        for m in t2tt_modules:
+            m.torch2tt_tensor = real_t2tt
+
+
+@contextlib.contextmanager
+def _stub_verifiers():
+    """Fuse off the host-side numeric verifiers during collect (results are meaningless anyway).
+
+    comp_pcc -> (True, ~1) and assert_numeric_metrics -> pass: a verifier failing on addr-0/zeros
+    readback aborts the rest of a multi-op body, losing its ops. Both helpers may also be bound via
+    `from ... import` in test modules, so patch every module attr pointing at the original.
+    """
+    import sys
+
+    saved = []  # (module, attr, original)
+    targets = {}
+    for src, attr, stub in (
+        ("tests.ttnn.utils_for_testing", "comp_pcc", lambda *a, **k: (True, 0.999999)),
+        ("models.common.utility_functions", "comp_pcc", lambda *a, **k: (True, 0.999999)),
+        ("tests.ttnn.utils_for_testing", "assert_numeric_metrics", lambda *a, **k: (True, "collect-stub")),
+    ):
+        mod = sys.modules.get(src)
+        orig = getattr(mod, attr, None) if mod is not None else None
+        if orig is not None:
+            targets[(attr, orig)] = stub
+    for (attr, orig), stub in targets.items():
+        for m in list(sys.modules.values()):
+            try:
+                if getattr(m, attr, None) is orig:
+                    saved.append((m, attr, orig))
+                    setattr(m, attr, stub)
+            except Exception:
+                pass
+    try:
+        yield
+    finally:
+        for m, attr, orig in saved:
+            setattr(m, attr, orig)
+
+
+def _drives_capture(item) -> bool:
+    fn = getattr(item, "function", None)
+    if fn is None:
+        return False
+    try:
+        src = inspect.getsource(fn)
+    except (OSError, TypeError):
+        return False
+    return any(m in src for m in _CAPTURE_MARKERS)
+
+
+@contextlib.contextmanager
+def _cheap_host_ops():
+    """Swap expensive host-side torch work for cheap shape-correct stand-ins during collect.
+
+    Only ttnn op shapes/config determine the collected programs, so zeroing the inputs, the
+    torch reference conv, and the PCC check does not change WHAT is collected — it just removes
+    the wasted golden-reference + PCC + RNG cost from the throwaway collect pass.
+    """
+    import torch
+    import torch.nn.functional as F
+
+    real_randn = torch.randn
+    real_rand = torch.rand
+    real_conv2d = F.conv2d
+    real_layer_norm = F.layer_norm
+    real_matmul = torch.matmul
+    real_bmm = torch.bmm
+    real_tensor_matmul = torch.Tensor.matmul
+    real_tensor_rmatmul = torch.Tensor.__matmul__
+
+    def _fast_randn(*size, **kw):
+        if len(size) == 1 and isinstance(size[0], (tuple, list, torch.Size)):
+            size = tuple(size[0])
+        kw.pop("generator", None)
+        return torch.zeros(*size, **kw)
+
+    def _pair(x):
+        return (x, x) if isinstance(x, int) else x
+
+    def _fast_conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+        sH, sW = _pair(stride)
+        pH, pW = _pair(padding)
+        dH, dW = _pair(dilation)
+        N, C_out = input.shape[0], weight.shape[0]
+        H, W = input.shape[-2], input.shape[-1]
+        kH, kW = weight.shape[-2], weight.shape[-1]
+        H_out = (H + 2 * pH - dH * (kH - 1) - 1) // sH + 1
+        W_out = (W + 2 * pW - dW * (kW - 1) - 1) // sW + 1
+        return input.new_zeros((N, C_out, H_out, W_out))
+
+    def _fast_layer_norm(input, *a, **k):
+        return torch.zeros_like(input)  # layer_norm / rms_norm output shape == input shape
+
+    def _fast_matmul(a, b):
+        # Host golden reference matmul/@/.matmul()/bmm -> shape-correct zeros, NO GEMM compute.
+        # Output shape via meta inference (no data) so all broadcasting rules stay exact. Only the
+        # host reference uses these; ttnn.matmul is untouched, so the collected programs are unchanged.
+        try:
+            shp = tuple(real_matmul(a.to("meta"), b.to("meta")).shape)
+            return torch.zeros(shp, dtype=getattr(a, "dtype", torch.bfloat16), device=getattr(a, "device", "cpu"))
+        except Exception:
+            return real_matmul(a, b)
+
+    torch.randn = _fast_randn
+    torch.rand = _fast_randn
+    F.conv2d = _fast_conv2d
+    F.layer_norm = _fast_layer_norm
+    torch.matmul = _fast_matmul
+    torch.bmm = lambda a, b, *x, **k: _fast_matmul(a, b)
+    torch.Tensor.matmul = lambda self, other: _fast_matmul(self, other)
+    torch.Tensor.__matmul__ = lambda self, other: _fast_matmul(self, other)
+    boundary = _shape_only_boundary(_fast_stats) if _FAST_SHALLOW else contextlib.nullcontext()
+    try:
+        with boundary, _stub_verifiers():
+            yield
+    finally:
+        torch.randn = real_randn
+        torch.rand = real_rand
+        F.conv2d = real_conv2d
+        F.layer_norm = real_layer_norm
+        torch.matmul = real_matmul
+        torch.bmm = real_bmm
+        torch.Tensor.matmul = real_tensor_matmul
+        torch.Tensor.__matmul__ = real_tensor_rmatmul
+
+
+@pytest.hookimpl(wrapper=True)
+def pytest_runtest_call(item):
+    """Run each body under one NO_DISPATCH collect window (call phase only)."""
+    if not _ACTIVE:
+        return (yield)
+
+    import ttnn
+
+    if _drives_capture(item):
+        _stats["skipped_capture"] += 1
+        return (yield)  # let it run normally; it cold-compiles in pass 2
+
+    _stats["bodies"] += 1
+    # UP_FRONT_LOG_SWALLOWED=1: per-body diagnostic — which tests threw under NO_DISPATCH and
+    # how many ops each stashed before the throw (reveals coverage: a body that throws BEFORE
+    # stashing its op is a real miss; one that throws on the addr-0 readback after stashing is fine).
+    _log = os.environ.get("UP_FRONT_LOG_SWALLOWED")
+    n_before = ttnn.graph.up_front_num_collected() if _log else 0
+    swallowed = False
+    exc_info = ""
+    ttnn.graph.up_front_begin_collect(clear=False, real_alloc=_REAL_ALLOC)  # accumulate; wraps ONLY the body
+    try:
+        if _FAST_COLLECT:
+            with _cheap_host_ops():
+                return (yield)  # body runs with cheap host stand-ins; ttnn ops still stash
+        return (yield)  # pytest runs the body with its real fixtures; ops stash into the collector
+    except Exception as e:
+        # Expected under NO_DISPATCH: a readback/assert on an addr-0 output. The
+        # program was already stashed by the funnel before the failure. Swallow so
+        # pass 1 stays green (its results are meaningless — pass 2 is the real run).
+        _stats["swallowed"] += 1
+        swallowed = True
+        exc_info = f"{type(e).__name__}: {str(e)[:140]}"
+        return None
+    finally:
+        ttnn.graph.up_front_end_collect()
+        if _log:
+            n_after = ttnn.graph.up_front_num_collected()
+            print(
+                f"UP_FRONT_BODY: {'SWALLOWED' if swallowed else 'ok       '} "
+                f"stashed={n_after - n_before:<3} {item.nodeid}" + (f"  -> {exc_info}" if swallowed else ""),
+                flush=True,
+            )
+
+
+def pytest_sessionstart(session):
+    if not _ACTIVE:
+        return
+    import ttnn
+
+    ttnn.graph.up_front_clear()  # clean slate before accumulating across the session
+
+
+def pytest_sessionfinish(session, exitstatus):
+    if not _ACTIVE:
+        return
+    import ttnn
+
+    n_unique = ttnn.graph.up_front_num_unique()
+    n_collected = ttnn.graph.up_front_num_collected()
+    print(
+        f"\nUP_FRONT_COLLECT: {n_collected} ops stashed across {_stats['bodies']} bodies "
+        f"-> {n_unique} unique programs "
+        f"(swallowed {_stats['swallowed']}, skipped-capture {_stats['skipped_capture']})",
+        flush=True,
+    )
+    if _FAST_COLLECT and _FAST_SHALLOW:
+        print(
+            f"UP_FRONT_COLLECT: fast-shallow from_torch — shape-only={_fast_stats['shallow']} "
+            f"fallback={_fast_stats['fallback']}",
+            flush=True,
+        )
+    if n_unique == 0:
+        print("UP_FRONT_COLLECT: nothing to compile", flush=True)
+        return
+    if _NO_COMPILE:
+        print(f"UP_FRONT_COLLECT: NO_COMPILE set — collected {n_unique}, skipping compile", flush=True)
+        return
+
+    device = None
+    try:
+        device = ttnn.CreateDevice(device_id=_DEVICE_ID)
+        try:
+            device.enable_program_cache()
+        except Exception:
+            pass
+        n_prog, n_err, used, wall = ttnn.graph.up_front_compile(device, _WORKERS, True)
+        print(
+            f"UP_FRONT_COLLECT: compiled {n_prog} programs in {wall:.1f}s "
+            f"(workers={used}, errors={n_err}) -> on-disk JIT cache warm",
+            flush=True,
+        )
+    except Exception as e:  # best-effort: never break the session
+        print(f"UP_FRONT_COLLECT: compile skipped (best-effort) — {e!r}", flush=True)
+    finally:
+        if device is not None:
+            try:
+                ttnn.close_device(device)
+            except Exception:
+                pass

--- a/tests/plugins/up_front_collect.py
+++ b/tests/plugins/up_front_collect.py
@@ -20,15 +20,15 @@ nothing dispatched), so its asserts fail and are swallowed — pass 1 only colle
 compiles. Re-run the SAME suite over the SAME on-disk cache for the real, now-warm
 results:
 
-    # pass 1 — collect every op + parallel-compile the distinct set (warms the cache)
+    # pass 1 — collect every op + parallel-compile the distinct set (warms the cache).
+    # Loading the plugin with -p IS the opt-in; it is active whenever loaded.
     # (run from the repo root; PYTHONPATH=$PWD ensures the local `tests` package wins
     #  over any foreign tt-metal checkout on an inherited PYTHONPATH)
-    UP_FRONT_COLLECT=1 TT_METAL_CACHE=/tmp/c  PYTHONPATH="$PWD" pytest -p tests.plugins.up_front_collect <tests>
-    # pass 2 — real run, warm (plugin off)
+    TT_METAL_CACHE=/tmp/c  PYTHONPATH="$PWD" pytest -p tests.plugins.up_front_collect <tests>
+    # pass 2 — real run, warm (plugin not loaded)
     TT_METAL_CACHE=/tmp/c  pytest <tests>
 
-Knobs:  UP_FRONT_COLLECT=1 (enable; no-op otherwise) ·
-        UP_FRONT_COLLECT_WORKERS=N (0 => hardware_concurrency) ·
+Knobs:  UP_FRONT_COLLECT_WORKERS=N (0 => hardware_concurrency) ·
         UP_FRONT_COLLECT_DEVICE_ID=N (device for the session-end compile, default 0)
 
 Limitations:
@@ -54,26 +54,22 @@ import sys
 
 import pytest
 
-_ACTIVE = os.environ.get("UP_FRONT_COLLECT") == "1"
+# The plugin is active whenever it is loaded (``-p tests.plugins.up_front_collect``); loading it IS
+# the opt-in. To disable a load that some config forces, use pytest's own ``-p no:up_front_collect``.
 _WORKERS = int(os.environ.get("UP_FRONT_COLLECT_WORKERS", "0"))  # 0 => hardware_concurrency
 _DEVICE_ID = int(os.environ.get("UP_FRONT_COLLECT_DEVICE_ID", "0"))
 # UP_FRONT_REAL_ALLOC=1: collect with REAL buffer addresses (dispatch still blocked) instead of
 # addr-0 mocking, so address-baked / address-branched kernels (pool reader, move fwd/bwd) warm.
 # Costs real device memory (~the real run's peak) — only use when the model fits.
 _REAL_ALLOC = os.environ.get("UP_FRONT_REAL_ALLOC") == "1"
-# UP_FRONT_FAST_COLLECT=1 (default): in the collect window (results thrown away under NO_DISPATCH),
-# replace expensive HOST-side torch work — torch.randn -> zeros, the torch *reference* conv
-# (torch.nn.functional.conv2d) -> shape-correct zeros, comp_pcc -> no-op. Values are irrelevant
-# under NO_DISPATCH and collected programs depend only on ttnn op shapes/config, so this does NOT
-# change what is collected — it stops pass 1 paying for the golden reference + PCC + RNG.
-# Set =0 to run the body with real torch (full-fidelity, slower collect).
+# Fast collect (default): in the collect window (results thrown away under NO_DISPATCH) replace
+# expensive HOST-side torch work — torch.randn -> zeros, the torch *reference* conv/matmul/layer_norm
+# -> shape-correct zeros, comp_pcc -> no-op — and allocate ttnn.from_torch SHAPE-ONLY (skip the host
+# tilize/convert/copy; the dominant collect cost on weight-heavy models). Values are irrelevant under
+# NO_DISPATCH and collected programs depend only on ttnn op shapes/config, so this does NOT change what
+# is collected; the shape-only boundary falls back to the real path for anything it can't safely fake.
+# UP_FRONT_FAST_COLLECT=0 is a debug escape hatch: run the body with real torch (full-fidelity, slow).
 _FAST_COLLECT = os.environ.get("UP_FRONT_FAST_COLLECT", "1") == "1"
-# UP_FRONT_FAST_COLLECT_SHALLOW=1 (default): within fast collect, make ttnn.from_torch allocate the
-# ttnn tensor SHAPE-ONLY (skip the host tilize/convert/copy) — program build needs only the spec, not
-# values. Removes the dominant collect cost on weight-heavy models (e.g. SDXL UNet weight prep, ~35s
-# of from_torch). Keeps REAL torch tensors so host-side weight prep value reads still work. Set =0 to
-# restore the original full from_torch inside fast collect.
-_FAST_SHALLOW = os.environ.get("UP_FRONT_FAST_COLLECT_SHALLOW", "1") == "1"
 # UP_FRONT_COLLECT_NO_COMPILE=1: collect/dedup only, skip the session-end parallel compile. Used to
 # isolate the body-run cost from the compile floor when benchmarking.
 _NO_COMPILE = os.environ.get("UP_FRONT_COLLECT_NO_COMPILE") == "1"
@@ -373,13 +369,12 @@ def _boundary_patches(stats):
 
 
 def _collect_patches(stats):
-    """The patch set active during the collect window, gated by the fast / shallow flags."""
+    """The patch set active during the collect window (empty unless fast collect is on)."""
     patches = []
     if _FAST_COLLECT:
         patches += _reference_op_patches()
         patches += _verifier_patches()
-        if _FAST_SHALLOW:
-            patches += _boundary_patches(stats)
+        patches += _boundary_patches(stats)
     return patches
 
 
@@ -410,9 +405,6 @@ def _drives_capture(item) -> bool:
 @pytest.hookimpl(wrapper=True)
 def pytest_runtest_call(item):
     """Run each body under one NO_DISPATCH collect window (call phase only)."""
-    if not _ACTIVE:
-        return (yield)
-
     import ttnn
 
     if _drives_capture(item):
@@ -451,16 +443,12 @@ def pytest_runtest_call(item):
 
 
 def pytest_sessionstart(session):
-    if not _ACTIVE:
-        return
     import ttnn
 
     ttnn.graph.up_front_clear()  # clean slate before accumulating across the session
 
 
 def pytest_sessionfinish(session, exitstatus):
-    if not _ACTIVE:
-        return
     import ttnn
 
     n_unique = ttnn.graph.up_front_num_unique()
@@ -471,7 +459,7 @@ def pytest_sessionfinish(session, exitstatus):
         f"(swallowed {_STATS.swallowed}, skipped-capture {_STATS.skipped_capture})",
         flush=True,
     )
-    if _FAST_COLLECT and _FAST_SHALLOW:
+    if _FAST_COLLECT:
         print(
             f"UP_FRONT_COLLECT: fast-shallow from_torch — shape-only={_STATS.shallow} " f"fallback={_STATS.fallback}",
             flush=True,

--- a/tests/plugins/up_front_collect.py
+++ b/tests/plugins/up_front_collect.py
@@ -3,27 +3,18 @@
 
 """Up-front precompile collector for any ttnn pytest suite.
 
-Drives the op-agnostic C++ collector (``ttnn.graph.up_front_*``) across a whole
-pytest session via a call-phase hookwrapper: every op of every test body is
-stashed and deduped, then the distinct set is JIT-compiled once, in parallel, at
-session end — warming the on-disk JIT cache (``TT_METAL_CACHE``) so a subsequent
-real run finds its kernels already built.
+A call-phase hookwrapper runs every test body under NO_DISPATCH, stashing and deduping
+its ops via the C++ collector (``ttnn.graph.up_front_*``), then JIT-compiles the distinct
+set once, in parallel, at session end — warming the on-disk cache (``TT_METAL_CACHE``).
+A hookwrapper (vs re-invoking tests) reuses each test's own fixtures, so any suite works.
+``begin_collect(clear=False)`` wraps only the call phase (device setup stays real) and
+accumulates across tests.
 
-A hookwrapper is used (rather than re-invoking each test) because pytest runs each
-body through its own fixture machinery, so this works for arbitrary tests without
-knowing their signatures. ``begin_collect(clear=False)`` wraps ONLY the call phase,
-so NO_DISPATCH never spans fixture setup/teardown (the device is created for real in
-setup); ``clear=False`` makes the collector ACCUMULATE across tests.
+TWO PASSES: under NO_DISPATCH each body runs neutered (addr-0 buffers), so its asserts
+fail and are swallowed — pass 1 only collects + compiles. Re-run for the real, warm results:
 
-TWO PASSES: under NO_DISPATCH each body runs "neutered" (mocked addr-0 buffers,
-nothing dispatched), so its asserts fail and are swallowed — pass 1 only collects +
-compiles. Re-run the SAME suite over the SAME on-disk cache for the real, now-warm
-results:
-
-    # pass 1 — collect every op + parallel-compile the distinct set (warms the cache).
-    # Loading the plugin with -p IS the opt-in; it is active whenever loaded.
-    # (run from the repo root; PYTHONPATH=$PWD ensures the local `tests` package wins
-    #  over any foreign tt-metal checkout on an inherited PYTHONPATH)
+    # pass 1 — collect + parallel-compile (warms the cache). Loading the plugin IS the opt-in.
+    # PYTHONPATH=$PWD makes the local `tests` package win over any foreign checkout on sys.path.
     TT_METAL_CACHE=/tmp/c  PYTHONPATH="$PWD" pytest -p tests.plugins.up_front_collect <tests>
     # pass 2 — real run, warm (plugin not loaded)
     TT_METAL_CACHE=/tmp/c  pytest <tests>
@@ -31,17 +22,13 @@ results:
 Knobs:  UP_FRONT_COLLECT_WORKERS=N (0 => hardware_concurrency) ·
         UP_FRONT_COLLECT_DEVICE_ID=N (device for the session-end compile, default 0)
 
-Limitations:
-  * Tests that drive trace/graph capture are SKIPPED — NO_DISPATCH blocks the real
-    dispatch + buffer allocation that recording needs. They cold-compile in pass 2.
-  * A body that reads a tensor back / branches on values mid-body breaks on addr-0:
-    we capture the ops before that point; the rest cold-compile in pass 2.
-  * Ops that pick their program from live allocator state see empty L1 under
-    NO_DISPATCH and may collect a different variant than the real run uses.
+Cold-compiled in pass 2 instead (NO_DISPATCH can't capture them faithfully): tests driving
+trace/graph capture (skipped); ops after a mid-body tensor readback; ops whose program is
+chosen from live allocator state (they see empty L1 and may collect a different variant).
 
-Collect-time substitutions are all expressed as one of two reversible primitives
-(_AttrPatch / _RebindPatch), grouped into declarative sets (reference ops, verifiers,
-boundary) and entered together under a single ExitStack — see _collect_window.
+Every collect-time substitution is one of two reversible primitives (_AttrPatch /
+_RebindPatch), grouped into declarative sets and entered under one ExitStack — see
+_collect_window.
 """
 
 from __future__ import annotations
@@ -54,28 +41,23 @@ import sys
 
 import pytest
 
-# The plugin is active whenever it is loaded (``-p tests.plugins.up_front_collect``); loading it IS
-# the opt-in. To disable a load that some config forces, use pytest's own ``-p no:up_front_collect``.
+# Active whenever loaded (-p tests.plugins.up_front_collect); disable a forced load with pytest's
+# own -p no:up_front_collect.
 _WORKERS = int(os.environ.get("UP_FRONT_COLLECT_WORKERS", "0"))  # 0 => hardware_concurrency
 _DEVICE_ID = int(os.environ.get("UP_FRONT_COLLECT_DEVICE_ID", "0"))
-# UP_FRONT_REAL_ALLOC=1: collect with REAL buffer addresses (dispatch still blocked) instead of
-# addr-0 mocking, so address-baked / address-branched kernels (pool reader, move fwd/bwd) warm.
-# Costs real device memory (~the real run's peak) — only use when the model fits.
+# Collect with REAL buffer addresses (dispatch still blocked) instead of addr-0 mocking, so
+# address-baked kernels (pool reader, move) warm. Costs ~the real run's peak memory; use when it fits.
 _REAL_ALLOC = os.environ.get("UP_FRONT_REAL_ALLOC") == "1"
-# Fast collect (default): in the collect window (results thrown away under NO_DISPATCH) replace
-# expensive HOST-side torch work — torch.randn -> zeros, the torch *reference* conv/matmul/layer_norm
-# -> shape-correct zeros, comp_pcc -> no-op — and allocate ttnn.from_torch SHAPE-ONLY (skip the host
-# tilize/convert/copy; the dominant collect cost on weight-heavy models). Values are irrelevant under
-# NO_DISPATCH and collected programs depend only on ttnn op shapes/config, so this does NOT change what
-# is collected; the shape-only boundary falls back to the real path for anything it can't safely fake.
-# UP_FRONT_FAST_COLLECT=0 is a debug escape hatch: run the body with real torch (full-fidelity, slow).
+# Fast collect (default): swap host reference work for shape-correct stand-ins (randn/conv/matmul/
+# layer_norm -> zeros, comp_pcc -> no-op) and allocate ttnn.from_torch shape-only. Values are
+# irrelevant under NO_DISPATCH and programs depend only on op shapes/config, so collection is
+# unchanged. =0 is a debug escape hatch: run the body with real torch (slow).
 _FAST_COLLECT = os.environ.get("UP_FRONT_FAST_COLLECT", "1") == "1"
-# UP_FRONT_COLLECT_NO_COMPILE=1: collect/dedup only, skip the session-end parallel compile. Used to
-# isolate the body-run cost from the compile floor when benchmarking.
+# Collect/dedup only, skip the session-end compile (isolates body-run cost when benchmarking).
 _NO_COMPILE = os.environ.get("UP_FRONT_COLLECT_NO_COMPILE") == "1"
 
-# Bodies that drive trace/graph capture can't run under NO_DISPATCH (it blocks the
-# dispatch + alloc that recording needs). Heuristic: scan the test function source.
+# A body is skipped (cold-compiles in pass 2) if its source names any of these: trace/graph capture
+# needs the real dispatch + alloc that NO_DISPATCH blocks.
 _CAPTURE_MARKERS = (
     "begin_trace_capture",
     "capture_trace",
@@ -87,8 +69,7 @@ _CAPTURE_MARKERS = (
 
 @dataclasses.dataclass
 class CollectStats:
-    """Session counters printed at the end. `bodies/swallowed/skipped_capture` are hook-level;
-    `shallow/fallback` count the shape-only boundary's hits vs real-path fallbacks."""
+    """Session counters printed at the end (shallow/fallback = shape-only boundary hits vs fallbacks)."""
 
     bodies: int = 0
     swallowed: int = 0
@@ -117,20 +98,13 @@ def _torch_to_ttnn_dtype(torch_dtype):
     }.get(torch_dtype, ttnn.bfloat16)
 
 
-# ---------------------------------------------------------------------------
-# Patch primitives. Every collect-time substitution is one of these two,
-# entered together under a single ExitStack (see _collect_window) so each has
-# uniform, automatic restore instead of a hand-rolled try/finally.
-# ---------------------------------------------------------------------------
+# Patch primitives: every collect-time substitution is one of these two, entered together under one
+# ExitStack (see _collect_window) for uniform automatic restore.
 
 
 class _AttrPatch:
-    """Reversibly replace ``obj.attr`` with ``build(original)`` for the collect window.
-
-    For callables reached by attribute access on a stable object — e.g. ``torch.randn``,
-    ``ttnn.from_torch``, ``torch.Tensor.__matmul__``. ``build`` receives the original (some
-    replacements wrap it; reference stand-ins ignore it).
-    """
+    """Reversibly set ``obj.attr = build(original)``. For attribute-reached callables —
+    torch.randn, ttnn.from_torch, torch.Tensor.__matmul__ (``build`` may wrap the original or ignore it)."""
 
     def __init__(self, obj, attr, build):
         self._obj, self._attr, self._build = obj, attr, build
@@ -146,11 +120,10 @@ class _AttrPatch:
 
 
 class _RebindPatch:
-    """Reversibly rebind EVERY module attribute that ``is`` ``home_module.attr`` to ``build(original)``.
+    """Reversibly rebind EVERY module attr that ``is`` ``home_module.attr`` to ``build(original)``.
 
-    Needed for helpers pulled into test modules via ``from x import y`` — patching the home module
-    alone wouldn't reach those local copies, so we rebind every reference. No-op if the home module
-    isn't imported or lacks the attribute. All matches share one original, so restore is to that.
+    Reaches helpers pulled in via ``from x import y`` (patching the home module alone wouldn't).
+    No-op if the home module isn't imported or lacks the attr; all matches share the one original.
     """
 
     def __init__(self, home_module, attr, build):
@@ -180,8 +153,8 @@ class _RebindPatch:
 
 
 def _try_shallow(stats, alloc):
-    """Run a shape-only ttnn allocation, tallying shallow vs fallback. Returns the allocated
-    tensor, or None if it raised — in which case the caller falls back to the real ttnn path."""
+    """Run a shape-only ttnn allocation; tally it. Returns the tensor, or None on failure
+    (caller then falls back to the real ttnn path)."""
     try:
         t = alloc()
         stats.shallow += 1
@@ -191,18 +164,12 @@ def _try_shallow(stats, alloc):
         return None
 
 
-# ---------------------------------------------------------------------------
 # Declarative patch sets, built lazily so torch/ttnn imports stay deferred.
-# ---------------------------------------------------------------------------
 
 
 def _reference_op_patches():
-    """Host reference compute -> cheap shape-correct stand-ins.
-
-    Under NO_DISPATCH the values are thrown away and the collected programs depend only on ttnn op
-    shapes/config, so zeroing the inputs / torch reference conv / matmul / layer_norm does not change
-    WHAT is collected — it just drops the wasted golden-reference + RNG cost. ttnn ops are untouched.
-    """
+    """Host reference compute -> shape-correct zeros. Drops the wasted golden-reference + RNG cost;
+    collection is unchanged (programs depend on shapes/config, not values). ttnn ops are untouched."""
     import torch
     import torch.nn.functional as F
 
@@ -232,9 +199,7 @@ def _reference_op_patches():
         return torch.zeros_like(input)  # layer_norm / rms_norm output shape == input shape
 
     def _fast_matmul(a, b):
-        # Host golden reference matmul/@/.matmul()/bmm -> shape-correct zeros, NO GEMM compute.
-        # Output shape via meta inference (no data) so all broadcasting rules stay exact. Only the
-        # host reference uses these; ttnn.matmul is untouched, so the collected programs are unchanged.
+        # Shape via meta inference (no data, broadcasting stays exact); no GEMM compute.
         try:
             shp = tuple(real_matmul(a.to("meta"), b.to("meta")).shape)
             return torch.zeros(shp, dtype=getattr(a, "dtype", torch.bfloat16), device=getattr(a, "device", "cpu"))
@@ -260,12 +225,9 @@ def _reference_op_patches():
 
 
 def _verifier_patches():
-    """Host numeric verifiers -> no-ops.
-
-    A verifier failing on the addr-0/zeros readback aborts the rest of a multi-op body and loses its
-    ops; results are meaningless under NO_DISPATCH anyway. Rebound across modules because tests pull
-    these in via ``from ... import``. comp_pcc has two possible homes; either (or both) is covered.
-    """
+    """Host numeric verifiers -> no-ops: a verifier failing on the addr-0 readback would abort the
+    rest of a multi-op body and lose its ops (results are meaningless under NO_DISPATCH anyway).
+    comp_pcc has two possible home modules; both are covered."""
 
     def _pcc(*a, **k):
         return (True, 0.999999)
@@ -281,12 +243,9 @@ def _verifier_patches():
 
 
 def _boundary_patches(stats):
-    """ttnn<->torch boundary -> SHAPE-ONLY device allocation.
-
-    Program build needs only the spec, so ttnn.from_torch and torch2tt_tensor skip the host
-    tilize/convert/copy (the dominant collect cost on weight-heavy bodies). Anything not safely
-    shape-only (mesh_mapper, custom tile, host/meta tensors) falls back to the real path.
-    """
+    """ttnn<->torch boundary -> shape-only device allocation: program build needs only the spec, so
+    from_torch / torch2tt_tensor skip the host tilize/convert/copy (the dominant collect cost on
+    weight-heavy bodies). Not-safely-shape-only cases (mesh_mapper, custom tile, host/meta) fall back."""
     import ttnn
 
     def _build_from_torch(real_from_torch):
@@ -339,7 +298,7 @@ def _boundary_patches(stats):
         return _shallow_from_torch
 
     def _build_torch2tt(real_t2tt):
-        # torch2tt_tensor builds device tensors outside from_torch (ttnn.Tensor(t).to(...)); same lever.
+        # torch2tt_tensor builds device tensors outside from_torch; same shape-only lever.
         interleaved_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED)
 
         def _shallow_torch2tt(
@@ -380,11 +339,8 @@ def _collect_patches(stats):
 
 @contextlib.contextmanager
 def _collect_window(stats):
-    """Enter every active patch under one ExitStack, run the body, restore all on exit (LIFO).
-
-    With no active patches (UP_FRONT_FAST_COLLECT=0) this is a transparent pass-through, so the body
-    runs with real torch.
-    """
+    """Enter every active patch under one ExitStack, run the body, restore on exit. With no active
+    patches (UP_FRONT_FAST_COLLECT=0) it's a transparent pass-through (body runs with real torch)."""
     with contextlib.ExitStack() as stack:
         for patch in _collect_patches(stats):
             stack.enter_context(patch)
@@ -409,12 +365,11 @@ def pytest_runtest_call(item):
 
     if _drives_capture(item):
         _STATS.skipped_capture += 1
-        return (yield)  # let it run normally; it cold-compiles in pass 2
+        return (yield)  # runs normally; cold-compiles in pass 2
 
     _STATS.bodies += 1
-    # UP_FRONT_LOG_SWALLOWED=1: per-body diagnostic — which tests threw under NO_DISPATCH and
-    # how many ops each stashed before the throw (reveals coverage: a body that throws BEFORE
-    # stashing its op is a real miss; one that throws on the addr-0 readback after stashing is fine).
+    # UP_FRONT_LOG_SWALLOWED=1: per-body trace of throw + ops-stashed-before-throw (a throw BEFORE
+    # stashing is a real miss; one on the addr-0 readback after stashing is fine).
     _log = os.environ.get("UP_FRONT_LOG_SWALLOWED")
     n_before = ttnn.graph.up_front_num_collected() if _log else 0
     swallowed = False
@@ -422,11 +377,10 @@ def pytest_runtest_call(item):
     ttnn.graph.up_front_begin_collect(clear=False, real_alloc=_REAL_ALLOC)  # accumulate; wraps ONLY the body
     try:
         with _collect_window(_STATS):
-            return (yield)  # body runs with the active collect-time patches; ttnn ops still stash
+            return (yield)  # ops stash into the collector as the body runs
     except Exception as e:
-        # Expected under NO_DISPATCH: a readback/assert on an addr-0 output. The
-        # program was already stashed by the funnel before the failure. Swallow so
-        # pass 1 stays green (its results are meaningless — pass 2 is the real run).
+        # Expected under NO_DISPATCH: a readback/assert on an addr-0 output, after the program was
+        # already stashed. Swallow so pass 1 stays green (its results are meaningless).
         _STATS.swallowed += 1
         swallowed = True
         exc_info = f"{type(e).__name__}: {str(e)[:140]}"
@@ -445,7 +399,7 @@ def pytest_runtest_call(item):
 def pytest_sessionstart(session):
     import ttnn
 
-    ttnn.graph.up_front_clear()  # clean slate before accumulating across the session
+    ttnn.graph.up_front_clear()  # clean slate before the session
 
 
 def pytest_sessionfinish(session, exitstatus):

--- a/tests/plugins/up_front_collect.py
+++ b/tests/plugins/up_front_collect.py
@@ -174,6 +174,7 @@ def _reference_op_patches():
     import torch.nn.functional as F
 
     real_matmul = torch.matmul
+    real_sdpa = getattr(F, "scaled_dot_product_attention", None)
 
     def _fast_randn(*size, **kw):
         if len(size) == 1 and isinstance(size[0], (tuple, list, torch.Size)):
@@ -181,22 +182,23 @@ def _reference_op_patches():
         kw.pop("generator", None)
         return torch.zeros(*size, **kw)
 
-    def _pair(x):
-        return (x, x) if isinstance(x, int) else x
+    def _ntuple(n, x):
+        return tuple(x) if isinstance(x, (tuple, list)) else (x,) * n
+
+    def _fast_conv(input, weight, stride, padding, dilation, n):
+        # n-D conv: out = (in + 2p - d(k-1) - 1)//s + 1 per spatial dim. Output (N, C_out, *spatial).
+        s, p, d = _ntuple(n, stride), _ntuple(n, padding), _ntuple(n, dilation)
+        spatial = [(input.shape[i - n] + 2 * p[i] - d[i] * (weight.shape[i - n] - 1) - 1) // s[i] + 1 for i in range(n)]
+        return input.new_zeros((input.shape[0], weight.shape[0], *spatial))
 
     def _fast_conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
-        sH, sW = _pair(stride)
-        pH, pW = _pair(padding)
-        dH, dW = _pair(dilation)
-        N, C_out = input.shape[0], weight.shape[0]
-        H, W = input.shape[-2], input.shape[-1]
-        kH, kW = weight.shape[-2], weight.shape[-1]
-        H_out = (H + 2 * pH - dH * (kH - 1) - 1) // sH + 1
-        W_out = (W + 2 * pW - dW * (kW - 1) - 1) // sW + 1
-        return input.new_zeros((N, C_out, H_out, W_out))
+        return _fast_conv(input, weight, stride, padding, dilation, 2)
 
-    def _fast_layer_norm(input, *a, **k):
-        return torch.zeros_like(input)  # layer_norm / rms_norm output shape == input shape
+    def _fast_conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
+        return _fast_conv(input, weight, stride, padding, dilation, 3)
+
+    def _fast_norm(input, *a, **k):
+        return torch.zeros_like(input)  # layer_norm / rms_norm / group_norm output shape == input shape
 
     def _fast_matmul(a, b):
         # Shape via meta inference (no data, broadcasting stays exact); no GEMM compute.
@@ -212,16 +214,30 @@ def _reference_op_patches():
     def _fast_tensor_matmul(self, other):
         return _fast_matmul(self, other)
 
-    return [
+    def _fast_sdpa(query, key, value, *a, **k):
+        # Output = (*query.shape[:-1], value.shape[-1]) for EVERY variant — MHA / MQA / GQA, causal,
+        # masked: query's batch/heads/seq are kept, only the head dim becomes value's. mask / scale /
+        # dropout / is_causal don't change shape. Fall back to the real op if the rule ever doesn't fit.
+        try:
+            return torch.zeros((*query.shape[:-1], value.shape[-1]), dtype=query.dtype, device=query.device)
+        except Exception:
+            return real_sdpa(query, key, value, *a, **k)
+
+    patches = [
         _AttrPatch(torch, "randn", lambda _orig: _fast_randn),
         _AttrPatch(torch, "rand", lambda _orig: _fast_randn),
         _AttrPatch(F, "conv2d", lambda _orig: _fast_conv2d),
-        _AttrPatch(F, "layer_norm", lambda _orig: _fast_layer_norm),
+        _AttrPatch(F, "conv3d", lambda _orig: _fast_conv3d),
+        _AttrPatch(F, "layer_norm", lambda _orig: _fast_norm),
+        _AttrPatch(F, "group_norm", lambda _orig: _fast_norm),
         _AttrPatch(torch, "matmul", lambda _orig: _fast_matmul),
         _AttrPatch(torch, "bmm", lambda _orig: _fast_bmm),
         _AttrPatch(torch.Tensor, "matmul", lambda _orig: _fast_tensor_matmul),
         _AttrPatch(torch.Tensor, "__matmul__", lambda _orig: _fast_tensor_matmul),
     ]
+    if real_sdpa is not None:  # added in torch 2.0; guard so loading never fails on older torch
+        patches.append(_AttrPatch(F, "scaled_dot_product_attention", lambda _orig: _fast_sdpa))
+    return patches
 
 
 def _verifier_patches():

--- a/tests/plugins/up_front_collect.py
+++ b/tests/plugins/up_front_collect.py
@@ -38,13 +38,19 @@ Limitations:
     we capture the ops before that point; the rest cold-compile in pass 2.
   * Ops that pick their program from live allocator state see empty L1 under
     NO_DISPATCH and may collect a different variant than the real run uses.
+
+Collect-time substitutions are all expressed as one of two reversible primitives
+(_AttrPatch / _RebindPatch), grouped into declarative sets (reference ops, verifiers,
+boundary) and entered together under a single ExitStack — see _collect_window.
 """
 
 from __future__ import annotations
 
 import contextlib
+import dataclasses
 import inspect
 import os
+import sys
 
 import pytest
 
@@ -82,8 +88,20 @@ _CAPTURE_MARKERS = (
     "begin_mesh_trace_capture",
 )
 
-_stats = {"bodies": 0, "swallowed": 0, "skipped_capture": 0}
-_fast_stats = {"shallow": 0, "fallback": 0}
+
+@dataclasses.dataclass
+class CollectStats:
+    """Session counters printed at the end. `bodies/swallowed/skipped_capture` are hook-level;
+    `shallow/fallback` count the shape-only boundary's hits vs real-path fallbacks."""
+
+    bodies: int = 0
+    swallowed: int = 0
+    skipped_capture: int = 0
+    shallow: int = 0
+    fallback: int = 0
+
+
+_STATS = CollectStats()
 
 
 def _torch_to_ttnn_dtype(torch_dtype):
@@ -103,173 +121,96 @@ def _torch_to_ttnn_dtype(torch_dtype):
     }.get(torch_dtype, ttnn.bfloat16)
 
 
-@contextlib.contextmanager
-def _shape_only_boundary(stats):
-    """Patch the ttnn<->torch boundary to allocate device tensors SHAPE-ONLY during collect.
+# ---------------------------------------------------------------------------
+# Patch primitives. Every collect-time substitution is one of these two,
+# entered together under a single ExitStack (see _collect_window) so each has
+# uniform, automatic restore instead of a hand-rolled try/finally.
+# ---------------------------------------------------------------------------
 
-    Program build needs only the spec, so ttnn.from_torch and torch2tt_tensor (incl. their
-    `from ... import` bindings) skip the host tilize/convert/copy — the dominant collect cost on
-    weight-heavy bodies. Falls back to the real path for anything not safely shape-only
-    (mesh_mapper, custom tile, host tensors, meta tensors). `stats` gets shallow/fallback counts.
+
+class _AttrPatch:
+    """Reversibly replace ``obj.attr`` with ``build(original)`` for the collect window.
+
+    For callables reached by attribute access on a stable object — e.g. ``torch.randn``,
+    ``ttnn.from_torch``, ``torch.Tensor.__matmul__``. ``build`` receives the original (some
+    replacements wrap it; reference stand-ins ignore it).
     """
-    import sys
 
-    import ttnn
+    def __init__(self, obj, attr, build):
+        self._obj, self._attr, self._build = obj, attr, build
 
-    real_from_torch = ttnn.from_torch
+    def __enter__(self):
+        self._orig = getattr(self._obj, self._attr)
+        setattr(self._obj, self._attr, self._build(self._orig))
+        return self
 
-    def _shallow_from_torch(
-        tensor,
-        dtype=None,
-        *,
-        spec=None,
-        tile=None,
-        layout=None,
-        device=None,
-        memory_config=None,
-        mesh_mapper=None,
-        **kw,
-    ):
-        if (
-            tensor is not None
-            and device is not None
-            and mesh_mapper is None
-            and tile is None
-            and not getattr(tensor, "is_meta", False)
-        ):
-            try:
-                if spec is not None:
-                    dt, lay, mc = spec.dtype, spec.layout, spec.memory_config
-                    shp = ttnn.Shape(tuple(spec.shape))
-                else:
-                    dt = dtype or _torch_to_ttnn_dtype(tensor.dtype)
-                    lay = layout or ttnn.ROW_MAJOR_LAYOUT
-                    mc = memory_config or ttnn.DRAM_MEMORY_CONFIG
-                    shp = ttnn.Shape(tuple(tensor.shape))
-                t = ttnn.allocate_tensor_on_device(shp, dt, lay, device, mc)
-                stats["shallow"] += 1
-                return t
-            except Exception:
-                stats["fallback"] += 1
-        return real_from_torch(
-            tensor,
-            dtype,
-            spec=spec,
-            tile=tile,
-            layout=layout,
-            device=device,
-            memory_config=memory_config,
-            mesh_mapper=mesh_mapper,
-            **kw,
-        )
+    def __exit__(self, *exc):
+        setattr(self._obj, self._attr, self._orig)
+        return False
 
-    # torch2tt_tensor builds device tensors outside from_torch (ttnn.Tensor(t).to(...)); same lever.
-    t2tt_modules = []
-    _ucf = sys.modules.get("models.common.utility_functions")
-    real_t2tt = getattr(_ucf, "torch2tt_tensor", None) if _ucf is not None else None
-    if real_t2tt is not None:
-        _interleaved_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED)
 
-        def _shallow_torch2tt(
-            py_tensor, tt_device, tt_layout=ttnn.TILE_LAYOUT, tt_memory_config=_interleaved_mc, tt_dtype=ttnn.bfloat16
-        ):
-            if tt_device is not None and not getattr(py_tensor, "is_meta", False):
-                try:
-                    size = list(py_tensor.size())
-                    while len(size) < 4:
-                        size.insert(0, 1)
-                    t = ttnn.allocate_tensor_on_device(
-                        ttnn.Shape(tuple(size)), tt_dtype, tt_layout, tt_device, tt_memory_config
-                    )
-                    stats["shallow"] += 1
-                    return t
-                except Exception:
-                    stats["fallback"] += 1
-            return real_t2tt(py_tensor, tt_device, tt_layout, tt_memory_config, tt_dtype)
+class _RebindPatch:
+    """Reversibly rebind EVERY module attribute that ``is`` ``home_module.attr`` to ``build(original)``.
 
+    Needed for helpers pulled into test modules via ``from x import y`` — patching the home module
+    alone wouldn't reach those local copies, so we rebind every reference. No-op if the home module
+    isn't imported or lacks the attribute. All matches share one original, so restore is to that.
+    """
+
+    def __init__(self, home_module, attr, build):
+        self._home_module, self._attr, self._build = home_module, attr, build
+        self._orig = None
+        self._patched = []
+
+    def __enter__(self):
+        home = sys.modules.get(self._home_module)
+        self._orig = getattr(home, self._attr, None) if home is not None else None
+        if self._orig is None:
+            return self
+        replacement = self._build(self._orig)
         for m in list(sys.modules.values()):
             try:
-                if getattr(m, "torch2tt_tensor", None) is real_t2tt:
-                    t2tt_modules.append(m)
-                    m.torch2tt_tensor = _shallow_torch2tt
+                if getattr(m, self._attr, None) is self._orig:
+                    self._patched.append(m)
+                    setattr(m, self._attr, replacement)
             except Exception:
                 pass
+        return self
 
-    ttnn.from_torch = _shallow_from_torch
-    try:
-        yield
-    finally:
-        ttnn.from_torch = real_from_torch
-        for m in t2tt_modules:
-            m.torch2tt_tensor = real_t2tt
-
-
-@contextlib.contextmanager
-def _stub_verifiers():
-    """Fuse off the host-side numeric verifiers during collect (results are meaningless anyway).
-
-    comp_pcc -> (True, ~1) and assert_numeric_metrics -> pass: a verifier failing on addr-0/zeros
-    readback aborts the rest of a multi-op body, losing its ops. Both helpers may also be bound via
-    `from ... import` in test modules, so patch every module attr pointing at the original.
-    """
-    import sys
-
-    saved = []  # (module, attr, original)
-    targets = {}
-    for src, attr, stub in (
-        ("tests.ttnn.utils_for_testing", "comp_pcc", lambda *a, **k: (True, 0.999999)),
-        ("models.common.utility_functions", "comp_pcc", lambda *a, **k: (True, 0.999999)),
-        ("tests.ttnn.utils_for_testing", "assert_numeric_metrics", lambda *a, **k: (True, "collect-stub")),
-    ):
-        mod = sys.modules.get(src)
-        orig = getattr(mod, attr, None) if mod is not None else None
-        if orig is not None:
-            targets[(attr, orig)] = stub
-    for (attr, orig), stub in targets.items():
-        for m in list(sys.modules.values()):
-            try:
-                if getattr(m, attr, None) is orig:
-                    saved.append((m, attr, orig))
-                    setattr(m, attr, stub)
-            except Exception:
-                pass
-    try:
-        yield
-    finally:
-        for m, attr, orig in saved:
-            setattr(m, attr, orig)
-
-
-def _drives_capture(item) -> bool:
-    fn = getattr(item, "function", None)
-    if fn is None:
+    def __exit__(self, *exc):
+        for m in self._patched:
+            setattr(m, self._attr, self._orig)
         return False
+
+
+def _try_shallow(stats, alloc):
+    """Run a shape-only ttnn allocation, tallying shallow vs fallback. Returns the allocated
+    tensor, or None if it raised — in which case the caller falls back to the real ttnn path."""
     try:
-        src = inspect.getsource(fn)
-    except (OSError, TypeError):
-        return False
-    return any(m in src for m in _CAPTURE_MARKERS)
+        t = alloc()
+        stats.shallow += 1
+        return t
+    except Exception:
+        stats.fallback += 1
+        return None
 
 
-@contextlib.contextmanager
-def _cheap_host_ops():
-    """Swap expensive host-side torch work for cheap shape-correct stand-ins during collect.
+# ---------------------------------------------------------------------------
+# Declarative patch sets, built lazily so torch/ttnn imports stay deferred.
+# ---------------------------------------------------------------------------
 
-    Only ttnn op shapes/config determine the collected programs, so zeroing the inputs, the
-    torch reference conv, and the PCC check does not change WHAT is collected — it just removes
-    the wasted golden-reference + PCC + RNG cost from the throwaway collect pass.
+
+def _reference_op_patches():
+    """Host reference compute -> cheap shape-correct stand-ins.
+
+    Under NO_DISPATCH the values are thrown away and the collected programs depend only on ttnn op
+    shapes/config, so zeroing the inputs / torch reference conv / matmul / layer_norm does not change
+    WHAT is collected — it just drops the wasted golden-reference + RNG cost. ttnn ops are untouched.
     """
     import torch
     import torch.nn.functional as F
 
-    real_randn = torch.randn
-    real_rand = torch.rand
-    real_conv2d = F.conv2d
-    real_layer_norm = F.layer_norm
     real_matmul = torch.matmul
-    real_bmm = torch.bmm
-    real_tensor_matmul = torch.Tensor.matmul
-    real_tensor_rmatmul = torch.Tensor.__matmul__
 
     def _fast_randn(*size, **kw):
         if len(size) == 1 and isinstance(size[0], (tuple, list, torch.Size)):
@@ -304,27 +245,166 @@ def _cheap_host_ops():
         except Exception:
             return real_matmul(a, b)
 
-    torch.randn = _fast_randn
-    torch.rand = _fast_randn
-    F.conv2d = _fast_conv2d
-    F.layer_norm = _fast_layer_norm
-    torch.matmul = _fast_matmul
-    torch.bmm = lambda a, b, *x, **k: _fast_matmul(a, b)
-    torch.Tensor.matmul = lambda self, other: _fast_matmul(self, other)
-    torch.Tensor.__matmul__ = lambda self, other: _fast_matmul(self, other)
-    boundary = _shape_only_boundary(_fast_stats) if _FAST_SHALLOW else contextlib.nullcontext()
+    def _fast_bmm(a, b, *x, **k):
+        return _fast_matmul(a, b)
+
+    def _fast_tensor_matmul(self, other):
+        return _fast_matmul(self, other)
+
+    return [
+        _AttrPatch(torch, "randn", lambda _orig: _fast_randn),
+        _AttrPatch(torch, "rand", lambda _orig: _fast_randn),
+        _AttrPatch(F, "conv2d", lambda _orig: _fast_conv2d),
+        _AttrPatch(F, "layer_norm", lambda _orig: _fast_layer_norm),
+        _AttrPatch(torch, "matmul", lambda _orig: _fast_matmul),
+        _AttrPatch(torch, "bmm", lambda _orig: _fast_bmm),
+        _AttrPatch(torch.Tensor, "matmul", lambda _orig: _fast_tensor_matmul),
+        _AttrPatch(torch.Tensor, "__matmul__", lambda _orig: _fast_tensor_matmul),
+    ]
+
+
+def _verifier_patches():
+    """Host numeric verifiers -> no-ops.
+
+    A verifier failing on the addr-0/zeros readback aborts the rest of a multi-op body and loses its
+    ops; results are meaningless under NO_DISPATCH anyway. Rebound across modules because tests pull
+    these in via ``from ... import``. comp_pcc has two possible homes; either (or both) is covered.
+    """
+
+    def _pcc(*a, **k):
+        return (True, 0.999999)
+
+    def _assert_numeric_metrics(*a, **k):
+        return (True, "collect-stub")
+
+    return [
+        _RebindPatch("tests.ttnn.utils_for_testing", "comp_pcc", lambda _orig: _pcc),
+        _RebindPatch("models.common.utility_functions", "comp_pcc", lambda _orig: _pcc),
+        _RebindPatch("tests.ttnn.utils_for_testing", "assert_numeric_metrics", lambda _orig: _assert_numeric_metrics),
+    ]
+
+
+def _boundary_patches(stats):
+    """ttnn<->torch boundary -> SHAPE-ONLY device allocation.
+
+    Program build needs only the spec, so ttnn.from_torch and torch2tt_tensor skip the host
+    tilize/convert/copy (the dominant collect cost on weight-heavy bodies). Anything not safely
+    shape-only (mesh_mapper, custom tile, host/meta tensors) falls back to the real path.
+    """
+    import ttnn
+
+    def _build_from_torch(real_from_torch):
+        def _shallow_from_torch(
+            tensor,
+            dtype=None,
+            *,
+            spec=None,
+            tile=None,
+            layout=None,
+            device=None,
+            memory_config=None,
+            mesh_mapper=None,
+            **kw,
+        ):
+            if (
+                tensor is not None
+                and device is not None
+                and mesh_mapper is None
+                and tile is None
+                and not getattr(tensor, "is_meta", False)
+            ):
+
+                def _alloc():
+                    if spec is not None:
+                        dt, lay, mc = spec.dtype, spec.layout, spec.memory_config
+                        shp = ttnn.Shape(tuple(spec.shape))
+                    else:
+                        dt = dtype or _torch_to_ttnn_dtype(tensor.dtype)
+                        lay = layout or ttnn.ROW_MAJOR_LAYOUT
+                        mc = memory_config or ttnn.DRAM_MEMORY_CONFIG
+                        shp = ttnn.Shape(tuple(tensor.shape))
+                    return ttnn.allocate_tensor_on_device(shp, dt, lay, device, mc)
+
+                t = _try_shallow(stats, _alloc)
+                if t is not None:
+                    return t
+            return real_from_torch(
+                tensor,
+                dtype,
+                spec=spec,
+                tile=tile,
+                layout=layout,
+                device=device,
+                memory_config=memory_config,
+                mesh_mapper=mesh_mapper,
+                **kw,
+            )
+
+        return _shallow_from_torch
+
+    def _build_torch2tt(real_t2tt):
+        # torch2tt_tensor builds device tensors outside from_torch (ttnn.Tensor(t).to(...)); same lever.
+        interleaved_mc = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED)
+
+        def _shallow_torch2tt(
+            py_tensor, tt_device, tt_layout=ttnn.TILE_LAYOUT, tt_memory_config=interleaved_mc, tt_dtype=ttnn.bfloat16
+        ):
+            if tt_device is not None and not getattr(py_tensor, "is_meta", False):
+
+                def _alloc():
+                    size = list(py_tensor.size())
+                    while len(size) < 4:
+                        size.insert(0, 1)
+                    return ttnn.allocate_tensor_on_device(
+                        ttnn.Shape(tuple(size)), tt_dtype, tt_layout, tt_device, tt_memory_config
+                    )
+
+                t = _try_shallow(stats, _alloc)
+                if t is not None:
+                    return t
+            return real_t2tt(py_tensor, tt_device, tt_layout, tt_memory_config, tt_dtype)
+
+        return _shallow_torch2tt
+
+    return [
+        _AttrPatch(ttnn, "from_torch", _build_from_torch),
+        _RebindPatch("models.common.utility_functions", "torch2tt_tensor", _build_torch2tt),
+    ]
+
+
+def _collect_patches(stats):
+    """The patch set active during the collect window, gated by the fast / shallow flags."""
+    patches = []
+    if _FAST_COLLECT:
+        patches += _reference_op_patches()
+        patches += _verifier_patches()
+        if _FAST_SHALLOW:
+            patches += _boundary_patches(stats)
+    return patches
+
+
+@contextlib.contextmanager
+def _collect_window(stats):
+    """Enter every active patch under one ExitStack, run the body, restore all on exit (LIFO).
+
+    With no active patches (UP_FRONT_FAST_COLLECT=0) this is a transparent pass-through, so the body
+    runs with real torch.
+    """
+    with contextlib.ExitStack() as stack:
+        for patch in _collect_patches(stats):
+            stack.enter_context(patch)
+        yield
+
+
+def _drives_capture(item) -> bool:
+    fn = getattr(item, "function", None)
+    if fn is None:
+        return False
     try:
-        with boundary, _stub_verifiers():
-            yield
-    finally:
-        torch.randn = real_randn
-        torch.rand = real_rand
-        F.conv2d = real_conv2d
-        F.layer_norm = real_layer_norm
-        torch.matmul = real_matmul
-        torch.bmm = real_bmm
-        torch.Tensor.matmul = real_tensor_matmul
-        torch.Tensor.__matmul__ = real_tensor_rmatmul
+        src = inspect.getsource(fn)
+    except (OSError, TypeError):
+        return False
+    return any(m in src for m in _CAPTURE_MARKERS)
 
 
 @pytest.hookimpl(wrapper=True)
@@ -336,10 +416,10 @@ def pytest_runtest_call(item):
     import ttnn
 
     if _drives_capture(item):
-        _stats["skipped_capture"] += 1
+        _STATS.skipped_capture += 1
         return (yield)  # let it run normally; it cold-compiles in pass 2
 
-    _stats["bodies"] += 1
+    _STATS.bodies += 1
     # UP_FRONT_LOG_SWALLOWED=1: per-body diagnostic — which tests threw under NO_DISPATCH and
     # how many ops each stashed before the throw (reveals coverage: a body that throws BEFORE
     # stashing its op is a real miss; one that throws on the addr-0 readback after stashing is fine).
@@ -349,15 +429,13 @@ def pytest_runtest_call(item):
     exc_info = ""
     ttnn.graph.up_front_begin_collect(clear=False, real_alloc=_REAL_ALLOC)  # accumulate; wraps ONLY the body
     try:
-        if _FAST_COLLECT:
-            with _cheap_host_ops():
-                return (yield)  # body runs with cheap host stand-ins; ttnn ops still stash
-        return (yield)  # pytest runs the body with its real fixtures; ops stash into the collector
+        with _collect_window(_STATS):
+            return (yield)  # body runs with the active collect-time patches; ttnn ops still stash
     except Exception as e:
         # Expected under NO_DISPATCH: a readback/assert on an addr-0 output. The
         # program was already stashed by the funnel before the failure. Swallow so
         # pass 1 stays green (its results are meaningless — pass 2 is the real run).
-        _stats["swallowed"] += 1
+        _STATS.swallowed += 1
         swallowed = True
         exc_info = f"{type(e).__name__}: {str(e)[:140]}"
         return None
@@ -388,15 +466,14 @@ def pytest_sessionfinish(session, exitstatus):
     n_unique = ttnn.graph.up_front_num_unique()
     n_collected = ttnn.graph.up_front_num_collected()
     print(
-        f"\nUP_FRONT_COLLECT: {n_collected} ops stashed across {_stats['bodies']} bodies "
+        f"\nUP_FRONT_COLLECT: {n_collected} ops stashed across {_STATS.bodies} bodies "
         f"-> {n_unique} unique programs "
-        f"(swallowed {_stats['swallowed']}, skipped-capture {_stats['skipped_capture']})",
+        f"(swallowed {_STATS.swallowed}, skipped-capture {_STATS.skipped_capture})",
         flush=True,
     )
     if _FAST_COLLECT and _FAST_SHALLOW:
         print(
-            f"UP_FRONT_COLLECT: fast-shallow from_torch — shape-only={_fast_stats['shallow']} "
-            f"fallback={_fast_stats['fallback']}",
+            f"UP_FRONT_COLLECT: fast-shallow from_torch — shape-only={_STATS.shallow} " f"fallback={_STATS.fallback}",
             flush=True,
         )
     if n_unique == 0:

--- a/tests/ttnn/unit_tests/test_up_front_compile.py
+++ b/tests/ttnn/unit_tests/test_up_front_compile.py
@@ -1,0 +1,146 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Smoke test + usage example for up-front parallel precompile.
+
+The flow (op-agnostic — works for any model whose ops dispatch through the
+device-op adapter, i.e. generic_op and every C++ ProgramDescriptor-migrated op):
+
+    ttnn.graph.up_front_begin_collect()        # NO_DISPATCH: nothing runs on HW;
+    model(dummy_input, device)                 #   each op stashes its program
+    ttnn.graph.up_front_end_collect()
+    ttnn.graph.up_front_compile(device, 4)     # parallel JIT -> warm on-disk cache
+    out = model(real_input, device)            # now runs warm
+
+For a real model (e.g. ResNet-50, models/demos/.../resnet50) the body in the
+collect block is the model's forward; everything else is identical. Run on a
+COLD program cache so every op is a cache miss (reaches the collector).
+"""
+
+import torch
+
+import ttnn
+
+
+def _chain(x):
+    """A tiny multi-op graph -> a few distinct programs.
+
+    c = (exp(x) + x) * exp(x)
+    """
+    a = ttnn.exp(x)
+    b = ttnn.add(a, x)
+    c = ttnn.multiply(b, a)
+    return c
+
+
+def test_up_front_compile(device):
+    torch.manual_seed(0)
+    t = torch.randn(1, 1, 64, 64, dtype=torch.bfloat16)
+    x = ttnn.from_torch(t, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+    # The collector is a process-wide singleton — clear it so this test is independent
+    # of whatever ran before it.
+    ttnn.graph.up_front_clear()
+
+    # Collect on a cold cache: run the graph in NO_DISPATCH; each op stashes its
+    # built-but-uncompiled program. Nothing executes on hardware here.
+    ttnn.graph.up_front_begin_collect()
+    try:
+        _chain(x)
+    finally:
+        ttnn.graph.up_front_end_collect()
+
+    n_collected = ttnn.graph.up_front_num_collected()
+    n_unique = ttnn.graph.up_front_num_unique()
+    print(f"\nup_front: collected {n_collected} ops, {n_unique} unique programs")
+    # The 3-op chain should have routed at least one op through the collector.
+    assert n_collected >= 1, "collect captured no programs — did the ops go through the device-op funnel?"
+    assert n_unique >= 1
+
+    # Parallel compile -> warms the on-disk kernel cache. Must report zero errors.
+    num_programs, num_errors, workers, wall = ttnn.graph.up_front_compile(device, 4)
+    print(f"up_front: compiled {num_programs} programs in {wall:.2f}s (workers={workers}, errors={num_errors})")
+    assert num_errors == 0, "parallel compile reported errors"
+
+    # The real run is now warm and must still be numerically correct. Use PCC
+    # (the idiomatic ttnn metric) — bf16 has ~3 sig figs, so allclose on the
+    # large magnitudes this chain produces is the wrong check.
+    out = _chain(x)
+    got = ttnn.to_torch(out).float().flatten()
+
+    a = torch.exp(t.float())
+    expected = ((a + t.float()) * a).flatten()
+    pcc = torch.corrcoef(torch.stack([got, expected]))[0, 1].item()
+    print(f"up_front: warm-run PCC vs torch reference = {pcc:.6f}")
+    assert pcc > 0.999, f"warm run incorrect: PCC {pcc}"
+
+
+def test_up_front_collect_mechanics(device):
+    """Lock down the collector invariants the feature depends on, independent of
+    timing or kernel-cache state: clear, stash/dedup accounting, compile↔unique
+    parity, post-compile reset, and empty-compile safety.
+
+    These are relational (no magic op counts) so they don't go stale if op→program
+    decomposition changes; the point is the plumbing, not the exact numbers.
+    """
+    torch.manual_seed(0)
+    t = torch.randn(1, 1, 64, 64, dtype=torch.bfloat16)
+    x = ttnn.from_torch(t, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+    # clear() empties the collector.
+    ttnn.graph.up_front_clear()
+    assert ttnn.graph.up_front_num_collected() == 0
+    assert ttnn.graph.up_front_num_unique() == 0
+
+    # A collect pass stashes a program per dispatched op; the deduped unique set is
+    # non-empty and never larger than the total stashed.
+    ttnn.graph.up_front_begin_collect()
+    try:
+        _chain(x)
+    finally:
+        ttnn.graph.up_front_end_collect()
+    collected = ttnn.graph.up_front_num_collected()
+    unique = ttnn.graph.up_front_num_unique()
+    assert collected >= 1, "collect captured nothing — ops didn't reach the device-op funnel"
+    assert 1 <= unique <= collected
+
+    # compile() JIT-builds exactly the deduped unique set, error-free, then resets the
+    # collector. If compile silently skipped programs this parity check would catch it.
+    num_programs, num_errors, _, _ = ttnn.graph.up_front_compile(device, 4)
+    assert num_errors == 0, "parallel compile reported errors"
+    assert num_programs == unique, f"compiled {num_programs} programs, expected the {unique} unique collected"
+    assert ttnn.graph.up_front_num_collected() == 0, "compile() should clear the collector"
+
+    # Compiling an empty collector is a no-op, not an error.
+    n, e, _, _ = ttnn.graph.up_front_compile(device, 4)
+    assert (n, e) == (0, 0), f"empty compile should be a no-op, got ({n}, {e})"
+
+
+def test_up_front_collect_accumulates(device):
+    """clear=False accumulates across collect passes — the pytest-plugin usage where
+    many test bodies feed one deduped set compiled once at the end."""
+    torch.manual_seed(0)
+    t = torch.randn(1, 1, 64, 64, dtype=torch.bfloat16)
+    x = ttnn.from_torch(t, layout=ttnn.TILE_LAYOUT, device=device, dtype=ttnn.bfloat16)
+
+    ttnn.graph.up_front_clear()
+
+    ttnn.graph.up_front_begin_collect(clear=False)
+    try:
+        _chain(x)
+    finally:
+        ttnn.graph.up_front_end_collect()
+    after_first = ttnn.graph.up_front_num_collected()
+
+    ttnn.graph.up_front_begin_collect(clear=False)
+    try:
+        _chain(x)
+    finally:
+        ttnn.graph.up_front_end_collect()
+    after_second = ttnn.graph.up_front_num_collected()
+
+    assert after_first >= 1
+    assert after_second > after_first, "clear=False should accumulate, not reset, across passes"
+    assert ttnn.graph.up_front_num_unique() <= after_second
+    ttnn.graph.up_front_clear()

--- a/tests/ttnn/unit_tests/test_up_front_compile.py
+++ b/tests/ttnn/unit_tests/test_up_front_compile.py
@@ -22,6 +22,9 @@ import torch
 
 import ttnn
 
+# Worker count for the parallel JIT compile. Hoisted so the tests share one value.
+_WORKERS = 4
+
 
 def _chain(x):
     """A tiny multi-op graph -> a few distinct programs.
@@ -59,7 +62,7 @@ def test_up_front_compile(device):
     assert n_unique >= 1
 
     # Parallel compile -> warms the on-disk kernel cache. Must report zero errors.
-    num_programs, num_errors, workers, wall = ttnn.graph.up_front_compile(device, 4)
+    num_programs, num_errors, workers, wall = ttnn.graph.up_front_compile(device, _WORKERS)
     print(f"up_front: compiled {num_programs} programs in {wall:.2f}s (workers={workers}, errors={num_errors})")
     assert num_errors == 0, "parallel compile reported errors"
 
@@ -107,13 +110,13 @@ def test_up_front_collect_mechanics(device):
 
     # compile() JIT-builds exactly the deduped unique set, error-free, then resets the
     # collector. If compile silently skipped programs this parity check would catch it.
-    num_programs, num_errors, _, _ = ttnn.graph.up_front_compile(device, 4)
+    num_programs, num_errors, _, _ = ttnn.graph.up_front_compile(device, _WORKERS)
     assert num_errors == 0, "parallel compile reported errors"
     assert num_programs == unique, f"compiled {num_programs} programs, expected the {unique} unique collected"
     assert ttnn.graph.up_front_num_collected() == 0, "compile() should clear the collector"
 
     # Compiling an empty collector is a no-op, not an error.
-    n, e, _, _ = ttnn.graph.up_front_compile(device, 4)
+    n, e, _, _ = ttnn.graph.up_front_compile(device, _WORKERS)
     assert (n, e) == (0, 0), f"empty compile should be a no-op, got ({n}, {e})"
 
 

--- a/tests/ttnn/unit_tests/test_up_front_compile_ccl.py
+++ b/tests/ttnn/unit_tests/test_up_front_compile_ccl.py
@@ -1,0 +1,105 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Up-front precompile on a CCL op (all_gather_async) across a multi-device mesh.
+
+A CCL op builds a MeshWorkload with multiple programs per device, unlike the
+homogeneous single-program mesh case. This drives all_gather_async through
+collect -> parallel compile -> warm run to confirm up-front precompile captures
+and warms the CCL program set, and that the warm run is correct.
+
+Needs fabric; parametrized for a 1x2 mesh (skips on fewer devices). Internal
+hardware test (mesh CCL goes over fabric / eth) — run under the device lock:
+    scripts/run_safe_pytest.sh tests/ttnn/unit_tests/test_up_front_compile_ccl.py
+"""
+
+import pytest
+import torch
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+OUTPUT_SHAPE = [1, 1, 32, 256]
+GATHER_DIM = 3
+NUM_LINKS = 1
+
+
+def _shard_input(mesh_device, num_devices, full):
+    """Shard `full` along GATHER_DIM across the mesh — the all_gather input."""
+    return ttnn.from_torch(
+        full,
+        device=mesh_device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.create_mesh_mapper(
+            mesh_device,
+            ttnn.MeshMapperConfig(
+                [ttnn.PlacementReplicate(), ttnn.PlacementShard(GATHER_DIM)], ttnn.MeshShape(1, num_devices)
+            ),
+        ),
+    )
+
+
+@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(1, 2)], indirect=True)
+def test_all_gather_up_front_compile(mesh_device):
+    num_devices = mesh_device.get_num_devices()
+
+    # CCL needs a worker sub-device + global semaphores.
+    grid = mesh_device.compute_with_storage_grid_size()
+    ccl_crs = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid.x - 1, grid.y - 1))})
+    worker_sub_device = ttnn.SubDevice([ccl_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+
+    # Two semaphores per all_gather_async call: one pair for the collect-build, one for the warm run.
+    sems = [ttnn.create_global_semaphore(mesh_device, ccl_crs, 0) for _ in range(4)]
+
+    torch.manual_seed(0)
+    full = torch.rand(OUTPUT_SHAPE).bfloat16()
+
+    def all_gather(inp, s0, s1):
+        return ttnn.experimental.all_gather_async(
+            inp,
+            GATHER_DIM,
+            multi_device_global_semaphore=[s0, s1],
+            num_links=NUM_LINKS,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            topology=ttnn.Topology.Linear,
+            subdevice_id=worker_sub_device_id,
+        )
+
+    # Collect (NO_DISPATCH): capture the all_gather MeshWorkload (multi-program per device).
+    ttnn.graph.up_front_clear()
+    ttnn.graph.up_front_begin_collect()
+    try:
+        all_gather(_shard_input(mesh_device, num_devices, full), sems[0], sems[1])
+    finally:
+        ttnn.graph.up_front_end_collect()
+    n_unique = ttnn.graph.up_front_num_unique()
+    print(f"\nCCL collect: {ttnn.graph.up_front_num_collected()} ops -> {n_unique} unique programs")
+    assert ttnn.graph.up_front_num_collected() >= 1, "collect captured no CCL programs"
+
+    # Parallel compile warms the cache, error-free. A CCL op's MeshWorkload holds multiple
+    # programs (sender/receiver), so compile builds >= the unique workload count — unlike a
+    # homogeneous op where one program covers the whole mesh.
+    num_programs, num_errors, _, wall = ttnn.graph.up_front_compile(mesh_device, 4)
+    print(
+        f"CCL parallel compile: {num_programs} programs in {wall:.2f}s (errors={num_errors}, unique workloads={n_unique})"
+    )
+    assert num_errors == 0, "parallel compile reported errors"
+    assert num_programs >= n_unique >= 1, f"expected >= {n_unique} programs compiled, got {num_programs}"
+
+    # Warm run + correctness: all_gather reconstructs the full tensor on every device.
+    out = all_gather(_shard_input(mesh_device, num_devices, full), sems[2], sems[3])
+    ttnn.synchronize_device(mesh_device, sub_device_ids=[worker_sub_device_id])
+
+    for t in ttnn.get_device_tensors(out):
+        got = t.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+        assert_with_pcc(full, got, 0.99)
+
+    mesh_device.reset_sub_device_stall_group()

--- a/tests/ttnn/unit_tests/test_up_front_compile_ccl.py
+++ b/tests/ttnn/unit_tests/test_up_front_compile_ccl.py
@@ -23,6 +23,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 OUTPUT_SHAPE = [1, 1, 32, 256]
 GATHER_DIM = 3
 NUM_LINKS = 1
+_WORKERS = 4  # parallel JIT compile workers
 
 
 def _shard_input(mesh_device, num_devices, full):
@@ -87,7 +88,7 @@ def test_all_gather_up_front_compile(mesh_device):
     # Parallel compile warms the cache, error-free. A CCL op's MeshWorkload holds multiple
     # programs (sender/receiver), so compile builds >= the unique workload count — unlike a
     # homogeneous op where one program covers the whole mesh.
-    num_programs, num_errors, _, wall = ttnn.graph.up_front_compile(mesh_device, 4)
+    num_programs, num_errors, _, wall = ttnn.graph.up_front_compile(mesh_device, _WORKERS)
     print(
         f"CCL parallel compile: {num_programs} programs in {wall:.2f}s (errors={num_errors}, unique workloads={n_unique})"
     )

--- a/tests/ttnn/unit_tests/test_up_front_compile_mesh.py
+++ b/tests/ttnn/unit_tests/test_up_front_compile_mesh.py
@@ -1,0 +1,94 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Up-front precompile across a multi-device mesh (MeshWorkload path).
+
+Drives ops on a MeshDevice through collect -> parallel compile -> warm forward,
+covering the multi-chip MeshWorkload path. Both cases here are homogeneous (every
+device runs the same program on its shard), so the collector dedups to a small
+unique set regardless of mesh size, and one compile warms every chip.
+
+Parametrized for a 1x2 mesh; the mesh_device fixture skips on machines with fewer
+devices. Mesh dispatch goes over fabric, so run under flock / run_safe_pytest.sh.
+"""
+
+import pytest
+import torch
+
+import ttnn
+
+
+def _chain(x):
+    """exp(x) + x, times exp(x) — a few distinct elementwise programs."""
+    a = ttnn.exp(x)
+    return ttnn.multiply(ttnn.add(a, x), a)
+
+
+def _torch_chain(t):
+    a = torch.exp(t.float())
+    return (a + t.float()) * a
+
+
+def _collect_and_compile(mesh_device, run_body):
+    """Collect run_body() under NO_DISPATCH, parallel-compile, assert the mechanics."""
+    ttnn.graph.up_front_clear()
+    ttnn.graph.up_front_begin_collect()
+    try:
+        run_body()
+    finally:
+        ttnn.graph.up_front_end_collect()
+    n_unique = ttnn.graph.up_front_num_unique()
+    assert ttnn.graph.up_front_num_collected() >= 1, "collect captured nothing on the mesh"
+    num_programs, num_errors, _, _ = ttnn.graph.up_front_compile(mesh_device, 4)
+    assert num_errors == 0, "parallel compile reported errors"
+    assert num_programs == n_unique, f"compiled {num_programs} programs, expected the {n_unique} unique collected"
+
+
+@pytest.mark.parametrize("mesh_device", [2], indirect=True)
+def test_mesh_replicated_up_front_compile(mesh_device):
+    """Same tensor replicated to every device; warm output on each device must match."""
+    torch.manual_seed(0)
+    t = torch.randn(1, 1, 64, 64, dtype=torch.bfloat16)
+    x = ttnn.from_torch(
+        t,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=ttnn.ReplicateTensorToMesh(mesh_device),
+    )
+
+    _collect_and_compile(mesh_device, lambda: _chain(x))
+
+    # Warm run, then bring back one output per device (concat on dim 0 -> [num_devices, 1, 64, 64]).
+    out = _chain(x)
+    got = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=0)).float()
+    expected = _torch_chain(t)[0].flatten()  # [1, 64, 64] -> flat
+
+    assert got.shape[0] == mesh_device.get_num_devices(), f"expected one replica per device, got {got.shape}"
+    for i in range(got.shape[0]):
+        pcc = torch.corrcoef(torch.stack([got[i].flatten(), expected]))[0, 1].item()
+        assert pcc > 0.999, f"device {i} warm output incorrect: PCC {pcc}"
+
+
+@pytest.mark.parametrize("mesh_device", [2], indirect=True)
+def test_mesh_sharded_up_front_compile(mesh_device):
+    """Tensor sharded row-wise across the mesh; recomposed warm output must match the whole."""
+    num_dev = mesh_device.get_num_devices()
+    torch.manual_seed(0)
+    t = torch.randn(1, 1, 32 * num_dev, 64, dtype=torch.bfloat16)  # 32 tile-aligned rows per device
+    x = ttnn.from_torch(
+        t,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensorToMesh(mesh_device, dim=2),
+    )
+
+    _collect_and_compile(mesh_device, lambda: _chain(x))
+
+    out = _chain(x)
+    got = ttnn.to_torch(out, mesh_composer=ttnn.ConcatMeshToTensor(mesh_device, dim=2)).float().flatten()
+    expected = _torch_chain(t).flatten()
+    pcc = torch.corrcoef(torch.stack([got, expected]))[0, 1].item()
+    assert pcc > 0.999, f"sharded warm output incorrect: PCC {pcc}"

--- a/tests/ttnn/unit_tests/test_up_front_compile_mesh.py
+++ b/tests/ttnn/unit_tests/test_up_front_compile_mesh.py
@@ -18,6 +18,8 @@ import torch
 
 import ttnn
 
+_WORKERS = 4  # parallel JIT compile workers
+
 
 def _chain(x):
     """exp(x) + x, times exp(x) — a few distinct elementwise programs."""
@@ -40,7 +42,7 @@ def _collect_and_compile(mesh_device, run_body):
         ttnn.graph.up_front_end_collect()
     n_unique = ttnn.graph.up_front_num_unique()
     assert ttnn.graph.up_front_num_collected() >= 1, "collect captured nothing on the mesh"
-    num_programs, num_errors, _, _ = ttnn.graph.up_front_compile(mesh_device, 4)
+    num_programs, num_errors, _, _ = ttnn.graph.up_front_compile(mesh_device, _WORKERS)
     assert num_errors == 0, "parallel compile reported errors"
     assert num_programs == n_unique, f"compiled {num_programs} programs, expected the {n_unique} unique collected"
 

--- a/tests/ttnn/unit_tests/test_up_front_compile_mlp.py
+++ b/tests/ttnn/unit_tests/test_up_front_compile_mlp.py
@@ -1,0 +1,71 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Up-front precompile on a small two-layer MLP (matmuls + weights).
+
+Builds a tiny MLP from plain ttnn ops -- linear -> gelu -> linear -- and drives it
+through collect -> parallel compile -> warm forward, exercising matmul programs and
+the ttnn.from_torch weight tensors the collector handles.
+
+Run on a FRESH cache so the parallel compile does real work, e.g.:
+    TT_METAL_CACHE=/tmp/upfront_mlp_$$ scripts/run_safe_pytest.sh \
+        tests/ttnn/unit_tests/test_up_front_compile_mlp.py
+"""
+
+import torch
+
+import ttnn
+from tests.ttnn.utils_for_testing import assert_with_pcc
+
+IN_DIM = 256
+HIDDEN_DIM = 512
+SEQ = 128
+
+
+def _build_mlp(device):
+    """Return (tt_x, tt_w1, tt_w2, torch_reference) for a random two-layer MLP.
+
+    Weights are stored [in, out], the layout ttnn.linear expects.
+    """
+    torch.manual_seed(0)
+    x = torch.randn(1, 1, SEQ, IN_DIM, dtype=torch.float32) * 0.5
+    w1 = torch.randn(IN_DIM, HIDDEN_DIM, dtype=torch.float32) * (IN_DIM**-0.5)
+    w2 = torch.randn(HIDDEN_DIM, IN_DIM, dtype=torch.float32) * (HIDDEN_DIM**-0.5)
+    torch_out = torch.nn.functional.gelu(x @ w1) @ w2
+
+    def to_tt(t):
+        return ttnn.from_torch(t, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+
+    return to_tt(x), to_tt(w1), to_tt(w2), torch_out
+
+
+def _mlp(x, w1, w2):
+    """linear -> gelu -> linear."""
+    h = ttnn.gelu(ttnn.linear(x, w1))
+    return ttnn.linear(h, w2)
+
+
+def test_mlp_up_front_compile(device):
+    tt_x, tt_w1, tt_w2, torch_out = _build_mlp(device)
+
+    # Collect (NO_DISPATCH): capture the MLP's programs without running anything.
+    ttnn.graph.up_front_clear()
+    ttnn.graph.up_front_begin_collect()
+    try:
+        _mlp(tt_x, tt_w1, tt_w2)
+    finally:
+        ttnn.graph.up_front_end_collect()
+    n_unique = ttnn.graph.up_front_num_unique()
+    assert ttnn.graph.up_front_num_collected() >= 2, "expected at least the two matmuls to be captured"
+    assert n_unique >= 1
+
+    # Parallel compile warms the kernel cache and must build exactly the unique set, error-free.
+    num_programs, num_errors, _, _ = ttnn.graph.up_front_compile(device, 4)
+    assert num_errors == 0, "parallel compile reported errors"
+    assert num_programs == n_unique, f"compiled {num_programs} programs, expected the {n_unique} unique collected"
+
+    # Warm forward must match the torch reference.
+    out = _mlp(tt_x, tt_w1, tt_w2)
+    passed, pcc = assert_with_pcc(torch_out, ttnn.to_torch(out).to(torch_out.dtype), 0.99)
+    assert passed, f"warm MLP forward PCC too low: {pcc}"

--- a/tests/ttnn/unit_tests/test_up_front_compile_mlp.py
+++ b/tests/ttnn/unit_tests/test_up_front_compile_mlp.py
@@ -21,6 +21,7 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 IN_DIM = 256
 HIDDEN_DIM = 512
 SEQ = 128
+_WORKERS = 4  # parallel JIT compile workers
 
 
 def _build_mlp(device):
@@ -61,7 +62,7 @@ def test_mlp_up_front_compile(device):
     assert n_unique >= 1
 
     # Parallel compile warms the kernel cache and must build exactly the unique set, error-free.
-    num_programs, num_errors, _, _ = ttnn.graph.up_front_compile(device, 4)
+    num_programs, num_errors, _, _ = ttnn.graph.up_front_compile(device, _WORKERS)
     assert num_errors == 0, "parallel compile reported errors"
     assert num_programs == n_unique, f"compiled {num_programs} programs, expected the {n_unique} unique collected"
 

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -333,12 +333,9 @@ void create_and_cache_mesh_workload(
             auto cached_workload = create_mesh_workload_from_workload_factory<WorkloadFactory, mesh_device_operation_t>(
                 operation_attributes, tensor_coords, tensor_args, tensor_return_value);
 
-            // Up-front parallel precompile: in collect mode, move the freshly
-            // built — but not-yet-compiled — workload into the collector keyed by its
-            // program hash, and skip caching + dispatch. The kernels are JIT-compiled
-            // later, in parallel, by ttnn::up_front_compile::parallel_compile (warming
-            // the on-disk cache). Collect runs under NO_DISPATCH so buffers are mocked
-            // (addr 0); that is fine because compilation is address-independent. See
+            // Up-front parallel precompile: in collect mode, move the built-but-uncompiled
+            // workload into the collector (keyed by program hash) and skip caching + dispatch;
+            // the kernels are JIT-compiled later in parallel by parallel_compile. See
             // ttnn/up_front_compile.hpp.
             if (auto* collector = ttnn::up_front_compile::ProgramCollector::active()) {
                 collector->collect(static_cast<std::uint64_t>(program_hash), std::move(cached_workload.workload));

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -19,6 +19,7 @@
 #include <tt_stl/concepts.hpp>
 #include "ttnn/graph/graph_processor.hpp"
 #include "ttnn/graph/graph_serialization.hpp"  // serialize_tracked_arg<T> definitions, used via track_function_start
+#include "ttnn/up_front_compile.hpp"           // up-front parallel precompile collect hook
 #include "ttnn/distributed/api.hpp"
 #include <tt-metalium/distributed.hpp>
 #include <tt-metalium/experimental/inspector.hpp>
@@ -331,6 +332,18 @@ void create_and_cache_mesh_workload(
             }
             auto cached_workload = create_mesh_workload_from_workload_factory<WorkloadFactory, mesh_device_operation_t>(
                 operation_attributes, tensor_coords, tensor_args, tensor_return_value);
+
+            // Up-front parallel precompile: in collect mode, move the freshly
+            // built — but not-yet-compiled — workload into the collector keyed by its
+            // program hash, and skip caching + dispatch. The kernels are JIT-compiled
+            // later, in parallel, by ttnn::up_front_compile::parallel_compile (warming
+            // the on-disk cache). Collect runs under NO_DISPATCH so buffers are mocked
+            // (addr 0); that is fine because compilation is address-independent. See
+            // ttnn/up_front_compile.hpp.
+            if (auto* collector = ttnn::up_front_compile::ProgramCollector::active()) {
+                collector->collect(static_cast<std::uint64_t>(program_hash), std::move(cached_workload.workload));
+                return;
+            }
 
             // Don't cache programs during NO_DISPATCH graph capture mode because
             // buffer addresses are invalid (address=0). Caching such programs would

--- a/ttnn/api/ttnn/graph/graph_processor.hpp
+++ b/ttnn/api/ttnn/graph/graph_processor.hpp
@@ -29,7 +29,10 @@ using node_id = int;
 
 class ProcessorHooks : public tt::tt_metal::IGraphHooks {
 private:
-    bool do_block = false;
+    bool do_block = false;     // gates dispatch / write / read (program execution)
+    bool block_alloc = false;  // gates allocate / deallocate, separable from do_block so a
+                               // "real-alloc" collect can assign real addresses (block_alloc=false)
+                               // while still blocking dispatch (do_block=true).
 
 public:
     ProcessorHooks() = default;
@@ -49,7 +52,8 @@ public:
 
     ~ProcessorHooks() override = default;
 
-    void set_block(bool block);
+    void set_block(bool block);        // sets BOTH do_block and block_alloc
+    void set_block_alloc(bool block);  // sets only block_alloc (for real-alloc collect)
 
     bool get_block() const;
 };

--- a/ttnn/api/ttnn/graph/graph_processor.hpp
+++ b/ttnn/api/ttnn/graph/graph_processor.hpp
@@ -27,9 +27,7 @@ namespace ttnn::graph {
 // Node identifiers in the graph
 using node_id = int;
 
-// What a capture blocks. Replaces the old (do_block, block_alloc) bool pair so the
-// only meaningful states are representable (the pair could also encode the nonsense
-// "allow dispatch but block alloc"):
+// What a capture blocks:
 //   None        - block nothing (NORMAL capture: record only).
 //   All         - block dispatch AND allocation (NO_DISPATCH: buffers mocked at addr 0).
 //   DispatchOnly - block dispatch, allow real allocation (real-alloc collect: kernels

--- a/ttnn/api/ttnn/graph/graph_processor.hpp
+++ b/ttnn/api/ttnn/graph/graph_processor.hpp
@@ -27,12 +27,19 @@ namespace ttnn::graph {
 // Node identifiers in the graph
 using node_id = int;
 
+// What a capture blocks. Replaces the old (do_block, block_alloc) bool pair so the
+// only meaningful states are representable (the pair could also encode the nonsense
+// "allow dispatch but block alloc"):
+//   None        - block nothing (NORMAL capture: record only).
+//   All         - block dispatch AND allocation (NO_DISPATCH: buffers mocked at addr 0).
+//   DispatchOnly - block dispatch, allow real allocation (real-alloc collect: kernels
+//                  that bake/branch on buffer addresses build the same program as the
+//                  real run, while nothing executes).
+enum class CaptureBlock { None, All, DispatchOnly };
+
 class ProcessorHooks : public tt::tt_metal::IGraphHooks {
 private:
-    bool do_block = false;     // gates dispatch / write / read (program execution)
-    bool block_alloc = false;  // gates allocate / deallocate, separable from do_block so a
-                               // "real-alloc" collect can assign real addresses (block_alloc=false)
-                               // while still blocking dispatch (do_block=true).
+    CaptureBlock block_mode = CaptureBlock::None;
 
 public:
     ProcessorHooks() = default;
@@ -52,10 +59,9 @@ public:
 
     ~ProcessorHooks() override = default;
 
-    void set_block(bool block);        // sets BOTH do_block and block_alloc
-    void set_block_alloc(bool block);  // sets only block_alloc (for real-alloc collect)
+    void set_capture_block(CaptureBlock mode);
 
-    bool get_block() const;
+    bool get_block() const;  // true if dispatch is blocked (mode != None)
 };
 class GraphProcessor : public tt::tt_metal::IGraphProcessor {
 public:

--- a/ttnn/api/ttnn/up_front_compile.hpp
+++ b/ttnn/api/ttnn/up_front_compile.hpp
@@ -1,0 +1,131 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+#include <cstdint>
+#include <mutex>
+#include <unordered_map>
+#include <vector>
+
+namespace tt::tt_metal {
+class Program;
+}  // namespace tt::tt_metal
+
+namespace tt::tt_metal::distributed {
+class MeshWorkload;
+class MeshDevice;
+}  // namespace tt::tt_metal::distributed
+
+namespace ttnn::up_front_compile {
+
+// Result of a parallel_compile pass.
+struct CompileStats {
+    std::size_t num_programs = 0;  // distinct programs JIT-compiled
+    std::size_t num_errors = 0;    // programs whose compile threw
+    int max_workers = 0;
+    double wall_seconds = 0.0;
+};
+
+// ---------------------------------------------------------------------------
+// Up-front parallel precompile.
+//
+// The expensive part of a cold model run is JIT kernel compilation, done one
+// program at a time behind sequential op dispatch. This warms the on-disk
+// kernel cache (TT_METAL_CACHE) for a model's whole distinct program set, up
+// front and in parallel, so the subsequent real run / trace capture runs warm.
+//
+// Usage (op-agnostic — works for any op that dispatches through the device-op
+// adapter, i.e. generic_op and every C++ ProgramDescriptor-migrated op):
+//
+//     ttnn.graph.up_front_begin_collect()           # NO_DISPATCH: nothing runs,
+//     model(dummy_input, device)                    #   each op stashes its workload
+//     ttnn.graph.up_front_end_collect()
+//     ttnn.graph.up_front_compile(device, workers)  # parallel JIT, warms the cache
+//     # real run / trace capture is now warm
+//
+// Requirements:
+//   * Run on a COLD device program cache with the cache ENABLED, so each op is
+//     a cache miss (reaches the collector) and carries a distinct program hash.
+//     (If the hash is 0 — cache disabled — the collector keeps every program
+//     distinct via a synthetic key, trading dedup for correctness.)
+//
+// Mechanism: a NO_DISPATCH graph capture mocks all buffer allocations (addr 0)
+// and blocks dispatch, so the collect pass uses no real device memory. The
+// dispatch funnel (device_operation.hpp::create_and_cache_mesh_workload) moves
+// the freshly-built-but-uncompiled MeshWorkload into the collector, keyed by
+// program hash, and skips caching + enqueue. parallel_compile then JIT-compiles
+// the distinct set. Address-independence of compilation makes addr-0 fine.
+// ---------------------------------------------------------------------------
+class ProgramCollector {
+public:
+    // Process-wide store of collected programs.
+    static ProgramCollector& instance();
+
+    // The active collector for the current (capturing) thread, or nullptr. The
+    // device-op dispatch funnel checks this on every op.
+    static ProgramCollector* active();
+
+    // Move a freshly-built workload in, keyed by its program-cache hash. The
+    // first entry per hash wins; later structural duplicates are dropped (same
+    // dedup the device program cache would do). Thread-safe.
+    void collect(std::uint64_t program_hash, tt::tt_metal::distributed::MeshWorkload&& workload);
+
+    std::size_t num_unique() const;     // distinct program hashes collected
+    std::size_t num_collected() const;  // total ops that stashed (incl. dropped dups)
+    void clear();
+
+    // Toggle the per-thread active flag. Used by begin/end_collect.
+    static void set_active(bool active);
+
+    // Borrowed pointers to every collected program (valid until clear()).
+    std::vector<tt::tt_metal::Program*> program_pointers();
+
+private:
+    ProgramCollector() = default;
+
+    mutable std::mutex mutex_;
+    std::unordered_map<std::uint64_t, tt::tt_metal::distributed::MeshWorkload> programs_;
+    std::size_t total_collected_ = 0;
+    std::uint64_t synthetic_key_ = 0;  // for hash==0 (cache-disabled) fallback
+};
+
+// Begin a collect pass: enables NO_DISPATCH graph capture (buffers mocked,
+// nothing dispatched) and marks the collector active on this thread.
+//
+// clear=true (default) drops any previously collected programs first — the
+// model-forward usage (one begin/end around a single run). clear=false
+// ACCUMULATES into the existing set — the cross-test usage: a pytest plugin
+// wraps each test body in begin_collect(clear=false)/end_collect(), so programs
+// from every test pile into one deduped set, then a single parallel_compile at
+// session end. (begin/end_collect push/pop a NO_DISPATCH graph-capture frame
+// per call and the hook is cleanly removed on end, so per-test wrapping is safe;
+// only the clear must be suppressed to accumulate — clear the collector once up
+// front via ProgramCollector::clear() / up_front_clear instead.)
+//
+// real_alloc=false (default): NO_DISPATCH mocks every buffer at address 0 → zero device
+// memory, scales to any model, but kernels that bake a buffer address into compile-time
+// args (e.g. pool reader_indices) or branch on addresses (e.g. move forward/backward)
+// collect the addr-0 variant and MISS on the real run. real_alloc=true: let the allocator
+// assign REAL addresses during collect (dispatch still blocked) so those build the same
+// program the real run will → they warm. The L1 allocator is deterministic across processes,
+// so a fresh-device collect and a fresh-device real run land buffers at identical addresses.
+// COST: real device memory (~the real run's peak; a collect OOM is a faithful signal the real
+// run would OOM too) + the alloc/free sequence must match the real run (it does if collect
+// replays the same forward). Use real_alloc for models that fit; addr-0 for the giant ones.
+void begin_collect(bool clear = true, bool real_alloc = false);
+
+// End the collect pass: stops NO_DISPATCH capture and deactivates the collector.
+// Collected programs remain in ProgramCollector::instance() until parallel_compile
+// (or ProgramCollector::clear) is called.
+void end_collect();
+
+// JIT-compile every distinct collected program in parallel, warming the on-disk
+// kernel cache. Compiles for devices.front() of the mesh — a homogeneous mesh
+// shares one build key, so one compile warms the whole mesh. max_workers<=0 uses
+// the hardware concurrency. If clear, the collected programs are released after.
+CompileStats parallel_compile(tt::tt_metal::distributed::MeshDevice* device, int max_workers = 0, bool clear = true);
+
+}  // namespace ttnn::up_front_compile

--- a/ttnn/api/ttnn/up_front_compile.hpp
+++ b/ttnn/api/ttnn/up_front_compile.hpp
@@ -89,10 +89,7 @@ private:
 // ACCUMULATES into the existing set — the cross-test usage: a pytest plugin
 // wraps each test body in begin_collect(clear=false)/end_collect(), so programs
 // from every test pile into one deduped set, then a single parallel_compile at
-// session end. (begin/end_collect push/pop a NO_DISPATCH graph-capture frame
-// per call and the hook is cleanly removed on end, so per-test wrapping is safe;
-// only the clear must be suppressed to accumulate — clear the collector once up
-// front via ProgramCollector::clear() / up_front_clear instead.)
+// session end.
 //
 // real_alloc=false (default): NO_DISPATCH mocks every buffer at address 0 → zero device
 // memory, scales to any model, but kernels that bake a buffer address into compile-time
@@ -101,9 +98,9 @@ private:
 // assign REAL addresses during collect (dispatch still blocked) so those build the same
 // program the real run will → they warm. The L1 allocator is deterministic across processes,
 // so a fresh-device collect and a fresh-device real run land buffers at identical addresses.
-// COST: real device memory (~the real run's peak; a collect OOM is a faithful signal the real
-// run would OOM too) + the alloc/free sequence must match the real run (it does if collect
-// replays the same forward). Use real_alloc for models that fit; addr-0 for the giant ones.
+// COST: real device memory (~the real run's peak) + the alloc/free sequence must match the
+// real run (it does if collect replays the same forward). Use real_alloc for models that fit;
+// addr-0 for the giant ones.
 void begin_collect(bool clear = true, bool real_alloc = false);
 
 // End the collect pass: stops NO_DISPATCH capture and deactivates the collector.

--- a/ttnn/api/ttnn/up_front_compile.hpp
+++ b/ttnn/api/ttnn/up_front_compile.hpp
@@ -80,8 +80,14 @@ public:
     // Toggle the per-thread active flag. Used by begin/end_collect.
     static void set_active(bool active);
 
-    // Borrowed pointers to every collected program (valid until clear()).
-    std::vector<tt::tt_metal::Program*> program_pointers();
+    // Move every collected workload out of the store under the collector mutex and
+    // reset the counters, returning the workloads by value. parallel_compile owns
+    // their lifetime for the duration of compilation, so a concurrent up_front_clear()
+    // / begin_collect(clear=true) — the GIL is released during up_front_compile —
+    // cannot destroy the MeshWorkloads (and the Program* borrowed into them) while
+    // worker threads are still compiling. Leaves the store empty; any collect() that
+    // races the compile lands in the fresh, emptied store for the next pass.
+    std::unordered_map<std::uint64_t, tt::tt_metal::distributed::MeshWorkload> take_workloads();
 
 private:
     ProgramCollector() = default;
@@ -125,7 +131,7 @@ void end_collect();
 // JIT-compile every distinct collected program in parallel, warming the on-disk
 // kernel cache. Compiles for devices.front() of the mesh — a homogeneous mesh
 // shares one build key, so one compile warms the whole mesh. max_workers<=0 uses
-// the hardware concurrency. If clear, the collected programs are released after.
-CompileStats parallel_compile(tt::tt_metal::distributed::MeshDevice* device, int max_workers = 0, bool clear = true);
+// the hardware concurrency. Consumes the collected set (the store is left empty).
+CompileStats parallel_compile(tt::tt_metal::distributed::MeshDevice* device, int max_workers = 0);
 
 }  // namespace ttnn::up_front_compile

--- a/ttnn/api/ttnn/up_front_compile.hpp
+++ b/ttnn/api/ttnn/up_front_compile.hpp
@@ -42,10 +42,11 @@ struct CompileStats {
 // Run on a COLD program cache with the cache ENABLED, so each op is a miss that
 // reaches the collector with a distinct hash.
 //
-// Mechanism: NO_DISPATCH graph capture mocks buffer allocations (addr 0) and blocks
-// dispatch; the device-op funnel moves each built-but-uncompiled MeshWorkload into
-// the collector (keyed by hash, skipping cache + enqueue), then parallel_compile
-// JIT-compiles the distinct set. Compilation is address-independent, so addr-0 is fine.
+// Mechanism: a graph-capture pass blocks dispatch while letting the allocator hand out
+// REAL buffer addresses (nothing executes); the device-op funnel moves each built-but-
+// uncompiled MeshWorkload into the collector (keyed by hash, skipping cache + enqueue),
+// then parallel_compile JIT-compiles the distinct set. Real addresses mean kernels that
+// bake or branch on a buffer address build the same program the real run will, so they warm.
 // ---------------------------------------------------------------------------
 class ProgramCollector {
 public:
@@ -81,8 +82,8 @@ private:
     std::uint64_t synthetic_key_ = 0;  // for hash==0 (cache-disabled) fallback
 };
 
-// Begin a collect pass: enables NO_DISPATCH graph capture (buffers mocked,
-// nothing dispatched) and marks the collector active on this thread.
+// Begin a collect pass: blocks dispatch (nothing executes) while the allocator hands out
+// REAL buffer addresses, and marks the collector active on this thread.
 //
 // clear=true (default) drops any previously collected programs first — the
 // model-forward usage (one begin/end around a single run). clear=false
@@ -91,17 +92,13 @@ private:
 // from every test pile into one deduped set, then a single parallel_compile at
 // session end.
 //
-// real_alloc=false (default): NO_DISPATCH mocks every buffer at address 0 → zero device
-// memory, scales to any model, but kernels that bake a buffer address into compile-time
-// args (e.g. pool reader_indices) or branch on addresses (e.g. move forward/backward)
-// collect the addr-0 variant and MISS on the real run. real_alloc=true: let the allocator
-// assign REAL addresses during collect (dispatch still blocked) so those build the same
-// program the real run will → they warm. The L1 allocator is deterministic across processes,
-// so a fresh-device collect and a fresh-device real run land buffers at identical addresses.
-// COST: real device memory (~the real run's peak) + the alloc/free sequence must match the
-// real run (it does if collect replays the same forward). Use real_alloc for models that fit;
-// addr-0 for the giant ones.
-void begin_collect(bool clear = true, bool real_alloc = false);
+// Real addresses mean address-baked / address-branched kernels (e.g. pool reader_indices,
+// move forward/backward) build the same program the real run will, so they warm too. The
+// allocator is deterministic across processes, so a fresh-device collect and a fresh-device
+// real run land buffers at identical addresses. COST: real device memory (~the real run's
+// peak) and the alloc/free sequence must match the real run (it does if collect replays the
+// same forward). A workload that would OOM the real run OOMs here too; that body is skipped.
+void begin_collect(bool clear = true);
 
 // End the collect pass: stops NO_DISPATCH capture and deactivates the collector.
 // Collected programs remain in ProgramCollector::instance() until parallel_compile

--- a/ttnn/api/ttnn/up_front_compile.hpp
+++ b/ttnn/api/ttnn/up_front_compile.hpp
@@ -8,7 +8,6 @@
 #include <cstdint>
 #include <mutex>
 #include <unordered_map>
-#include <vector>
 
 namespace tt::tt_metal {
 class Program;
@@ -30,34 +29,23 @@ struct CompileStats {
 };
 
 // ---------------------------------------------------------------------------
-// Up-front parallel precompile.
+// Up-front parallel precompile: JIT-compile a distinct set of programs in parallel
+// to warm the on-disk kernel cache (TT_METAL_CACHE), so the subsequent real run is
+// warm. Works for any op dispatched through the device-op adapter.
 //
-// The expensive part of a cold model run is JIT kernel compilation, done one
-// program at a time behind sequential op dispatch. This warms the on-disk
-// kernel cache (TT_METAL_CACHE) for a model's whole distinct program set, up
-// front and in parallel, so the subsequent real run / trace capture runs warm.
-//
-// Usage (op-agnostic — works for any op that dispatches through the device-op
-// adapter, i.e. generic_op and every C++ ProgramDescriptor-migrated op):
-//
+// Usage:
 //     ttnn.graph.up_front_begin_collect()           # NO_DISPATCH: nothing runs,
 //     model(dummy_input, device)                    #   each op stashes its workload
 //     ttnn.graph.up_front_end_collect()
 //     ttnn.graph.up_front_compile(device, workers)  # parallel JIT, warms the cache
-//     # real run / trace capture is now warm
 //
-// Requirements:
-//   * Run on a COLD device program cache with the cache ENABLED, so each op is
-//     a cache miss (reaches the collector) and carries a distinct program hash.
-//     (If the hash is 0 — cache disabled — the collector keeps every program
-//     distinct via a synthetic key, trading dedup for correctness.)
+// Run on a COLD program cache with the cache ENABLED, so each op is a miss that
+// reaches the collector with a distinct hash.
 //
-// Mechanism: a NO_DISPATCH graph capture mocks all buffer allocations (addr 0)
-// and blocks dispatch, so the collect pass uses no real device memory. The
-// dispatch funnel (device_operation.hpp::create_and_cache_mesh_workload) moves
-// the freshly-built-but-uncompiled MeshWorkload into the collector, keyed by
-// program hash, and skips caching + enqueue. parallel_compile then JIT-compiles
-// the distinct set. Address-independence of compilation makes addr-0 fine.
+// Mechanism: NO_DISPATCH graph capture mocks buffer allocations (addr 0) and blocks
+// dispatch; the device-op funnel moves each built-but-uncompiled MeshWorkload into
+// the collector (keyed by hash, skipping cache + enqueue), then parallel_compile
+// JIT-compiles the distinct set. Compilation is address-independent, so addr-0 is fine.
 // ---------------------------------------------------------------------------
 class ProgramCollector {
 public:
@@ -80,13 +68,8 @@ public:
     // Toggle the per-thread active flag. Used by begin/end_collect.
     static void set_active(bool active);
 
-    // Move every collected workload out of the store under the collector mutex and
-    // reset the counters, returning the workloads by value. parallel_compile owns
-    // their lifetime for the duration of compilation, so a concurrent up_front_clear()
-    // / begin_collect(clear=true) — the GIL is released during up_front_compile —
-    // cannot destroy the MeshWorkloads (and the Program* borrowed into them) while
-    // worker threads are still compiling. Leaves the store empty; any collect() that
-    // races the compile lands in the fresh, emptied store for the next pass.
+    // Move the collected set out under the mutex and reset the counters; the caller
+    // owns it for the whole compile. Leaves the store empty.
     std::unordered_map<std::uint64_t, tt::tt_metal::distributed::MeshWorkload> take_workloads();
 
 private:

--- a/ttnn/core/graph/graph_nanobind.cpp
+++ b/ttnn/core/graph/graph_nanobind.cpp
@@ -21,7 +21,9 @@
 #include "ttnn/graph/graph_processor.hpp"
 #include "ttnn/graph/graph_trace_utils.hpp"
 #include "ttnn/graph/graph_consts.hpp"
+#include "ttnn/up_front_compile.hpp"
 #include <tt-metalium/graph_tracking.hpp>
+#include <tt-metalium/mesh_device.hpp>
 
 namespace ttnn::graph {
 
@@ -359,6 +361,85 @@ void py_graph_module(nb::module_& m) {
         R"doc(is_detailed_buffer_tracing_enabled() -> bool
 
         Check if detailed per-page buffer tracing is currently enabled.
+        )doc");
+
+    // ----- Up-front parallel precompile (ttnn/up_front_compile.hpp) -----
+    m.def(
+        "up_front_begin_collect",
+        &ttnn::up_front_compile::begin_collect,
+        nb::arg("clear") = true,
+        nb::arg("real_alloc") = false,
+        R"doc(up_front_begin_collect(clear=True, real_alloc=False) -> None
+
+        Begin a precompile "collect" pass. Enables NO_DISPATCH graph capture (buffer
+        allocations mocked at address 0, nothing dispatched) and marks the collector
+        active on this thread. Run a model forward after this; every op stashes its
+        built-but-uncompiled program into the collector. Pair with up_front_end_collect().
+
+        clear=True (default) drops previously collected programs first (single-run
+        usage). clear=False ACCUMULATES — a pytest plugin wraps each test body in
+        up_front_begin_collect(clear=False)/up_front_end_collect() so programs from
+        every test pile into one deduped set for a single up_front_compile() at the
+        end. Clear once up front with up_front_clear() when accumulating.
+
+        real_alloc=False (default): NO_DISPATCH mocks buffers at address 0 (zero device
+        memory). real_alloc=True: assign REAL addresses during collect (dispatch still
+        blocked) so address-baked / address-branched kernels build the same program the real
+        run will and thus warm — at the cost of real device memory (~the real run's peak).
+
+        Run on a COLD device program cache with the cache ENABLED so each op is a miss
+        (reaches the collector) and carries a distinct program hash.
+        )doc");
+
+    m.def(
+        "up_front_end_collect",
+        &ttnn::up_front_compile::end_collect,
+        R"doc(up_front_end_collect() -> None
+
+        End the collect pass (stops NO_DISPATCH capture, deactivates the collector).
+        Collected programs remain until up_front_compile() (or up_front_clear()).
+        )doc");
+
+    m.def(
+        "up_front_num_unique",
+        []() { return ttnn::up_front_compile::ProgramCollector::instance().num_unique(); },
+        R"doc(up_front_num_unique() -> int
+
+        Number of distinct programs collected so far.
+        )doc");
+
+    m.def(
+        "up_front_num_collected",
+        []() { return ttnn::up_front_compile::ProgramCollector::instance().num_collected(); },
+        R"doc(up_front_num_collected() -> int
+
+        Total op invocations that stashed a program (including dropped duplicates).
+        )doc");
+
+    m.def(
+        "up_front_clear",
+        []() { ttnn::up_front_compile::ProgramCollector::instance().clear(); },
+        R"doc(up_front_clear() -> None
+
+        Drop all collected programs without compiling.
+        )doc");
+
+    m.def(
+        "up_front_compile",
+        [](tt::tt_metal::distributed::MeshDevice* device, int max_workers, bool clear) {
+            auto s = ttnn::up_front_compile::parallel_compile(device, max_workers, clear);
+            return std::make_tuple(s.num_programs, s.num_errors, s.max_workers, s.wall_seconds);
+        },
+        nb::arg("device"),
+        nb::arg("max_workers") = 0,
+        nb::arg("clear") = true,
+        nb::call_guard<nb::gil_scoped_release>(),
+        R"doc(up_front_compile(device, max_workers=0, clear=True) -> (num_programs, num_errors, max_workers, wall_seconds)
+
+        JIT-compile every distinct collected program in parallel, warming the on-disk
+        kernel cache (TT_METAL_CACHE). The subsequent real run / trace capture runs warm.
+        max_workers<=0 uses hardware concurrency (note: the build executor saturates
+        ~4 workers, so higher buys little). The GIL is released for the duration.
         )doc");
 }
 

--- a/ttnn/core/graph/graph_nanobind.cpp
+++ b/ttnn/core/graph/graph_nanobind.cpp
@@ -436,9 +436,8 @@ void py_graph_module(nb::module_& m) {
         R"doc(up_front_compile(device, max_workers=0) -> (num_programs, num_errors, max_workers, wall_seconds)
 
         JIT-compile every distinct collected program in parallel, warming the on-disk
-        kernel cache (TT_METAL_CACHE). The subsequent real run / trace capture runs warm.
-        max_workers<=0 uses hardware concurrency (note: the build executor saturates
-        ~4 workers, so higher buys little). The GIL is released for the duration.
+        kernel cache (TT_METAL_CACHE). The subsequent real run runs warm. max_workers<=0
+        uses hardware concurrency. The GIL is released for the duration.
         )doc");
 }
 

--- a/ttnn/core/graph/graph_nanobind.cpp
+++ b/ttnn/core/graph/graph_nanobind.cpp
@@ -426,15 +426,14 @@ void py_graph_module(nb::module_& m) {
 
     m.def(
         "up_front_compile",
-        [](tt::tt_metal::distributed::MeshDevice* device, int max_workers, bool clear) {
-            auto s = ttnn::up_front_compile::parallel_compile(device, max_workers, clear);
+        [](tt::tt_metal::distributed::MeshDevice* device, int max_workers) {
+            auto s = ttnn::up_front_compile::parallel_compile(device, max_workers);
             return std::make_tuple(s.num_programs, s.num_errors, s.max_workers, s.wall_seconds);
         },
         nb::arg("device"),
         nb::arg("max_workers") = 0,
-        nb::arg("clear") = true,
         nb::call_guard<nb::gil_scoped_release>(),
-        R"doc(up_front_compile(device, max_workers=0, clear=True) -> (num_programs, num_errors, max_workers, wall_seconds)
+        R"doc(up_front_compile(device, max_workers=0) -> (num_programs, num_errors, max_workers, wall_seconds)
 
         JIT-compile every distinct collected program in parallel, warming the on-disk
         kernel cache (TT_METAL_CACHE). The subsequent real run / trace capture runs warm.

--- a/ttnn/core/graph/graph_nanobind.cpp
+++ b/ttnn/core/graph/graph_nanobind.cpp
@@ -371,24 +371,13 @@ void py_graph_module(nb::module_& m) {
         nb::arg("real_alloc") = false,
         R"doc(up_front_begin_collect(clear=True, real_alloc=False) -> None
 
-        Begin a precompile "collect" pass. Enables NO_DISPATCH graph capture (buffer
-        allocations mocked at address 0, nothing dispatched) and marks the collector
-        active on this thread. Run a model forward after this; every op stashes its
+        Begin a precompile "collect" pass: run a model forward and every op stashes its
         built-but-uncompiled program into the collector. Pair with up_front_end_collect().
+        Run on a COLD program cache (cache enabled). See ttnn/up_front_compile.hpp.
 
-        clear=True (default) drops previously collected programs first (single-run
-        usage). clear=False ACCUMULATES — a pytest plugin wraps each test body in
-        up_front_begin_collect(clear=False)/up_front_end_collect() so programs from
-        every test pile into one deduped set for a single up_front_compile() at the
-        end. Clear once up front with up_front_clear() when accumulating.
-
-        real_alloc=False (default): NO_DISPATCH mocks buffers at address 0 (zero device
-        memory). real_alloc=True: assign REAL addresses during collect (dispatch still
-        blocked) so address-baked / address-branched kernels build the same program the real
-        run will and thus warm — at the cost of real device memory (~the real run's peak).
-
-        Run on a COLD device program cache with the cache ENABLED so each op is a miss
-        (reaches the collector) and carries a distinct program hash.
+        Args:
+            clear: drop previously collected programs first (False accumulates across passes).
+            real_alloc: assign real buffer addresses during collect (default mocks at addr 0).
         )doc");
 
     m.def(
@@ -396,8 +385,7 @@ void py_graph_module(nb::module_& m) {
         &ttnn::up_front_compile::end_collect,
         R"doc(up_front_end_collect() -> None
 
-        End the collect pass (stops NO_DISPATCH capture, deactivates the collector).
-        Collected programs remain until up_front_compile() (or up_front_clear()).
+        End the collect pass. Collected programs remain until up_front_compile() or up_front_clear().
         )doc");
 
     m.def(
@@ -436,8 +424,7 @@ void py_graph_module(nb::module_& m) {
         R"doc(up_front_compile(device, max_workers=0) -> (num_programs, num_errors, max_workers, wall_seconds)
 
         JIT-compile every distinct collected program in parallel, warming the on-disk
-        kernel cache (TT_METAL_CACHE). The subsequent real run runs warm. max_workers<=0
-        uses hardware concurrency. The GIL is released for the duration.
+        kernel cache so the subsequent real run runs warm. max_workers<=0 uses hardware concurrency.
         )doc");
 }
 

--- a/ttnn/core/graph/graph_nanobind.cpp
+++ b/ttnn/core/graph/graph_nanobind.cpp
@@ -368,16 +368,15 @@ void py_graph_module(nb::module_& m) {
         "up_front_begin_collect",
         &ttnn::up_front_compile::begin_collect,
         nb::arg("clear") = true,
-        nb::arg("real_alloc") = false,
-        R"doc(up_front_begin_collect(clear=True, real_alloc=False) -> None
+        R"doc(up_front_begin_collect(clear=True) -> None
 
         Begin a precompile "collect" pass: run a model forward and every op stashes its
-        built-but-uncompiled program into the collector. Pair with up_front_end_collect().
+        built-but-uncompiled program into the collector. Dispatch is blocked but buffers get
+        real addresses, so address-baked kernels warm too. Pair with up_front_end_collect().
         Run on a COLD program cache (cache enabled). See ttnn/up_front_compile.hpp.
 
         Args:
             clear: drop previously collected programs first (False accumulates across passes).
-            real_alloc: assign real buffer addresses during collect (default mocks at addr 0).
         )doc");
 
     m.def(

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -691,7 +691,7 @@ void GraphProcessor::begin_capture(RunMode mode) {
     if (!tt::tt_metal::GraphTracker::instance().get_hook()) {
         hook = std::make_shared<ProcessorHooks>();
         tt::tt_metal::GraphTracker::instance().add_hook(hook);
-        hook->set_block(mode == RunMode::NO_DISPATCH);
+        hook->set_capture_block(mode == RunMode::NO_DISPATCH ? CaptureBlock::All : CaptureBlock::None);
     }
     current_op_id.push(0);
 }
@@ -881,30 +881,32 @@ nlohmann::json GraphProcessor::end_graph_capture_to_file(const std::filesystem::
     return graph_json;
 }
 
-bool ProcessorHooks::hook_allocate(const tt::tt_metal::Buffer* /*buffer*/) { return block_alloc; }
+// Allocation is blocked only by All (DispatchOnly deliberately lets real addresses through).
+bool ProcessorHooks::hook_allocate(const tt::tt_metal::Buffer* /*buffer*/) { return block_mode == CaptureBlock::All; }
 
-bool ProcessorHooks::hook_deallocate(tt::tt_metal::Buffer* /*buffer*/) { return block_alloc; }
+bool ProcessorHooks::hook_deallocate(tt::tt_metal::Buffer* /*buffer*/) { return block_mode == CaptureBlock::All; }
 
-bool ProcessorHooks::hook_write_to_device(const tt::tt_metal::Buffer* /*buffer*/) { return do_block; }
+// Dispatch / write / read / program are blocked by both All and DispatchOnly (i.e. anything but None).
+bool ProcessorHooks::hook_write_to_device(const tt::tt_metal::Buffer* /*buffer*/) {
+    return block_mode != CaptureBlock::None;
+}
 
 bool ProcessorHooks::hook_write_to_device(const tt::tt_metal::distributed::MeshBuffer* /*mesh_buffer*/) {
-    return do_block;
+    return block_mode != CaptureBlock::None;
 }
 
-bool ProcessorHooks::hook_read_from_device(tt::tt_metal::Buffer* /*buffer*/) { return do_block; }
+bool ProcessorHooks::hook_read_from_device(tt::tt_metal::Buffer* /*buffer*/) {
+    return block_mode != CaptureBlock::None;
+}
 
 bool ProcessorHooks::hook_read_from_device(const tt::tt_metal::distributed::MeshBuffer* /*mesh_buffer*/) {
-    return do_block;
+    return block_mode != CaptureBlock::None;
 }
 
-bool ProcessorHooks::hook_program(tt::tt_metal::Program*) { return do_block; }
+bool ProcessorHooks::hook_program(tt::tt_metal::Program*) { return block_mode != CaptureBlock::None; }
 
-void ProcessorHooks::set_block(bool block) {
-    do_block = block;
-    block_alloc = block;
-}
-void ProcessorHooks::set_block_alloc(bool block) { block_alloc = block; }
-bool ProcessorHooks::get_block() const { return do_block; }
+void ProcessorHooks::set_capture_block(CaptureBlock mode) { block_mode = mode; }
+bool ProcessorHooks::get_block() const { return block_mode != CaptureBlock::None; }
 
 ScopedGraphCapture::ScopedGraphCapture(GraphProcessor::RunMode mode) : is_active(true) {
     GraphProcessor::begin_graph_capture(mode);

--- a/ttnn/core/graph/graph_processor.cpp
+++ b/ttnn/core/graph/graph_processor.cpp
@@ -881,9 +881,9 @@ nlohmann::json GraphProcessor::end_graph_capture_to_file(const std::filesystem::
     return graph_json;
 }
 
-bool ProcessorHooks::hook_allocate(const tt::tt_metal::Buffer* /*buffer*/) { return do_block; }
+bool ProcessorHooks::hook_allocate(const tt::tt_metal::Buffer* /*buffer*/) { return block_alloc; }
 
-bool ProcessorHooks::hook_deallocate(tt::tt_metal::Buffer* /*buffer*/) { return do_block; }
+bool ProcessorHooks::hook_deallocate(tt::tt_metal::Buffer* /*buffer*/) { return block_alloc; }
 
 bool ProcessorHooks::hook_write_to_device(const tt::tt_metal::Buffer* /*buffer*/) { return do_block; }
 
@@ -899,7 +899,11 @@ bool ProcessorHooks::hook_read_from_device(const tt::tt_metal::distributed::Mesh
 
 bool ProcessorHooks::hook_program(tt::tt_metal::Program*) { return do_block; }
 
-void ProcessorHooks::set_block(bool block) { do_block = block; }
+void ProcessorHooks::set_block(bool block) {
+    do_block = block;
+    block_alloc = block;
+}
+void ProcessorHooks::set_block_alloc(bool block) { block_alloc = block; }
 bool ProcessorHooks::get_block() const { return do_block; }
 
 ScopedGraphCapture::ScopedGraphCapture(GraphProcessor::RunMode mode) : is_active(true) {

--- a/ttnn/core/up_front_compile.cpp
+++ b/ttnn/core/up_front_compile.cpp
@@ -1,0 +1,164 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/up_front_compile.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <thread>
+
+#include <tt_stl/assert.hpp>
+#include <tt-metalium/program.hpp>
+#include <tt-metalium/mesh_workload.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/tt_metal.hpp>  // tt::tt_metal::detail::CompileProgram
+
+#include "ttnn/graph/graph_processor.hpp"
+#include <tt-metalium/graph_tracking.hpp>  // GraphTracker (for real-alloc hook tweak)
+
+namespace ttnn::up_front_compile {
+
+namespace {
+// Per-thread "currently collecting" flag, matching GraphTracker's per-thread
+// capture semantics: the collect forward pass runs on one thread, and the
+// device-op funnel that consults active() runs on that same thread.
+thread_local bool t_collecting = false;
+}  // namespace
+
+ProgramCollector& ProgramCollector::instance() {
+    static ProgramCollector inst;
+    return inst;
+}
+
+ProgramCollector* ProgramCollector::active() { return t_collecting ? &instance() : nullptr; }
+
+void ProgramCollector::set_active(bool active) { t_collecting = active; }
+
+void ProgramCollector::collect(std::uint64_t program_hash, tt::tt_metal::distributed::MeshWorkload&& workload) {
+    std::lock_guard<std::mutex> lk(mutex_);
+    ++total_collected_;
+    // hash==0 means the device program cache was disabled, so no real structural
+    // hash was computed. Fall back to a unique synthetic key so distinct programs
+    // are NOT collapsed into one (we lose dedup, but stay correct). Synthetic keys
+    // count down from the top of the range to avoid colliding with real hashes.
+    std::uint64_t key = program_hash != 0 ? program_hash : (UINT64_MAX - synthetic_key_++);
+    // First entry per key wins; later structural duplicates are dropped.
+    programs_.try_emplace(key, std::move(workload));
+}
+
+std::size_t ProgramCollector::num_unique() const {
+    std::lock_guard<std::mutex> lk(mutex_);
+    return programs_.size();
+}
+
+std::size_t ProgramCollector::num_collected() const {
+    std::lock_guard<std::mutex> lk(mutex_);
+    return total_collected_;
+}
+
+void ProgramCollector::clear() {
+    std::lock_guard<std::mutex> lk(mutex_);
+    programs_.clear();
+    total_collected_ = 0;
+    synthetic_key_ = 0;
+}
+
+std::vector<tt::tt_metal::Program*> ProgramCollector::program_pointers() {
+    std::lock_guard<std::mutex> lk(mutex_);
+    std::vector<tt::tt_metal::Program*> out;
+    for (auto& [hash, workload] : programs_) {
+        for (auto& [range, program] : workload.get_programs()) {
+            out.push_back(&program);
+        }
+    }
+    return out;
+}
+
+void begin_collect(bool clear, bool real_alloc) {
+    if (clear) {
+        ProgramCollector::instance().clear();
+    }
+    ProgramCollector::set_active(true);
+    // NO_DISPATCH: buffer allocations are mocked (addr 0) and nothing dispatches,
+    // so the collect pass uses no real device memory. The funnel's stash + early
+    // return (device_operation.hpp) handles program collection.
+    ttnn::graph::GraphProcessor::begin_graph_capture(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH);
+    if (real_alloc) {
+        // Real-alloc collect: unblock the allocator so buffers get REAL (deterministic)
+        // addresses — so address-baked kernels (e.g. pool reader_indices) and
+        // address-branched program selection (e.g. move forward/backward) build the SAME
+        // program the real run will, and thus warm. Dispatch/write stay blocked (no compute).
+        // Costs real device memory (~the real run's peak) and requires the dealloc lifecycle
+        // to run (deallocate is host-side, so it does). See up_front_compile.hpp.
+        if (auto hook = tt::tt_metal::GraphTracker::instance().get_hook()) {
+            if (auto* ph = dynamic_cast<ttnn::graph::ProcessorHooks*>(hook.get())) {
+                ph->set_block_alloc(false);
+            }
+        }
+    }
+}
+
+void end_collect() {
+    // Discard the JSON graph; we only used NO_DISPATCH for allocation blocking.
+    ttnn::graph::GraphProcessor::end_graph_capture();
+    ProgramCollector::set_active(false);
+}
+
+CompileStats parallel_compile(tt::tt_metal::distributed::MeshDevice* device, int max_workers, bool clear) {
+    using clock = std::chrono::steady_clock;
+
+    TT_FATAL(device != nullptr, "up_front_compile: device must not be null");
+    auto devices = device->get_devices();
+    TT_FATAL(!devices.empty(), "up_front_compile: mesh device has no devices");
+    tt::tt_metal::IDevice* dev = devices.front();
+
+    auto& store = ProgramCollector::instance();
+    std::vector<tt::tt_metal::Program*> progs = store.program_pointers();
+
+    if (max_workers <= 0) {
+        max_workers = static_cast<int>(std::max(1u, std::thread::hardware_concurrency()));
+    }
+
+    CompileStats stats;
+    stats.num_programs = progs.size();
+    stats.max_workers = max_workers;
+
+    auto t0 = clock::now();
+    if (!progs.empty()) {
+        std::atomic<std::size_t> next{0};
+        std::atomic<std::size_t> errors{0};
+        auto worker = [&]() {
+            std::size_t i;
+            while ((i = next.fetch_add(1)) < progs.size()) {
+                try {
+                    // Compile-only: builds kernels into the on-disk JIT cache. No command
+                    // queue / program-cache state is touched, so distinct programs compile
+                    // concurrently and safely. Buffer addresses are irrelevant to compile.
+                    tt::tt_metal::detail::CompileProgram(dev, *progs[i]);
+                } catch (...) {
+                    errors.fetch_add(1);
+                }
+            }
+        };
+        int n = std::min<int>(max_workers, static_cast<int>(progs.size()));
+        std::vector<std::thread> pool;
+        pool.reserve(n);
+        for (int w = 0; w < n; ++w) {
+            pool.emplace_back(worker);
+        }
+        for (auto& t : pool) {
+            t.join();
+        }
+        stats.num_errors = errors.load();
+    }
+    stats.wall_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(clock::now() - t0).count();
+
+    if (clear) {
+        store.clear();
+    }
+    return stats;
+}
+
+}  // namespace ttnn::up_front_compile

--- a/ttnn/core/up_front_compile.cpp
+++ b/ttnn/core/up_front_compile.cpp
@@ -17,7 +17,7 @@
 #include <tt-metalium/tt_metal.hpp>  // tt::tt_metal::detail::CompileProgram
 
 #include "ttnn/graph/graph_processor.hpp"
-#include <tt-metalium/graph_tracking.hpp>  // GraphTracker (for real-alloc hook tweak)
+#include <tt-metalium/graph_tracking.hpp>  // GraphTracker
 
 namespace ttnn::up_front_compile {
 
@@ -40,12 +40,10 @@ void ProgramCollector::set_active(bool active) { t_collecting = active; }
 void ProgramCollector::collect(std::uint64_t program_hash, tt::tt_metal::distributed::MeshWorkload&& workload) {
     std::lock_guard<std::mutex> lk(mutex_);
     ++total_collected_;
-    // hash==0 means the device program cache was disabled, so no real structural
-    // hash was computed. Fall back to a unique synthetic key so distinct programs
-    // are NOT collapsed into one (we lose dedup, but stay correct). Synthetic keys
-    // count down from the top of the range to avoid colliding with real hashes.
+    // hash==0 means the program cache was disabled (no real hash). Use a synthetic key
+    // counting down from UINT64_MAX so distinct programs aren't collapsed into one and we
+    // don't collide with real hashes.
     std::uint64_t key = program_hash != 0 ? program_hash : (UINT64_MAX - synthetic_key_++);
-    // First entry per key wins; later structural duplicates are dropped.
     programs_.try_emplace(key, std::move(workload));
 }
 
@@ -76,11 +74,8 @@ std::unordered_map<std::uint64_t, tt::tt_metal::distributed::MeshWorkload> Progr
 }
 
 void begin_collect(bool clear, bool real_alloc) {
-    // Reject nesting on top of an existing capture/hook: begin_capture only installs
-    // the NO_DISPATCH blocking hook when no hook is already present, so collecting
-    // under an active capture would leave the collector active WITHOUT dispatch
-    // actually blocked — ops would silently early-return from the funnel on a live
-    // device. This feature owns the capture frame exclusively.
+    // Nesting under an existing capture would skip our blocking hook (begin_capture only
+    // installs one when none is present), leaving the collector active but dispatch unblocked.
     TT_FATAL(
         tt::tt_metal::GraphTracker::instance().get_hook() == nullptr,
         "up_front_compile: begin_collect cannot run while a graph capture / hook is already active");
@@ -91,21 +86,10 @@ void begin_collect(bool clear, bool real_alloc) {
     // so the collect pass uses no real device memory. The funnel's stash + early
     // return (device_operation.hpp) handles program collection.
     ttnn::graph::GraphProcessor::begin_graph_capture(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH);
-    // Mark the collector active only AFTER capture (and thus the blocking hook) is
-    // successfully in place — if begin_graph_capture throws, the thread-local flag
-    // must not be left set, or subsequent ops would early-return without blocking.
     ProgramCollector::set_active(true);
     if (real_alloc) {
-        // Real-alloc collect: unblock the allocator so buffers get REAL (deterministic)
-        // addresses — so address-baked kernels (e.g. pool reader_indices) and
-        // address-branched program selection (e.g. move forward/backward) build the SAME
-        // program the real run will, and thus warm. Dispatch/write stay blocked (no compute).
-        // Costs real device memory (~the real run's peak) and requires the dealloc lifecycle
-        // to run (deallocate is host-side, so it does). See up_front_compile.hpp.
-        // The NO_DISPATCH capture above installs this hook unconditionally, and
-        // begin_collect asserts no other hook pre-exists, so the cast cannot fail
-        // here — assert the invariant (debug-only) rather than silently degrading
-        // real_alloc to an addr-0 collect.
+        // Block dispatch only, letting the allocator hand out live addresses: this better
+        // captures ops that rely on live allocator state, ensuring higher JIT hit rates.
         auto* ph = dynamic_cast<ttnn::graph::ProcessorHooks*>(tt::tt_metal::GraphTracker::instance().get_hook().get());
         TT_ASSERT(ph != nullptr, "up_front_compile: real_alloc requires the NO_DISPATCH ProcessorHooks to be active");
         ph->set_capture_block(ttnn::graph::CaptureBlock::DispatchOnly);
@@ -113,9 +97,6 @@ void begin_collect(bool clear, bool real_alloc) {
 }
 
 void end_collect() {
-    // Deactivate the collector FIRST so the thread-local active flag is reset even
-    // if end_graph_capture() throws — otherwise it would leak into subsequent ops
-    // on this thread, which would early-return from the funnel.
     ProgramCollector::set_active(false);
     // Discard the JSON graph; we only used NO_DISPATCH for allocation blocking.
     ttnn::graph::GraphProcessor::end_graph_capture();

--- a/ttnn/core/up_front_compile.cpp
+++ b/ttnn/core/up_front_compile.cpp
@@ -65,14 +65,12 @@ void ProgramCollector::clear() {
     synthetic_key_ = 0;
 }
 
-std::vector<tt::tt_metal::Program*> ProgramCollector::program_pointers() {
+std::unordered_map<std::uint64_t, tt::tt_metal::distributed::MeshWorkload> ProgramCollector::take_workloads() {
     std::lock_guard<std::mutex> lk(mutex_);
-    std::vector<tt::tt_metal::Program*> out;
-    for (auto& [hash, workload] : programs_) {
-        for (auto& [range, program] : workload.get_programs()) {
-            out.push_back(&program);
-        }
-    }
+    auto out = std::move(programs_);
+    programs_.clear();  // a moved-from map is valid-but-unspecified; force it empty
+    total_collected_ = 0;
+    synthetic_key_ = 0;
     return out;
 }
 
@@ -122,7 +120,7 @@ void end_collect() {
     ttnn::graph::GraphProcessor::end_graph_capture();
 }
 
-CompileStats parallel_compile(tt::tt_metal::distributed::MeshDevice* device, int max_workers, bool clear) {
+CompileStats parallel_compile(tt::tt_metal::distributed::MeshDevice* device, int max_workers) {
     using clock = std::chrono::steady_clock;
 
     TT_FATAL(device != nullptr, "up_front_compile: device must not be null");
@@ -131,7 +129,18 @@ CompileStats parallel_compile(tt::tt_metal::distributed::MeshDevice* device, int
     tt::tt_metal::IDevice* dev = devices.front();
 
     auto& store = ProgramCollector::instance();
-    std::vector<tt::tt_metal::Program*> progs = store.program_pointers();
+    // Take ownership of the collected workloads up front so the worker threads
+    // compile from a snapshot whose lifetime we control. up_front_compile releases
+    // the GIL, so without this a concurrent up_front_clear() / begin_collect(clear=true)
+    // could destroy the MeshWorkloads — and the Program* borrowed into them — while
+    // workers are still compiling (use-after-free).
+    auto workloads = store.take_workloads();
+    std::vector<tt::tt_metal::Program*> progs;
+    for (auto& [hash, workload] : workloads) {
+        for (auto& [range, program] : workload.get_programs()) {
+            progs.push_back(&program);
+        }
+    }
 
     if (max_workers <= 0) {
         max_workers = static_cast<int>(std::max(1u, std::thread::hardware_concurrency()));
@@ -171,9 +180,7 @@ CompileStats parallel_compile(tt::tt_metal::distributed::MeshDevice* device, int
     }
     stats.wall_seconds = std::chrono::duration_cast<std::chrono::duration<double>>(clock::now() - t0).count();
 
-    if (clear) {
-        store.clear();
-    }
+    // take_workloads() already emptied the store; the local snapshot drops here.
     return stats;
 }
 

--- a/ttnn/core/up_front_compile.cpp
+++ b/ttnn/core/up_front_compile.cpp
@@ -77,14 +77,25 @@ std::vector<tt::tt_metal::Program*> ProgramCollector::program_pointers() {
 }
 
 void begin_collect(bool clear, bool real_alloc) {
+    // Reject nesting on top of an existing capture/hook: begin_capture only installs
+    // the NO_DISPATCH blocking hook when no hook is already present, so collecting
+    // under an active capture would leave the collector active WITHOUT dispatch
+    // actually blocked — ops would silently early-return from the funnel on a live
+    // device. This feature owns the capture frame exclusively.
+    TT_FATAL(
+        tt::tt_metal::GraphTracker::instance().get_hook() == nullptr,
+        "up_front_compile: begin_collect cannot run while a graph capture / hook is already active");
     if (clear) {
         ProgramCollector::instance().clear();
     }
-    ProgramCollector::set_active(true);
     // NO_DISPATCH: buffer allocations are mocked (addr 0) and nothing dispatches,
     // so the collect pass uses no real device memory. The funnel's stash + early
     // return (device_operation.hpp) handles program collection.
     ttnn::graph::GraphProcessor::begin_graph_capture(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH);
+    // Mark the collector active only AFTER capture (and thus the blocking hook) is
+    // successfully in place — if begin_graph_capture throws, the thread-local flag
+    // must not be left set, or subsequent ops would early-return without blocking.
+    ProgramCollector::set_active(true);
     if (real_alloc) {
         // Real-alloc collect: unblock the allocator so buffers get REAL (deterministic)
         // addresses — so address-baked kernels (e.g. pool reader_indices) and
@@ -92,18 +103,23 @@ void begin_collect(bool clear, bool real_alloc) {
         // program the real run will, and thus warm. Dispatch/write stay blocked (no compute).
         // Costs real device memory (~the real run's peak) and requires the dealloc lifecycle
         // to run (deallocate is host-side, so it does). See up_front_compile.hpp.
-        if (auto hook = tt::tt_metal::GraphTracker::instance().get_hook()) {
-            if (auto* ph = dynamic_cast<ttnn::graph::ProcessorHooks*>(hook.get())) {
-                ph->set_block_alloc(false);
-            }
-        }
+        // The NO_DISPATCH capture above installs this hook unconditionally, and
+        // begin_collect asserts no other hook pre-exists, so the cast cannot fail
+        // here — assert the invariant (debug-only) rather than silently degrading
+        // real_alloc to an addr-0 collect.
+        auto* ph = dynamic_cast<ttnn::graph::ProcessorHooks*>(tt::tt_metal::GraphTracker::instance().get_hook().get());
+        TT_ASSERT(ph != nullptr, "up_front_compile: real_alloc requires the NO_DISPATCH ProcessorHooks to be active");
+        ph->set_block_alloc(false);
     }
 }
 
 void end_collect() {
+    // Deactivate the collector FIRST so the thread-local active flag is reset even
+    // if end_graph_capture() throws — otherwise it would leak into subsequent ops
+    // on this thread, which would early-return from the funnel.
+    ProgramCollector::set_active(false);
     // Discard the JSON graph; we only used NO_DISPATCH for allocation blocking.
     ttnn::graph::GraphProcessor::end_graph_capture();
-    ProgramCollector::set_active(false);
 }
 
 CompileStats parallel_compile(tt::tt_metal::distributed::MeshDevice* device, int max_workers, bool clear) {

--- a/ttnn/core/up_front_compile.cpp
+++ b/ttnn/core/up_front_compile.cpp
@@ -10,6 +10,7 @@
 #include <thread>
 
 #include <tt_stl/assert.hpp>
+#include <tt-logger/tt-logger.hpp>
 #include <tt-metalium/program.hpp>
 #include <tt-metalium/mesh_workload.hpp>
 #include <tt-metalium/mesh_device.hpp>
@@ -162,8 +163,14 @@ CompileStats parallel_compile(tt::tt_metal::distributed::MeshDevice* device, int
                     // queue / program-cache state is touched, so distinct programs compile
                     // concurrently and safely. Buffer addresses are irrelevant to compile.
                     tt::tt_metal::detail::CompileProgram(dev, *progs[i]);
+                } catch (const std::exception& e) {
+                    // Non-fatal: a failed warm-up compile just leaves that program cold for the
+                    // real run. Log the reason so the failure isn't silent behind the error count.
+                    errors.fetch_add(1);
+                    log_warning(tt::LogAlways, "up_front_compile: program {} failed to compile: {}", i, e.what());
                 } catch (...) {
                     errors.fetch_add(1);
+                    log_warning(tt::LogAlways, "up_front_compile: program {} failed to compile (unknown exception)", i);
                 }
             }
         };

--- a/ttnn/core/up_front_compile.cpp
+++ b/ttnn/core/up_front_compile.cpp
@@ -74,7 +74,7 @@ std::unordered_map<std::uint64_t, tt::tt_metal::distributed::MeshWorkload> Progr
     return out;
 }
 
-void begin_collect(bool clear, bool real_alloc) {
+void begin_collect(bool clear) {
     // Nesting under an existing capture would skip our blocking hook (begin_capture only
     // installs one when none is present), leaving the collector active but dispatch unblocked.
     TT_FATAL(
@@ -83,18 +83,15 @@ void begin_collect(bool clear, bool real_alloc) {
     if (clear) {
         ProgramCollector::instance().clear();
     }
-    // NO_DISPATCH: buffer allocations are mocked (addr 0) and nothing dispatches,
-    // so the collect pass uses no real device memory. The funnel's stash + early
-    // return (device_operation.hpp) handles program collection.
+    // Install the NO_DISPATCH hook (skips program cache + enqueue), then downgrade it to block
+    // dispatch ONLY — the allocator hands out real addresses so address-baked kernels build the
+    // same program the real run will. The funnel's stash + early return (device_operation.hpp)
+    // handles program collection.
     ttnn::graph::GraphProcessor::begin_graph_capture(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH);
+    auto* ph = dynamic_cast<ttnn::graph::ProcessorHooks*>(tt::tt_metal::GraphTracker::instance().get_hook().get());
+    TT_ASSERT(ph != nullptr, "up_front_compile: collect requires the NO_DISPATCH ProcessorHooks to be active");
+    ph->set_capture_block(ttnn::graph::CaptureBlock::DispatchOnly);
     ProgramCollector::set_active(true);
-    if (real_alloc) {
-        // Block dispatch only, letting the allocator hand out live addresses: this better
-        // captures ops that rely on live allocator state, ensuring higher JIT hit rates.
-        auto* ph = dynamic_cast<ttnn::graph::ProcessorHooks*>(tt::tt_metal::GraphTracker::instance().get_hook().get());
-        TT_ASSERT(ph != nullptr, "up_front_compile: real_alloc requires the NO_DISPATCH ProcessorHooks to be active");
-        ph->set_capture_block(ttnn::graph::CaptureBlock::DispatchOnly);
-    }
 }
 
 void end_collect() {

--- a/ttnn/core/up_front_compile.cpp
+++ b/ttnn/core/up_front_compile.cpp
@@ -107,7 +107,7 @@ void begin_collect(bool clear, bool real_alloc) {
         // real_alloc to an addr-0 collect.
         auto* ph = dynamic_cast<ttnn::graph::ProcessorHooks*>(tt::tt_metal::GraphTracker::instance().get_hook().get());
         TT_ASSERT(ph != nullptr, "up_front_compile: real_alloc requires the NO_DISPATCH ProcessorHooks to be active");
-        ph->set_block_alloc(false);
+        ph->set_capture_block(ttnn::graph::CaptureBlock::DispatchOnly);
     }
 }
 

--- a/ttnn/core/up_front_compile.cpp
+++ b/ttnn/core/up_front_compile.cpp
@@ -8,6 +8,7 @@
 #include <atomic>
 #include <chrono>
 #include <thread>
+#include <vector>
 
 #include <tt_stl/assert.hpp>
 #include <tt-logger/tt-logger.hpp>

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -29,6 +29,7 @@ set(TTNN_CORE_SRCS
     core/graph/graph_processor.cpp
     core/graph/graph_trace_utils.cpp
     core/graph/levelized_graph.cpp
+    core/up_front_compile.cpp
     core/reports.cpp
     core/tensor/flatbuffer/tensor_flatbuffer.cpp
     core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -468,6 +469,7 @@ set(TTNNCPP_API_HEADERS
     api/ttnn/mesh_device_operation_adapter.hpp
     api/ttnn/mesh_device_operation_utils.hpp
     api/ttnn/metal2_artifacts.hpp
+    api/ttnn/up_front_compile.hpp
     api/ttnn/operation.hpp
     api/ttnn/operation_concepts.hpp
     api/ttnn/reports.hpp

--- a/ttnn/ttnn/graph.py
+++ b/ttnn/ttnn/graph.py
@@ -30,6 +30,13 @@ from ttnn._ttnn.graph import (
     is_graph_capture_active,
     track_function_start,
     track_function_end,
+    # Tier-1 up-front parallel precompile (ttnn/up_front_compile.hpp)
+    up_front_begin_collect,
+    up_front_end_collect,
+    up_front_num_unique,
+    up_front_num_collected,
+    up_front_clear,
+    up_front_compile,
 )
 
 from ttnn.graph_report import (


### PR DESCRIPTION
Adds a feature to collect all of the programs that TTNN ops launch inside of a process, and then, instead of them being compiled JIT, serially, as the test executed, collect them all upfront and then compile them together, in parallel.

This PR adds the mechanism for doing so (up_front_compile.cpp), as well as a driver for collecting multiple programs across multiple pytest parametrizations (up_front_compile.py). Combines the mechanism for full e2e testing with the option --precompile in run_safe_pytest.sh

## Why

JIT compilation is a large share of test wall time, and it runs serially: each op compiles its
kernels the first time it is dispatched, one program at a time. Compilation is parallel only across
the kernels within a single program, never across programs, because only one program is ever in
flight.

## Mechanism (`up_front_compile.cpp`)

A `NO_DISPATCH` graph-capture mode builds each op's program but mocks its buffer allocations and skips
dispatch, so nothing runs on hardware. The device-op adapter that every op dispatches through hands
each built-but-uncompiled MeshWorkload to a collector instead of executing it; the collector dedups by
program hash. After collection, `up_front_compile` compiles the distinct set across a worker thread
pool and writes the results to the on-disk kernel cache. It is op-agnostic — any op that goes through
the adapter is collected.

```python
ttnn.graph.up_front_begin_collect()   # NO_DISPATCH: nothing runs; each op stashes its workload
model(dummy_input, device)
ttnn.graph.up_front_end_collect()
ttnn.graph.up_front_compile(device)   # parallel JIT, warms the cache
```

## Driver (`tests/plugins/up_front_collect.py`)

The mechanism needs something to drive the ops between `begin_collect` and `end_collect`. For a single
model that is one `model(input)` call. A test suite has no such entry point: each test is a pytest
function with its own fixtures and parametrizations, so there is nothing to call directly. The driver
is a pytest plugin that runs the collect pass across a whole session — a hookwrapper wraps each test's
call phase, so every parametrization runs through pytest's normal machinery and its ops accumulate
into one collector, compiled once at the end.

Driving arbitrary test bodies this way is invasive, for two reasons:

- Under `NO_DISPATCH` the outputs are never computed, so the tests' own readbacks and
  `comp_pcc`/`assert` checks fail. The driver swallows those failures; the op was already stashed
  before the check ran.
- A test body also does host work unrelated to compilation: RNG inputs, the torch golden reference
  (`conv2d`/`matmul`/…), `from_torch` weight prep (tilize/convert, often the largest cost), and the
  numeric checks. If the suite were simply run once to collect and again for real, all of that host
  work would be done twice. To avoid it, the driver monkeypatches those host-side calls during the
  collect window with shape-only stand-ins (`randn`/`conv2d`/`matmul`/`layer_norm`/`group_norm` →
  zeros, `comp_pcc` → no-op, `from_torch` → shape-only allocation), patched across every module that
  imported them and reversed afterward. This is safe because the collected programs depend only on op
  shape and config, not on values, so the stand-ins do not change what is collected — they only keep
  the collect pass cheap.

The monkeypatching and exception-swallowing are why the plugin looks the way it does; both are
required to reuse test bodies the plugin does not own as an op source.

## Allocation modes and misses

A *miss* is an op whose collected program differs from the one the real run uses: it isn't in the warm
cache, so it cold-compiles in the real run as before (never wrong, just not warmed).

By default NO_DISPATCH mocks allocations to address 0, so collection uses no device memory;
`UP_FRONT_REAL_ALLOC` instead runs the allocator for real (dispatch still blocked, nothing computes) at
the cost of ~the real run's peak memory. Real allocation is worth it for ops that select their program
from allocator state — real buffer addresses or L1 occupancy, e.g. pool reader-indices or `move` —
which otherwise collect the wrong program under addr-0 and miss. (`run_safe_pytest.sh --precompile`
uses real allocation.)

Other misses, which real allocation cannot fix:

- value-dependent program selection (data-dependent shapes, or a readback whose value steers a later
  op) — nothing is computed under NO_DISPATCH;
- trace/graph-capture tests, skipped because NO_DISPATCH blocks the dispatch/allocation that recording
  needs;
- ops after a point where the body throws before they are reached and stashed.

## Running it: `run_safe_pytest.sh --precompile`

All of the above is hidden behind one flag:

```bash
scripts/run_safe_pytest.sh --precompile <test_path> [pytest args…]
```

It runs the warmup (collect + parallel compile) on the same device the tests will use, then runs the
suite normally against the now-warm cache. There are no env vars and no second command — plugin
loading, `NO_DISPATCH`, real allocation, and worker count are all set internally; the selection passed
to pytest (`-k`, markers, paths) is applied to the warmup too. If anything in the warmup fails it is
skipped and the suite runs cold, so `--precompile` can only make a run slower, never wrong. Hardware
only.

## Validation: real run rebuilds nothing

n300, fresh cache, `linear → gelu → add → mul`:

| | warmup | real run | kernels built during run |
|---|---|---|---|
| with warmup | 2.44 s | 0.014 s | 0 |
| cold | — | 2.865 s | 193 |

## Conv2d nightly A/B (full job, e2e)

| arch | cold | precompile | speedup |
|---|---|---|---|
| wormhole_b0 N300 | 120.9 min | 75.3 min | 1.6× |
| blackhole P150b | 102.0 min | 75.1 min | 1.4× |

- Cold: https://github.com/tenstorrent/tt-metal/actions/runs/27155076535
- Precompile: https://github.com/tenstorrent/tt-metal/actions/runs/27155085099

## Tests

`tests/ttnn/unit_tests/test_up_front_compile*.py` — collector mechanics + warm-run correctness
(eltwise chain, two-layer MLP, mesh, CCL `all_gather`). Plugin exercised on
layernorm/matmul/groupnorm/conv2d/conv3d (0 swallowed / fallback / errors).

CI: sanity https://github.com/tenstorrent/tt-metal/actions/runs/27285998679 · blackhole post-commit
https://github.com/tenstorrent/tt-metal/actions/runs/27286044070

Draft.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/precompile-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/precompile-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/precompile-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/precompile-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/precompile-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/precompile-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/precompile-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/precompile-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/precompile-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/precompile-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/precompile-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/precompile-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/precompile-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/precompile-core)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/precompile-core)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/precompile-core)