### PR TITLE
[Bug fix] register binary_ng descriptor runtime-arg bindings

### DIFF
--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -24,6 +24,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_levelized_graph.cpp
     test_graph_capture_arguments_morehdot.cpp
     test_graph_capture_arguments_transpose.cpp
+    test_graph_capture_arguments_untilize_with_unpadding.cpp
     test_graph_query_op_constraints.cpp
     test_graph_query_op_runtime.cpp
     test_launch_operation.cpp

--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -24,7 +24,6 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_levelized_graph.cpp
     test_graph_capture_arguments_morehdot.cpp
     test_graph_capture_arguments_transpose.cpp
-    test_graph_capture_arguments_untilize_with_unpadding.cpp
     test_graph_query_op_constraints.cpp
     test_graph_query_op_runtime.cpp
     test_launch_operation.cpp
@@ -93,4 +92,7 @@ set(TEST_CCL_MULTI_CQ_MULTI_DEVICE_SOURCES multi_thread/test_ccl_multi_cq_multi_
 
 set(UNIT_TESTS_TTNN_EMITC_SOURCES emitc/test_sanity.cpp)
 
-set(UNIT_TESTS_TTNN_MOCK_ALLOCATOR_SOURCES test_query_op_constraints_mock_device.cpp)
+set(UNIT_TESTS_TTNN_MOCK_ALLOCATOR_SOURCES
+    test_query_op_constraints_mock_device.cpp
+    test_binary_ng_descriptor_bindings.cpp
+)

--- a/tests/ttnn/unit_tests/gtests/test_binary_ng_descriptor_bindings.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_binary_ng_descriptor_bindings.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <cstdlib>
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+#include <gtest/gtest.h>
+
+#include <tt-metalium/distributed.hpp>
+#include <tt-metalium/experimental/context/metal_env.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/mesh_device.hpp>
+#include <tt-metalium/program.hpp>
+
+#include "ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/types.hpp"
+
+namespace ttnn::operations::binary_ng::test {
+
+namespace {
+
+using tt::tt_metal::Buffer;
+using tt::tt_metal::CoreCoord;
+using tt::tt_metal::DataType;
+using tt::tt_metal::HalProgrammableCoreType;
+using tt::tt_metal::Layout;
+using tt::tt_metal::MetalEnv;
+using tt::tt_metal::MetalEnvDescriptor;
+using tt::tt_metal::MemoryConfig;
+using tt::tt_metal::PageConfig;
+using tt::tt_metal::Program;
+using tt::tt_metal::TensorLayout;
+using tt::tt_metal::TensorMemoryLayout;
+using tt::tt_metal::BufferType;
+
+bool has_binding(
+    const tt::tt_metal::ResolvedBindings& bindings, uint32_t kernel_idx, uint32_t arg_idx, uint32_t tensor_buffer_idx) {
+    return std::any_of(bindings.rt_args.begin(), bindings.rt_args.end(), [&](const auto& binding) {
+        return binding.kernel_idx == kernel_idx && binding.arg_idx == arg_idx &&
+               binding.tensor_buffer_idx == tensor_buffer_idx;
+    });
+}
+
+}  // namespace
+
+class BinaryNgDescriptorBindingsFixture : public ::testing::Test {
+protected:
+    std::unique_ptr<MetalEnv> mock_env_;
+    std::shared_ptr<tt::tt_metal::distributed::MeshDevice> device_holder_;
+    tt::tt_metal::distributed::MeshDevice* device_ = nullptr;
+
+    void SetUp() override {
+        std::filesystem::path repo_root;
+        for (auto current = std::filesystem::path(__FILE__).parent_path(); !current.empty(); current = current.parent_path()) {
+            const auto mock_cluster_desc =
+                current / "tt_metal" / "third_party" / "umd" / "tests" / "cluster_descriptor_examples" /
+                "wormhole_N150.yaml";
+            if (std::filesystem::exists(mock_cluster_desc)) {
+                repo_root = current;
+                break;
+            }
+        }
+        ASSERT_FALSE(repo_root.empty());
+        ASSERT_EQ(::setenv("TT_METAL_RUNTIME_ROOT", repo_root.c_str(), 1), 0);
+
+        mock_env_ = std::make_unique<MetalEnv>(MetalEnvDescriptor(std::string("wormhole_N150.yaml")));
+        auto mesh_shape = mock_env_->get_system_mesh().shape();
+        device_holder_ = mock_env_->create_mesh_device(tt::tt_metal::distributed::MeshDeviceConfig(mesh_shape));
+        device_ = device_holder_.get();
+        ASSERT_GT(device_->num_devices(), 0u);
+        device_->disable_and_clear_program_cache();
+    }
+
+    void TearDown() override {
+        device_holder_.reset();
+        mock_env_.reset();
+        ::unsetenv("TT_METAL_RUNTIME_ROOT");
+    }
+};
+
+TEST_F(BinaryNgDescriptorBindingsFixture, InplaceAddDescriptorRegistersPatchableBufferBindings) {
+    auto* device = device_;
+
+    const auto tensor_spec = ttnn::TensorSpec(
+        ttnn::Shape(tt::tt_metal::Array2D{32, 64}),
+        TensorLayout(
+            DataType::BFLOAT16,
+            PageConfig(Layout::TILE),
+            MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM}));
+
+    const auto input_tensor_a = tt::tt_metal::create_device_tensor(tensor_spec, device);
+    const auto input_tensor_b = tt::tt_metal::create_device_tensor(tensor_spec, device);
+    auto output_tensor = input_tensor_a;
+
+    const auto worker_grid =
+        device->worker_cores(HalProgrammableCoreType::TENSIX, device->get_sub_device_ids().front());
+
+    const auto operation_attributes = BinaryNgDeviceOperation::operation_attributes_t{
+        BinaryOpType::ADD,
+        {},
+        {},
+        {},
+        std::nullopt,
+        input_tensor_a.memory_config(),
+        input_tensor_a.dtype(),
+        std::nullopt,
+        worker_grid,
+        std::nullopt,
+        std::nullopt,
+        std::nullopt,
+        SubtileBroadcastType::NONE,
+        false,
+        false,
+        false,
+        0.0f,
+        0.0f,
+        false,
+        input_tensor_a.layout(),
+        input_tensor_b.layout(),
+        output_tensor.layout(),
+    };
+
+    const auto tensor_args =
+        BinaryNgDeviceOperation::tensor_args_t{input_tensor_a, input_tensor_b, std::optional<Tensor>{output_tensor}};
+
+    const auto descriptor =
+        BinaryNgDeviceOperation::ProgramFactory::create_descriptor(operation_attributes, tensor_args, output_tensor);
+    Program program{descriptor};
+
+    std::vector<Buffer*> tensor_buffers = {input_tensor_a.buffer(), input_tensor_b.buffer(), output_tensor.buffer()};
+    const auto bindings =
+        tt::tt_metal::resolve_bindings(program, descriptor, tensor_buffers, /*num_input_buffers=*/2);
+
+    EXPECT_FALSE(bindings.rt_args.empty());
+
+    // reader kernel arg[0] = input A base address
+    EXPECT_TRUE(has_binding(bindings, /*kernel_idx=*/0, /*arg_idx=*/0, /*tensor_buffer_idx=*/0));
+    // reader kernel arg[15] = input B base address in the interleaved tensor-tensor path
+    EXPECT_TRUE(has_binding(bindings, /*kernel_idx=*/0, /*arg_idx=*/15, /*tensor_buffer_idx=*/1));
+    // In-place output alias keeps the first input-slot mapping. That preserves a stable
+    // cache-hit patch target while still rejecting ambiguous duplicate inputs.
+    EXPECT_TRUE(has_binding(bindings, /*kernel_idx=*/1, /*arg_idx=*/0, /*tensor_buffer_idx=*/0));
+}
+
+}  // namespace ttnn::operations::binary_ng::test

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory.cpp
@@ -1111,38 +1111,36 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                         b_num_tiles = b_shard_shape[0] * b_shard_shape[1];
                     }
                 }
