### PR TITLE
[TTNN] Four explicit Metal 2.0 ProgramSpec factory concepts (progressive ladder) + migrate rand

### DIFF
--- a/tech_reports/Metal2OpMigration/TTNN_OP_MIGRATION_RECIPE.md
+++ b/tech_reports/Metal2OpMigration/TTNN_OP_MIGRATION_RECIPE.md
@@ -1,0 +1,127 @@
+# Porting a TTNN op to Metal 2.0 — the factory recipe
+
+> Companion to the Metal 2.0 documentation set (`metal2_migration_guide.md`, `port_op_to_metal2_recipe.md`,
+> `port_op_to_metal2_ttnn_factory.md` on the documentation branch). Those docs own *how to build* a
+> `ProgramSpec` + `ProgramRunArgs` (kernels, DFBs, named args, tensor parameters). **This document owns
+> the TTNN factory shape decision**: which of the four factory concepts the op lands on, and the rule for
+> deciding — *measure dispatch time and compare, never guess*.
+
+## Read this first
+
+A Metal 2.0 op factory produces exactly two things: the immutable **`ProgramSpec`** (the blueprint) and
+the **`ProgramRunArgs`** (the per-execution values). The four factory concepts below are points on a
+**progressive ladder**. You climb only as far as **measured** performance forces you — each rung adds
+authoring work in exchange for a cheaper cache-hit dispatch, and on most ops the cheaper dispatch does
+not matter.
+
+| rung | concept | factory methods | cache key | cache-hit work |
+|---|---|---|---|---|
+| **1 (default)** | `ProgramSpecFactoryConcept` | `create_program_spec` → `{spec, run_args}` | spec | factory re-runs; tensors refreshed (`UpdateTensorArgs`) |
+| **2** | `AdvancedProgramSpecFactoryConcept` | + `create_enqueue_invariant_args`, `create_per_enqueue_args` | spec | only per-enqueue args rebuilt + re-applied (`UpdateProgramRunArgs`) |
+| **3** | `ImmutableProgramSpecFactoryConcept` | + `extract_immutable_info` | ImmutableInfo | no spec rebuild; tensors refreshed |
+| **4** | `AdvancedImmutableProgramSpecFactoryConcept` | both | ImmutableInfo | no spec rebuild; only per-enqueue args re-applied |
+
+The concepts are detected by the factory's method surface (`extract_immutable_info` ⇒ immutable-keyed;
+`create_enqueue_invariant_args` + `create_per_enqueue_args` ⇒ split). The method names are the
+documentation: a reader of the factory knows what is fixed per cache entry and what changes per dispatch.
+
+**No `select_program_factory`** for single-factory ops — the framework auto-selects a single-alternative
+`program_factory_t`. **No `compute_program_hash`** for immutable-keyed ops — `extract_immutable_info` is
+the key.
+
+---
+
+## Step 0 — Port to rung 1 (everyone starts here)
+
+Any dev should be able to do this without thinking about caching at all.
+
+1. Build the `ProgramSpec` and the full `ProgramRunArgs` exactly as the legacy factory built its
+   descriptor (per `port_op_to_metal2_recipe.md`: CBs → DFBs, positional args → named args, tensor
+   addresses → `TensorParameter` + binding). Keep kernels faithful — change *only* binding mechanisms
+   (`dfb::`, `ta::`, `args::`), never logic.
+2. Return both, bundled:
+
+```cpp
+struct MyOpProgramFactory {
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
+        const operation_attributes_t& attrs, const tensor_args_t& tensor_args, tensor_return_value_t& out);
+};
+using program_factory_t = std::variant<MyOpProgramFactory>;
+```
+
+3. Delete a custom `compute_program_hash` if the op has one (sanctioned device-op edit; the framework
+   hash is the cache key at rungs 1–2). Delete pybind hooks for vanished legacy entry points.
+4. Validate correctness (op's test suite + cache regression if it has one). **Done. Most ops stop here.**
+
+## Step 1 — Measure before climbing (the gate, not a formality)
+
+Climbing is justified by **one number**: warm cache-hit host dispatch time, before vs after, same shape,
+same machine. The discipline (skipping it produces fiction; we have produced fiction):
+
+- **Verify which binary you measure** (`print(ttnn.__file__)`; worktree `.pth` shadowing is real).
+- **Wipe the kernel cache once**, warm ≥ 50 calls, then time ≥ 1000 calls; report median + p10/p90 (the
+  dispatch distribution is bimodal; a mean alone lies).
+- **Run a no-op control** to know your timer floor; measure host dispatch, not device time (migration
+  shifts host cost only — kernels are unchanged).
+- **Baseline = the legacy/descriptor path for the same shape**, measured the same way the same day.
+
+Climbing pays only if the workload **cache-hits frequently** (enqueue loops). A cold-path or
+shape-churning op never repays factory complexity. Indicative magnitudes from the rand/matmul case
+studies (WH B0, ~64-core shapes): rung 1 hit ≈ 130–160µs (full factory re-run + full re-apply); rung
+2/4 hit ≈ 25–40µs (≈ descriptor parity at best); rung 3 only skips the spec rebuild. Your op will
+differ — **measure**.
+
+## Step 2 — Rung 2 if the hit cost hurts: split the run-args
+
+Split run-args by one question: *can the value differ between two dispatches that share a cache entry?*
+
+- **No** → `create_enqueue_invariant_args` (work splits, shape scalars). Declare each invariant in the
+  spec: `KernelAdvancedOptions::enqueue_invariant_runtime_args` / `_common_runtime_args`,
+  `TensorParameterAdvancedOptions::enqueue_invariant`. Applied once on miss, retained.
+- **Yes** → `create_per_enqueue_args` (tensor addresses, RNG seed, fill value). Rebuilt every dispatch.
+  Takes the mesh coordinate (per-device values, e.g. a sharded-mesh seed offset).
+
+Miss merges both (`MergeProgramRunArgs`) + `SetProgramRunArgs`; hit re-applies only the per-enqueue set
+(`UpdateProgramRunArgs`). The runtime validates that every omitted arg was declared invariant — a
+forgotten per-enqueue value is a hard error, not stale "random" data. **Measure again.** If hit time
+hit your budget, stop.
+
+## Step 3 — Rungs 3–4 if the spec rebuild still dominates: ImmutableInfo
+
+If profiling shows the remaining hit cost is `create_program_spec` itself, add the immutable-keyed shape:
+
+```cpp
+struct immutable_info_t {
+    TensorSpec output_spec;
+    CoreCoord  grid;   // everything the spec depends on — and ONLY that (no seed/from/to)
+    static constexpr auto attribute_names = std::forward_as_tuple("output_spec", "grid");
+    auto attribute_values() const { return std::forward_as_tuple(output_spec, grid); }
+};
+static immutable_info_t extract_immutable_info(const operation_attributes_t&, const tensor_args_t&);
+static ProgramSpec      create_program_spec(const immutable_info_t&);              // miss-only
+static ProgramRunArgs   create_enqueue_invariant_args(const immutable_info_t&);    // miss-only
+static ProgramRunArgs   create_per_enqueue_args(attrs, tensor_args, out, coord);   // every dispatch
+```
+
+ImmutableInfo is the cache key **and** the sole input to the spec/invariant builders — a mutable value
+structurally cannot leak into the key or the spec. Worked example: `rand`
+(`ttnn/cpp/ttnn/operations/rand/device/`), validated by `test_rand_different_seed_values` (one cache
+entry across seeds; different seed ⇒ different output). **Measure once more** and record before/after
+in the port report. If rung 4 still misses budget, the bottleneck is elsewhere — profile, don't tune.
+
+## Blocked cases
+
+Multi-program / per-coord-varying ops (CCL-style), op-owned device resources (scratch `MeshTensor`s,
+`GlobalSemaphore`s), per-device seed offsets needing per-coord programs: park (the workload-factory
+family is pending) and record in the audit.
+
+## Port report (append to METAL2_PORT_REPORT.md)
+
+```markdown
+## TTNN Factory
+- Rung & concept: [1–4] [name]
+- Measurements (median/p10/p90, ≥1000 iters): legacy = __µs; rung 1 = __µs; final rung = __µs
+- Climb justification: [link table — "no climb needed" is a fine answer]
+- Device-op edits: [custom hash deleted; select_program_factory removed; pybind hooks removed]
+- Open items: [blockers, relaxation candidates]
+```

--- a/tech_reports/Metal2OpMigration/TTNN_OP_MIGRATION_RECIPE.md
+++ b/tech_reports/Metal2OpMigration/TTNN_OP_MIGRATION_RECIPE.md
@@ -1,56 +1,60 @@
 # Porting a TTNN op to Metal 2.0 — the factory recipe
 
 > Companion to the Metal 2.0 documentation set (`metal2_migration_guide.md`, `port_op_to_metal2_recipe.md`,
-> `port_op_to_metal2_ttnn_factory.md` on the documentation branch). Those docs own *how to build* a
-> `ProgramSpec` + `ProgramRunArgs` (kernels, DFBs, named args, tensor parameters). **This document owns
-> the TTNN factory shape decision**: which of the four factory concepts the op lands on, and the rule for
-> deciding — *measure dispatch time and compare, never guess*.
+> `port_op_to_metal2_ttnn_factory.md`). Those docs own *how to build* a `ProgramSpec` + `ProgramRunArgs`
+> (kernels, DFBs, named args, tensor parameters). **This document owns the TTNN factory shape decision**:
+> which factory concept the op lands on, and the rule for deciding — *measure dispatch time and compare,
+> never guess*.
 
 ## Read this first
 
-A Metal 2.0 op factory produces exactly two things: the immutable **`ProgramSpec`** (the blueprint) and
-the **`ProgramRunArgs`** (the per-execution values). The four factory concepts below are points on a
-**progressive ladder**. You climb only as far as **measured** performance forces you — each rung adds
-authoring work in exchange for a cheaper cache-hit dispatch, and on most ops the cheaper dispatch does
-not matter.
+A Metal 2.0 op factory produces a **`ProgramArtifacts`**: the immutable `ProgramSpec` (the blueprint) plus
+its `ProgramRunArgs` (the per-execution values). There are exactly **TWO concepts**, distinguished by ONE
+thing — the cache key:
 
-| rung | concept | factory methods | cache key | cache-hit work |
-|---|---|---|---|---|
-| **1 (default)** | `ProgramSpecFactoryConcept` | `create_program_spec` → `{spec, run_args}` | spec | factory re-runs; tensors refreshed (`UpdateTensorArgs`) |
-| **2** | `AdvancedProgramSpecFactoryConcept` | + `create_enqueue_invariant_args`, `create_per_enqueue_args` | spec | only per-enqueue args rebuilt + re-applied (`UpdateProgramRunArgs`) |
-| **3** | `ImmutableProgramSpecFactoryConcept` | + `extract_immutable_info` | ImmutableInfo | no spec rebuild; tensors refreshed |
-| **4** | `AdvancedImmutableProgramSpecFactoryConcept` | both | ImmutableInfo | no spec rebuild; only per-enqueue args re-applied |
+| concept | extra method | cache key | buys you |
+|---|---|---|---|
+| **`ProgramSpecFactoryConcept`** | — | the generated `ProgramSpec` | the default |
+| **`AdvancedProgramSpecFactoryConcept`** | `extract_immutable_info` | a small hashable `ImmutableInfo` | skips the spec rebuild on a hit; structurally excludes mutable values (e.g. a seed) from the key |
 
-The concepts are detected by the factory's method surface (`extract_immutable_info` ⇒ immutable-keyed;
-`create_enqueue_invariant_args` + `create_per_enqueue_args` ⇒ split). The method names are the
-documentation: a reader of the factory knows what is fixed per cache entry and what changes per dispatch.
+Within **either** concept, the enqueue-invariant fast path is an **optional, incremental** refinement —
+add a `create_per_enqueue_args` method (Audrey's "Option 2 → 2++" / "Option 3 → 3++"):
 
-**No `select_program_factory`** for single-factory ops — the framework auto-selects a single-alternative
-`program_factory_t`. **No `compute_program_hash`** for immutable-keyed ops — `extract_immutable_info` is
-the key.
+| | `create_program_artifacts` returns | `create_per_enqueue_args`? | cache-hit work |
+|---|---|---|---|
+| **degenerate** | spec + **all** run-args | absent | refresh tensor bindings (`UpdateTensorArgs`) |
+| **++** | spec + **enqueue-invariant** run-args | present (the per-dispatch rest) | re-apply only the per-enqueue set (`UpdateProgramRunArgs`) |
+
+You only move **enough** args into the invariant bundle to clear your perf target — moving one more arg
+from `create_per_enqueue_args` into `create_program_artifacts`'s run-args (and declaring it invariant in
+the spec) is a one-line, behavior-preserving optimization. **Leaving some on the table is fine.**
+
+Detected by method surface: `extract_immutable_info` ⇒ Advanced (immutable-keyed); `create_per_enqueue_args`
+⇒ ++. **No `select_program_factory`** for single-factory ops (auto-selected). **No `compute_program_hash`**
+for the Advanced concept — `extract_immutable_info` is the key.
 
 ---
 
-## Step 0 — Port to rung 1 (everyone starts here)
+## Step 0 — Port to the degenerate `ProgramSpecFactoryConcept` (everyone starts here)
 
-Any dev should be able to do this without thinking about caching at all.
+Do this without thinking about caching at all.
 
 1. Build the `ProgramSpec` and the full `ProgramRunArgs` exactly as the legacy factory built its
    descriptor (per `port_op_to_metal2_recipe.md`: CBs → DFBs, positional args → named args, tensor
    addresses → `TensorParameter` + binding). Keep kernels faithful — change *only* binding mechanisms
    (`dfb::`, `ta::`, `args::`), never logic.
