### PR TITLE
Sequential Metal compute tests

### DIFF
--- a/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
+++ b/tests/tt_metal/tt_metal/llk/test_single_core_binary_compute.cpp
@@ -117,12 +117,12 @@ static BinaryStimulus generate_binary_stimulus(const SingleCoreBinaryConfig& tes
     // Use fixed seeds so test results are deterministic and reproducible.
     // Using wall-clock seeds caused intermittent tolerance failures depending on
     // which random inputs were drawn (see https://github.com/tenstorrent/tt-metal/issues/46284).
-    s.packed_input0 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        -1.0f, 1.0f, byte_size / sizeof(bfloat16), 0);
-    s.packed_input1 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        -1.0f, 1.0f, byte_size / sizeof(bfloat16), 1);
-    s.packed_input2 = generate_packed_uniform_random_vector<uint32_t, bfloat16>(
-        -1.0f, 1.0f, byte_size / sizeof(bfloat16), 2);
+    s.packed_input0 =
+        generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, byte_size / sizeof(bfloat16), 0);
+    s.packed_input1 =
+        generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, byte_size / sizeof(bfloat16), 1);
+    s.packed_input2 =
+        generate_packed_uniform_random_vector<uint32_t, bfloat16>(-1.0f, 1.0f, byte_size / sizeof(bfloat16), 2);
 
     auto input0 = unpack_vector<bfloat16, uint32_t>(s.packed_input0);
     auto input1 = unpack_vector<bfloat16, uint32_t>(s.packed_input1);
@@ -467,10 +467,6 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
         }
     }
 }
@@ -491,10 +487,6 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
         }
     }
 }
@@ -515,10 +507,6 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
         }
     }
 }
@@ -540,10 +528,6 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
         }
     }
 }
@@ -565,10 +549,6 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
         }
     }
 }
@@ -590,10 +570,6 @@ TEST_F(LLKMeshDeviceFixtureSlowDispatchOnly, TensixBinaryComputeSingleCoreSingle
         log_info(tt::LogTest, "Math Fidelity = {}", i);
         for (unsigned int id = 0; id < num_devices_; id++) {
             ASSERT_TRUE(unit_tests::compute::binary::single_core_binary(devices_.at(id), test_config));
-            // TODO: Remove early return once back-to-back tests are passing on Quasar
-            if (this->arch_ == ARCH::QUASAR) {
-                return;
-            }
         }
     }
 }

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_pack_common_api.h
@@ -116,6 +116,11 @@ inline void llk_pack_dest_section_done() {
 }
 
 /**
+ * @brief Reset packer dest-bank parity to bank 0 at program start (pack-side mirror of llk_math_pack_sync_init).
+ */
+inline void llk_pack_dest_init() { _llk_pack_dest_init_<p_pacr::PACK0, DST_SYNC_MODE>(); }
+
+/**
  * @brief Configure packer ReLU at runtime from a packed uint32.
  * @param config Packed uint32: bits [1:0] = ReluType, bits [31:16] = threshold.
  */

--- a/tt_metal/hw/inc/api/compute/bcast.h
+++ b/tt_metal/hw/inc/api/compute/bcast.h
@@ -71,6 +71,7 @@ ALWI void unary_bcast_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __bu
 
     PACK((llk_pack_hw_configure(ocb)));
     PACK((llk_pack_init(ocb)));
+    PACK((llk_pack_dest_init()));
 #endif
 }
 
@@ -306,6 +307,7 @@ void init_bcast(uint32_t icb0, uint32_t icb1, uint32_t ocb, uint32_t call_line =
 
     PACK((llk_pack_hw_configure(ocb)));
     PACK((llk_pack_init(ocb)));
+    PACK((llk_pack_dest_init()));
 
     MATH((llk_math_pack_sync_init()));
     MATH((llk_math_hw_configure<DST_ACCUM_MODE>(icb0, icb1)));

--- a/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
+++ b/tt_metal/hw/inc/api/compute/compute_kernel_hw_startup.h
@@ -96,6 +96,7 @@ ALWI void compute_kernel_hw_startup(uint32_t icb0, uint32_t icb1, uint32_t ocb) 
 
     PACK((llk_pack_hw_configure(ocb)));
     PACK((llk_pack_init(ocb)));
+    PACK((llk_pack_dest_init()));
 #endif
 }
 

