### PR TITLE
Skip 25k-ISL prefill-block tests on non-8x4 meshes (L1 OOM)

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -94,6 +94,13 @@ def run_model(
     if (is_ci_env or is_ci_v2_env) and not is_balanced and variant.name != "kimi_k2_6":
         pytest.skip("Skip non_balanced variant in CI — runnable locally for non_balanced-mode validation")
 
+    # The 25k-ISL cases only fit L1 on the full 8x4 mesh. There sp_factor=8 keeps the per-chip
+    # sequence at 3200 tokens, so the shared-expert down-projection matmul runs with per_core_M=2.
+    # On the smaller 2x4 meshes the per-chip sequence is 12800 tokens, pushing per_core_M to 5 and
+    # growing the down-matmul output circular buffer to ~2.9 MB — beyond the 1.5 MB L1 (OOM).
+    if isl_total == 25 * 1024 and tuple(mesh_device.shape) != (8, 4):
+        pytest.skip("25k ISL only fits L1 on the full 8x4 mesh; skipping on smaller meshes")
+
     profiler.clear()
     profiler.start("total_test_time")
     config.max_seq_len = isl_total


### PR DESCRIPTION
### Summary
The `perf-prompt_25k` (25k ISL) prefill-block cases OOM on the 2x4 meshes. On 2x4, `sp_factor=2` gives 12800 tokens/chip, which forces the shared-expert **down-projection** matmul to `per_core_M=5`. Its output circular buffer (`out_block_h*out_block_w` defaulting to `per_core_M*per_core_N = 5*224`) grows to ~2.9 MB, exceeding the 1.5 MB L1.

Only the full **8x4** mesh keeps the per-chip sequence small enough (`sp_factor=8` → 3200 tok/chip → `per_core_M=2`) to fit L1.

### Change
Skip any 25k-ISL case in `run_model` unless the mesh is 8x4. Runs after the existing CI skips; no-op for the Kimi test (8x4-only).

## CI Pipelines
[![Galaxy DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch%3Afbajraktari%2Ffix_shared_expert_oom)
[![T3K e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch%3Afbajraktari%2Ffix_shared_expert_oom)
[![SP Release DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch%3Afbajraktari%2Ffix_shared_expert_oom)
[![BH e2e DeepSeek Prefill](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch%3Afbajraktari%2Ffix_shared_expert_oom)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fbajraktari/fix_shared_expert_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fbajraktari/fix_shared_expert_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fbajraktari/fix_shared_expert_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fbajraktari/fix_shared_expert_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fbajraktari/fix_shared_expert_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fbajraktari/fix_shared_expert_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fbajraktari/fix_shared_expert_oom)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fbajraktari/fix_shared_expert_oom)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fbajraktari/fix_shared_expert_oom)