-2. Return both, bundled:
+2. Return both, bundled — one method, no split:
 
 ```cpp
 struct MyOpProgramFactory {
-    static ttnn::device_operation::ProgramArtifacts create_program_spec(
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(
         const operation_attributes_t& attrs, const tensor_args_t& tensor_args, tensor_return_value_t& out);
 };
 using program_factory_t = std::variant<MyOpProgramFactory>;
 ```
 
 3. Delete a custom `compute_program_hash` if the op has one (sanctioned device-op edit; the framework
-   hash is the cache key at rungs 1–2). Delete pybind hooks for vanished legacy entry points.
+   hashes the spec). Delete pybind hooks for vanished legacy entry points.
 4. Validate correctness (op's test suite + cache regression if it has one). **Done. Most ops stop here.**
 
 ## Step 1 — Measure before climbing (the gate, not a formality)
@@ -64,31 +68,39 @@ same machine. The discipline (skipping it produces fiction; we have produced fic
 - **Run a no-op control** to know your timer floor; measure host dispatch, not device time (migration
   shifts host cost only — kernels are unchanged).
 - **Baseline = the legacy/descriptor path for the same shape**, measured the same way the same day.
+- **Measure the realistic workload.** If a per-dispatch value (an RNG seed) is in the legacy cache key,
+  the legacy op *recompiles every call* — measure with that value VARYING, not pinned. (Real example:
+  legacy `sampling` with a pinned seed hit ≈ 33µs, but with a varying seed it recompiled every call at
+  ≈ 1 *second* — the pinned number hid a 30000× cliff.)
 
 Climbing pays only if the workload **cache-hits frequently** (enqueue loops). A cold-path or
 shape-churning op never repays factory complexity. Indicative magnitudes from the rand/matmul case
-studies (WH B0, ~64-core shapes): rung 1 hit ≈ 130–160µs (full factory re-run + full re-apply); rung
-2/4 hit ≈ 25–40µs (≈ descriptor parity at best); rung 3 only skips the spec rebuild. Your op will
-differ — **measure**.
+studies (WH B0, ~64-core shapes): degenerate hit ≈ 130–160µs (full factory re-run + full re-apply); ++
+hit ≈ 25–40µs. Your op will differ — **measure**.
 
-## Step 2 — Rung 2 if the hit cost hurts: split the run-args
+## Step 2 — "++": split off the per-enqueue args (if the hit cost hurts)
 
-Split run-args by one question: *can the value differ between two dispatches that share a cache entry?*
+Add `create_per_enqueue_args` and move the args that change per dispatch into it; leave everything else
+in `create_program_artifacts`'s run-args and declare those enqueue-invariant in the spec. Split by one
+question: *can the value differ between two dispatches that share a cache entry?*
 
-- **No** → `create_enqueue_invariant_args` (work splits, shape scalars). Declare each invariant in the
-  spec: `KernelAdvancedOptions::enqueue_invariant_runtime_args` / `_common_runtime_args`,
-  `TensorParameterAdvancedOptions::enqueue_invariant`. Applied once on miss, retained.
-- **Yes** → `create_per_enqueue_args` (tensor addresses, RNG seed, fill value). Rebuilt every dispatch.
-  Takes the mesh coordinate (per-device values, e.g. a sharded-mesh seed offset).
+- **No** (work splits, shape scalars) → keep in `create_program_artifacts`'s run-args; declare invariant
+  (`KernelAdvancedOptions::enqueue_invariant_runtime_args` / `_common_runtime_args`,
+  `TensorParameterAdvancedOptions::enqueue_invariant`). Set once on miss, retained.
+- **Yes** (tensor addresses, RNG seed, fill value) → `create_per_enqueue_args`. Rebuilt every dispatch;
+  takes the mesh coordinate (per-device values, e.g. a sharded-mesh seed offset).
 
 Miss merges both (`MergeProgramRunArgs`) + `SetProgramRunArgs`; hit re-applies only the per-enqueue set
 (`UpdateProgramRunArgs`). The runtime validates that every omitted arg was declared invariant — a
-forgotten per-enqueue value is a hard error, not stale "random" data. **Measure again.** If hit time
-hit your budget, stop.
+forgotten per-enqueue value is a hard error, not stale "random" data. **You need only move ENOUGH args
+into the invariant bundle to clear your target — leaving some on the table is fine.** Measure again; stop
+when you hit budget.
 
-## Step 3 — Rungs 3–4 if the spec rebuild still dominates: ImmutableInfo
+## Step 3 — `AdvancedProgramSpecFactoryConcept`: switch the key to ImmutableInfo
 
-If profiling shows the remaining hit cost is `create_program_spec` itself, add the immutable-keyed shape:
+Use this when (a) the remaining hit cost is the `create_program_artifacts` rebuild itself, or (b) a
+per-dispatch value is polluting the cache key (the sampling/​rand seed cliff above). Add
+`extract_immutable_info` and make `create_program_artifacts` take it:
 
 ```cpp
 struct immutable_info_t {
@@ -97,31 +109,29 @@ struct immutable_info_t {
     static constexpr auto attribute_names = std::forward_as_tuple("output_spec", "grid");
     auto attribute_values() const { return std::forward_as_tuple(output_spec, grid); }
 };
-static immutable_info_t extract_immutable_info(const operation_attributes_t&, const tensor_args_t&);
-static ProgramSpec      create_program_spec(const immutable_info_t&);              // miss-only
-static ProgramRunArgs   create_enqueue_invariant_args(const immutable_info_t&);    // miss-only
-static ProgramRunArgs   create_per_enqueue_args(attrs, tensor_args, out, coord);   // every dispatch
+static immutable_info_t      extract_immutable_info(const operation_attributes_t&, const tensor_args_t&);
+static ProgramArtifacts      create_program_artifacts(const immutable_info_t&);     // miss-only; spec + invariant args
+static ProgramRunArgs        create_per_enqueue_args(attrs, tensor_args, out, coord);  // optional "++"; every dispatch
 ```
 
-ImmutableInfo is the cache key **and** the sole input to the spec/invariant builders — a mutable value
+ImmutableInfo is the cache key **and** the sole input to `create_program_artifacts` — a mutable value
 structurally cannot leak into the key or the spec. Worked example: `rand`
 (`ttnn/cpp/ttnn/operations/rand/device/`), validated by `test_rand_different_seed_values` (one cache
-entry across seeds; different seed ⇒ different output). **Measure once more** and record before/after
-in the port report. If rung 4 still misses budget, the bottleneck is elsewhere — profile, don't tune.
+entry across seeds; different seed ⇒ different output). **Measure once more** and record before/after in
+the port report. If it still misses budget, the bottleneck is elsewhere — profile, don't tune.
 
 ## Blocked cases
 
-Multi-program / per-coord-varying ops (CCL-style), op-owned device resources (scratch `MeshTensor`s,
-`GlobalSemaphore`s), per-device seed offsets needing per-coord programs: park (the workload-factory
-family is pending) and record in the audit.
+Multi-program / per-coord-varying ops (CCL-style); op-owned device resources beyond what enqueue-invariant
+tensor args cover. Park (the workload-factory family is pending) and record in the audit.
 
 ## Port report (append to METAL2_PORT_REPORT.md)
 
 ```markdown
 ## TTNN Factory
-- Rung & concept: [1–4] [name]
-- Measurements (median/p10/p90, ≥1000 iters): legacy = __µs; rung 1 = __µs; final rung = __µs
-- Climb justification: [link table — "no climb needed" is a fine answer]
+- Concept: ProgramSpecFactoryConcept | AdvancedProgramSpecFactoryConcept; per-enqueue split: yes/no
+- Measurements (median/p10/p90, ≥1000 iters, realistic varying inputs): legacy = __µs; degenerate = __µs; final = __µs
+- Climb justification: [why this rung — "no climb needed" is a fine answer]
 - Device-op edits: [custom hash deleted; select_program_factory removed; pybind hooks removed]
 - Open items: [blockers, relaxation candidates]
 ```

--- a/tech_reports/Metal2OpMigration/TTNN_OP_MIGRATION_RECIPE.md
+++ b/tech_reports/Metal2OpMigration/TTNN_OP_MIGRATION_RECIPE.md
@@ -33,6 +33,20 @@ Detected by method surface: `extract_immutable_info` ⇒ Advanced (immutable-key
 ⇒ ++. **No `select_program_factory`** for single-factory ops (auto-selected). **No `compute_program_hash`**
 for the Advanced concept — `extract_immutable_info` is the key.
 
+> ### 🚪👹 Never write a custom hash. The boogeyman will eat you.
+>
+> A Metal 2.0 op **must not** define a custom `compute_program_hash`, and must not hand-roll the key by any
+> other means — e.g. an `attribute_values()` that omits a field to "hide" it from the hash. Both are
+> custom hashes wearing a disguise, and both let a mutable value silently corrupt the cache.
+>
+> **The legitimate need** — "I want value X (a seed, a runtime scalar) OUT of the cache key" — has exactly
+> one sanctioned answer: **climb to `AdvancedProgramSpecFactoryConcept` and define an `immutable_info_t`
+> struct that simply doesn't contain X.** Option 3 *bounds* you to do it the safe way: the struct you
+> declare *is* the key, the builder receives *only* that struct, so X cannot leak into either the key or
+> the spec — not by oversight, not ever. You get correctness by construction instead of by discipline.
+>
+> If you catch yourself reaching for a custom hash, stop and write the `immutable_info_t` instead.
+
 ---
 
 ## Step 0 — Port to the degenerate `ProgramSpecFactoryConcept` (everyone starts here)

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -245,7 +245,9 @@ void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, co
                 using AdaptedMeshWorkloadFactory = mesh_device_operation_t::template DescriptorMeshWorkloadAdapter<T>;
                 fn.template operator()<AdaptedMeshWorkloadFactory>();
             },
-            [&]<ProgramSpecFactoryConcept T>(const T&) {
+            [&]<Metal2SpecFactoryConcept T>(const T&) {
+                // All four Metal 2.0 spec factory shapes (basic/advanced x spec-keyed/immutable-keyed)
+                // route to the one ProgramSpec adapter, which branches on the factory's method surface.
                 using AdaptedMeshWorkloadFactory =
                     mesh_device_operation_t::template ProgramSpecMeshWorkloadFactoryAdapter<T>;
                 fn.template operator()<AdaptedMeshWorkloadFactory>();

--- a/ttnn/api/ttnn/device_operation.hpp
+++ b/ttnn/api/ttnn/device_operation.hpp
@@ -246,8 +246,30 @@ void dispatch_to_mesh_workload_factory(const ProgramFactory& program_factory, co
                 fn.template operator()<AdaptedMeshWorkloadFactory>();
             },
             [&]<Metal2SpecFactoryConcept T>(const T&) {
-                // All four Metal 2.0 spec factory shapes (basic/advanced x spec-keyed/immutable-keyed)
-                // route to the one ProgramSpec adapter, which branches on the factory's method surface.
+                // Both Metal 2.0 spec factory shapes (spec-keyed and ImmutableInfo-keyed, each with or
+                // without the per-enqueue split) route to the one ProgramSpec adapter, which branches on
+                // the factory's method surface.
+                //
+                // A Metal 2.0 op must NOT define a custom compute_program_hash. The cache key is the
+                // generated ProgramSpec (ProgramSpecFactoryConcept) or the factory's ImmutableInfo
+                // (AdvancedProgramSpecFactoryConcept) — never a hand-rolled hash, which can silently drop
+                // a mutable value (e.g. an RNG seed) from the key. To exclude a value from the key, climb
+                // to AdvancedProgramSpecFactoryConcept and give it an immutable_info_t that omits the
+                // value (see TTNN_OP_MIGRATION_RECIPE.md — "the boogeyman will eat you").
+                //
+                // Check the UNDERLYING device operation, not the mesh adapter wrapper: the adapter always
+                // synthesizes a compute_program_hash (it hashes every op), so only the user op's own
+                // definition signals an intentional custom hash.
+                using metal2_device_operation_t = typename mesh_device_operation_t::device_operation_t;
+                static_assert(
+                    !requires(
+                        const typename metal2_device_operation_t::operation_attributes_t& a,
+                        const typename metal2_device_operation_t::tensor_args_t& t) {
+                        metal2_device_operation_t::compute_program_hash(a, t);
+                    },
+                    "Metal 2.0 spec-factory ops must not define a custom compute_program_hash. Exclude a "
+                    "value from the cache key via AdvancedProgramSpecFactoryConcept's immutable_info_t "
+                    "instead of hand-rolling a hash.");
                 using AdaptedMeshWorkloadFactory =
                     mesh_device_operation_t::template ProgramSpecMeshWorkloadFactoryAdapter<T>;
                 fn.template operator()<AdaptedMeshWorkloadFactory>();

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -611,12 +611,12 @@ public:
     //
     // Adapts a ProgramSpecFactoryConcept factory (Metal 2.0, single-program /
     // SPMD-flavored) for mesh dispatch. The op author writes ONLY
-    // create_program_spec, returning a single ProgramArtifacts (one ProgramSpec
+    // create_program_artifacts, returning a single ProgramArtifacts (one ProgramSpec
     // + ProgramRunArgs). The adapter stamps a Program from that spec onto
     // each mesh coordinate range covered by the workload — mirroring the
     // descriptor adapter's per-range build pattern.
     //
-    // On cache miss: the adapter calls create_program_spec, builds one Program
+    // On cache miss: the adapter calls create_program_artifacts, builds one Program
     // per coordinate range via experimental::MakeProgramFromSpec, applies
     // the initial ProgramRunArgs via SetProgramRunArgs, then resolves
     // each TensorArgument against the io_tensors enumerated from tensor_args /
@@ -725,56 +725,50 @@ public:
             auto* mesh_device = first_tensor.value().device();
             TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
 
-            // Method-surface traits select one of the four factory shapes (see operation_concepts.hpp):
-            //   kImmutable → cache key & spec input come from extract_immutable_info (option 3);
-            //   kSplit     → run-args are split into static (create_enqueue_invariant_args) + dynamic
-            //                (create_per_enqueue_args), re-applied partially on a hit (the "Advanced" tier).
+            // Method-surface traits (see operation_concepts.hpp):
+            //   kImmutable → cache key & create_program_artifacts input come from extract_immutable_info
+            //                (the Advanced concept).
+            //   kSplit     → the optional "++" refinement: create_program_artifacts's run-args carry only
+            //                the enqueue-invariant set; create_per_enqueue_args carries the per-dispatch
+            //                rest, merged on miss and re-applied alone on a hit.
             constexpr bool kImmutable = HasImmutableInfoExtraction<ProgramSpecFactory>;
-            constexpr bool kSplit = HasEnqueueInvariantArgSplit<ProgramSpecFactory>;
+            constexpr bool kSplit = HasPerEnqueueArgs<ProgramSpecFactory>;
 
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
-            if constexpr (kSplit) {
-                // Advanced tier: the immutable blueprint + the enqueue-invariant (static) run-args are
-                // built once; the per-dispatch (dynamic) run-args are built per coordinate range (so a
-                // per-device value such as a seed offset can vary across the mesh) and merged with the
-                // static set for the complete cache-miss SetProgramRunArgs.
-                tt::tt_metal::experimental::ProgramSpec spec;
-                tt::tt_metal::experimental::ProgramRunArgs static_args;
+            // create_program_artifacts always returns the spec + its run-args (the enqueue-invariant
+            // bundle when split, or the complete set when degenerate). For the Advanced concept it takes
+            // the extracted ImmutableInfo; otherwise (attrs, tensor_args, tensor_return_value).
+            auto artifacts = [&] {
                 if constexpr (kImmutable) {
-                    const auto info = ProgramSpecFactory::extract_immutable_info(attrs, tensor_args);
-                    spec = ProgramSpecFactory::create_program_spec(info);
-                    static_args = ProgramSpecFactory::create_enqueue_invariant_args(info);
+                    return ProgramSpecFactory::create_program_artifacts(
+                        ProgramSpecFactory::extract_immutable_info(attrs, tensor_args));
                 } else {
-                    spec = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
-                    static_args =
-                        ProgramSpecFactory::create_enqueue_invariant_args(attrs, tensor_args, tensor_return_value);
+                    return ProgramSpecFactory::create_program_artifacts(attrs, tensor_args, tensor_return_value);
                 }
+            }();
+
+            if constexpr (kSplit) {
+                // ++ : per-dispatch run-args are built per coordinate range (so a per-device value such
+                // as a seed offset can vary across the mesh) and merged with the invariant set from
+                // create_program_artifacts for the complete cache-miss SetProgramRunArgs.
                 for (const auto& range : tensor_coords.ranges()) {
                     const std::optional<ttnn::MeshCoordinate> coord(*range.begin());
                     auto dynamic_args =
                         ProgramSpecFactory::create_per_enqueue_args(attrs, tensor_args, tensor_return_value, coord);
                     std::array<tt::tt_metal::experimental::ProgramRunArgs, 1> appended{std::move(dynamic_args)};
-                    auto run_params = tt::tt_metal::experimental::MergeProgramRunArgs(static_args, appended);
-                    auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, spec);
+                    auto run_params = tt::tt_metal::experimental::MergeProgramRunArgs(artifacts.run_params, appended);
+                    auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
                     tt::tt_metal::experimental::SetProgramRunArgs(program, run_params);
-                    // The advanced hit path rebuilds the full dynamic set (incl. tensors) each dispatch,
-                    // so no tensor bindings need to be cached here.
+                    // The ++ hit path rebuilds the full per-enqueue set (incl. tensors) each dispatch, so
+                    // no tensor bindings need to be cached here.
                     shared_variables.emplace(range, shared_variables_t{});
                     mesh_workload.add_program(range, std::move(program));
                 }
             } else {
-                // Basic tier: create_program_spec returns the full ProgramArtifacts (spec + all run-args).
-                auto artifacts = [&] {
-                    if constexpr (kImmutable) {
-                        return ProgramSpecFactory::create_program_spec(
-                            ProgramSpecFactory::extract_immutable_info(attrs, tensor_args));
-                    } else {
-                        return ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
-                    }
-                }();
+                // Degenerate: create_program_artifacts's run-args are the complete set; apply as-is.
                 auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
                 for (const auto& range : tensor_coords.ranges()) {
                     auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
@@ -796,11 +790,11 @@ public:
             [[maybe_unused]] const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            if constexpr (HasEnqueueInvariantArgSplit<ProgramSpecFactory>) {
-                // Advanced tier: rebuild ONLY the dynamic run-args per coordinate (the per-dispatch
-                // scalars AND the tensor addresses) and re-apply them via UpdateProgramRunArgs. The
-                // static (enqueue-invariant) set stays baked from the cache-miss SetProgramRunArgs; the
-                // metal runtime validates that every omitted arg was declared enqueue-invariant.
+            if constexpr (HasPerEnqueueArgs<ProgramSpecFactory>) {
+                // ++ : rebuild ONLY the per-enqueue run-args per coordinate (the per-dispatch scalars AND
+                // the tensor addresses) and re-apply them via UpdateProgramRunArgs. The enqueue-invariant
+                // set stays baked from the cache-miss SetProgramRunArgs; the metal runtime validates that
+                // every omitted arg was declared enqueue-invariant.
                 for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                     const std::optional<ttnn::MeshCoordinate> coord(*coordinate_range.begin());
                     auto dynamic_args =
@@ -831,7 +825,7 @@ public:
         ttsl::hash::hash_t hash;
 
         // Route the cache key through the selected factory. An immutable-info-keyed factory (option 3)
-        // hashes its ImmutableInfo — the same projection that feeds create_program_spec — so a mutable
+        // hashes its ImmutableInfo — the same projection that feeds create_program_artifacts — so a mutable
         // value (e.g. an RNG seed) that is excluded from the ImmutableInfo structurally cannot enter the
         // cache key. Other factories fall back to a custom compute_program_hash if present, else the
         // default reflection hash of (op type + attributes + tensor args).

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -636,7 +636,7 @@ public:
     //
     // TODO: consider replacing with a general MeshWorkloadSpecFactoryAdapter?
     // -----------------------------------------------------------------------
-    template <ProgramSpecFactoryConcept ProgramSpecFactory>
+    template <Metal2SpecFactoryConcept ProgramSpecFactory>
     struct ProgramSpecMeshWorkloadFactoryAdapter {
         using TensorParamName = tt::tt_metal::experimental::TensorParamName;
         using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
@@ -725,37 +725,62 @@ public:
             auto* mesh_device = first_tensor.value().device();
             TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
 
-            // The factory produces a single ProgramArtifacts; the adapter stamps it
-            // across all coordinate ranges. Bindings derive from the (single) set of
-            // factory tensor_args and are identical for every stamped program; copy
-            // per range into the cached shared state.
-            auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
-
-            // Assemble the complete cache-miss run-args. A per-enqueue factory returns only the
-            // enqueue-invariant run-args from create_program_spec, so merge in the per-enqueue set
-            // (MergeProgramRunArgs) for a complete initial SetProgramRunArgs; the hit path will then
-            // re-apply only the per-enqueue set. A plain factory's run_params are already complete.
-            tt::tt_metal::experimental::ProgramRunArgs full_run_args = [&] {
-                if constexpr (ProgramSpecFactoryWithPerEnqueueArgsConcept<ProgramSpecFactory>) {
-                    auto per_enqueue =
-                        ProgramSpecFactory::create_per_enqueue_run_args(attrs, tensor_args, tensor_return_value);
-                    std::array<tt::tt_metal::experimental::ProgramRunArgs, 1> appended{std::move(per_enqueue)};
-                    return tt::tt_metal::experimental::MergeProgramRunArgs(std::move(artifacts.run_params), appended);
-                } else {
-                    return std::move(artifacts.run_params);
-                }
-            }();
+            // Method-surface traits select one of the four factory shapes (see operation_concepts.hpp):
+            //   kImmutable → cache key & spec input come from extract_immutable_info (option 3);
+            //   kSplit     → run-args are split into static (create_static_args) + dynamic
+            //                (create_dynamic_args), re-applied partially on a hit (the "Advanced" tier).
+            constexpr bool kImmutable = HasImmutableInfoExtraction<ProgramSpecFactory>;
+            constexpr bool kSplit = HasStaticDynamicArgSplit<ProgramSpecFactory>;
 
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
-            auto bindings = resolve_bindings(full_run_args.tensor_args, io_mesh_tensors);
-
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
-            for (const auto& range : tensor_coords.ranges()) {
-                auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
-                tt::tt_metal::experimental::SetProgramRunArgs(program, full_run_args);
-                shared_variables.emplace(range, shared_variables_t{.bindings = bindings});
-                mesh_workload.add_program(range, std::move(program));
+
+            if constexpr (kSplit) {
+                // Advanced tier: the immutable blueprint + the enqueue-invariant (static) run-args are
+                // built once; the per-dispatch (dynamic) run-args are built per coordinate range (so a
+                // per-device value such as a seed offset can vary across the mesh) and merged with the
+                // static set for the complete cache-miss SetProgramRunArgs.
+                tt::tt_metal::experimental::ProgramSpec spec;
+                tt::tt_metal::experimental::ProgramRunArgs static_args;
+                if constexpr (kImmutable) {
+                    const auto info = ProgramSpecFactory::extract_immutable_info(attrs, tensor_args);
+                    spec = ProgramSpecFactory::create_program_spec(info);
+                    static_args = ProgramSpecFactory::create_static_args(info);
+                } else {
+                    spec = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
+                    static_args = ProgramSpecFactory::create_static_args(attrs, tensor_args, tensor_return_value);
+                }
+                for (const auto& range : tensor_coords.ranges()) {
+                    const std::optional<ttnn::MeshCoordinate> coord(*range.begin());
+                    auto dynamic_args =
+                        ProgramSpecFactory::create_dynamic_args(attrs, tensor_args, tensor_return_value, coord);
+                    std::array<tt::tt_metal::experimental::ProgramRunArgs, 1> appended{std::move(dynamic_args)};
+                    auto run_params = tt::tt_metal::experimental::MergeProgramRunArgs(static_args, appended);
+                    auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, spec);
+                    tt::tt_metal::experimental::SetProgramRunArgs(program, run_params);
+                    // The advanced hit path rebuilds the full dynamic set (incl. tensors) each dispatch,
+                    // so no tensor bindings need to be cached here.
+                    shared_variables.emplace(range, shared_variables_t{});
+                    mesh_workload.add_program(range, std::move(program));
+                }
+            } else {
+                // Basic tier: create_program_spec returns the full ProgramArtifacts (spec + all run-args).
+                auto artifacts = [&] {
+                    if constexpr (kImmutable) {
+                        return ProgramSpecFactory::create_program_spec(
+                            ProgramSpecFactory::extract_immutable_info(attrs, tensor_args));
+                    } else {
+                        return ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
+                    }
+                }();
+                auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
+                for (const auto& range : tensor_coords.ranges()) {
+                    auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
+                    tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+                    shared_variables.emplace(range, shared_variables_t{.bindings = bindings});
+                    mesh_workload.add_program(range, std::move(program));
+                }
             }
             return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
         }
@@ -770,19 +795,20 @@ public:
             [[maybe_unused]] const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            if constexpr (ProgramSpecFactoryWithPerEnqueueArgsConcept<ProgramSpecFactory>) {
-                // Enqueue-invariant fast path: rebuild ONLY the per-enqueue run-args (tensor addresses,
-                // seeds, fill values, ...) and re-apply them via UpdateProgramRunArgs. The
-                // enqueue-invariant set declared in the spec stays baked from the cache-miss
-                // SetProgramRunArgs; the metal runtime validates that every omitted arg was so declared.
-                auto per_enqueue =
-                    ProgramSpecFactory::create_per_enqueue_run_args(attrs, tensor_args, tensor_return_value);
+            if constexpr (HasStaticDynamicArgSplit<ProgramSpecFactory>) {
+                // Advanced tier: rebuild ONLY the dynamic run-args per coordinate (the per-dispatch
+                // scalars AND the tensor addresses) and re-apply them via UpdateProgramRunArgs. The
+                // static (enqueue-invariant) set stays baked from the cache-miss SetProgramRunArgs; the
+                // metal runtime validates that every omitted arg was declared enqueue-invariant.
                 for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                    tt::tt_metal::experimental::UpdateProgramRunArgs(program, per_enqueue);
+                    const std::optional<ttnn::MeshCoordinate> coord(*coordinate_range.begin());
+                    auto dynamic_args =
+                        ProgramSpecFactory::create_dynamic_args(attrs, tensor_args, tensor_return_value, coord);
+                    tt::tt_metal::experimental::UpdateProgramRunArgs(program, dynamic_args);
                 }
             } else {
-                // Plain factory: the only per-enqueue variation is which tensors are bound, so refresh
-                // the tensor bindings in place via UpdateTensorArgs (no Program rebuild, no factory re-run).
+                // Basic tier: the only per-dispatch variation is which tensors are bound, so refresh the
+                // tensor bindings in place via UpdateTensorArgs (no Program rebuild, no factory re-run).
                 auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
                 for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                     const auto& sv = cached_workload.shared_variables.at(coordinate_range);
@@ -803,11 +829,29 @@ public:
         const tensor_args_t& tensor_args) {
         ttsl::hash::hash_t hash;
 
-        if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
-            hash = DeviceOperation::compute_program_hash(attrs, tensor_args);
-        } else {
-            hash =
-                ttsl::hash::hash_objects_with_default_seed(ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
+        // Route the cache key through the selected factory. An immutable-info-keyed factory (option 3)
+        // hashes its ImmutableInfo — the same projection that feeds create_program_spec — so a mutable
+        // value (e.g. an RNG seed) that is excluded from the ImmutableInfo structurally cannot enter the
+        // cache key. Other factories fall back to a custom compute_program_hash if present, else the
+        // default reflection hash of (op type + attributes + tensor args).
+        const bool routed_via_immutable_info = std::visit(
+            [&]<typename Factory>(const Factory&) -> bool {
+                if constexpr (HasImmutableInfoExtraction<Factory>) {
+                    hash = ttsl::hash::hash_objects_with_default_seed(
+                        ttsl::hash::type_hash<DeviceOperation>, Factory::extract_immutable_info(attrs, tensor_args));
+                    return true;
+                }
+                return false;
+            },
+            select_program_factory(attrs, tensor_args));
+
+        if (!routed_via_immutable_info) {
+            if constexpr (requires { DeviceOperation::compute_program_hash(attrs, tensor_args); }) {
+                hash = DeviceOperation::compute_program_hash(attrs, tensor_args);
+            } else {
+                hash = ttsl::hash::hash_objects_with_default_seed(
+                    ttsl::hash::type_hash<DeviceOperation>, attrs, tensor_args);
+            }
         }
 
         // Combine with the mesh coordinates the workload is targeting.

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -727,10 +727,10 @@ public:
 
             // Method-surface traits select one of the four factory shapes (see operation_concepts.hpp):
             //   kImmutable → cache key & spec input come from extract_immutable_info (option 3);
-            //   kSplit     → run-args are split into static (create_static_args) + dynamic
-            //                (create_dynamic_args), re-applied partially on a hit (the "Advanced" tier).
+            //   kSplit     → run-args are split into static (create_enqueue_invariant_args) + dynamic
+            //                (create_per_enqueue_args), re-applied partially on a hit (the "Advanced" tier).
             constexpr bool kImmutable = HasImmutableInfoExtraction<ProgramSpecFactory>;
-            constexpr bool kSplit = HasStaticDynamicArgSplit<ProgramSpecFactory>;
+            constexpr bool kSplit = HasEnqueueInvariantArgSplit<ProgramSpecFactory>;
 
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
@@ -746,15 +746,16 @@ public:
                 if constexpr (kImmutable) {
                     const auto info = ProgramSpecFactory::extract_immutable_info(attrs, tensor_args);
                     spec = ProgramSpecFactory::create_program_spec(info);
-                    static_args = ProgramSpecFactory::create_static_args(info);
+                    static_args = ProgramSpecFactory::create_enqueue_invariant_args(info);
                 } else {
                     spec = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
-                    static_args = ProgramSpecFactory::create_static_args(attrs, tensor_args, tensor_return_value);
+                    static_args =
+                        ProgramSpecFactory::create_enqueue_invariant_args(attrs, tensor_args, tensor_return_value);
                 }
                 for (const auto& range : tensor_coords.ranges()) {
                     const std::optional<ttnn::MeshCoordinate> coord(*range.begin());
                     auto dynamic_args =
-                        ProgramSpecFactory::create_dynamic_args(attrs, tensor_args, tensor_return_value, coord);
+                        ProgramSpecFactory::create_per_enqueue_args(attrs, tensor_args, tensor_return_value, coord);
                     std::array<tt::tt_metal::experimental::ProgramRunArgs, 1> appended{std::move(dynamic_args)};
                     auto run_params = tt::tt_metal::experimental::MergeProgramRunArgs(static_args, appended);
                     auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, spec);
@@ -795,7 +796,7 @@ public:
             [[maybe_unused]] const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            if constexpr (HasStaticDynamicArgSplit<ProgramSpecFactory>) {
+            if constexpr (HasEnqueueInvariantArgSplit<ProgramSpecFactory>) {
                 // Advanced tier: rebuild ONLY the dynamic run-args per coordinate (the per-dispatch
                 // scalars AND the tensor addresses) and re-apply them via UpdateProgramRunArgs. The
                 // static (enqueue-invariant) set stays baked from the cache-miss SetProgramRunArgs; the
@@ -803,7 +804,7 @@ public:
                 for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                     const std::optional<ttnn::MeshCoordinate> coord(*coordinate_range.begin());
                     auto dynamic_args =
-                        ProgramSpecFactory::create_dynamic_args(attrs, tensor_args, tensor_return_value, coord);
+                        ProgramSpecFactory::create_per_enqueue_args(attrs, tensor_args, tensor_return_value, coord);
                     tt::tt_metal::experimental::UpdateProgramRunArgs(program, dynamic_args);
                 }
             } else {

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -710,14 +710,18 @@ public:
             const ttnn::MeshCoordinateRangeSet& tensor_coords,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            // Metal 2.0's MakeProgramFromSpec needs a MeshDevice; pull from the
-            // first device tensor reachable from tensor_args. Op factories
-            // satisfying this concept are tensor-driven, so first_tensor is
-            // always populated for current callers.
+            // Metal 2.0's MakeProgramFromSpec needs a MeshDevice; pull it from the first device tensor
+            // reachable from tensor_args, falling back to tensor_return_value. The fallback covers
+            // output-only ops (e.g. rand) that take no input tensor — their device-resident output has
+            // already been allocated by create_output_tensors before the factory runs.
             auto first_tensor = ttsl::reflection::get_first_object_of_type<tt::tt_metal::Tensor>(tensor_args);
+            if (!first_tensor.has_value()) {
+                first_tensor = ttsl::reflection::get_first_object_of_type<tt::tt_metal::Tensor>(tensor_return_value);
+            }
             TT_FATAL(
                 first_tensor.has_value(),
-                "ProgramSpec factory adapter requires at least one Tensor in tensor_args to source the MeshDevice");
+                "ProgramSpec factory adapter requires at least one Tensor in tensor_args or "
+                "tensor_return_value to source the MeshDevice");
             auto* mesh_device = first_tensor.value().device();
             TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
 
@@ -726,14 +730,30 @@ public:
             // factory tensor_args and are identical for every stamped program; copy
             // per range into the cached shared state.
             auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
+
+            // Assemble the complete cache-miss run-args. A per-enqueue factory returns only the
+            // enqueue-invariant run-args from create_program_spec, so merge in the per-enqueue set
+            // (MergeProgramRunArgs) for a complete initial SetProgramRunArgs; the hit path will then
+            // re-apply only the per-enqueue set. A plain factory's run_params are already complete.
+            tt::tt_metal::experimental::ProgramRunArgs full_run_args = [&] {
+                if constexpr (ProgramSpecFactoryWithPerEnqueueArgsConcept<ProgramSpecFactory>) {
+                    auto per_enqueue =
+                        ProgramSpecFactory::create_per_enqueue_run_args(attrs, tensor_args, tensor_return_value);
+                    std::array<tt::tt_metal::experimental::ProgramRunArgs, 1> appended{std::move(per_enqueue)};
+                    return tt::tt_metal::experimental::MergeProgramRunArgs(std::move(artifacts.run_params), appended);
+                } else {
+                    return std::move(artifacts.run_params);
+                }
+            }();
+
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
-            auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
+            auto bindings = resolve_bindings(full_run_args.tensor_args, io_mesh_tensors);
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (const auto& range : tensor_coords.ranges()) {
                 auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
-                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, full_run_args);
                 shared_variables.emplace(range, shared_variables_t{.bindings = bindings});
                 mesh_workload.add_program(range, std::move(program));
             }
@@ -747,18 +767,32 @@ public:
         // dispatcher's historical naming, not a reference to ProgramDescriptor.
         static void apply_descriptor(
             cached_mesh_workload_t& cached_workload,
-            const operation_attributes_t& /*attrs*/,
+            [[maybe_unused]] const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
-            for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                const auto& sv = cached_workload.shared_variables.at(coordinate_range);
-                tt::tt_metal::experimental::Table<TensorParamName, TensorArgument> fresh_tensor_args;
-                for (const auto& b : sv.bindings) {
-                    fresh_tensor_args.emplace(
-                        b.tensor_parameter_name, TensorArgument{io_mesh_tensors[b.io_tensor_idx]});
+            if constexpr (ProgramSpecFactoryWithPerEnqueueArgsConcept<ProgramSpecFactory>) {
+                // Enqueue-invariant fast path: rebuild ONLY the per-enqueue run-args (tensor addresses,
+                // seeds, fill values, ...) and re-apply them via UpdateProgramRunArgs. The
+                // enqueue-invariant set declared in the spec stays baked from the cache-miss
+                // SetProgramRunArgs; the metal runtime validates that every omitted arg was so declared.
+                auto per_enqueue =
+                    ProgramSpecFactory::create_per_enqueue_run_args(attrs, tensor_args, tensor_return_value);
+                for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                    tt::tt_metal::experimental::UpdateProgramRunArgs(program, per_enqueue);
                 }
-                tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
+            } else {
+                // Plain factory: the only per-enqueue variation is which tensors are bound, so refresh
+                // the tensor bindings in place via UpdateTensorArgs (no Program rebuild, no factory re-run).
+                auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+                for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                    const auto& sv = cached_workload.shared_variables.at(coordinate_range);
+                    tt::tt_metal::experimental::Table<TensorParamName, TensorArgument> fresh_tensor_args;
+                    for (const auto& b : sv.bindings) {
+                        fresh_tensor_args.emplace(
+                            b.tensor_parameter_name, TensorArgument{io_mesh_tensors[b.io_tensor_idx]});
+                    }
+                    tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
+                }
             }
         }
     };

--- a/ttnn/api/ttnn/metal2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal2_artifacts.hpp
@@ -9,13 +9,10 @@
 
 namespace ttnn::device_operation {
 
-// Build product of a Metal 2.0 op factory: the immutable ProgramSpec plus the
-// mutable ProgramRunArgs. Returned by a ProgramSpecFactoryConcept factory's
-// create_program_spec method; the framework adapter stamps a Program out of
-// this artifact onto each mesh coordinate range of the workload.
-//
-// A future MeshWorkloadSpecFactoryConcept will return a different (multi-program)
-// artifact type for ops whose programs vary across the mesh.
+// Build product of a Metal 2.0 op factory's create_program_artifacts: the immutable ProgramSpec plus
+// the run-args bundled with it (the enqueue-invariant set when the factory also provides
+// create_per_enqueue_args, or the complete set in the degenerate case). The framework merges these with
+// the per-enqueue set on a cache miss and retains them across hits.
 struct ProgramArtifacts {
     tt::tt_metal::experimental::ProgramSpec spec;
     tt::tt_metal::experimental::ProgramRunArgs run_params;

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -84,21 +84,21 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 //      ALL its run-args bundled. Migrate here first; it is the least to write.
 //
 //   2. AdvancedProgramSpecFactoryConcept — if the cache-HIT cost hurts. Keep the same cache key, but
-//      split the run-args into STATIC (create_static_args — fixed for a cache entry, set once on miss
-//      and retained) and DYNAMIC (create_dynamic_args — the per-dispatch values, e.g. an RNG seed or
+//      split the run-args into STATIC (create_enqueue_invariant_args — fixed for a cache entry, set once on miss
+//      and retained) and DYNAMIC (create_per_enqueue_args — the per-dispatch values, e.g. an RNG seed or
 //      tensor addresses). The framework re-applies ONLY the dynamic set on a hit (UpdateProgramRunArgs),
 //      not the whole arg set.
 //
 //   3. ImmutableProgramSpecFactoryConcept / AdvancedImmutableProgramSpecFactoryConcept — if it STILL
 //      hurts. Add extract_immutable_info: a small, hashable projection of (attributes, tensor_args)
-//      that becomes the cache key AND the sole input to create_program_spec / create_static_args. This
+//      that becomes the cache key AND the sole input to create_program_spec / create_enqueue_invariant_args. This
 //      lets the framework skip the spec rebuild on a hit, and structurally prevents a mutable value
 //      (the seed) from leaking into the spec — it isn't even visible to create_program_spec. Available
 //      both bare (combined run-args) and with the static/dynamic split.
 //
 // The concepts are detected by method surface and are mutually exclusive by construction:
 //   - extract_immutable_info present        => Immutable-keyed (3/4)
-//   - create_static_args + create_dynamic_args present => Advanced / split (2/4)
+//   - create_enqueue_invariant_args + create_per_enqueue_args present => Advanced / split (2/4)
 //
 // Run-args contract for the split (2 and 4): static run-args are declared enqueue-invariant in the spec
 // (KernelAdvancedOptions::enqueue_invariant_runtime_args / _common_runtime_args,
@@ -117,9 +117,9 @@ concept HasCreateProgramSpec = requires { &T::create_program_spec; };
 template <typename T>
 concept HasImmutableInfoExtraction = requires { &T::extract_immutable_info; };
 template <typename T>
-concept HasStaticDynamicArgSplit = requires {
-    &T::create_static_args;
-    &T::create_dynamic_args;
+concept HasEnqueueInvariantArgSplit = requires {
+    &T::create_enqueue_invariant_args;
+    &T::create_per_enqueue_args;
 };
 // Shared exclusion: a Metal 2.0 spec factory is none of the legacy factory shapes.
 template <typename T>
@@ -128,27 +128,27 @@ concept NotALegacyFactory =
 
 // 1. Basic, spec-keyed (the default). create_program_spec -> ProgramArtifacts{spec, run_args}.
 template <typename T>
-concept ProgramSpecFactoryConcept =
-    HasCreateProgramSpec<T> && !HasImmutableInfoExtraction<T> && !HasStaticDynamicArgSplit<T> && NotALegacyFactory<T>;
+concept ProgramSpecFactoryConcept = HasCreateProgramSpec<T> && !HasImmutableInfoExtraction<T> &&
+                                    !HasEnqueueInvariantArgSplit<T> && NotALegacyFactory<T>;
 
 // 2. Advanced (static/dynamic split), spec-keyed. create_program_spec -> ProgramSpec;
-//    create_static_args -> ProgramRunArgs; create_dynamic_args -> ProgramRunArgs.
+//    create_enqueue_invariant_args -> ProgramRunArgs; create_per_enqueue_args -> ProgramRunArgs.
 template <typename T>
 concept AdvancedProgramSpecFactoryConcept =
-    HasCreateProgramSpec<T> && HasStaticDynamicArgSplit<T> && !HasImmutableInfoExtraction<T> && NotALegacyFactory<T>;
+    HasCreateProgramSpec<T> && HasEnqueueInvariantArgSplit<T> && !HasImmutableInfoExtraction<T> && NotALegacyFactory<T>;
 
 // 3. Basic, immutable-info-keyed. extract_immutable_info -> ImmutableInfo (cache key);
 //    create_program_spec(ImmutableInfo) -> ProgramArtifacts{spec, run_args}.
 template <typename T>
 concept ImmutableProgramSpecFactoryConcept =
-    HasCreateProgramSpec<T> && HasImmutableInfoExtraction<T> && !HasStaticDynamicArgSplit<T> && NotALegacyFactory<T>;
+    HasCreateProgramSpec<T> && HasImmutableInfoExtraction<T> && !HasEnqueueInvariantArgSplit<T> && NotALegacyFactory<T>;
 
 // 4. Advanced (static/dynamic split), immutable-info-keyed.
 //    extract_immutable_info -> ImmutableInfo; create_program_spec(ImmutableInfo) -> ProgramSpec;
-//    create_static_args(ImmutableInfo) -> ProgramRunArgs; create_dynamic_args(...) -> ProgramRunArgs.
+//    create_enqueue_invariant_args(ImmutableInfo) -> ProgramRunArgs; create_per_enqueue_args(...) -> ProgramRunArgs.
 template <typename T>
 concept AdvancedImmutableProgramSpecFactoryConcept =
-    HasCreateProgramSpec<T> && HasImmutableInfoExtraction<T> && HasStaticDynamicArgSplit<T> && NotALegacyFactory<T>;
+    HasCreateProgramSpec<T> && HasImmutableInfoExtraction<T> && HasEnqueueInvariantArgSplit<T> && NotALegacyFactory<T>;
 
 // Umbrella: any of the four Metal 2.0 spec factory shapes (exactly one is satisfied by construction).
 template <typename T>

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -73,88 +73,73 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
                                           !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T>;
 
 // ============================================================================
-//  Metal 2.0 ProgramSpec factory concepts — a progressive ladder
+//  Metal 2.0 ProgramSpec factory concepts
 // ============================================================================
 //
-// A Metal 2.0 op factory's job is to produce TWO things: the immutable ProgramSpec (the "blueprint":
-// kernels, DFBs, work-units, argument schemas) and the ProgramRunArgs (the per-execution values). The
-// four concepts below are points on a ladder a dev climbs ONLY as far as performance forces them:
+// A Metal 2.0 op factory produces a ProgramArtifacts: the immutable ProgramSpec (the "blueprint" —
+// kernels, DFBs, work-units, argument schemas) plus the ProgramRunArgs (the per-execution values).
+// There are exactly TWO concepts, distinguished by ONE thing — the cache key:
 //
-//   1. ProgramSpecFactoryConcept — THE DEFAULT. One method, create_program_spec, returns the spec and
-//      ALL its run-args bundled. Migrate here first; it is the least to write.
+//   - ProgramSpecFactoryConcept         — the cache key is the generated ProgramSpec.
+//   - AdvancedProgramSpecFactoryConcept — the cache key is a small hashable ImmutableInfo that the
+//                                         factory extracts up front (extract_immutable_info), which is
+//                                         also the SOLE input to create_program_artifacts. This lets the
+//                                         framework skip the spec rebuild on a cache hit, and structurally
+//                                         prevents a mutable value (e.g. an RNG seed) from leaking into
+//                                         the key or the spec — it isn't even visible to the builder.
 //
-//   2. AdvancedProgramSpecFactoryConcept — if the cache-HIT cost hurts. Keep the same cache key, but
-//      split the run-args into STATIC (create_enqueue_invariant_args — fixed for a cache entry, set once on miss
-//      and retained) and DYNAMIC (create_per_enqueue_args — the per-dispatch values, e.g. an RNG seed or
-//      tensor addresses). The framework re-applies ONLY the dynamic set on a hit (UpdateProgramRunArgs),
-//      not the whole arg set.
+// Within EITHER concept, the enqueue-invariant fast path is an OPTIONAL, INCREMENTAL refinement — NOT a
+// separate concept (Audrey's "Option 2 / Option 2++"; "Option 3 / Option 3++"):
 //
-//   3. ImmutableProgramSpecFactoryConcept / AdvancedImmutableProgramSpecFactoryConcept — if it STILL
-//      hurts. Add extract_immutable_info: a small, hashable projection of (attributes, tensor_args)
-//      that becomes the cache key AND the sole input to create_program_spec / create_enqueue_invariant_args. This
-//      lets the framework skip the spec rebuild on a hit, and structurally prevents a mutable value
-//      (the seed) from leaking into the spec — it isn't even visible to create_program_spec. Available
-//      both bare (combined run-args) and with the static/dynamic split.
+//   - Degenerate (no create_per_enqueue_args): create_program_artifacts returns the spec + ALL run-args.
+//     Cache hit refreshes tensor bindings (UpdateTensorArgs). The least to write — migrate here first.
+//   - ++ (add create_per_enqueue_args): create_program_artifacts's run_args carry only the
+//     ENQUEUE-INVARIANT args (declared invariant in the spec via
+//     KernelAdvancedOptions::enqueue_invariant_runtime_args / _common_runtime_args,
+//     TensorParameterAdvancedOptions::enqueue_invariant); create_per_enqueue_args carries the rest.
+//     Cache miss merges the two (MergeProgramRunArgs) + SetProgramRunArgs; cache hit re-applies ONLY the
+//     per-enqueue set (UpdateProgramRunArgs). The metal runtime validates that every omitted arg was
+//     declared invariant — a per-enqueue value the factory forgets to refresh is a hard error, not a
+//     silently-stale wrong answer.
 //
-// The concepts are detected by method surface and are mutually exclusive by construction:
-//   - extract_immutable_info present        => Immutable-keyed (3/4)
-//   - create_enqueue_invariant_args + create_per_enqueue_args present => Advanced / split (2/4)
-//
-// Run-args contract for the split (2 and 4): static run-args are declared enqueue-invariant in the spec
-// (KernelAdvancedOptions::enqueue_invariant_runtime_args / _common_runtime_args,
-// TensorParameterAdvancedOptions::enqueue_invariant). The framework merges static + dynamic
-// (MergeProgramRunArgs) for the cache-miss SetProgramRunArgs, and re-applies dynamic alone
-// (UpdateProgramRunArgs) on a hit. The metal runtime validates that every arg omitted on the hit path
-// was declared invariant — a dynamic value the factory forgets to refresh is a hard error, not a
-// silently-stale wrong answer.
+// You only need to move ENOUGH args into the invariant bundle to clear your performance target — moving
+// one more arg from create_per_enqueue_args into create_program_artifacts's run_args (and declaring it
+// invariant) is a one-line, behavior-preserving optimization. Pick the rung by MEASURING dispatch time
+// (see TTNN_OP_MIGRATION_RECIPE.md).
 //
 // NOTE: Each TensorArgument.tensor in ProgramRunArgs MUST reference a MeshTensor reachable from the
 // factory's tensor_args / tensor_return_value — the adapter matches by pointer identity.
 
-// --- method-surface building blocks (not used directly; compose the four leaf concepts) ---
+// --- method-surface building blocks ---
 template <typename T>
-concept HasCreateProgramSpec = requires { &T::create_program_spec; };
+concept HasCreateProgramArtifacts = requires { &T::create_program_artifacts; };
 template <typename T>
 concept HasImmutableInfoExtraction = requires { &T::extract_immutable_info; };
+// The optional "++" refinement: present => the factory splits invariant (create_program_artifacts
+// run-args) from per-enqueue (create_per_enqueue_args), and the hit path re-applies only the latter.
 template <typename T>
-concept HasEnqueueInvariantArgSplit = requires {
-    &T::create_enqueue_invariant_args;
-    &T::create_per_enqueue_args;
-};
+concept HasPerEnqueueArgs = requires { &T::create_per_enqueue_args; };
 // Shared exclusion: a Metal 2.0 spec factory is none of the legacy factory shapes.
 template <typename T>
 concept NotALegacyFactory =
     !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
 
-// 1. Basic, spec-keyed (the default). create_program_spec -> ProgramArtifacts{spec, run_args}.
+// Spec-keyed factory (Option 2 / 2++). create_program_artifacts(attrs, tensor_args, tensor_return_value)
+// -> ProgramArtifacts. Optionally also create_per_enqueue_args for the enqueue-invariant fast path.
 template <typename T>
-concept ProgramSpecFactoryConcept = HasCreateProgramSpec<T> && !HasImmutableInfoExtraction<T> &&
-                                    !HasEnqueueInvariantArgSplit<T> && NotALegacyFactory<T>;
+concept ProgramSpecFactoryConcept =
+    HasCreateProgramArtifacts<T> && !HasImmutableInfoExtraction<T> && NotALegacyFactory<T>;
 
-// 2. Advanced (static/dynamic split), spec-keyed. create_program_spec -> ProgramSpec;
-//    create_enqueue_invariant_args -> ProgramRunArgs; create_per_enqueue_args -> ProgramRunArgs.
+// ImmutableInfo-keyed factory (Option 3 / 3++). extract_immutable_info -> ImmutableInfo (cache key);
+// create_program_artifacts(ImmutableInfo) -> ProgramArtifacts. Optionally create_per_enqueue_args too.
+// ("Advanced" = it does the extra immutable-info extraction step that buys the cheaper cache key.)
 template <typename T>
 concept AdvancedProgramSpecFactoryConcept =
-    HasCreateProgramSpec<T> && HasEnqueueInvariantArgSplit<T> && !HasImmutableInfoExtraction<T> && NotALegacyFactory<T>;
+    HasCreateProgramArtifacts<T> && HasImmutableInfoExtraction<T> && NotALegacyFactory<T>;
 
-// 3. Basic, immutable-info-keyed. extract_immutable_info -> ImmutableInfo (cache key);
-//    create_program_spec(ImmutableInfo) -> ProgramArtifacts{spec, run_args}.
+// Umbrella: either Metal 2.0 spec factory shape (exactly one is satisfied by construction).
 template <typename T>
-concept ImmutableProgramSpecFactoryConcept =
-    HasCreateProgramSpec<T> && HasImmutableInfoExtraction<T> && !HasEnqueueInvariantArgSplit<T> && NotALegacyFactory<T>;
-
-// 4. Advanced (static/dynamic split), immutable-info-keyed.
-//    extract_immutable_info -> ImmutableInfo; create_program_spec(ImmutableInfo) -> ProgramSpec;
-//    create_enqueue_invariant_args(ImmutableInfo) -> ProgramRunArgs; create_per_enqueue_args(...) -> ProgramRunArgs.
-template <typename T>
-concept AdvancedImmutableProgramSpecFactoryConcept =
-    HasCreateProgramSpec<T> && HasImmutableInfoExtraction<T> && HasEnqueueInvariantArgSplit<T> && NotALegacyFactory<T>;
-
-// Umbrella: any of the four Metal 2.0 spec factory shapes (exactly one is satisfied by construction).
-template <typename T>
-concept Metal2SpecFactoryConcept =
-    ProgramSpecFactoryConcept<T> || AdvancedProgramSpecFactoryConcept<T> || ImmutableProgramSpecFactoryConcept<T> ||
-    AdvancedImmutableProgramSpecFactoryConcept<T>;
+concept Metal2SpecFactoryConcept = ProgramSpecFactoryConcept<T> || AdvancedProgramSpecFactoryConcept<T>;
 
 // Detect operations that put create_descriptor directly on the operation struct
 // (no program_factory_t wrapper needed for single-descriptor operations).

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -90,6 +90,42 @@ template <typename T>
 concept ProgramSpecFactoryConcept = requires { &T::create_program_spec; } && !ProgramFactoryConcept<T> &&
                                     !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
 
+// Opt-in refinement of ProgramSpecFactoryConcept that turns on the Metal 2.0 enqueue-invariant
+// fast path (UpdateProgramRunArgs). A factory satisfying this splits its run-args into two sets:
+//
+//   - ENQUEUE-INVARIANT run-args — work-split scalars, shape constants: every run-arg whose value is
+//     identical for every dispatch that shares a program-cache entry. The factory returns these as the
+//     `run_params` of create_program_spec's ProgramArtifacts AND declares each one invariant in the
+//     ProgramSpec (KernelAdvancedOptions::enqueue_invariant_runtime_args / _common_runtime_args,
+//     TensorParameterAdvancedOptions::enqueue_invariant). They are applied ONCE, on cache miss, and
+//     statefully retained on every subsequent enqueue.
+//
+//   - PER-ENQUEUE run-args — tensor addresses, an RNG seed, a fill value: anything that may differ
+//     between two dispatches that hit the same cache entry. The factory returns these from
+//     create_per_enqueue_run_args, which the framework re-applies on EVERY dispatch.
+//
+// The framework adapter then:
+//   - on cache miss, merges the two sets (experimental::MergeProgramRunArgs) and applies the union via
+//     SetProgramRunArgs — a complete initial specification;
+//   - on cache hit, re-applies ONLY the per-enqueue set via experimental::UpdateProgramRunArgs, leaving
+//     the invariant set baked from the miss.
+//
+// This is safe-by-construction: the metal runtime validates that every run-arg omitted on the hit path
+// was declared enqueue-invariant in the spec. A per-enqueue value the factory forgets to refresh is a
+// hard validation error, not a silently-stale wrong answer — the failure mode the plain hit path
+// (UpdateTensorArgs, which can only refresh tensors) hides for ops with dynamic non-tensor args.
+//
+// A plain ProgramSpecFactoryConcept factory (no create_per_enqueue_run_args) is unaffected: it returns
+// the full run-args from create_program_spec and the adapter refreshes only tensors on hit.
+//
+// NOTE: This is a deliberately minimal consumer of the partial-update primitive — a single opt-in
+// method on top of the one existing factory concept. It is NOT the richer split-method factory shape
+// (immutable-info extraction, a caching-strategy axis, op-owned resources) that is being reworked
+// upstream; none of that is introduced here.
+template <typename T>
+concept ProgramSpecFactoryWithPerEnqueueArgsConcept =
+    ProgramSpecFactoryConcept<T> && requires { &T::create_per_enqueue_run_args; };
+
 // Detect operations that put create_descriptor directly on the operation struct
 // (no program_factory_t wrapper needed for single-descriptor operations).
 template <typename T>

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -72,59 +72,89 @@ template <typename T>
 concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } || WorkloadDescriptorConcept<T>) &&
                                           !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T>;
 
-// Metal 2.0 factory concept: factories that return ProgramArtifacts (a ProgramSpec +
-// ProgramRunArgs) from create_program_spec. The framework adapter stamps a Program
-// from the spec onto each mesh coordinate range on cache miss, and patches TensorArgs
-// via experimental::UpdateTensorArgs on cache hit.
+// ============================================================================
+//  Metal 2.0 ProgramSpec factory concepts — a progressive ladder
+// ============================================================================
 //
-// NOTE: Each TensorArgument.tensor in ProgramRunArgs MUST reference a MeshTensor reachable
-// from the factory's `tensor_args` / `tensor_return_value` parameters — the adapter
-// matches by pointer identity. Constructing or copying a MeshTensor and referencing the
-// copy will TT_FATAL at runtime.
+// A Metal 2.0 op factory's job is to produce TWO things: the immutable ProgramSpec (the "blueprint":
+// kernels, DFBs, work-units, argument schemas) and the ProgramRunArgs (the per-execution values). The
+// four concepts below are points on a ladder a dev climbs ONLY as far as performance forces them:
 //
-// NOTE: A separate MeshWorkloadSpecFactoryConcept is planned for ops whose programs vary
-// across the mesh (CCL-style); that one will require a multi-program artifact.
-// Alternatively, we could have only a single, common MeshWorkloadSpecFactoryConcept.
-// (Should follow whatever style ProgramDescriptor port ends up using.)
-template <typename T>
-concept ProgramSpecFactoryConcept = requires { &T::create_program_spec; } && !ProgramFactoryConcept<T> &&
-                                    !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
+//   1. ProgramSpecFactoryConcept — THE DEFAULT. One method, create_program_spec, returns the spec and
+//      ALL its run-args bundled. Migrate here first; it is the least to write.
+//
+//   2. AdvancedProgramSpecFactoryConcept — if the cache-HIT cost hurts. Keep the same cache key, but
+//      split the run-args into STATIC (create_static_args — fixed for a cache entry, set once on miss
+//      and retained) and DYNAMIC (create_dynamic_args — the per-dispatch values, e.g. an RNG seed or
+//      tensor addresses). The framework re-applies ONLY the dynamic set on a hit (UpdateProgramRunArgs),
+//      not the whole arg set.
+//
+//   3. ImmutableProgramSpecFactoryConcept / AdvancedImmutableProgramSpecFactoryConcept — if it STILL
+//      hurts. Add extract_immutable_info: a small, hashable projection of (attributes, tensor_args)
+//      that becomes the cache key AND the sole input to create_program_spec / create_static_args. This
+//      lets the framework skip the spec rebuild on a hit, and structurally prevents a mutable value
+//      (the seed) from leaking into the spec — it isn't even visible to create_program_spec. Available
+//      both bare (combined run-args) and with the static/dynamic split.
+//
+// The concepts are detected by method surface and are mutually exclusive by construction:
+//   - extract_immutable_info present        => Immutable-keyed (3/4)
+//   - create_static_args + create_dynamic_args present => Advanced / split (2/4)
+//
+// Run-args contract for the split (2 and 4): static run-args are declared enqueue-invariant in the spec
+// (KernelAdvancedOptions::enqueue_invariant_runtime_args / _common_runtime_args,
+// TensorParameterAdvancedOptions::enqueue_invariant). The framework merges static + dynamic
+// (MergeProgramRunArgs) for the cache-miss SetProgramRunArgs, and re-applies dynamic alone
+// (UpdateProgramRunArgs) on a hit. The metal runtime validates that every arg omitted on the hit path
+// was declared invariant — a dynamic value the factory forgets to refresh is a hard error, not a
+// silently-stale wrong answer.
+//
+// NOTE: Each TensorArgument.tensor in ProgramRunArgs MUST reference a MeshTensor reachable from the
+// factory's tensor_args / tensor_return_value — the adapter matches by pointer identity.
 
-// Opt-in refinement of ProgramSpecFactoryConcept that turns on the Metal 2.0 enqueue-invariant
-// fast path (UpdateProgramRunArgs). A factory satisfying this splits its run-args into two sets:
-//
-//   - ENQUEUE-INVARIANT run-args — work-split scalars, shape constants: every run-arg whose value is
-//     identical for every dispatch that shares a program-cache entry. The factory returns these as the
-//     `run_params` of create_program_spec's ProgramArtifacts AND declares each one invariant in the
-//     ProgramSpec (KernelAdvancedOptions::enqueue_invariant_runtime_args / _common_runtime_args,
-//     TensorParameterAdvancedOptions::enqueue_invariant). They are applied ONCE, on cache miss, and
-//     statefully retained on every subsequent enqueue.
-//
-//   - PER-ENQUEUE run-args — tensor addresses, an RNG seed, a fill value: anything that may differ
-//     between two dispatches that hit the same cache entry. The factory returns these from
-//     create_per_enqueue_run_args, which the framework re-applies on EVERY dispatch.
-//
-// The framework adapter then:
-//   - on cache miss, merges the two sets (experimental::MergeProgramRunArgs) and applies the union via
-//     SetProgramRunArgs — a complete initial specification;
-//   - on cache hit, re-applies ONLY the per-enqueue set via experimental::UpdateProgramRunArgs, leaving
-//     the invariant set baked from the miss.
-//
-// This is safe-by-construction: the metal runtime validates that every run-arg omitted on the hit path
-// was declared enqueue-invariant in the spec. A per-enqueue value the factory forgets to refresh is a
-// hard validation error, not a silently-stale wrong answer — the failure mode the plain hit path
-// (UpdateTensorArgs, which can only refresh tensors) hides for ops with dynamic non-tensor args.
-//
-// A plain ProgramSpecFactoryConcept factory (no create_per_enqueue_run_args) is unaffected: it returns
-// the full run-args from create_program_spec and the adapter refreshes only tensors on hit.
-//
-// NOTE: This is a deliberately minimal consumer of the partial-update primitive — a single opt-in
-// method on top of the one existing factory concept. It is NOT the richer split-method factory shape
-// (immutable-info extraction, a caching-strategy axis, op-owned resources) that is being reworked
-// upstream; none of that is introduced here.
+// --- method-surface building blocks (not used directly; compose the four leaf concepts) ---
 template <typename T>
-concept ProgramSpecFactoryWithPerEnqueueArgsConcept =
-    ProgramSpecFactoryConcept<T> && requires { &T::create_per_enqueue_run_args; };
+concept HasCreateProgramSpec = requires { &T::create_program_spec; };
+template <typename T>
+concept HasImmutableInfoExtraction = requires { &T::extract_immutable_info; };
+template <typename T>
+concept HasStaticDynamicArgSplit = requires {
+    &T::create_static_args;
+    &T::create_dynamic_args;
+};
+// Shared exclusion: a Metal 2.0 spec factory is none of the legacy factory shapes.
+template <typename T>
+concept NotALegacyFactory =
+    !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
+
+// 1. Basic, spec-keyed (the default). create_program_spec -> ProgramArtifacts{spec, run_args}.
+template <typename T>
+concept ProgramSpecFactoryConcept =
+    HasCreateProgramSpec<T> && !HasImmutableInfoExtraction<T> && !HasStaticDynamicArgSplit<T> && NotALegacyFactory<T>;
+
+// 2. Advanced (static/dynamic split), spec-keyed. create_program_spec -> ProgramSpec;
+//    create_static_args -> ProgramRunArgs; create_dynamic_args -> ProgramRunArgs.
+template <typename T>
+concept AdvancedProgramSpecFactoryConcept =
+    HasCreateProgramSpec<T> && HasStaticDynamicArgSplit<T> && !HasImmutableInfoExtraction<T> && NotALegacyFactory<T>;
+
+// 3. Basic, immutable-info-keyed. extract_immutable_info -> ImmutableInfo (cache key);
+//    create_program_spec(ImmutableInfo) -> ProgramArtifacts{spec, run_args}.
+template <typename T>
+concept ImmutableProgramSpecFactoryConcept =
+    HasCreateProgramSpec<T> && HasImmutableInfoExtraction<T> && !HasStaticDynamicArgSplit<T> && NotALegacyFactory<T>;
+
+// 4. Advanced (static/dynamic split), immutable-info-keyed.
+//    extract_immutable_info -> ImmutableInfo; create_program_spec(ImmutableInfo) -> ProgramSpec;
+//    create_static_args(ImmutableInfo) -> ProgramRunArgs; create_dynamic_args(...) -> ProgramRunArgs.
+template <typename T>
+concept AdvancedImmutableProgramSpecFactoryConcept =
+    HasCreateProgramSpec<T> && HasImmutableInfoExtraction<T> && HasStaticDynamicArgSplit<T> && NotALegacyFactory<T>;
+
+// Umbrella: any of the four Metal 2.0 spec factory shapes (exactly one is satisfied by construction).
+template <typename T>
+concept Metal2SpecFactoryConcept =
+    ProgramSpecFactoryConcept<T> || AdvancedProgramSpecFactoryConcept<T> || ImmutableProgramSpecFactoryConcept<T> ||
+    AdvancedImmutableProgramSpecFactoryConcept<T>;
 
 // Detect operations that put create_descriptor directly on the operation struct
 // (no program_factory_t wrapper needed for single-descriptor operations).
@@ -163,7 +193,7 @@ concept HasSelectProgramFactory = requires(
 
 // Validate that all variant alternatives in a program_factory_t satisfy exactly one of
 // ProgramFactoryConcept, MeshWorkloadFactoryConcept, ProgramDescriptorFactoryConcept,
-// or ProgramSpecFactoryConcept.
+// or one of the Metal 2.0 spec factory shapes (Metal2SpecFactoryConcept — itself exactly one of four).
 namespace detail {
 template <typename Variant, std::size_t... Is>
 consteval bool all_factories_valid(std::index_sequence<Is...>) {
@@ -171,7 +201,7 @@ consteval bool all_factories_valid(std::index_sequence<Is...>) {
         ((ProgramFactoryConcept<std::variant_alternative_t<Is, Variant>> +
           MeshWorkloadFactoryConcept<std::variant_alternative_t<Is, Variant>> +
           ProgramDescriptorFactoryConcept<std::variant_alternative_t<Is, Variant>> +
-          ProgramSpecFactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
+          Metal2SpecFactoryConcept<std::variant_alternative_t<Is, Variant>>) == 1) &&
         ...);
 }
 }  // namespace detail

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp
@@ -6,35 +6,42 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/rand.h"
 
+// Metal 2.0 compute producer of the rand DFB. The only changes from the descriptor-era kernel: the
+// DFB id and runtime args come from the spec binding namespaces (dfb:: / args::) instead of positional
+// compile-time/runtime slots. The DFB is an fp32 intermediate (as before): pack_tile writes fp32->fp32
+// and the writer narrows to the output dtype.
+//
+// seed/from/to are PER-ENQUEUE runtime args (rebuilt and re-applied via UpdateProgramRunArgs on every
+// dispatch); start_id/num_tiles are the enqueue-invariant work split (set once on cache miss).
 void kernel_main() {
-    constexpr uint32_t intermed_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t rand_cb = dfb::rand_tiles;
 
-    const uint32_t seed = get_arg_val<uint32_t>(0);
+    const uint32_t seed = get_arg(args::seed);
     union {
         float f;
         uint32_t u;
     } f2u_from, f2u_to, f2u_scale;
-    f2u_from.u = get_arg_val<uint32_t>(1);
-    f2u_to.u = get_arg_val<uint32_t>(2);
+    f2u_from.u = get_arg(args::from);
+    f2u_to.u = get_arg(args::to);
     f2u_scale.f = f2u_to.f - f2u_from.f;
-    const uint32_t start_id = get_arg_val<uint32_t>(3);
-    const uint32_t num_tiles = get_arg_val<uint32_t>(4);
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t num_tiles = get_arg(args::num_tiles);
     const uint32_t end_id = start_id + num_tiles;
 
-    init_sfpu(intermed_cb_id, intermed_cb_id);
+    init_sfpu(rand_cb, rand_cb);
 
     rand_tile_init(seed);
     for (uint32_t i = start_id; i < end_id; ++i) {
-        cb_reserve_back(intermed_cb_id, 1);
+        cb_reserve_back(rand_cb, 1);
 
         tile_regs_acquire();
         rand_tile(0, f2u_from.u, f2u_scale.u);
         tile_regs_commit();
 
         tile_regs_wait();
-        pack_tile(0, intermed_cb_id, 0);
+        pack_tile(0, rand_cb, 0);
         tile_regs_release();
 
-        cb_push_back(intermed_cb_id, 1);
+        cb_push_back(rand_cb, 1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp
@@ -7,17 +7,27 @@
 
 using namespace tt;
 
+// Metal 2.0 writer — the descriptor-era writer, ported to the spec binding namespaces and otherwise
+// unchanged. Two buffers, as before: an fp32 intermediate (dfb::rand_tiles) produced by the compute
+// kernel, and an output-dtype scratch (dfb::rand_out) the writer narrows into. fp32 output is written
+// straight from the intermediate; bf16 output is produced by truncating each fp32 element to its high
+// 16 bits (= bf16), which keeps every value strictly < `to`. The fp32-vs-bf16 path is selected by an
+// OUTPUT_DTYPE_* define set host-side; only those two dtypes are supported.
+//
+// Only-allowed changes from the descriptor era: CB ids come from the DFB binding tokens (dfb::), the
+// output address comes from the TensorAccessor binding (ta::), and start_id/num_tiles come from the
+// named-arg namespace (args::) instead of positional compile-time / runtime slots. start_id/num_tiles
+// are the enqueue-invariant work split; the output tensor binding is per-enqueue. The logic — the
+// two-buffer structure, the OUTPUT_DTYPE_* paths, and the high-16-bits truncation — is preserved.
 void kernel_main() {
-    constexpr uint32_t intermed_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t dst_cb_id = get_compile_time_arg_val(1);
-    constexpr auto dst_args = TensorAccessorArgs<2>();
+    constexpr uint32_t intermed_cb_id = dfb::rand_tiles;
+    constexpr uint32_t dst_cb_id = dfb::rand_out;
 
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_id = get_arg_val<uint32_t>(1);
-    uint32_t num_tiles = get_arg_val<uint32_t>(2);
-    uint32_t end_id = start_id + num_tiles;
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t num_tiles = get_arg(args::num_tiles);
+    const uint32_t end_id = start_id + num_tiles;
 
-    const auto output_addrg = TensorAccessor(dst_args, dst_addr);
+    TensorAccessor out(ta::output);
 
     cb_reserve_back(dst_cb_id, 1);
     uint32_t dst_cb_write_ptr = get_write_ptr(dst_cb_id);
@@ -29,7 +39,7 @@ void kernel_main() {
         auto intermed_cb_addr = reinterpret_cast<float*>(intermed_cb_read_ptr);
 
 #ifdef OUTPUT_DTYPE_FLOAT32
-        noc_async_write_page(i, output_addrg, intermed_cb_read_ptr);
+        noc_async_write_page(i, out, intermed_cb_read_ptr);
         noc_async_write_barrier();
         cb_pop_front(intermed_cb_id, 1);
 #endif
@@ -48,7 +58,7 @@ void kernel_main() {
         }
         cb_pop_front(intermed_cb_id, 1);
 
-        noc_async_write_page(i, output_addrg, dst_cb_write_ptr);
+        noc_async_write_page(i, out, dst_cb_write_ptr);
         noc_async_write_barrier();
 #endif
     }

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -5,13 +5,13 @@
 #pragma once
 
 #include <optional>
-
+#include <tuple>
+#include <variant>
 #include <vector>
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::operations::rand {
 
@@ -27,10 +27,12 @@ struct RandDeviceOperation {
         uint32_t seed;
         ttsl::SmallVector<bool> mesh_dim_is_sharded;
 
-        // Program identity. seed/from/to are re-applied via get_dynamic_runtime_args (excluded
-        // here). `device` must be FIRST: rand has no input tensor, so the framework discovers the
-        // mesh device via get_first_object_of_type over attribute_values(), and its tuple path only
-        // inspects element 0.
+        // seed/from/to are PER-ENQUEUE values (Metal 2.0): they are carried by
+        // create_per_enqueue_run_args and re-applied on every dispatch via UpdateProgramRunArgs. They
+        // are deliberately EXCLUDED from attribute_values() so the framework's program hash treats two
+        // calls that differ only in seed/from/to as a CACHE HIT (a single cached program), rather than
+        // recompiling per seed. `device` is FIRST so the framework can discover the mesh device via
+        // get_first_object_of_type over attribute_values() — rand has no input tensor.
         static constexpr auto attribute_names =
             std::forward_as_tuple("device", "shape", "dtype", "layout", "memory_config");
         auto attribute_values() const { return std::forward_as_tuple(device, shape, dtype, layout, memory_config); }
@@ -41,27 +43,33 @@ struct RandDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+    // Metal 2.0 factory (ProgramSpecFactoryWithPerEnqueueArgsConcept).
+    //
+    // create_program_spec builds the immutable ProgramSpec and the ENQUEUE-INVARIANT run-args (the
+    // per-core work split: start_id / num_tiles), declaring those args invariant in the spec. They are
+    // applied once on cache miss and retained across enqueues.
+    //
+    // create_per_enqueue_run_args carries the PER-ENQUEUE values: the per-core RNG seed and the
+    // from/to range, plus the output tensor binding. The framework merges these with the invariant set
+    // for the cache-miss SetProgramRunArgs, and on every cache hit re-applies ONLY this set via
+    // UpdateProgramRunArgs — so a different seed produces different output while the program is reused.
+    //
+    // This replaces the legacy descriptor + get_dynamic_runtime_args + descriptor-patching machinery
+    // that rand previously used to refresh the seed on a cache hit.
+    struct RandProgramFactory {
+        static ttnn::device_operation::ProgramArtifacts create_program_spec(
+            const operation_attributes_t& attributes, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+        static tt::tt_metal::experimental::ProgramRunArgs create_per_enqueue_run_args(
+            const operation_attributes_t& attributes, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+    };
+
+    using program_factory_t = std::variant<RandProgramFactory>;
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    // seed/from/to are excluded from the program hash (so calls differing only in
-    // those values cache-hit instead of recompiling).  They are therefore DYNAMIC: this returns the
-    // current per-core (seed) and per-call (from/to) values so the framework re-applies them to the
-    // cached program on every dispatch.  Must mirror the seed/from/to runtime args built in
-    // create_descriptor() — the test_rand_different_seed_values regression test enforces this.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -7,8 +7,8 @@
 #include <optional>
 #include <tuple>
 #include <variant>
-#include <vector>
 
+#include <tt-metalium/core_coord.hpp>
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/metal2_artifacts.hpp"
@@ -26,16 +26,6 @@ struct RandDeviceOperation {
         const float to;
         uint32_t seed;
         ttsl::SmallVector<bool> mesh_dim_is_sharded;
-
-        // seed/from/to are PER-ENQUEUE values (Metal 2.0): they are carried by
-        // create_per_enqueue_run_args and re-applied on every dispatch via UpdateProgramRunArgs. They
-        // are deliberately EXCLUDED from attribute_values() so the framework's program hash treats two
-        // calls that differ only in seed/from/to as a CACHE HIT (a single cached program), rather than
-        // recompiling per seed. `device` is FIRST so the framework can discover the mesh device via
-        // get_first_object_of_type over attribute_values() — rand has no input tensor.
-        static constexpr auto attribute_names =
-            std::forward_as_tuple("device", "shape", "dtype", "layout", "memory_config");
-        auto attribute_values() const { return std::forward_as_tuple(device, shape, dtype, layout, memory_config); }
     };
 
     struct tensor_args_t {};
@@ -43,28 +33,45 @@ struct RandDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    // Metal 2.0 factory (ProgramSpecFactoryWithPerEnqueueArgsConcept).
+    // Metal 2.0 factory — option 3, enhanced (AdvancedImmutableProgramSpecFactoryConcept).
     //
-    // create_program_spec builds the immutable ProgramSpec and the ENQUEUE-INVARIANT run-args (the
-    // per-core work split: start_id / num_tiles), declaring those args invariant in the spec. They are
-    // applied once on cache miss and retained across enqueues.
+    // The four-method surface IS the documentation of what's what:
+    //   - extract_immutable_info → the cache key AND the sole input to create_program_spec /
+    //     create_static_args. It is the structural projection of the request (output layout + grid).
+    //     It deliberately EXCLUDES seed/from/to, so two calls that differ only in those values map to
+    //     the same cache entry — and a mutable value cannot leak into the spec, because the spec
+    //     builders never see anything but the ImmutableInfo.
+    //   - create_program_spec → the immutable blueprint (DFBs, kernels, work-units, schemas).
+    //   - create_static_args → the ENQUEUE-INVARIANT run-args: the per-core work split (start_id /
+    //     num_tiles), declared invariant in the spec, set once on cache miss and retained.
+    //   - create_dynamic_args → the PER-ENQUEUE run-args: the per-core RNG seed + from/to range and
+    //     the output tensor. Re-applied on every dispatch via UpdateProgramRunArgs, so a new seed
+    //     produces new output while the cached program is reused.
     //
-    // create_per_enqueue_run_args carries the PER-ENQUEUE values: the per-core RNG seed and the
-    // from/to range, plus the output tensor binding. The framework merges these with the invariant set
-    // for the cache-miss SetProgramRunArgs, and on every cache hit re-applies ONLY this set via
-    // UpdateProgramRunArgs — so a different seed produces different output while the program is reused.
-    //
-    // This replaces the legacy descriptor + get_dynamic_runtime_args + descriptor-patching machinery
-    // that rand previously used to refresh the seed on a cache hit.
+    // This replaces the legacy descriptor + get_dynamic_runtime_args + descriptor-patching machinery.
     struct RandProgramFactory {
-        static ttnn::device_operation::ProgramArtifacts create_program_spec(
-            const operation_attributes_t& attributes, const tensor_args_t& tensor_args, tensor_return_value_t& output);
-        static tt::tt_metal::experimental::ProgramRunArgs create_per_enqueue_run_args(
-            const operation_attributes_t& attributes, const tensor_args_t& tensor_args, tensor_return_value_t& output);
+        struct immutable_info_t {
+            tt::tt_metal::TensorSpec output_spec;
+            CoreCoord grid;
+
+            static constexpr auto attribute_names = std::forward_as_tuple("output_spec", "grid");
+            auto attribute_values() const { return std::forward_as_tuple(output_spec, grid); }
+        };
+
+        static immutable_info_t extract_immutable_info(
+            const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
+        static tt::tt_metal::experimental::ProgramSpec create_program_spec(const immutable_info_t& info);
+        static tt::tt_metal::experimental::ProgramRunArgs create_static_args(const immutable_info_t& info);
+        static tt::tt_metal::experimental::ProgramRunArgs create_dynamic_args(
+            const operation_attributes_t& attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output,
+            const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
     };
 
     using program_factory_t = std::variant<RandProgramFactory>;
-    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+    // No select_program_factory: program_factory_t is a single alternative, so the framework selects it
+    // automatically. No compute_program_hash: the cache key is the factory's ImmutableInfo.
 
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -37,14 +37,14 @@ struct RandDeviceOperation {
     //
     // The four-method surface IS the documentation of what's what:
     //   - extract_immutable_info → the cache key AND the sole input to create_program_spec /
-    //     create_static_args. It is the structural projection of the request (output layout + grid).
+    //     create_enqueue_invariant_args. It is the structural projection of the request (output layout + grid).
     //     It deliberately EXCLUDES seed/from/to, so two calls that differ only in those values map to
     //     the same cache entry — and a mutable value cannot leak into the spec, because the spec
     //     builders never see anything but the ImmutableInfo.
     //   - create_program_spec → the immutable blueprint (DFBs, kernels, work-units, schemas).
-    //   - create_static_args → the ENQUEUE-INVARIANT run-args: the per-core work split (start_id /
+    //   - create_enqueue_invariant_args → the ENQUEUE-INVARIANT run-args: the per-core work split (start_id /
     //     num_tiles), declared invariant in the spec, set once on cache miss and retained.
-    //   - create_dynamic_args → the PER-ENQUEUE run-args: the per-core RNG seed + from/to range and
+    //   - create_per_enqueue_args → the PER-ENQUEUE run-args: the per-core RNG seed + from/to range and
     //     the output tensor. Re-applied on every dispatch via UpdateProgramRunArgs, so a new seed
     //     produces new output while the cached program is reused.
     //
@@ -61,8 +61,8 @@ struct RandDeviceOperation {
         static immutable_info_t extract_immutable_info(
             const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
         static tt::tt_metal::experimental::ProgramSpec create_program_spec(const immutable_info_t& info);
-        static tt::tt_metal::experimental::ProgramRunArgs create_static_args(const immutable_info_t& info);
-        static tt::tt_metal::experimental::ProgramRunArgs create_dynamic_args(
+        static tt::tt_metal::experimental::ProgramRunArgs create_enqueue_invariant_args(const immutable_info_t& info);
+        static tt::tt_metal::experimental::ProgramRunArgs create_per_enqueue_args(
             const operation_attributes_t& attributes,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -33,17 +33,17 @@ struct RandDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    // Metal 2.0 factory — option 3, enhanced (AdvancedImmutableProgramSpecFactoryConcept).
+    // Metal 2.0 factory — AdvancedProgramSpecFactoryConcept with the per-enqueue split (Option 3++).
     //
-    // The four-method surface IS the documentation of what's what:
-    //   - extract_immutable_info → the cache key AND the sole input to create_program_spec /
-    //     create_enqueue_invariant_args. It is the structural projection of the request (output layout + grid).
-    //     It deliberately EXCLUDES seed/from/to, so two calls that differ only in those values map to
-    //     the same cache entry — and a mutable value cannot leak into the spec, because the spec
-    //     builders never see anything but the ImmutableInfo.
-    //   - create_program_spec → the immutable blueprint (DFBs, kernels, work-units, schemas).
-    //   - create_enqueue_invariant_args → the ENQUEUE-INVARIANT run-args: the per-core work split (start_id /
-    //     num_tiles), declared invariant in the spec, set once on cache miss and retained.
+    // The method surface IS the documentation of what's what:
+    //   - extract_immutable_info → the cache key AND the sole input to create_program_artifacts. It is
+    //     the structural projection of the request (output layout + grid). It deliberately EXCLUDES
+    //     seed/from/to, so two calls that differ only in those values map to the same cache entry — and
+    //     a mutable value cannot leak into the spec, because the builder never sees anything but the
+    //     ImmutableInfo.
+    //   - create_program_artifacts → the immutable blueprint (DFBs, kernels, work-units, schemas) PLUS
+    //     the ENQUEUE-INVARIANT run-args (the per-core work split start_id / num_tiles, declared
+    //     invariant in the spec), bundled as a ProgramArtifacts. Set once on cache miss and retained.
     //   - create_per_enqueue_args → the PER-ENQUEUE run-args: the per-core RNG seed + from/to range and
     //     the output tensor. Re-applied on every dispatch via UpdateProgramRunArgs, so a new seed
     //     produces new output while the cached program is reused.
@@ -60,8 +60,7 @@ struct RandDeviceOperation {
 
         static immutable_info_t extract_immutable_info(
             const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
-        static tt::tt_metal::experimental::ProgramSpec create_program_spec(const immutable_info_t& info);
-        static tt::tt_metal::experimental::ProgramRunArgs create_enqueue_invariant_args(const immutable_info_t& info);
+        static ttnn::device_operation::ProgramArtifacts create_program_artifacts(const immutable_info_t& info);
         static tt::tt_metal::experimental::ProgramRunArgs create_per_enqueue_args(
             const operation_attributes_t& attributes,
             const tensor_args_t& tensor_args,

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -2,10 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 #include <bit>
+#include <cstdint>
 #include <ctime>
 #include <filesystem>
 #include <limits>
 #include <random>
+#include <vector>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
@@ -20,6 +22,7 @@ namespace ttnn::operations::rand {
 using namespace tt;
 using namespace tt::tt_metal;
 namespace m2 = tt::tt_metal::experimental;
+using immutable_info_t = RandDeviceOperation::RandProgramFactory::immutable_info_t;
 
 namespace {
 
@@ -31,10 +34,10 @@ auto get_random_seed() -> uint32_t { return distribution(rng); }
 constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp";
 constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp";
 
-// Work split over the output tiles. Derived only from the output tensor + the device grid (the
-// immutable program structure), so create_program_spec (which bakes the per-core start_id/num_tiles as
-// enqueue-invariant) and create_per_enqueue_run_args (which walks the same core list to assign seeds)
-// produce a consistent core enumeration.
+// Work split over the output tiles — a pure function of (grid, tile count). create_program_spec and
+// create_static_args derive it from the ImmutableInfo; create_dynamic_args re-derives the identical
+// split from the output tensor, so the per-core seed assignment lines up with the static start_id /
+// num_tiles for the same cores.
 struct RandWorkSplit {
     CoreRangeSet all_cores;
     CoreRangeSet core_group_1;
@@ -44,9 +47,7 @@ struct RandWorkSplit {
     std::vector<CoreCoord> cores;
 };
 
-RandWorkSplit compute_rand_work_split(RandDeviceOperation::tensor_return_value_t& output) {
-    auto grid = output.device()->compute_with_storage_grid_size();
-    uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
+RandWorkSplit compute_work_split(const CoreCoord& grid, uint32_t units_to_divide) {
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
     auto cores = grid_to_cores(num_cores, grid.x, grid.y);
@@ -63,36 +64,26 @@ uint32_t units_for_core(const RandWorkSplit& ws, const CoreCoord& core) {
     TT_THROW("Core not in specified core ranges");
 }
 
-// Per-core seed. seed == 0 means "non-deterministic": draw a fresh host seed each call (so repeated
-// calls differ). seed != 0 means "deterministic": seed + core_index, so the same seed reproduces the
-// same output (and a different seed changes it). The legacy per-DEVICE seed offset for sharded meshes
-// is not expressible on the single-program ProgramSpec path (one spec stamped across the mesh) — that
-// case needs a multi-program workload concept; see create_per_enqueue_run_args.
-uint32_t rand_seed_for_core(const RandDeviceOperation::operation_attributes_t& attrs, int i) {
-    return attrs.seed != 0 ? attrs.seed + static_cast<uint32_t>(i) : get_random_seed();
-}
-
 }  // namespace
 
-RandDeviceOperation::program_factory_t RandDeviceOperation::select_program_factory(
-    const operation_attributes_t&, const tensor_args_t&) {
-    return RandProgramFactory{};
+// extract_immutable_info — the cache key + sole input to the spec/static builders. The structural
+// projection of the request: output layout + compute grid. Excludes seed/from/to (those are dynamic).
+RandDeviceOperation::RandProgramFactory::immutable_info_t
+RandDeviceOperation::RandProgramFactory::extract_immutable_info(
+    const operation_attributes_t& attrs, const tensor_args_t& /*tensor_args*/) {
+    TensorSpec output_spec(attrs.shape, TensorLayout(attrs.dtype, PageConfig(attrs.layout), attrs.memory_config));
+    return immutable_info_t{
+        .output_spec = std::move(output_spec), .grid = attrs.device->compute_with_storage_grid_size()};
 }
 
-// ===================================================================================
-// create_program_spec — the immutable spec + the ENQUEUE-INVARIANT run-args (per-core work split).
-// Runs on cache miss. start_id / num_tiles are declared enqueue-invariant so the hit path may omit
-// them (they are retained from this miss-time SetProgramRunArgs).
-// ===================================================================================
-ttnn::device_operation::ProgramArtifacts RandDeviceOperation::RandProgramFactory::create_program_spec(
-    const operation_attributes_t& /*attributes*/, const tensor_args_t& /*tensor_args*/, tensor_return_value_t& output) {
-    const auto ws = compute_rand_work_split(output);
-    const DataType output_dtype = output.dtype();
+// create_program_spec — the immutable blueprint. Derives ONLY from the ImmutableInfo.
+m2::ProgramSpec RandDeviceOperation::RandProgramFactory::create_program_spec(const immutable_info_t& info) {
+    const uint32_t units = info.output_spec.padded_shape().volume() / constants::TILE_HW;
+    const auto ws = compute_work_split(info.grid, units);
+    const DataType output_dtype = info.output_spec.data_type();
     const auto out_data_format = datatype_to_dataformat_converter(output_dtype);
     constexpr auto fp32_format = tt::DataFormat::Float32;
 
-    // Two DFBs: an fp32 intermediate produced by compute, and an output-dtype scratch the writer
-    // narrows into (bound both producer and consumer on the writer so it has both endpoints).
     m2::DataflowBufferSpec intermed_dfb{
         .unique_id = m2::DFBSpecName{"rand_tiles"},
         .entry_size = tile_size(fp32_format),
@@ -146,56 +137,80 @@ ttnn::device_operation::ProgramArtifacts RandDeviceOperation::RandProgramFactory
     spec.name = "rand";
     spec.kernels = {std::move(compute_kernel), std::move(writer_kernel)};
     spec.dataflow_buffers = {std::move(intermed_dfb), std::move(out_dfb)};
-    // The output tensor is per-enqueue (its address is refreshed each dispatch), so it is NOT declared
-    // enqueue-invariant.
     spec.tensor_parameters = {
-        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output.tensor_spec()}};
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = info.output_spec}};
     spec.work_units = {m2::WorkUnitSpec{
         .name = "rand_work",
         .kernels = {m2::KernelSpecName{"compute"}, m2::KernelSpecName{"writer"}},
         .target_nodes = ws.all_cores}};
-
-    // Enqueue-invariant run-args: the per-core work split, identical for every dispatch sharing this
-    // cache entry. Applied once on miss and retained thereafter.
-    m2::ProgramRunArgs::KernelRunArgs compute_inv{.kernel = m2::KernelSpecName{"compute"}};
-    m2::ProgramRunArgs::KernelRunArgs writer_inv{.kernel = m2::KernelSpecName{"writer"}};
-    uint32_t tile_offset = 0;
-    for (const auto& core : ws.cores) {
-        const uint32_t units = units_for_core(ws, core);
-        compute_inv.runtime_arg_values.push_back({core, {{"start_id", tile_offset}, {"num_tiles", units}}});
-        writer_inv.runtime_arg_values.push_back({core, {{"start_id", tile_offset}, {"num_tiles", units}}});
-        tile_offset += units;
-    }
-    m2::ProgramRunArgs invariant_run_args;
-    invariant_run_args.kernel_run_args.push_back(std::move(compute_inv));
-    invariant_run_args.kernel_run_args.push_back(std::move(writer_inv));
-
-    return ttnn::device_operation::ProgramArtifacts{
-        .spec = std::move(spec), .run_params = std::move(invariant_run_args)};
+    return spec;
 }
 
-// ===================================================================================
-// create_per_enqueue_run_args — the PER-ENQUEUE values: per-core seed + from/to, and the output
-// tensor binding. Merged with the invariant set on cache miss; re-applied alone (UpdateProgramRunArgs)
-// on every cache hit, so a new seed yields new output while the cached program is reused.
-// ===================================================================================
-m2::ProgramRunArgs RandDeviceOperation::RandProgramFactory::create_per_enqueue_run_args(
-    const operation_attributes_t& attributes, const tensor_args_t& /*tensor_args*/, tensor_return_value_t& output) {
-    const auto ws = compute_rand_work_split(output);
-    const float eps = 1e-6f;
-    const uint32_t from_bits = std::bit_cast<uint32_t>(attributes.from);
-    const uint32_t to_bits = std::bit_cast<uint32_t>(attributes.to - eps);
+// create_static_args — the enqueue-invariant per-core work split (start_id / num_tiles). Derived only
+// from the ImmutableInfo and declared invariant in the spec, so the hit path may omit it.
+m2::ProgramRunArgs RandDeviceOperation::RandProgramFactory::create_static_args(const immutable_info_t& info) {
+    const uint32_t units = info.output_spec.padded_shape().volume() / constants::TILE_HW;
+    const auto ws = compute_work_split(info.grid, units);
 
-    m2::ProgramRunArgs::KernelRunArgs compute_dyn{.kernel = m2::KernelSpecName{"compute"}};
-    for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
-        const uint32_t seed = rand_seed_for_core(attributes, i);
-        compute_dyn.runtime_arg_values.push_back({ws.cores[i], {{"seed", seed}, {"from", from_bits}, {"to", to_bits}}});
+    m2::ProgramRunArgs::KernelRunArgs compute_args{.kernel = m2::KernelSpecName{"compute"}};
+    m2::ProgramRunArgs::KernelRunArgs writer_args{.kernel = m2::KernelSpecName{"writer"}};
+    uint32_t tile_offset = 0;
+    for (const auto& core : ws.cores) {
+        const uint32_t n = units_for_core(ws, core);
+        compute_args.runtime_arg_values.push_back({core, {{"start_id", tile_offset}, {"num_tiles", n}}});
+        writer_args.runtime_arg_values.push_back({core, {{"start_id", tile_offset}, {"num_tiles", n}}});
+        tile_offset += n;
     }
-    // (The writer kernel's only per-enqueue input is the output tensor binding below; its start_id /
-    // num_tiles are enqueue-invariant, so it needs no per-enqueue KernelRunArgs entry.)
+    m2::ProgramRunArgs args;
+    args.kernel_run_args.push_back(std::move(compute_args));
+    args.kernel_run_args.push_back(std::move(writer_args));
+    return args;
+}
+
+// create_dynamic_args — the per-enqueue values: per-core seed + from/to range, and the output tensor.
+// Re-applied on every dispatch via UpdateProgramRunArgs. The per-coordinate seed offset gives distinct
+// streams across a sharded mesh.
+m2::ProgramRunArgs RandDeviceOperation::RandProgramFactory::create_dynamic_args(
+    const operation_attributes_t& attrs,
+    const tensor_args_t& /*tensor_args*/,
+    tensor_return_value_t& output,
+    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+    const uint32_t units = output.physical_volume() / constants::TILE_HW;
+    const auto grid = output.device()->compute_with_storage_grid_size();
+    const auto ws = compute_work_split(grid, units);
+
+    // Per-device seed offset on a sharded mesh, so each device produces a distinct stream.
+    uint32_t device_seed_offset = 0;
+    const auto& shard_mask = attrs.mesh_dim_is_sharded;
+    if (!shard_mask.empty()) {
+        const ttnn::MeshCoordinate mesh_coordinate =
+            mesh_dispatch_coordinate.value_or(ttnn::MeshCoordinate::zero_coordinate(attrs.device->shape().dims()));
+        const auto& mesh_shape = attrs.device->shape();
+        size_t shard_linear_idx = 0;
+        size_t shard_stride = 1;
+        for (int i = static_cast<int>(shard_mask.size()) - 1; i >= 0; --i) {
+            if (shard_mask[i]) {
+                shard_linear_idx += mesh_coordinate[i] * shard_stride;
+                shard_stride *= mesh_shape[i];
+            }
+        }
+        device_seed_offset = static_cast<uint32_t>(shard_linear_idx) * static_cast<uint32_t>(ws.cores.size());
+    }
+
+    const float eps = 1e-6f;
+    const uint32_t from_bits = std::bit_cast<uint32_t>(attrs.from);
+    const uint32_t to_bits = std::bit_cast<uint32_t>(attrs.to - eps);
+
+    m2::ProgramRunArgs::KernelRunArgs compute_args{.kernel = m2::KernelSpecName{"compute"}};
+    for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
+        const uint32_t seed =
+            attrs.seed != 0 ? attrs.seed + static_cast<uint32_t>(i) + device_seed_offset : get_random_seed();
+        compute_args.runtime_arg_values.push_back(
+            {ws.cores[i], {{"seed", seed}, {"from", from_bits}, {"to", to_bits}}});
+    }
 
     m2::ProgramRunArgs args;
-    args.kernel_run_args.push_back(std::move(compute_dyn));
+    args.kernel_run_args.push_back(std::move(compute_args));
     args.tensor_args.emplace(
         m2::TensorParamName{"output"}, m2::ProgramRunArgs::TensorArgument{std::cref(output.mesh_tensor())});
     return args;

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -3,19 +3,23 @@
 // SPDX-License-Identifier: Apache-2.0
 #include <bit>
 #include <ctime>
+#include <filesystem>
 #include <limits>
 #include <random>
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/tensor/types.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "rand_device_operation.hpp"
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 namespace ttnn::operations::rand {
 
 using namespace tt;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace {
 
@@ -27,208 +31,174 @@ auto get_random_seed() -> uint32_t { return distribution(rng); }
 constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp";
 constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp";
 
-// Work split + per-device seed offset, shared by create_descriptor (cache miss) and
-// get_dynamic_runtime_args (cache hit) so both derive the identical core list and seed offset.
+// Work split over the output tiles. Derived only from the output tensor + the device grid (the
+// immutable program structure), so create_program_spec (which bakes the per-core start_id/num_tiles as
+// enqueue-invariant) and create_per_enqueue_run_args (which walks the same core list to assign seeds)
+// produce a consistent core enumeration.
 struct RandWorkSplit {
-    uint32_t num_cores = 0;
     CoreRangeSet all_cores;
     CoreRangeSet core_group_1;
     CoreRangeSet core_group_2;
     uint32_t units_per_core_group_1 = 0;
     uint32_t units_per_core_group_2 = 0;
     std::vector<CoreCoord> cores;
-    uint32_t device_seed_offset = 0;
 };
 
-RandWorkSplit compute_rand_work_split(
-    const RandDeviceOperation::operation_attributes_t& attrs,
-    RandDeviceOperation::tensor_return_value_t& output,
-    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
+RandWorkSplit compute_rand_work_split(RandDeviceOperation::tensor_return_value_t& output) {
     auto grid = output.device()->compute_with_storage_grid_size();
     uint32_t units_to_divide = output.physical_volume() / constants::TILE_HW;
     auto [num_cores, all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2] =
         split_work_to_cores(grid, units_to_divide);
     auto cores = grid_to_cores(num_cores, grid.x, grid.y);
-
-    const ttnn::MeshCoordinate mesh_coordinate =
-        mesh_dispatch_coordinate.value_or(ttnn::MeshCoordinate::zero_coordinate(attrs.device->shape().dims()));
-    uint32_t device_seed_offset = 0;
-    const auto& shard_mask = attrs.mesh_dim_is_sharded;
-    if (!shard_mask.empty()) {
-        const auto& mesh_shape = attrs.device->shape();
-        size_t shard_linear_idx = 0;
-        size_t shard_stride = 1;
-        for (int i = static_cast<int>(shard_mask.size()) - 1; i >= 0; --i) {
-            if (shard_mask[i]) {
-                shard_linear_idx += mesh_coordinate[i] * shard_stride;
-                shard_stride *= mesh_shape[i];
-            }
-        }
-        device_seed_offset = static_cast<uint32_t>(shard_linear_idx) * static_cast<uint32_t>(cores.size());
-    }
-    return {
-        num_cores,
-        all_cores,
-        core_group_1,
-        core_group_2,
-        units_per_core_group_1,
-        units_per_core_group_2,
-        std::move(cores),
-        device_seed_offset};
+    return {all_cores, core_group_1, core_group_2, units_per_core_group_1, units_per_core_group_2, std::move(cores)};
 }
 
-// Per-core seed; shared so the miss-build and the hit-patch produce identical values.
-uint32_t rand_seed_for_core(
-    const RandDeviceOperation::operation_attributes_t& attrs, int i, uint32_t device_seed_offset) {
-    return attrs.seed != 0 ? attrs.seed + i + device_seed_offset : get_random_seed();
+uint32_t units_for_core(const RandWorkSplit& ws, const CoreCoord& core) {
+    if (ws.core_group_1.contains(core)) {
+        return ws.units_per_core_group_1;
+    }
+    if (ws.core_group_2.contains(core)) {
+        return ws.units_per_core_group_2;
+    }
+    TT_THROW("Core not in specified core ranges");
+}
+
+// Per-core seed. seed == 0 means "non-deterministic": draw a fresh host seed each call (so repeated
+// calls differ). seed != 0 means "deterministic": seed + core_index, so the same seed reproduces the
+// same output (and a different seed changes it). The legacy per-DEVICE seed offset for sharded meshes
+// is not expressible on the single-program ProgramSpec path (one spec stamped across the mesh) — that
+// case needs a multi-program workload concept; see create_per_enqueue_run_args.
+uint32_t rand_seed_for_core(const RandDeviceOperation::operation_attributes_t& attrs, int i) {
+    return attrs.seed != 0 ? attrs.seed + static_cast<uint32_t>(i) : get_random_seed();
 }
 
 }  // namespace
 
-ProgramDescriptor RandDeviceOperation::create_descriptor(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output,
-    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    auto
-        [num_cores,
-         all_cores,
-         core_group_1,
-         core_group_2,
-         units_per_core_group_1,
-         units_per_core_group_2,
-         cores,
-         device_seed_offset] = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
-    const auto num_cores_total = cores.size();
-
-    DataType output_dtype = output.dtype();
-    auto out_data_format = datatype_to_dataformat_converter(output_dtype);
-    const uint32_t dtype_tile_size = tile_size(out_data_format);
-    const uint32_t intermed_tile_size = tile_size(tt::DataFormat::Float32);
-
-    constexpr uint32_t in_out_num_tiles = 1;
-    constexpr uint32_t intermed_num_tiles = 2;
-
-    constexpr uint32_t intermed_cb_id = CBIndex::c_24;
-    constexpr uint32_t dst_cb_id = CBIndex::c_0;
-
-    ProgramDescriptor desc;
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = intermed_num_tiles * intermed_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = intermed_cb_id,
-            .data_format = tt::DataFormat::Float32,
-            .page_size = intermed_tile_size,
-        }}},
-    });
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = in_out_num_tiles * dtype_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = dst_cb_id,
-            .data_format = out_data_format,
-            .page_size = dtype_tile_size,
-        }}},
-    });
-
-    KernelDescriptor::CompileTimeArgs writer_ct_args;
-    writer_ct_args.reserve(8);
-    writer_ct_args.push_back(intermed_cb_id);
-    writer_ct_args.push_back(dst_cb_id);
-    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source = WRITER_KERNEL_PATH;
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
-    switch (output_dtype) {
-        case DataType::BFLOAT16: writer_desc.defines.emplace_back("OUTPUT_DTYPE_BFLOAT16", "1"); break;
-        case DataType::FLOAT32: writer_desc.defines.emplace_back("OUTPUT_DTYPE_FLOAT32", "1"); break;
-        default:
-            // The writer kernel only implements float32 and bfloat16 output paths.
-            // Fail fast here so we never instantiate a program that can hang at runtime.
-            TT_THROW("RandDeviceOperation: unsupported output dtype for writer kernel");
-    }
-    writer_desc.runtime_args.reserve(num_cores_total);
-
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = {intermed_cb_id};
-    compute_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-        .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
-                                   // generated number out of range [from, to)
-        .dst_full_sync_en = false,
-        .math_approx_mode = true,
-    };
-    compute_desc.runtime_args.reserve(num_cores_total);
-
-    const float eps = 1e-6f;
-    const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
-    const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
-
-    uint32_t tile_offset = 0;
-    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
-        const auto& core = cores[i];
-        uint32_t units_per_core;
-        if (core_group_1.contains(core)) {
-            units_per_core = units_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            units_per_core = units_per_core_group_2;
-        } else {
-            TT_THROW("Core not in specified core ranges");
-        }
-
-        uint32_t seed = rand_seed_for_core(operation_attributes, i, device_seed_offset);
-
-        // seed/from/to are DYNAMIC (excluded from compute_program_hash): baked here for the
-        // cache-miss build, and re-applied on every cache hit via get_dynamic_runtime_args().
-        compute_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{seed, from_bits, to_bits, tile_offset, units_per_core});
-
-        // Register the output address as a Buffer* binding so rand takes the fast cache-hit path
-        // (real program caching) with the address correctly re-patched each dispatch.
-        writer_desc.emplace_runtime_args(core, {output.buffer(), tile_offset, units_per_core});
-
-        tile_offset += units_per_core;
-    }
-
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
-
-    return desc;
+RandDeviceOperation::program_factory_t RandDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return RandProgramFactory{};
 }
 
-std::vector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dynamic_runtime_args(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output,
-    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    // compute is kernel 1; its runtime args are {seed, from_bits, to_bits, tile_offset, units_per_core}.
-    // seed/from/to are excluded from the hash and re-applied here; the rest are static.
-    constexpr uint32_t kComputeKernelIdx = 1;
-    auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
+// ===================================================================================
+// create_program_spec — the immutable spec + the ENQUEUE-INVARIANT run-args (per-core work split).
+// Runs on cache miss. start_id / num_tiles are declared enqueue-invariant so the hit path may omit
+// them (they are retained from this miss-time SetProgramRunArgs).
+// ===================================================================================
+ttnn::device_operation::ProgramArtifacts RandDeviceOperation::RandProgramFactory::create_program_spec(
+    const operation_attributes_t& /*attributes*/, const tensor_args_t& /*tensor_args*/, tensor_return_value_t& output) {
+    const auto ws = compute_rand_work_split(output);
+    const DataType output_dtype = output.dtype();
+    const auto out_data_format = datatype_to_dataformat_converter(output_dtype);
+    constexpr auto fp32_format = tt::DataFormat::Float32;
 
-    const float eps = 1e-6f;
-    const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
-    const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
+    // Two DFBs: an fp32 intermediate produced by compute, and an output-dtype scratch the writer
+    // narrows into (bound both producer and consumer on the writer so it has both endpoints).
+    m2::DataflowBufferSpec intermed_dfb{
+        .unique_id = m2::DFBSpecName{"rand_tiles"},
+        .entry_size = tile_size(fp32_format),
+        .num_entries = 2,
+        .data_format_metadata = fp32_format,
+    };
+    m2::DataflowBufferSpec out_dfb{
+        .unique_id = m2::DFBSpecName{"rand_out"},
+        .entry_size = tile_size(out_data_format),
+        .num_entries = 1,
+        .data_format_metadata = out_data_format,
+    };
 
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(ws.cores.size() * 3);
-    for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
-        const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 0, seed});
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 1, from_bits});
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 2, to_bits});
+    m2::KernelSpec compute_kernel{
+        .unique_id = m2::KernelSpecName{"compute"},
+        .source = std::filesystem::path{COMPUTE_KERNEL_PATH},
+        .dfb_bindings = {m2::ProducerOf(m2::DFBSpecName{"rand_tiles"}, "rand_tiles")},
+        .runtime_arg_schema = {.runtime_arg_names = {"seed", "from", "to", "start_id", "num_tiles"}},
+        .hw_config =
+            m2::ComputeHardwareConfig{
+                .math_fidelity = MathFidelity::HiFi4,
+                .fp32_dest_acc_en = true,
+                .dst_full_sync_en = false,
+                .math_approx_mode = true,
+            },
+        .advanced_options = m2::KernelAdvancedOptions{.enqueue_invariant_runtime_args = {"start_id", "num_tiles"}},
+    };
+
+    m2::KernelSpec::CompilerOptions writer_opts;
+    switch (output_dtype) {
+        case DataType::BFLOAT16: writer_opts.defines.emplace("OUTPUT_DTYPE_BFLOAT16", "1"); break;
+        case DataType::FLOAT32: writer_opts.defines.emplace("OUTPUT_DTYPE_FLOAT32", "1"); break;
+        default: TT_THROW("RandDeviceOperation: unsupported output dtype for writer kernel");
     }
-    return dynamic_args;
+    m2::KernelSpec writer_kernel{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{WRITER_KERNEL_PATH},
+        .compiler_options = std::move(writer_opts),
+        .dfb_bindings =
+            {m2::ConsumerOf(m2::DFBSpecName{"rand_tiles"}, "rand_tiles"),
+             m2::ProducerOf(m2::DFBSpecName{"rand_out"}, "rand_out"),
+             m2::ConsumerOf(m2::DFBSpecName{"rand_out"}, "rand_out")},
+        .tensor_bindings = {m2::TensorBinding{
+            .tensor_parameter_name = m2::TensorParamName{"output"}, .accessor_name = "output"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_tiles"}},
+        .hw_config = m2::DataMovementHardwareConfig{.gen1_config = m2::DataMovementHardwareConfig::Gen1Config{}},
+        .advanced_options = m2::KernelAdvancedOptions{.enqueue_invariant_runtime_args = {"start_id", "num_tiles"}},
+    };
+
+    m2::ProgramSpec spec;
+    spec.name = "rand";
+    spec.kernels = {std::move(compute_kernel), std::move(writer_kernel)};
+    spec.dataflow_buffers = {std::move(intermed_dfb), std::move(out_dfb)};
+    // The output tensor is per-enqueue (its address is refreshed each dispatch), so it is NOT declared
+    // enqueue-invariant.
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output.tensor_spec()}};
+    spec.work_units = {m2::WorkUnitSpec{
+        .name = "rand_work",
+        .kernels = {m2::KernelSpecName{"compute"}, m2::KernelSpecName{"writer"}},
+        .target_nodes = ws.all_cores}};
+
+    // Enqueue-invariant run-args: the per-core work split, identical for every dispatch sharing this
+    // cache entry. Applied once on miss and retained thereafter.
+    m2::ProgramRunArgs::KernelRunArgs compute_inv{.kernel = m2::KernelSpecName{"compute"}};
+    m2::ProgramRunArgs::KernelRunArgs writer_inv{.kernel = m2::KernelSpecName{"writer"}};
+    uint32_t tile_offset = 0;
+    for (const auto& core : ws.cores) {
+        const uint32_t units = units_for_core(ws, core);
+        compute_inv.runtime_arg_values.push_back({core, {{"start_id", tile_offset}, {"num_tiles", units}}});
+        writer_inv.runtime_arg_values.push_back({core, {{"start_id", tile_offset}, {"num_tiles", units}}});
+        tile_offset += units;
+    }
+    m2::ProgramRunArgs invariant_run_args;
+    invariant_run_args.kernel_run_args.push_back(std::move(compute_inv));
+    invariant_run_args.kernel_run_args.push_back(std::move(writer_inv));
+
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec), .run_params = std::move(invariant_run_args)};
+}
+
+// ===================================================================================
+// create_per_enqueue_run_args — the PER-ENQUEUE values: per-core seed + from/to, and the output
+// tensor binding. Merged with the invariant set on cache miss; re-applied alone (UpdateProgramRunArgs)
+// on every cache hit, so a new seed yields new output while the cached program is reused.
+// ===================================================================================
+m2::ProgramRunArgs RandDeviceOperation::RandProgramFactory::create_per_enqueue_run_args(
+    const operation_attributes_t& attributes, const tensor_args_t& /*tensor_args*/, tensor_return_value_t& output) {
+    const auto ws = compute_rand_work_split(output);
+    const float eps = 1e-6f;
+    const uint32_t from_bits = std::bit_cast<uint32_t>(attributes.from);
+    const uint32_t to_bits = std::bit_cast<uint32_t>(attributes.to - eps);
+
+    m2::ProgramRunArgs::KernelRunArgs compute_dyn{.kernel = m2::KernelSpecName{"compute"}};
+    for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
+        const uint32_t seed = rand_seed_for_core(attributes, i);
+        compute_dyn.runtime_arg_values.push_back({ws.cores[i], {{"seed", seed}, {"from", from_bits}, {"to", to_bits}}});
+    }
+    // (The writer kernel's only per-enqueue input is the output tensor binding below; its start_id /
+    // num_tiles are enqueue-invariant, so it needs no per-enqueue KernelRunArgs entry.)
+
+    m2::ProgramRunArgs args;
+    args.kernel_run_args.push_back(std::move(compute_dyn));
+    args.tensor_args.emplace(
+        m2::TensorParamName{"output"}, m2::ProgramRunArgs::TensorArgument{std::cref(output.mesh_tensor())});
+    return args;
 }
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -35,7 +35,7 @@ constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device
 constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp";
 
 // Work split over the output tiles — a pure function of (grid, tile count). create_program_spec and
-// create_static_args derive it from the ImmutableInfo; create_dynamic_args re-derives the identical
+// create_enqueue_invariant_args derive it from the ImmutableInfo; create_per_enqueue_args re-derives the identical
 // split from the output tensor, so the per-core seed assignment lines up with the static start_id /
 // num_tiles for the same cores.
 struct RandWorkSplit {
@@ -146,9 +146,10 @@ m2::ProgramSpec RandDeviceOperation::RandProgramFactory::create_program_spec(con
     return spec;
 }
 
-// create_static_args — the enqueue-invariant per-core work split (start_id / num_tiles). Derived only
+// create_enqueue_invariant_args — the enqueue-invariant per-core work split (start_id / num_tiles). Derived only
 // from the ImmutableInfo and declared invariant in the spec, so the hit path may omit it.
-m2::ProgramRunArgs RandDeviceOperation::RandProgramFactory::create_static_args(const immutable_info_t& info) {
+m2::ProgramRunArgs RandDeviceOperation::RandProgramFactory::create_enqueue_invariant_args(
+    const immutable_info_t& info) {
     const uint32_t units = info.output_spec.padded_shape().volume() / constants::TILE_HW;
     const auto ws = compute_work_split(info.grid, units);
 
@@ -167,10 +168,10 @@ m2::ProgramRunArgs RandDeviceOperation::RandProgramFactory::create_static_args(c
     return args;
 }
 
-// create_dynamic_args — the per-enqueue values: per-core seed + from/to range, and the output tensor.
+// create_per_enqueue_args — the per-enqueue values: per-core seed + from/to range, and the output tensor.
 // Re-applied on every dispatch via UpdateProgramRunArgs. The per-coordinate seed offset gives distinct
 // streams across a sharded mesh.
-m2::ProgramRunArgs RandDeviceOperation::RandProgramFactory::create_dynamic_args(
+m2::ProgramRunArgs RandDeviceOperation::RandProgramFactory::create_per_enqueue_args(
     const operation_attributes_t& attrs,
     const tensor_args_t& /*tensor_args*/,
     tensor_return_value_t& output,

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -34,10 +34,10 @@ auto get_random_seed() -> uint32_t { return distribution(rng); }
 constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp";
 constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp";
 
-// Work split over the output tiles — a pure function of (grid, tile count). create_program_spec and
-// create_enqueue_invariant_args derive it from the ImmutableInfo; create_per_enqueue_args re-derives the identical
-// split from the output tensor, so the per-core seed assignment lines up with the static start_id /
-// num_tiles for the same cores.
+// Work split over the output tiles — a pure function of (grid, tile count). create_program_artifacts
+// derives it from the ImmutableInfo; create_per_enqueue_args re-derives the identical split from the
+// output tensor, so the per-core seed assignment lines up with the work-split start_id / num_tiles for
+// the same cores.
 struct RandWorkSplit {
     CoreRangeSet all_cores;
     CoreRangeSet core_group_1;
@@ -76,8 +76,11 @@ RandDeviceOperation::RandProgramFactory::extract_immutable_info(
         .output_spec = std::move(output_spec), .grid = attrs.device->compute_with_storage_grid_size()};
 }
 
-// create_program_spec — the immutable blueprint. Derives ONLY from the ImmutableInfo.
-m2::ProgramSpec RandDeviceOperation::RandProgramFactory::create_program_spec(const immutable_info_t& info) {
+// create_program_artifacts — the immutable blueprint + the enqueue-invariant per-core work split
+// (start_id / num_tiles), bundled as a ProgramArtifacts. Derives ONLY from the ImmutableInfo. The work
+// split is declared enqueue-invariant in the spec, so the hit path (create_per_enqueue_args) omits it.
+ttnn::device_operation::ProgramArtifacts RandDeviceOperation::RandProgramFactory::create_program_artifacts(
+    const immutable_info_t& info) {
     const uint32_t units = info.output_spec.padded_shape().volume() / constants::TILE_HW;
     const auto ws = compute_work_split(info.grid, units);
     const DataType output_dtype = info.output_spec.data_type();
@@ -143,16 +146,9 @@ m2::ProgramSpec RandDeviceOperation::RandProgramFactory::create_program_spec(con
         .name = "rand_work",
         .kernels = {m2::KernelSpecName{"compute"}, m2::KernelSpecName{"writer"}},
         .target_nodes = ws.all_cores}};
-    return spec;
-}
 
-// create_enqueue_invariant_args — the enqueue-invariant per-core work split (start_id / num_tiles). Derived only
-// from the ImmutableInfo and declared invariant in the spec, so the hit path may omit it.
-m2::ProgramRunArgs RandDeviceOperation::RandProgramFactory::create_enqueue_invariant_args(
-    const immutable_info_t& info) {
-    const uint32_t units = info.output_spec.padded_shape().volume() / constants::TILE_HW;
-    const auto ws = compute_work_split(info.grid, units);
-
+    // Enqueue-invariant run-args: the per-core work split, bundled into the artifacts. Applied once on
+    // cache miss and retained; create_per_enqueue_args carries the rest.
     m2::ProgramRunArgs::KernelRunArgs compute_args{.kernel = m2::KernelSpecName{"compute"}};
     m2::ProgramRunArgs::KernelRunArgs writer_args{.kernel = m2::KernelSpecName{"writer"}};
     uint32_t tile_offset = 0;
@@ -162,10 +158,11 @@ m2::ProgramRunArgs RandDeviceOperation::RandProgramFactory::create_enqueue_invar
         writer_args.runtime_arg_values.push_back({core, {{"start_id", tile_offset}, {"num_tiles", n}}});
         tile_offset += n;
     }
-    m2::ProgramRunArgs args;
-    args.kernel_run_args.push_back(std::move(compute_args));
-    args.kernel_run_args.push_back(std::move(writer_args));
-    return args;
+    m2::ProgramRunArgs invariant_args;
+    invariant_args.kernel_run_args.push_back(std::move(compute_args));
+    invariant_args.kernel_run_args.push_back(std::move(writer_args));
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(invariant_args)};
 }
 
 // create_per_enqueue_args — the per-enqueue values: per-core seed + from/to range, and the output tensor.

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp
@@ -392,26 +392,30 @@ void mul_block_bcast_scalar_inplace() {
 }
 
 void kernel_main() {
-    constexpr uint32_t input_values_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t index_cb_index = get_compile_time_arg_val(1);
-    constexpr uint32_t input_transposed_cb_index = get_compile_time_arg_val(2);
-    constexpr uint32_t index_transposed_cb_index = get_compile_time_arg_val(3);
-    constexpr uint32_t values_cb_index = get_compile_time_arg_val(4);
-    constexpr uint32_t output_ind_cb_index = get_compile_time_arg_val(5);
+    // Metal 2.0: CB ids come from the DFB binding tokens (dfb::), the template-argument scalars
+    // (Ht/Wt/logWt/tile_width) from named compile-time args (args::, still constexpr so they remain
+    // usable as template parameters), and the RNG seed from a named RUNTIME arg (args::seed) — the only
+    // per-enqueue value, so two dispatches differing only in seed reuse the same compiled Program.
+    constexpr uint32_t input_values_cb_index = dfb::input_values;
+    constexpr uint32_t index_cb_index = dfb::index;
+    constexpr uint32_t input_transposed_cb_index = dfb::input_transposed;
+    constexpr uint32_t index_transposed_cb_index = dfb::index_transposed;
+    constexpr uint32_t values_cb_index = dfb::values;
+    constexpr uint32_t output_ind_cb_index = dfb::output_ind;
 
-    constexpr uint32_t topk_mask_cb_index = get_compile_time_arg_val(6);
-    constexpr uint32_t scaler_max_cb_index = get_compile_time_arg_val(7);
-    constexpr uint32_t scaler_sum_cb_index = get_compile_time_arg_val(8);
-    constexpr uint32_t cb_cur_max = get_compile_time_arg_val(9);
-    constexpr uint32_t cb_cur_sum = get_compile_time_arg_val(10);
-    constexpr uint32_t Ht = get_compile_time_arg_val(11);
-    constexpr uint32_t Wt = get_compile_time_arg_val(12);
-    constexpr uint32_t logWt = get_compile_time_arg_val(13);
-    constexpr uint32_t rand_tile_index = get_compile_time_arg_val(14);
-    constexpr uint32_t seed = get_compile_time_arg_val(15);
-    constexpr uint32_t cb_local_vals = get_compile_time_arg_val(16);
-    constexpr uint32_t temp_cb_index = get_compile_time_arg_val(17);
-    constexpr uint32_t tile_width = get_compile_time_arg_val(18);
+    constexpr uint32_t topk_mask_cb_index = dfb::topk_mask;
+    constexpr uint32_t scaler_max_cb_index = dfb::scaler_max;
+    constexpr uint32_t scaler_sum_cb_index = dfb::scaler_sum;
+    constexpr uint32_t cb_cur_max = dfb::cur_max;
+    constexpr uint32_t cb_cur_sum = dfb::cur_sum;
+    constexpr uint32_t Ht = get_arg(args::Ht);
+    constexpr uint32_t Wt = get_arg(args::Wt);
+    constexpr uint32_t logWt = get_arg(args::logWt);
+    constexpr uint32_t rand_tile_index = dfb::rand_tile;
+    const uint32_t seed = get_arg(args::seed);
+    constexpr uint32_t cb_local_vals = dfb::local_vals;
+    constexpr uint32_t temp_cb_index = dfb::temp;
+    constexpr uint32_t tile_width = get_arg(args::tile_width);
     generate_rand_tile(rand_tile_index, seed);
 
     const uint32_t nearest32_K = 32;

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp
@@ -14,33 +14,21 @@
  * first 32 elements are {0,..31}, then next 32 are {32,..64}
  * wt is which tile it is along the row [0, Wt) so j + 32*wt is the value in the tile at each element
  */
-// USE_32BIT == false (WH/BH): pack two 16-bit indices per 32-bit word (UInt16 index tile, LO16
-// dest mode). USE_32BIT == true (Quasar): write one 32-bit index per element (Int32 index tile,
-// INT32 dest mode). The index width must match the top-k LLK's fp32_dest_acc_en setting.
-template <bool USE_32BIT>
 FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
     // TODO: investigate moving to compile time (binary size is at risk)
     CircularBuffer cb(cb_id);
     cb.reserve_back(1);
     CoreLocalMem<volatile uint32_t> ptr(cb.get_write_ptr());
-    uint32_t wt_offset = wt << 5;
+    uint16_t wt_offset = wt << 5;
 
     uint32_t count = 0;
     for (uint32_t i = 0; i < 2; ++i) {
         for (uint32_t j = 0; j < 2; ++j) {
             for (uint32_t k = 0; k < 16; ++k) {
-                if constexpr (USE_32BIT) {
-                    for (uint32_t l = 0; l < 16; ++l) {
-                        uint32_t value = l + 16 * j + wt_offset;
-                        ptr[count] = value;
-                        count++;
-                    }
-                } else {
-                    for (uint32_t l = 0; l < 16; l += 2) {
-                        uint16_t value = l + 16 * j + wt_offset;
-                        ptr[count] = (value + 1) << 16 | value;
-                        count++;
-                    }
+                for (uint32_t l = 0; l < 16; l += 2) {
+                    uint16_t value = l + 16 * j + wt_offset;
+                    ptr[count] = (value + 1) << 16 | value;
+                    count++;
                 }
             }
         }
@@ -49,28 +37,23 @@ FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
 }
 
 void kernel_main() {
-    uint32_t values_addr = get_arg_val<uint32_t>(0);
-    uint32_t indices_addr = get_arg_val<uint32_t>(1);
+    // Metal 2.0: tensor addresses come from the TensorAccessor bindings (ta::), CB ids from the DFB
+    // tokens (dfb::), and the shape/work-split scalars from named compile-time args (args::).
+    constexpr uint32_t input_values_cb_index = dfb::input_values;
+    constexpr uint32_t input_indices_cb_index = dfb::final_indices;
+    constexpr uint32_t cb_intermed_index = dfb::index;
 
-    constexpr uint32_t input_values_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t input_indices_cb_index = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_intermed_index = get_compile_time_arg_val(2);
-
-    constexpr uint32_t Ht = get_compile_time_arg_val(3);
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t input_indices_page_size = get_compile_time_arg_val(5);
-    constexpr uint32_t tile_height = get_compile_time_arg_val(6);
-    constexpr bool use_32bit_index = get_compile_time_arg_val(7) == 1;
-
-    constexpr auto s0_args = TensorAccessorArgs<8>();
-    constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
+    constexpr uint32_t Ht = get_arg(args::Ht);
+    constexpr uint32_t Wt = get_arg(args::Wt);
+    constexpr uint32_t input_indices_page_size = get_arg(args::final_indices_stick_size);
+    constexpr uint32_t tile_height = get_arg(args::tile_height);
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
 
-    const auto s0 = TensorAccessor(s0_args, values_addr);
+    const auto s0 = TensorAccessor(ta::input_values);
 
-    const auto s1 = TensorAccessor(s1_args, indices_addr);
+    const auto s1 = TensorAccessor(ta::input_indices);
 
     Noc noc;
     CircularBuffer input_values_cb(input_values_cb_index);
@@ -86,7 +69,7 @@ void kernel_main() {
             noc.async_read(
                 s0, input_values_cb, tile_bytes_input_values, {.page_id = tile_id_input_values}, {.offset_bytes = 0});
             tile_id_input_values++;
-            generate_index_tile<use_32bit_index>(cb_intermed_index, j);
+            generate_index_tile(cb_intermed_index, j);
             noc.async_read_barrier();
             input_values_cb.push_back(onetile);
         }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp
@@ -14,21 +14,33 @@
  * first 32 elements are {0,..31}, then next 32 are {32,..64}
  * wt is which tile it is along the row [0, Wt) so j + 32*wt is the value in the tile at each element
  */
+// USE_32BIT == false (WH/BH): pack two 16-bit indices per 32-bit word (UInt16 index tile, LO16
+// dest mode). USE_32BIT == true (Quasar): write one 32-bit index per element (Int32 index tile,
+// INT32 dest mode). The index width must match the top-k LLK's fp32_dest_acc_en setting.
+template <bool USE_32BIT>
 FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
     // TODO: investigate moving to compile time (binary size is at risk)
     CircularBuffer cb(cb_id);
     cb.reserve_back(1);
     CoreLocalMem<volatile uint32_t> ptr(cb.get_write_ptr());
-    uint16_t wt_offset = wt << 5;
+    uint32_t wt_offset = wt << 5;
 
     uint32_t count = 0;
     for (uint32_t i = 0; i < 2; ++i) {
         for (uint32_t j = 0; j < 2; ++j) {
             for (uint32_t k = 0; k < 16; ++k) {
-                for (uint32_t l = 0; l < 16; l += 2) {
-                    uint16_t value = l + 16 * j + wt_offset;
-                    ptr[count] = (value + 1) << 16 | value;
-                    count++;
+                if constexpr (USE_32BIT) {
+                    for (uint32_t l = 0; l < 16; ++l) {
+                        uint32_t value = l + 16 * j + wt_offset;
+                        ptr[count] = value;
+                        count++;
+                    }
+                } else {
+                    for (uint32_t l = 0; l < 16; l += 2) {
+                        uint16_t value = l + 16 * j + wt_offset;
+                        ptr[count] = (value + 1) << 16 | value;
+                        count++;
+                    }
                 }
             }
         }
@@ -47,6 +59,9 @@ void kernel_main() {
     constexpr uint32_t Wt = get_arg(args::Wt);
     constexpr uint32_t input_indices_page_size = get_arg(args::final_indices_stick_size);
     constexpr uint32_t tile_height = get_arg(args::tile_height);
+    // Index intermediate width: 32-bit (Int32) on Quasar, 16-bit (UInt16) on WH/BH — must match the
+    // index DFB format and the compute kernel's fp32_dest_acc_en chosen by the host factory.
+    constexpr bool use_32bit_index = get_arg(args::use_32bit_index) == 1;
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
@@ -69,7 +84,7 @@ void kernel_main() {
             noc.async_read(
                 s0, input_values_cb, tile_bytes_input_values, {.page_id = tile_id_input_values}, {.offset_bytes = 0});
             tile_id_input_values++;
-            generate_index_tile(cb_intermed_index, j);
+            generate_index_tile<use_32bit_index>(cb_intermed_index, j);
             noc.async_read_barrier();
             input_values_cb.push_back(onetile);
         }

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -4,7 +4,6 @@
 
 #include "api/numeric/bfloat16.h"
 #include <stdint.h>
-#include <type_traits>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
@@ -36,37 +35,25 @@ FORCE_INLINE float bf16_to_f32(uint16_t bf16) {
 }
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t temp_addr = get_arg_val<uint32_t>(1);
-    uint32_t k_addr = get_arg_val<uint32_t>(2);
-    uint32_t p_addr = get_arg_val<uint32_t>(3);
-
-    uint32_t arg_id = 0;
-    constexpr auto dst_args = TensorAccessorArgs<0>();
-    constexpr auto temp_args = TensorAccessorArgs<dst_args.next_compile_time_args_offset()>();
-    constexpr auto k_args = TensorAccessorArgs<temp_args.next_compile_time_args_offset()>();
-    constexpr auto p_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
-
-    constexpr uint32_t args_base = p_args.next_compile_time_args_offset();
-    constexpr uint32_t cb_id_out = get_compile_time_arg_val(args_base + 0);
-    constexpr uint32_t cb_id_mask = get_compile_time_arg_val(args_base + 1);
-    constexpr uint32_t scaler_max_cb_id = get_compile_time_arg_val(args_base + 2);
-    constexpr uint32_t scaler_sum_cb_id = get_compile_time_arg_val(args_base + 3);
-    constexpr uint32_t output_final_indices_rm_cb_index = get_compile_time_arg_val(args_base + 4);
-    constexpr uint32_t output_local_values_cb_index = get_compile_time_arg_val(args_base + 5);
-    constexpr uint32_t output_local_indices_cb_index = get_compile_time_arg_val(args_base + 6);
-    constexpr uint32_t final_indices_stick_size = get_compile_time_arg_val(args_base + 7);
-    // args_base + 8: out_stick_size (passed from factory, unused in kernel)
-    constexpr uint32_t rand_tile_index = get_compile_time_arg_val(args_base + 9);
-    constexpr uint32_t cb_id_k = get_compile_time_arg_val(args_base + 10);
-    constexpr uint32_t cb_id_p = get_compile_time_arg_val(args_base + 11);
-    constexpr uint32_t cb_id_temp = get_compile_time_arg_val(args_base + 12);
-    constexpr uint32_t core_id = get_compile_time_arg_val(args_base + 13);
-    constexpr uint32_t ids_per_batch = get_compile_time_arg_val(args_base + 14);
-    constexpr uint32_t num_cores = get_compile_time_arg_val(args_base + 15);
-    // Local sort-index width must match the index CB format / fp32_dest_acc_en chosen by the host:
-    // 32-bit (Int32) on Quasar, 16-bit (UInt16) on WH/BH.
-    constexpr bool use_32bit_index = get_compile_time_arg_val(args_base + 16) == 1;
+    // Metal 2.0: the four tensor addresses come from TensorAccessor bindings (ta::), CB ids from DFB
+    // tokens (dfb::), structural scalars from named compile-time args (args::, constexpr — some feed
+    // chunk-size constexprs below), and core_id from a per-core RUNTIME arg (args::core_id) so the writer
+    // is ONE KernelSpec on all cores rather than one specialized binary per core.
+    constexpr uint32_t cb_id_out = dfb::output;
+    constexpr uint32_t cb_id_mask = dfb::topk_mask;
+    constexpr uint32_t scaler_max_cb_id = dfb::scaler_max;
+    constexpr uint32_t scaler_sum_cb_id = dfb::scaler_sum;
+    constexpr uint32_t output_final_indices_rm_cb_index = dfb::final_indices;
+    constexpr uint32_t output_local_values_cb_index = dfb::local_vals;
+    constexpr uint32_t output_local_indices_cb_index = dfb::output_ind;
+    constexpr uint32_t final_indices_stick_size = get_arg(args::final_indices_stick_size);
+    constexpr uint32_t rand_tile_index = dfb::rand_tile;
+    constexpr uint32_t cb_id_k = dfb::k;
+    constexpr uint32_t cb_id_p = dfb::p;
+    constexpr uint32_t cb_id_temp = dfb::temp;
+    const uint32_t core_id = get_arg(args::core_id);
+    constexpr uint32_t ids_per_batch = get_arg(args::ids_per_batch);
+    constexpr uint32_t num_cores = get_arg(args::num_cores);
     constexpr uint32_t k_chunk_size = num_cores * sizeof(uint32_t);     // 4 bytes per uint32_t
     constexpr uint32_t p_chunk_size = num_cores * sizeof(uint16_t);     // 2 bytes per uint16_t
     constexpr uint32_t temp_chunk_size = num_cores * sizeof(uint16_t);  // 2 bytes per uint16_t
@@ -87,7 +74,7 @@ void kernel_main() {
     CircularBuffer cb_local_indices(output_local_indices_cb_index);
     CircularBuffer cb_out(cb_id_out);
 
-    const auto addrg_k = TensorAccessor(k_args, k_addr);
+    const auto addrg_k = TensorAccessor(ta::k);
     cb_k.reserve_back(1);
     uint32_t cb_id_k_ptr = cb_k.get_write_ptr();
     // Read the entire aligned chunk to avoid NOC alignment issues
@@ -98,7 +85,7 @@ void kernel_main() {
     // Index into the chunk to get this core's value
     uint32_t k = k_ptr[core_id];
 
-    const auto addrg_p = TensorAccessor(p_args, p_addr);
+    const auto addrg_p = TensorAccessor(ta::p);
     cb_p.reserve_back(1);
     uint32_t cb_id_p_ptr = cb_p.get_write_ptr();
     // Read the entire aligned chunk to avoid NOC alignment issues
@@ -109,7 +96,7 @@ void kernel_main() {
     // Index into the chunk to get this core's value
     uint32_t p = p_ptr[core_id];
 
-    const auto addrg_temp = TensorAccessor(temp_args, temp_addr);
+    const auto addrg_temp = TensorAccessor(ta::temp);
     // cb_temp.reserve_back(1);
     uint32_t cb_id_temp_ptr = cb_temp.get_write_ptr();
     // Read the entire aligned chunk to avoid NOC alignment issues
@@ -136,8 +123,7 @@ void kernel_main() {
     // Read producer-written compute outputs from these CBs in L1.
     CoreLocalMem<volatile uint16_t> local_values(cb_local_values.get_read_ptr());
 
-    using local_index_t = std::conditional_t<use_32bit_index, uint32_t, uint16_t>;
-    CoreLocalMem<volatile local_index_t> local_indices(cb_local_indices.get_read_ptr());
+    CoreLocalMem<volatile uint16_t> local_indices(cb_local_indices.get_read_ptr());
 
     CoreLocalMem<volatile uint32_t> final_indices(cb_final_indices.get_read_ptr() + core_id * final_indices_stick_size);
 
@@ -233,7 +219,7 @@ void kernel_main() {
     cb_local_indices.pop_front(1);
     cb_final_indices.pop_front(32);
 
-    const auto s_out = TensorAccessor(dst_args, dst_addr);
+    const auto s_out = TensorAccessor(ta::output);
     // Write individual core result - output buffer should handle alignment
     noc.async_write(
         use<CircularBuffer::AddrSelector::WRITE_PTR>(cb_out),

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -4,6 +4,7 @@
 
 #include "api/numeric/bfloat16.h"
 #include <stdint.h>
+#include <type_traits>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
@@ -54,6 +55,9 @@ void kernel_main() {
     const uint32_t core_id = get_arg(args::core_id);
     constexpr uint32_t ids_per_batch = get_arg(args::ids_per_batch);
     constexpr uint32_t num_cores = get_arg(args::num_cores);
+    // Local sort-index width must match the index DFB format / fp32_dest_acc_en chosen by the host:
+    // 32-bit (Int32) on Quasar, 16-bit (UInt16) on WH/BH.
+    constexpr bool use_32bit_index = get_arg(args::use_32bit_index) == 1;
     constexpr uint32_t k_chunk_size = num_cores * sizeof(uint32_t);     // 4 bytes per uint32_t
     constexpr uint32_t p_chunk_size = num_cores * sizeof(uint16_t);     // 2 bytes per uint16_t
     constexpr uint32_t temp_chunk_size = num_cores * sizeof(uint16_t);  // 2 bytes per uint16_t
@@ -123,7 +127,8 @@ void kernel_main() {
     // Read producer-written compute outputs from these CBs in L1.
     CoreLocalMem<volatile uint16_t> local_values(cb_local_values.get_read_ptr());
 
-    CoreLocalMem<volatile uint16_t> local_indices(cb_local_indices.get_read_ptr());
+    using local_index_t = std::conditional_t<use_32bit_index, uint32_t, uint16_t>;
+    CoreLocalMem<volatile local_index_t> local_indices(cb_local_indices.get_read_ptr());
 
     CoreLocalMem<volatile uint32_t> final_indices(cb_final_indices.get_read_ptr() + core_id * final_indices_stick_size);
 

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -78,6 +78,7 @@ struct SamplingDerived {
     uint32_t k_chunk_size = 0;
     uint32_t p_chunk_size = 0;
     uint32_t temp_chunk_size = 0;
+    bool use_32bit_index = false;
 
     CoreRangeSet core_grid;
     std::vector<CoreCoord> cores;
@@ -87,9 +88,15 @@ struct SamplingDerived {
 // grid + the optional sub-core grid. No live Tensor, no addresses, no seed.
 SamplingDerived derive_from_info(const immutable_info_t& info) {
     SamplingDerived derived;
+    // The bitonic top-k LLK carries sort indices through the dest register, and the index load/store
+    // width is tied to fp32_dest_acc_en (INT32 when enabled, LO16 otherwise). WH/BH use the cheaper
+    // 16-bit (UInt16) path with fp32 dest accumulation disabled; every other architecture (e.g. Quasar,
+    // which also lacks UInt16/UInt32 DFB metadata support) uses 32-bit (Int32) index intermediates with
+    // fp32 dest accumulation enabled. Gated on !(WH || BH) so new architectures default to 32-bit.
+    derived.use_32bit_index = !(info.arch == tt::ARCH::WORMHOLE_B0 || info.arch == tt::ARCH::BLACKHOLE);
     derived.input_values_df = datatype_to_dataformat_converter(info.input_values_spec.data_type());
     derived.input_indices_df = datatype_to_dataformat_converter(info.input_indices_spec.data_type());
-    derived.index_df = tt::DataFormat::UInt16;
+    derived.index_df = derived.use_32bit_index ? tt::DataFormat::Int32 : tt::DataFormat::UInt16;
     derived.k_df = datatype_to_dataformat_converter(info.k_spec.data_type());
     derived.p_df = datatype_to_dataformat_converter(info.p_spec.data_type());
     derived.temp_df = datatype_to_dataformat_converter(info.temp_spec.data_type());
@@ -149,6 +156,7 @@ SamplingProgramFactory::immutable_info_t SamplingProgramFactory::extract_immutab
         .output_spec = std::move(output_spec),
         .grid = tensor_args.input_values.device()->compute_with_storage_grid_size(),
         .sub_core_grids = attrs.sub_core_grids,
+        .arch = tensor_args.input_values.device()->arch(),
     };
 }
 
@@ -204,7 +212,8 @@ ttnn::device_operation::ProgramArtifacts SamplingProgramFactory::create_program_
             {{"Ht", derived.Ht},
              {"Wt", derived.Wt},
              {"final_indices_stick_size", derived.aligned_final_indices_rm_unit_size},
-             {"tile_height", derived.tile_height}},
+             {"tile_height", derived.tile_height},
+             {"use_32bit_index", static_cast<uint32_t>(derived.use_32bit_index)}},
         // Reader on NCRISC (RISCV_1 / NOC1), writer on BRISC — mirrors the legacy Reader/Writer configs
         // so the two data-movement kernels don't collide on the same DM processor.
         .hw_config =
@@ -241,7 +250,9 @@ ttnn::device_operation::ProgramArtifacts SamplingProgramFactory::create_program_
         .compile_time_args =
             {{"Ht", derived.Ht}, {"Wt", derived.Wt}, {"logWt", derived.logWt}, {"tile_width", derived.tile_width}},
         .runtime_arg_schema = {.runtime_arg_names = {"seed"}},
-        .hw_config = m2::ComputeHardwareConfig{},
+        // 32-bit (Int32) sort indices require fp32 dest accumulation so the top-k LLK loads/stores indices
+        // in INT32 mode; the 16-bit (UInt16) path uses LO16 mode with fp32 dest acc off.
+        .hw_config = m2::ComputeHardwareConfig{.fp32_dest_acc_en = derived.use_32bit_index},
     };
 
     m2::KernelSpec writer{
@@ -266,7 +277,8 @@ ttnn::device_operation::ProgramArtifacts SamplingProgramFactory::create_program_
         .compile_time_args =
             {{"final_indices_stick_size", derived.aligned_final_indices_rm_unit_size},
              {"ids_per_batch", derived.tile_width},
-             {"num_cores", derived.num_cores}},
+             {"num_cores", derived.num_cores},
+             {"use_32bit_index", static_cast<uint32_t>(derived.use_32bit_index)}},
         // core_id is a per-core RUNTIME arg, declared enqueue-invariant (it's a function of the grid,
         // identical for every dispatch that shares this cache entry).
         .runtime_arg_schema = {.runtime_arg_names = {"core_id"}},

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -6,430 +6,338 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <vector>
 
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/math.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/reduction/reduce_op_validation.hpp"
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
-    const SamplingParams& operation_attributes, const SamplingInputs& tensor_args, Tensor& output_tensor) {
-    using namespace tt::tt_metal;
+using namespace tt;
+using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
-    const auto& input_values_tensor = tensor_args.input_values.mesh_tensor();
-    const auto& input_indices_tensor = tensor_args.input_indices.mesh_tensor();
-    const auto& k = tensor_args.k.mesh_tensor();
-    const auto& p = tensor_args.p.mesh_tensor();
-    const auto& temp = tensor_args.temp.mesh_tensor();
+namespace {
 
-    const auto& seed = operation_attributes.seed;
-    const auto& sub_core_grids = operation_attributes.sub_core_grids;
+constexpr const char* READER_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp";
+constexpr const char* WRITER_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp";
+constexpr const char* COMPUTE_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp";
 
-    uint32_t random_seed = 0;
+using immutable_info_t = SamplingProgramFactory::immutable_info_t;
 
-    auto* device = &input_values_tensor.mutable_device();
-
-    // The bitonic top-k LLK carries sort indices through the dest register, and the index
-    // load/store width is tied to fp32_dest_acc_en (INT32 when enabled, LO16 otherwise). WH/BH
-    // support the cheaper 16-bit (UInt16) path with fp32 dest accumulation disabled (unchanged
-    // behaviour) so that WH/BH does not suffer any restrictions on the dest register. Every other
-    // architecture (e.g. Quasar, which additionally lacks UInt16/UInt32 tile (DFB) metadata
-    // support) uses 32-bit (Int32) index intermediates with fp32 dest accumulation enabled. This
-    // is gated on !(WH || BH) so new architectures default to the safe 32-bit path.
-    const bool use_32bit_index = !(device->arch() == tt::ARCH::WORMHOLE_B0 || device->arch() == tt::ARCH::BLACKHOLE);
-
-    tt::DataFormat input_values_cb_data_format =
-        tt::tt_metal::datatype_to_dataformat_converter(input_values_tensor.dtype());
-    tt::DataFormat input_indices_cb_data_format =
-        tt::tt_metal::datatype_to_dataformat_converter(input_indices_tensor.dtype());
-    tt::DataFormat index_cb_data_format = use_32bit_index ? tt::DataFormat::Int32 : tt::DataFormat::UInt16;
-    // On the 32-bit path (e.g. Quasar), validation already requires k to be INT32 (UInt32 DFB
-    // metadata is unsupported there), so the dtype-derived format is correct as-is.
-    tt::DataFormat k_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(k.dtype());
-    tt::DataFormat p_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(p.dtype());
-    tt::DataFormat temp_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(temp.dtype());
-
-    uint32_t input_values_tile_size = tile_size(input_values_cb_data_format);
-    uint32_t index_tile_size = tile_size(index_cb_data_format);
-
-    const auto& output_mesh = output_tensor.mesh_tensor();
-
-    auto input_shape = input_values_tensor.logical_shape();
-    const uint32_t tile_height = input_values_tensor.tensor_spec().tile().get_height();
-    const uint32_t tile_width = input_values_tensor.tensor_spec().tile().get_width();
-    uint32_t Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / tile_height;
-    uint32_t Wt = input_shape[3] / tile_width;
-    auto num_cores = Ht * tile_height;
-
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    CoreRangeSet core_grid = tt::tt_metal::num_cores_to_corerangeset(num_cores, compute_with_storage_grid_size, true);
-
-    if (sub_core_grids.has_value()) {
-        core_grid = sub_core_grids.value();
+// Bytes per element of a dtype — mirrors Tensor::element_size() so derive_from_info can reconstruct the
+// row/stick sizes from the TensorSpec alone (no live Tensor).
+uint32_t element_size_of(DataType dt) {
+    switch (dt) {
+        case DataType::BFLOAT16: return sizeof(uint16_t);
+        case DataType::FLOAT32: return sizeof(float);
+        case DataType::INT32: return sizeof(int32_t);
+        case DataType::UINT32: return sizeof(uint32_t);
+        case DataType::UINT16: return sizeof(uint16_t);
+        case DataType::UINT8: return sizeof(uint8_t);
+        default: TT_THROW("sampling: unsupported data type for element size");
     }
-    auto cores = corerange_to_cores(core_grid, num_cores, true);
+}
 
-    validate_reduce_op_program_grid(
-        "Sampling",
-        core_grid,
-        compute_with_storage_grid_size,
-        sub_core_grids.has_value() ? &sub_core_grids.value() : nullptr,
-        true,
-        {});
+// Everything the ProgramSpec + run-args derive from. A pure function of the input/output tensor layouts
+// + the (optional sub-)grid — i.e. the immutable structure. The only per-dispatch variation is the seed
+// and the tensor addresses; neither appears here.
+struct SamplingDerived {
+    tt::DataFormat input_values_df;
+    tt::DataFormat input_indices_df;
+    tt::DataFormat index_df;  // UInt16
+    tt::DataFormat k_df;
+    tt::DataFormat p_df;
+    tt::DataFormat temp_df;
+    tt::DataFormat scalar_df;
 
-    if (seed.has_value()) {
-        random_seed = seed.value();
+    uint32_t input_values_tile_size = 0;
+    uint32_t index_tile_size = 0;
+    uint32_t scalar_tile_size = 0;
+    uint32_t rand_tile_size = 0;
+
+    uint32_t Ht = 0;
+    uint32_t Wt = 0;
+    uint32_t logWt = 0;
+    uint32_t tile_height = 0;
+    uint32_t tile_width = 0;
+    uint32_t num_cores = 0;
+
+    uint32_t aligned_final_indices_rm_unit_size = 0;
+    uint32_t aligned_out0_unit_size = 0;
+    uint32_t k_chunk_size = 0;
+    uint32_t p_chunk_size = 0;
+    uint32_t temp_chunk_size = 0;
+
+    CoreRangeSet core_grid;
+    std::vector<CoreCoord> cores;
+};
+
+// Reconstruct the full structural derivation from the ImmutableInfo alone — the six tensor specs + the
+// grid + the optional sub-core grid. No live Tensor, no addresses, no seed.
+SamplingDerived derive_from_info(const immutable_info_t& info) {
+    SamplingDerived derived;
+    derived.input_values_df = datatype_to_dataformat_converter(info.input_values_spec.data_type());
+    derived.input_indices_df = datatype_to_dataformat_converter(info.input_indices_spec.data_type());
+    derived.index_df = tt::DataFormat::UInt16;
+    derived.k_df = datatype_to_dataformat_converter(info.k_spec.data_type());
+    derived.p_df = datatype_to_dataformat_converter(info.p_spec.data_type());
+    derived.temp_df = datatype_to_dataformat_converter(info.temp_spec.data_type());
+    derived.scalar_df =
+        (info.input_values_spec.data_type() == DataType::FLOAT32) ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
+
+    derived.input_values_tile_size = tile_size(derived.input_values_df);
+    derived.index_tile_size = tile_size(derived.index_df);
+    derived.scalar_tile_size = tile_size(derived.scalar_df);
+    derived.rand_tile_size = tile_size(tt::DataFormat::Float16_b);
+
+    const auto input_shape = info.input_values_spec.logical_shape();
+    derived.tile_height = info.input_values_spec.tile().get_height();
+    derived.tile_width = info.input_values_spec.tile().get_width();
+    derived.Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / derived.tile_height;
+    derived.Wt = input_shape[3] / derived.tile_width;
+    derived.logWt = static_cast<uint32_t>(std::log2(derived.Wt));
+    derived.num_cores = derived.Ht * derived.tile_height;
+
+    derived.core_grid = tt::tt_metal::num_cores_to_corerangeset(derived.num_cores, info.grid, true);
+    if (info.sub_core_grids.has_value()) {
+        derived.core_grid = info.sub_core_grids.value();
     }
+    derived.cores = corerange_to_cores(derived.core_grid, derived.num_cores, true);
 
-    // for streaming in input
-    uint32_t num_cb_unit = 2;
-    uint32_t cb_in_units = 2 * num_cb_unit;
+    derived.aligned_final_indices_rm_unit_size =
+        derived.Wt * derived.tile_width * element_size_of(info.input_indices_spec.data_type());
+    derived.aligned_out0_unit_size = derived.Ht * derived.tile_height * element_size_of(info.output_spec.data_type());
+    derived.k_chunk_size = derived.num_cores * 4;  // uint32
+    derived.p_chunk_size = derived.num_cores * 2;  // bf16
+    derived.temp_chunk_size = derived.num_cores * 2;
+    return derived;
+}
 
-    ProgramDescriptor desc;
+}  // namespace
 
-    // Two tiles are loaded in for sampling_local_sort at a time, and we double buffer to avoid stalls, so allocate four
-    // tiles of space
-    uint32_t input_values_cb_index = tt::CBIndex::c_0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_in_units * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(input_values_cb_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
+// extract_immutable_info — the cache key + sole input to create_program_artifacts. The structural
+// projection of the request (the six tensor specs + grid + sub-core grid). Deliberately EXCLUDES the
+// seed, so calls differing only in seed share a cache entry and the seed can never leak into the spec.
+SamplingProgramFactory::immutable_info_t SamplingProgramFactory::extract_immutable_info(
+    const SamplingParams& attrs, const SamplingInputs& tensor_args) {
+    // Output spec — mirrors SamplingDeviceOperation::compute_output_specs.
+    TensorSpec output_spec =
+        tensor_args.preallocated_output.has_value()
+            ? tensor_args.preallocated_output->tensor_spec()
+            : TensorSpec(
+                  ttnn::Shape({1, 1, 1, tensor_args.input_values.logical_shape()[2]}),
+                  TensorLayout(
+                      DataType::UINT32, PageConfig(Layout::ROW_MAJOR), tensor_args.input_values.memory_config()));
 
-    uint32_t index_cb_index = tt::CBIndex::c_2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_in_units * index_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(index_cb_index),
-            .data_format = index_cb_data_format,
-            .page_size = index_tile_size,
-        }}},
-    });
+    return immutable_info_t{
+        .input_values_spec = tensor_args.input_values.tensor_spec(),
+        .input_indices_spec = tensor_args.input_indices.tensor_spec(),
+        .k_spec = tensor_args.k.tensor_spec(),
+        .p_spec = tensor_args.p.tensor_spec(),
+        .temp_spec = tensor_args.temp.tensor_spec(),
+        .output_spec = std::move(output_spec),
+        .grid = tensor_args.input_values.device()->compute_with_storage_grid_size(),
+        .sub_core_grids = attrs.sub_core_grids,
+    };
+}
 
-    // Reduce scaler CBs — separate because MAX and SUM use different tile fill layouts
-    tt::DataFormat scalar_df =
-        (input_values_tensor.dtype() == DataType::FLOAT32) ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
-    uint32_t scale_tiles = 1;
-    uint32_t scalar_tile_size = tile_size(scalar_df);
+ttnn::device_operation::ProgramArtifacts SamplingProgramFactory::create_program_artifacts(
+    const immutable_info_t& info) {
+    const auto derived = derive_from_info(info);
 
-    uint32_t scaler_max_cb_index = tt::CBIndex::c_3;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = scale_tiles * scalar_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(scaler_max_cb_index),
-            .data_format = scalar_df,
-            .page_size = scalar_tile_size,
-        }}},
-    });
+    constexpr uint32_t num_cb_unit = 2;
+    constexpr uint32_t cb_in_units = 2 * num_cb_unit;
 
-    uint32_t scaler_sum_cb_index = tt::CBIndex::c_17;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = scale_tiles * scalar_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(scaler_sum_cb_index),
-            .data_format = scalar_df,
-            .page_size = scalar_tile_size,
-        }}},
-    });
+    // ---- 18 DFBs (formerly CBs c_0..c_17). entry_size = page_size, num_entries = total/page. ----
+    auto dfb = [](const char* id, uint32_t entry, uint32_t n, tt::DataFormat f) {
+        return m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{id}, .entry_size = entry, .num_entries = n, .data_format_metadata = f};
+    };
+    std::vector<m2::DataflowBufferSpec> dfbs = {
+        dfb("input_values", derived.input_values_tile_size, cb_in_units, derived.input_values_df),
+        dfb("index", derived.index_tile_size, cb_in_units, derived.index_df),
+        dfb("scaler_max", derived.scalar_tile_size, 1, derived.scalar_df),
+        dfb("scaler_sum", derived.scalar_tile_size, 1, derived.scalar_df),
+        dfb("topk_mask", derived.input_values_tile_size, cb_in_units, derived.input_values_df),
+        dfb("input_transposed", derived.input_values_tile_size, derived.Wt, derived.input_values_df),
+        dfb("index_transposed", derived.index_tile_size, derived.Wt, derived.index_df),
+        dfb("values", derived.input_values_tile_size, num_cb_unit, derived.input_values_df),
+        dfb("local_vals", derived.input_values_tile_size, num_cb_unit, derived.input_values_df),
+        dfb("output_ind", derived.index_tile_size, num_cb_unit, derived.index_df),
+        dfb("cur_max", derived.input_values_tile_size, derived.Ht, derived.input_values_df),
+        dfb("cur_sum", derived.input_values_tile_size, derived.Ht, derived.input_values_df),
+        dfb("rand_tile", derived.rand_tile_size, 1, tt::DataFormat::Float16_b),
+        dfb("final_indices",
+            derived.aligned_final_indices_rm_unit_size,
+            derived.Ht * derived.tile_height,
+            derived.input_indices_df),
+        dfb("output", derived.aligned_out0_unit_size, 1, derived.index_df),
+        dfb("k", derived.k_chunk_size, 1, derived.k_df),
+        dfb("p", derived.p_chunk_size, 1, derived.p_df),
+        dfb("temp", derived.temp_chunk_size, 1, derived.temp_df),
+    };
 
-    uint32_t topk_mask_cb_index = tt::CBIndex::c_4;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_in_units * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(topk_mask_cb_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
+    // ---- kernels ----
+    auto P = [](const char* dfb_id) { return m2::ProducerOf(m2::DFBSpecName{dfb_id}, dfb_id); };
+    auto C = [](const char* dfb_id) { return m2::ConsumerOf(m2::DFBSpecName{dfb_id}, dfb_id); };
+    auto TB = [](const char* name) {
+        return m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{name}, .accessor_name = name};
+    };
 
-    // Compute kernel CBs
-    // Single buffered circular buffer that holds the transposed input tiles
-    uint32_t input_transposed_cb_index = tt::CBIndex::c_5;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = Wt * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(input_transposed_cb_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{READER_KERNEL_PATH},
+        .dfb_bindings = {P("input_values"), P("index"), P("final_indices")},
+        .tensor_bindings = {TB("input_values"), TB("input_indices")},
+        .compile_time_args =
+            {{"Ht", derived.Ht},
+             {"Wt", derived.Wt},
+             {"final_indices_stick_size", derived.aligned_final_indices_rm_unit_size},
+             {"tile_height", derived.tile_height}},
+        // Reader on NCRISC (RISCV_1 / NOC1), writer on BRISC — mirrors the legacy Reader/Writer configs
+        // so the two data-movement kernels don't collide on the same DM processor.
+        .hw_config =
+            m2::DataMovementHardwareConfig{
+                .gen1_config =
+                    m2::DataMovementHardwareConfig::Gen1Config{
+                        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
+                        .noc = tt::tt_metal::NOC::RISCV_1_default}},
+    };
 
-    // Single buffered circular buffer that holds the transposed index tiles
-    uint32_t index_transposed_cb_index = tt::CBIndex::c_6;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = Wt * index_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(index_transposed_cb_index),
-            .data_format = index_cb_data_format,
-            .page_size = index_tile_size,
-        }}},
-    });
+    m2::KernelSpec compute{
+        .unique_id = m2::KernelSpecName{"compute"},
+        .source = std::filesystem::path{COMPUTE_KERNEL_PATH},
+        .dfb_bindings =
+            {C("input_values"),
+             C("index"),
+             P("input_transposed"),
+             C("input_transposed"),
+             P("index_transposed"),
+             C("index_transposed"),
+             P("values"),
+             C("values"),
+             P("output_ind"),
+             C("topk_mask"),
+             C("scaler_max"),
+             C("scaler_sum"),
+             P("cur_max"),
+             C("cur_max"),
+             P("cur_sum"),
+             C("cur_sum"),
+             P("rand_tile"),
+             P("local_vals"),
+             C("temp")},
+        .compile_time_args =
+            {{"Ht", derived.Ht}, {"Wt", derived.Wt}, {"logWt", derived.logWt}, {"tile_width", derived.tile_width}},
+        .runtime_arg_schema = {.runtime_arg_names = {"seed"}},
+        .hw_config = m2::ComputeHardwareConfig{},
+    };
 
-    // Output sampling values
-    uint32_t values_cb_index = tt::CBIndex::c_7;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_cb_unit * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(values_cb_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{WRITER_KERNEL_PATH},
+        .dfb_bindings =
+            {P("output"),
+             C("output"),
+             P("topk_mask"),
+             P("scaler_max"),
+             P("scaler_sum"),
+             C("final_indices"),
+             C("local_vals"),
+             C("output_ind"),
+             C("rand_tile"),
+             P("k"),
+             C("k"),
+             P("p"),
+             C("p"),
+             P("temp")},
+        .tensor_bindings = {TB("output"), TB("temp"), TB("k"), TB("p")},
+        .compile_time_args =
+            {{"final_indices_stick_size", derived.aligned_final_indices_rm_unit_size},
+             {"ids_per_batch", derived.tile_width},
+             {"num_cores", derived.num_cores}},
+        // core_id is a per-core RUNTIME arg, declared enqueue-invariant (it's a function of the grid,
+        // identical for every dispatch that shares this cache entry).
+        .runtime_arg_schema = {.runtime_arg_names = {"core_id"}},
+        .hw_config = m2::DataMovementHardwareConfig{.gen1_config = m2::DataMovementHardwareConfig::Gen1Config{}},
+        .advanced_options = m2::KernelAdvancedOptions{.enqueue_invariant_runtime_args = {"core_id"}},
+    };
 
-    uint32_t cb_local_vals_index = tt::CBIndex::c_1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_cb_unit * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(cb_local_vals_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
+    m2::ProgramSpec spec;
+    spec.name = "sampling";
+    spec.kernels = {std::move(reader), std::move(writer), std::move(compute)};
+    spec.dataflow_buffers = std::move(dfbs);
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input_values"}, .spec = info.input_values_spec},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input_indices"}, .spec = info.input_indices_spec},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = info.output_spec},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"temp"}, .spec = info.temp_spec},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"k"}, .spec = info.k_spec},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"p"}, .spec = info.p_spec}};
+    spec.work_units = {m2::WorkUnitSpec{
+        .name = "sampling",
+        .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}, m2::KernelSpecName{"compute"}},
+        .target_nodes = derived.core_grid}};
 
-    // Output local indices
-    uint32_t output_ind_cb_index = tt::CBIndex::c_8;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_cb_unit * index_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_ind_cb_index),
-            .data_format = index_cb_data_format,
-            .page_size = index_tile_size,
-        }}},
-    });
-
-    uint32_t num_out_tiles = Ht;
-    uint32_t cb_cur_max_index = tt::CBIndex::c_9;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_out_tiles * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(cb_cur_max_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
-
-    uint32_t cb_cur_sum_index = tt::CBIndex::c_10;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_out_tiles * input_values_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(cb_cur_sum_index),
-            .data_format = input_values_cb_data_format,
-            .page_size = input_values_tile_size,
-        }}},
-    });
-
-    // RM CBs for sampling
-
-    // random number
-    const uint32_t rand_tile_size = tile_size(tt::DataFormat::Float16_b);
-    constexpr uint32_t rand_tile_index = tt::CBIndex::c_11;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = rand_tile_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(rand_tile_index),
-            .data_format = tt::DataFormat::Float16_b,
-            .page_size = rand_tile_size,
-        }}},
-    });
-
-    // final indices
-    uint32_t final_indices_rm_unit_size = input_indices_tensor.element_size();  // 4 for int32
-    uint32_t aligned_final_indices_rm_unit_size = Wt * tile_width * final_indices_rm_unit_size;
-    uint32_t final_indices_rm_cb_index = tt::CBIndex::c_12;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = Ht * tile_height * aligned_final_indices_rm_unit_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(final_indices_rm_cb_index),
-            .data_format = input_indices_cb_data_format,
-            .page_size = aligned_final_indices_rm_unit_size,
-        }}},
-    });
-
-    // Output sampling indices
-    uint32_t output_unit_size = output_mesh.element_size();
-    uint32_t aligned_out0_unit_size = Ht * tile_height * output_unit_size;
-    uint32_t output_cb_index = tt::CBIndex::c_13;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = aligned_out0_unit_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = index_cb_data_format,
-            .page_size = aligned_out0_unit_size,
-        }}},
-    });
-
-    // Add k and p circular buffers
-    const uint32_t uint32_bytes = 4;
-    const uint32_t bf16_bytes = 2;
-    uint32_t k_cb_index = tt::CBIndex::c_14;
-    // Increase buffer size to accommodate all cores to avoid unaligned NOC reads
-    uint32_t k_chunk_size = num_cores * uint32_bytes;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = k_chunk_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(k_cb_index),
-            .data_format = k_cb_data_format,
-            .page_size = k_chunk_size,
-        }}},
-    });
-
-    uint32_t p_cb_index = tt::CBIndex::c_15;
-    // Increase buffer size to accommodate all cores to avoid unaligned NOC reads
-    uint32_t p_chunk_size = num_cores * bf16_bytes;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = p_chunk_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(p_cb_index),
-            .data_format = p_cb_data_format,
-            .page_size = p_chunk_size,
-        }}},
-    });
-
-    // Add temp circular buffer
-    uint32_t temp_cb_index = tt::CBIndex::c_16;
-    // Increase buffer size to accommodate all cores to avoid unaligned NOC reads
-    uint32_t temp_chunk_size = num_cores * bf16_bytes;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = temp_chunk_size,
-        .core_ranges = core_grid,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(temp_cb_index),
-            .data_format = temp_cb_data_format,
-            .page_size = temp_chunk_size,
-        }}},
-    });
-
-    std::vector<uint32_t> reader_compile_time_args = {
-        input_values_cb_index,
-        final_indices_rm_cb_index,
-        index_cb_index,
-        Ht,
-        Wt,
-        aligned_final_indices_rm_unit_size,
-        tile_height,
-        static_cast<uint32_t>(use_32bit_index)};
-    tt::tt_metal::TensorAccessorArgs(input_values_tensor).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(input_indices_tensor).append_to(reader_compile_time_args);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = core_grid;
-    reader_desc.compile_time_args = reader_compile_time_args;
-    reader_desc.config = ReaderConfigDescriptor{};
-    // The reader kernel is created once on the entire core_grid; set the same runtime args on every core
-    for (const auto& core : cores) {
-        reader_desc.emplace_runtime_args(
-            core,
-            {
-                input_values_tensor,
-                input_indices_tensor,
-            });
+    // Enqueue-invariant run-args: the per-core core_id (user index). Set once on cache miss, retained.
+    m2::ProgramRunArgs::KernelRunArgs writer_args{.kernel = m2::KernelSpecName{"writer"}};
+    for (uint32_t i = 0; i < derived.cores.size(); ++i) {
+        writer_args.runtime_arg_values.push_back({derived.cores[i], {{"core_id", i}}});
     }
-    desc.kernels.push_back(std::move(reader_desc));
+    // The reader has no named runtime args, but it binds tensor parameters (input_values / input_indices)
+    // whose base addresses the framework fills from the run-args — so it still needs a (named-arg-empty)
+    // KernelRunArgs entry to be registered.
+    m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
+    m2::ProgramRunArgs invariant_args;
+    invariant_args.kernel_run_args.push_back(std::move(writer_args));
+    invariant_args.kernel_run_args.push_back(std::move(reader_args));
 
-    for (uint32_t i = 0; i < cores.size(); ++i) {
-        const auto& core = cores[i];
-        CoreRangeSet single_core{CoreRange(core, core)};
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(invariant_args)};
+}
 
