### PR TITLE
[tt-train] Efficient kv_down split in MLA backward

### DIFF
--- a/tt-train/sources/ttml/ttml/models/deepseek/autograd_ops.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/autograd_ops.py
@@ -107,7 +107,7 @@ class Split(ttml.autograd.Function):
     This is the cheap inverse of :class:`Concat` and the efficient replacement
     for calling :func:`autograd_slice` several times on the same tensor.
 
-    Forward: ``len(sizes)`` contiguous ``ttnn.slice`` views.
+    Forward: ``len(sizes)`` contiguous chunks via ``ttnn.split``.
     Backward: a single ``ttnn.concat`` of the upstream gradients.
 
     Why a dedicated op: two adjacent ``autograd_slice`` calls each rebuild a
@@ -127,24 +127,13 @@ class Split(ttml.autograd.Function):
             raise ValueError(f"autograd_split dim {dim} out of range for rank-{rank} tensor")
         ctx.dim = dim
 
-        # Chunks must be positive and tile the split dim exactly: otherwise the forward
-        # would drop/overrun data and the backward concat would not reconstruct the input.
+        # Chunks must tile the split dim exactly: otherwise the forward could drop
+        # data and the backward concat would not reconstruct the input gradient.
         axis_size = val.shape[dim]
-        if any(s <= 0 for s in sizes):
-            raise ValueError(f"autograd_split sizes must be positive, got {list(sizes)}")
         if sum(sizes) != axis_size:
             raise ValueError(f"autograd_split sizes {list(sizes)} must tile dim {dim} (size {axis_size})")
 
-        outputs = []
-        offset = 0
-        for size in sizes:
-            start = [0] * rank
-            end = list(val.shape)
-            start[dim] = offset
-            end[dim] = offset + size
-            outputs.append(ttnn.slice(val, start, end))
-            offset += size
-        return tuple(outputs)
+        return tuple(ttnn.split(val, list(sizes), dim))
 
     @staticmethod
     def backward(ctx, *grad_outputs):

--- a/tt-train/sources/ttml/ttml/models/deepseek/autograd_ops.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/autograd_ops.py
@@ -125,6 +125,12 @@ class Split(ttml.autograd.Function):
             dim += rank
         ctx.dim = dim
 
+        # Chunks must tile the split dim exactly: otherwise the forward would drop
+        # or overrun data and the backward concat would not reconstruct the input.
+        assert (
+            sum(sizes) == val.shape[dim]
+        ), f"autograd_split sizes {list(sizes)} must sum to dim {dim} length {val.shape[dim]}"
+
         outputs = []
         offset = 0
         for size in sizes:

--- a/tt-train/sources/ttml/ttml/models/deepseek/autograd_ops.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/autograd_ops.py
@@ -101,6 +101,48 @@ class Concat(ttml.autograd.Function):
         return tuple(grads)
 
 