-                std::vector<uint32_t> writer_runtime_args;
+                KernelDescriptor::RTArgList writer_runtime_args;
                 if (row_major_inputs) {
-                    writer_runtime_args = {
-                        c.buffer()->address(),
-                        common_row_width_elements,
-                        c_num_tiles_core,
-                        cD,
-                        cN,
-                        cC,
-                        cHt_r,
-                        cND,
-                        current_block,
-                        num_rows_per_tile,
-                        static_cast<uint32_t>(c.buffer()->aligned_page_size()),
-                        c_alignment,
-                        tiles_per_row_width,
-                        writer_stride_size_bytes};
+                    writer_runtime_args.push_back(c.buffer());
+                    writer_runtime_args.push_back(common_row_width_elements);
+                    writer_runtime_args.push_back(c_num_tiles_core);
+                    writer_runtime_args.push_back(cD);
+                    writer_runtime_args.push_back(cN);
+                    writer_runtime_args.push_back(cC);
+                    writer_runtime_args.push_back(cHt_r);
+                    writer_runtime_args.push_back(cND);
+                    writer_runtime_args.push_back(current_block);
+                    writer_runtime_args.push_back(num_rows_per_tile);
+                    writer_runtime_args.push_back(static_cast<uint32_t>(c.buffer()->aligned_page_size()));
+                    writer_runtime_args.push_back(c_alignment);
+                    writer_runtime_args.push_back(tiles_per_row_width);
+                    writer_runtime_args.push_back(writer_stride_size_bytes);
                 } else {
-                    writer_runtime_args = {
-                        c.buffer()->address(),
-                        c_start_id,
-                        c_num_tiles_core,
-                        c_current_shard_width,
-                        cD,
-                        cN,
-                        cC,
-                        cHt,
-                        cWt,
-                        cND,
-                        0u};
+                    writer_runtime_args.push_back(c.buffer());
+                    writer_runtime_args.push_back(c_start_id);
+                    writer_runtime_args.push_back(c_num_tiles_core);
+                    writer_runtime_args.push_back(c_current_shard_width);
+                    writer_runtime_args.push_back(cD);
+                    writer_runtime_args.push_back(cN);
+                    writer_runtime_args.push_back(cC);
+                    writer_runtime_args.push_back(cHt);
+                    writer_runtime_args.push_back(cWt);
+                    writer_runtime_args.push_back(cND);
+                    writer_runtime_args.push_back(0u);
                 }