-        std::vector<uint32_t> writer_compile_time_args;
-        tt::tt_metal::TensorAccessorArgs(output_mesh).append_to(writer_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(temp).append_to(writer_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(k).append_to(writer_compile_time_args);
-        tt::tt_metal::TensorAccessorArgs(p).append_to(writer_compile_time_args);
-        writer_compile_time_args.insert(
-            writer_compile_time_args.end(),
-            {
-                output_cb_index,
-                topk_mask_cb_index,
-                scaler_max_cb_index,
-                scaler_sum_cb_index,
-                final_indices_rm_cb_index,
-                cb_local_vals_index,
-                output_ind_cb_index,
-                aligned_final_indices_rm_unit_size,
-                aligned_out0_unit_size,
-                rand_tile_index,
-                k_cb_index,
-                p_cb_index,
-                temp_cb_index,
-                i,
-                tile_width,
-                num_cores,
-                static_cast<uint32_t>(use_32bit_index),
-            });
+m2::ProgramRunArgs SamplingProgramFactory::create_per_enqueue_args(
+    const SamplingParams& attrs,
+    const SamplingInputs& tensor_args,
+    Tensor& output_tensor,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    const auto derived = derive_from_info(extract_immutable_info(attrs, tensor_args));
+    const uint32_t seed = attrs.seed.has_value() ? attrs.seed.value() : 0;
 
-        KernelDescriptor writer_desc;
-        writer_desc.kernel_source =
-            "ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp";
-        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        writer_desc.core_ranges = single_core;
-        writer_desc.compile_time_args = writer_compile_time_args;
-        writer_desc.config = WriterConfigDescriptor{};
-        writer_desc.emplace_runtime_args(core, {output_mesh, temp, k, p});
-        desc.kernels.push_back(std::move(writer_desc));
-
-        std::vector<uint32_t> compute_args = {
-            input_values_cb_index,
-            index_cb_index,
-            input_transposed_cb_index,
-            index_transposed_cb_index,
-            values_cb_index,
-            output_ind_cb_index,
-            topk_mask_cb_index,
-            scaler_max_cb_index,
-            scaler_sum_cb_index,
-            cb_cur_max_index,
-            cb_cur_sum_index,
-            Ht,
-            Wt,
-            static_cast<uint32_t>(std::log2(Wt)),
-            rand_tile_index,
-            random_seed,
-            cb_local_vals_index,
-            temp_cb_index,
-            tile_width};
-
-        KernelDescriptor compute_desc;
-        compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/compute/sampling.cpp";
-        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_desc.core_ranges = single_core;
-        compute_desc.compile_time_args = compute_args;
-        // 32-bit (Int32) sort indices require fp32 dest accumulation so the top-k LLK loads/stores
-        // indices in INT32 mode; the 16-bit (UInt16) path uses LO16 mode with fp32 dest acc off.
-        compute_desc.config = ComputeConfigDescriptor{
-            .fp32_dest_acc_en = use_32bit_index,
-        };
-        desc.kernels.push_back(std::move(compute_desc));
+    // Per-core seed (every core runs the same kernel; the seed is broadcast identically here — the
+    // kernel recovers per-core distinctness internally, matching the legacy behavior).
+    m2::ProgramRunArgs::KernelRunArgs compute_args{.kernel = m2::KernelSpecName{"compute"}};
+    for (const auto& core : derived.cores) {
+        compute_args.runtime_arg_values.push_back({core, {{"seed", seed}}});
     }
 
-    return desc;
+    m2::ProgramRunArgs args;
+    args.kernel_run_args.push_back(std::move(compute_args));
+    args.tensor_args.emplace(
+        m2::TensorParamName{"input_values"},
+        m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.input_values.mesh_tensor())});
+    args.tensor_args.emplace(
+        m2::TensorParamName{"input_indices"},
+        m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.input_indices.mesh_tensor())});
+    args.tensor_args.emplace(
+        m2::TensorParamName{"output"}, m2::ProgramRunArgs::TensorArgument{std::cref(output_tensor.mesh_tensor())});
+    args.tensor_args.emplace(
+        m2::TensorParamName{"temp"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.temp.mesh_tensor())});
+    args.tensor_args.emplace(
+        m2::TensorParamName{"k"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.k.mesh_tensor())});
+    args.tensor_args.emplace(
+        m2::TensorParamName{"p"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.p.mesh_tensor())});
+    return args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.hpp
@@ -4,15 +4,66 @@
 
 #pragma once
 
