### PR TITLE
[Test Only] Cover HW 8D BF16 sum reduction cases

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -284,18 +284,22 @@ def test_prod(device, input_shape, dim, keepdim, force_implicit_pad, dtype):
 @pytest.mark.parametrize("dim_6", [6])
 @pytest.mark.parametrize("dim_7", [7])
 @pytest.mark.parametrize("dim_8", [8, 32, 63])
-@pytest.mark.parametrize(
-    ("dim", "atol"),
-    [
-        ([3, 7], 0.03),
-        # BF16 HW reductions can produce a few near-zero outputs where a small
-        # absolute delta inflates RTOL without moving the global error metrics.
-        ([6, 7], 0.25),
-        ([-2, -1], 0.25),
-    ],
-)
+def _sum_8d_expected_atol(dim, dim_8):
+    if dim == [3, 7]:
+        return 0.03
+
+    # Issue #46472 observed a smaller absolute envelope for dim_8=8 than for
+    # the larger HW reductions, so keep the threshold as tight as the logs
+    # support for each shape.
+    if dim_8 == 8:
+        return 0.125
+
+    return 0.25
+
+
+@pytest.mark.parametrize("dim", [[3, 7], [6, 7], [-2, -1]])
 @pytest.mark.parametrize("keepdim", [True, False])
-def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8, dim, atol, keepdim):
+def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8, dim, keepdim):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8), dtype=torch.bfloat16)
@@ -315,7 +319,7 @@ def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, di
         output_tensor,
         pcc_threshold=0.999,
         rtol=0.01,
-        atol=atol,
+        atol=_sum_8d_expected_atol(dim, dim_8),
         frobenius_threshold=0.003,
     )
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -284,9 +284,18 @@ def test_prod(device, input_shape, dim, keepdim, force_implicit_pad, dtype):
 @pytest.mark.parametrize("dim_6", [6])
 @pytest.mark.parametrize("dim_7", [7])
 @pytest.mark.parametrize("dim_8", [8, 32, 63])
-@pytest.mark.parametrize("dim", [[3, 7]])
+@pytest.mark.parametrize(
+    ("dim", "atol"),
+    [
+        ([3, 7], 0.03),
+        # BF16 HW reductions can produce a few near-zero outputs where a small
+        # absolute delta inflates RTOL without moving the global error metrics.
+        ([6, 7], 0.25),
+        ([-2, -1], 0.25),
+    ],
+)
 @pytest.mark.parametrize("keepdim", [True, False])
-def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8, dim, keepdim):
+def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8, dim, atol, keepdim):
     torch.manual_seed(0)
 
     torch_input_tensor = torch.randn((dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, dim_7, dim_8), dtype=torch.bfloat16)
@@ -306,7 +315,7 @@ def test_sum_8d_tensor_dims(device, dim_1, dim_2, dim_3, dim_4, dim_5, dim_6, di
         output_tensor,
         pcc_threshold=0.999,
         rtol=0.01,
-        atol=0.03,
+        atol=atol,
         frobenius_threshold=0.003,
     )
 


### PR DESCRIPTION
### PR Category
Test Only

### Summary
- Add the missing HW-only 8D BF16 `ttnn.sum` cases from `#46472` to `test_sum_8d_tensor_dims`.
- Keep the existing `[3, 7]` coverage at `atol=0.03`.
- Calibrate the HW-only `[6, 7]` and `[-2, -1]` lanes to the issue-observed shape-specific absolute-error envelopes:
  - `dim_8=8`: `atol=0.125`
  - `dim_8=32` or `63`: `atol=0.25`

### Notes for reviewers
- This PR does not change `ttnn.sum` runtime code.
- The remaining change is in `tests/ttnn/unit_tests/operations/reduce/test_reduction.py`.
- `#43367` already fixed the earlier multi-stage BF16 intermediate-rounding bug for 8D sum. This patch only restores the missing HW-reduction coverage and matches the current issue evidence for the remaining BF16 tolerance shape.
- Local validation in this worktree was limited to:
  - `python3 -m py_compile tests/ttnn/unit_tests/operations/reduce/test_reduction.py`
  - `git diff --check upstream/main...HEAD`
