### PR TITLE
sim: advance HD socket waits (2x cross-device sim)

### DIFF
--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -43,6 +43,19 @@ namespace {
 // `_mm_clflush` invalidates one host cache line; 64 B is the line size on typical x86-64.
 constexpr uint32_t k_x86_clflush_line_bytes = 64;
 
+void advance_d2h_simulator_socket_device(MeshDevice* mesh_device, const MeshCoordinate& device_coord) {
+    if (mesh_device == nullptr) {
+        return;
+    }
+
+    const auto& cluster = MetalContext::instance().get_cluster();
+    if (cluster.get_target_device_type() != tt::TargetDevice::Simulator) {
+        return;
+    }
+
+    cluster.advance_device_execution(mesh_device->get_device(device_coord)->id());
+}
+
 }  // namespace
 
 D2HSocket::PinnedBufferInfo D2HSocket::init_host_buffer(
@@ -397,6 +410,7 @@ void D2HSocket::wait_for_bytes(uint32_t num_bytes) {
     }
     uint32_t bytes_recv = bytes_sent_ - bytes_acked_;
     while (bytes_recv < num_bytes) {
+        advance_d2h_simulator_socket_device(mesh_device_, sender_core_.device_coord);
         if (using_hugepage_) {
             _mm_clflush(const_cast<void*>(reinterpret_cast<const volatile void*>(hugepage_bytes_sent_host_ptr_)));
             _mm_lfence();

--- a/tt_metal/distributed/d2h_socket.cpp
+++ b/tt_metal/distributed/d2h_socket.cpp
@@ -48,12 +48,18 @@ void advance_d2h_simulator_socket_device(MeshDevice* mesh_device, const MeshCoor
         return;
     }
 
-    const auto& cluster = MetalContext::instance().get_cluster();
+    const auto context_id = tt::tt_metal::extract_context_id(mesh_device);
+    const auto& cluster = MetalContext::instance(context_id).get_cluster();
     if (cluster.get_target_device_type() != tt::TargetDevice::Simulator) {
         return;
     }
 
-    cluster.advance_device_execution(mesh_device->get_device(device_coord)->id());
+    IDevice* device = mesh_device->get_device(device_coord);
+    if (device == nullptr) {
+        return;
+    }
+
+    cluster.advance_device_execution(device->id());
 }
 
 }  // namespace

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -32,12 +32,18 @@ void advance_h2d_simulator_socket_device(MeshDevice* mesh_device, const MeshCoor
         return;
     }
 
-    const auto& cluster = MetalContext::instance().get_cluster();
+    const auto context_id = tt::tt_metal::extract_context_id(mesh_device);
+    const auto& cluster = MetalContext::instance(context_id).get_cluster();
     if (cluster.get_target_device_type() != tt::TargetDevice::Simulator) {
         return;
     }
 
-    cluster.advance_device_execution(mesh_device->get_device(device_coord)->id());
+    IDevice* device = mesh_device->get_device(device_coord);
+    if (device == nullptr) {
+        return;
+    }
+
+    cluster.advance_device_execution(device->id());
 }
 
 }  // namespace

