### PR TITLE
ds_prefill - Fix for weights tensor making for embedding sizes different from DS V3

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/init_helpers.py
@@ -514,7 +514,7 @@ def initialize_test_inputs(
     indices_shape = (dispatch_group_size, seq_len_per_chip, num_experts_per_tok)
 
     weights = torch.randn(weights_shape, dtype=torch.bfloat16)
-    weights = weights / weights.sum(dim=-1, keepdim=True)  # Normalize so topk sums to 1
+    weights = torch.softmax(weights.float(), dim=-1).to(torch.bfloat16)
     indices = torch.randint(0, num_routed_experts, indices_shape, dtype=torch.int32)
 
     # Validate expert activations


### PR DESCRIPTION
### Problem description
`weights = torch.randn(weights_shape, dtype=torch.bfloat16)` is signed so some values in `weights` tensor can be positive, while others are negative. That can cause problem with `weights.sum(dim=-1, keepdim=True)` because that sum can be very close to 0 in some cases where some values are positive, while others are negative, so `weights / weights.sum` produces `infinite value`, which is why PCC drops when emb_dim is changed from `DeepSeek V3 7168 dimension` to some others like `6144 for GLM5.1 emb_dim`. Problem was seen inside of `models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py` test.

### What's changed
- Changed `weights / weights.sum` with `torch.softmax(weights.float()` in order to escape this part where weights.sum is close to 0, so division with value close to 0 produces **inf** value.

### DeepSeek CI

- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/reducetest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/reducetest-fix)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/reducetest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/reducetest-fix)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/reducetest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/reducetest-fix)
- [x] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=pmilojevic/reducetest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:pmilojevic/reducetest-fix)


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/reducetest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/reducetest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/reducetest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/reducetest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilojevic/reducetest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilojevic/reducetest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/reducetest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/reducetest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/reducetest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/reducetest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/reducetest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/reducetest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/reducetest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/reducetest-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/reducetest-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/reducetest-fix)