### PR TITLE
[Runtime Ci] : Expand runtime CI to multichip topologies (#46302)

### DIFF
--- a/.github/scripts/utils/find-changed-files.sh
+++ b/.github/scripts/utils/find-changed-files.sh
@@ -32,6 +32,7 @@ LLK_TESTS_CHANGED=false
 LLK_UNIT_TESTS_CHANGED=false
 LLK_PERF_CHANGED=false
 LLK_CI_CHANGED=false
+WORKFLOWS_CHANGED=false
 
 
 while IFS= read -r FILE; do
@@ -145,6 +146,13 @@ while IFS= read -r FILE; do
             BUILD_WORKFLOWS_CHANGED=true
             ANY_CODE_CHANGED=true
             ;;
+        # Any other workflow change runs the standard PR gate. More specific workflow
+        # patterns above (e.g. llk-*.yaml, build-artifact.yaml) match first and keep
+        # their targeted behavior; this catch-all ensures a workflow-only PR never
+        # silently skips CI. Fanned out to the full gate below (same as submodule).
+        .github/workflows/*.yaml|.github/workflows/*.yml)
+            WORKFLOWS_CHANGED=true
+            ;;
     esac
 done <<< "$CHANGED_FILES"
 
@@ -156,8 +164,10 @@ for submodule_path in $SUBMODULE_PATHS; do
         break
     fi
 done
-if [[ "$SUBMODULE_CHANGED" = true ]]; then
-    # Treat any submodule change as a change to everything; not going to manage dependency trees for this
+if [[ "$SUBMODULE_CHANGED" = true || "$WORKFLOWS_CHANGED" = true ]]; then
+    # Treat any submodule or workflow change as a change to everything; not going to manage dependency trees for this.
+    # For workflows this guarantees a workflow-only PR runs the full standard gate (build + smoke + examples + code-analysis)
+    # rather than silently skipping, matching every other PR.
     TTMETALIUM_CHANGED=true
     TTNN_CHANGED=true
     TTMETALIUM_TESTS_CHANGED=true

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -223,7 +223,7 @@ runtime:
     wh_n150_civ2: 226
     wh_n300_civ2: 99
     wh_llmbox: 20
-    bh_p150b_civ2: 210
+    bh_p150b_civ2: 214
     bh_p300: 69
     bh_p150b_civ2_viommu: 5
     bh_p100a_civ2_viommu: 74

--- a/.github/time_budget.yaml
+++ b/.github/time_budget.yaml
@@ -221,8 +221,10 @@ runtime:
     sim_blackhole_galaxy: 10
   unit:
     wh_n150_civ2: 226
-    wh_n300_civ2: 74
+    wh_n300_civ2: 99
+    wh_llmbox: 20
     bh_p150b_civ2: 210
+    bh_p300: 69
     bh_p150b_civ2_viommu: 5
     bh_p100a_civ2_viommu: 74
     bh_loudbox: 20
@@ -231,6 +233,8 @@ runtime:
     wh_n150_civ2: 360
     bh_p150b_civ2: 360
     bh_loudbox: 25
+    wh_galaxy: 15
+    bh_galaxy: 15
   perf:
     wh_n300_civ2: 55
     bh_p150_perf: 40

--- a/.github/workflows/runtime-integration-tests-impl.yaml
+++ b/.github/workflows/runtime-integration-tests-impl.yaml
@@ -91,7 +91,7 @@ jobs:
           build-artifact-name: ${{ inputs.build-artifact-name }}
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: Ensure BH links online
-        if: ${{ contains(matrix.test-group.sku, 'bh_loudbox') }}
+        if: ${{ contains(matrix.test-group.sku, 'bh_loudbox') || contains(matrix.test-group.sku, 'bh_galaxy') }}
         uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         timeout-minutes: 10
       - name: ${{ matrix.test-group.name }}

--- a/.github/workflows/runtime-integration-tests.yaml
+++ b/.github/workflows/runtime-integration-tests.yaml
@@ -7,6 +7,11 @@ on:
     - cron: "0 5 * * *" # 05:00 UTC daily
   workflow_dispatch:
     inputs:
+      all:
+        description: "All SKUs (every Wormhole + Blackhole SKU)"
+        required: false
+        type: boolean
+        default: false
       wormhole:
         description: "All Wormhole SKUs (wh_n150_civ2, wh_galaxy)"
         required: false
@@ -23,7 +28,7 @@ on:
         type: boolean
         default: false
       skus:
-        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_galaxy, wh_galaxy'. Leave everything empty to run ALL."
+        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_galaxy, wh_galaxy'. Tick the 'all' box above to run every SKU."
         required: false
         type: string
         default: ""
@@ -78,6 +83,7 @@ jobs:
 
           # Group checkboxes.
           SELECTED=""
+          [[ "${{ inputs.all }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$ALL_SKUS"
           [[ "${{ inputs.wormhole }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$WH_SKUS"
           [[ "${{ inputs.blackhole }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$BH_SKUS"
           [[ "${{ inputs.multichip }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$MULTICHIP_SKUS"
@@ -103,8 +109,11 @@ jobs:
             done
           fi
 
-          # Nothing ticked and nothing typed -> run everything.
-          [[ -z "$SELECTED" ]] && SELECTED="$ALL_SKUS"
+          # Require an explicit selection now that "empty = all" is replaced by the 'all' checkbox.
+          if [[ -z "$SELECTED" ]]; then
+            echo "::error::No SKUs selected. Tick 'all' (or wormhole/blackhole/multichip) or list SKUs in the 'skus' box."
+            exit 1
+          fi
 
           # Deduplicate, preserving first-seen order.
           declare -A seen

--- a/.github/workflows/runtime-integration-tests.yaml
+++ b/.github/workflows/runtime-integration-tests.yaml
@@ -7,18 +7,26 @@ on:
     - cron: "0 5 * * *" # 05:00 UTC daily
   workflow_dispatch:
     inputs:
-      sku:
-        description: "Select machine/SKU to test (jobs with no coverage for the SKU are skipped)"
+      wormhole:
+        description: "All Wormhole SKUs (wh_n150_civ2, wh_galaxy)"
         required: false
-        default: all
-        type: choice
-        options:
-          - all
-          - "wh_n150_civ2 (N150)"
-          - "bh_p150b_civ2 (P150b)"
-          - "bh_loudbox (BH LoudBox)"
-          - "wh_galaxy (WH Galaxy)"
-          - "bh_galaxy (BH Galaxy)"
+        type: boolean
+        default: false
+      blackhole:
+        description: "All Blackhole SKUs (bh_p150b_civ2, bh_loudbox, bh_galaxy)"
+        required: false
+        type: boolean
+        default: false
+      multichip:
+        description: "Multichip SKUs only (bh_loudbox, wh_galaxy, bh_galaxy)"
+        required: false
+        type: boolean
+        default: false
+      skus:
+        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_galaxy, wh_galaxy'. Leave everything empty to run ALL."
+        required: false
+        type: string
+        default: ""
       platform:
         required: false
         type: choice
@@ -55,18 +63,63 @@ jobs:
       - name: Resolve SKU selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150_civ2,bh_p150b_civ2,bh_loudbox,wh_galaxy,bh_galaxy"
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            SKU_INPUT="${{ inputs.sku || 'all' }}"
-            if [[ "$SKU_INPUT" == "all" ]]; then
-              echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
-            else
-              SKU_NAME=$(echo "$SKU_INPUT" | sed 's/ (.*//')
-              echo "enabled-skus=$SKU_NAME" >> $GITHUB_OUTPUT
-            fi
+          WH_SKUS="wh_n150_civ2,wh_galaxy"
+          BH_SKUS="bh_p150b_civ2,bh_loudbox,bh_galaxy"
+          MULTICHIP_SKUS="bh_loudbox,wh_galaxy,bh_galaxy"
+          ALL_SKUS="$WH_SKUS,$BH_SKUS"
+          VALID_SKUS="wh_n150_civ2 wh_galaxy bh_p150b_civ2 bh_loudbox bh_galaxy wh_all bh_all multichip all"
+
+          # Scheduled (non-dispatch) runs always cover everything.
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
+            echo "Selected SKUs (scheduled): $ALL_SKUS"
             exit 0
           fi
-          echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
+
+          # Group checkboxes.
+          SELECTED=""
+          [[ "${{ inputs.wormhole }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$WH_SKUS"
+          [[ "${{ inputs.blackhole }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$BH_SKUS"
+          [[ "${{ inputs.multichip }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$MULTICHIP_SKUS"
+
+          # Specific SKUs / group keywords from the text box, added to the ticked boxes.
+          SKU_INPUT=$(echo "${{ inputs.skus }}" | xargs)
+          if [[ -n "$SKU_INPUT" ]]; then
+            IFS=',' read -ra ITEMS <<< "$SKU_INPUT"
+            for item in "${ITEMS[@]}"; do
+              item=$(echo "$item" | xargs)
+              [[ -z "$item" ]] && continue
+              if [[ ! " $VALID_SKUS " =~ " $item " ]]; then
+                echo "::error::Invalid SKU '$item'. Valid: [all, wh_all, bh_all, multichip] or one of: $WH_SKUS,$BH_SKUS"
+                exit 1
+              fi
+              case "$item" in
+                all) SELECTED="${SELECTED:+$SELECTED,}$ALL_SKUS" ;;
+                wh_all) SELECTED="${SELECTED:+$SELECTED,}$WH_SKUS" ;;
+                bh_all) SELECTED="${SELECTED:+$SELECTED,}$BH_SKUS" ;;
+                multichip) SELECTED="${SELECTED:+$SELECTED,}$MULTICHIP_SKUS" ;;
+                *) SELECTED="${SELECTED:+$SELECTED,}$item" ;;
+              esac
+            done
+          fi
+
+          # Nothing ticked and nothing typed -> run everything.
+          [[ -z "$SELECTED" ]] && SELECTED="$ALL_SKUS"
+
+          # Deduplicate, preserving first-seen order.
+          declare -A seen
+          SKUS=""
+          IFS=',' read -ra EXPANDED <<< "$SELECTED"
+          for sku in "${EXPANDED[@]}"; do
+            [[ -z "$sku" ]] && continue
+            if [[ -z "${seen[$sku]}" ]]; then
+              seen[$sku]=1
+              SKUS="${SKUS:+$SKUS,}$sku"
+            fi
+          done
+
+          echo "enabled-skus=$SKUS" >> $GITHUB_OUTPUT
+          echo "Selected SKUs: $SKUS"
   build-artifact:
     needs: check-harbor
     uses: ./.github/workflows/build-artifact.yaml

--- a/.github/workflows/runtime-integration-tests.yaml
+++ b/.github/workflows/runtime-integration-tests.yaml
@@ -7,16 +7,18 @@ on:
     - cron: "0 5 * * *" # 05:00 UTC daily
   workflow_dispatch:
     inputs:
-      wormhole:
-        description: "Run on Wormhole"
+      sku:
+        description: "Select machine/SKU to test (jobs with no coverage for the SKU are skipped)"
         required: false
-        type: boolean
-        default: true
-      blackhole:
-        description: "Run on Blackhole"
-        required: false
-        type: boolean
-        default: true
+        default: all
+        type: choice
+        options:
+          - all
+          - "wh_n150_civ2 (N150)"
+          - "bh_p150b_civ2 (P150b)"
+          - "bh_loudbox (BH LoudBox)"
+          - "wh_galaxy (WH Galaxy)"
+          - "bh_galaxy (BH Galaxy)"
       platform:
         required: false
         type: choice
@@ -45,6 +47,26 @@ on:
 jobs:
   check-harbor:
     uses: ./.github/workflows/check-harbor.yaml
+  resolve-skus:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled-skus: ${{ steps.resolve.outputs.enabled-skus }}
+    steps:
+      - name: Resolve SKU selection
+        id: resolve
+        run: |
+          ALL_SKUS="wh_n150_civ2,bh_p150b_civ2,bh_loudbox,wh_galaxy,bh_galaxy"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            SKU_INPUT="${{ inputs.sku || 'all' }}"
+            if [[ "$SKU_INPUT" == "all" ]]; then
+              echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
+            else
+              SKU_NAME=$(echo "$SKU_INPUT" | sed 's/ (.*//')
+              echo "enabled-skus=$SKU_NAME" >> $GITHUB_OUTPUT
+            fi
+            exit 0
+          fi
+          echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
   build-artifact:
     needs: check-harbor
     uses: ./.github/workflows/build-artifact.yaml
@@ -60,20 +82,11 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
 
   runtime-integration-tests:
-    needs: [check-harbor, build-artifact]
+    needs: [check-harbor, build-artifact, resolve-skus]
     uses: ./.github/workflows/runtime-integration-tests-impl.yaml
     secrets: inherit
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
-      enabled-skus: >-
-        ${{
-          github.event_name == 'schedule'
-            && 'wh_n150_civ2,bh_p150b_civ2,bh_loudbox'
-            || format('{0}{1}',
-              inputs.wormhole && 'wh_n150_civ2' || '',
-              inputs.blackhole && format('{0}bh_p150b_civ2,bh_loudbox',
-                inputs.wormhole && ',' || '') || ''
-            )
-        }}
+      enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}

--- a/.github/workflows/runtime-integration-tests.yaml
+++ b/.github/workflows/runtime-integration-tests.yaml
@@ -11,7 +11,7 @@ on:
         description: "All SKUs (every Wormhole + Blackhole SKU)"
         required: false
         type: boolean
-        default: false
+        default: true
       wormhole:
         description: "All Wormhole SKUs (wh_n150_civ2, wh_galaxy)"
         required: false
@@ -28,7 +28,7 @@ on:
         type: boolean
         default: false
       skus:
-        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_galaxy, wh_galaxy'. Tick the 'all' box above to run every SKU."
+        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_galaxy, wh_galaxy'. The 'all' box above is ticked by default (every SKU); untick it to run only the boxes/SKUs you pick."
         required: false
         type: string
         default: ""

--- a/.github/workflows/runtime-sanity-tests.yaml
+++ b/.github/workflows/runtime-sanity-tests.yaml
@@ -7,16 +7,16 @@ on:
     - cron: "0 3 * * *" # 03:00 UTC daily
   workflow_dispatch:
     inputs:
-      wormhole:
-        description: "Run on Wormhole"
+      sku:
+        description: "Select machine/SKU to test (jobs with no coverage for the SKU are skipped)"
         required: false
-        type: boolean
-        default: true
-      blackhole:
-        description: "Run on Blackhole"
-        required: false
-        type: boolean
-        default: true
+        default: all
+        type: choice
+        options:
+          - all
+          - "wh_n150_civ2 (N150)"
+          - "bh_p150b_civ2 (P150b)"
+          - "bh_loudbox (BH LoudBox)"
       platform:
         required: false
         type: choice
@@ -45,6 +45,26 @@ on:
 jobs:
   check-harbor:
     uses: ./.github/workflows/check-harbor.yaml
+  resolve-skus:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled-skus: ${{ steps.resolve.outputs.enabled-skus }}
+    steps:
+      - name: Resolve SKU selection
+        id: resolve
+        run: |
+          ALL_SKUS="wh_n150_civ2,bh_p150b_civ2,bh_loudbox"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            SKU_INPUT="${{ inputs.sku || 'all' }}"
+            if [[ "$SKU_INPUT" == "all" ]]; then
+              echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
+            else
+              SKU_NAME=$(echo "$SKU_INPUT" | sed 's/ (.*//')
+              echo "enabled-skus=$SKU_NAME" >> $GITHUB_OUTPUT
+            fi
+            exit 0
+          fi
+          echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
   build-artifact:
     needs: check-harbor
     uses: ./.github/workflows/build-artifact.yaml
@@ -59,19 +79,10 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
 
   runtime-sanity-tests:
-    needs: [check-harbor, build-artifact]
+    needs: [check-harbor, build-artifact, resolve-skus]
     uses: ./.github/workflows/runtime-sanity-tests-impl.yaml
     secrets: inherit
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: >-
-        ${{
-          github.event_name == 'schedule'
-            && 'wh_n150_civ2,bh_p150b_civ2,bh_loudbox'
-            || format('{0}{1}',
-              inputs.wormhole && 'wh_n150_civ2' || '',
-              inputs.blackhole && format('{0}bh_p150b_civ2,bh_loudbox',
-                inputs.wormhole && ',' || '') || ''
-            )
-        }}
+      enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}