-                writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{writer_runtime_args.begin(), writer_runtime_args.end()});
+                writer_desc.emplace_runtime_args(core, writer_runtime_args);
 
                 auto [freq, counter] =
                     CMAKE_UNIQUE_NAMESPACE::calculate_compute_kernel_args(operation_attributes.subtile_broadcast_type, c_start_id, cHt, cWt);
@@ -1177,107 +1175,101 @@ tt::tt_metal::ProgramDescriptor BinaryNgDeviceOperation::ProgramFactory::create_
                 const auto scalar = *operation_attributes.scalar;
                 const auto packed_scalar = pack_scalar_runtime_arg(scalar, a.dtype(), rt_is_quant_op);
                 packed_scalar_for_reader = packed_scalar;
-                std::vector<uint32_t> writer_runtime_args;
+                KernelDescriptor::RTArgList writer_runtime_args;
                 if (row_major_inputs) {
-                    writer_runtime_args = {
-                        c.buffer()->address(),
-                        common_row_width_elements,
-                        c_num_tiles_core,
-                        cD,
-                        cN,
-                        cC,
-                        cHt_r,
-                        cND,
-                        current_block,
-                        num_rows_per_tile,
-                        static_cast<uint32_t>(c.buffer()->aligned_page_size()),
-                        c_alignment,
-                        tiles_per_row_width,
-                        writer_stride_size_bytes};
+                    writer_runtime_args.push_back(c.buffer());
+                    writer_runtime_args.push_back(common_row_width_elements);
+                    writer_runtime_args.push_back(c_num_tiles_core);
+                    writer_runtime_args.push_back(cD);
+                    writer_runtime_args.push_back(cN);
+                    writer_runtime_args.push_back(cC);
+                    writer_runtime_args.push_back(cHt_r);
+                    writer_runtime_args.push_back(cND);
+                    writer_runtime_args.push_back(current_block);
+                    writer_runtime_args.push_back(num_rows_per_tile);
+                    writer_runtime_args.push_back(static_cast<uint32_t>(c.buffer()->aligned_page_size()));
+                    writer_runtime_args.push_back(c_alignment);
+                    writer_runtime_args.push_back(tiles_per_row_width);
+                    writer_runtime_args.push_back(writer_stride_size_bytes);
                 } else {
-                    writer_runtime_args = {
-                        packed_scalar,
-                        c.buffer()->address(),
-                        c_start_id,
-                        c_num_tiles_core,
-                        c_current_shard_width,
-                        cD,
-                        cN,
-                        cC,
-                        cHt,
-                        cWt,
-                        cND,
-                        0u};
+                    writer_runtime_args.push_back(packed_scalar);
+                    writer_runtime_args.push_back(c.buffer());
+                    writer_runtime_args.push_back(c_start_id);
+                    writer_runtime_args.push_back(c_num_tiles_core);
+                    writer_runtime_args.push_back(c_current_shard_width);
+                    writer_runtime_args.push_back(cD);
+                    writer_runtime_args.push_back(cN);
+                    writer_runtime_args.push_back(cC);
+                    writer_runtime_args.push_back(cHt);
+                    writer_runtime_args.push_back(cWt);
+                    writer_runtime_args.push_back(cND);
+                    writer_runtime_args.push_back(0u);
                 }
