### PR TITLE
CI disable: skip flux.1-dev BH performance tests on bh_loudbox and bh_quietbox_2 (mesh_trace TT_FATAL)

### DIFF
--- a/models/tt_dit/tests/models/flux1/test_performance_flux1.py
+++ b/models/tt_dit/tests/models/flux1/test_performance_flux1.py
@@ -27,9 +27,15 @@ from ....pipelines.flux1.pipeline_flux1 import Flux1Pipeline, Flux1PipelineConfi
     "mesh_device, sp, tp, encoder_tp, vae_tp, topology, num_links",
     [
         [(1, 2), (1, 0), (2, 1), (2, 1), (2, 1), ttnn.Topology.Linear, 2],
-        [(2, 2), (2, 0), (2, 1), (2, 1), (2, 1), ttnn.Topology.Linear, 2],
+        pytest.param(
+            (2, 2), (2, 0), (2, 1), (2, 1), (2, 1), ttnn.Topology.Linear, 2,
+            marks=pytest.mark.skip(reason="Disabled on bh_quietbox_2 (2x2 blackhole mesh): see #46697"),
+        ),
         [(2, 4), (2, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 1],
-        [(2, 4), (2, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 2],
+        pytest.param(
+            (2, 4), (2, 0), (4, 1), (4, 1), (4, 1), ttnn.Topology.Linear, 2,
+            marks=pytest.mark.skip(reason="Disabled on bh_loudbox (bh_2x4 blackhole mesh): see #46697"),
+        ),
         [(4, 8), (4, 0), (8, 1), (4, 0), (4, 0), ttnn.Topology.Linear, 4],
         [(4, 8), (4, 0), (8, 1), (4, 0), (4, 0), ttnn.Topology.Linear, 2],
     ],


### PR DESCRIPTION
Disable deterministically failing flux.1-dev performance test on blackhole bh_loudbox and bh_quietbox_2 (mesh_trace TT_FATAL: trace buffers exceed region)

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| models/tt_dit/tests/models/flux1/test_performance_flux1.py::test_flux1_pipeline_performance[blackhole-device_params0-bh_2x4sp0tp1-1024-1024-3.5-28] [bh_loudbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27326025746/job/80728202149 | [798b264](https://github.com/tenstorrent/tt-metal/commit/798b264f40bb40c93fa4d2f1e161a774a8ce1420) | 2026-06-11 06:25 UTC |
| models/tt_dit/tests/models/flux1/test_performance_flux1.py::test_flux1_pipeline_performance[blackhole-device_params0-2x2sp0tp1-1024-1024-3.5-28] [bh_quietbox_2] | https://github.com/tenstorrent/tt-metal/actions/runs/27326025746/job/80728202166 | [798b264](https://github.com/tenstorrent/tt-metal/commit/798b264f40bb40c93fa4d2f1e161a774a8ce1420) | 2026-06-11 06:25 UTC |