--- a/.github/workflows/runtime-sanity-tests.yaml
+++ b/.github/workflows/runtime-sanity-tests.yaml
@@ -7,6 +7,11 @@ on:
     - cron: "0 3 * * *" # 03:00 UTC daily
   workflow_dispatch:
     inputs:
+      all:
+        description: "All SKUs (every Wormhole + Blackhole SKU)"
+        required: false
+        type: boolean
+        default: false
       wormhole:
         description: "All Wormhole SKUs (wh_n150_civ2)"
         required: false
@@ -23,7 +28,7 @@ on:
         type: boolean
         default: false
       skus:
-        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_loudbox'. Leave everything empty to run ALL."
+        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_loudbox'. Tick the 'all' box above to run every SKU."
         required: false
         type: string
         default: ""
@@ -78,6 +83,7 @@ jobs:
 
           # Group checkboxes.
           SELECTED=""
+          [[ "${{ inputs.all }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$ALL_SKUS"
           [[ "${{ inputs.wormhole }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$WH_SKUS"
           [[ "${{ inputs.blackhole }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$BH_SKUS"
           [[ "${{ inputs.multichip }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$MULTICHIP_SKUS"
@@ -103,8 +109,11 @@ jobs:
             done
           fi
 
-          # Nothing ticked and nothing typed -> run everything.
-          [[ -z "$SELECTED" ]] && SELECTED="$ALL_SKUS"
+          # Require an explicit selection now that "empty = all" is replaced by the 'all' checkbox.
+          if [[ -z "$SELECTED" ]]; then
+            echo "::error::No SKUs selected. Tick 'all' (or wormhole/blackhole/multichip) or list SKUs in the 'skus' box."
+            exit 1
+          fi
 
           # Deduplicate, preserving first-seen order.
           declare -A seen

--- a/.github/workflows/runtime-sanity-tests.yaml
+++ b/.github/workflows/runtime-sanity-tests.yaml
@@ -7,16 +7,26 @@ on:
     - cron: "0 3 * * *" # 03:00 UTC daily
   workflow_dispatch:
     inputs:
-      sku:
-        description: "Select machine/SKU to test (jobs with no coverage for the SKU are skipped)"
+      wormhole:
+        description: "All Wormhole SKUs (wh_n150_civ2)"
         required: false
-        default: all
-        type: choice
-        options:
-          - all
-          - "wh_n150_civ2 (N150)"
-          - "bh_p150b_civ2 (P150b)"
-          - "bh_loudbox (BH LoudBox)"
+        type: boolean
+        default: false
+      blackhole:
+        description: "All Blackhole SKUs (bh_p150b_civ2, bh_loudbox)"
+        required: false
+        type: boolean
+        default: false
+      multichip:
+        description: "Multichip SKUs only (bh_loudbox)"
+        required: false
+        type: boolean
+        default: false
+      skus:
+        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_loudbox'. Leave everything empty to run ALL."
+        required: false
+        type: string
+        default: ""
       platform:
         required: false
         type: choice
@@ -53,18 +63,63 @@ jobs:
       - name: Resolve SKU selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150_civ2,bh_p150b_civ2,bh_loudbox"
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            SKU_INPUT="${{ inputs.sku || 'all' }}"
-            if [[ "$SKU_INPUT" == "all" ]]; then
-              echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
-            else
-              SKU_NAME=$(echo "$SKU_INPUT" | sed 's/ (.*//')
-              echo "enabled-skus=$SKU_NAME" >> $GITHUB_OUTPUT
-            fi
+          WH_SKUS="wh_n150_civ2"
+          BH_SKUS="bh_p150b_civ2,bh_loudbox"
+          MULTICHIP_SKUS="bh_loudbox"
+          ALL_SKUS="$WH_SKUS,$BH_SKUS"
+          VALID_SKUS="wh_n150_civ2 bh_p150b_civ2 bh_loudbox wh_all bh_all multichip all"
+
+          # Scheduled (non-dispatch) runs always cover everything.
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
+            echo "Selected SKUs (scheduled): $ALL_SKUS"
             exit 0
           fi
-          echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
+
+          # Group checkboxes.
+          SELECTED=""
+          [[ "${{ inputs.wormhole }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$WH_SKUS"
+          [[ "${{ inputs.blackhole }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$BH_SKUS"
+          [[ "${{ inputs.multichip }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$MULTICHIP_SKUS"
+
+          # Specific SKUs / group keywords from the text box, added to the ticked boxes.
+          SKU_INPUT=$(echo "${{ inputs.skus }}" | xargs)
+          if [[ -n "$SKU_INPUT" ]]; then
+            IFS=',' read -ra ITEMS <<< "$SKU_INPUT"
+            for item in "${ITEMS[@]}"; do
+              item=$(echo "$item" | xargs)
+              [[ -z "$item" ]] && continue
+              if [[ ! " $VALID_SKUS " =~ " $item " ]]; then
+                echo "::error::Invalid SKU '$item'. Valid: [all, wh_all, bh_all, multichip] or one of: $WH_SKUS,$BH_SKUS"
+                exit 1
+              fi
+              case "$item" in
+                all) SELECTED="${SELECTED:+$SELECTED,}$ALL_SKUS" ;;
+                wh_all) SELECTED="${SELECTED:+$SELECTED,}$WH_SKUS" ;;
+                bh_all) SELECTED="${SELECTED:+$SELECTED,}$BH_SKUS" ;;
+                multichip) SELECTED="${SELECTED:+$SELECTED,}$MULTICHIP_SKUS" ;;
+                *) SELECTED="${SELECTED:+$SELECTED,}$item" ;;
+              esac
+            done
+          fi
+
+          # Nothing ticked and nothing typed -> run everything.
+          [[ -z "$SELECTED" ]] && SELECTED="$ALL_SKUS"
+
+          # Deduplicate, preserving first-seen order.
+          declare -A seen
+          SKUS=""
+          IFS=',' read -ra EXPANDED <<< "$SELECTED"
+          for sku in "${EXPANDED[@]}"; do
+            [[ -z "$sku" ]] && continue
+            if [[ -z "${seen[$sku]}" ]]; then
+              seen[$sku]=1
+              SKUS="${SKUS:+$SKUS,}$sku"
+            fi
+          done
+
+          echo "enabled-skus=$SKUS" >> $GITHUB_OUTPUT
+          echo "Selected SKUs: $SKUS"
   build-artifact:
     needs: check-harbor
     uses: ./.github/workflows/build-artifact.yaml

--- a/.github/workflows/runtime-sanity-tests.yaml
+++ b/.github/workflows/runtime-sanity-tests.yaml
@@ -11,7 +11,7 @@ on:
         description: "All SKUs (every Wormhole + Blackhole SKU)"
         required: false
         type: boolean
-        default: false
+        default: true
       wormhole:
         description: "All Wormhole SKUs (wh_n150_civ2)"
         required: false
@@ -28,7 +28,7 @@ on:
         type: boolean
         default: false
       skus:
-        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_loudbox'. Tick the 'all' box above to run every SKU."
+        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_loudbox'. The 'all' box above is ticked by default (every SKU); untick it to run only the boxes/SKUs you pick."
         required: false
         type: string
         default: ""

--- a/.github/workflows/runtime-unit-tests-impl.yaml
+++ b/.github/workflows/runtime-unit-tests-impl.yaml
@@ -6,10 +6,6 @@ on:
       docker-image:
         required: true
         type: string
-      harbor-prefix:
-        required: false
-        type: string
-        default: ""
       build-artifact-name:
         required: true
         type: string
@@ -65,12 +61,16 @@ jobs:
     name: ${{ matrix.test-group.name }}
     runs-on: ${{ matrix.test-group.runs_on }}
     container:
-      image: >-
-        ${{
-          !contains(fromJSON('["wh_galaxy","bh_loudbox","wh_llmbox","bh_galaxy"]'), matrix.test-group.sku) &&
-            format('{0}{1}', inputs.harbor-prefix, inputs.docker-image) ||
-          inputs.docker-image || 'docker-image-unresolved!'
-        }}
+      # Pull the canonical GHCR image directly rather than via the Harbor
+      # pull-through mirror. A job-level `container:` image is resolved and pulled by
+      # the runner harness *before any step runs*, so there is no opportunity to retry
+      # or fall back if an individual silicon runner transiently cannot resolve
+      # harbor.ci.tenstorrent.net. check-harbor probes from a different runner, so a
+      # globally-healthy Harbor can still yield an unresolvable image on the box that
+      # actually pulls (DNS split-brain). GHCR-direct is the path the multi-host SKUs
+      # and the Harbor-outage fallback already use, so harbor-prefix is intentionally
+      # not applied here.
+      image: ${{ inputs.docker-image || 'docker-image-unresolved!' }}
       env:
         TT_METAL_HOME: /work
         ARCH_NAME: ${{ contains(matrix.test-group.sku, 'bh_') && 'blackhole' || 'wormhole_b0' }}

--- a/.github/workflows/runtime-unit-tests-impl.yaml
+++ b/.github/workflows/runtime-unit-tests-impl.yaml
@@ -67,7 +67,7 @@ jobs:
     container:
       image: >-
         ${{
-          !contains(fromJSON('["wh_galaxy","bh_loudbox"]'), matrix.test-group.sku) &&
+          !contains(fromJSON('["wh_galaxy","bh_loudbox","wh_llmbox","bh_galaxy"]'), matrix.test-group.sku) &&
             format('{0}{1}', inputs.harbor-prefix, inputs.docker-image) ||
           inputs.docker-image || 'docker-image-unresolved!'
         }}
@@ -100,7 +100,7 @@ jobs:
         with:
           build-artifact-name: ${{ inputs.build-artifact-name }}
       - name: Ensure BH links online
-        if: ${{ contains(matrix.test-group.sku, 'bh_loudbox') }}
+        if: ${{ contains(matrix.test-group.sku, 'bh_loudbox') || contains(matrix.test-group.sku, 'bh_galaxy') }}
         uses: tenstorrent/tt-metal/.github/actions/ensure-bh-links-online@main
         timeout-minutes: 10
       - name: Set up coverage profiling

--- a/.github/workflows/runtime-unit-tests.yaml
+++ b/.github/workflows/runtime-unit-tests.yaml
@@ -90,6 +90,5 @@ jobs:
     secrets: inherit
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
-      harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
       enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}

--- a/.github/workflows/runtime-unit-tests.yaml
+++ b/.github/workflows/runtime-unit-tests.yaml
@@ -7,22 +7,26 @@ on:
     - cron: "0 4 * * *" # 04:00 UTC daily
   workflow_dispatch:
     inputs:
-      sku:
-        description: "Select machine/SKU to test (jobs with no coverage for the SKU are skipped)"
+      wormhole:
+        description: "All Wormhole SKUs (wh_n150_civ2, wh_n300_civ2, wh_llmbox, wh_galaxy)"
         required: false
-        default: all
-        type: choice
-        options:
-          - all
-          - "wh_n150_civ2 (N150)"
-          - "wh_n300_civ2 (N300)"
-          - "wh_llmbox (WH LLMBox)"
-          - "wh_galaxy (WH Galaxy)"
-          - "bh_p150b_civ2 (P150b)"
-          - "bh_p100a_civ2_viommu (P100a viommu)"
-          - "bh_p150b_civ2_viommu (P150b viommu)"
-          - "bh_p300 (P300)"
-          - "bh_loudbox (BH LoudBox)"
+        type: boolean
+        default: false
+      blackhole:
+        description: "All Blackhole SKUs (bh_p150b_civ2, bh_p100a_civ2_viommu, bh_p150b_civ2_viommu, bh_p300, bh_loudbox)"
+        required: false
+        type: boolean
+        default: false
+      multichip:
+        description: "Multichip SKUs only (wh_n300_civ2, wh_llmbox, wh_galaxy, bh_p300, bh_loudbox)"
+        required: false
+        type: boolean
+        default: false
+      skus:
+        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_p300, wh_llmbox'. Leave everything empty to run ALL."
+        required: false
+        type: string
+        default: ""
       platform:
         required: false
         type: choice
@@ -59,18 +63,63 @@ jobs:
       - name: Resolve SKU selection
         id: resolve
         run: |
-          ALL_SKUS="wh_n150_civ2,wh_n300_civ2,wh_llmbox,bh_p150b_civ2,bh_p100a_civ2_viommu,bh_p150b_civ2_viommu,bh_p300,bh_loudbox,wh_galaxy"
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            SKU_INPUT="${{ inputs.sku || 'all' }}"
-            if [[ "$SKU_INPUT" == "all" ]]; then
-              echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
-            else
-              SKU_NAME=$(echo "$SKU_INPUT" | sed 's/ (.*//')
-              echo "enabled-skus=$SKU_NAME" >> $GITHUB_OUTPUT
-            fi
+          WH_SKUS="wh_n150_civ2,wh_n300_civ2,wh_llmbox,wh_galaxy"
+          BH_SKUS="bh_p150b_civ2,bh_p100a_civ2_viommu,bh_p150b_civ2_viommu,bh_p300,bh_loudbox"
+          MULTICHIP_SKUS="wh_n300_civ2,wh_llmbox,wh_galaxy,bh_p300,bh_loudbox"
+          ALL_SKUS="$WH_SKUS,$BH_SKUS"
+          VALID_SKUS="wh_n150_civ2 wh_n300_civ2 wh_llmbox wh_galaxy bh_p150b_civ2 bh_p100a_civ2_viommu bh_p150b_civ2_viommu bh_p300 bh_loudbox wh_all bh_all multichip all"
+
+          # Scheduled (non-dispatch) runs always cover everything.
+          if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
+            echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
+            echo "Selected SKUs (scheduled): $ALL_SKUS"
             exit 0
           fi
-          echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
+
+          # Group checkboxes.
+          SELECTED=""
+          [[ "${{ inputs.wormhole }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$WH_SKUS"
+          [[ "${{ inputs.blackhole }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$BH_SKUS"
+          [[ "${{ inputs.multichip }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$MULTICHIP_SKUS"
+
+          # Specific SKUs / group keywords from the text box, added to the ticked boxes.
+          SKU_INPUT=$(echo "${{ inputs.skus }}" | xargs)
+          if [[ -n "$SKU_INPUT" ]]; then
+            IFS=',' read -ra ITEMS <<< "$SKU_INPUT"
+            for item in "${ITEMS[@]}"; do
+              item=$(echo "$item" | xargs)
+              [[ -z "$item" ]] && continue
+              if [[ ! " $VALID_SKUS " =~ " $item " ]]; then
+                echo "::error::Invalid SKU '$item'. Valid: [all, wh_all, bh_all, multichip] or one of: $WH_SKUS,$BH_SKUS"
+                exit 1
+              fi
+              case "$item" in
+                all) SELECTED="${SELECTED:+$SELECTED,}$ALL_SKUS" ;;
+                wh_all) SELECTED="${SELECTED:+$SELECTED,}$WH_SKUS" ;;
+                bh_all) SELECTED="${SELECTED:+$SELECTED,}$BH_SKUS" ;;
+                multichip) SELECTED="${SELECTED:+$SELECTED,}$MULTICHIP_SKUS" ;;
+                *) SELECTED="${SELECTED:+$SELECTED,}$item" ;;
+              esac
+            done
+          fi
+
+          # Nothing ticked and nothing typed -> run everything.
+          [[ -z "$SELECTED" ]] && SELECTED="$ALL_SKUS"
+
+          # Deduplicate, preserving first-seen order.
+          declare -A seen
+          SKUS=""
+          IFS=',' read -ra EXPANDED <<< "$SELECTED"
+          for sku in "${EXPANDED[@]}"; do
+            [[ -z "$sku" ]] && continue
+            if [[ -z "${seen[$sku]}" ]]; then
+              seen[$sku]=1
+              SKUS="${SKUS:+$SKUS,}$sku"
+            fi
+          done
+
+          echo "enabled-skus=$SKUS" >> $GITHUB_OUTPUT
+          echo "Selected SKUs: $SKUS"
   build-artifact:
     needs: check-harbor
     uses: ./.github/workflows/build-artifact.yaml

--- a/.github/workflows/runtime-unit-tests.yaml
+++ b/.github/workflows/runtime-unit-tests.yaml
@@ -7,16 +7,22 @@ on:
     - cron: "0 4 * * *" # 04:00 UTC daily
   workflow_dispatch:
     inputs:
-      wormhole:
-        description: "Run on Wormhole"
+      sku:
+        description: "Select machine/SKU to test (jobs with no coverage for the SKU are skipped)"
         required: false
-        type: boolean
-        default: true
-      blackhole:
-        description: "Run on Blackhole"
-        required: false
-        type: boolean
-        default: true
+        default: all
+        type: choice
+        options:
+          - all
+          - "wh_n150_civ2 (N150)"
+          - "wh_n300_civ2 (N300)"
+          - "wh_llmbox (WH LLMBox)"
+          - "wh_galaxy (WH Galaxy)"
+          - "bh_p150b_civ2 (P150b)"
+          - "bh_p100a_civ2_viommu (P100a viommu)"
+          - "bh_p150b_civ2_viommu (P150b viommu)"
+          - "bh_p300 (P300)"
+          - "bh_loudbox (BH LoudBox)"
       platform:
         required: false
         type: choice
@@ -45,6 +51,26 @@ on:
 jobs:
   check-harbor:
     uses: ./.github/workflows/check-harbor.yaml
+  resolve-skus:
+    runs-on: ubuntu-latest
+    outputs:
+      enabled-skus: ${{ steps.resolve.outputs.enabled-skus }}
+    steps:
+      - name: Resolve SKU selection
+        id: resolve
+        run: |
+          ALL_SKUS="wh_n150_civ2,wh_n300_civ2,wh_llmbox,bh_p150b_civ2,bh_p100a_civ2_viommu,bh_p150b_civ2_viommu,bh_p300,bh_loudbox,wh_galaxy"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            SKU_INPUT="${{ inputs.sku || 'all' }}"
+            if [[ "$SKU_INPUT" == "all" ]]; then
+              echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
+            else
+              SKU_NAME=$(echo "$SKU_INPUT" | sed 's/ (.*//')
+              echo "enabled-skus=$SKU_NAME" >> $GITHUB_OUTPUT
+            fi
+            exit 0
+          fi
+          echo "enabled-skus=$ALL_SKUS" >> $GITHUB_OUTPUT
   build-artifact:
     needs: check-harbor
     uses: ./.github/workflows/build-artifact.yaml
@@ -59,20 +85,11 @@ jobs:
       enable-lto: ${{ inputs.enable-lto || false }}
 
   runtime-unit-tests:
-    needs: [check-harbor, build-artifact]
+    needs: [check-harbor, build-artifact, resolve-skus]
     uses: ./.github/workflows/runtime-unit-tests-impl.yaml
     secrets: inherit
     with:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: >-
-        ${{
-          github.event_name == 'schedule'
-            && 'wh_n150_civ2,wh_n300_civ2,bh_p150b_civ2,bh_p100a_civ2_viommu,bh_p150b_civ2_viommu,bh_loudbox,wh_galaxy'
-            || format('{0}{1}',
-              inputs.wormhole && 'wh_n150_civ2,wh_n300_civ2,wh_galaxy' || '',
-              inputs.blackhole && format('{0}bh_p150b_civ2,bh_p100a_civ2_viommu,bh_p150b_civ2_viommu,bh_loudbox',
-                inputs.wormhole && ',' || '') || ''
-            )
-        }}
+      enabled-skus: ${{ needs.resolve-skus.outputs.enabled-skus }}

--- a/.github/workflows/runtime-unit-tests.yaml
+++ b/.github/workflows/runtime-unit-tests.yaml
@@ -7,6 +7,11 @@ on:
     - cron: "0 4 * * *" # 04:00 UTC daily
   workflow_dispatch:
     inputs:
+      all:
+        description: "All SKUs (every Wormhole + Blackhole SKU)"
+        required: false
+        type: boolean
+        default: false
       wormhole:
         description: "All Wormhole SKUs (wh_n150_civ2, wh_n300_civ2, wh_llmbox, wh_galaxy)"
         required: false
@@ -23,7 +28,7 @@ on:
         type: boolean
         default: false
       skus:
-        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_p300, wh_llmbox'. Leave everything empty to run ALL."
+        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_p300, wh_llmbox'. Tick the 'all' box above to run every SKU."
         required: false
         type: string
         default: ""
@@ -78,6 +83,7 @@ jobs:
 
           # Group checkboxes.
           SELECTED=""
+          [[ "${{ inputs.all }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$ALL_SKUS"
           [[ "${{ inputs.wormhole }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$WH_SKUS"
           [[ "${{ inputs.blackhole }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$BH_SKUS"
           [[ "${{ inputs.multichip }}" == "true" ]] && SELECTED="${SELECTED:+$SELECTED,}$MULTICHIP_SKUS"
@@ -103,8 +109,11 @@ jobs:
             done
           fi
 
-          # Nothing ticked and nothing typed -> run everything.
-          [[ -z "$SELECTED" ]] && SELECTED="$ALL_SKUS"
+          # Require an explicit selection now that "empty = all" is replaced by the 'all' checkbox.
+          if [[ -z "$SELECTED" ]]; then
+            echo "::error::No SKUs selected. Tick 'all' (or wormhole/blackhole/multichip) or list SKUs in the 'skus' box."
+            exit 1
+          fi
 
           # Deduplicate, preserving first-seen order.
           declare -A seen

--- a/.github/workflows/runtime-unit-tests.yaml
+++ b/.github/workflows/runtime-unit-tests.yaml
@@ -11,7 +11,7 @@ on:
         description: "All SKUs (every Wormhole + Blackhole SKU)"
         required: false
         type: boolean
-        default: false
+        default: true
       wormhole:
         description: "All Wormhole SKUs (wh_n150_civ2, wh_n300_civ2, wh_llmbox, wh_galaxy)"
         required: false
@@ -28,7 +28,7 @@ on:
         type: boolean
         default: false
       skus:
-        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_p300, wh_llmbox'. Tick the 'all' box above to run every SKU."
+        description: "Specific SKUs (comma-separated), added to any boxes ticked above. e.g. 'bh_p300, wh_llmbox'. The 'all' box above is ticked by default (every SKU); untick it to run only the boxes/SKUs you pick."
         required: false
         type: string
         default: ""

--- a/tests/pipeline_reorg/runtime_integration_tests.yaml
+++ b/tests/pipeline_reorg/runtime_integration_tests.yaml
@@ -38,6 +38,19 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
+# --- Galaxy: Ethernet only (#46302; fabric team owns full galaxy stress) ---
+- name: galaxy_eth
+  cmd: |
+    ./build/test/tt_metal/unit_tests_eth
+    TT_METAL_SLOW_DISPATCH_MODE=true ./build/test/tt_metal/unit_tests_eth
+  skus:
+    wh_galaxy:
+      timeout: 15
+    bh_galaxy:
+      timeout: 15
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+  team: runtime
+
 # =============================================================================
 # FD Python API Tests (eager ops + sweep)
 # =============================================================================

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -169,10 +169,25 @@
       timeout: 15
     wh_n300_civ2:
       timeout: 15
-    wh_llmbox:
-      timeout: 15
     bh_p150b_civ2:
       timeout: 8
+  owner_id: U099A7FMKL2 # Manish Sudumbrekar
+  team: runtime
+
+# wh_llmbox runs the same distributed suite but excludes the multi-CQ mesh-event tests
+# (MeshEventsTestSuite.* and MeshEventsTest2x4.*). They deadlock on the 8-device LLMBox mesh
+# (2 CQs + FABRIC_1D multi-device event sync) and hang the job to a 15-min timeout. Confirmed on
+# MultiCQNonBlockingReads and AsyncWorkloadAndIO; the whole family shares the deadlock-prone
+# GenericMultiCQMeshDeviceFixture (num_cqs=2, auto-sized to the full system mesh). This is a hang,
+# not slowness (ReplicatedAsyncIO completes in <1s), so a larger timeout does not help.
+# Kept as a separate entry rather than an in-cmd branch because the container only exposes ARCH_NAME,
+# which cannot distinguish wh_llmbox from other wormhole_b0 boards. Re-enable once the deadlock is fixed.
+# TODO(tracking-issue): re-enable the mesh-event suites on wh_llmbox once the LLMBox multi-CQ event-sync deadlock is resolved.
+- name: runtime_distributed
+  cmd: ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter='-MeshEventsTestSuite.*:MeshEventsTest2x4.*'
+  skus:
+    wh_llmbox:
+      timeout: 15
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -29,6 +29,10 @@
   skus:
     wh_n150_civ2:
       timeout: 5
+    wh_n300_civ2:
+      timeout: 5
+    wh_llmbox:
+      timeout: 5
     bh_p150b_civ2:
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
@@ -139,6 +143,8 @@
   skus:
     wh_n150_civ2:
       timeout: 5
+    wh_n300_civ2:
+      timeout: 5
     bh_p150b_civ2:
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
@@ -160,6 +166,10 @@
   cmd: ./build/test/tt_metal/distributed/distributed_unit_tests
   skus:
     wh_n150_civ2:
+      timeout: 15
+    wh_n300_civ2:
+      timeout: 15
+    wh_llmbox:
       timeout: 15
     bh_p150b_civ2:
       timeout: 8
@@ -216,6 +226,8 @@
       timeout: 20
     bh_p150b_civ2:
       timeout: 15
+    bh_p300:
+      timeout: 15
     bh_p100a_civ2_viommu:
       timeout: 15
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
@@ -230,6 +242,8 @@
     wh_n300_civ2:
       timeout: 10
     bh_p150b_civ2:
+      timeout: 10
+    bh_p300:
       timeout: 10
     bh_p100a_civ2_viommu:
       timeout: 10
@@ -258,6 +272,8 @@
       timeout: 17
     bh_p150b_civ2:
       timeout: 17
+    bh_p300:
+      timeout: 17
     bh_p100a_civ2_viommu:
       timeout: 17
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
@@ -276,6 +292,8 @@
       timeout: 12
     bh_p150b_civ2:
       timeout: 10
+    bh_p300:
+      timeout: 12
     bh_p100a_civ2_viommu:
       timeout: 12
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
@@ -290,6 +308,8 @@
     wh_n300_civ2:
       timeout: 5
     bh_p150b_civ2:
+      timeout: 5
+    bh_p300:
       timeout: 5
     bh_p100a_civ2_viommu:
       timeout: 5
@@ -306,13 +326,15 @@
       timeout: 10
     bh_p150b_civ2:
       timeout: 10
+    bh_p300:
+      timeout: 10
     bh_p100a_civ2_viommu:
       timeout: 10
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
 # =============================================================================
-# Multi-Card Unit Tests (Galaxy)
+# Multi-Card Unit Tests (BH + Galaxy) — see #46302 for topology matrix
 # =============================================================================
 
 # --- BH Multi-Card: Debug Tools (mesh filters + single AERISC) ---
@@ -391,6 +413,8 @@
     bh_p150b_civ2:
       timeout: 5
     bh_p100a_civ2_viommu:
+      timeout: 5
+    bh_loudbox:
       timeout: 5
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -96,7 +96,9 @@
   team: runtime
 
 # --- LLK + SFPI Tests ---
-# WH timeout raised from 8→12 min: full LLK+SFPI suite exceeds 8 min wall clock on wh_n150_civ2.
+# WH/BH timeout raised to 12 min: full LLK+SFPI suite exceeds 8 min wall clock (measured
+# ~12.3 min on bh_p150b_civ2). Cost is genuine passing-test work (LLKMeshDeviceFixture reduce
+# family dominates); skipped Quasar-only tests are free (~130 ms total), not the cause.
 - name: runtime_llk
   # 4 tests disabled by #44767.
   disabled_llk_filter: &disabled_llk 'LLKBlackholeSingleCardFixture.TensixComputePackUntilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixComputeUnpackTilizeFp8e4m3:LLKBlackholeSingleCardFixture.TensixFp8e4m3ToFp8e4m3:MeshDeviceFixture.Top32RmDevPipelineCompletes'
@@ -107,7 +109,7 @@
     wh_n150_civ2:
       timeout: 12
     bh_p150b_civ2:
-      timeout: 8
+      timeout: 12
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
@@ -174,17 +176,20 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
-# wh_llmbox runs the same distributed suite but excludes the multi-CQ mesh-event tests
-# (MeshEventsTestSuite.* and MeshEventsTest2x4.*). They deadlock on the 8-device LLMBox mesh
-# (2 CQs + FABRIC_1D multi-device event sync) and hang the job to a 15-min timeout. Confirmed on
-# MultiCQNonBlockingReads and AsyncWorkloadAndIO; the whole family shares the deadlock-prone
-# GenericMultiCQMeshDeviceFixture (num_cqs=2, auto-sized to the full system mesh). This is a hang,
-# not slowness (ReplicatedAsyncIO completes in <1s), so a larger timeout does not help.
+# wh_llmbox runs the same distributed suite but excludes the multi-device workload/trace/event
+# EXECUTION tests that deadlock on the 8-device (2x4) LLMBox mesh. wh_llmbox is the only SKU here
+# large enough to actually run these suites (smaller SKUs skip them; 4x8/32-device suites skip
+# everywhere on an 8-device system), so this PR is the first to exercise them on this topology and
+# they hang the job to a 15-min timeout. Confirmed hangs: MeshEventsTestSuite (MultiCQNonBlockingReads,
+# AsyncWorkloadAndIO) and MeshTraceTest2x4 (EltwiseBinaryMeshTrace); the rest below share the same
+# full-mesh cross-device execution/sync path. These are genuine hangs, not slowness (e.g.
+# ReplicatedAsyncIO completes in <1s), so a larger timeout does not help. Device-management, buffer,
+# view, reshape, and generic single-CQ mesh suites (e.g. MeshTraceTestSuite, which passes) still run.
 # Kept as a separate entry rather than an in-cmd branch because the container only exposes ARCH_NAME,
 # which cannot distinguish wh_llmbox from other wormhole_b0 boards. Re-enable once the deadlock is fixed.
-# TODO(tracking-issue): re-enable the mesh-event suites on wh_llmbox once the LLMBox multi-CQ event-sync deadlock is resolved.
+# TODO(tracking-issue): re-enable the multi-device execution suites on wh_llmbox once the LLMBox mesh event/trace-sync deadlock is resolved.
 - name: runtime_distributed
-  cmd: ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter='-MeshEventsTestSuite.*:MeshEventsTest2x4.*'
+  cmd: ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter='-MeshEventsTestSuite.*:MeshEventsTest2x4.*:MeshTraceTest2x4.*:MeshTraceSweepTest2x4*:MeshWorkloadTest2x4.*:MeshEndToEnd2x4Tests.*:MeshEndToEnd2x4TraceTests.*'
   skus:
     wh_llmbox:
       timeout: 15

--- a/tests/pipeline_reorg/runtime_unit_tests.yaml
+++ b/tests/pipeline_reorg/runtime_unit_tests.yaml
@@ -176,25 +176,11 @@
   owner_id: U099A7FMKL2 # Manish Sudumbrekar
   team: runtime
 
-# wh_llmbox runs the same distributed suite but excludes the multi-device workload/trace/event
-# EXECUTION tests that deadlock on the 8-device (2x4) LLMBox mesh. wh_llmbox is the only SKU here
-# large enough to actually run these suites (smaller SKUs skip them; 4x8/32-device suites skip
-# everywhere on an 8-device system), so this PR is the first to exercise them on this topology and
-# they hang the job to a 15-min timeout. Confirmed hangs: MeshEventsTestSuite (MultiCQNonBlockingReads,
-# AsyncWorkloadAndIO) and MeshTraceTest2x4 (EltwiseBinaryMeshTrace); the rest below share the same
-# full-mesh cross-device execution/sync path. These are genuine hangs, not slowness (e.g.
-# ReplicatedAsyncIO completes in <1s), so a larger timeout does not help. Device-management, buffer,
-# view, reshape, and generic single-CQ mesh suites (e.g. MeshTraceTestSuite, which passes) still run.
-# Kept as a separate entry rather than an in-cmd branch because the container only exposes ARCH_NAME,
-# which cannot distinguish wh_llmbox from other wormhole_b0 boards. Re-enable once the deadlock is fixed.
-# TODO(tracking-issue): re-enable the multi-device execution suites on wh_llmbox once the LLMBox mesh event/trace-sync deadlock is resolved.
-- name: runtime_distributed
-  cmd: ./build/test/tt_metal/distributed/distributed_unit_tests --gtest_filter='-MeshEventsTestSuite.*:MeshEventsTest2x4.*:MeshTraceTest2x4.*:MeshTraceSweepTest2x4*:MeshWorkloadTest2x4.*:MeshEndToEnd2x4Tests.*:MeshEndToEnd2x4TraceTests.*'
-  skus:
-    wh_llmbox:
-      timeout: 15
-  owner_id: U099A7FMKL2 # Manish Sudumbrekar
-  team: runtime
+# NOTE: wh_llmbox is intentionally NOT listed here. The full distributed_unit_tests suite already
+# runs on wh_llmbox (the T3000 8-device box) via the scaleout-owned t3k_ttmetal_tests job
+# (tests/scripts/t3000/run_t3000_unit_tests.sh), which budgets 40 min for it. Adding a second
+# runtime_distributed run on wh_llmbox with the 15-min unit budget was redundant and could not
+# complete in time on 8 devices. Smaller SKUs above skip the multi-device (2x4/4x8) suites.
 
 # --- IOMMU PinnedMemory Tests (SD + FD) ---
 - name: runtime_iommu_pinned_memory

--- a/tests/tt_metal/tt_metal/device/test_release_ownership.cpp
+++ b/tests/tt_metal/tt_metal/device/test_release_ownership.cpp
@@ -31,11 +31,16 @@ static void open_and_close_device() {
     ASSERT_GT(ids.size(), 0);
     const auto& dispatch_core_config = tt::tt_metal::MetalContext::instance().rtoptions().get_dispatch_core_config();
 
+    // Open one unit mesh per MMIO chip. Multi-chip boards (e.g. P300) expose more than one
+    // MMIO chip, so assert against the number of chips opened rather than hardcoding a single device.
     auto devices = distributed::MeshDevice::create_unit_meshes(
         ids, DEFAULT_L1_SMALL_SIZE, DEFAULT_TRACE_REGION_SIZE, 1, dispatch_core_config);
 
-    ASSERT_EQ(devices.size(), 1);
-    devices[0]->close();
+    ASSERT_EQ(devices.size(), ids.size());
+    for (auto& [id, device] : devices) {
+        (void)id;
+        device->close();
+    }
 }
 
 TEST(TensixReleaseOwnership, BasicReleaseOwnership) {


### PR DESCRIPTION
## Summary

Fixes #46302.

Expands runtime CI so multichip topologies can be targeted in CI. Builds on the post–LoudBox migration on `main` (no QuietBox SKUs in workflows). Additive for coverage — existing jobs are unchanged except where noted (timeouts and a multichip-correctness test fix).

**Unit test matrix (`runtime_unit_tests.yaml`)**
- `wh_n300_civ2`: `runtime_fast_dispatch_multi_cq`, `runtime_eth`, `runtime_distributed`, and all slow-dispatch (`runtime_sd_*`) jobs
- `wh_llmbox`: `runtime_fast_dispatch_multi_cq` only
  - `runtime_distributed` is intentionally **not** run here: the full `distributed_unit_tests` suite already runs on `wh_llmbox` via the scaleout-owned `t3k_ttmetal_tests` job (`tests/scripts/t3000/run_t3000_unit_tests.sh`, 40-min budget). A second 15-min run on 8 devices was redundant and could not finish in the unit budget.
- `bh_p300`: all slow-dispatch unit jobs
- `bh_loudbox`: `service_core_manager`

**Integration (`runtime_integration_tests.yaml`)**
- New `galaxy_eth` job: `unit_tests_eth` (fast dispatch + slow dispatch) on `wh_galaxy` and `bh_galaxy`

**Manual dispatch / machine selection (runtime unit, integration, sanity)**
- Replaced the old wormhole/blackhole toggles with an explicit selection model:
  - `all` checkbox — every Wormhole + Blackhole SKU
  - `wormhole` / `blackhole` / `multichip` group checkboxes
  - `skus` free-text box — specific comma-separated SKUs, or the keywords `all` / `wh_all` / `bh_all` / `multichip`, added on top of any ticked boxes
- Selection is now **required**: an empty form errors out instead of silently running everything (removes the old implicit "empty = all"). Scheduled/nightly runs still cover the full SKU list.
- `resolve-skus` job maps the checkboxes + text box → `enabled-skus`, de-duplicating.
- Unit nightly SKUs: `wh_n150_civ2`, `wh_n300_civ2`, `wh_llmbox`, `bh_p150b_civ2`, `bh_p100a_civ2_viommu`, `bh_p150b_civ2_viommu`, `bh_p300`, `bh_loudbox`, `wh_galaxy`
- Integration nightly SKUs: adds `wh_galaxy`, `bh_galaxy` (alongside existing N150 / P150b / LoudBox)

**Test fix**
- `TensixReleaseOwnership` (`test_release_ownership.cpp`): made multichip-aware — opens one unit mesh per MMIO chip and asserts against the number of chips opened (was hardcoded to a single device), so it passes on multi-MMIO boards like `bh_p300`.

**Infra**
- **Harbor bypass (unit impl):** removed the `harbor-prefix` input entirely and pull the canonical GHCR image directly for **all** SKUs. A job-level `container:` image is resolved/pulled by the runner harness *before any step runs*, with no retry/fallback if a silicon runner transiently can't resolve `harbor.ci.tenstorrent.net` (DNS split-brain: `check-harbor` probes from a different runner). GHCR-direct is the path the multi-host SKUs already use.
- **BH links:** `ensure-bh-links-online` now also runs for `bh_galaxy` (unit + integration impl), alongside existing `bh_loudbox`.
- **CI gating (`find-changed-files.sh`):** a workflow-only PR (`.github/workflows/*.yaml|*.yml`) now fans out to the full standard gate (build + smoke + examples + code-analysis) instead of potentially skipping, matching every other PR.
- **`time_budget.yaml`:**
  - unit: `wh_n300_civ2` 74→99, `bh_p150b_civ2` 210→214, new `wh_llmbox` (20) and `bh_p300` (69)
  - integration: new `wh_galaxy` (15), `bh_galaxy` (15)
- **`runtime_llk` timeout:** `bh_p150b_civ2` raised 8→12 min (matching WH). Measured ~12.3 min wall clock; the cost is genuine passing-test work (`LLKMeshDeviceFixture` reduce family), not skip overhead (skipped Quasar-only tests total ~130 ms).


## Test plan

- [x] `workflow_dispatch` **(Runtime) Unit Tests** — `wh_n300_civ2`, `wh_llmbox`, `bh_p300`, `bh_loudbox`
- [x] `workflow_dispatch` **(Runtime) Integration Tests** — `wh_galaxy`, `bh_galaxy` (`galaxy_eth`)
- [ ] `workflow_dispatch` with an empty form errors out; `all` checkbox runs every SKU
- [x] Confirm CI budget verification passes in load-test-matrix
- [x] Watch first nightly for timeouts on new SKUs

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=msudumbrekar/runtime-ci-topologies-46302)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:msudumbrekar/runtime-ci-topologies-46302)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=msudumbrekar/runtime-ci-topologies-46302)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:msudumbrekar/runtime-ci-topologies-46302)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=msudumbrekar/runtime-ci-topologies-46302)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:msudumbrekar/runtime-ci-topologies-46302)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=msudumbrekar/runtime-ci-topologies-46302)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:msudumbrekar/runtime-ci-topologies-46302)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=msudumbrekar/runtime-ci-topologies-46302)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:msudumbrekar/runtime-ci-topologies-46302)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=msudumbrekar/runtime-ci-topologies-46302)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:msudumbrekar/runtime-ci-topologies-46302)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=msudumbrekar/runtime-ci-topologies-46302)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:msudumbrekar/runtime-ci-topologies-46302)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=msudumbrekar/runtime-ci-topologies-46302)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:msudumbrekar/runtime-ci-topologies-46302)