+#include <optional>
+#include <tuple>
+
+#include <tt-metalium/core_coord.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "ttnn/operations/reduction/sampling/device/sampling_device_operation_types.hpp"
-#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
+// Metal 2.0 sampling factory — AdvancedProgramSpecFactoryConcept with the per-enqueue split (Option 3++).
+//
+// The legacy sampling op baked the RNG seed as a COMPILE-TIME arg, so it lived in the program and every
+// distinct seed forced a recompile (≈1 s/call on the realistic per-token decode path). This port moves
+// the seed to a per-enqueue RUNTIME arg AND keys the cache on a structural ImmutableInfo that doesn't
+// contain the seed at all — so two calls differing only in seed map to the same cache entry, and a
+// mutable value cannot leak into the key or the spec because the builder never sees anything but the
+// ImmutableInfo. (No custom hash function — the ImmutableInfo struct IS the key.)
+//
+//   - extract_immutable_info → the cache key AND the sole input to create_program_artifacts: the
+//     structural projection of the request (the six tensor specs + the compute grid + sub-core grid).
+//   - create_program_artifacts → the immutable ProgramSpec (18 DFBs, 3 kernels, named-arg schemas, the
+//     6 tensor parameters) PLUS the ENQUEUE-INVARIANT run-args: the per-core core_id (a function of the
+//     grid, fixed for a cache entry; declared enqueue-invariant in the spec).
+//   - create_per_enqueue_args → the PER-ENQUEUE run-args: the per-core RNG seed + the 6 tensor addresses,
+//     re-applied on every dispatch via UpdateProgramRunArgs.
 struct SamplingProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