--- a/tt_metal/distributed/h2d_socket.cpp
+++ b/tt_metal/distributed/h2d_socket.cpp
@@ -25,6 +25,23 @@
 
 namespace tt::tt_metal::distributed {
 
+namespace {
+
+void advance_h2d_simulator_socket_device(MeshDevice* mesh_device, const MeshCoordinate& device_coord) {
+    if (mesh_device == nullptr) {
+        return;
+    }
+
+    const auto& cluster = MetalContext::instance().get_cluster();
+    if (cluster.get_target_device_type() != tt::TargetDevice::Simulator) {
+        return;
+    }
+
+    cluster.advance_device_execution(mesh_device->get_device(device_coord)->id());
+}
+
+}  // namespace
+
 H2DSocket::PinnedBufferInfo H2DSocket::init_bytes_acked_buffer(
     const std::shared_ptr<MeshDevice>& mesh_device,
     const MeshCoordinateRangeSet& device_range,
@@ -459,6 +476,7 @@ H2DSocket::~H2DSocket() noexcept {
 void H2DSocket::reserve_bytes(uint32_t num_bytes) {
     uint32_t bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_);
     while (bytes_free < num_bytes) {
+        advance_h2d_simulator_socket_device(mesh_device_, recv_core_.device_coord);
         tt_driver_atomics::mfence();
         volatile uint32_t bytes_acked_value = bytes_acked_ptr_[0];
         bytes_free = fifo_size_ - (bytes_sent_ - bytes_acked_value);
@@ -529,6 +547,7 @@ void H2DSocket::barrier(std::optional<uint32_t> timeout_ms) {
     volatile uint32_t bytes_acked_value = bytes_acked_ptr_[0];
     auto start_time = std::chrono::high_resolution_clock::now();
     while (bytes_sent_ - bytes_acked_value != 0) {
+        advance_h2d_simulator_socket_device(mesh_device_, recv_core_.device_coord);
         tt_driver_atomics::mfence();
         bytes_acked_value = bytes_acked_ptr_[0];
         if (timeout_ms.has_value()) {


### PR DESCRIPTION
## Summary
On TTSim, cross-device **H2D/D2H socket** busy-wait loops must advance simulated device execution or the host spins forever while the simulator never makes progress.

This PR adds simulator-only `Cluster::advance_device_execution()` calls in:
- `H2DSocket::reserve_bytes` and `H2DSocket::barrier`
- `D2HSocket::wait_for_bytes`

Silicon paths are unchanged (guarded by `TargetDevice::Simulator`).

Cherry-picked from Nachiket Kapre's multichip work (`de91fce7948` on blaze-metal-main / #46668). The original commit also bumped UMD; that is **omitted** here because `main` already exposes `advance_device_execution()` via #43403.

## Parity with #46668 (blaze-metal-main → main)
#46668 has three commits on `blaze-metal-main`:

| Commit | Description | On `main` via #46705? |
|--------|-------------|----------------------|
| `633013c` | FD on TTSim (`num_host_mem_ch=1`, dispatch `advance_device_execution`) | **Already on `main`** (#43403) — no cherry-pick needed |
| `751a6b8` | ct/fabric cluster update (`cluster_desc_` refactor) | **Not needed on `main`** — upstream evolved with `get_cluster_desc()` and newer SIENAD8 tray logic; cherry-pick is empty after conflict resolution |
| `de91fce` | HD socket simulator waits | **This PR** (`e4b904cbd49`) |

**Removed from earlier draft:** `dense_norm` scaling in `sdpa.h` was incorrectly included in a prior push. That change is **not** part of #46668 and regresses S9 PCC; it stays in tt-blaze only.

Test-side S5/S9 fixes (BlazeMetadata, PCC-only gates, worker-core layout, weight cache hash) remain in tt-blaze — see tt-blaze #1347.

## Motivation
Part of the multichip sim stack for craq-sim S-ladder S0–S10 (backed layers using host sockets across the 8-chip mesh). Complements existing FD-on-TTSim / `num_host_mem_ch` fixes already on `main`.

## Test plan
- [ ] craq-sim multi-chip S-ladder S0–S10 on sim (with this SHA on tt-metal)
- [ ] Existing HD socket unit / integration tests on silicon (no-op path)
- [ ] TTSim multichip backed-layer S10 smoke

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rsong/sim-hd-socket-waits)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rsong/sim-hd-socket-waits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rsong/sim-hd-socket-waits)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rsong/sim-hd-socket-waits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rsong/sim-hd-socket-waits)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rsong/sim-hd-socket-waits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rsong/sim-hd-socket-waits)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rsong/sim-hd-socket-waits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rsong/sim-hd-socket-waits)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rsong/sim-hd-socket-waits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rsong/sim-hd-socket-waits)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rsong/sim-hd-socket-waits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rsong/sim-hd-socket-waits)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rsong/sim-hd-socket-waits)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rsong/sim-hd-socket-waits)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rsong/sim-hd-socket-waits)