### PR TITLE
Split Quasar DPRINT buffer

### DIFF
--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -125,7 +125,7 @@ TEST_F(DevicePrintOutputFixture, PrintConcurrentAllRiscs) {
 
         constexpr CoreCoord core = {0, 0};
         // Quasar prints from many more concurrent RISCs (22 on this test) than WH/BH (5).
-        // 1000 × 22 = 22k contended prints take well over 10 minutes on the RTL simulator,
+        // 1000 × 22 = 22k contended prints take well over 10 minutes on the RTL emulator,
         // so reduce the iteration count on Quasar. The race-detection signal does not require
         // a large count — even a small number of iterations with high concurrency exposes any
         // memory-ordering bugs immediately, and the assertion is per-iteration.
@@ -164,7 +164,8 @@ TEST_F(DevicePrintOutputFixture, PrintConcurrentAllRiscs) {
                 });
 
             risc_count_per_iter = (experimental::quasar::QUASAR_NUM_DM_CORES_PER_CLUSTER - 2) +
-                                  (experimental::quasar::QUASAR_NUM_TENSIX_ENGINES_PER_CLUSTER * 4);
+                                  (experimental::quasar::QUASAR_NUM_TENSIX_ENGINES_PER_CLUSTER *
+                                   experimental::quasar::QUASAR_NUM_COMPUTE_PROCESSORS_PER_TENSIX_ENGINE);
         } else {
             // WH/BH: BRISC
             auto kernel_handle = CreateKernel(
@@ -193,7 +194,9 @@ TEST_F(DevicePrintOutputFixture, PrintConcurrentAllRiscs) {
 
             SetRuntimeArgs(program_, kernel_handle, core, runtime_args);
 
-            risc_count_per_iter = 5;  // BRISC + NCRISC + TRISC0/1/2
+            // Every RISC on a WH/BH Tensix core: BRISC + NCRISC + TRISC0/1/2.
+            risc_count_per_iter = static_cast<int>(
+                MetalContext::instance().hal().get_num_risc_processors(HalProgrammableCoreType::TENSIX));
         }
 
         DebugToolsMeshFixture::RunProgram(mesh_device, workload);
@@ -301,7 +304,8 @@ TEST_F(DevicePrintOutputFixture, PrintConcurrentBabyRiscs) {
         std::vector<uint32_t> compile_args = {iterations_count};
 
         constexpr int kNumTensixEngines = experimental::quasar::QUASAR_NUM_TENSIX_ENGINES_PER_CLUSTER;
-        constexpr int kTriscsPerEngine = 4;  // unpack + math + pack + extra
+        // unpack + math + pack + extra
+        constexpr int kTriscsPerEngine = experimental::quasar::QUASAR_NUM_COMPUTE_PROCESSORS_PER_TENSIX_ENGINE;
         CreateKernel(
             program_,
             "tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations_compile_time.cpp",

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_print_output.cpp
@@ -109,8 +109,9 @@ TEST_F(DevicePrintOutputFixture, PrintManyIterations) {
 TEST_F(DevicePrintOutputFixture, PrintConcurrentAllRiscs) {
     size_t device_counter = 0;
     for (auto& mesh_device : this->devices_) {
-        if (mesh_device->arch() != tt::ARCH::WORMHOLE_B0 && mesh_device->arch() != tt::ARCH::BLACKHOLE) {
-            // Test currently works only on WH and BH
+        if (mesh_device->arch() != tt::ARCH::WORMHOLE_B0 && mesh_device->arch() != tt::ARCH::BLACKHOLE &&
+            mesh_device->arch() != tt::ARCH::QUASAR) {
+            // Test currently works on WH, BH, and Quasar
             continue;
         }
         device_counter++;
@@ -123,38 +124,83 @@ TEST_F(DevicePrintOutputFixture, PrintConcurrentAllRiscs) {
         auto& program_ = workload.get_programs().at(device_range);
 
         constexpr CoreCoord core = {0, 0};
-        uint32_t iterations_count = 1000;
+        // Quasar prints from many more concurrent RISCs (22 on this test) than WH/BH (5).
+        // 1000 × 22 = 22k contended prints take well over 10 minutes on the RTL simulator,
+        // so reduce the iteration count on Quasar. The race-detection signal does not require
+        // a large count — even a small number of iterations with high concurrency exposes any
+        // memory-ordering bugs immediately, and the assertion is per-iteration.
+        const uint32_t iterations_count = (mesh_device->arch() == tt::ARCH::QUASAR) ? 100u : 1000u;
         std::vector<uint32_t> runtime_args = {iterations_count};
 
-        // BRISC
-        auto kernel_handle = CreateKernel(
-            program_,
-            "tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations.cpp",
-            core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
+        // Per-arch expected number of distinct RISCs printing concurrently on the same core.
+        //   WH/BH: 5  (BRISC + NCRISC + TRISC0/1/2)
+        //   Quasar: 6 user DMs (DM2..DM7) + 16 TRISCs (4 Tensix engines × 4 TRISCs) = 22
+        int risc_count_per_iter = 0;
 
-        SetRuntimeArgs(program_, kernel_handle, core, runtime_args);
+        if (mesh_device->arch() == tt::ARCH::QUASAR) {
+            // Quasar QuasarDataMovementConfig/QuasarComputeConfig don't have a runtime-args path
+            // hooked up yet; pass the iteration count as a compile-time arg instead. Use a
+            // kernel variant that reads get_compile_time_arg_val(0).
+            std::vector<uint32_t> compile_args = {iterations_count};
 
-        // NCRISC
-        kernel_handle = CreateKernel(
-            program_,
-            "tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations.cpp",
-            core,
-            DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+            // Single DM kernel covering all 6 user DM threads in the cluster (DM0/DM1 reserved).
+            CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations_compile_time.cpp",
+                core,
+                experimental::quasar::QuasarDataMovementConfig{
+                    .num_threads_per_cluster = experimental::quasar::QUASAR_NUM_DM_CORES_PER_CLUSTER - 2,
+                    .compile_args = compile_args,
+                });
 
-        SetRuntimeArgs(program_, kernel_handle, core, runtime_args);
+            // Single compute kernel covering all 4 Tensix engines × 4 TRISCs = 16 baby-RISCs.
+            CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations_compile_time.cpp",
+                core,
+                experimental::quasar::QuasarComputeConfig{
+                    .num_threads_per_cluster = experimental::quasar::QUASAR_NUM_TENSIX_ENGINES_PER_CLUSTER,
+                    .compile_args = compile_args,
+                });
 
-        // TRISC0 (Unpack), TRISC1 (Math), TRISC2 (Pack)
-        kernel_handle = CreateKernel(
-            program_, "tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations.cpp", core, ComputeConfig{});
+            risc_count_per_iter = (experimental::quasar::QUASAR_NUM_DM_CORES_PER_CLUSTER - 2) +
+                                  (experimental::quasar::QUASAR_NUM_TENSIX_ENGINES_PER_CLUSTER * 4);
+        } else {
+            // WH/BH: BRISC
+            auto kernel_handle = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations.cpp",
+                core,
+                DataMovementConfig{.processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default});
 
-        SetRuntimeArgs(program_, kernel_handle, core, runtime_args);
+            SetRuntimeArgs(program_, kernel_handle, core, runtime_args);
+
+            // NCRISC
+            kernel_handle = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations.cpp",
+                core,
+                DataMovementConfig{.processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default});
+
+            SetRuntimeArgs(program_, kernel_handle, core, runtime_args);
+
+            // TRISC0 (Unpack), TRISC1 (Math), TRISC2 (Pack)
+            kernel_handle = CreateKernel(
+                program_,
+                "tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations.cpp",
+                core,
+                ComputeConfig{});
+
+            SetRuntimeArgs(program_, kernel_handle, core, runtime_args);
+
+            risc_count_per_iter = 5;  // BRISC + NCRISC + TRISC0/1/2
+        }
 
         DebugToolsMeshFixture::RunProgram(mesh_device, workload);
         MetalContext::instance().dprint_server()->await();
 
-        // Verify all 5*N messages (5 RISCs x N iterations) are correctly formatted.
-        // Each iteration value must appear exactly 5 times — once per RISC.
+        // Verify all risc_count_per_iter * N messages are correctly formatted.
+        // Each iteration value must appear exactly risc_count_per_iter times — once per RISC.
         std::fstream log_file;
         ASSERT_TRUE(OpenFile(dprint_file_name, log_file, std::fstream::in));
         std::vector<int> counts(iterations_count, 0);
@@ -168,9 +214,123 @@ TEST_F(DevicePrintOutputFixture, PrintConcurrentAllRiscs) {
                 counts[iter]++;
             }
         }
+        const int expected_count = risc_count_per_iter * static_cast<int>(device_counter);
         for (int i = 0; i < static_cast<int>(counts.size()); i++) {
-            EXPECT_EQ(counts[i], 5 * device_counter) << "Iteration " << i << " appeared " << counts[i]
-                                                     << " times (expected " << 5 * device_counter << " times)";
+            EXPECT_EQ(counts[i], expected_count)
+                << "Iteration " << i << " appeared " << counts[i] << " times (expected " << expected_count << " times)";
+        }
+    }
+}
+
+// Quasar-only race-detection variant of PrintConcurrentAllRiscs that uses *only the rocket-core
+// DMs* (DM2..DM7). Isolates whether the contention bug is within a single rocket-core group, or
+// requires the mix of rocket + baby-risc contenders.
+TEST_F(DevicePrintOutputFixture, PrintConcurrentRocketRiscs) {
+    size_t device_counter = 0;
+    for (auto& mesh_device : this->devices_) {
+        if (mesh_device->arch() != tt::ARCH::QUASAR) {
+            continue;  // Quasar-only: rocket cores are a Quasar-specific concept.
+        }
+        device_counter++;
+
+        distributed::MeshWorkload workload;
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+        Program program = Program();
+        workload.add_program(device_range, std::move(program));
+        auto& program_ = workload.get_programs().at(device_range);
+
+        constexpr CoreCoord core = {0, 0};
+        const uint32_t iterations_count = 5;
+        std::vector<uint32_t> compile_args = {iterations_count};
+
+        constexpr int kNumUserDms = experimental::quasar::QUASAR_NUM_DM_CORES_PER_CLUSTER - 2;
+        CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations_compile_time.cpp",
+            core,
+            experimental::quasar::QuasarDataMovementConfig{
+                .num_threads_per_cluster = kNumUserDms,
+                .compile_args = compile_args,
+            });
+
+        DebugToolsMeshFixture::RunProgram(mesh_device, workload);
+        MetalContext::instance().dprint_server()->await();
+
+        std::fstream log_file;
+        ASSERT_TRUE(OpenFile(dprint_file_name, log_file, std::fstream::in));
+        std::vector<int> counts(iterations_count, 0);
+        std::string line;
+        for (;;) {
+            if (!getline(log_file, line)) {
+                break;
+            }
+            int iter = -1;
+            if (sscanf(line.c_str(), "Test iteration: %d", &iter) == 1 && iter >= 0 && iter < counts.size()) {
+                counts[iter]++;
+            }
+        }
+        const int expected_count = kNumUserDms * static_cast<int>(device_counter);
+        for (int i = 0; i < static_cast<int>(counts.size()); i++) {
+            EXPECT_EQ(counts[i], expected_count)
+                << "Iteration " << i << " appeared " << counts[i] << " times (expected " << expected_count << " times)";
+        }
+    }
+}
+
+// Quasar-only race-detection variant of PrintConcurrentAllRiscs that uses *only baby-risc TRISCs*
+// (4 Tensix engines × 4 TRISCs = 16 threads). Complements PrintConcurrentRocketRiscs so we can
+// localize the locking bug to rocket-only, baby-risc-only, or the cross-group case.
+TEST_F(DevicePrintOutputFixture, PrintConcurrentBabyRiscs) {
+    size_t device_counter = 0;
+    for (auto& mesh_device : this->devices_) {
+        if (mesh_device->arch() != tt::ARCH::QUASAR) {
+            continue;  // Quasar-only.
+        }
+        device_counter++;
+
+        distributed::MeshWorkload workload;
+        auto zero_coord = distributed::MeshCoordinate(0, 0);
+        auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+        Program program = Program();
+        workload.add_program(device_range, std::move(program));
+        auto& program_ = workload.get_programs().at(device_range);
+
+        constexpr CoreCoord core = {0, 0};
+        const uint32_t iterations_count = 5;
+        std::vector<uint32_t> compile_args = {iterations_count};
+
+        constexpr int kNumTensixEngines = experimental::quasar::QUASAR_NUM_TENSIX_ENGINES_PER_CLUSTER;
+        constexpr int kTriscsPerEngine = 4;  // unpack + math + pack + extra
+        CreateKernel(
+            program_,
+            "tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations_compile_time.cpp",
+            core,
+            experimental::quasar::QuasarComputeConfig{
+                .num_threads_per_cluster = kNumTensixEngines,
+                .compile_args = compile_args,
+            });
+
+        DebugToolsMeshFixture::RunProgram(mesh_device, workload);
+        MetalContext::instance().dprint_server()->await();
+
+        std::fstream log_file;
+        ASSERT_TRUE(OpenFile(dprint_file_name, log_file, std::fstream::in));
+        std::vector<int> counts(iterations_count, 0);
+        std::string line;
+        for (;;) {
+            if (!getline(log_file, line)) {
+                break;
+            }
+            int iter = -1;
+            if (sscanf(line.c_str(), "Test iteration: %d", &iter) == 1 && iter >= 0 && iter < counts.size()) {
+                counts[iter]++;
+            }
+        }
+        const int expected_count = kNumTensixEngines * kTriscsPerEngine * static_cast<int>(device_counter);
+        for (int i = 0; i < static_cast<int>(counts.size()); i++) {
+            EXPECT_EQ(counts[i], expected_count)
+                << "Iteration " << i << " appeared " << counts[i] << " times (expected " << expected_count << " times)";
         }
     }
 }

--- a/tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations_compile_time.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/device_print/print_iterations_compile_time.cpp
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#if defined(UCK_CHLKC_UNPACK) || defined(UCK_CHLKC_MATH) || defined(UCK_CHLKC_PACK)
+#include "api/compute/common.h"
+#endif
+#include "api/debug/device_print.h"
+
+/*
+ * Same as print_iterations.cpp but takes the iteration count as a compile-time arg.
+ * Used by tests that need to run on Quasar where runtime args via SetRuntimeArgs/get_arg_val
+ * are not exposed for the QuasarDataMovementConfig/QuasarComputeConfig kernel path yet.
+ */
+void kernel_main() {
+    constexpr uint32_t count = get_compile_time_arg_val(0);
+    for (uint32_t i = 0; i < count; i++) {
+        DEVICE_PRINT("Test iteration: {}\n", i);
+    }
+}

--- a/tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/dprint_common.h
@@ -25,6 +25,7 @@ using CommonDataFormat = DataFormat;
 #include <cstddef>
 
 #if !defined(ENV_LLK_INFRA)
+// Deprecated buffer size from old DPRINT implementation. Used only to verify that buffers are still the same size.
 constexpr static std::uint32_t DPRINT_BUFFER_SIZE = 204;  // per thread
 #endif
 

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -197,7 +197,7 @@ struct dp_typed_array_t {
         device_print_detail::invoke_by_value(                                                                      \
             [_device_print_write_position](auto&&... args) __attribute__((always_inline)) {                        \
                 /* Get device_print buffer*/                                                                       \
-                volatile tt_l1_ptr DevicePrintMemoryLayout* _device_print_buffer = get_device_print_buffer();      \
+                volatile tt_l1_ptr DevicePrintBufferType* _device_print_buffer = get_device_print_buffer();        \
                 auto _device_print_buffer_ptr = &(_device_print_buffer->data[0]) + _device_print_write_position;   \
                 device_print_detail::serialization::serialize_arguments(_device_print_buffer_ptr, args...);        \
             },                                                                                                     \
@@ -1332,7 +1332,7 @@ using arg_reorder_seq_t = typename arg_reorder_seq<Args...>::type;
 
 namespace locking {
 
-uint32_t wait_for_space(volatile tt_l1_ptr DevicePrintMemoryLayout* device_print_buffer, uint32_t message_size);
+uint32_t wait_for_space(volatile tt_l1_ptr DevicePrintBufferType* device_print_buffer, uint32_t message_size);
 void release_lock();
 
 #if !defined(ARCH_WORMHOLE)
@@ -1341,7 +1341,7 @@ volatile tt_l1_ptr std::atomic<uint32_t>& get_lock_atomic() {
     return get_device_print_buffer()->aux.lock;
 #else
     // Atomics require the cached L1 alias.
-    return GET_MAILBOX_ADDRESS_DEV_CACHED(dprint_buf)->aux.lock;
+    return GET_MAILBOX_ADDRESS_DEV_CACHED(dprint_buf.buffer)->aux.lock;
 #endif
 }
 #endif
@@ -1349,7 +1349,7 @@ volatile tt_l1_ptr std::atomic<uint32_t>& get_lock_atomic() {
 // Takes lock unconditionally. Prints kernel id message if needed.
 void acquire_lock() {
     // We need to acquire lock only if we have more than 1 processor, otherwise there is no contention.
-    if constexpr (DevicePrintMemoryLayout::PROCESSOR_COUNT > 1) {
+    if constexpr (DevicePrintBufferType::processor_count > 1) {
 #if defined(ARCH_WORMHOLE)
         volatile uint32_t* lock_ptr = &(get_device_print_buffer()->aux.lock);
 
@@ -1366,7 +1366,7 @@ void acquire_lock() {
             // Write risc_id to lock to attempt to acquire it
             *lock_ptr = PROCESSOR_INDEX + 1;  // Use 1-based index to avoid writing 0 which is the free state
 
-            for (uint32_t repeat = 0; repeat < DevicePrintMemoryLayout::PROCESSOR_COUNT; ++repeat) {
+            for (uint32_t repeat = 0; repeat < DevicePrintBufferType::processor_count; ++repeat) {
                 // Make sure the write has propagated and other riscs see the updated value.
                 invalidate_l1_cache();
                 if (*lock_ptr != PROCESSOR_INDEX + 1) {
@@ -1398,7 +1398,7 @@ void acquire_lock() {
 
 #if defined(KERNEL_BUILD)
     // Check if we should print kernel id
-    volatile tt_l1_ptr DevicePrintMemoryLayout* device_print_buffer = get_device_print_buffer();
+    volatile tt_l1_ptr DevicePrintBufferType* device_print_buffer = get_device_print_buffer();
     if (device_print_buffer->aux.wpos != DEBUG_PRINT_SERVER_DISABLED_MAGIC) {
 #if PROCESSOR_INDEX_DEFINED
         constexpr auto processor_index = PROCESSOR_INDEX;
@@ -1431,7 +1431,7 @@ void acquire_lock() {
 }
 
 void update_kernel_finished() {
-    volatile tt_l1_ptr DevicePrintMemoryLayout* device_print_buffer = get_device_print_buffer();
+    volatile tt_l1_ptr DevicePrintBufferType* device_print_buffer = get_device_print_buffer();
 #if PROCESSOR_INDEX_DEFINED
     constexpr auto processor_index = PROCESSOR_INDEX;
 #else
@@ -1467,7 +1467,7 @@ void initialize_lock() {
 #endif
 }
 
-uint32_t wait_for_space(volatile tt_l1_ptr DevicePrintMemoryLayout* device_print_buffer, uint32_t message_size) {
+uint32_t wait_for_space(volatile tt_l1_ptr DevicePrintBufferType* device_print_buffer, uint32_t message_size) {
     // Read pointers
     auto write_position = device_print_buffer->aux.wpos;
     auto read_position = device_print_buffer->aux.rpos;
@@ -1677,7 +1677,7 @@ begin_message_write(structures::DevicePrintHeader header, std::uintptr_t string_
     locking::acquire_lock();
 
     // Check if we need to wrap buffer and wait for enough space in it
-    volatile tt_l1_ptr DevicePrintMemoryLayout* device_print_buffer = get_device_print_buffer();
+    volatile tt_l1_ptr DevicePrintBufferType* device_print_buffer = get_device_print_buffer();
     uint32_t message_size = sizeof(header.value) + header.message_payload;
     auto write_position = locking::wait_for_space(device_print_buffer, message_size);
 
@@ -1712,7 +1712,7 @@ __attribute__((noinline)) void end_message_write() {
     // that argument (one more instruction). Here, since we don't care about code execution time, but code size, we read
     // the message header back from the buffer to get the message size, which allows us to avoid passing message size as
     // an argument and save some code size.
-    volatile tt_l1_ptr DevicePrintMemoryLayout* device_print_buffer = get_device_print_buffer();
+    volatile tt_l1_ptr DevicePrintBufferType* device_print_buffer = get_device_print_buffer();
     auto write_position = device_print_buffer->aux.wpos;
     if (device_print_buffer->aux.wpos != DEBUG_PRINT_SERVER_DISABLED_MAGIC) {
         auto message_header_value =

--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -1405,7 +1405,8 @@ void acquire_lock() {
 #else
         auto processor_index = internal_::get_hw_thread_idx();
 #endif
-        auto risc_state = device_print_buffer->aux.risc_state[processor_index];
+        auto risc_state =
+            device_print_buffer->aux.risc_state[processor_index - DevicePrintBufferType::processor_offset];
         if (risc_state != DevicePrintRiscCoreState::PrintingDisabled) {
             if (risc_state == DevicePrintRiscCoreState::KernelNotPrinted) {
                 uint32_t launch_idx = *GET_MAILBOX_ADDRESS_DEV(launch_msg_rd_ptr);
@@ -1423,7 +1424,8 @@ void acquire_lock() {
                 formatting::device_print_type<decltype(header_value)>::serialize(
                     device_print_buffer_ptr, 0, header_value);
                 device_print_buffer->aux.wpos += sizeof(new_kernel_message);
-                device_print_buffer->aux.risc_state[processor_index] = DevicePrintRiscCoreState::KernelPrinted;
+                device_print_buffer->aux.risc_state[processor_index - DevicePrintBufferType::processor_offset] =
+                    DevicePrintRiscCoreState::KernelPrinted;
             }
         }
     }
@@ -1437,8 +1439,10 @@ void update_kernel_finished() {
 #else
     auto processor_index = internal_::get_hw_thread_idx();
 #endif
-    if (device_print_buffer->aux.risc_state[processor_index] != DevicePrintRiscCoreState::PrintingDisabled) {
-        device_print_buffer->aux.risc_state[processor_index] = DevicePrintRiscCoreState::KernelNotPrinted;
+    if (device_print_buffer->aux.risc_state[processor_index - DevicePrintBufferType::processor_offset] !=
+        DevicePrintRiscCoreState::PrintingDisabled) {
+        device_print_buffer->aux.risc_state[processor_index - DevicePrintBufferType::processor_offset] =
+            DevicePrintRiscCoreState::KernelNotPrinted;
     }
 }
 

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -29,7 +29,6 @@
 
 #include "hostdevcommon/profiler_common.h"
 #include "hostdevcommon/dprint_common.h"
-#include "hostdev/device_print_common.h"
 
 #ifdef HAL_BUILD
 // HAL will include this file for different arch/cores, resulting in conflicting definitions that
@@ -50,6 +49,7 @@ namespace HAL_BUILD {  // NOLINT(modernize-concat-nested-namespaces)
 #include "dev_mem_map.h"
 // Deprecated in favor of dev_mem_map.h. Keep to avoid breaking changes.
 #include "eth_l1_address_map.h"
+#include "device_print_mem.h"
 
 #if defined(COMPILE_FOR_ERISC)
 #define GET_MAILBOX_ADDRESS_DEV(x) (&(((mailboxes_t tt_l1_ptr*)eth_l1_mem::address_map::ERISC_MEM_MAILBOX_BASE)->x))
@@ -419,6 +419,13 @@ struct mailboxes_t {
     alignas(TT_ARCH_MAX_NOC_WRITE_ALIGNMENT)  // CODEGEN:skip
         profiler_msg_t profiler;
 };
+
+// DevicePrintMemoryLayout asserts
+static_assert(sizeof(DevicePrintMemoryLayout) == DPRINT_BUFFER_SIZE * PROCESSOR_COUNT);
+static_assert(sizeof(DevicePrintMemoryLayout) % 4 == 0);
+#if defined(ARCH_WORMHOLE) || defined(ARCH_BLACKHOLE)
+static_assert(decltype(DevicePrintMemoryLayout::buffer)::processor_count == PROCESSOR_COUNT);
+#endif
 
 // Watcher struct needs to be 32b-divisible, since we need to write it from host using write_core().
 static_assert(sizeof(watcher_msg_t) % sizeof(uint32_t) == 0);

--- a/tt_metal/hw/inc/hostdev/device_print_common.h
+++ b/tt_metal/hw/inc/hostdev/device_print_common.h
@@ -32,7 +32,10 @@ struct DevicePrintBuffer {
 #endif
     } aux;
     static_assert(
-        sizeof(Aux) == 4 + 4 + (ProcessorCount * sizeof(DevicePrintRiscCoreState) + 3) / 4 * 4 + 4,
+        sizeof(Aux) == sizeof(uint32_t) + sizeof(uint32_t) +
+                           (ProcessorCount * sizeof(DevicePrintRiscCoreState) + sizeof(uint32_t) - 1) /
+                               sizeof(uint32_t) * sizeof(uint32_t) +
+                           sizeof(uint32_t),
         "Aux struct size must be correct");
     static_assert(sizeof(Aux) % 4 == 0, "Aux struct must be a multiple of 4 bytes for proper alignment of data");
     uint8_t data[BufferSize - sizeof(Aux)];

--- a/tt_metal/hw/inc/hostdev/device_print_common.h
+++ b/tt_metal/hw/inc/hostdev/device_print_common.h
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 
 enum class DevicePrintRiscCoreState : uint8_t {
     KernelNotPrinted = 0,

--- a/tt_metal/hw/inc/hostdev/device_print_common.h
+++ b/tt_metal/hw/inc/hostdev/device_print_common.h
@@ -2,13 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-/*
- *
- * Type ids shared between the debug print server and on-device debug prints.
- *
- */
-
 #pragma once
+
+#include <atomic>
 
 enum class DevicePrintRiscCoreState : uint8_t {
     KernelNotPrinted = 0,
@@ -16,25 +12,17 @@ enum class DevicePrintRiscCoreState : uint8_t {
     PrintingDisabled = 2,
 };
 
-#if defined(KERNEL_BUILD) || defined(FW_BUILD) || defined(HAL_BUILD) || defined(ENV_LLK_INFRA)
-
-#include "core_config.h"
-#include <atomic>
-
-struct DevicePrintMemoryLayout {
-#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
-    static constexpr uint32_t PROCESSOR_COUNT = static_cast<uint32_t>(EthProcessorTypes::COUNT);
-#elif defined(COMPILE_FOR_DRISC)
-    static constexpr uint32_t PROCESSOR_COUNT = static_cast<uint32_t>(DramProcessorTypes::COUNT);
-#else
-    static constexpr uint32_t PROCESSOR_COUNT = static_cast<uint32_t>(TensixProcessorTypes::COUNT);
-#endif
+template <uint32_t BufferSize, uint32_t ProcessorCount, uint32_t ProcessorOffset = 0>
+struct DevicePrintBuffer {
+    static constexpr uint32_t buffer_size = BufferSize;
+    static constexpr uint32_t processor_count = ProcessorCount;
+    static constexpr uint32_t processor_offset = ProcessorOffset;
 
     struct Aux {
         // current writer offset in buffer
         uint32_t wpos;
         uint32_t rpos;
-        DevicePrintRiscCoreState risc_state[PROCESSOR_COUNT];  // Has kernel printed since starting
+        DevicePrintRiscCoreState risc_state[ProcessorCount];  // Has kernel printed since starting
 #if defined(ARCH_WORMHOLE)
         uint32_t lock;  // Lock for synchronizing access to the buffer. 0 means free, other values indicate locked by
                         // that processor.
@@ -43,17 +31,9 @@ struct DevicePrintMemoryLayout {
 #endif
     } aux;
     static_assert(
-        sizeof(Aux) == 4 + 4 + (PROCESSOR_COUNT * sizeof(DevicePrintRiscCoreState) + 3) / 4 * 4 + 4,
+        sizeof(Aux) == 4 + 4 + (ProcessorCount * sizeof(DevicePrintRiscCoreState) + 3) / 4 * 4 + 4,
         "Aux struct size must be correct");
     static_assert(sizeof(Aux) % 4 == 0, "Aux struct must be a multiple of 4 bytes for proper alignment of data");
-    uint8_t data[DPRINT_BUFFER_SIZE * PROCESSOR_COUNT - sizeof(Aux)];
+    uint8_t data[BufferSize - sizeof(Aux)];
     static_assert(sizeof(data) % 4 == 0, "Data array size must be a multiple of 4 bytes for proper alignment");
 };
-static_assert(
-    sizeof(DevicePrintMemoryLayout) == DPRINT_BUFFER_SIZE * DevicePrintMemoryLayout::PROCESSOR_COUNT,
-    "DevicePrintMemoryLayout size must match total buffer size");
-static_assert(
-    sizeof(DevicePrintMemoryLayout) % 4 == 0,
-    "DevicePrintMemoryLayout size must be a multiple of 4 bytes for proper alignment");
-
-#endif

--- a/tt_metal/hw/inc/internal/debug/dprint_buffer.h
+++ b/tt_metal/hw/inc/internal/debug/dprint_buffer.h
@@ -10,12 +10,16 @@
 #include "hostdev/dev_msgs.h"
 #endif
 
-inline volatile tt_l1_ptr DevicePrintMemoryLayout* get_device_print_buffer() {
+#include "device_print_mem.h"
+
+using DevicePrintBufferType = decltype(DevicePrintMemoryLayout::buffer);
+
+inline volatile tt_l1_ptr DevicePrintBufferType* get_device_print_buffer() {
 #ifdef ENV_LLK_INFRA
     // LLK has a different memory layout; this must match
     // DEVICE_PRINT_BUFFER_BASE in tests/python_tests/helpers/test_config.py.
-    return reinterpret_cast<volatile tt_l1_ptr DevicePrintMemoryLayout*>(LLK_DEVICE_PRINT_BUFFER_BASE);
+    return reinterpret_cast<volatile tt_l1_ptr DevicePrintBufferType*>(LLK_DEVICE_PRINT_BUFFER_BASE);
 #else
-    return GET_MAILBOX_ADDRESS_DEV(dprint_buf);
+    return GET_MAILBOX_ADDRESS_DEV(dprint_buf.buffer);
 #endif
 }

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/device_print_mem.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/device_print_mem.h
@@ -8,10 +8,25 @@
 
 struct DevicePrintMemoryLayout {
 #if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
-    DevicePrintBuffer<408, 2> buffer;  // BH ETH 2 processors
-#elif defined(COMPILE_FOR_DRISC)
-    DevicePrintBuffer<204, 1> buffer;  // BH DRAM 1 processor
+    // BH has 2 processors on ETH
+#if !defined(DEVICE_PRINT_BUFFER_SIZE)
+    DevicePrintBuffer<408, 2> buffer;
 #else
-    DevicePrintBuffer<1020, 5> buffer;  // BH TENSIX 5 processors
+    DevicePrintBuffer<DEVICE_PRINT_BUFFER_SIZE, 2> buffer;
+#endif
+#elif defined(COMPILE_FOR_DRISC)
+    // BH has 1 processor on DRAM
+#if !defined(DEVICE_PRINT_BUFFER_SIZE)
+    DevicePrintBuffer<204, 1> buffer;
+#else
+    DevicePrintBuffer<DEVICE_PRINT_BUFFER_SIZE, 1> buffer;
+#endif
+#else
+    // BH has 5 processors on TENSIX
+#if !defined(DEVICE_PRINT_BUFFER_SIZE)
+    DevicePrintBuffer<1020, 5> buffer;
+#else
+    DevicePrintBuffer<DEVICE_PRINT_BUFFER_SIZE, 5> buffer;
+#endif
 #endif
 };

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/device_print_mem.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/device_print_mem.h
@@ -1,0 +1,17 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "hostdev/device_print_common.h"
+
+struct DevicePrintMemoryLayout {
+#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
+    DevicePrintBuffer<408, 2> buffer;  // BH ETH 2 processors
+#elif defined(COMPILE_FOR_DRISC)
+    DevicePrintBuffer<204, 1> buffer;  // BH DRAM 1 processor
+#else
+    DevicePrintBuffer<1020, 5> buffer;  // BH TENSIX 5 processors
+#endif
+};

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/device_print_mem.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/device_print_mem.h
@@ -1,0 +1,15 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "hostdev/device_print_common.h"
+
+struct DevicePrintMemoryLayout {
+#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
+    DevicePrintBuffer<204, 1> buffer;  // WH ETH 1 processor
+#else
+    DevicePrintBuffer<1020, 5> buffer;  // WH TENSIX 5 processors
+#endif
+};

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/device_print_mem.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/device_print_mem.h
@@ -8,8 +8,18 @@
 
 struct DevicePrintMemoryLayout {
 #if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
-    DevicePrintBuffer<204, 1> buffer;  // WH ETH 1 processor
+    // WH has 1 processor on ETH
+#if !defined(DEVICE_PRINT_BUFFER_SIZE)
+    DevicePrintBuffer<204, 1> buffer;
 #else
-    DevicePrintBuffer<1020, 5> buffer;  // WH TENSIX 5 processors
+    DevicePrintBuffer<DEVICE_PRINT_BUFFER_SIZE, 1> buffer;
+#endif
+#else
+    // WH has 5 processors on TENSIX
+#if !defined(DEVICE_PRINT_BUFFER_SIZE)
+    DevicePrintBuffer<1020, 5> buffer;
+#else
+    DevicePrintBuffer<DEVICE_PRINT_BUFFER_SIZE, 5> buffer;
+#endif
 #endif
 };

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/device_print_mem.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/device_print_mem.h
@@ -9,20 +9,38 @@
 struct DevicePrintMemoryLayout {
 #if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
     // TODO: This needs to be properly defined
+#if !defined(DEVICE_PRINT_BUFFER_SIZE)
     DevicePrintBuffer<408, 2> buffer;
+#else
+    DevicePrintBuffer<DEVICE_PRINT_BUFFER_SIZE, 2> buffer;
+#endif
 #elif defined(COMPILE_FOR_DRISC)
     // TODO: This needs to be properly defined
+#if !defined(DEVICE_PRINT_BUFFER_SIZE)
     DevicePrintBuffer<204, 1> buffer;
 #else
-#if defined(COMPILE_FOR_DM)
-    DevicePrintBuffer<3264, 16, 8> buffer_triscs;  // Quasar TRISC 16 processors
-    DevicePrintBuffer<1632, 8, 0> buffer;          // Quasar DM 8 processors
-#elif defined(COMPILE_FOR_TRISC)
-    DevicePrintBuffer<3264, 16, 8> buffer;     // Quasar TRISC 16 processors
-    DevicePrintBuffer<1632, 8, 0> buffer_dms;  // Quasar DM 8 processors
+    DevicePrintBuffer<DEVICE_PRINT_BUFFER_SIZE, 1> buffer;
+#endif
 #else
-    DevicePrintBuffer<3264, 16, 8> buffer_triscs;  // Quasar TRISC 16 processors
-    DevicePrintBuffer<1632, 8, 0> buffer_dms;      // Quasar DM 8 processors
+#if !defined(DEVICE_PRINT_BUFFER_SIZE)
+    static constexpr size_t buffer_size_triscs = 3264;
+#else
+    static constexpr size_t buffer_size_triscs = DEVICE_PRINT_BUFFER_SIZE;
+#endif
+#if !defined(DEVICE_PRINT_BUFFER_SIZE2)
+    static constexpr size_t buffer_size_dms = 3264;
+#else
+    static constexpr size_t buffer_size_dms = DEVICE_PRINT_BUFFER_SIZE2;
+#endif
+#if defined(COMPILE_FOR_DM)
+    DevicePrintBuffer<buffer_size_triscs, 16, 8> buffer_triscs;  // Quasar TRISC 16 processors
+    DevicePrintBuffer<buffer_size_dms, 8, 0> buffer;             // Quasar DM 8 processors
+#elif defined(COMPILE_FOR_TRISC)
+    DevicePrintBuffer<buffer_size_triscs, 16, 8> buffer;  // Quasar TRISC 16 processors
+    DevicePrintBuffer<buffer_size_dms, 8, 0> buffer_dms;  // Quasar DM 8 processors
+#else
+    DevicePrintBuffer<buffer_size_triscs, 16, 8> buffer_triscs;  // Quasar TRISC 16 processors
+    DevicePrintBuffer<buffer_size_dms, 8, 0> buffer_dms;         // Quasar DM 8 processors
 #endif
 #endif
 };

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/device_print_mem.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/device_print_mem.h
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "hostdev/device_print_common.h"
+
+struct DevicePrintMemoryLayout {
+#if defined(COMPILE_FOR_ERISC) || defined(COMPILE_FOR_IDLE_ERISC)
+    // TODO: This needs to be properly defined
+    DevicePrintBuffer<408, 2> buffer;
+#elif defined(COMPILE_FOR_DRISC)
+    // TODO: This needs to be properly defined
+    DevicePrintBuffer<204, 1> buffer;
+#else
+#if defined(COMPILE_FOR_DM)
+    DevicePrintBuffer<3264, 16, 8> buffer_triscs;  // Quasar TRISC 16 processors
+    DevicePrintBuffer<1632, 8, 0> buffer;          // Quasar DM 8 processors
+#elif defined(COMPILE_FOR_TRISC)
+    DevicePrintBuffer<3264, 16, 8> buffer;     // Quasar TRISC 16 processors
+    DevicePrintBuffer<1632, 8, 0> buffer_dms;  // Quasar DM 8 processors
+#else
+    DevicePrintBuffer<3264, 16, 8> buffer_triscs;  // Quasar TRISC 16 processors
+    DevicePrintBuffer<1632, 8, 0> buffer_dms;      // Quasar DM 8 processors
+#endif
+#endif
+};

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/device_print_mem.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/device_print_mem.h
@@ -28,7 +28,7 @@ struct DevicePrintMemoryLayout {
     static constexpr size_t buffer_size_triscs = DEVICE_PRINT_BUFFER_SIZE;
 #endif
 #if !defined(DEVICE_PRINT_BUFFER_SIZE2)
-    static constexpr size_t buffer_size_dms = 3264;
+    static constexpr size_t buffer_size_dms = 1632;
 #else
     static constexpr size_t buffer_size_dms = DEVICE_PRINT_BUFFER_SIZE2;
 #endif

--- a/tt_metal/hw/inc/internal/tt-2xx/quasar/device_print_mem.h
+++ b/tt_metal/hw/inc/internal/tt-2xx/quasar/device_print_mem.h
@@ -23,14 +23,14 @@ struct DevicePrintMemoryLayout {
 #endif
 #else
 #if !defined(DEVICE_PRINT_BUFFER_SIZE)
-    static constexpr size_t buffer_size_triscs = 3264;
+    static constexpr uint32_t buffer_size_triscs = 3264;
 #else
-    static constexpr size_t buffer_size_triscs = DEVICE_PRINT_BUFFER_SIZE;
+    static constexpr uint32_t buffer_size_triscs = DEVICE_PRINT_BUFFER_SIZE;
 #endif
 #if !defined(DEVICE_PRINT_BUFFER_SIZE2)
-    static constexpr size_t buffer_size_dms = 1632;
+    static constexpr uint32_t buffer_size_dms = 1632;
 #else
-    static constexpr size_t buffer_size_dms = DEVICE_PRINT_BUFFER_SIZE2;
+    static constexpr uint32_t buffer_size_dms = DEVICE_PRINT_BUFFER_SIZE2;
 #endif
 #if defined(COMPILE_FOR_DM)
     DevicePrintBuffer<buffer_size_triscs, 16, 8> buffer_triscs;  // Quasar TRISC 16 processors

--- a/tt_metal/hw/sources.cmake
+++ b/tt_metal/hw/sources.cmake
@@ -179,6 +179,7 @@ set(HW_JIT_API_HEADERS
     inc/internal/tt-1xx/blackhole/cfg_defines.h
     inc/internal/tt-1xx/blackhole/core_config.h
     inc/internal/tt-1xx/blackhole/dev_mem_map.h
+    inc/internal/tt-1xx/blackhole/device_print_mem.h
     inc/internal/tt-1xx/blackhole/eth_chan_noc_mapping.h
     inc/internal/tt-1xx/blackhole/eth_fw_api.h
     inc/internal/tt-1xx/blackhole/eth_l1_address_map.h
@@ -201,6 +202,7 @@ set(HW_JIT_API_HEADERS
     inc/internal/tt-2xx/quasar/cfg_defines.h
     inc/internal/tt-2xx/quasar/core_config.h
     inc/internal/tt-2xx/quasar/dev_mem_map.h
+    inc/internal/tt-2xx/quasar/device_print_mem.h
     inc/internal/tt-2xx/quasar/eth_chan_noc_mapping.h
     inc/internal/tt-2xx/quasar/eth_fw_api.h
     inc/internal/tt-2xx/quasar/eth_l1_address_map.h
@@ -217,6 +219,7 @@ set(HW_JIT_API_HEADERS
     inc/internal/tt-1xx/wormhole/c_tensix_core.h
     inc/internal/tt-1xx/wormhole/core_config.h
     inc/internal/tt-1xx/wormhole/dev_mem_map.h
+    inc/internal/tt-1xx/wormhole/device_print_mem.h
     inc/internal/tt-1xx/wormhole/eth_chan_noc_mapping.h
     inc/internal/tt-1xx/wormhole/eth_fw_api.h
     inc/internal/tt-1xx/wormhole/eth_l1_address_map.h

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -186,7 +186,7 @@ public:
     // DevicePrintMemoryLayout in device_print_mem.h) — a TRISC/compute buffer followed by a DM
     // buffer — so it returns two entries, in memory order.
     std::vector<DPrintBufferInfo> get_core_buffers(ChipId device_id, const umd::CoreDescriptor& print_core) const {
-        auto& cluster = env_.get_cluster();
+        const auto& cluster = env_.get_cluster();
         const auto& hal = env_.get_hal();
         auto virtual_core =
             cluster.get_virtual_coordinate_from_logical_coordinates(device_id, print_core.coord, print_core.type);

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -123,14 +123,13 @@ void WriteInitMagic(
     tt::Cluster& cluster,
     ChipId device_id,
     const CoreCoord& virtual_core,
-    uint64_t base_addr,
-    bool enabled,
-    uint32_t buffer_size = DPRINT_BUFFER_SIZE) {
+    const tt::tt_metal::DPrintBufferInfo& buffer_info,
+    bool enabled) {
     // TODO(AP): this could use a cleanup - need a different mechanism to know if a kernel is running on device.
     // Force wait for first kernel launch by first writing a non-zero and waiting for a zero.
-    std::vector<uint32_t> initbuf = std::vector<uint32_t>(buffer_size / sizeof(uint32_t), 0);
+    std::vector<uint32_t> initbuf = std::vector<uint32_t>(buffer_info.structure_size / sizeof(uint32_t), 0);
     initbuf[0] = uint32_t(enabled ? DEBUG_PRINT_SERVER_STARTING_MAGIC : DEBUG_PRINT_SERVER_DISABLED_MAGIC);
-    cluster.write_core(device_id, virtual_core, initbuf, base_addr);
+    cluster.write_core(device_id, virtual_core, initbuf, buffer_info.structure_address);
 
     // Prevent race conditions during runtime by waiting until the init value is actually written
     // DPrint is only used for debug purposes so this delay should not be a big issue.
@@ -140,7 +139,7 @@ void WriteInitMagic(
     // 4. now we will access wpos at the starting magic which is incorrect
     uint32_t num_tries = 100000;
     while (num_tries-- > 0) {
-        auto result = cluster.read_core(device_id, virtual_core, base_addr, 4);
+        auto result = cluster.read_core(device_id, virtual_core, buffer_info.structure_address, 4);
         if ((result[0] == DEBUG_PRINT_SERVER_STARTING_MAGIC && enabled) ||
             (result[0] == DEBUG_PRINT_SERVER_DISABLED_MAGIC && !enabled)) {
             return;
@@ -181,12 +180,69 @@ public:
         return it->second;
     }
 
+    // Returns the layout of every DPRINT buffer in a core's DPRINT_BUFFERS region. Most arch/core
+    // combinations use a single buffer covering all of the core's RISC processors. Quasar TENSIX is
+    // special: it splits its processors across two physically separate buffers (see
+    // DevicePrintMemoryLayout in device_print_mem.h) — a TRISC/compute buffer followed by a DM
+    // buffer — so it returns two entries, in memory order.
+    std::vector<DPrintBufferInfo> get_core_buffers(ChipId device_id, const umd::CoreDescriptor& print_core) const {
+        auto& cluster = env_.get_cluster();
+        const auto& hal = env_.get_hal();
+        auto virtual_core =
+            cluster.get_virtual_coordinate_from_logical_coordinates(device_id, print_core.coord, print_core.type);
+        auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
+        const uint64_t structure_address =
+            hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::DPRINT_BUFFERS);
+        const uint32_t structure_size = hal.get_dev_size(programmable_core_type, HalL1MemAddrType::DPRINT_BUFFERS);
+
+        TT_FATAL(structure_size <= 0xFFFFu, "DPRINT buffer size {} doesn't fit uint16_t", structure_size);
+
+        // Each buffer has the layout (see DevicePrintBuffer in device_print_common.h):
+        // uint32_t wpos;
+        // uint32_t rpos;
+        // uint8_t risc_state[processor_count]; // Rounded up to nearest word
+        // uint32_t lock;
+        // byte print_buffer[remaining buffer];
+        auto make_buffer = [](uint64_t address, uint16_t size, uint16_t processor_count, uint16_t processor_offset) {
+            const uint16_t risc_state_bytes = ((processor_count + 3) / 4) * 4;
+            const uint16_t buffer_offset = 8u + risc_state_bytes + sizeof(uint32_t);
+            const uint16_t buffer_size = size - buffer_offset;
+            return DPrintBufferInfo{address, size, 0, buffer_offset, buffer_size, processor_count, processor_offset};
+        };
+
+        // Quasar TENSIX uses two buffers: the compute (TRISC) processors first, then the DM
+        // processors, each sized DPRINT_BUFFER_SIZE * (its processor count). The compute buffer's
+        // processors are offset by the DM count in the core's global processor index space (DM
+        // processors occupy global indices 0..dm_count-1, compute the rest).
+        if (hal.get_arch() == tt::ARCH::QUASAR && programmable_core_type == HalProgrammableCoreType::TENSIX) {
+            const uint16_t dm_count = static_cast<uint16_t>(hal.get_processor_types_count(
+                programmable_core_type, static_cast<uint32_t>(HalProcessorClassType::DM)));
+            const uint16_t compute_count = static_cast<uint16_t>(hal.get_processor_types_count(
+                programmable_core_type, static_cast<uint32_t>(HalProcessorClassType::COMPUTE)));
+            const uint16_t compute_size = static_cast<uint16_t>(DPRINT_BUFFER_SIZE * compute_count);
+            const uint16_t dm_size = static_cast<uint16_t>(DPRINT_BUFFER_SIZE * dm_count);
+            TT_FATAL(
+                static_cast<uint32_t>(compute_size) + dm_size == structure_size,
+                "Quasar TENSIX DPRINT buffer split (compute {} + DM {}) doesn't match region size {}",
+                compute_size,
+                dm_size,
+                structure_size);
+            return {
+                make_buffer(structure_address, compute_size, compute_count, dm_count),
+                make_buffer(structure_address + compute_size, dm_size, dm_count, 0),
+            };
+        }
+
+        const uint16_t num_processors = static_cast<uint16_t>(hal.get_num_risc_processors(programmable_core_type));
+        return {make_buffer(structure_address, static_cast<uint16_t>(structure_size), num_processors, 0)};
+    }
+
 private:
     bool poll_one_core(ChipId device_id, const umd::CoreDescriptor& logical_core, bool new_data_this_iter);
-    void init_print_buffers_for_core(
-        ChipId device_id, const CoreCoord& virtual_core, HalProgrammableCoreType core_type);
-    void enable_print_buffers_for_core(
-        ChipId device_id, const CoreCoord& virtual_core, HalProgrammableCoreType core_type);
+    bool poll_print_buffer(
+        ChipId device_id, const umd::CoreDescriptor& logical_core, const DPrintBufferInfo& buffer_info);
+    void init_print_buffers_for_core(ChipId device_id, const umd::CoreDescriptor& logical_core);
+    void enable_print_buffers_for_core(ChipId device_id, const umd::CoreDescriptor& logical_core);
 
     struct RiscData {
         std::string firmware_elf_path;
@@ -470,30 +526,17 @@ void DPrintServer::Impl::print_buffer_data(
     }
 }
 
-bool DPrintServer::Impl::poll_one_core(
-    ChipId device_id, const umd::CoreDescriptor& logical_core, bool /*new_data_this_iter*/) {
+bool DPrintServer::Impl::poll_print_buffer(
+    ChipId device_id, const umd::CoreDescriptor& logical_core, const DPrintBufferInfo& buffer_info) {
     auto& cluster = env_.get_cluster();
     auto virtual_core =
         cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
-    auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
-    uint32_t num_processors = env_.get_hal().get_num_risc_processors(programmable_core_type);
-
-    // Memory layout:
-    // uint32_t wpos;
-    // uint32_t rpos;
-    // uint8_t risc_state[num_processors]; // Rounded up to nearest word
-    // uint32_t lock;
-    // byte print_buffer[remaining buffer];
-
-    auto buffer_address = GetDevicePrintBufAddr(device_id, virtual_core);
-    uint32_t buffer_size = DPRINT_BUFFER_SIZE * num_processors;
+    auto print_buffer_address = buffer_info.structure_address + buffer_info.buffer_offset;
+    auto print_buffer_size = buffer_info.buffer_size;
+    auto read_write_pointer_address = buffer_info.get_read_write_pointer_address();
     constexpr uint32_t eightbytes = 8;
-    uint32_t risc_state_bytes = ((num_processors + 3) / 4) * 4;  // Round up to nearest word
-    auto from_dev = cluster.read_core(device_id, virtual_core, buffer_address, eightbytes);
+    auto from_dev = cluster.read_core(device_id, virtual_core, read_write_pointer_address, eightbytes);
     uint32_t wpos = from_dev[0], rpos = from_dev[1];
-    uint64_t print_buffer_address =
-        buffer_address + eightbytes + risc_state_bytes + sizeof(uint32_t);  // Skip wpos, rpos, risc state, and lock
-    uint32_t print_buffer_size = buffer_size - eightbytes - risc_state_bytes - sizeof(uint32_t);
 
     if (wpos == DEBUG_PRINT_SERVER_DISABLED_MAGIC || wpos == DEBUG_PRINT_SERVER_STARTING_MAGIC || wpos == rpos) {
         return false;
@@ -531,11 +574,11 @@ bool DPrintServer::Impl::poll_one_core(
         if (stall) {
             // Write clear buffer.
             rpos = DEVICE_PRINT_RESET_BUFFER_MAGIC;
-            cluster.write_core(device_id, virtual_core, std::vector<uint32_t>{rpos}, buffer_address + 4);
+            cluster.write_core(device_id, virtual_core, std::vector<uint32_t>{rpos}, read_write_pointer_address + 4);
 
             // We should probably drain while core is in stall state.
             // Read wpos and rpos again and repeat
-            from_dev = cluster.read_core(device_id, virtual_core, buffer_address, eightbytes);
+            from_dev = cluster.read_core(device_id, virtual_core, read_write_pointer_address, eightbytes);
             wpos = from_dev[0];
             rpos = from_dev[1];
             continue;
@@ -544,45 +587,54 @@ bool DPrintServer::Impl::poll_one_core(
         // We have caught up to the writer, break out of the loop and wait for more data to arrive
         break;
     }
-    cluster.write_core(device_id, virtual_core, std::vector<uint32_t>{rpos}, buffer_address + 4);
+    cluster.write_core(device_id, virtual_core, std::vector<uint32_t>{rpos}, read_write_pointer_address + 4);
     return true;
 }
 
-void DPrintServer::Impl::init_print_buffers_for_core(
-    ChipId device_id, const CoreCoord& virtual_core, HalProgrammableCoreType core_type) {
-    const auto& hal = env_.get_hal();
-    auto& cluster = env_.get_cluster();
-    uint32_t num_processors = hal.get_num_risc_processors(core_type);
-    uint32_t buffer_size = DPRINT_BUFFER_SIZE * num_processors;
-    // Default every core to disabled; enable_print_buffers_for_core flips opted-in cores to the
-    // starting magic. Muted cores must see the disabled magic or their kernels will write into the
-    // buffer and wait forever for a drain that never comes.
-    WriteInitMagic(
-        cluster, device_id, virtual_core, GetDevicePrintBufAddr(device_id, virtual_core), false, buffer_size);
+bool DPrintServer::Impl::poll_one_core(
+    ChipId device_id, const umd::CoreDescriptor& logical_core, bool /*new_data_this_iter*/) {
+    bool result = false;
+    for (auto& buffer_info : get_core_buffers(device_id, logical_core)) {
+        result |= poll_print_buffer(device_id, logical_core, buffer_info);
+    }
+    return result;
 }
 
-void DPrintServer::Impl::enable_print_buffers_for_core(
-    ChipId device_id, const CoreCoord& virtual_core, HalProgrammableCoreType core_type) {
+void DPrintServer::Impl::init_print_buffers_for_core(ChipId device_id, const umd::CoreDescriptor& logical_core) {
     auto& cluster = env_.get_cluster();
-    const auto& hal = env_.get_hal();
-    uint32_t num_processors = hal.get_num_risc_processors(core_type);
-    uint64_t device_print_buffer_address = GetDevicePrintBufAddr(device_id, virtual_core);
-    uint32_t buffer_size = DPRINT_BUFFER_SIZE * num_processors;
-    WriteInitMagic(cluster, device_id, virtual_core, device_print_buffer_address, true, buffer_size);
-    uint64_t risc_flags_address = device_print_buffer_address + 8;  // sizeof(wpos) + sizeof(rpos)
-    std::vector<uint8_t> risc_flags(
-        (num_processors + 3) / 4 * 4, static_cast<uint8_t>(DevicePrintRiscCoreState::KernelNotPrinted));
-    for (int risc_index = 0; risc_index < num_processors; risc_index++) {
-        if (!RiscEnabled(env_.get_rtoptions(), core_type, risc_index)) {
-            risc_flags[risc_index] = static_cast<uint8_t>(DevicePrintRiscCoreState::PrintingDisabled);
-        }
+    CoreCoord virtual_core =
+        cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
+    for (auto& buffer_info : get_core_buffers(device_id, logical_core)) {
+        WriteInitMagic(cluster, device_id, virtual_core, buffer_info, false);
     }
+}
 
-    // We created array of flags for each risc. We will write it to the device at an offset from the print buffer
-    // address. It is OK to do this write any time to update flags. Flags carry info about if kernel already sent kernel
-    // loaded structure and if printing is enabled. If we overwrite flags while kernel is running, all we can do is make
-    // kernel print more data (repeat kernel loaded structure). We will handle this on server side.
-    cluster.write_core(device_id, virtual_core, risc_flags, risc_flags_address);
+void DPrintServer::Impl::enable_print_buffers_for_core(ChipId device_id, const umd::CoreDescriptor& logical_core) {
+    auto& cluster = env_.get_cluster();
+    CoreCoord virtual_core =
+        cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
+    auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
+    for (auto& buffer_info : get_core_buffers(device_id, logical_core)) {
+        WriteInitMagic(cluster, device_id, virtual_core, buffer_info, true);
+
+        uint64_t risc_flags_address = buffer_info.get_read_write_pointer_address() + 8;  // sizeof(wpos) + sizeof(rpos)
+        uint16_t num_processors = buffer_info.processor_count;
+        std::vector<uint8_t> risc_flags(
+            (num_processors + 3) / 4 * 4, static_cast<uint8_t>(DevicePrintRiscCoreState::KernelNotPrinted));
+        for (int risc_index = 0; risc_index < num_processors; risc_index++) {
+            // This buffer's risc_state slots are local; map them to the core's global processor indices
+            // (which RiscEnabled / the feature processor set are keyed by) via the buffer's offset.
+            if (!RiscEnabled(env_.get_rtoptions(), programmable_core_type, buffer_info.processor_offset + risc_index)) {
+                risc_flags[risc_index] = static_cast<uint8_t>(DevicePrintRiscCoreState::PrintingDisabled);
+            }
+        }
+
+        // We created array of flags for each risc. We will write it to the device at an offset from the print buffer
+        // address. It is OK to do this write any time to update flags. Flags carry info about if kernel already sent
+        // kernel loaded structure and if printing is enabled. If we overwrite flags while kernel is running, all we can
+        // do is make kernel print more data (repeat kernel loaded structure). We will handle this on server side.
+        cluster.write_core(device_id, virtual_core, risc_flags, risc_flags_address);
+    }
 }
 
 bool DPrintServer::Impl::poll_device_print_data(
@@ -946,10 +998,7 @@ void DPrintServer::Impl::init_device(ChipId device_id) {
     // skip prints entirely to prevent kernel code from hanging waiting for the print buffer to be
     // flushed from the host.
     for (const auto& logical_core : all_cores) {
-        CoreCoord virtual_core =
-            cluster.get_virtual_coordinate_from_logical_coordinates(
-                device_id, logical_core.coord, logical_core.type);
-        init_print_buffers_for_core(device_id, virtual_core, llrt::get_core_type(device_id, virtual_core));
+        init_print_buffers_for_core(device_id, logical_core);
     }
 }
 
@@ -1084,10 +1133,7 @@ void DPrintServer::Impl::attach_device(ChipId device_id) {
 
     // Write print enable magic for the cores the user specified.
     for (auto& logical_core : print_cores_sanitized) {
-        CoreCoord virtual_core =
-            cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
-        auto programmable_core_type = llrt::get_core_type(device_id, virtual_core);
-        enable_print_buffers_for_core(device_id, virtual_core, programmable_core_type);
+        enable_print_buffers_for_core(device_id, logical_core);
         if (dispatch_cores.contains(logical_core)) {
             device_reads_dispatch_cores_[device_id] = true;
         }
@@ -1177,9 +1223,7 @@ void DPrintServer::Impl::detach_device(ChipId device_id) {
     // When detaching a device, disable prints on it.
     tt::tt_metal::CoreDescriptorSet all_cores = tt::tt_metal::GetAllCores(cluster, control_plane, device_id);
     for (const auto& logical_core : all_cores) {
-        CoreCoord virtual_core =
-            cluster.get_virtual_coordinate_from_logical_coordinates(device_id, logical_core.coord, logical_core.type);
-        init_print_buffers_for_core(device_id, virtual_core, llrt::get_core_type(device_id, virtual_core));
+        init_print_buffers_for_core(device_id, logical_core);
     }
 }  // detach_device
 
@@ -1309,4 +1353,9 @@ bool DPrintServer::hang_detected() { return impl_->hang_detected(); }
 std::vector<umd::CoreDescriptor> DPrintServer::get_print_cores(ChipId device_id) const {
     return impl_->get_print_cores(device_id);
 }
+std::vector<DPrintBufferInfo> DPrintServer::get_core_buffers(
+    ChipId device_id, const umd::CoreDescriptor& print_core) const {
+    return impl_->get_core_buffers(device_id, print_core);
+}
+
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -211,16 +211,15 @@ public:
         };
 
         // Quasar TENSIX uses two buffers: the compute (TRISC) processors first, then the DM
-        // processors, each sized DPRINT_BUFFER_SIZE * (its processor count). The compute buffer's
-        // processors are offset by the DM count in the core's global processor index space (DM
-        // processors occupy global indices 0..dm_count-1, compute the rest).
+        // processors. The compute buffer's processors are offset by the DM count in the core's
+        // global processor index space (DM processors occupy global indices 0..dm_count-1, compute the rest).
         if (hal.get_arch() == tt::ARCH::QUASAR && programmable_core_type == HalProgrammableCoreType::TENSIX) {
             const uint16_t dm_count = static_cast<uint16_t>(hal.get_processor_types_count(
                 programmable_core_type, static_cast<uint32_t>(HalProcessorClassType::DM)));
             const uint16_t compute_count = static_cast<uint16_t>(hal.get_processor_types_count(
                 programmable_core_type, static_cast<uint32_t>(HalProcessorClassType::COMPUTE)));
-            const uint16_t compute_size = static_cast<uint16_t>(DPRINT_BUFFER_SIZE * compute_count);
-            const uint16_t dm_size = static_cast<uint16_t>(DPRINT_BUFFER_SIZE * dm_count);
+            const uint16_t compute_size = 3264;
+            const uint16_t dm_size = 1632;
             TT_FATAL(
                 static_cast<uint32_t>(compute_size) + dm_size == structure_size,
                 "Quasar TENSIX DPRINT buffer split (compute {} + DM {}) doesn't match region size {}",

--- a/tt_metal/impl/debug/dprint_server.hpp
+++ b/tt_metal/impl/debug/dprint_server.hpp
@@ -19,6 +19,18 @@ class MetalContext;
 class MetalEnv;
 class DispatchCoreConfig;
 
+struct DPrintBufferInfo {
+    uint64_t structure_address;
+    uint16_t structure_size;
+    uint16_t read_write_pointer_offset;
+    uint16_t buffer_offset;
+    uint16_t buffer_size;
+    uint16_t processor_count;
+    uint16_t processor_offset;
+
+    uint64_t get_read_write_pointer_address() const { return structure_address + read_write_pointer_offset; }
+};
+
 class DPrintServer {
 public:
     // Constructor/destructor, reads dprint options from RTOptions.
@@ -46,6 +58,9 @@ public:
 
     // Returns the list of cores the print server polls for the given device.
     std::vector<umd::CoreDescriptor> get_print_cores(ChipId device_id) const;
+
+    // Returns the print buffer info (rw pointer address, buffer offset, and buffer size) for the given core.
+    std::vector<DPrintBufferInfo> get_core_buffers(ChipId device_id, const umd::CoreDescriptor& print_core) const;
 
     // Check whether a print hand has been detected by the server.
     // The print server tries to determine if a core is stalled due to the combination of (1) a WAIT

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -366,28 +366,22 @@ void DispatchSKernel::ConfigureCore() {
     }
 
     auto& cluster = descriptor_.cluster();
-    const auto& hal = descriptor_.hal();
     std::vector<device_print_dispatch::NocLocationInputInfo> entries;
     entries.reserve(print_cores.size());
 
     for (const auto& core_desc : print_cores) {
         auto virtual_core =
             cluster.get_virtual_coordinate_from_logical_coordinates(device_->id(), core_desc.coord, core_desc.type);
-        auto programmable_core_type = llrt::get_core_type(device_->id(), virtual_core);
-        const uint64_t rw_ptr_addr = hal.get_dev_noc_addr(programmable_core_type, HalL1MemAddrType::DPRINT_BUFFERS);
-        const uint32_t num_processors = hal.get_num_risc_processors(programmable_core_type);
-        const uint32_t risc_state_bytes = ((num_processors + 3) / 4) * 4;
-        const uint32_t buf_offset = 8u + risc_state_bytes + sizeof(uint32_t);
-        const uint32_t buf_size = (DPRINT_BUFFER_SIZE * num_processors) - buf_offset;
-        TT_FATAL(buf_size <= 0xFFFFu, "DPRINT buffer size {} doesn't fit in NocLocationInputInfo::buf_size", buf_size);
-
-        device_print_dispatch::NocLocationInputInfo entry{};
-        entry.x = virtual_core.x;
-        entry.y = virtual_core.y;
-        entry.rw_ptr_addr = rw_ptr_addr;
-        entry.buf_offset = static_cast<uint16_t>(buf_offset);
-        entry.buf_size = static_cast<uint16_t>(buf_size);
-        entries.push_back(entry);
+        for (auto& buffer_info :
+             descriptor_.metal_context().dprint_server()->get_core_buffers(device_->id(), core_desc)) {
+            device_print_dispatch::NocLocationInputInfo entry{};
+            entry.x = virtual_core.x;
+            entry.y = virtual_core.y;
+            entry.rw_ptr_addr = buffer_info.get_read_write_pointer_address();
+            entry.buf_offset = buffer_info.buffer_offset;
+            entry.buf_size = buffer_info.buffer_size;
+            entries.push_back(entry);
+        }
     }
 
     // Write the packed array bitwise to L1. Each entry is 12 bytes.

--- a/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
+++ b/tt_metal/impl/dispatch/kernel_config/dispatch_s.cpp
@@ -372,7 +372,7 @@ void DispatchSKernel::ConfigureCore() {
     for (const auto& core_desc : print_cores) {
         auto virtual_core =
             cluster.get_virtual_coordinate_from_logical_coordinates(device_->id(), core_desc.coord, core_desc.type);
-        for (auto& buffer_info :
+        for (const auto& buffer_info :
              descriptor_.metal_context().dprint_server()->get_core_buffers(device_->id(), core_desc)) {
             device_print_dispatch::NocLocationInputInfo entry{};
             entry.x = virtual_core.x;

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device_print.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device_print.py
@@ -8,7 +8,7 @@ and tt_metal/hw/inc/hostdev/device_print_common.h):
 
     DEVICE_PRINT_BUFFER_BASE = TestConfig.DEVICE_PRINT_BUFFER_BASE (layout:
     - struct Aux { uint32 wpos; uint32 rpos; uint8 risc_state[5]; uint32 lock; }
-    - uint8 data[DPRINT_BUFFER_SIZE * PROCESSOR_COUNT - sizeof(struct Aux)]
+    - uint8 data[DEVICE_PRINT_BUFFER_SIZE - sizeof(struct Aux)]
 
     Each record:
     - [4-byte DevicePrintHeader]

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -1199,7 +1199,7 @@ class TestConfig:
                     device_print_flags = (
                         f"-DLLK_DEVICE_PRINT_BUFFER_BASE={kernel_buffer_base:#x} "
                         f"-DLLK_RUNTIME_ARGS_START={TestConfig.DEVICE_PRINT_RUNTIME_ARGS_START:#x} "
-                        f"-DDPRINT_BUFFER_SIZE={TestConfig.DEVICE_PRINT_PER_THREAD_SIZE} "
+                        f"-DDEVICE_PRINT_BUFFER_SIZE={TestConfig.DEVICE_PRINT_BUFFER_SIZE} "
                         f"-DPROCESSOR_INDEX={risc_id} "
                     )
                 compile_command = (


### PR DESCRIPTION
Problem:
Quasar `std::atomic<uint32_t>` doesn't work between DM cores and TRISC cores. It works for one type of cores.

Solution:
Split DPRINT buffer on Quasar into two buffers, so that each core type can target its own buffer.

Changes:
- Move away from `DPRINT_BUFFER_SIZE` as it should be deprecated (now that `DEVICE_PRINT` buffer is mostly one per L1)
- Split Quasar `DevicePrintMemoryLayout` into `buffer_dms` and `buffer_triscs` (instead of just `buffer` as in other architectures)
- Change LLK device_print to use optional `DEVICE_PRINT_BUFFER_SIZE` macro.
- Adding DEVICE_PRINT concurrent tests for Quasar

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/split_quasar_dprint_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/split_quasar_dprint_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/split_quasar_dprint_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/split_quasar_dprint_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vjovanovic/split_quasar_dprint_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/split_quasar_dprint_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/split_quasar_dprint_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/split_quasar_dprint_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/split_quasar_dprint_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/split_quasar_dprint_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/split_quasar_dprint_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/split_quasar_dprint_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/split_quasar_dprint_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/split_quasar_dprint_buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/split_quasar_dprint_buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/split_quasar_dprint_buffer)