-        const SamplingParams& operation_attributes, const SamplingInputs& tensor_args, Tensor& output_tensor);
+    struct immutable_info_t {
+        tt::tt_metal::TensorSpec input_values_spec;
+        tt::tt_metal::TensorSpec input_indices_spec;
+        tt::tt_metal::TensorSpec k_spec;
+        tt::tt_metal::TensorSpec p_spec;
+        tt::tt_metal::TensorSpec temp_spec;
+        tt::tt_metal::TensorSpec output_spec;
+        CoreCoord grid;
+        std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids;
+
+        static constexpr auto attribute_names = std::forward_as_tuple(
+            "input_values_spec",
+            "input_indices_spec",
+            "k_spec",
+            "p_spec",
+            "temp_spec",
+            "output_spec",
+            "grid",
+            "sub_core_grids");
+        auto attribute_values() const {
+            return std::forward_as_tuple(
+                input_values_spec, input_indices_spec, k_spec, p_spec, temp_spec, output_spec, grid, sub_core_grids);
+        }
+    };
+
+    static immutable_info_t extract_immutable_info(
+        const SamplingParams& operation_attributes, const SamplingInputs& tensor_args);
+    static ttnn::device_operation::ProgramArtifacts create_program_artifacts(const immutable_info_t& info);
+    static tt::tt_metal::experimental::ProgramRunArgs create_per_enqueue_args(
+        const SamplingParams& operation_attributes,
+        const SamplingInputs& tensor_args,
+        Tensor& output_tensor,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.hpp
@@ -40,6 +40,9 @@ struct SamplingProgramFactory {
         tt::tt_metal::TensorSpec output_spec;
         CoreCoord grid;
         std::optional<tt::tt_metal::CoreRangeSet> sub_core_grids;
+        // Architecture is structural: it selects the index intermediate width (Int32 on Quasar,
+        // UInt16 on WH/BH) and the compute kernel's fp32_dest_acc_en, so it belongs in the key.
+        tt::ARCH arch = tt::ARCH::Invalid;
 
         static constexpr auto attribute_names = std::forward_as_tuple(
             "input_values_spec",
@@ -49,10 +52,19 @@ struct SamplingProgramFactory {
             "temp_spec",
             "output_spec",
             "grid",
-            "sub_core_grids");
+            "sub_core_grids",
+            "arch");
         auto attribute_values() const {
             return std::forward_as_tuple(
-                input_values_spec, input_indices_spec, k_spec, p_spec, temp_spec, output_spec, grid, sub_core_grids);
+                input_values_spec,
+                input_indices_spec,
+                k_spec,
+                p_spec,
+                temp_spec,
+                output_spec,
+                grid,
+                sub_core_grids,
+                arch);
         }
     };
 


