### PR TITLE
[bug]: Add missing CB pops to softmax kernel

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/compute/softmax.cpp
@@ -318,6 +318,15 @@ void kernel_main() {
         cb_recipsumexps_obj.pop_front(1);
         cb_exps_obj.pop_front(Wt);
     }  // NCHt loop
-    // cb_pop_front(cb_max_scaler, 1); // we don't actually have to do this
-    // cb_pop_front(cb_fused_scale, 1); // we don't actually have to do this
+
+    // The scaler CBs (and the fused-scale CB) are waited on once and reused as broadcast
+    // scalars across every NCHt iteration, so they are intentionally not popped inside the
+    // loop. Drain them here so the CBs are flushed at kernel exit. Leaving a page resident is
+    // benign per-launch (FIFO re-init) but a real hazard on a program-cache hit, where the
+    // reused program skips CB re-init and the leftover page back-pressures the next call.
+    cb_max_scaler_obj.pop_front(1);
+    cb_sum_scaler_obj.pop_front(1);
+#if FUSED_SCALE_MASK
+    cb_fused_scale_obj.pop_front(1);
+#endif
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Adds missing circular buffer pop operations to properly release pages and prevent deadlocks. The pops were previously commented out because the author assumed the scaler CBs get re-initialized on every program launch, so leaving a page un-popped was harmless. Re-introduced them because that assumption breaks on a program-cache hit (CB re-init is skipped), where the stale un-popped page persists into the next run and corrupts the producer/consumer handshake, so we balance the CB explicitly.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=smeydanshahiTT/softmax-cb-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:smeydanshahiTT/softmax-cb-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=smeydanshahiTT/softmax-cb-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:smeydanshahiTT/softmax-cb-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=smeydanshahiTT/softmax-cb-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:smeydanshahiTT/softmax-cb-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=smeydanshahiTT/softmax-cb-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:smeydanshahiTT/softmax-cb-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=smeydanshahiTT/softmax-cb-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:smeydanshahiTT/softmax-cb-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=smeydanshahiTT/softmax-cb-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:smeydanshahiTT/softmax-cb-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=smeydanshahiTT/softmax-cb-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:smeydanshahiTT/softmax-cb-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=smeydanshahiTT/softmax-cb-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smeydanshahiTT/softmax-cb-fix)