### PR TITLE
tt-dit: fix Wan text embedder PCC regression from fused tanh-GELU

### DIFF
--- a/models/tt_dit/layers/embeddings.py
+++ b/models/tt_dit/layers/embeddings.py
@@ -574,9 +574,11 @@ class WanTimeTextImageEmbedding(Module):
             mesh_axis=tp_mesh_axis,
             ccl_manager=ccl_manager,
         )  # Output is fractured according to the older behaviour when sharding from torch. See _prepare_torch_state(...)
-        # NOTE: Reference cose uses gelu_tanh. We have gelu fused with matmul, and use this instead. Test indicates little to no difference in results.
+        # Reference uses gelu_tanh. The fused tanh-LUT GELU (act_fn="gelu_tanh") regresses the
+        # encoder_hidden_states PCC here (~99.92% vs the >99.99% gate), so use the higher-precision
+        # unfused decomposition. LTX/Gemma keep the fused LUT path for its NaN-safety.
         self.text_embedder = PixArtAlphaTextProjection(
-            text_embed_dim, dim, act_fn="gelu_tanh", mesh_device=self.mesh_device
+            text_embed_dim, dim, act_fn="gelu_tanh_decomposed", mesh_device=self.mesh_device
         )
 
     def forward_timestep(self, timestep: ttnn.Tensor, timestep_seq_len: int | None = None) -> ttnn.Tensor:

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -93,6 +93,21 @@ def gelu_decomposed(x: ttnn.Tensor) -> ttnn.Tensor:
     return ttnn.multiply(x_times_bracket, 0.5)
 
 
+def gelu_tanh_decomposed(x: ttnn.Tensor) -> ttnn.Tensor:
+    # GELU tanh approximation: 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))
+    #
+    # This unfused decomposition is higher precision than the fused tanh-LUT GELU
+    # (ttnn.UnaryOpType.GELU, True) and recovers PCC on the Wan text embedder, which
+    # regressed when the fused LUT path was introduced. The cube is computed as
+    # x * x * x (not ttnn.pow(x, 3)): pow uses exp(3 * log(x)) internally and returns
+    # NaN for negative inputs, the very failure mode the fused LUT path was added to avoid.
+    sqrt_2_over_pi = math.sqrt(2.0 / math.pi)
+    x_cubed = ttnn.multiply(ttnn.multiply(x, x), x)
+    inner = ttnn.add(x, ttnn.multiply(x_cubed, 0.044715))
+    one_plus_tanh = ttnn.add(ttnn.tanh(ttnn.multiply(inner, sqrt_2_over_pi)), 1.0)
+    return ttnn.multiply(ttnn.multiply(x, one_plus_tanh), 0.5)
+
+
 class ColParallelLinear(Module):
     """
     Linear layer with column parallel weights
@@ -449,6 +464,8 @@ def _apply_activation_fn(t: ttnn.Tensor, activation_fn: str | None) -> ttnn.Tens
         return ttnn.silu(t)
     if activation_fn == "decomposed_gelu":
         return gelu_decomposed(t)
+    if activation_fn == "gelu_tanh_decomposed":
+        return gelu_tanh_decomposed(t)
     if activation_fn == "quick_gelu":
         return t * ttnn.sigmoid(1.702 * t)  # quick approx gelu
     if activation_fn == "swiglu":

--- a/models/tt_dit/layers/linear.py
+++ b/models/tt_dit/layers/linear.py
@@ -99,8 +99,8 @@ def gelu_tanh_decomposed(x: ttnn.Tensor) -> ttnn.Tensor:
     # This unfused decomposition is higher precision than the fused tanh-LUT GELU
     # (ttnn.UnaryOpType.GELU, True) and recovers PCC on the Wan text embedder, which
     # regressed when the fused LUT path was introduced. The cube is computed as
-    # x * x * x (not ttnn.pow(x, 3)): pow uses exp(3 * log(x)) internally and returns
-    # NaN for negative inputs, the very failure mode the fused LUT path was added to avoid.
+    # x * x * x (instead of ttnn.pow(x, 3)) to keep the decomposition explicit and
+    # avoid relying on ttnn.pow implementation details.
     sqrt_2_over_pi = math.sqrt(2.0 / math.pi)
     x_cubed = ttnn.multiply(ttnn.multiply(x, x), x)
     inner = ttnn.add(x, ttnn.multiply(x_cubed, 0.044715))


### PR DESCRIPTION
## Summary

`test_wan_time_text_image_embedding` regressed to `PCC = 99.9203% >= 99.9900%` after the LTX-2.3 change made `act_fn="gelu_tanh"` fuse to the approximate tanh-LUT GELU `(ttnn.UnaryOpType.GELU, True)` in `Linear`/`ColParallelLinear`.

Wan's `WanTimeTextImageEmbedding.text_embedder` (`PixArtAlphaTextProjection`) used `gelu_tanh`, so it inherited the LUT approximation and the `encoder_hidden_states` PCC dropped below the `>99.99%` gate.

This PR:
- Adds a higher-precision **unfused** `gelu_tanh_decomposed` activation in `models/tt_dit/layers/linear.py`. It implements `0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 * x^3)))` and computes the cube as `x * x * x` (instead of `ttnn.pow(x, 3)`) to keep the decomposition explicit and avoid relying on `ttnn.pow` implementation details.
- Points the Wan text embedder at `gelu_tanh_decomposed` to recover PCC.
- Leaves LTX (`transformer_ltx.py`) and Gemma (`model_gemma.py`) on the fused `gelu_tanh` LUT path, preserving their NaN-safety (the "mesh of 4 voices" audio-decoder fix).

## Test plan

- [ ] `pytest models/tt_dit/tests/unit/test_embeddings.py::test_wan_time_text_image_embedding -k t3k` (t3000) — expect `encoder_hidden_states` PCC back above 99.99%
- [ ] CI: `t3000-unit-tests / t3k_dits_tests`
- [ ] Confirm LTX and Gemma demo/unit tests are unaffected (still using the fused tanh-LUT GELU)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kevinmi/wan-gelu-tanh-unfused)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kevinmi/wan-gelu-tanh-unfused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kevinmi/wan-gelu-tanh-unfused)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kevinmi/wan-gelu-tanh-unfused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kevinmi/wan-gelu-tanh-unfused)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kevinmi/wan-gelu-tanh-unfused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kevinmi/wan-gelu-tanh-unfused)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kevinmi/wan-gelu-tanh-unfused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kevinmi/wan-gelu-tanh-unfused)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kevinmi/wan-gelu-tanh-unfused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kevinmi/wan-gelu-tanh-unfused)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kevinmi/wan-gelu-tanh-unfused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kevinmi/wan-gelu-tanh-unfused)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kevinmi/wan-gelu-tanh-unfused)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kevinmi/wan-gelu-tanh-unfused)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kevinmi/wan-gelu-tanh-unfused)