### PR TITLE
[skip ci] #MINFRA-615: remove bh_loudbox from model perf workflows

### DIFF
--- a/.github/workflows/blackhole-demo-tests.yaml
+++ b/.github/workflows/blackhole-demo-tests.yaml
@@ -30,7 +30,6 @@ on:
           - all
           - P150 (1xP150)
           - P150 CIv2 (1xP150)
-          - LoudBox (8xP150)
           - P300 (1xP300)
           - QuietBox 2 (2xP300)
       build-type:

--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -85,7 +85,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: bh_galaxy,wh_llmbox_perf,bh_loudbox,bh_quietbox_2
+      enabled-skus: bh_galaxy,wh_llmbox_perf,bh_quietbox_2
       model: deepseek_prefill
       mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
       job-prefix: "[DeepSeek Prefill] "

--- a/tests/pipeline_reorg/blackhole_demo_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_demo_tests.yaml
@@ -23,38 +23,6 @@
 # Exceptions: bh_p300 (LFC) entries keep file-path / HF_HUB_CACHE form because the LFC
 # server hosts checkpoints in a layout that does not match the canonical hub cache.
 
-# ─── mistral-small-3.1-24b ──────────────────────────────────────────────────
-
-- name: mistral-small-3.1-24b e2e tests
-  cmd: |
-    set -e
-    export HF_HOME=/localdev/blackhole_demos/huggingface_data
-    export HF_MODEL=mistralai/Mistral-Small-3.1-24B-Instruct-2503
-    export TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/tt_cache/mistralai--Mistral-Small-3.1-24B-Instruct-2503
-    export MESH_DEVICE=T3K
-    pytest --timeout 600 models/experimental/mistral_24b/tests/pipeline_tests
-  skus:
-    bh_loudbox:
-      timeout: 10
-  owner_id: U03PUAKE719 # Miguel Tairum
-  team: models
-  model-name: mistral-small-3.1-24b
-
-# ─── Mochi ──────────────────────────────────────────────────────────────────
-
-- name: Mochi pipeline performance
-  cmd: |
-    set -e
-    export HF_HOME=/localdev/blackhole_demos/huggingface_data
-    export TT_DIT_CACHE_DIR=/tmp/TT_DIT_CACHE
-    pytest --timeout=1500 models/tt_dit/tests/models/mochi/test_pipeline_mochi.py -k "4x8sp1tp0"
-  skus:
-    bh_loudbox:
-      timeout: 20
-  owner_id: U09ELB03XRU # Stephen Osborne
-  team: models
-  model-name: mochi
-
 # ─── stable_diffusion_xl ────────────────────────────────────────────────────
 
 - name: stable_diffusion_xl demos
@@ -97,18 +65,6 @@
   team: models
   model-name: flux.1-dev
 
-- name: Flux.1-dev BH LoudBox performance (bh_2x4sp0tp1)
-  cmd: |
-    set -e
-    export HF_HOME=/localdev/blackhole_demos/huggingface_data
-    pytest models/tt_dit/tests/models/flux1/test_performance_flux1.py -k "bh_2x4sp0tp1" --timeout=600
-  skus:
-    bh_loudbox:
-      timeout: 10
-  owner_id: U09ELB03XRU # Stephen Osborne
-  team: models
-  model-name: flux.1-dev
-
 # ─── Mochi (BH QuietBox 2) ──────────────────────────────────────────────────
 
 - name: Mochi BH QuietBox 2 performance (2x2sp0tp1)
@@ -136,18 +92,6 @@
     bh_quietbox_2:
       timeout: 20
   owner_id: U08TED0JM9D # Samuel Adesoye
-  team: models
-  model-name: wan2.2-t2v-a14b
-
-- name: Wan2.2-T2V-A14B BH LoudBox performance
-  cmd: |
-    set -e
-    export HF_HOME=/localdev/blackhole_demos/huggingface_data
-    pytest models/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "bh_2x4_sp1tp0 and resolution_480p and t2v" --timeout=1200
-  skus:
-    bh_loudbox:
-      timeout: 20
-  owner_id: U09ELB03XRU # Stephen Osborne
   team: models
   model-name: wan2.2-t2v-a14b
 

--- a/tests/pipeline_reorg/blackhole_demo_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_demo_tests.yaml
@@ -23,6 +23,26 @@
 # Exceptions: bh_p300 (LFC) entries keep file-path / HF_HUB_CACHE form because the LFC
 # server hosts checkpoints in a layout that does not match the canonical hub cache.
 
