### PR TITLE
Move QB2 sdpa nightly tests from BH e2e to BH post-commit

### DIFF
--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -69,11 +69,15 @@ jobs:
               # pytest tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH.py
             timeout: 15
             test-type: fast
+          - name: sdpa nightly tests (QB2 only)
+            cmd: pytest tests/nightly/blackhole/sdpa/ -svv
+            timeout: 20
+            test-type: fast-qb2
           # NOTE: All slow / loudbox / qb multi-card BH tests have been migrated
           # into tests/pipeline_reorg/blackhole_e2e_tests.yaml and are now run by
           # the blackhole-e2e-tests workflow. This file only carries the
-          # fast / fast-viommu legs that blackhole-post-commit invokes with
-          # fast-only: true.
+          # fast / fast-viommu / fast-qb2 legs that blackhole-post-commit invokes
+          # with fast-only: true.
           YAML_EOF
           )
           all_tests=$(echo "$all_tests_yaml" | ruby -r yaml -r json -e 'puts YAML.load(STDIN.read).to_json')
@@ -85,13 +89,15 @@ jobs:
           if [[ "$runner_label" == *viommu* ]]; then viommu_json="true"; fi
           loudbox_json="false"
           if [[ "$runner_label" == *LoudBox* ]]; then loudbox_json="true"; fi
+          qb2_json="false"
+          if [[ "$runner_label" == *Quietbox-2* ]]; then qb2_json="true"; fi
 
           if [ "$fast_only" == "true" ]; then
-            filtered_tests=$(echo "$all_tests" | jq -c --argjson viommu "$viommu_json" --argjson loudbox "$loudbox_json" \
-              '[.[] | select(((.["test-type"] == "fast") or (.["test-type"] == "fast-viommu" and $viommu)) and ((.["test-type"] != "loudbox") or $loudbox))]')
+            filtered_tests=$(echo "$all_tests" | jq -c --argjson viommu "$viommu_json" --argjson loudbox "$loudbox_json" --argjson qb2 "$qb2_json" \
+              '[.[] | select(((.["test-type"] == "fast") or (.["test-type"] == "fast-viommu" and $viommu) or (.["test-type"] == "fast-qb2" and $qb2)) and ((.["test-type"] != "loudbox") or $loudbox))]')
           else
-            filtered_tests=$(echo "$all_tests" | jq -c --argjson viommu "$viommu_json" --argjson loudbox "$loudbox_json" \
-              '[.[] | select(((.["test-type"] != "fast-viommu" and .["test-type"] != "slow-viommu") or $viommu) and ((.["test-type"] != "loudbox") or $loudbox))]')
+            filtered_tests=$(echo "$all_tests" | jq -c --argjson viommu "$viommu_json" --argjson loudbox "$loudbox_json" --argjson qb2 "$qb2_json" \
+              '[.[] | select(((.["test-type"] != "fast-viommu" and .["test-type"] != "slow-viommu") or $viommu) and ((.["test-type"] != "fast-qb2") or $qb2) and ((.["test-type"] != "loudbox") or $loudbox))]')
           fi
 
           # Filter by model if specified

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -65,8 +65,6 @@
       timeout: 60
     bh_p300:
       timeout: 60
-    bh_quietbox_2:
-      timeout: 60
   owner_id: U07RD9YRFT9 # Slavko Krstic
   team: ttnn
 


### PR DESCRIPTION
### What
Moves the QB2 (2xP300) functional sdpa nightly leg from the BH e2e pipeline to BH post-commit, as a new `fast-qb2` test type gated to Quietbox-2 runners. Other e2e SKUs (4xP150, 8xP150, P300) and the perf row are unchanged.

### CI
[![Blackhole post-commit](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic%2Fmove-qb2-sdpa-to-bh-post-commit)](https://github.com/tenstorrent/tt-metal/actions/runs/27540116764)
[![Blackhole e2e (sdpa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic%2Fmove-qb2-sdpa-to-bh-post-commit)](https://github.com/tenstorrent/tt-metal/actions/runs/27540119002)

🤖 Generated with [Claude Code](https://claude.com/claude-code)