### PR TITLE
[Bug fix] Preserve shard orientation in narrow

### DIFF
--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -28,6 +28,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_graph_query_op_constraints.cpp
     test_graph_query_op_runtime.cpp
     test_launch_operation.cpp
+    test_narrow.cpp
     test_matmul.cpp
     test_matmul_multicore.cpp
     test_matmul_sweep.cpp

--- a/tests/ttnn/unit_tests/gtests/test_narrow.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_narrow.cpp
@@ -36,9 +36,10 @@ TEST_F(TestNarrow, PreservesColMajorShardOrientation) {
 
     const auto& output_memory_config = output_tensor.memory_config();
     ASSERT_TRUE(output_memory_config.shard_spec().has_value());
+    ASSERT_TRUE(input_memory_config.shard_spec().has_value());
     EXPECT_EQ(output_memory_config.memory_layout(), input_memory_config.memory_layout());
     EXPECT_EQ(output_memory_config.buffer_type(), input_memory_config.buffer_type());
-    EXPECT_EQ(output_memory_config.shard_spec()->orientation, ShardOrientation::COL_MAJOR);
+    EXPECT_EQ(output_memory_config.shard_spec()->orientation, input_memory_config.shard_spec()->orientation);
 }
 
 }  // namespace

--- a/tests/ttnn/unit_tests/gtests/test_narrow.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_narrow.cpp
@@ -1,0 +1,45 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+
+#include <tt-metalium/shape.hpp>
+
+#include "ttnn/operations/data_movement/narrow/narrow.hpp"
+#include "ttnn/tensor/layout/page_config.hpp"
+#include "ttnn/tensor/layout/tensor_layout.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn_test_fixtures.hpp"
+
+namespace ttnn::test {
+namespace {
+
+using TestNarrow = TTNNFixtureWithDevice;
+
+TEST_F(TestNarrow, PreservesColMajorShardOrientation) {
+    const auto input_memory_config = MemoryConfig(
+        TensorMemoryLayout::HEIGHT_SHARDED,
+        BufferType::L1,
+        ShardSpec(
+            CoreRangeSet{CoreRange{CoreCoord{0, 0}, CoreCoord{3, 3}}},
+            Shape2D{64, 128},
+            ShardOrientation::COL_MAJOR));
+    const auto input_spec = TensorSpec(
+        ttnn::Shape({1, 8, 128, 128}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), input_memory_config));
+
+    auto input_tensor = create_device_tensor(input_spec, device_);
+    auto output_tensor = ttnn::narrow(input_tensor, /*narrow_dim=*/2, /*narrow_start=*/96, /*length=*/32);
+
+    const auto& output_memory_config = output_tensor.memory_config();
+    ASSERT_TRUE(output_memory_config.shard_spec().has_value());
+    EXPECT_EQ(output_memory_config.memory_layout(), input_memory_config.memory_layout());
+    EXPECT_EQ(output_memory_config.buffer_type(), input_memory_config.buffer_type());
+    EXPECT_EQ(output_memory_config.shard_spec()->orientation, ShardOrientation::COL_MAJOR);
+}
+
+}  // namespace
+}  // namespace ttnn::test

--- a/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
@@ -258,7 +258,8 @@ ttnn::Tensor narrow(
         }
 
         // Create new shard specifications
-        tt::tt_metal::ShardSpec narrowed_shard_spec(new_core_grid, narrowed_shard_shape, ShardOrientation::ROW_MAJOR);
+        tt::tt_metal::ShardSpec narrowed_shard_spec(
+            new_core_grid, narrowed_shard_shape, shard_spec_buffer.orientation());
         tt::tt_metal::ShardSpecBuffer narrowed_shard_spec_buffer =
             tt::tt_metal::ShardSpecBuffer(narrowed_shard_spec, shard_spec_buffer.page_shape, narrowed_pages_shape);
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The sharded L1 narrow path already reads the input shard metadata and uses the input orientation when it rebuilds the filtered core grid, but it hardcodes `ROW_MAJOR` when it constructs the output `ShardSpec`.

This patch preserves the input shard orientation when `ttnn::narrow(...)` rebuilds sharded L1 output metadata from an existing sharded input.

The new gtest covers the missing `COL_MAJOR` case directly. The existing Python narrow matrix already exercises the same shape in `tests/ttnn/unit_tests/base_functionality/test_narrow.py`, but it only checks layout, buffer type, memory layout, and numeric readback.

Closes #46718

### Notes for reviewers
The behavior change is local to `ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp`.

The regression lives in `tests/ttnn/unit_tests/gtests/test_narrow.cpp` because the missing contract is physical metadata, not values.

### Validation
cmake -S . -B .build-narrow-col-major-sim -G Ninja -DCMAKE_C_COMPILER=/usr/bin/cc -DCMAKE_CXX_COMPILER=/usr/bin/c++ -DTTNN_BUILD_TESTS=ON -DTT_METAL_BUILD_TESTS=OFF -DWITH_PYTHON_BINDINGS=OFF -DENABLE_DISTRIBUTED=OFF -DTT_UMD_BUILD_SIMULATION=ON -DBUILD_PROGRAMMING_EXAMPLES=OFF
cmake --build .build-narrow-col-major-sim --target unit_tests_ttnn -j4
TT_METAL_MOCK_CLUSTER_DESC_PATH=./tt_metal/third_party/umd/tests/cluster_descriptor_examples/wormhole_N150.yaml TT_METAL_SLOW_DISPATCH_MODE=1 ARCH_NAME=wormhole_b0 ./.build-narrow-col-major-sim/test/ttnn/unit_tests_ttnn --gtest_filter=TestNarrow.PreservesColMajorShardOrientation