### PR TITLE
Bump models QB2 e2e time budget 30 -> 70 to unblock BH e2e

### DIFF
--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -197,7 +197,7 @@ models:
     bh_p300: 20
     bh_loudbox: 160
     bh_llmbox: 30
-    bh_quietbox_2: 30
+    bh_quietbox_2: 70
   # Per-tier e2e budgets, consumed by the tiered model pipelines;
   # The plain `e2e` key is used for the non-tiered pipelines (blackhole-e2e, t3000-e2e).
   e2e_tier1:


### PR DESCRIPTION
### What
BH e2e is currently **blocked on main**: every run fails at `load-test-matrix` with

> Total Time Budget FAILED for Team 'models', SKU 'bh_quietbox_2'! The sum of test timeouts (70 min) exceeds the allocated budget of 30 min.

#46515 bumped the QB2 DeepSeek prefill op-tests row from 20 to 60 min without a matching `time_budget.yaml` bump. This raises `models.e2e.bh_quietbox_2` 30 -> 70 to match.

cc @pmilojevicTT

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/fix-bh-e2e-models-qb2-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/fix-bh-e2e-models-qb2-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/fix-bh-e2e-models-qb2-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/fix-bh-e2e-models-qb2-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/fix-bh-e2e-models-qb2-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/fix-bh-e2e-models-qb2-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/fix-bh-e2e-models-qb2-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/fix-bh-e2e-models-qb2-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/fix-bh-e2e-models-qb2-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/fix-bh-e2e-models-qb2-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/fix-bh-e2e-models-qb2-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/fix-bh-e2e-models-qb2-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/fix-bh-e2e-models-qb2-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/fix-bh-e2e-models-qb2-budget)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/fix-bh-e2e-models-qb2-budget)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/fix-bh-e2e-models-qb2-budget)