### PR DESCRIPTION
## What

Give TTNN's Metal 2.0 op infrastructure the **four explicit ProgramSpec factory concepts** — a progressive ladder a dev climbs only as far as performance forces — built on Audrey's partial-run-args API (#46568). Migrate `rand` to the top rung as the study case.

> **Base:** targets `akertesz/partial-run-args-update` (not `main`); the diff is only the TTNN-side work.

## The ladder (method surface = the documentation)

| concept | cache key | run-args | when |
|---|---|---|---|
| `ProgramSpecFactoryConcept` | spec | `create_program_spec → {spec, run_args}` | **default — migrate here first** |
| `AdvancedProgramSpecFactoryConcept` | spec | `create_program_spec` + `create_static_args` + `create_dynamic_args` | cache-hit cost hurts |
| `ImmutableProgramSpecFactoryConcept` | ImmutableInfo | `extract_immutable_info` + `create_program_spec(info) → {spec, run_args}` | still hurts |
| `AdvancedImmutableProgramSpecFactoryConcept` | ImmutableInfo | `extract_immutable_info` + `create_program_spec(info)` + `create_static_args` + `create_dynamic_args` | needs both |

You read the factory and you *know* what each thing is: `create_program_spec` = the immutable blueprint, `create_static_args` = values fixed for a cache entry, `create_dynamic_args` = values that vary per dispatch, `extract_immutable_info` = the cache key (and the *sole* input to the spec builders, so a mutable value like a seed structurally can't leak in).

Two orthogonal axes, detected by method surface (mutually exclusive by construction):
- `extract_immutable_info` present → **immutable-keyed** (option 3)
- `create_static_args` + `create_dynamic_args` present → **advanced** (static/dynamic split)

## Framework

One `ProgramSpecMeshWorkloadFactoryAdapter` branches on the traits:
- **miss**: `MergeProgramRunArgs(static, dynamic)` → `SetProgramRunArgs`.
- **advanced hit**: re-apply only the dynamic set via `UpdateProgramRunArgs` (the static/invariant set stays baked; the metal runtime validates every omitted arg was declared enqueue-invariant).
- **basic hit**: refresh tensors via `UpdateTensorArgs`.
- cache key routes through the factory's `extract_immutable_info` when present; dispatch routes all four via `Metal2SpecFactoryConcept`; device sourced from `tensor_args` **or** `tensor_return_value` (output-only ops).

## Study case: rand → `AdvancedImmutableProgramSpec`

`immutable_info = {output_spec, grid}` (no seed) → the key. Work split is **static**; seed/from/to + output are **dynamic**. Drops `select_program_factory` (single-variant is auto-selected) and the old `attribute_values` seed-exclusion (ImmutableInfo is the key now). Kernels on `dfb::`/`ta::`/`args::`.

rand is the canonical case: its seed is exactly the dynamic scalar the plain `UpdateTensorArgs`-only hit path leaves **stale** (identical "random" output — a silent wrong answer).

## Validation

`test_rand_different_seed_values` passes on hardware: **one** cache entry across seeds (seed excluded from the key) **and** different output per seed (dynamic re-applied on the cache hit). Full single-device `test_rand.py` green (44 passed).

## Open items

- Per-**device** seed offset on a sharded mesh: `create_dynamic_args` takes the mesh coordinate, so the advanced path supports it; covered for the single-program case here.
- Multi-program (mesh-workload) factory shapes are out of scope for this PR (single-program ProgramSpec only).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metal2-enqueue-invariant-ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metal2-enqueue-invariant-ttnn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-enqueue-invariant-ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metal2-enqueue-invariant-ttnn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/metal2-enqueue-invariant-ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/metal2-enqueue-invariant-ttnn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metal2-enqueue-invariant-ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metal2-enqueue-invariant-ttnn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metal2-enqueue-invariant-ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metal2-enqueue-invariant-ttnn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metal2-enqueue-invariant-ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metal2-enqueue-invariant-ttnn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metal2-enqueue-invariant-ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metal2-enqueue-invariant-ttnn)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metal2-enqueue-invariant-ttnn)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metal2-enqueue-invariant-ttnn)