### PR TITLE
[Bug fix] Preserve ND output config in indexed_fill fallback

### DIFF
--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -21,6 +21,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_generic_op.cpp
     test_graph_add.cpp
     test_graph_basic.cpp
+    test_graph_capture_arguments_indexed_fill.cpp
     test_levelized_graph.cpp
     test_graph_capture_arguments_morehdot.cpp
     test_graph_capture_arguments_transpose.cpp

--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_indexed_fill.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_indexed_fill.cpp
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <nlohmann/json.hpp>
+#include "ttnn/tensor/tensor_ops.hpp"
+#include <algorithm>
+#include <vector>
+
+#include <tt-metalium/graph_tracking.hpp>
+#include "gtest/gtest.h"
+#include <tt-metalium/shape.hpp>
+#include "ttnn/graph/graph_processor.hpp"
+#include "ttnn/graph/graph_trace_utils.hpp"
+#include "ttnn/operations/data_movement/indexed_fill/indexed_fill.hpp"
+#include "ttnn/tensor/layout/page_config.hpp"
+#include "ttnn/tensor/layout/tensor_layout.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn_test_fixtures.hpp"
+
+namespace ttnn::graph::arguments::test {
+namespace {
+
+using TestGraphCaptureArgumentsIndexedFill = TTNNFixtureWithDevice;
+
+TEST_F(TestGraphCaptureArgumentsIndexedFill, IndexedFillPreservesNdOutputMemoryConfig) {
+    const CoreRangeSet cores(CoreRange(CoreCoord{0, 0}, CoreCoord{2, 3}));
+    const MemoryConfig input_memory_config(
+        BufferType::L1, NdShardSpec{Shape({1, 1, 32, 32}), cores, ShardOrientation::ROW_MAJOR});
+    const TensorSpec input_spec(
+        ttnn::Shape({2, 1, 64, 64}),
+        TensorLayout(tt::tt_metal::DataType::BFLOAT16, PageConfig(tt::tt_metal::Layout::TILE), input_memory_config));
+    ASSERT_TRUE(input_spec.memory_config().created_with_nd_shard_spec());
+    ASSERT_FALSE(input_spec.memory_config().shard_spec().has_value());
+
+    const TensorSpec input_b_spec(
+        ttnn::Shape({1, 1, 64, 64}),
+        TensorLayout(tt::tt_metal::DataType::BFLOAT16, PageConfig(tt::tt_metal::Layout::TILE), L1_MEMORY_CONFIG));
+    const TensorSpec batch_id_spec(
+        ttnn::Shape({1, 1, 1, 1}),
+        TensorLayout(tt::tt_metal::DataType::UINT32, PageConfig(tt::tt_metal::Layout::ROW_MAJOR), L1_MEMORY_CONFIG));
+
+    auto input_tensor_a = create_device_tensor(input_spec, device_);
+    auto input_tensor_b = create_device_tensor(input_b_spec, device_);
+    auto batch_id = create_device_tensor(batch_id_spec, device_);
+
+    ttnn::graph::GraphProcessor::begin_graph_capture(tt::tt_metal::IGraphProcessor::RunMode::NO_DISPATCH);
+    ttnn::indexed_fill(batch_id, input_tensor_a, input_tensor_b);
+    auto trace = ttnn::graph::GraphProcessor::end_graph_capture();
+    auto operations = ttnn::graph::extract_arguments(trace);
+
+    const auto it = std::find_if(operations.begin(), operations.end(), [](const auto& op) {
+        return op.operation_name == "IndexedFillDeviceOperation";
+    });
+    ASSERT_NE(it, operations.end()) << "IndexedFillDeviceOperation not found";
+
+    const auto& operation = *it;
+    ASSERT_EQ(operation.arguments.size(), 2u);
+
+    const auto& op_attrs = operation.arguments[0];
+    EXPECT_TRUE(op_attrs.find("TensorMemoryLayout::ND_SHARDED") != std::string::npos) << op_attrs;
+    EXPECT_TRUE(op_attrs.find("created_with_nd_shard_spec=1") != std::string::npos) << op_attrs;
+    EXPECT_TRUE(op_attrs.find("shard_spec=std::nullopt") != std::string::npos) << op_attrs;
+    EXPECT_TRUE(op_attrs.find("nd_shard_spec={\"shard_shape\":[1, 1, 32, 32]") != std::string::npos) << op_attrs;
+
+    const auto& tensor_args = operation.arguments[1];
+    EXPECT_TRUE(tensor_args.find("Tensor(") != std::string::npos);
+    EXPECT_TRUE(tensor_args.find("Shape([2, 1, 64, 64])") != std::string::npos);
+    EXPECT_TRUE(tensor_args.find("DataType::BFLOAT16") != std::string::npos);
+    EXPECT_TRUE(tensor_args.find("TilePageConfig") != std::string::npos);
+    EXPECT_TRUE(tensor_args.find("DeviceStorage()") != std::string::npos);
+}
+
+}  // namespace
+}  // namespace ttnn::graph::arguments::test

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_utils.cpp
@@ -288,6 +288,13 @@ tt::tt_metal::MemoryConfig resolve_output_memory_config(
     const Tensor& input_tensor_a,
     const ttnn::Shape& padded_out_shape,
     const tt::tt_metal::MemoryConfig& output_mem_config) {
+    // indexed_fill preserves the output shape, so an ND-sharded output config already
+    // carries the authoritative shard distribution. Re-deriving a legacy shard_spec here
+    // is unnecessary and would rewrite an ND-origin config onto the legacy shard-spec path.
+    if (output_mem_config.created_with_nd_shard_spec()) {
+        return output_mem_config;
+    }
+
     if (!output_mem_config.is_sharded() || output_mem_config.shard_spec().has_value()) {
         return output_mem_config;
     }


### PR DESCRIPTION
PR Category
Bug fix

Summary
Relates to #46716

indexed_fill defaults the output MemoryConfig from input_tensor_a when the caller leaves output_memory_config unset, then routes that config through resolve_output_memory_config(...) on both the wrapper fallback path and the device-op output-spec path.

That resolver still synthesizes a legacy ShardSpec whenever the output config is sharded and does not already carry shard_spec().

That behavior is correct for legacy sharded configs that still need a concrete ShardSpec. It is wrong for ND-created configs. indexed_fill preserves output shape, so an ND-created output config already carries the authoritative shard distribution in nd_shard_spec plus created_with_nd_shard_spec. Rebuilding it through the legacy shard-spec path rewrites the output contract.

This patch keeps the change narrow:

- return ND-created output configs unchanged from resolve_output_memory_config(...)
- keep the existing legacy-shard-spec synthesis path for non-ND sharded configs
- add one focused graph-capture regression for the ND-preservation contract

Notes for reviewers
Please focus on:

- ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/indexed_fill_utils.cpp
- tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_indexed_fill.cpp

The regression builds an ND-sharded TILE input, runs ttnn::indexed_fill(...) under graph capture, and checks that the captured IndexedFillDeviceOperation arguments still show:

- TensorMemoryLayout::ND_SHARDED
- created_with_nd_shard_spec=1
- shard_spec=std::nullopt
- the original nd_shard_spec shard shape

Validation notes:

- cmake -S . -B .build-indexed-fill-nd-ready -G Ninja -DCMAKE_C_COMPILER=/usr/bin/cc -DCMAKE_CXX_COMPILER=/usr/bin/c++ -DTTNN_BUILD_TESTS=ON -DTT_METAL_BUILD_TESTS=OFF -DWITH_PYTHON_BINDINGS=OFF -DENABLE_DISTRIBUTED=OFF -DTT_UMD_BUILD_SIMULATION=ON -DBUILD_PROGRAMMING_EXAMPLES=OFF
- cmake --build .build-indexed-fill-nd-ready --target unit_tests_ttnn -j4
- TT_METAL_MOCK_CLUSTER_DESC_PATH=$PWD/tt_metal/third_party/umd/tests/cluster_descriptor_examples/wormhole_N150.yaml ARCH_NAME=wormhole_b0 TT_METAL_SLOW_DISPATCH_MODE=1 ./.build-indexed-fill-nd-ready/test/ttnn/unit_tests_ttnn --gtest_filter=TestGraphCaptureArgumentsIndexedFill.IndexedFillPreservesNdOutputMemoryConfig
