### PR TITLE
tracy: tolerate incomplete device-perf capture instead of aborting the report

### DIFF
--- a/tests/ttnn/tracy/test_process_ops_logs.py
+++ b/tests/ttnn/tracy/test_process_ops_logs.py
@@ -40,6 +40,30 @@ class _FakeNpeStats:
         return _FakeNpeDatapoint(result)
 
 
+def test_enrich_ops_from_perf_csv_keeps_unmatched_ops():
+    """When the on-device profiler buffer overflows, most ops have no device-perf
+    row; that (or a whole missing device) must not abort the merge — unmatched ops
+    are kept without device metrics so the rest of the report still builds."""
+    host_ops = {
+        0: [{"global_call_count": 1}, {"global_call_count": 2}],  # op 2 has no perf row
+        7: [{"global_call_count": 99}],  # entire device missing from perf report
+    }
+    device_perf = {
+        0: {
+            (1, None, None): {"GLOBAL CALL COUNT": 1, "CORE COUNT": 64},
+        },
+        # device 7 deliberately absent
+    }
+
+    enriched = process_ops_logs._enrich_ops_from_perf_csv(host_ops, device_perf, None)
+
+    by_id = {op["global_call_count"]: op for op in enriched[0]}
+    assert set(by_id) == {1, 2}  # neither dropped
+    assert "_device_perf_row" in by_id[1]  # matched op enriched
+    assert "_device_perf_row" not in by_id[2]  # unmatched op kept, no fabricated metrics
+    assert [op["global_call_count"] for op in enriched[7]] == [99]  # missing device survives
+
+
 @pytest.mark.skip(reason="Missing mock for device log file; needs fix to properly stub _enrich_ops_from_device_logs")
 def test_append_device_data_populates_multicast_noc_util(monkeypatch, tmp_path):
     ops = {

--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -573,9 +573,15 @@ def _enrich_ops_from_perf_csv(
     trace_replays: Optional[TraceReplayDict],
 ) -> DeviceOpsDict:
     for device_id in host_ops_by_device:
-        assert (
-            device_id in device_perf_by_device
-        ), f"Device {device_id} present in host logs but missing from {PROFILER_CPP_DEVICE_PERF_REPORT}"
+        if device_id not in device_perf_by_device:
+            # No device-perf rows for this chip (e.g. its profiler buffer was not
+            # captured). Leave its host ops without device metrics rather than
+            # discarding every other device's data.
+            logger.warning(
+                f"Device {device_id} present in host logs but missing from "
+                f"{PROFILER_CPP_DEVICE_PERF_REPORT}; reported without device metrics"
+            )
+            continue
 
         # Build a lookup that matches the C++ ProgramExecutionUID structure:
         # (GLOBAL CALL COUNT, METAL TRACE ID) -> list of perf rows (one per replay session, or one for non-trace)
@@ -584,6 +590,7 @@ def _enrich_ops_from_perf_csv(
             perf_rows_by_key.setdefault((op_id, trace_id), []).append(row)
 
         enriched_ops = []
+        unmatched_op_ids = []
         for host_op in host_ops_by_device[device_id]:
             op_id = int(host_op["global_call_count"])
             host_trace_id = host_op.get("metal_trace_id")
@@ -603,10 +610,17 @@ def _enrich_ops_from_perf_csv(
                     if cand_op_id == op_id:
                         candidates.extend(rows)
 
-            assert candidates, (
-                f"Device data missing: Op {op_id} not present in {PROFILER_CPP_DEVICE_PERF_REPORT} "
-                f"for device {device_id} (trace_id={host_trace_id})"
-            )
+            if not candidates:
+                # The op ran on device but its timing was not captured. The usual
+                # cause is on-device profiler buffer overflow: each device holds a
+                # bounded number of program-timing slots (PROFILER_PROGRAM_SUPPORT_COUNT,
+                # default 1000), so a long run without periodic ReadDeviceProfiler drops
+                # the timing for most ops. Keep the op without device metrics so the
+                # report still builds, and surface the coverage gap below — one missing
+                # op (of potentially most of them) must not discard the whole profile.
+                unmatched_op_ids.append(op_id)
+                enriched_ops.append(copy.deepcopy(host_op))
+                continue
 
             # Create one enriched op per ProgramExecutionUID row in the C++ report.
             for perf_row in candidates:
@@ -630,6 +644,20 @@ def _enrich_ops_from_perf_csv(
 
                 enriched_op["_device_perf_row"] = perf_row
                 enriched_ops.append(enriched_op)
+
+        if unmatched_op_ids:
+            n_missing = len(unmatched_op_ids)
+            n_total = len(host_ops_by_device[device_id])
+            pct = 100.0 * n_missing / n_total if n_total else 0.0
+            sample = ", ".join(str(i) for i in unmatched_op_ids[:10])
+            logger.warning(
+                f"Device {device_id}: {n_missing}/{n_total} ops ({pct:.0f}%) missing from "
+                f"{PROFILER_CPP_DEVICE_PERF_REPORT}; reported without device metrics. "
+                f"A large fraction means the on-device profiler buffer overflowed "
+                f"(PROFILER_PROGRAM_SUPPORT_COUNT, default 1000/device) — enable periodic "
+                f"ReadDeviceProfiler or raise the buffer for full device-time coverage "
+                f"(missing op ids: {sample}{', ...' if n_missing > 10 else ''})"
+            )
 
         host_ops_by_device[device_id] = enriched_ops
     return host_ops_by_device


### PR DESCRIPTION
## Root cause

`process_ops_logs._enrich_ops_from_perf_csv` asserted that **every** host op has a matching row in `cpp_device_perf_report.csv`:

```
AssertionError: Device data missing: Op 1044480 not present in cpp_device_perf_report.csv ...
```

Investigated against a real failing dataset (a long LTX-2 audio decode on a bh 4x8 mesh). Op `1044480` is a genuine `SliceDeviceOperation` that **ran on device** — not a host-only op, not a trace-replay artifact (trace-id/session columns are empty). The numbers:

- Host op log: **346,848** distinct device ops (~10,800/device across 32 devices).
- `cpp_device_perf_report.csv`: **63,104** rows — exactly **1972/device**, uniform.
- → **~82% of device ops have no timing row**, systematically across *every* op type.

That flat per-device cap is **on-device profiler buffer overflow**: each device holds a bounded number of program-timing slots (`PROFILER_PROGRAM_SUPPORT_COUNT`, default **1000**), and this run did ~10.8k ops/device with no periodic `ReadDeviceProfiler` flush, so most ops' timing is dropped. The hard assert then fires on the first of ~283k unmatched ops and **discards the entire report** (the run crashed before building one — its reports dir is empty).

## Fix

This is a post-processor change, not the infra fix — the real remedy for *complete* coverage is a bigger buffer or periodic flush. But the post-processor shouldn't throw away the data it *does* have:

- Unmatched ops (and whole missing devices) are kept **without** device metrics instead of aborting.
- The merge logs a **quantified, actionable** per-device warning: `N/total (X%) missing ... profiler buffer likely overflowed (PROFILER_PROGRAM_SUPPORT_COUNT) — enable periodic ReadDeviceProfiler or raise the buffer`. The partial coverage is loud and explained, not silent.

Downstream already tolerates a missing `_device_perf_row` (`.get`/`.pop(..., None)`).

## For reviewers

Open question: should the post-processor **hard-fail** below some coverage threshold rather than emit a partial report? I went with partial-report-plus-loud-warning so profiling a large model isn't blocked outright; happy to add a `--min-coverage` gate if preferred.

## Tests

`test_enrich_ops_from_perf_csv_keeps_unmatched_ops` covers unmatched-op + missing-device. Existing `tests/ttnn/tracy/test_process_ops_logs.py` pass (5 passed, 1 pre-existing skip).

🤖 Generated with [Claude Code](https://claude.com/claude-code)