-                writer_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{writer_runtime_args.begin(), writer_runtime_args.end()});
+                writer_desc.emplace_runtime_args(core, writer_runtime_args);
 
                 std::array compute_runtime_args = {compute_tiles, 0u, 0u, compute_scalar_value};
                 compute_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{compute_runtime_args.begin(), compute_runtime_args.end()});
             }
-            std::vector<uint32_t> reader_runtime_args;
+            KernelDescriptor::RTArgList reader_runtime_args;
 
             if (row_major_inputs) {
-                const uint32_t b_addr = b.has_value() ? b->buffer()->address() : 0u;
                 const uint32_t b_page_size = b.has_value() ? static_cast<uint32_t>(b->buffer()->aligned_page_size())
                                                            : static_cast<uint32_t>(a.buffer()->aligned_page_size());
                 const uint32_t bD_arg = b.has_value() ? bD : 1u;
                 const uint32_t bN_arg = b.has_value() ? bN : 1u;
                 const uint32_t bC_arg = b.has_value() ? bC : 1u;
                 const uint32_t bHt_r_arg = b.has_value() ? bHt_r : 1u;
-                reader_runtime_args = {
-                    a.buffer()->address(),
-                    c_num_tiles_core,
-                    aD,
-                    aN,
-                    aC,
-                    aHt_r,
-                    aND,
-                    b_addr,
-                    bD_arg,
-                    bN_arg,
-                    bC_arg,
-                    bHt_r_arg,
-                    bND,
-                    cHt_r,
-                    cC,
-                    cND,
-                    current_block,
-                    num_rows_per_tile,
-                    common_row_width_elements,
-                    static_cast<uint32_t>(a.buffer()->aligned_page_size()),
-                    b_page_size,
-                    a_alignment,
-                    b_alignment,
-                    tiles_per_row_width,
-                    reader_stride_size_bytes,
-                    packed_scalar_for_reader};
+                reader_runtime_args.push_back(a.buffer());
+                reader_runtime_args.push_back(c_num_tiles_core);
+                reader_runtime_args.push_back(aD);
+                reader_runtime_args.push_back(aN);
+                reader_runtime_args.push_back(aC);
+                reader_runtime_args.push_back(aHt_r);
+                reader_runtime_args.push_back(aND);
+                reader_runtime_args.push_back(b.has_value() ? b->buffer() : nullptr);
+                reader_runtime_args.push_back(bD_arg);
+                reader_runtime_args.push_back(bN_arg);
+                reader_runtime_args.push_back(bC_arg);
+                reader_runtime_args.push_back(bHt_r_arg);
+                reader_runtime_args.push_back(bND);
+                reader_runtime_args.push_back(cHt_r);
+                reader_runtime_args.push_back(cC);
+                reader_runtime_args.push_back(cND);
+                reader_runtime_args.push_back(current_block);
+                reader_runtime_args.push_back(num_rows_per_tile);
+                reader_runtime_args.push_back(common_row_width_elements);
+                reader_runtime_args.push_back(static_cast<uint32_t>(a.buffer()->aligned_page_size()));
+                reader_runtime_args.push_back(b_page_size);
+                reader_runtime_args.push_back(a_alignment);
+                reader_runtime_args.push_back(b_alignment);
+                reader_runtime_args.push_back(tiles_per_row_width);
+                reader_runtime_args.push_back(reader_stride_size_bytes);
+                reader_runtime_args.push_back(packed_scalar_for_reader);
             } else {
-                reader_runtime_args = {
-                    a.buffer()->address(),
-                    c_start_id,
-                    a_num_tiles,
-                    c_num_tiles_core,
-                    c_current_shard_width,
-                    aHt * aWt * aC * aN * aD * (aND > 1),
-                    aHt * aWt * aC * aN * (aD > 1),
-                    aHt * aWt * aC * (aN > 1),
-                    aHt * aWt * (aC > 1),
-                    cD,
-                    cN,
-                    cC,
-                    cHt,
-                    cWt,
-                    cND,
-                    b.has_value() ? b->buffer()->address() : 0u,
-                    bHt * bWt * bC * bN * bD * (bND > 1),
-                    bHt * bWt * bC * bN * (bD > 1),
-                    bHt * bWt * bC * (bN > 1),
-                    bHt * bWt * (bC > 1),
-                    b_num_tiles,
-                };
+                reader_runtime_args.push_back(a.buffer());
+                reader_runtime_args.push_back(c_start_id);
+                reader_runtime_args.push_back(a_num_tiles);
+                reader_runtime_args.push_back(c_num_tiles_core);
+                reader_runtime_args.push_back(c_current_shard_width);
+                reader_runtime_args.push_back(aHt * aWt * aC * aN * aD * (aND > 1));
+                reader_runtime_args.push_back(aHt * aWt * aC * aN * (aD > 1));
+                reader_runtime_args.push_back(aHt * aWt * aC * (aN > 1));
+                reader_runtime_args.push_back(aHt * aWt * (aC > 1));
+                reader_runtime_args.push_back(cD);
+                reader_runtime_args.push_back(cN);
+                reader_runtime_args.push_back(cC);
+                reader_runtime_args.push_back(cHt);
+                reader_runtime_args.push_back(cWt);
+                reader_runtime_args.push_back(cND);
+                reader_runtime_args.push_back(b.has_value() ? b->buffer() : nullptr);
+                reader_runtime_args.push_back(bHt * bWt * bC * bN * bD * (bND > 1));
+                reader_runtime_args.push_back(bHt * bWt * bC * bN * (bD > 1));
+                reader_runtime_args.push_back(bHt * bWt * bC * (bN > 1));
+                reader_runtime_args.push_back(bHt * bWt * (bC > 1));
+                reader_runtime_args.push_back(b_num_tiles);
             }
 
