### PR TITLE
Fix `block_ct_dim` for GPT-OSS 120B

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -691,6 +691,15 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
 
     // Compute kernel on untilize cores
     {
+        // Largest divisor of (hidden_size / 32) that is <= 8.  Mirrors the combine program factory.
+        // Avoids the static_assert in llk_pack_untilize when full_ct_dim is not divisible by 8
+        // (e.g. gptoss-120b: hidden_size=2880, full_ct_dim=90, block_ct_dim=6).
+        const uint32_t full_ct_dim_dispatch = static_cast<uint32_t>(hidden_size) / 32u;
+        uint32_t block_ct_dim_dispatch = 8;
+        while (full_ct_dim_dispatch % block_ct_dim_dispatch != 0) {
+            --block_ct_dim_dispatch;
+        }
+
         tt::tt_metal::KernelDescriptor untilize_compute_kd;
         untilize_compute_kd.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"
@@ -703,6 +712,7 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
             static_cast<uint32_t>(tt::CBIndex::c_0),   // cb_in_id
             (uint32_t)hidden_size,
             read_batch_size,
+            block_ct_dim_dispatch,  // block_ct_dim
         };
         untilize_compute_kd.config = tt::tt_metal::ComputeConfigDescriptor{
             .math_fidelity = MathFidelity::HiFi4,
@@ -711,8 +721,8 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
             // Fp8_e4m3, so fp32_dest_acc_en must be enabled there.
             .fp32_dest_acc_en = operation_attributes.use_fp8_dispatch,
             // 32-bit DEST halves pack_untilize block capacity: half-sync 32-bit allows only 4
-            // tiles, but pack_untilize_block uses block_ct_dim=8. Full-sync 32-bit restores the
-            // 8-tile budget so the block still fits. Only needed on the FP8 (32-bit) path.
+            // tiles, but pack_untilize_block uses block_ct_dim. Full-sync 32-bit restores the
+            // full tile budget so the block still fits. Only needed on the FP8 (32-bit) path.
             .dst_full_sync_en = operation_attributes.use_fp8_dispatch,
         };
         desc.kernels.push_back(std::move(untilize_compute_kd));

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -226,6 +226,14 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     const auto l1_alignment = tt::tt_metal::hal::get_l1_alignment();
     uint32_t total_batches = (tokens_per_device + read_batch_size - 1) / read_batch_size;
 
+    // Largest divisor of (hidden_size / 32) that is <= 8.  Mirrors the combine program factory.
+    // Avoids the static_assert in llk_pack_untilize when full_ct_dim is not divisible by 8
+    const uint32_t full_ct_dim_dispatch = static_cast<uint32_t>(hidden_size) / 32u;
+    uint32_t block_ct_dim_dispatch = 8;
+    while (full_ct_dim_dispatch % block_ct_dim_dispatch != 0) {
+        --block_ct_dim_dispatch;
+    }
+
     // ==================== Semaphores ====================
     // Per-entry credit, each kept on the consumer's L1 (producer NOC-incs):
     //   data_avail  (sender L1, init=0):                untilize → sender, "entry ready".
@@ -251,11 +259,14 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     // ==================== Circular Buffers for untilize cores ====================
     // Routing decisions and offsets[] live on the untilize core — sender is fabric-only.
     // c_0: tiled input stripe (reader → compute)
+    // buffering_factor MUST be a multiple of block_ct_dim_dispatch (the reader's per-chunk push
+    // size) so untilize blocks never straddle the CB ring wrap.  2 * block_ct_dim gives double
+    // buffering (=16 for the common block_ct_dim=8 case, unchanged).
     detail::create_tensor_cb(
         desc,
         untilize_core_grid,
         input_tensor,
-        /*buffering_factor=*/16,
+        /*buffering_factor=*/2 * block_ct_dim_dispatch,
         /*cb_id=*/tt::CBIndex::c_0,
         "untilize_input_scratch");
     // c_1: indices scratch (untilize reader does per-batch DRAM reads)
@@ -591,6 +602,8 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     std::vector<tt::tt_metal::KernelHandle> writer_untilize_kernel_ids;
     reader_untilize_kernel_ids.reserve(num_untilize_cores);
     writer_untilize_kernel_ids.reserve(num_untilize_cores);
+
+    // block_ct_dim_dispatch is derived once above (shared with c_0 sizing and the compute kernel).
     for (uint32_t j = 0; j < num_untilize_cores; j++) {
         uint32_t s = untilize_sender_map[j];
         // Each sender owns num_untilizers cores; they split batches round-robin by local_core_id
@@ -629,6 +642,7 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
             mesh_view.num_cols(),                                  // 26
             linearized_mesh_coord,                                 // 27
             static_cast<uint32_t>(topology),                       // 28
+            block_ct_dim_dispatch,                                 // 29: must match the compute kernel
         };
         tt::tt_metal::TensorAccessorArgs(input_tensor.buffer()).append_to(untilize_reader_compile_args);
         tt::tt_metal::TensorAccessorArgs(indices_tensor.buffer()).append_to(untilize_reader_compile_args);
