### PR TITLE
Fix Quasar watcher stack painter wiping legacy-kernel globals

### DIFF
--- a/tt_metal/hw/inc/internal/debug/stack_usage.h
+++ b/tt_metal/hw/inc/internal/debug/stack_usage.h
@@ -20,7 +20,11 @@ constexpr uint32_t stack_usage_pattern = 0xBABABABA;
 static inline uint32_t* get_stack_base() {
 #if defined(ARCH_QUASAR)
     extern thread_local uint32_t __stack_base_lwm[];
-    return __stack_base_lwm;
+    // Legacy (lgc) kernels place their globals in the TLS region after
+    // .tbss.end; the linker exports their size as __stack_base_offset (in
+    // words) so painting starts above them. TLS-mode kernels set it to 0.
+    extern uint32_t __stack_base_offset[];
+    return __stack_base_lwm + (uintptr_t)__stack_base_offset;
 #else
     extern uint32_t __stack_base[];
     return __stack_base;


### PR DESCRIPTION
Legacy (lgc) kernels place their globals in the TLS region after .tbss.end, where __stack_base_lwm points. The watcher stack painter used __stack_base_lwm directly as the paint floor, so on every kernel launch it painted 0xBABABABA over those globals (e.g. unpack_src_format, unpack_tile_face_r_dim, unpack_tile_num_faces) before the LLKs read them, corrupting buffer descriptors and tripping an UNPACKER_0 hardware fault. The corruption only appeared with watcher enabled.

Add __stack_base_offset (defined by kernel_trisc_lgc.ld as kernel data size in words, 0 for TLS-mode kernels) so painting starts at the true data/stack watermark — the same boundary __stack_base provides on earlier architectures.

Fixes MeshDeviceFixture.TensixSingleCoreDirectDramReaderDatacopyWriter on Quasar with TT_METAL_WATCHER set; verified watcher on and off.

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/fix-quasar-stack-paint-lgc-globals)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/fix-quasar-stack-paint-lgc-globals)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rtawfik/fix-quasar-stack-paint-lgc-globals)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rtawfik/fix-quasar-stack-paint-lgc-globals)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rtawfik/fix-quasar-stack-paint-lgc-globals)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rtawfik/fix-quasar-stack-paint-lgc-globals)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/fix-quasar-stack-paint-lgc-globals)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/fix-quasar-stack-paint-lgc-globals)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rtawfik/fix-quasar-stack-paint-lgc-globals)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rtawfik/fix-quasar-stack-paint-lgc-globals)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/fix-quasar-stack-paint-lgc-globals)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/fix-quasar-stack-paint-lgc-globals)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/fix-quasar-stack-paint-lgc-globals)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/fix-quasar-stack-paint-lgc-globals)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/fix-quasar-stack-paint-lgc-globals)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/fix-quasar-stack-paint-lgc-globals)