+# ─── mistral-small-3.1-24b ──────────────────────────────────────────────────
+# TEMPORARILY DISABLED: bh_loudbox is being removed from CI (MINFRA-615). Mistral
+# still needs to be tested on QB2 (bh_quietbox_2) before this entry can be re-enabled
+# or migrated. Left commented (not deleted) so we don't lose track of it.
+#
+# - name: mistral-small-3.1-24b e2e tests
+#   cmd: |
+#     set -e
+#     export HF_HOME=/localdev/blackhole_demos/huggingface_data
+#     export HF_MODEL=mistralai/Mistral-Small-3.1-24B-Instruct-2503
+#     export TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/tt_cache/mistralai--Mistral-Small-3.1-24B-Instruct-2503
+#     export MESH_DEVICE=T3K
+#     pytest --timeout 600 models/experimental/mistral_24b/tests/pipeline_tests
+#   skus:
+#     bh_loudbox:
+#       timeout: 10
+#   owner_id: U03PUAKE719 # Miguel Tairum
+#   team: models
+#   model-name: mistral-small-3.1-24b
+
 # ─── stable_diffusion_xl ────────────────────────────────────────────────────
 
 - name: stable_diffusion_xl demos


### PR DESCRIPTION
## Summary
- `demo-sp-release.yaml` — drop `bh_loudbox` from the DeepSeek Prefill `enabled-skus`. Remaining SKUs (`bh_galaxy`, `wh_llmbox_perf`, `bh_quietbox_2`) cover both scheduled and manual runs.
- `blackhole-demo-tests.yaml` — drop `LoudBox (8xP150)` from the `system-type` `workflow_dispatch` choice list.
- `tests/pipeline_reorg/blackhole_demo_tests.yaml` — remove 4 `bh_loudbox`-only test rows + the now-empty mistral and Mochi section headers:
  - `mistral-small-3.1-24b e2e tests`
  - `Mochi pipeline performance`
  - `Flux.1-dev BH LoudBox performance (bh_2x4sp0tp1)`
  - `Wan2.2-T2V-A14B BH LoudBox performance`

Functional / integration workflows (`blackhole-post-commit`, `blackhole-e2e-tests`, `runtime-sanity-tests`, `runtime-unit-tests`, `runtime-integration-tests`, `upstream-tests`, `tm-fabric-tests`, `metal-run-microbenchmarks-impl`, etc.) and the manual `ttnn-run-model-trace` utility are intentionally left as-is.

Tier model workflows (`models-t{1,2,3}-{unit,e2e}-tests.yaml`) already had `bh_loudbox` removed on main by #45300, so they require no change here.

## Test plan
- [x] Diff inspected — 3 files; remaining files in scope verified to have no `bh_loudbox` references.
- [ ] Reviewer: confirm next scheduled `demo-sp-release` and `blackhole-demo-tests` runs produce the expected matrix (no `bh_loudbox` jobs).
- [ ] Reviewer: confirm manual `workflow_dispatch` of `blackhole-demo-tests` no longer offers `LoudBox (8xP150)` as a system-type option.

---
**Jira:** [MINFRA-615](https://tenstorrent.atlassian.net/browse/MINFRA-615)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mchiou/MINFRA-615-disable-bh-loudbox-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mchiou/MINFRA-615-disable-bh-loudbox-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mchiou/MINFRA-615-disable-bh-loudbox-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mchiou/MINFRA-615-disable-bh-loudbox-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mchiou/MINFRA-615-disable-bh-loudbox-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mchiou/MINFRA-615-disable-bh-loudbox-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mchiou/MINFRA-615-disable-bh-loudbox-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mchiou/MINFRA-615-disable-bh-loudbox-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mchiou/MINFRA-615-disable-bh-loudbox-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mchiou/MINFRA-615-disable-bh-loudbox-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mchiou/MINFRA-615-disable-bh-loudbox-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mchiou/MINFRA-615-disable-bh-loudbox-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mchiou/MINFRA-615-disable-bh-loudbox-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mchiou/MINFRA-615-disable-bh-loudbox-ci)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mchiou/MINFRA-615-disable-bh-loudbox-ci)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mchiou/MINFRA-615-disable-bh-loudbox-ci)