### PR TITLE
Revert "build: update tt-llk test harness requirements (#46540)"

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/device.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device.py
@@ -13,7 +13,7 @@ from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.debug_tensix import TensixDebug
 from ttexalens.hardware.risc_debug import CallstackEntry
 from ttexalens.tt_exalens_lib import (
-    ElfFile,
+    ParsedElfFile,
     TTException,
     arc_msg,
     callstack,
@@ -360,7 +360,7 @@ def reset_mailboxes(location: str = "0,0"):
 
 def pull_coverage_stream_from_tensix(
     location: str | OnChipCoordinate,
-    elf: str | ElfFile,
+    elf: str | ParsedElfFile,
     stream_path: str,
     device_id: int = 0,
     context: Context | None = None,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device_print.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device_print.py
@@ -31,10 +31,10 @@ from helpers.logger import logger
 from ttexalens.tt_exalens_lib import parse_elf, read_from_device, write_words_to_device
 
 # hostdev/device_print_structures.h: DevicePrintStringInfo is four uint32_t
-# on 4-byte ELFs, and four uint64_t on 8-byte ELFs (Rocket cores on Quasar).
+# on 32-bit ELFs, and four uint64_t on 64-bit ELFs (Rocket cores on Quasar).
 _STRING_INFO_LAYOUT: dict[int, tuple[int, str]] = {
-    4: (16, "<IIII"),
-    8: (32, "<QQQQ"),
+    32: (16, "<IIII"),
+    64: (32, "<QQQQ"),
 }
 
 
@@ -295,16 +295,16 @@ class ElfStrings:
         try:
             elf = parse_elf(elf_path, require_debug_symbols=False)
             self._parsed_elf = elf
-            self.pointer_size = elf.get_pointer_size()
+            self.pointer_size = elf.elf.elfclass // 8
             self.type_table = _type_table_for(self.pointer_size)
             self._info_record_size, self._info_unpack_fmt = _STRING_INFO_LAYOUT[
-                self.pointer_size
+                elf.elf.elfclass
             ]
-            strings = elf.get_section_by_name(".device_print_strings")
+            strings = elf.sections.get(".device_print_strings")
             if strings is not None:
                 self._strings_addr = strings.address
                 self._strings_data = bytes(strings.data)
-            info = elf.get_section_by_name(".device_print_strings_info")
+            info = elf.sections.get(".device_print_strings_info")
             if info is not None:
                 self._info_addr = info.address
                 self._info_data = bytes(info.data)
@@ -327,10 +327,7 @@ class ElfStrings:
             try:
                 die = self._parsed_elf.find_die_by_name(enum_name)
                 if die is not None:
-                    result = [
-                        (int(c.get_constant_value()), c.name)
-                        for c in die.iter_children()
-                    ]
+                    result = [(int(c.value), c.name) for c in die.iter_children()]
             except Exception:
                 result = None
         self._enum_cache[enum_name] = result

--- a/tt_metal/tt-llk/tests/requirements.txt
+++ b/tt_metal/tt-llk/tests/requirements.txt
@@ -1,10 +1,13 @@
 --index-url https://pypi.org/simple/
+--extra-index-url https://test.pypi.org/simple/
 --extra-index-url https://download.pytorch.org/whl/cpu
 
-## TT packages available on PyPI
-tt-exalens==0.3.22
+# tt packages from test.pypi.org
+tt-exalens==0.3.20
+tt-umd==0.9.5
+
+# tt-smi from pypi
 tt-smi==3.1.1
-tt-umd==0.9.6
 
 coverage[toml]==7.10.5
 exceptiongroup==1.3.0


### PR DESCRIPTION
This reverts commit 83c026d364956ba5da597204657732fe16ffce16 (PR #46540).

Restores the previous tt-llk test harness requirements and the associated changes in:
- `tt_metal/tt-llk/tests/python_tests/helpers/device.py`
- `tt_metal/tt-llk/tests/python_tests/helpers/device_print.py`
- `tt_metal/tt-llk/tests/requirements.txt`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=revert-tt-llk-test-harness-requirements)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:revert-tt-llk-test-harness-requirements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=revert-tt-llk-test-harness-requirements)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:revert-tt-llk-test-harness-requirements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=revert-tt-llk-test-harness-requirements)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:revert-tt-llk-test-harness-requirements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=revert-tt-llk-test-harness-requirements)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:revert-tt-llk-test-harness-requirements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=revert-tt-llk-test-harness-requirements)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:revert-tt-llk-test-harness-requirements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=revert-tt-llk-test-harness-requirements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:revert-tt-llk-test-harness-requirements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=revert-tt-llk-test-harness-requirements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:revert-tt-llk-test-harness-requirements)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=revert-tt-llk-test-harness-requirements)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:revert-tt-llk-test-harness-requirements)