### PR TITLE
25k Kimi smoke MoE in CI

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -657,8 +657,10 @@ def test_ds_moe(
     ),
     [
         # fmt: off
+        pytest.param( 640, KimiK26Config.EMB_SIZE, KimiK26Config.MOE_INTERMEDIATE_SIZE, KimiK26Config.NUM_ROUTED_EXPERTS, KimiK26Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.HOST_ALL, False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi-5k-perf"),
         pytest.param( 640, KimiK26Config.EMB_SIZE, KimiK26Config.MOE_INTERMEDIATE_SIZE, KimiK26Config.NUM_ROUTED_EXPERTS, KimiK26Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.HOST_ALL, True, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi-5k-pcc"),
         pytest.param(3200, KimiK26Config.EMB_SIZE, KimiK26Config.MOE_INTERMEDIATE_SIZE, KimiK26Config.NUM_ROUTED_EXPERTS, KimiK26Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.HOST_ALL, False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi-25k-perf"),
+        pytest.param(3200, KimiK26Config.EMB_SIZE, KimiK26Config.MOE_INTERMEDIATE_SIZE, KimiK26Config.NUM_ROUTED_EXPERTS, KimiK26Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.HOST_ALL, True, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi-25k-pcc"),
         # fmt: on
     ],
 )

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -657,8 +657,8 @@ def test_ds_moe(
     ),
     [
         # fmt: off
-        pytest.param( 640, KimiK26Config.EMB_SIZE, KimiK26Config.MOE_INTERMEDIATE_SIZE, KimiK26Config.NUM_ROUTED_EXPERTS, KimiK26Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.HOST_ALL, True, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi-5k"),
-        pytest.param(3200, KimiK26Config.EMB_SIZE, KimiK26Config.MOE_INTERMEDIATE_SIZE, KimiK26Config.NUM_ROUTED_EXPERTS, KimiK26Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.HOST_ALL, True, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi-25k"),
+        pytest.param( 640, KimiK26Config.EMB_SIZE, KimiK26Config.MOE_INTERMEDIATE_SIZE, KimiK26Config.NUM_ROUTED_EXPERTS, KimiK26Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.HOST_ALL, True, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi-5k-pcc"),
+        pytest.param(3200, KimiK26Config.EMB_SIZE, KimiK26Config.MOE_INTERMEDIATE_SIZE, KimiK26Config.NUM_ROUTED_EXPERTS, KimiK26Config.NUM_EXPERTS_PER_TOKEN, 5, GateComputeMode.HOST_ALL, False, marks=[pytest.mark.skipif(not is_blackhole(), reason="Blackhole only"), pytest.mark.timeout(0)], id="kimi-25k-perf"),
         # fmt: on
     ],
 )

--- a/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_deepseek_prefill_tests.yaml
@@ -107,12 +107,12 @@
 - name: "(Galaxy) DeepSeek Prefill - Kimi MoE"
   cmd: |
     export MESH_DEVICE=TG
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "mesh-8x4" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "mesh-8x4 and (kimi-5k-pcc or kimi-25k-perf)" -vvv --tb=short
   test_type: kimi_moe
   test_group: module
   skus:
     bh_galaxy:
-      timeout: 45
+      timeout: 30
   owner_id: U08RL15T4N8
   team: models
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
MoE test in CI for Kimi runs `test_ttnn_moe.py` test for 5k and 25k. Total test time is ~45 minutes, which is too long given that we aim to reduce CI time for prefill tests.

I used [this](https://github.com/tenstorrent/tt-metal/actions/runs/27208280220/job/80428410363) CI run for analysis.

5k test analysis per phase:
```
┌───────────────────────────────────────────────┬──────┐
│                     Phase                     │ Time │
├───────────────────────────────────────────────┼──────┤
│ Torch weight creation (384 experts)           │ ~92s │
├───────────────────────────────────────────────┼──────┤
│ TTNN cache build (one-time; 5k only)          │ 324s │
├───────────────────────────────────────────────┼──────┤
│ torch_forward + setup                         │ ~60s │
├───────────────────────────────────────────────┼──────┤
│ tt_forward (device, incl. 33s compile)        │ 44s  │
├───────────────────────────────────────────────┼──────┤
│ validate_dispatch_buffer                      │ 96s  │
├───────────────────────────────────────────────┼──────┤
│ validate_dispatch_buffer_pcc (expert_outputs) │ 113s │
├───────────────────────────────────────────────┼──────┤
│ validate_combine_output                       │ 42s  │
├───────────────────────────────────────────────┼──────┤
│ reference cross-check                         │ ~81s │
└───────────────────────────────────────────────┴──────┘
Sum ≈ 852s ≈ 14.2 min
```

25k test analysis per phase:
```
┌───────────────────────────────────────────────┬──────┐
│                     Phase                     │ Time │
├───────────────────────────────────────────────┼──────┤
│ Torch weight creation (384 experts)           │ ~92s │
├───────────────────────────────────────────────┼──────┤
│ TTNN cache build (reused from 5k)             │ 0s   │
├───────────────────────────────────────────────┼──────┤
│ torch_forward + setup                         │ ~90s │
├───────────────────────────────────────────────┼──────┤
│ tt_forward (device, incl. 33s compile)        │ 42s  │
├───────────────────────────────────────────────┼──────┤
│ validate_dispatch_buffer                      │ 480s │
├───────────────────────────────────────────────┼──────┤
│ validate_dispatch_buffer_pcc (expert_outputs) │ 556s │
├───────────────────────────────────────────────┼──────┤
│ validate_combine_output                       │ 210s │
├───────────────────────────────────────────────┼──────┤
│ reference cross-check                         │ ~90s │
└───────────────────────────────────────────────┴──────┘
Sum ≈ 1560s ≈ 26.0 min
```
We notice a few things:
1) TTNN cache created once in the first run, then reused in 25k case.
2) `validate_dispatch_buffer`, `validate_dispatch_buffer_pcc` and `validate_combine_output` in case of 25k last 5 times longer as ISL is 5 times larger.
3) Most time in test is spent on PCC comparison of TTNN output against CPU reference.

The proposal here is to remove PCC comparison for 25k, so we have 5k test with full PCC check and smoke 25k test that skips PCC comparison.

### DeepSeek Prefill CI

- [ ] [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=nbabin/kimi_moe_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:nbabin/kimi_moe_ci)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nbabin/kimi_moe_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nbabin/kimi_moe_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nbabin/kimi_moe_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nbabin/kimi_moe_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nbabin/kimi_moe_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nbabin/kimi_moe_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nbabin/kimi_moe_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nbabin/kimi_moe_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nbabin/kimi_moe_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nbabin/kimi_moe_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nbabin/kimi_moe_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nbabin/kimi_moe_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nbabin/kimi_moe_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nbabin/kimi_moe_ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nbabin/kimi_moe_ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nbabin/kimi_moe_ci)