### PR TITLE
[Bug fix] Preserve transpose shard orientation

### DIFF
--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -28,6 +28,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_graph_query_op_constraints.cpp
     test_graph_query_op_runtime.cpp
     test_launch_operation.cpp
+    test_transpose.cpp
     test_matmul.cpp
     test_matmul_multicore.cpp
     test_matmul_sweep.cpp

--- a/tests/ttnn/unit_tests/gtests/test_transpose.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_transpose.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gtest/gtest.h"
+
+#include <tt-metalium/shape.hpp>
+
+#include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/tensor/layout/page_config.hpp"
+#include "ttnn/tensor/layout/tensor_layout.hpp"
+#include "ttnn/tensor/shape/shape.hpp"
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn_test_fixtures.hpp"
+
+namespace ttnn::test {
+namespace {
+
+using TestTranspose = TTNNFixtureWithDevice;
+
+TEST_F(TestTranspose, PreservesColMajorShardOrientationOnFallbackGeneratedSpec) {
+    const auto input_memory_config = MemoryConfig(
+        TensorMemoryLayout::WIDTH_SHARDED,
+        BufferType::L1,
+        ShardSpec(
+            CoreRangeSet{CoreRange{CoreCoord{0, 0}, CoreCoord{0, 5}}},
+            Shape2D{160, 16},
+            ShardOrientation::COL_MAJOR));
+    const auto input_spec = TensorSpec(
+        ttnn::Shape({1, 1, 160, 96}),
+        TensorLayout(DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), input_memory_config));
+
+    auto input_tensor = create_device_tensor(input_spec, device_);
+    auto output_tensor = ttnn::transpose(input_tensor, /*dim1=*/2, /*dim2=*/3);
+
+    const auto& output_memory_config = output_tensor.memory_config();
+    ASSERT_TRUE(output_memory_config.is_sharded());
+    ASSERT_TRUE(output_memory_config.shard_spec().has_value());
+    EXPECT_EQ(output_memory_config.memory_layout(), input_memory_config.memory_layout());
+    EXPECT_EQ(output_memory_config.buffer_type(), input_memory_config.buffer_type());
+    EXPECT_EQ(output_memory_config.shard_spec()->orientation, ShardOrientation::COL_MAJOR);
+}
+
+}  // namespace
+}  // namespace ttnn::test

--- a/tests/ttnn/unit_tests/gtests/test_transpose.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_transpose.cpp
@@ -39,7 +39,7 @@ TEST_F(TestTranspose, PreservesColMajorShardOrientationOnFallbackGeneratedSpec) 
     ASSERT_TRUE(output_memory_config.shard_spec().has_value());
     EXPECT_EQ(output_memory_config.memory_layout(), input_memory_config.memory_layout());
     EXPECT_EQ(output_memory_config.buffer_type(), input_memory_config.buffer_type());
-    EXPECT_EQ(output_memory_config.shard_spec()->orientation, ShardOrientation::COL_MAJOR);
+    EXPECT_EQ(output_memory_config.shard_spec()->orientation, input_memory_config.shard_spec()->orientation);
 }
 
 }  // namespace

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -166,8 +166,12 @@ ShardSpec generate_transpose_shard_spec(
             tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(grid_size.x)), tt::constants::TILE_WIDTH);
         shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)};
     }
+    const auto orientation =
+        input_tensor.is_sharded() && input_tensor.shard_spec().has_value()
+            ? input_tensor.shard_spec()->orientation
+            : ShardOrientation::ROW_MAJOR;
     log_debug(tt::LogOp, "Transpose: generated shard spec over full compute grid ({} cores)", num_cores);
-    return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
+    return ShardSpec(all_cores, shard_shape, orientation);
 }
 
 }  // namespace ttnn::operations::data_movement::transpose


### PR DESCRIPTION
PR Category
Bug fix

Summary
Preserve the input shard orientation when `ttnn::transpose(...)` has to generate a fresh sharded output spec.

This patch fixes the generated-shard-spec path in transpose. When the output sharded memory config has no explicit shard spec and the existing input spec cannot be reused directly, `generate_transpose_shard_spec(...)` rebuilt the output metadata with `ROW_MAJOR` even if the input tensor was already `COL_MAJOR` sharded.

It also adds a focused mock-device gtest that starts from a `COL_MAJOR` `WIDTH_SHARDED` L1 tensor and checks that `ttnn::transpose(input_tensor, 2, 3)` preserves the output shard orientation on that generated-spec lane.

Closes #46725

Notes for reviewers
Validation
`cmake -S . -B .build-transpose-generated-orientation-sim -G Ninja -DCMAKE_C_COMPILER=/usr/bin/cc -DCMAKE_CXX_COMPILER=/usr/bin/c++ -DTTNN_BUILD_TESTS=ON -DTT_METAL_BUILD_TESTS=OFF -DWITH_PYTHON_BINDINGS=OFF -DENABLE_DISTRIBUTED=OFF -DTT_UMD_BUILD_SIMULATION=ON -DBUILD_PROGRAMMING_EXAMPLES=OFF`
`cmake --build .build-transpose-generated-orientation-sim --target unit_tests_ttnn -j4`
`TT_METAL_MOCK_CLUSTER_DESC_PATH=$PWD/tt_metal/third_party/umd/tests/cluster_descriptor_examples/wormhole_N150.yaml TT_METAL_SLOW_DISPATCH_MODE=1 ARCH_NAME=wormhole_b0 ./.build-transpose-generated-orientation-sim/test/ttnn/unit_tests_ttnn --gtest_filter=TestTranspose.PreservesColMajorShardOrientationOnFallbackGeneratedSpec`
