### PR TITLE
Bug fix: Fix issues with capturing perf counters

### DIFF
--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
@@ -55,7 +55,7 @@
 
 /////////////
 // Firmware/kernel code holes
-#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 256)
+#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 2560)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
 #define MEM_NCRISC_FIRMWARE_SIZE 2048
 #define MEM_TRISC0_FIRMWARE_SIZE 1536

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
@@ -55,7 +55,7 @@
 
 /////////////
 // Firmware/kernel code holes
-#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 1552)
+#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 1568)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
 #define MEM_NCRISC_FIRMWARE_SIZE 2048
 #define MEM_TRISC0_FIRMWARE_SIZE 1536

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/dev_mem_map.h
@@ -55,7 +55,7 @@
 
 /////////////
 // Firmware/kernel code holes
-#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 2560)
+#define MEM_BRISC_FIRMWARE_SIZE (6 * 1024 + 1552)
 // TODO: perhaps put NCRISC FW in the scratch area and free 1.5K after init (GS/WH)
 #define MEM_NCRISC_FIRMWARE_SIZE 2048
 #define MEM_TRISC0_FIRMWARE_SIZE 1536

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1892,7 +1892,7 @@ void DeviceProfiler::readDeviceMarkerData(
         timer_id,
         timestamp,
         data,
-        std::vector<uint64_t>{},
+        tracy::TTDeviceMarker::INVALID_NUM,
         op_name,
         marker_details.source_line_num,
         marker_details.source_file,
@@ -2009,7 +2009,7 @@ void DeviceProfiler::readTsData16BMarkerData(
         timer_id,
         timestamp,
         data,
-        trailer_data,
+        trailer_data[0],
         op_name,
         marker_details.source_line_num,
         marker_details.source_file,
@@ -2195,7 +2195,7 @@ void DeviceProfiler::processDeviceMarkerData(std::set<tracy::TTDeviceMarker>& de
 
                 // If this is a performance counter, extract fields from data and store in marker meta_data
                 if (marker.marker_id == PERF_COUNTER_PROFILER_ID) {
-                    const PerfCounter perf_counter(marker.data, marker.trailer_data[0]);
+                    const PerfCounter perf_counter(marker.data, marker.data_high);
                     const uint32_t counter_type_raw = perf_counter.counter_type;
                     // Skip markers with out-of-range counter_type (stale/dropped data).
                     if (!enchantum::contains<PerfCounterType>(counter_type_raw)) {
@@ -2593,7 +2593,7 @@ void DeviceProfiler::pushTracyDeviceResults(
                 orig_marker.marker_id,
                 adjusted_timestamp,
                 orig_marker.data,
-                orig_marker.trailer_data,
+                orig_marker.data_high,
                 orig_marker.op_name,
                 orig_marker.line,
                 orig_marker.file,

--- a/tt_metal/impl/profiler/profiler.cpp
+++ b/tt_metal/impl/profiler/profiler.cpp
@@ -1892,6 +1892,7 @@ void DeviceProfiler::readDeviceMarkerData(
         timer_id,
         timestamp,
         data,
+        std::vector<uint64_t>{},
         op_name,
         marker_details.source_line_num,
         marker_details.source_file,
@@ -1945,34 +1946,53 @@ void DeviceProfiler::readTsData16BMarkerData(
     const std::vector<uint64_t>& trailer_data,
     uint32_t timer_id,
     uint64_t timestamp) {
-#if defined(TRACY_ENABLE)
     ZoneScoped;
 
-    using EMD = KernelProfilerNocEventMetadata;
-
     nlohmann::json meta_data;
+#if defined(TRACY_ENABLE)
+    if ((timer_id & 0xFFFF) == kernel_profiler::NOC_TRACING_STATIC_ID) {
+        using EMD = KernelProfilerNocEventMetadata;
 
-    EMD event_metadata(data);
-    auto event_contents = event_metadata.getContents();
+        EMD event_metadata(data);
+        auto event_contents = event_metadata.getContents();
 
-    // Local Noc Event is expected to have one trailer with dst_addr
-    if (!std::holds_alternative<EMD::LocalNocEvent>(event_contents)) {
-        TT_THROW("TS_DATA_16B marker contains unexpected event contents {:#X}", event_metadata.asU64());
+        // Local Noc Event is expected to have one trailer with dst_addr
+        if (!std::holds_alternative<EMD::LocalNocEvent>(event_contents)) {
+            TT_THROW("TS_DATA_16B marker contains unexpected event contents {:#X}", event_metadata.asU64());
+        }
+
+        const uint32_t total_data_size = trailer_data.size() + 1;
+        if (total_data_size != kernel_profiler::TimestampedDataSize<kernel_profiler::PacketTypes::TS_DATA_16B>::size) {
+            TT_THROW(
+                "TS_DATA_16B marker expected {} trailers, got {}",
+                kernel_profiler::TimestampedDataSize<kernel_profiler::PacketTypes::TS_DATA_16B>::size,
+                total_data_size);
+        }
+
+        EMD trailer_metadata(trailer_data[0]);
+        const auto& trailer = trailer_metadata.getLocalNocEventDstTrailer();
+        meta_data["dst_addr"] = trailer.getDstAddr();
+        meta_data["src_addr"] = trailer.getSrcAddr();
+        meta_data["noc_status_counter"] = static_cast<uint32_t>(trailer.counter_value);
+
+        auto& noc_debug_state = MetalContext::instance(context_id).noc_debug_state();
+        if (noc_debug_state) {
+            EMD::LocalNocEvent local_noc_event = std::get<EMD::LocalNocEvent>(event_contents);
+            const metal_SocDescriptor& soc_desc =
+                MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);
+            // disable linting here; slicing is __intended__
+            // NOLINTBEGIN
+            const CoreCoord virtual_core =
+                soc_desc.translate_coord_to(physical_core, CoordSystem::NOC0, CoordSystem::TRANSLATED);
+            // NOLINTEND
+            noc_debug_state->push_event(
+                device_id,
+                timestamp,
+                get_processor_id(risc_type),
+                make_noc_debug_event(virtual_core, local_noc_event, trailer_metadata.getLocalNocEventDstTrailer()));
+        }
     }
-
-    const uint32_t total_data_size = trailer_data.size() + 1;
-    if (total_data_size != kernel_profiler::TimestampedDataSize<kernel_profiler::PacketTypes::TS_DATA_16B>::size) {
-        TT_THROW(
-            "TS_DATA_16B marker expected {} trailers, got {}",
-            kernel_profiler::TimestampedDataSize<kernel_profiler::PacketTypes::TS_DATA_16B>::size,
-            total_data_size);
-    }
-
-    EMD trailer_metadata(trailer_data[0]);
-    const auto& trailer = trailer_metadata.getLocalNocEventDstTrailer();
-    meta_data["dst_addr"] = trailer.getDstAddr();
-    meta_data["src_addr"] = trailer.getSrcAddr();
-    meta_data["noc_status_counter"] = static_cast<uint32_t>(trailer.counter_value);
+#endif
 
     const tracy::MarkerDetails marker_details = getMarkerDetails(timer_id);
     const kernel_profiler::PacketTypes packet_type = get_packet_type(timer_id);
@@ -1989,6 +2009,7 @@ void DeviceProfiler::readTsData16BMarkerData(
         timer_id,
         timestamp,
         data,
+        trailer_data,
         op_name,
         marker_details.source_line_num,
         marker_details.source_file,
@@ -2001,26 +2022,9 @@ void DeviceProfiler::readTsData16BMarkerData(
         return;
     }
 
-    auto& noc_debug_state = MetalContext::instance(context_id).noc_debug_state();
-    if (noc_debug_state) {
-        EMD::LocalNocEvent local_noc_event = std::get<EMD::LocalNocEvent>(event_contents);
-        const metal_SocDescriptor& soc_desc = MetalContext::instance(context_id).get_cluster().get_soc_desc(device_id);
-        // disable linting here; slicing is __intended__
-        // NOLINTBEGIN
-        const CoreCoord virtual_core =
-            soc_desc.translate_coord_to(physical_core, CoordSystem::NOC0, CoordSystem::TRANSLATED);
-        // NOLINTEND
-        noc_debug_state->push_event(
-            device_id,
-            timestamp,
-            get_processor_id(risc_type),
-            make_noc_debug_event(virtual_core, local_noc_event, trailer_metadata.getLocalNocEventDstTrailer()));
-    }
-
     device_tracy_contexts.try_emplace({device_id, physical_core}, nullptr);
 
     updateFirstTimestamp(timestamp);
-#endif
 }
 
 struct DispatchMetaData {
@@ -2191,7 +2195,7 @@ void DeviceProfiler::processDeviceMarkerData(std::set<tracy::TTDeviceMarker>& de
 
                 // If this is a performance counter, extract fields from data and store in marker meta_data
                 if (marker.marker_id == PERF_COUNTER_PROFILER_ID) {
-                    const PerfCounter perf_counter(marker.data);
+                    const PerfCounter perf_counter(marker.data, marker.trailer_data[0]);
                     const uint32_t counter_type_raw = perf_counter.counter_type;
                     // Skip markers with out-of-range counter_type (stale/dropped data).
                     if (!enchantum::contains<PerfCounterType>(counter_type_raw)) {
@@ -2589,6 +2593,7 @@ void DeviceProfiler::pushTracyDeviceResults(
                 orig_marker.marker_id,
                 adjusted_timestamp,
                 orig_marker.data,
+                orig_marker.trailer_data,
                 orig_marker.op_name,
                 orig_marker.line,
                 orig_marker.file,

--- a/tt_metal/tools/profiler/kernel_profiler.hpp
+++ b/tt_metal/tools/profiler/kernel_profiler.hpp
@@ -210,6 +210,10 @@ inline __attribute__((always_inline)) void set_profiler_zone_valid(bool conditio
     profiler_control_buffer[PROFILER_DONE] = !condition;
 }
 
+inline __attribute__((always_inline)) bool get_profiler_zone_valid() {
+    return profiler_control_buffer[PROFILER_DONE] == 1;
+}
+
 inline __attribute__((always_inline)) void risc_finished_profiling() {
     for (int i = 0; i < SUM_COUNT; i++) {
         if (sums[i] > 0) {

--- a/tt_metal/tools/profiler/perf_counters.hpp
+++ b/tt_metal/tools/profiler/perf_counters.hpp
@@ -425,6 +425,9 @@ __attribute__((noinline)) void read_single_group(PerfCounterGroup counter_group)
         PerfCounter counter(counter_val, ref_cnt_val, counters[i].first);
         timeStampedData<PERF_COUNTER_PROFILER_ID>(counter.raw_data);
     }
+    // Toggle start bit to clear the counters for this group
+    cntl_reg[2] = 0;
+    cntl_reg[2] = PERF_CNT_START_VALUE;
 }
 
 void read_perf_counters() {

--- a/tt_metal/tools/profiler/perf_counters.hpp
+++ b/tt_metal/tools/profiler/perf_counters.hpp
@@ -209,18 +209,22 @@ static_assert(ANY_THREAD_STALL <= 255, "PerfCounterType enum exceeds 8-bit count
 union PerfCounter {
     struct {
         uint32_t counter_value;
-        uint32_t ref_cnt : 24;
+        uint32_t ref_cnt;
         uint32_t counter_type : 8;
+        uint32_t unused : 24;
     } __attribute__((packed));
-    uint64_t raw_data;
+    struct {
+        uint64_t raw_data_1;
+        uint64_t raw_data_2;
+    } __attribute__((packed));
 
     PerfCounter() = delete;
     PerfCounter(uint32_t counter_value, uint32_t ref_cnt, PerfCounterType counter_type) :
         counter_value(counter_value), ref_cnt(ref_cnt), counter_type(static_cast<uint32_t>(counter_type)) {}
 
-    PerfCounter(uint64_t raw_data) : raw_data(raw_data) {}
+    PerfCounter(uint64_t raw_data_1, uint64_t raw_data_2) : raw_data_1(raw_data_1), raw_data_2(raw_data_2) {}
 };
-static_assert(sizeof(PerfCounter) == sizeof(uint64_t), "PerfCounter must be 64-bit");
+static_assert(sizeof(PerfCounter) == sizeof(uint64_t) * 2, "PerfCounter must be 128-bit");
 
 // Perf counter start/stop runs on TRISC1 (wraps the compute kernel).
 // Counter readout and DRAM push runs on BRISC (has NOC access for DRAM writes).
@@ -423,7 +427,10 @@ __attribute__((noinline)) void read_single_group(PerfCounterGroup counter_group)
         uint32_t ref_cnt_val = read_reg[0];
         uint32_t counter_val = read_reg[1];
         PerfCounter counter(counter_val, ref_cnt_val, counters[i].first);
-        timeStampedData<PERF_COUNTER_PROFILER_ID>(counter.raw_data);
+        kernel_profiler::timeStampedData<
+            PERF_COUNTER_PROFILER_ID,
+            kernel_profiler::DoingDispatch::NOT_DISPATCH,
+            kernel_profiler::PacketTypes::TS_DATA_16B>(counter.raw_data_1, counter.raw_data_2);
     }
     // Toggle start bit to clear the counters for this group
     cntl_reg[2] = 0;

--- a/tt_metal/tools/profiler/perf_counters.hpp
+++ b/tt_metal/tools/profiler/perf_counters.hpp
@@ -427,9 +427,11 @@ __attribute__((noinline)) void read_single_group(PerfCounterGroup counter_group)
         uint32_t ref_cnt_val = read_reg[0];
         uint32_t counter_val = read_reg[1];
         PerfCounter counter(counter_val, ref_cnt_val, counters[i].first);
+        kernel_profiler::flush_to_dram_if_full<kernel_profiler::DoingDispatch::DISPATCH>(
+            kernel_profiler::PROFILER_L1_MARKER_UINT32_SIZE * 2);
         kernel_profiler::timeStampedData<
             PERF_COUNTER_PROFILER_ID,
-            kernel_profiler::DoingDispatch::NOT_DISPATCH,
+            kernel_profiler::DoingDispatch::DISPATCH,
             kernel_profiler::PacketTypes::TS_DATA_16B>(counter.raw_data_1, counter.raw_data_2);
     }
     // Toggle start bit to clear the counters for this group
@@ -438,6 +440,9 @@ __attribute__((noinline)) void read_single_group(PerfCounterGroup counter_group)
 }
 
 void read_perf_counters() {
+    if (kernel_profiler::get_profiler_zone_valid()) {
+        return;
+    }
 #if (PROFILE_PERF_COUNTERS) & PROFILE_PERF_COUNTERS_FPU
     read_single_group(PerfCounterGroup::FPU);
 #endif


### PR DESCRIPTION
### PR Category
Bug fix

### Summary

#### Fix 1: Toggle the start bit on perf counters after reading to clear the counters for next op

This is needed because the next op can be purely data movement and therefore not have any TRISC kernel which means the counters won't be recorded for that op and we would end up reading the counter values from the previous op if they aren't cleared.

This fixes incorrect utilization metrics seen in data movement ops.

#### Fix 2: Increase counter_value and ref_cnt fields in PerfCounter to 32 bits to support profiling larger kernels. 

Previously ref_cnt was 24 bits which would only give correct data for kernels that are shorter than 2^24 ~= 16 million cycles. However certain ops can take longer than that (e.g. SDPA in llama 8B with large seq len during prefill) so we should increase the size of ref_cnt to 32 bits (which is the size of the actual HW registers for these counters) to allow profiling longer kernels. However, this requires using larger packets in the profiler since the PerfCounter struct now requires at least 32 (ref_cnt) + 32 (counter_value) + 8 (counter_type) = 72 bits so we use the TS_DATA_16B packet type. We also add support for pushing to DRAM in ReadPerfCounters if the profiler l1 buffer is full (and bump BRISC FW size to accommodate this extra code).

### Notes for reviewers
None

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=snadeem/fix_perf_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:snadeem/fix_perf_counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=snadeem/fix_perf_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:snadeem/fix_perf_counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=snadeem/fix_perf_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:snadeem/fix_perf_counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=snadeem/fix_perf_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:snadeem/fix_perf_counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=snadeem/fix_perf_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:snadeem/fix_perf_counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=snadeem/fix_perf_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:snadeem/fix_perf_counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=snadeem/fix_perf_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:snadeem/fix_perf_counters)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=snadeem/fix_perf_counters)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:snadeem/fix_perf_counters)