@@ -691,15 +705,7 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
 
     // Compute kernel on untilize cores
     {
-        // Largest divisor of (hidden_size / 32) that is <= 8.  Mirrors the combine program factory.
-        // Avoids the static_assert in llk_pack_untilize when full_ct_dim is not divisible by 8
-        // (e.g. gptoss-120b: hidden_size=2880, full_ct_dim=90, block_ct_dim=6).
-        const uint32_t full_ct_dim_dispatch = static_cast<uint32_t>(hidden_size) / 32u;
-        uint32_t block_ct_dim_dispatch = 8;
-        while (full_ct_dim_dispatch % block_ct_dim_dispatch != 0) {
-            --block_ct_dim_dispatch;
-        }
-
+        // block_ct_dim_dispatch is derived once above (shared with the reader kernel).
         tt::tt_metal::KernelDescriptor untilize_compute_kd;
         untilize_compute_kd.kernel_source =
             "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/"

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
@@ -27,6 +27,7 @@ constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 //   2: cb_in_id        - CB for untilize input tile data (c_0)
 //   3: hidden_size     - hidden dimension (e.g., 7168)
 //   4: read_batch_size - number of rows per untilize batch (32)
+//   5: block_ct_dim    - tiles per pack call (largest divisor of full_ct_dim <= 8)
 
 void kernel_main() {
     constexpr uint32_t cb_signal_id = get_compile_time_arg_val(0);
@@ -34,8 +35,8 @@ void kernel_main() {
     constexpr uint32_t cb_in_id = get_compile_time_arg_val(2);
     constexpr uint32_t hidden_size = get_compile_time_arg_val(3);
     constexpr uint32_t read_batch_size = get_compile_time_arg_val(4);
+    constexpr uint32_t block_ct_dim = get_compile_time_arg_val(5);
 
-    constexpr uint32_t block_ct_dim = 8;
     constexpr uint32_t full_ct_dim = hidden_size / 32;
     constexpr uint32_t num_blocks = full_ct_dim / block_ct_dim;
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/reader_untilize_dispatch.cpp
@@ -95,14 +95,15 @@ void kernel_main() {
     constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(27);
     constexpr tt::tt_fabric::Topology topology = (tt::tt_fabric::Topology)get_compile_time_arg_val(28);
 
-    constexpr auto input_args = TensorAccessorArgs<29>();
+    constexpr uint32_t block_ct_dim = get_compile_time_arg_val(29);
+
+    constexpr auto input_args = TensorAccessorArgs<30>();
     constexpr auto indices_args = TensorAccessorArgs<input_args.next_compile_time_args_offset()>();
     constexpr auto weights_args = TensorAccessorArgs<indices_args.next_compile_time_args_offset()>();
     constexpr auto offsets_args = TensorAccessorArgs<weights_args.next_compile_time_args_offset()>();
     constexpr auto dispatch_table_args = TensorAccessorArgs<offsets_args.next_compile_time_args_offset()>();
 
     constexpr uint32_t tiles_per_row = hidden_size / 32;
-    constexpr uint32_t block_ct_dim = 8;
     constexpr uint32_t num_tile_blocks = tiles_per_row / block_ct_dim;
 
 #ifdef AXIS
@@ -206,7 +207,7 @@ void kernel_main() {
         signal_ptr[0] = 0x00000000;
         cb_push_back(cb_signal_id, 1);
 
-        // 2. Stream tiled input stripe from DRAM in blocks of 8 tiles
+        // 2. Stream tiled input stripe from DRAM in blocks of block_ct_dim tiles
         for (uint32_t blk = 0; blk < num_tile_blocks; blk++) {
             cb_reserve_back(cb_input_id, block_ct_dim);
             uint32_t blk_write_ptr = get_write_ptr(cb_input_id);


### PR DESCRIPTION
Resolves issues : 
- https://github.com/tenstorrent/tt-metal/issues/46606
- https://github.com/tenstorrent/tt-metal/issues/46607


- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nostojic/gptoss_dispatch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nostojic/gptoss_dispatch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nostojic/gptoss_dispatch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nostojic/gptoss_dispatch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=nostojic/gptoss_dispatch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:nostojic/gptoss_dispatch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=nostojic/gptoss_dispatch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:nostojic/gptoss_dispatch_fix)


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/gptoss_dispatch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/gptoss_dispatch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/gptoss_dispatch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/gptoss_dispatch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nostojic/gptoss_dispatch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nostojic/gptoss_dispatch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/gptoss_dispatch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/gptoss_dispatch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/gptoss_dispatch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/gptoss_dispatch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/gptoss_dispatch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/gptoss_dispatch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/gptoss_dispatch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/gptoss_dispatch_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/gptoss_dispatch_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/gptoss_dispatch_fix)