+class Split(ttml.autograd.Function):
+    """Autograd-aware split of one tensor into contiguous chunks along a dim.
+
+    This is the cheap inverse of :class:`Concat` and the efficient replacement
+    for calling :func:`autograd_slice` several times on the same tensor.
+
+    Forward: ``len(sizes)`` contiguous ``ttnn.slice`` views.
+    Backward: a single ``ttnn.concat`` of the upstream gradients.
+
+    Why a dedicated op: two adjacent ``autograd_slice`` calls each rebuild a
+    full-width gradient (allocate zeros + concat) and those then get summed,
+    i.e. ``2x (zeros + concat) + add``. Because the chunks tile the split dim,
+    the true input gradient is just ``concat(grad_chunks)`` -- one op, no zeros,
+    no add. On N300 this cuts the kv_down split backward ~5x (see PR).
+    """
+
+    @staticmethod
+    def forward(ctx, input, sizes, dim):
+        val = input.get_value()
+        rank = len(val.shape)
+        if dim < 0:
+            dim += rank
+        ctx.dim = dim
+
+        outputs = []
+        offset = 0
+        for size in sizes:
+            start = [0] * rank
+            end = list(val.shape)
+            start[dim] = offset
+            end[dim] = offset + size
+            outputs.append(ttnn.slice(val, start, end))
+            offset += size
+        return tuple(outputs)
+
+    @staticmethod
+    def backward(ctx, *grad_outputs):
+        # grad_outputs are ordered like the forward chunks, so a single concat
+        # along the split dim reconstructs the gradient w.r.t. the input.
+        return ttnn.concat(list(grad_outputs), ctx.dim)
+
+
 class Sigmoid(ttml.autograd.Function):
     """Autograd-aware sigmoid.
 
@@ -255,6 +297,14 @@ def autograd_slice(tensor, start, end):
 def autograd_concat(tensors, dim):
     """Concat with autograd backward."""
     return Concat.apply(dim, *tensors)
+
+
+def autograd_split(tensor, sizes, dim):
+    """Split a tensor into contiguous chunks of ``sizes`` along ``dim``.
+
+    Cheaper backward than repeated :func:`autograd_slice` (single concat).
+    """
+    return Split.apply(tensor, sizes, dim)
 
 
 def autograd_sigmoid(tensor):

--- a/tt-train/sources/ttml/ttml/models/deepseek/autograd_ops.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/autograd_ops.py
@@ -123,13 +123,17 @@ class Split(ttml.autograd.Function):
         rank = len(val.shape)
         if dim < 0:
             dim += rank
+        if dim < 0 or dim >= rank:
+            raise ValueError(f"autograd_split dim {dim} out of range for rank-{rank} tensor")
         ctx.dim = dim
 
-        # Chunks must tile the split dim exactly: otherwise the forward would drop
-        # or overrun data and the backward concat would not reconstruct the input.
-        assert (
-            sum(sizes) == val.shape[dim]
-        ), f"autograd_split sizes {list(sizes)} must sum to dim {dim} length {val.shape[dim]}"
+        # Chunks must be positive and tile the split dim exactly: otherwise the forward
+        # would drop/overrun data and the backward concat would not reconstruct the input.
+        axis_size = val.shape[dim]
+        if any(s <= 0 for s in sizes):
+            raise ValueError(f"autograd_split sizes must be positive, got {list(sizes)}")
+        if sum(sizes) != axis_size:
+            raise ValueError(f"autograd_split sizes {list(sizes)} must tile dim {dim} (size {axis_size})")
 
         outputs = []
         offset = 0

--- a/tt-train/sources/ttml/ttml/models/deepseek/mla.py
+++ b/tt-train/sources/ttml/ttml/models/deepseek/mla.py
@@ -19,7 +19,7 @@ import ttml
 from ttml.modules import AbstractModuleBase, LinearLayer
 
 from .transformer import RMSNormLayer
-from .autograd_ops import autograd_slice, autograd_concat, split_heads
+from .autograd_ops import autograd_slice, autograd_concat, autograd_split, split_heads
 
 
 class MultiHeadLatentAttention(AbstractModuleBase):
@@ -93,8 +93,9 @@ class MultiHeadLatentAttention(AbstractModuleBase):
         kv_full = self.wkv_a(x)  # [B, 1, S, kv_lora_rank + qk_rope]
         kv_lora = self.kv_lora_rank
 
-        kv = autograd_slice(kv_full, [0, 0, 0, 0], [B, 1, S, kv_lora])
-        k_pe = autograd_slice(kv_full, [0, 0, 0, kv_lora], [B, 1, S, kv_lora + qk_rope])
+        # Single split (one concat in backward) instead of two autograd_slice
+        # (which each rebuild a full-width grad with zeros + concat, then sum).
+        kv, k_pe = autograd_split(kv_full, [kv_lora, qk_rope], dim=3)
 
         # RoPE on k_pe (shared across heads, shape [B, 1, S, qk_rope])
         k_pe = ttml.ops.rope.rope(k_pe, self.rope_params)

--- a/tt-train/tests/python/test_deepseek_autograd_split.py
+++ b/tt-train/tests/python/test_deepseek_autograd_split.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: (c) 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Parity tests for ``autograd_split`` against the ``autograd_slice`` it replaces.
+
+``autograd_split`` is the efficient drop-in for splitting one tensor into
+contiguous chunks (used by the MLA kv_down path). It must be value- and
+gradient-identical to calling ``autograd_slice`` once per chunk, which is the
+reference these tests pin it to.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import ttnn
+import ttml
+from ttml.models.deepseek.autograd_ops import autograd_slice, autograd_split
+
+
+# (shape, chunk sizes along dim, dim) -- chunks tile the whole axis.
+CASES = [
+    ((2, 1, 256, 160), [128, 32], 3),  # MLA kv_down split (kv_lora=128, qk_rope=32)
+    ((1, 1, 128, 160), [96, 32, 32], 3),  # 3-way, uneven
+    ((1, 1, 64, 192), [64, 64, 64], 3),  # 3-way, even
+    ((1, 4, 64, 32), [1, 3], 1),  # split on a non-last dim
+    ((1, 1, 64, 96), [32, 64], 3),  # asymmetric 2-way
+]
+
+
+@pytest.fixture(autouse=True)
+def reset_graph():
+    yield
+    ttml.autograd.AutoContext.get_instance().reset_graph()
+
+
+def _make_leaf(x_np):
+    t = ttml.autograd.Tensor.from_numpy(x_np, layout=ttnn.Layout.TILE, new_type=ttnn.DataType.BFLOAT16)
+    t.set_requires_grad(True)
+    return t
+
+
+def _weighted_loss(chunks):
+    # Distinct per-chunk weights so an ordering/placement bug in backward
+    # produces a different input gradient than the slice reference.
+    loss = None
+    for i, chunk in enumerate(chunks):
+        term = ttml.ops.unary.mean(chunk) * float(i + 1)
+        loss = term if loss is None else loss + term
+    return loss
+
+
+def _run(x_np, split_fn):
+    leaf = _make_leaf(x_np)
+    chunks = split_fn(leaf)
+    _weighted_loss(chunks).backward(False)
+    return [c.to_numpy() for c in chunks], leaf.get_grad_tensor().to_numpy()
+
+
+@pytest.mark.requires_device
+@pytest.mark.parametrize("shape,sizes,dim", CASES)
+def test_split_matches_slice(shape, sizes, dim):
+    ctx = ttml.autograd.AutoContext.get_instance()
+    x_np = np.random.default_rng(0).standard_normal(shape, dtype=np.float32)
+
+    def via_split(leaf):
+        return list(autograd_split(leaf, sizes, dim))
+
+    def via_slice(leaf):
+        chunks = []
+        offset = 0
+        for size in sizes:
+            start = [0] * len(shape)
+            end = list(shape)
+            start[dim] = offset
+            end[dim] = offset + size
+            chunks.append(autograd_slice(leaf, start, end))
+            offset += size
+        return chunks
+
+    ctx.reset_graph()
+    split_chunks, split_grad = _run(x_np, via_split)
+    ctx.reset_graph()
+    slice_chunks, slice_grad = _run(x_np, via_slice)
+
+    for sc, lc in zip(split_chunks, slice_chunks):
+        np.testing.assert_array_equal(sc, lc)  # pure copy -> bit-exact
+    np.testing.assert_allclose(split_grad, slice_grad, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
## What this is

DeepSeek MLA's KV path down-projects `x` with `wkv_a` and then splits the packed result into the latent `kv` and the shared `k_pe`:

```python
kv_full = wkv_a(x)                       # matmul, [B, 1, S, kv_lora + qk_rope]
kv   = autograd_slice(kv_full, ..., 0,        kv_lora)            # [B, 1, S, kv_lora]
k_pe = autograd_slice(kv_full, ..., kv_lora,  kv_lora + qk_rope)  # [B, 1, S, qk_rope]
```

This PR replaces the two `autograd_slice` calls with a single `autograd_split` op. The forward delegates to `ttnn.split` (which uses the same contiguous slice path for this uneven split); the **backward** goes from a full-width scatter per slice to a single concat.

## Why we need it

`autograd_slice`'s backward rebuilds a full-width gradient for its slice by allocating a zeros block and concatenating the grad into place. With two adjacent slices feeding the same `kv_full`, the backward is therefore:

```
2 × (allocate full-width zeros + concat) + add        # current
```

But the two chunks tile the split axis, so the true gradient of `kv_full` is just the concatenation of the two chunk gradients:

```
concat([grad_kv, grad_k_pe], dim=-1)                  # one op, no zeros, no add
```

This is an **autograd-graph** inefficiency, not a kernel one: there is no math around the split (the `wkv_a` matmul is the only compute, and we deliberately leave it untouched — matmul is already heavily optimized). So the fix is a lightweight autograd op, not a new device kernel.

## How it works

`Split` is a multi-output autograd `Function`:

- **forward:** `len(sizes)` contiguous chunks from `ttnn.split` along `dim` (for MLA's uneven split this is identical to the slices it replaces).
- **backward:** a single `ttnn.concat` of the upstream chunk gradients along `dim` — which *is* the gradient w.r.t. the un-split input, with no zero allocations and no extra add.

It is the cheap inverse of the existing `Concat` op. MLA uses it as `autograd_split(kv_full, [kv_lora, qk_rope], dim=3)`.

## Impact

Two measurements, both on N300 / BF16, gradient enabled. **No benchmark script is merged** (it is a host-side autograd change, not a device kernel, so it does not fit the gtest/gbenchmark op harness); the numbers were produced as follows.

### 1. Isolated (what actually changed)

A micro-benchmark times the `kv_down_split` section's two ingredients separately — the `wkv_a` matmul backward (which we do **not** touch) and the split backward — and compares the current `autograd_slice` backward against the proposed single-concat backward:

```
# matmul_bw  : kv_full = wkv_a(x); mean(kv_full).backward()        -> time backward
# cur_bw     : 2 × (ttnn.zeros + ttnn.concat) + ttnn.add           -> time
# new_bw     : ttnn.concat([grad_kv, grad_k_pe], dim=-1)           -> time
# report: cur_bw vs new_bw, and cur_bw / (matmul_bw + cur_bw)
```

| shape | matmul bwd | split bwd (slice) | split bwd (new) | speedup | split share of section bwd | section bwd removed |
|---|---:|---:|---:|---:|---:|---:|
| nano B=1 S=256        | 355 | 314 | 62 | 5.1× | 47% | 38% |
| nano B=32 S=256       | 682 | 603 | 67 | 9.0× | 47% | 42% |
| tiny-short B=1 S=512  | 362 | 345 | 65 | 5.3× | 49% | 40% |
| tiny-full B=1 S=2048  | 593 | 469 | 66 | 7.1× | 44% | 38% |
| tiny-long B=1 S=4096  | 723 | 589 | 66 | 8.9× | 45% | 40% |
| tiny-8k B=1 S=8192    | 1323 | 780 | 65 | 12.1× | 37% | 34% |

µs/iter. The slice backward is ~37–49% of the section backward (the matmul is the rest), and replacing it removes **~34–42% of the whole `kv_down_split` section backward** through `S=8192`.

### 2. Module-level (the full layer)

A second script builds the real `MultiHeadLatentAttention`, fixes its weights, and times forward+backward with the two split implementations swapped in (the old path is reconstructed by monkeypatching the split with two `autograd_slice`):

| case | layer bwd (slice) | layer bwd (split) | Δ |
|---|---:|---:|---:|
| nano B=1 S=256        | 5239 | 4969 | −270 µs (1.05×) |
| nano B=32 S=256       | 19459 | 18751 | −708 µs (1.04×) |
| tiny-short B=1 S=512  | 6931 | 6493 | −439 µs (1.07×) |
| tiny-s1024 B=1 S=1024 | 8842 | 9182 | +340 µs (0.96×) |

The absolute saving matches the isolated number on the shorter cases. The long-sequence full-layer run is dominated by the composite SDPA path and is noisy enough to hide this small autograd-graph win, which is why the isolated measurement above is the primary evidence. Once fused SDPA and qkv_assemble land, the backward shrinks and this section becomes the ~20%+ share that profiling projected.

## Correctness

New device test `tt-train/tests/python/test_deepseek_autograd_split.py` pins `autograd_split` to the `autograd_slice` path it replaces: forward chunks are compared **bit-exact** and the reconstructed input gradient with `rtol = atol = 1e-3`, across the kv_down shape, even/uneven 3-way splits, and a non-last-dim split. 5/5 pass. (The deepseek autograd ops were previously only covered indirectly by the full-model parity test.)

## Scope

- Single PR, not a fw/bw stack: `Split` is one inherently differentiable autograd op, so there is no separable forward/backward kernel to split out. Forward is unchanged.
- The same `autograd_split` is a drop-in for MLA's other slice-pairs (`q_nope`/`q_pe`, `k_nope`/`v`), but those paths are being collapsed into dedicated fused kernels (q-rope, qkv_assemble) that supersede it, so they are left untouched here.
- `wkv_a` is left as-is; the only remaining theoretical fusion (demuxing the matmul output write into the two chunks) is matmul-bound and low-value.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mdragula/mla_kv_down_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mdragula/mla_kv_down_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mdragula/mla_kv_down_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mdragula/mla_kv_down_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mdragula/mla_kv_down_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mdragula/mla_kv_down_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mdragula/mla_kv_down_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mdragula/mla_kv_down_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mdragula/mla_kv_down_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mdragula/mla_kv_down_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mdragula/mla_kv_down_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mdragula/mla_kv_down_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mdragula/mla_kv_down_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mdragula/mla_kv_down_split)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mdragula/mla_kv_down_split)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mdragula/mla_kv_down_split)
