### PR TITLE
#46628 and #46629: Drain down-matmul L1_ACC partials in rexpert kernel

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -86,19 +86,29 @@ FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t 
     PACK((llk_pack_reconfig_l1_acc(0)));  // block 0 must overwrite, not accumulate
 #endif
 
-    // Reserve the FULL per-core output block in partials once. Then use
-    // pack_tile's output_tile_index parameter to write each subblock to an
-    // absolute slot WITHIN this reserved region. WrPtr does NOT advance until
-    // the final cb_push_back at the end of the K-loop — so on K-blocks
-    // 1..N-1 the L1_ACC packs land at the SAME L1 addresses as K-block 0's
-    // packs, accumulating physically. Saves the per-K-block pop+repush dance.
-    cb_reserve_back(partials_cb_id, out_block_num_tiles);
+    // Cross-K-block accumulation via PACKER_L1_ACC, using the proven production
+    // matmul packing discipline (see bmm_large_block_zm_fused_bias_activation.cpp):
+    // each subblock is reserved → packed in-order (pack_tile_block) → pushed, and
+    // the full block is drained (wait_front + pop_front) BETWEEN K-blocks.
+    //
+    // The drain is load-bearing for correctness, not just ring hygiene. wait_front
+    // blocks until the packer has committed the tiles it just wrote, so block N+1's
+    // L1_ACC read-modify-write cannot race ahead of block N's write landing in the
+    // same L1 slot; the matching pop_front wraps the CB write pointer back so the
+    // next block accumulates physically into block 0's slots. A previous
+    // whole-block-reserve / out-of-order-pack variant skipped this drain — it
+    // nondeterministically lost a subblock's first-tile (column 0) contribution
+    // when out_subblock_w > 1 (PCC ~0.83-0.98 run-to-run on the small-token
+    // routed-expert test). It "worked" only at out_subblock_w == 1, where the
+    // extra tile_regs barrier per pack incidentally serialised the writes — at the
+    // cost of down-matmul efficiency. The fused gate/up phase escapes the race
+    // because its two interleaved matmuls already separate consecutive same-slot
+    // packs. Keeping the perf-optimal wide subblock here is now safe.
     for (uint32_t block = 0; block < num_blocks; ++block) {
         cb_wait_front(in0_cb_id, in0_block_num_tiles);
         cb_wait_front(in1_cb_id, in1_block_num_tiles);
 
         int in0_index_subblock_offset = 0;
-        uint32_t partials_slot_idx = 0;  // absolute slot within partials_cb's reserved region
         for (uint32_t sb_m = 0; sb_m < in0_num_subblocks; ++sb_m) {
             int in1_index_subblock_offset = 0;
             for (uint32_t sb_n = 0; sb_n < in1_num_subblocks; ++sb_n) {
@@ -123,14 +133,12 @@ FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t 
                 }
 
                 tile_regs_commit();
+                cb_reserve_back(partials_cb_id, out_subblock_num_tiles);
                 tile_regs_wait();
-
-                for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
-                    pack_tile<true>(i, partials_cb_id, partials_slot_idx + i);
-                }
-                partials_slot_idx += out_subblock_num_tiles;
-
+                pack_tile_block(0, partials_cb_id, out_subblock_num_tiles);
                 tile_regs_release();
+                cb_push_back(partials_cb_id, out_subblock_num_tiles);
+
                 in1_index_subblock_offset += out_subblock_w;
             }
             in0_index_subblock_offset += in0_subblock_num_tiles;
@@ -145,9 +153,18 @@ FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t 
 
         cb_pop_front(in0_cb_id, in0_block_num_tiles);
         cb_pop_front(in1_cb_id, in1_block_num_tiles);
+
+        // Drain all but the last K-block (see header comment): forces the
+        // packer's writes visible before the next block's L1_ACC RMW and wraps
+        // the write pointer back to block 0's slots. The last block's output is
+        // left pushed for the second-pass copy below.
+        if (block + 1 < num_blocks) {
+            for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
+                cb_wait_front(partials_cb_id, out_subblock_num_tiles);
+                cb_pop_front(partials_cb_id, out_subblock_num_tiles);
+            }
+        }
     }
-    // Make the accumulated partials visible to the second-pass loop below.
-    cb_push_back(partials_cb_id, out_block_num_tiles);
 
     // After the K-loop: partials_cb_id has out_block_num_tiles tiles holding
     // the final accumulated sum. Move them through dst into final_cb_id,


### PR DESCRIPTION
## Summary
The `unified_routed_expert_ffn` down matmul produced run-to-run nondeterministic PCC (~0.83–0.98, below the 0.97 threshold) on `test_ttnn_routed_expert`'s small-token cases. This PR fixes the underlying packer race so the wide (perf-optimal) output subblock width is safe to use, restoring both correctness and down-matmul throughput.

## Root cause
The down `matmul_phase` (`fused_swiglu.cpp`) accumulated across K-blocks under `PACKER_L1_ACC` using a whole-block-`reserve_back` + out-of-order `pack_tile<true>` scheme that **never drained the partials CB between K-blocks**. Because the write pointer didn't advance until the end of the K-loop, block N+1's L1 read-modify-write could race ahead of block N's write landing in the same L1 slot — nondeterministically dropping a subblock's first-tile (column-0) contributionwhenever `out_subblock_w > 1`. This only manifested on small-token inputs where each expert holds a single partial token tile.

## Fix
Rewrite the down `matmul_phase` to the proven production packing discipline (matching `bmm_large_block_zm_fused_bias_activation.cpp`):
- **Per-subblock** `reserve_back` → in-order `pack_tile_block` → `push_back`, instead of one whole-block reserve with absolute-slot out-of-order packs.
- An **inter-K-block drain** (`wait_front` + `pop_front` of the full block) for all but the last K-block. The `wait_front` forces the packer's writes visiblebefore the next block's L1_ACC RMW; the matching `pop_front` wraps the CB write pointer back so the next block accumulates physically into block 0's slots.

The host factory keeps the perf-optimal divisor width (`d_sub_w`) — no width-1 workaround needed. The fused gate/up phase escapes the race incidentally (its two interleaved matmuls already separate consecutive same-slot packs) and is left unchanged.

## CI Status
- [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=kgrujcic%2Ffix_46629)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml)
- [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=kgrujcic%2Ffix_46629)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml) failed state is unrelated to my changes; tests I fixed are passing

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/fix_46629)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/fix_46629)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/fix_46629)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/fix_46629)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kgrujcic/fix_46629)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kgrujcic/fix_46629)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/fix_46629)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/fix_46629)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/fix_46629)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/fix_46629)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/fix_46629)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/fix_46629)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/fix_46629)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/fix_46629)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/fix_46629)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/fix_46629)