### PR TITLE
Updates to TTTv2 sampling module

### DIFF
--- a/models/common/models/executor.py
+++ b/models/common/models/executor.py
@@ -74,15 +74,22 @@ def make_contiguous_page_table(
     return page_table
 
 
-def _build_decode_topk_param_tensors(mesh_device, sampling_params, batch_size):
+def _build_decode_topk_param_tensors(mesh_device, sampling_params, batch_size, allow_force_argmax=True):
     """Build replicated (k, p, temp) device tensors for ``Sampling1D``'s top-k path.
 
     Reuses ``format_sampling_params`` (so temperature inversion, top-p clamping and the
     ``temp==0 -> k=1`` rewrite match TTTv1 / PERF.md exactly), then mirrors TTSampling's
     1D layout: ROW_MAJOR, uint32 k / bfloat16 p / bfloat16 temp, replicated across the mesh.
 
-    Returns ``None`` when the formatted params reduce to force-argmax (all k==1, p==0,
-    temp==1) — the caller should then use the argmax path instead.
+    Returns ``None`` **only when force-argmax is allowed** and the formatted params reduce to
+    greedy (all k==1, p==0, temp==1) — the caller then uses the cheaper full-vocab argmax path.
+    When ``allow_force_argmax`` is False the model has no argmax path, so greedy params must
+    still build real tensors and route through the top-k op (k=1 top-k == argmax-via-topk),
+    exactly as TTTv1 does for the ``temp=0`` PERF.md recipe — never returning ``None``.
+
+    Note: ``format_sampling_params`` rewrites every ``temp==0`` row to ``(temp=1, k=1, p=0)``
+    (generator.py:512-517) — top_p is zeroed too — so the PERF.md ``temp=0, top_k=32, top_p=0.08``
+    recipe reduces to the greedy representation, not ``k=1/p=0.08/temp=1``.
     """
     from models.common.sampling import format_sampling_params
 
@@ -96,7 +103,7 @@ def _build_decode_topk_param_tensors(mesh_device, sampling_params, batch_size):
     p = list(fmt.top_p)[:batch_size]
     temp = list(fmt.temperature)[:batch_size]
 
-    if all(kk == 1 for kk in k) and all(pp == 0 for pp in p) and all(tt == 1 for tt in temp):
+    if allow_force_argmax and all(kk == 1 for kk in k) and all(pp == 0 for pp in p) and all(tt == 1 for tt in temp):
         return None
 
     mapper = ttnn.ReplicateTensorToMesh(mesh_device)
@@ -281,11 +288,15 @@ class EagerLLMExecutor:
     def _sampling_decode_forward(self, logits, sampling_params, tt_out_tok=None):
         """Run ``model.sampling`` on device, choosing the path that matches PERF.md.
 
-        Greedy params that reduce to (k==1, p==0, temp==1) take the force-argmax
-        full-vocab all-gather path (``decode_forward`` with no k/p/temp). Anything
-        else — including the PERF.md ``temp=0, top_k=32, top_p=0.08`` recipe, which
-        formats to k=1/p=0.08/temp=1 — takes the **top-k op path**: per-device
-        ``ttnn.topk`` → barrier-free all-gather of the ``[*,32]`` tuples → ``ttnn.sampling``.
+        Routing depends on the model's ``allow_force_argmax``:
+          * ``allow_force_argmax=True``  — greedy params reducing to (k==1, p==0, temp==1) take
+            the force-argmax full-vocab all-gather path (``decode_forward`` with no k/p/temp).
+          * ``allow_force_argmax=False`` (the 1B/7B recipe) — there is no argmax path, so *every*
+            recipe, greedy included, builds k/p/temp tensors and takes the **top-k op path**:
+            per-device ``ttnn.topk`` → barrier-free all-gather of the ``[*,32]`` tuples →
+            ``ttnn.sampling``. This mirrors TTTv1, whose ``temp=0`` PERF.md recipe always runs
+            ``ttnn.topk`` (``format_sampling_params`` rewrites ``temp=0`` to the greedy k=1/p=0/temp=1
+            representation, so k=1 top-k == argmax-via-topk).
 
         The k/p/temp tensors are built once and cached so the *same* persistent device
         tensors are referenced during trace warmup, capture and replay (greedy decode
@@ -302,7 +313,10 @@ class EagerLLMExecutor:
         if getattr(self, "_decode_sampling_kpt_built", False):
             return self._decode_sampling_kpt
         self._decode_sampling_kpt = _build_decode_topk_param_tensors(
-            self.mesh_device, sampling_params, self.model.sampling.config.max_batch_size
+            self.mesh_device,
+            sampling_params,
+            self.model.sampling.config.max_batch_size,
+            allow_force_argmax=self.model.sampling.config.allow_force_argmax,
         )
         self._decode_sampling_kpt_built = True
         return self._decode_sampling_kpt

--- a/models/common/models/executor.py
+++ b/models/common/models/executor.py
@@ -74,6 +74,56 @@ def make_contiguous_page_table(
     return page_table
 
 
+def _build_decode_topk_param_tensors(mesh_device, sampling_params, batch_size):
+    """Build replicated (k, p, temp) device tensors for ``Sampling1D``'s top-k path.
+
+    Reuses ``format_sampling_params`` (so temperature inversion, top-p clamping and the
+    ``temp==0 -> k=1`` rewrite match TTTv1 / PERF.md exactly), then mirrors TTSampling's
+    1D layout: ROW_MAJOR, uint32 k / bfloat16 p / bfloat16 temp, replicated across the mesh.
+
+    Returns ``None`` when the formatted params reduce to force-argmax (all k==1, p==0,
+    temp==1) — the caller should then use the argmax path instead.
+    """
+    from models.common.sampling import format_sampling_params
+
+    # format_sampling_params asserts the batch is a multiple of 32; round up for the call (the
+    # greedy params are uniform/broadcast) then slice back to batch_size. This lets the argmax
+    # reduction below return None for batch_size < 32 (argmax works at any batch) instead of
+    # tripping that assert before we ever reach the check.
+    fmt_len = ((batch_size + 31) // 32) * 32
+    fmt = format_sampling_params(sampling_params, fmt_len)
+    k = list(fmt.top_k)[:batch_size]
+    p = list(fmt.top_p)[:batch_size]
+    temp = list(fmt.temperature)[:batch_size]
+
+    if all(kk == 1 for kk in k) and all(pp == 0 for pp in p) and all(tt == 1 for tt in temp):
+        return None
+
+    mapper = ttnn.ReplicateTensorToMesh(mesh_device)
+    k_tt = ttnn.from_torch(
+        torch.tensor(k, dtype=torch.int32),
+        device=mesh_device,
+        dtype=ttnn.uint32,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=mapper,
+    )
+    p_tt = ttnn.from_torch(
+        torch.tensor(p, dtype=torch.float32),
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=mapper,
+    )
+    temp_tt = ttnn.from_torch(
+        torch.tensor(temp, dtype=torch.float32),
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        mesh_mapper=mapper,
+    )
+    return k_tt, p_tt, temp_tt
+
+
 # =============================================================================
 # Protocol: LLMModel
 # =============================================================================
@@ -223,6 +273,39 @@ class EagerLLMExecutor:
         self._kv_cache = kv_cache
         self.model.set_kv_cache(kv_cache)
         return kv_cache
+
+    # =========================================================================
+    # On-device sampling routing (argmax vs top-k op path)
+    # =========================================================================
+
+    def _sampling_decode_forward(self, logits, sampling_params, tt_out_tok=None):
+        """Run ``model.sampling`` on device, choosing the path that matches PERF.md.
+
+        Greedy params that reduce to (k==1, p==0, temp==1) take the force-argmax
+        full-vocab all-gather path (``decode_forward`` with no k/p/temp). Anything
+        else — including the PERF.md ``temp=0, top_k=32, top_p=0.08`` recipe, which
+        formats to k=1/p=0.08/temp=1 — takes the **top-k op path**: per-device
+        ``ttnn.topk`` → barrier-free all-gather of the ``[*,32]`` tuples → ``ttnn.sampling``.
+
+        The k/p/temp tensors are built once and cached so the *same* persistent device
+        tensors are referenced during trace warmup, capture and replay (greedy decode
+        keeps them constant, so no per-step update is needed).
+        """
+        kpt = self._get_decode_sampling_kpt(sampling_params)
+        if kpt is None:
+            return self.model.sampling.decode_forward(logits, tt_out_tok=tt_out_tok)
+        k_tt, p_tt, temp_tt = kpt
+        return self.model.sampling.decode_forward(logits, k=k_tt, p=p_tt, temp=temp_tt, tt_out_tok=tt_out_tok)
+
+    def _get_decode_sampling_kpt(self, sampling_params):
+        """Lazily build + cache (k, p, temp) device tensors, or None for force-argmax."""
+        if getattr(self, "_decode_sampling_kpt_built", False):
+            return self._decode_sampling_kpt
+        self._decode_sampling_kpt = _build_decode_topk_param_tensors(
+            self.mesh_device, sampling_params, self.model.sampling.config.max_batch_size
+        )
+        self._decode_sampling_kpt_built = True
+        return self._decode_sampling_kpt
 
     def _assert_kv_cache_identity(self, kv_cache):
         """Verify kv_cache passed to forward is the same object bound at allocation."""
@@ -687,8 +770,14 @@ class EagerLLMExecutor:
 
         sampling_on_device = sampling_params is not None
 
-        if sampling_on_device and self.model.sampling is not None:
-            # todo)) move this import to the top of the file? --> TTTv2 sampling does not have this?
+        if (
+            sampling_on_device
+            and self.model.sampling is not None
+            and hasattr(self.model.sampling, "apply_decode_state")
+        ):
+            # TTTv1 SamplingGenerator pushes per-request k/p/temp into persistent device buffers
+            # via apply_decode_state + seed_manager. The TTTv2 Sampling1D module holds no mutable
+            # state (k/p/temp are per-call args; greedy/argmax needs none), so skip when absent.
             from models.common.sampling import broadcast_sampling_params, format_sampling_params
 
             per_request_params = format_sampling_params(broadcast_sampling_params(sampling_params, 0, slot_len=B), B)
@@ -714,8 +803,12 @@ class EagerLLMExecutor:
         )
 
         if sampling_on_device and self.model.sampling is not None:
-            self.model.increment_positions(tt_current_pos, tt_rot_mat_idxs)
-            tt_toks, tt_log_probs = self.model.sampling.decode_forward(logits, tt_out_tok=tt_tokens)
+            # increment_positions omitted: positions are re-supplied from host each decode step
+            # (see TracedLLMExecutor._capture_decode_trace for the trace-capture rationale).
+            # tt_out_tok=None: let sampling allocate its own correctly-shaped output token tensor.
+            # Reusing the [1,1,1,32] input-token buffer as the argmax output ([1,1,32]) is a shape
+            # mismatch that forces a realloc — fatal during trace capture.
+            tt_toks, tt_log_probs = self._sampling_decode_forward(logits, sampling_params, tt_out_tok=None)
             if read_from_device:
                 ttnn.synchronize_device(self.mesh_device)
                 toks = _process_output_decode_tokens(tt_toks.cpu(), B, cluster_shape)
@@ -1253,7 +1346,13 @@ class TracedLLMExecutor:
         num_devices = self.model.num_devices
         cluster_shape = self.model_args.cluster_shape if self.model_args else [1, 1]
 
-        if sampling_on_device and self.model.sampling is not None:
+        if (
+            sampling_on_device
+            and self.model.sampling is not None
+            and hasattr(self.model.sampling, "apply_decode_state")
+        ):
+            # TTTv1-only: push per-request k/p/temp into persistent device buffers before replay.
+            # TTTv2 Sampling1D has no such state (greedy/argmax needs none) — skip when absent.
             from models.common.sampling import broadcast_sampling_params, format_sampling_params
 
             per_request_params = format_sampling_params(broadcast_sampling_params(sampling_params, 0, slot_len=B), B)
@@ -1264,7 +1363,7 @@ class TracedLLMExecutor:
             self.model.sampling.seed_manager.get_new_values()
 
         if not self.trace_ids_decode[sampling_on_device]:
-            self._capture_decode_trace(tokens, start_pos, page_table, kv_cache, sampling_on_device)
+            self._capture_decode_trace(tokens, start_pos, page_table, kv_cache, sampling_on_device, sampling_params)
 
         host_inputs = self._eager.prepare_decode_inputs_host(tokens, start_pos, page_table)
         copy_host_to_device(
@@ -1294,7 +1393,7 @@ class TracedLLMExecutor:
 
         return tt_output
 
-    def _capture_decode_trace(self, tokens, start_pos, page_table, kv_cache, sampling_on_device):
+    def _capture_decode_trace(self, tokens, start_pos, page_table, kv_cache, sampling_on_device, sampling_params=None):
         """Compile + capture decode trace."""
         self._eager.decode_forward(
             tokens,
@@ -1309,6 +1408,31 @@ class TracedLLMExecutor:
 
         host_inputs = self._eager.prepare_decode_inputs_host(tokens, start_pos, page_table)
         device_inputs = copy_host_to_device(host_inputs, mesh_device=self.mesh_device)
+
+        # On-device sampling: materialise sampling buffers AND JIT-compile the sampling program
+        # BEFORE trace capture. Both buffer materialisation (Sampling1D LazyBuffers + the
+        # LogProbsCalculator's ttnn.as_tensor scratch) and a first-run program compile issue device
+        # writes, which are illegal inside begin/end_trace_capture
+        # ("TT_FATAL: Writes are not supported during trace capture"). The eager warmup above runs
+        # the non-sampling path (sampling_params=None), so the argmax/all-gather sampling op is not
+        # yet compiled — warm it up here against real device logits.
+        if (
+            sampling_on_device
+            and self.model.sampling is not None
+            and hasattr(self.model.sampling, "load_device_buffers")
+        ):
+            self.model.sampling.load_device_buffers()
+            ttnn.synchronize_device(self.mesh_device)
+            with suspend_module_input_validation():
+                wu_tokens, wu_current_pos, wu_rot_mat_idxs, wu_page_table = device_inputs
+                wu_rot_mats = self.model.rope_setup.get_rot_mats(wu_rot_mat_idxs)
+                wu_embed = self.model.embed_decode(wu_tokens)
+                wu_logits = self.model.decode_forward(wu_embed, wu_current_pos, wu_rot_mats, page_table=wu_page_table)
+                wu_toks, _ = self._eager._sampling_decode_forward(wu_logits, sampling_params, tt_out_tok=None)
+            ttnn.synchronize_device(self.mesh_device)
+            cleanup_ttnn_value(wu_toks)
+            ttnn.synchronize_device(self.mesh_device)
+            logger.info("Compiled on-device sampling")
 
         trace_id = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
 
@@ -1325,8 +1449,15 @@ class TracedLLMExecutor:
             )
 
             if sampling_on_device and self.model.sampling is not None:
-                self.model.increment_positions(tt_current_pos, tt_rot_mat_idxs)
-                tt_toks, tt_log_probs = self.model.sampling.decode_forward(logits, tt_out_tok=tt_tokens)
+                # NOTE: increment_positions (ttnn.plus_one) is intentionally NOT called inside the
+                # captured body. plus_one issues per-device host-assisted writes that are illegal
+                # during trace capture ("Writes are not supported during trace capture"), and it is
+                # redundant here: decode_forward re-supplies current_pos/rot_mat_idxs from the host
+                # via copy_host_to_device at the start of every step, so any in-trace increment is
+                # overwritten before the next replay. Host owns position bookkeeping.
+                # tt_out_tok=None: sampling allocates its own [1,1,32] argmax output captured in the
+                # trace (reusing the [1,1,1,32] input-token buffer is a shape mismatch -> realloc).
+                tt_toks, tt_log_probs = self._eager._sampling_decode_forward(logits, sampling_params, tt_out_tok=None)
                 output = (tt_toks, tt_log_probs)
             else:
                 logits = self.model.gather_and_untilize_logits(logits)

--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -297,10 +297,12 @@ class Sampling1D(LightweightModule):
         confirmed for Linear+barrier) is that the Linear all-gather's barrier issues a host-assisted
         event-sync + per-device semaphore writes that are illegal inside capture; Ring is
         self-synchronising and needs no barrier. This matches the model's own
-        ``gather_and_untilize_logits`` (Ring, no barrier), which captures cleanly — and is what
-        unblocks on-device greedy sampling under the traced executor. Below 8 devices (no ring) fall
-        back to the clamped Linear+barrier path (correct eagerly, but not trace-capture safe —
-        N150/N300 sampling stays on the eager executor).
+"""Multi-device: all-gather logits before argmax.
+
+On ring-capable meshes (e.g. T3K 1×8) use Ring topology with no barrier semaphore to match the
+model's logits gather and avoid trace-capture issues seen with some barrier-based configurations.
+For other meshes, fall back to the clamped Linear+barrier path.
+"""
         """
         cfg = self.config
         if default_topology(cfg.mesh_device) == ttnn.Topology.Ring:

--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -288,7 +288,7 @@ class Sampling1D(LightweightModule):
 
     def _argmax_all_gather(self, logits):
         """Multi-device: all-gather logits before argmax.
-        
+
         On ring-capable meshes (e.g. T3K 1×8) use Ring topology with no barrier semaphore to match the
         model's logits gather and avoid trace-capture issues seen with some barrier-based configurations.
         For other meshes, fall back to the clamped Linear+barrier path.

--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -288,21 +288,10 @@ class Sampling1D(LightweightModule):
 
     def _argmax_all_gather(self, logits):
         """Multi-device: all-gather logits before argmax.
-
-        On ring-capable meshes (e.g. T3K 1×8) use the same trace-capture-safe configuration as a
-        model's own logits gather: Ring topology, no ``cluster_axis``, and crucially **no barrier
-        semaphore**. The Linear+barrier configuration cannot be captured — trace aborts with
-        "TT_FATAL: Event Synchronization / Writes are not supported during trace capture". The
-        likely cause (hypothesis: Ring+barrier was not isolated in testing, so the blocker is only
-        confirmed for Linear+barrier) is that the Linear all-gather's barrier issues a host-assisted
-        event-sync + per-device semaphore writes that are illegal inside capture; Ring is
-        self-synchronising and needs no barrier. This matches the model's own
-"""Multi-device: all-gather logits before argmax.
-
-On ring-capable meshes (e.g. T3K 1×8) use Ring topology with no barrier semaphore to match the
-model's logits gather and avoid trace-capture issues seen with some barrier-based configurations.
-For other meshes, fall back to the clamped Linear+barrier path.
-"""
+        
+        On ring-capable meshes (e.g. T3K 1×8) use Ring topology with no barrier semaphore to match the
+        model's logits gather and avoid trace-capture issues seen with some barrier-based configurations.
+        For other meshes, fall back to the clamped Linear+barrier path.
         """
         cfg = self.config
         if default_topology(cfg.mesh_device) == ttnn.Topology.Ring:

--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -13,6 +13,7 @@ See also: models/common/sampling/tt_sampling.py (TTTv1 source)
 from __future__ import annotations
 
 import inspect
+import sys
 from dataclasses import dataclass, replace
 from typing import Any, Optional
 
@@ -22,6 +23,21 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.modules.lazy_buffer import LazyBuffer, resolve_lazy_buffer
 from models.common.modules.tt_ccl import get_tt_ccl
+
+# ---------------------------------------------------------------------------
+# Power-of-2 helpers (local copies; keep this TTTv2 module self-contained)
+# ---------------------------------------------------------------------------
+
+
+def _is_power_of_2(n: int) -> bool:
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def _upper_power_of_2(n: int) -> int:
+    if n <= 1:
+        return 1
+    return 1 << (n - 1).bit_length()
+
 
 # ---------------------------------------------------------------------------
 # Config
@@ -49,6 +65,11 @@ class Sampling1DConfig:
     allow_force_argmax: bool = False
     num_argmax_gather_links: Optional[int] = None  # None → same as num_gather_links
     ag_topology: Optional[ttnn.Topology] = None  # None → Topology.Linear
+    # Pad each per-device logit shard up to the next power of 2 before ttnn.topk. Big device-perf
+    # win for non-power-of-2 vocab on the multi-device path (TTTv1's pad_logits_to_power_of_2).
+    # Strict TTTv1 parity: only the multi-device path is padded — the 1×1 multi_step split path
+    # is left unpadded.
+    pad_to_power_of_2: bool = False
 
     # --- Persistent buffer specs (LazyBuffer | ttnn.Tensor | None) ---
     # Static index buffers (computed from vocab_size + num_devices, never mutated)
@@ -191,6 +212,7 @@ class Sampling1D(LightweightModule):
         temp: ttnn.Tensor | None = None,
         seeds: ttnn.Tensor | None = None,
         tt_out_tok: ttnn.Tensor | None = None,
+        enable_log_probs: bool | list[bool] = False,
     ):
         """Sample tokens from logits.
 
@@ -200,12 +222,22 @@ class Sampling1D(LightweightModule):
                 All provided → top-k sampling path.
             seeds: Optional per-call seed override. If None, uses config seeds buffer.
             tt_out_tok: Optional output tensor to write results to.
+            enable_log_probs: Per-call logprobs toggle (bool, or per-user list of bool — if any
+                user is enabled the whole batch computes logprobs). Refreshed every call, so no
+                mutable logprobs state is stored on the module. Only the top-k path emits logprobs
+                (sampled-token logprob); the argmax path never does (see ``_sample_argmax``). The
+                calculator additionally requires a multi-device shard (T3K 1×8) — it returns ``None``
+                on 1×1/1×2 even when enabled.
 
         Returns:
             (token_ids, log_probs_or_none)
         """
         self.load_device_buffers()
         cfg = self.config
+
+        # Per-call logprobs mode — refreshed each forward from the arg, never persisted on the
+        # module (TTTv2 principle: no mutable sampling state). Mirrors main's reset_params path.
+        self._log_probs_calculator.set_log_probs_mode(enable_log_probs)
 
         # Route: argmax or top-k
         if k is None and p is None and temp is None:
@@ -234,22 +266,40 @@ class Sampling1D(LightweightModule):
             keepdim=False,
             use_multicore=True,
         )
-        log_probs = self._log_probs_calculator.calculate_log_probs(logits, tt_out_tok)
-        return tt_out_tok, log_probs
+        # Argmax path never emits logprobs (main's contract: force-argmax is disabled whenever
+        # logprobs are requested). Return None unconditionally — do not call the calculator.
+        return tt_out_tok, None
+
+    def _get_argmax_all_gather_config(self, cluster_axis):
+        """Clamp the tuned all-gather config to what the actual submesh supports.
+
+        Port of main's ``_get_force_argmax_all_gather_config`` (#44246): bound num_links to the
+        links available on the submesh, and force Linear topology below 8 devices (Ring routing
+        like D0→D12 only wraps cleanly on T3K-class 8-device groups).
+        """
+        cfg = self.config
+        num_links = cfg.num_argmax_gather_links
+        if hasattr(cfg.tt_ccl, "get_num_links"):
+            num_links = min(num_links, cfg.tt_ccl.get_num_links(cluster_axis))
+        topology = cfg.ag_topology
+        if cfg.mesh_device.get_num_devices() < 8:
+            topology = ttnn.Topology.Linear
+        return max(1, num_links), topology
 
     def _argmax_all_gather(self, logits):
         """Multi-device: all-gather logits before argmax."""
         cfg = self.config
         cluster_axis = 1
+        num_links, topology = self._get_argmax_all_gather_config(cluster_axis)
         return ttnn.experimental.all_gather_async(
             logits,
             persistent_output_buffer=None,
             dim=3,
             multi_device_global_semaphore=cfg.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis),
-            num_links=cfg.num_argmax_gather_links,
+            num_links=num_links,
             memory_config=logits.memory_config(),
             cluster_axis=cluster_axis,
-            topology=cfg.ag_topology,
+            topology=topology,
             barrier_semaphore=cfg.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
             chunks_per_sync=10,
             num_workers_per_link=1,
@@ -332,7 +382,13 @@ class Sampling1D(LightweightModule):
         ttnn.deallocate(topk_values)
         ttnn.deallocate(topk_global_indices)
 
-        log_probs = self._log_probs_calculator.calculate_log_probs(logits, tt_out_tok)
+        # Logprobs (old path: single sampled-token logprob). Gated on enable_log_probs so the
+        # disabled case incurs zero extra ops. The calculator itself returns None unless the mesh
+        # is multi-device with num_devices ∈ {8, 32} (T3K 1×8).
+        if self._log_probs_calculator.enable_log_probs:
+            log_probs = self._log_probs_calculator.calculate_log_probs(logits, tt_out_tok)
+        else:
+            log_probs = None
         return tt_out_tok, log_probs
 
     # -- Top-k strategies (bound at init, no if-else in forward) --------------
@@ -371,6 +427,18 @@ class Sampling1D(LightweightModule):
         """Local topk → all_gather across devices. Port of tt_sampling.py:372-421."""
         cfg = self.config
         cluster_shape = cfg.mesh_device.shape
+
+        # Pad the per-device shard up to the next power of 2 so ttnn.topk hits its fast path.
+        # Padded entries get -inf so they are never selected; the pre-padded _local_indices buffer
+        # is widened to match (see _resolve_sampling1d_config). Mirrors tt_sampling.py:451-458.
+        if cfg.pad_to_power_of_2 and not _is_power_of_2(x_bf16.shape[-1]):
+            padded_width = _upper_power_of_2(x_bf16.shape[-1])
+            x_bf16 = ttnn.pad(
+                x_bf16,
+                [(0, 0), (0, 0), (0, 0), (0, padded_width - x_bf16.shape[-1])],
+                value=-sys.float_info.max,
+                sub_core_grids=cfg.sub_core_grids,
+            )
 
         topk_values, topk_indices = ttnn.topk(
             x_bf16,
@@ -484,6 +552,7 @@ class Sampling1D(LightweightModule):
             allow_force_argmax=allow_force_argmax,
             num_argmax_gather_links=num_argmax_gather_links,
             ag_topology=ag_topology,
+            pad_to_power_of_2=getattr(args, "pad_logits_to_power_of_2", False),
         )
         return cls.from_config(config)
 
@@ -572,7 +641,14 @@ def _resolve_sampling1d_config(config: Sampling1DConfig) -> Sampling1DConfig:
             row = torch.cat([r, r])
         else:
             row = torch.arange(local_indices_width, dtype=torch.int32)
-        return row.unsqueeze(0).unsqueeze(0).expand(1, 1, B, -1).contiguous()
+        out = row.unsqueeze(0).unsqueeze(0).expand(1, 1, B, -1).contiguous()
+        # Pad the indices buffer to match the power-of-2-padded topk input width (multi-device
+        # path only — strict TTTv1 parity, so the 1×1 split path is never padded). Fill with -1
+        # (invalid index) so the padded slots are never used. Mirrors tt_sampling.py:277-284.
+        if config.pad_to_power_of_2 and not multi_step_reduction and not _is_power_of_2(local_indices_width):
+            padded_width = _upper_power_of_2(local_indices_width)
+            out = torch.nn.functional.pad(out, (0, padded_width - local_indices_width), mode="constant", value=-1)
+        return out
 
     local_idx_defaults = dict(
         dtype=ttnn.uint16,

--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -22,7 +22,7 @@ from loguru import logger
 import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.modules.lazy_buffer import LazyBuffer, resolve_lazy_buffer
-from models.common.modules.tt_ccl import get_tt_ccl
+from models.common.modules.tt_ccl import default_topology, get_tt_ccl
 
 # ---------------------------------------------------------------------------
 # Power-of-2 helpers (local copies; keep this TTTv2 module self-contained)
@@ -287,8 +287,35 @@ class Sampling1D(LightweightModule):
         return max(1, num_links), topology
 
     def _argmax_all_gather(self, logits):
-        """Multi-device: all-gather logits before argmax."""
+        """Multi-device: all-gather logits before argmax.
+
+        On ring-capable meshes (e.g. T3K 1×8) use the same trace-capture-safe configuration as a
+        model's own logits gather: Ring topology, no ``cluster_axis``, and crucially **no barrier
+        semaphore**. The Linear+barrier configuration cannot be captured — trace aborts with
+        "TT_FATAL: Event Synchronization / Writes are not supported during trace capture". The
+        likely cause (hypothesis: Ring+barrier was not isolated in testing, so the blocker is only
+        confirmed for Linear+barrier) is that the Linear all-gather's barrier issues a host-assisted
+        event-sync + per-device semaphore writes that are illegal inside capture; Ring is
+        self-synchronising and needs no barrier. This matches the model's own
+        ``gather_and_untilize_logits`` (Ring, no barrier), which captures cleanly — and is what
+        unblocks on-device greedy sampling under the traced executor. Below 8 devices (no ring) fall
+        back to the clamped Linear+barrier path (correct eagerly, but not trace-capture safe —
+        N150/N300 sampling stays on the eager executor).
+        """
         cfg = self.config
+        if default_topology(cfg.mesh_device) == ttnn.Topology.Ring:
+            return ttnn.experimental.all_gather_async(
+                logits,
+                persistent_output_buffer=None,
+                dim=3,
+                multi_device_global_semaphore=cfg.tt_ccl.get_and_cycle_ag_semaphore_handles(),
+                num_links=1,
+                memory_config=logits.memory_config(),
+                topology=ttnn.Topology.Ring,
+                chunks_per_sync=24,
+                num_workers_per_link=4,
+                num_buffers_per_channel=2,
+            )
         cluster_axis = 1
         num_links, topology = self._get_argmax_all_gather_config(cluster_axis)
         return ttnn.experimental.all_gather_async(

--- a/models/common/tests/modules/sampling/test_sampling_1d.py
+++ b/models/common/tests/modules/sampling/test_sampling_1d.py
@@ -1345,3 +1345,195 @@ def test_ttnn_topk_correctness(ttnn_mesh_device, input_width, dtype):
         test_label=f"ttnn.topk isolation (width={input_width}, dtype={dtype_tag}, B={B}, K={K})",
         quant_tolerance=quant_tolerance,
     )
+
+
+# ==============================================================================
+# Logprobs plumbing (enable_log_probs per-call arg)
+# ==============================================================================
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+def test_sampling1d_logprobs_disabled_returns_none(ttnn_mesh_device):
+    """Default (enable_log_probs=False) → log_probs is None on every mesh, both paths."""
+    torch.manual_seed(42)
+    B = 32
+    vocab_size = 1024
+
+    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_force_argmax=True)
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+
+    # Top-k path
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+    k, p, temp = _make_sampling_params(
+        ttnn_mesh_device, B, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=cluster_shape
+    )
+    _, log_probs = sampler.decode_forward(logits_tt, k=k, p=p, temp=temp)
+    assert log_probs is None, "top-k path must return None when enable_log_probs=False"
+
+    # Argmax path
+    logits_tt2 = _make_logits_tt(logits_host, ttnn_mesh_device)
+    _, log_probs_argmax = sampler.decode_forward(logits_tt2)
+    assert log_probs_argmax is None, "argmax path must return None when enable_log_probs=False"
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+def test_sampling1d_argmax_never_emits_logprobs(ttnn_mesh_device):
+    """Argmax contract (P0): argmax path returns None even when enable_log_probs=True."""
+    torch.manual_seed(42)
+    B = 32
+    vocab_size = 1024
+
+    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device, allow_force_argmax=True)
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
+
+    _, log_probs = sampler.decode_forward(logits_tt, enable_log_probs=True)
+    assert log_probs is None, "argmax path must never compute logprobs (force-argmax ⇒ no logprobs)"
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
+def test_sampling1d_logprobs_topk(ttnn_mesh_device):
+    """enable_log_probs=True on the top-k path.
+
+    The old single-token logprob path only computes on multi-device shards with
+    num_devices ∈ {8, 32} (T3K 1×8). On 1×1/1×2 the calculator returns None even when enabled.
+    On 1×8, with k=1/p=0/temp=1 the sampled token is the argmax, so its logprob must match
+    torch.log_softmax(logits)[argmax].
+    """
+    from models.common.utility_functions import comp_pcc
+
+    torch.manual_seed(42)
+    B = 32
+    vocab_size = 32768  # divisible by 8
+
+    sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    k, p, temp = _make_sampling_params(
+        ttnn_mesh_device, B, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=cluster_shape
+    )
+
+    tokens_tt, log_probs = sampler.decode_forward(logits_tt, k=k, p=p, temp=temp, enable_log_probs=True)
+
+    num_devices = max(cluster_shape)
+    if num_devices not in (8, 32):
+        assert log_probs is None, f"logprobs unsupported on {num_devices} devices → expected None"
+        return
+
+    assert log_probs is not None, "logprobs must be computed on a 1×8 mesh when enabled"
+
+    # output_tensor is replicated across devices; read a single device copy → shape (1,1,1,B)
+    lp_host = ttnn.to_torch(ttnn.get_device_tensors(log_probs)[0]).reshape(-1)[:B].float()
+    tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B].long()
+
+    # Reference: log_softmax over the full vocab (fp32), indexed at the sampled token.
+    ref_log_softmax = torch.log_softmax(logits_host.float().squeeze(), dim=-1)  # [B, V]
+    ref_lp = ref_log_softmax[torch.arange(B), tokens_host]
+
+    passing, pcc_msg = comp_pcc(ref_lp, lp_host, pcc=0.99)
+    print(f"\n  logprobs PCC (V={vocab_size}, mesh={cluster_shape}): {pcc_msg}")
+    assert passing, f"logprobs PCC below threshold: {pcc_msg}"
+
+
+# ==============================================================================
+# Trace capture — on-device sampling under begin/end_trace_capture (N150/N300)
+# ==============================================================================
+#
+# The tests above prove the sampler is correct *eagerly* on every mesh. They do NOT exercise the
+# thing that actually gates on-device sampling in a model: whether the sampling op graph can be
+# captured inside ttnn.begin_trace_capture / ttnn.end_trace_capture. TracedLLMExecutor runs
+# model.sampling.decode_forward *inside* trace capture (executor.py:_capture_decode_trace).
+#
+# The TTTv2 perf-recovery handoff gated models' supports_on_device_sampling on num_devices >= 8,
+# assuming the sub-8-device Linear+barrier all-gather could not be trace-captured. The cases below
+# DISPROVE that at the op level: argmax and top-k both capture AND replay correctly on 1x1 (N150,
+# no CCL) and 1x2 (N300, Linear+barrier all-gather). See the handoff doc's "wrong assumption" note.
+#
+# Note the dict-form ttnn_mesh_device param: it carries trace_region_size so the device is opened
+# with a trace region (the fixture does not set one by default).
+
+_TRACE_REGION_SIZE = 32 << 20
+
+
+@pytest.mark.parametrize(
+    "ttnn_mesh_device",
+    [
+        {"mesh_shape": (1, 1), "trace_region_size": _TRACE_REGION_SIZE},
+        {"mesh_shape": (1, 2), "trace_region_size": _TRACE_REGION_SIZE},
+    ],
+    ids=["1x1", "1x2"],
+    indirect=True,
+)
+@pytest.mark.parametrize("mode", ["argmax", "topk"])
+def test_sampling1d_trace_capture(ttnn_mesh_device, mode):
+    """Sampling1D.decode_forward must trace-capture and replay correctly on N150/N300.
+
+    Mirrors TracedLLMExecutor._capture_decode_trace: warmup-compile + load_device_buffers OUTSIDE
+    capture (those issue device writes that are illegal mid-capture), then run decode_forward
+    inside begin/end_trace_capture and replay, asserting replayed tokens == eager tokens.
+
+    All four (mesh x mode) combos pass — including the 1x2 Linear+barrier all-gather the
+    ``num_devices >= 8`` model gate assumes is not capturable.
+    """
+    mesh_device = ttnn_mesh_device
+    num_devices = mesh_device.get_num_devices()
+    cluster_shape = tuple(mesh_device.shape)
+
+    torch.manual_seed(0)
+    B = 32
+    vocab_size = 128256  # Llama-class vocab; per-device shard on 1x2 (64128) >> max_top_k=32
+    logits_host = torch.randn(1, 1, B, vocab_size, dtype=torch.bfloat16)
+
+    sampler = Sampling1D(
+        vocab_size=vocab_size,
+        mesh_device=mesh_device,
+        max_batch_size=B,
+        allow_force_argmax=True,
+        pad_to_power_of_2=(mode == "topk" and num_devices > 1),
+    )
+
+    # k/p/temp built ONCE, OUTSIDE capture, and the same persistent tensors are referenced inside
+    # it — exactly as TracedLLMExecutor caches them (executor.py:_get_decode_sampling_kpt).
+    # Building them inside capture would itself be an illegal in-capture host->device write.
+    kpt = (
+        _make_sampling_params(mesh_device, B, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=cluster_shape)
+        if mode == "topk"
+        else None
+    )
+
+    def _forward(logits_tt):
+        if mode == "argmax":
+            return sampler.decode_forward(logits_tt)
+        k, p, temp = kpt
+        return sampler.decode_forward(logits_tt, k=k, p=p, temp=temp)
+
+    # Persistent input buffer, reused across warmup / capture / replay (as the executor does).
+    logits_tt = _make_logits_tt(logits_host, mesh_device, shard_vocab=True)
+
+    # --- Warmup: load buffers + JIT-compile the sampling program OUTSIDE capture ---
+    sampler.load_device_buffers()
+    eager_tok, _ = _forward(logits_tt)
+    ttnn.synchronize_device(mesh_device)
+    eager_host = to_torch_auto_compose(eager_tok).flatten()[:B].long()
+
+    # --- Capture (close+release in finally so a failed capture can't wedge the next case) ---
+    trace_id = ttnn.begin_trace_capture(mesh_device, cq_id=0)
+    captured_tok = None
+    try:
+        captured_tok, _ = _forward(logits_tt)
+    finally:
+        ttnn.end_trace_capture(mesh_device, trace_id, cq_id=0)
+        ttnn.synchronize_device(mesh_device)
+
+    # --- Replay (same logits -> same tokens) ---
+    ttnn.execute_trace(mesh_device, trace_id, cq_id=0, blocking=True)
+    replay_host = to_torch_auto_compose(captured_tok).flatten()[:B].long()
+    ttnn.release_trace(mesh_device, trace_id)
+
+    assert torch.equal(replay_host, eager_host), (
+        f"[{mode} mesh={cluster_shape}] traced tokens diverged from eager:\n"
+        f"  eager:  {eager_host[:8]}\n  replay: {replay_host[:8]}"
+    )


### PR DESCRIPTION
Closes #45947

This PR updates TTTv2 sampling module with features present on TTTv1 that haven't been added to TTTv2 yet, mainly related to performance, since sampling was causing the main gap in performance for TTTv2 modules. Indeed, there are some functional features in TTTv1 sampling, like seed managers, that haven't been added to TTTv2 (it's not clear if they will) 


## Summary

Brings the shared TTTv2 on-device sampler (`models/common/modules/sampling/sampling_1d.py`,
`Sampling1D`) toward `main`'s `TTSampling` parity and makes it **trace-safe**, then routes it from the
shared engine (`executor.py`) so any TTTv2 model can sample on device via per-request `sampling_params`.

The branch is intentionally **self-contained**: it touches only files that already exist in `main`. No
per-model bringup code is included — models adopt the sampler separately.

**Footprint (3 files):**

| File | Change |
|---|---|
| `models/common/modules/sampling/sampling_1d.py` | logprobs plumbing, all-gather robustness, power-of-2 top-k padding, ring/no-barrier argmax gather |
| `models/common/models/executor.py` | model-agnostic on-device sampling routing (argmax vs top-k), capture-safe decode trace |
| `models/common/tests/modules/sampling/test_sampling_1d.py` | logprobs tests + N150/N300 trace-capture coverage |

## Motivation

On-device sampling avoids a device→host→device round trip per decode step and is a clear win on large
ring meshes (e.g. Qwen2.5-Coder-32B on T3K). The blocker for traced decode was that the
`Linear`+barrier all-gather aborts under `ttnn.begin_trace_capture` (Event Sync / Writes unsupported);
this PR adds a self-synchronising `Ring` gather that captures cleanly.

> Scope note: on small models / sub-8-device meshes (1B on N150/N300) on-device sampling is currently
> *not* a win — it is at parity with TTTv1 and both are bottlenecked by an upstream `ttnn.topk`
> supposed regression (~18 ms for `k=32` over a 64k-wide row), not by anything in this PR. Models therefore keep
> the host sampling path as default below 8 devices; this PR only makes on-device sampling **correct and
> capturable** everywhere, leaving the path choice to the model/request.

> Logprobs — optional, could be dropped: logprobs is a request-driven feature (`SamplingParams.enable_log_probs`,
> defaults off) and is **inert on the current TTTv2 targets** — `LogProbsCalculator` only produces values on
> `num_devices ∈ {8, 32}`, so on N150/N300 it always returns `None`, and the shared executor discards it in the
> default `read_from_device=True` path. It becomes functional only on T3K (1×8), where it would matter for a
> future vLLM-served model honoring OpenAI `logprobs` requests (and even then only the single sampled-token
> logprob — the top-K `top_logprobs` path is intentionally not ported). Since this PR is focused on
> **performance and trace-safety**, the logprobs plumbing here is purely `main`-parity insurance for that future
> goal; it carries no runtime cost when disabled but is not exercised by anything today, and could reasonably be
> dropped (or deferred to the vLLM-on-T3K bringup) to keep the change minimal.

## Changes

### 1. `Sampling1D` — logprobs, robustness, power-of-2 top-k padding
- **Logprobs**: `enable_log_probs` is now a per-call `decode_forward` arg (bool or per-user list),
  refreshed each call — no mutable sampling state on the module. The top-k path computes logprobs only
  when requested (disabled ⇒ zero extra ops ⇒ `None`); wires the existing single-token logprob
  calculator (T3K `num_devices ∈ {8, 32}`). Argmax path never emits logprobs (returns `None`), matching
  `main`'s contract.
- **All-gather robustness**: clamp `num_links` to `tt_ccl.get_num_links()` and force `Topology.Linear`
  below 8 devices (port of `main`'s `_get_force_argmax_all_gather_config`).
- **Power-of-2 top-k padding** (`pad_to_power_of_2`): pad each per-device logit shard (and the
  `local_indices` buffer) up to the next power of 2 before `ttnn.topk` so it hits the fast kernel path;
  padded logits get `-inf` / indices `-1` so they're never selected. Multi-device path only (strict
  TTTv1 parity — the 1×1 split path is left unpadded).

### 2. `Sampling1D` — ring/no-barrier argmax all-gather (trace-safe)
- On ring-capable meshes (T3K 1×8) gather full-vocab logits via `Ring` topology with no barrier
  semaphore, matching the model's own `gather_and_untilize_logits`. The `Linear`+barrier path is kept
  as a clamped fallback below 8 devices. This is what unblocks traced on-device greedy sampling.

### 3. `executor.py` — model-agnostic on-device sampling routing
- `_build_decode_topk_param_tensors` builds replicated `(k, p, temp)` device tensors via the shared
  `format_sampling_params` (so temperature inversion, top-p clamping, and the `temp==0 ⇒ k=1` rewrite
  match TTTv1 / PERF.md exactly), returning `None` when the params reduce to force-argmax.
- `_sampling_decode_forward` / `_get_decode_sampling_kpt` pick the path per request: greedy
  `(k==1, p==0, temp==1)` ⇒ force-argmax gather; otherwise the top-k op path (`ttnn.topk` →
  barrier-free all-gather of the `[*,32]` tuples → `ttnn.sampling`).
- `_capture_decode_trace` runs the sampler **inside** trace capture; persistent k/p/temp tensors are
  built once outside capture and referenced inside (no illegal in-capture host→device writes).

## Testing

`pytest models/common/tests/modules/sampling/test_sampling_1d.py`

- **Logprobs**: disabled ⇒ `None`; argmax-never-emits; 1×8 PCC ≥ 0.99 vs `torch.log_softmax`.
- **Trace capture** (new, `test_sampling1d_trace_capture`): argmax **and** top-k both capture and
  replay correctly on **1×1 (N150)** and **1×2 (N300)** — replayed tokens == eager tokens. This
  directly exercises the `begin/end_trace_capture` path the engine uses.

Results from the original development stack (pre-rebase):
- Suite green on N300 (1×1 / 1×2) and T3K (1×8).
- `pad_to_power_of_2`: ~17× device speedup on 1×8 for non-power-of-2 vocab (e.g. Llama 128256).
- Qwen2.5-Coder-32B T3K batch-1: **22.9 tok/s/u (~102 % of the 22.4 PERF.md target)**, coherent output.

> ⚠️ These numbers were measured before rebasing onto current `main` (large divergence).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=apascual/tttv2-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:apascual/tttv2-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=apascual/tttv2-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:apascual/tttv2-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=apascual/tttv2-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:apascual/tttv2-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=apascual/tttv2-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:apascual/tttv2-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=apascual/tttv2-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:apascual/tttv2-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=apascual/tttv2-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:apascual/tttv2-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=apascual/tttv2-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:apascual/tttv2-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=apascual/tttv2-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:apascual/tttv2-sampling)