--- a/tt_metal/hw/inc/api/compute/eltwise_binary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_binary.h
@@ -50,6 +50,7 @@ ALWI void binary_op_init_common(uint32_t icb0, uint32_t icb1, uint32_t ocb, uint
 
     PACK((llk_pack_hw_configure(ocb)));
     PACK((llk_pack_init(ocb)));
+    PACK((llk_pack_dest_init()));
 #endif
 }
 

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/eltwise_unary.h
@@ -40,6 +40,7 @@ ALWI void unary_op_init_common(uint32_t icb, uint32_t ocb, uint32_t call_line = 
 
     PACK((llk_pack_hw_configure(ocb)));
     PACK((llk_pack_init(ocb)));
+    PACK((llk_pack_dest_init()));
 
     MATH((llk_math_eltwise_unary_datacopy_init<ckernel::DataCopyType::A2D, DST_ACCUM_MODE>(icb)));
     MATH((llk_math_pack_sync_init()));

--- a/tt_metal/hw/inc/api/compute/matmul.h
+++ b/tt_metal/hw/inc/api/compute/matmul.h
@@ -125,6 +125,7 @@ ALWI void mm_init(
 
     PACK((llk_pack_hw_configure(out_cb_id)));
     PACK((llk_pack_init(out_cb_id)));
+    PACK((llk_pack_dest_init()));
 #endif
 }
 
@@ -282,6 +283,7 @@ ALWI void mm_block_init(
 
     PACK((llk_pack_hw_configure(out_cb_id)));
     PACK((llk_pack_init(out_cb_id)));
+    PACK((llk_pack_dest_init()));
 #endif
 }
 

--- a/tt_metal/hw/inc/api/compute/transpose_wh.h
+++ b/tt_metal/hw/inc/api/compute/transpose_wh.h
@@ -82,6 +82,7 @@ ALWI void transpose_wh_init(uint32_t icb, uint32_t ocb, uint32_t call_line = __b
 #else
     PACK((llk_pack_hw_configure(ocb)));
     PACK((llk_pack_init(ocb)));
+    PACK((llk_pack_dest_init()));
 #endif
 }
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_pack_common.h
@@ -326,3 +326,17 @@ inline void _llk_pack_dest_semaphore_section_done_()
         _set_packer_dest_registers_<PACK_SEL, DST>();
     }
 }
+
+/**
+ * @brief Reset the pack thread's dest-bank tracking to bank 0 at the start of a program.
+ *
+ * @tparam PACK_SEL: Packer to configure, values = <p_pacr::PACK0/PACK1>
+ * @tparam DST: Destination register buffering mode, values = <DstSync::SyncHalf/DstSync::SyncFull>
+ * @note Pair with @ref _llk_math_pack_sync_init_ (T1); call once per program before the first pack.
+ */
+template <std::uint32_t PACK_SEL, DstSync DST>
+inline void _llk_pack_dest_init_()
+{
+    _reset_dest_register_offset_();
+    _set_packer_dest_registers_<PACK_SEL, DST>();
+}


### PR DESCRIPTION
### Summary

Running metal tests sequentially for compute was causing every test after the first to output zeroes. Turns out dest bank id was never cleared to 0 at every kernel load, because it was missing llk_pack_dest_init API. This PR fixes the state issue of the bank ID while also re-enabling some of the sequential tests

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rtawfik/back-to-back-compute-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rtawfik/back-to-back-compute-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rtawfik/back-to-back-compute-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rtawfik/back-to-back-compute-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rtawfik/back-to-back-compute-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rtawfik/back-to-back-compute-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rtawfik/back-to-back-compute-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rtawfik/back-to-back-compute-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rtawfik/back-to-back-compute-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rtawfik/back-to-back-compute-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rtawfik/back-to-back-compute-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rtawfik/back-to-back-compute-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rtawfik/back-to-back-compute-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rtawfik/back-to-back-compute-tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rtawfik/back-to-back-compute-tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rtawfik/back-to-back-compute-tests)