-            reader_desc.runtime_args.emplace_back(core, KernelDescriptor::CoreRuntimeArgs{reader_runtime_args.begin(), reader_runtime_args.end()});
+            reader_desc.emplace_runtime_args(core, reader_runtime_args);
 
             start_tile_id += c_num_tiles_core;
             if (row_major_inputs) {


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`binary_ng` builds a `ProgramDescriptor`, but its reader and writer descriptors still wrote tensor base addresses as raw runtime-arg integers.

That left `resolved_bindings.rt_args` empty on repeated non-trace dispatches, so cache hits could not patch the buffer addresses back into the cached program and had to fall back to the slow path.

This change registers those runtime-arg slots through `KernelDescriptor::RTArgList` and `emplace_runtime_args(...)` instead of writing bare `buffer()->address()` values.

The runtime-arg layout stays the same. The existing resolver policy for inplace aliasing also stays the same: when the output aliases an input, the descriptor keeps the first input-slot mapping instead of inventing a second patch target.

Relates to #46506.

### Notes for reviewers
The new regression is a mock-only gtest that builds an inplace `binary_ng` descriptor, resolves bindings with `{input_a, input_b, output_aliasing_input_a}`, and checks the three patchable address slots that matter on this path:

- reader arg 0 -> input A
- reader arg 15 -> input B
- writer arg 0 -> aliased output via the first input slot

I reran that test in a mock verification environment without hardware:
`BinaryNgDescriptorBindingsFixture.InplaceAddDescriptorRegistersPatchableBufferBindings`

I am not claiming this PR closes all of #46506 by itself. It fixes one narrower non-trace `binary_ng` descriptor lane that still bypassed cache-hit patching after #46569.
