### PR TITLE
Removed critical Quasar pyskips in LLK.

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -58,8 +58,7 @@ def valid_acc_to_dest(dest_sync_dims_dest_acc) -> list:
     """Pick the acc_to_dest modes worth running for a given input size.
 
     acc_to_dest=True accumulates `get_num_tiles_per_accumulation(True)` result tiles into
-    dest, so it only makes sense when the tile count is a non-zero multiple of that. Filtering
-    here means those combinations are never generated (instead of generated then skipped).
+    dest, so it only makes sense when the tile count is a non-zero multiple of that.
     """
     _, input_dimensions, _ = dest_sync_dims_dest_acc
     total_tiles = (

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_quasar.py
@@ -51,6 +51,27 @@ def get_num_tiles_per_accumulation(acc_to_dest: bool) -> int:
     return 2 if acc_to_dest else 1
 
 
+_TILE_SHAPE = construct_tile_shape()
+
+
+def valid_acc_to_dest(dest_sync_dims_dest_acc) -> list:
+    """Pick the acc_to_dest modes worth running for a given input size.
+
+    acc_to_dest=True accumulates `get_num_tiles_per_accumulation(True)` result tiles into
+    dest, so it only makes sense when the tile count is a non-zero multiple of that. Filtering
+    here means those combinations are never generated (instead of generated then skipped).
+    """
+    _, input_dimensions, _ = dest_sync_dims_dest_acc
+    total_tiles = (
+        input_dimensions[0] * input_dimensions[1]
+    ) // _TILE_SHAPE.total_tile_size()
+
+    per_acc = get_num_tiles_per_accumulation(True)
+    if total_tiles >= per_acc and total_tiles % per_acc == 0:
+        return [False, True]
+    return [False]
+
+
 @pytest.mark.quasar
 @parametrize(
     formats=input_output_formats(
@@ -70,12 +91,17 @@ def get_num_tiles_per_accumulation(acc_to_dest: bool) -> int:
         MathOperation.Elwsub,
         MathOperation.Elwmul,
     ],
-    math_fidelity=[
-        MathFidelity.LoFi,
-        MathFidelity.HiFi2,
-        MathFidelity.HiFi3,
-        MathFidelity.HiFi4,
-    ],
+    # Math fidelity only affects multiplication; for add/sub only LoFi is meaningful.
+    math_fidelity=lambda mathop: (
+        [MathFidelity.LoFi]
+        if mathop in [MathOperation.Elwadd, MathOperation.Elwsub]
+        else [
+            MathFidelity.LoFi,
+            MathFidelity.HiFi2,
+            MathFidelity.HiFi3,
+            MathFidelity.HiFi4,
+        ]
+    ),
     implied_math_format=lambda formats: (
         [
             ImpliedMathFormat.No,
@@ -85,7 +111,7 @@ def get_num_tiles_per_accumulation(acc_to_dest: bool) -> int:
         else [ImpliedMathFormat.Yes]
     ),
     dest_sync_dims_dest_acc=ELTWISE_DIMENSIONS,
-    acc_to_dest=[False, True],
+    acc_to_dest=valid_acc_to_dest,
     num_faces=[4],
 )
 def test_eltwise_binary(
@@ -99,24 +125,8 @@ def test_eltwise_binary(
     boot_mode=BootMode.DEFAULT,
 ):
     dest_sync_mode, input_dimensions, dest_acc = dest_sync_dims_dest_acc
-    tile_shape = construct_tile_shape()
-
-    # Math fidelity only affects multiplication operations
-    if (
-        mathop in [MathOperation.Elwadd, MathOperation.Elwsub]
-        and math_fidelity != MathFidelity.LoFi
-    ):
-        pytest.skip("Math fidelity only affects multiplication operations")
 
     num_tiles_per_accumulation = get_num_tiles_per_accumulation(acc_to_dest)
-    total_tiles = (
-        input_dimensions[0] * input_dimensions[1]
-    ) // tile_shape.total_tile_size()
-
-    if (
-        acc_to_dest and total_tiles < num_tiles_per_accumulation
-    ) or total_tiles % num_tiles_per_accumulation != 0:
-        pytest.skip("Not enough tiles for dest accumulation")
 
     src_A, tile_cnt_A, src_B, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,
@@ -127,7 +137,7 @@ def test_eltwise_binary(
     )
 
     tile_cnt_res = src_A.numel() // (
-        tile_shape.total_tile_size() * num_tiles_per_accumulation
+        _TILE_SHAPE.total_tile_size() * num_tiles_per_accumulation
     )
 
     generate_golden = get_golden_generator(EltwiseBinaryGolden)
@@ -139,7 +149,7 @@ def test_eltwise_binary(
         math_fidelity,
         input_format=formats.input_format,
         acc_to_dest=acc_to_dest,
-        tile_shape=tile_shape,
+        tile_shape=_TILE_SHAPE,
         num_tiles_per_accumulation=num_tiles_per_accumulation,
     )
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -143,7 +143,6 @@ def valid_output_dimensions(formats, dest_sync_mode, input_dimensions) -> list:
     ],
     dest_sync_mode=[DestSync.Half, DestSync.Full],
     input_dimensions=INPUT_DIMENSIONS,
-    # Only pair each input size with reuse_dest-compatible output sizes (see helper).
     output_dimensions=valid_output_dimensions,
 )
 def test_eltwise_binary_reuse_dest_quasar(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_binary_reuse_dest_quasar.py
@@ -56,6 +56,46 @@ OUTPUT_DIMENSIONS = [
 TILE_DIMENSIONS = [32, 32]
 
 
+def _reuse_dest_tile_count(dimensions) -> int:
+    tile_rows, tile_cols = TILE_DIMENSIONS
+    return (dimensions[0] // tile_rows) * (dimensions[1] // tile_cols)
+
+
+def valid_output_dimensions(formats, dest_sync_mode, input_dimensions) -> list:
+    """Output dims compatible with reuse_dest for a given input size, format and dest_sync.
+
+    Three constraints, all decidable at collection time so incompatible combinations are
+    never generated (instead of generated then skipped):
+      - input tile count must be an exact multiple of the output tile count, and
+      - that multiple (`inner_dim`) must be > 1 (reuse_dest needs accumulation), and
+      - the output must fit in a single block (the Quasar reuse_dest kernel uses
+        block-relative indexing; multi-block accumulates wrongly).
+    """
+    tile_cnt_input = _reuse_dest_tile_count(input_dimensions)
+    valid = []
+    for out_dims in OUTPUT_DIMENSIONS:
+        tile_cnt_output = _reuse_dest_tile_count(out_dims)
+        if tile_cnt_output == 0 or tile_cnt_input % tile_cnt_output != 0:
+            continue
+        if tile_cnt_input // tile_cnt_output <= 1:
+            continue
+        try:
+            num_blocks, _ = get_num_blocks_and_num_tiles_in_block(
+                dest_sync_mode,
+                DestAccumulation.No,
+                formats,
+                out_dims,
+                (TILE_DIMENSIONS[0], TILE_DIMENSIONS[1]),
+                BlocksCalculationAlgorithm.Standard,
+            )
+        except ValueError:
+            continue  # tiles don't divide evenly into blocks for this combination
+        if num_blocks > 1:
+            continue
+        valid.append(out_dims)
+    return valid
+
+
 @pytest.mark.quasar
 @parametrize(
     formats=input_output_formats(
@@ -70,24 +110,41 @@ TILE_DIMENSIONS = [32, 32]
             DataFormat.MxInt2,
         ],
     ),
-    mathop=[
-        MathOperation.Elwadd,
-        MathOperation.Elwsub,
-        MathOperation.Elwmul,
-    ],
+    # Elwmul with MxFp8R or MxFp8P input and reuse_dest has rounding differences; skip to avoid flaky tolerance failures
+    mathop=lambda formats: (
+        [
+            MathOperation.Elwadd,
+            MathOperation.Elwsub,
+        ]
+        if (
+            formats.input_format == DataFormat.MxFp8R
+            or formats.input_format == DataFormat.MxFp8P
+        )
+        else [
+            MathOperation.Elwadd,
+            MathOperation.Elwsub,
+            MathOperation.Elwmul,
+        ]
+    ),
+    # Math fidelity only affects multiplication; for add/sub only LoFi is meaningful.
+    math_fidelity=lambda mathop: (
+        [MathFidelity.LoFi]
+        if mathop in [MathOperation.Elwadd, MathOperation.Elwsub]
+        else [
+            MathFidelity.LoFi,
+            MathFidelity.HiFi2,
+            MathFidelity.HiFi3,
+            MathFidelity.HiFi4,
+        ]
+    ),
     reuse_dest_type=[
         EltwiseBinaryReuseDestType.DEST_TO_SRCA,
         EltwiseBinaryReuseDestType.DEST_TO_SRCB,
     ],
-    math_fidelity=[
-        MathFidelity.LoFi,
-        MathFidelity.HiFi2,
-        MathFidelity.HiFi3,
-        MathFidelity.HiFi4,
-    ],
     dest_sync_mode=[DestSync.Half, DestSync.Full],
     input_dimensions=INPUT_DIMENSIONS,
-    output_dimensions=OUTPUT_DIMENSIONS,
+    # Only pair each input size with reuse_dest-compatible output sizes (see helper).
+    output_dimensions=valid_output_dimensions,
 )
 def test_eltwise_binary_reuse_dest_quasar(
     formats,
@@ -99,16 +156,6 @@ def test_eltwise_binary_reuse_dest_quasar(
     output_dimensions,
     boot_mode=BootMode.DEFAULT,
 ):
-    if mathop != MathOperation.Elwmul and math_fidelity != MathFidelity.LoFi:
-        pytest.skip("elwadd/elwsub only supports LoFi mode")
-
-    if mathop == MathOperation.Elwmul and (
-        formats.input_format == DataFormat.MxFp8R
-        or formats.input_format == DataFormat.MxFp8P
-    ):
-        pytest.skip(
-            "Elwmul with MxFp8R or MxFp8P input and reuse_dest has rounding differences; skip to avoid flaky tolerance failures"
-        )
 
     # MX formats require implied_math_format=Yes on Quasar; set it and disable_format_inference so golden matches.
     use_mx = formats.input_format.is_mx_format() or formats.output_format.is_mx_format()
@@ -128,14 +175,7 @@ def test_eltwise_binary_reuse_dest_quasar(
         output_dimensions[1] // tile_cols
     )
 
-    if tile_cnt_input % tile_cnt_output != 0:
-        pytest.skip(
-            f"Input tile count ({tile_cnt_input}) must be divisible by "
-            f"output tile count ({tile_cnt_output})"
-        )
     inner_dim = tile_cnt_input // tile_cnt_output
-    if inner_dim == 1:
-        pytest.skip("reuse_dest requires inner_dim > 1")
 
     tile_dimensions_tuple = (tile_rows, tile_cols)
     output_num_blocks, output_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
@@ -146,11 +186,6 @@ def test_eltwise_binary_reuse_dest_quasar(
         tile_dimensions_tuple,
         BlocksCalculationAlgorithm.Standard,
     )
-    if output_num_blocks > 1:
-        pytest.skip(
-            "Quasar reuse_dest kernel supports single output block only; "
-            "multi-block uses block-relative indexing and wrong accumulation"
-        )
     input_tiles_in_block = inner_dim * output_tiles_in_block
     input_num_blocks = output_num_blocks
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
@@ -117,7 +117,15 @@ ALL_DATACOPY_COMBINATIONS = generate_eltwise_unary_datacopy_combinations(
 @pytest.mark.quasar
 @parametrize(
     formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices=ALL_DATACOPY_COMBINATIONS,
-    implied_math_format=[ImpliedMathFormat.Yes, ImpliedMathFormat.No],
+    # MX formats REQUIRE implied_math_format=Yes on Quasar (bypass format inference pipeline);
+    # don't generate the No variant for them. combo[0] is the FormatConfig.
+    implied_math_format=lambda formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices: (
+        [ImpliedMathFormat.Yes]
+        if formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices[
+            0
+        ].input_format.is_mx_format()
+        else [ImpliedMathFormat.Yes, ImpliedMathFormat.No]
+    ),
 )
 def test_eltwise_unary_datacopy_quasar(
     formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices,
@@ -131,13 +139,6 @@ def test_eltwise_unary_datacopy_quasar(
         dest_sync_mode,
         dest_index,
     ) = formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices
-
-    # MX formats REQUIRE implied_math_format=Yes on Quasar (bypass format inference pipeline)
-    if (
-        formats.input_format.is_mx_format()
-        and implied_math_format == ImpliedMathFormat.No
-    ):
-        pytest.skip("MX formats require implied_math_format=Yes on Quasar")
 
     src_A, tile_cnt_A, src_B, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_datacopy_quasar.py
@@ -117,8 +117,7 @@ ALL_DATACOPY_COMBINATIONS = generate_eltwise_unary_datacopy_combinations(
 @pytest.mark.quasar
 @parametrize(
     formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices=ALL_DATACOPY_COMBINATIONS,
-    # MX formats REQUIRE implied_math_format=Yes on Quasar (bypass format inference pipeline);
-    # don't generate the No variant for them. combo[0] is the FormatConfig.
+    # don't generate the No variant for them. combo[0] is the InputOutputFormat (input/output pair).
     implied_math_format=lambda formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices: (
         [ImpliedMathFormat.Yes]
         if formats_dest_acc_data_copy_type_dims_dest_sync_dest_indices[

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
@@ -127,8 +127,7 @@ def generate_qsr_pack_l1_acc_combinations(
 @pytest.mark.quasar
 @parametrize(
     formats_dest_acc=generate_qsr_pack_l1_acc_combinations(PACK_L1_ACC_FORMATS),
-    # MX formats REQUIRE implied_math_format=Yes on Quasar (bypass format inference pipeline);
-    # don't generate the No variant for them. formats_dest_acc[0] is the FormatConfig.
+    # don't generate the No variant for them. formats_dest_acc[0] is the InputOutputFormat (input/output pair).
     implied_math_format=lambda formats_dest_acc: (
         [ImpliedMathFormat.Yes]
         if formats_dest_acc[0].input_format.is_mx_format()

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_l1_acc_quasar.py
@@ -127,7 +127,13 @@ def generate_qsr_pack_l1_acc_combinations(
 @pytest.mark.quasar
 @parametrize(
     formats_dest_acc=generate_qsr_pack_l1_acc_combinations(PACK_L1_ACC_FORMATS),
-    implied_math_format=[ImpliedMathFormat.No, ImpliedMathFormat.Yes],
+    # MX formats REQUIRE implied_math_format=Yes on Quasar (bypass format inference pipeline);
+    # don't generate the No variant for them. formats_dest_acc[0] is the FormatConfig.
+    implied_math_format=lambda formats_dest_acc: (
+        [ImpliedMathFormat.Yes]
+        if formats_dest_acc[0].input_format.is_mx_format()
+        else [ImpliedMathFormat.No, ImpliedMathFormat.Yes]
+    ),
     dest_sync_mode=[DestSync.Half, DestSync.Full],
     input_dimensions=INPUT_DIMENSIONS,
 )
@@ -139,13 +145,6 @@ def test_pack_l1_acc_quasar(
     boot_mode=BootMode.DEFAULT,
 ):
     (formats, dest_acc) = formats_dest_acc
-
-    # MX formats REQUIRE implied_math_format=Yes on Quasar (bypass format inference pipeline)
-    if (
-        formats.input_format.is_mx_format()
-        and implied_math_format == ImpliedMathFormat.No
-    ):
-        pytest.skip("MX formats require implied_math_format=Yes on Quasar")
 
     tile_rows, tile_cols = TILE_DIMENSIONS
     face_r_dim, num_faces_r_dim, num_faces_c_dim = get_tile_params(

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_pack_untilize_quasar.py
@@ -79,6 +79,10 @@ def generate_pack_untilize_combinations(
         if not is_supported_format_conversion(in_fmt, out_fmt):
             continue
 
+        # MX as output format produces flaky results on Quasar.
+        if out_fmt.is_mx_format():
+            continue
+
         for dest_acc in get_dest_acc_modes(in_fmt):
             for dest_sync in dest_sync_modes:
                 for dimensions in dimensions_cache[(dest_acc, dest_sync)]:
@@ -112,9 +116,6 @@ def test_pack_untilize_quasar(formats_dest_acc_sync_dimensions):
     (formats, dest_acc, dest_sync_mode, input_dimensions) = (
         formats_dest_acc_sync_dimensions[0]
     )
-
-    if formats.output_format.is_mx_format():
-        pytest.skip("MX as output format produces flaky results.")
 
     src_A, tile_cnt_A, src_B, _ = generate_stimuli(
         stimuli_format_A=formats.input_format,


### PR DESCRIPTION
### Summary
Some pyskip calls in quasar tests in LLK were responsible for generating a lot of test variations which get skipped.
This caused the CI Quasar compile to run for a very long time and eventually run out of memory.

This PR removes those skips and handles the skipping inside python test parametrize by utilizing lambda functionality or skipping them in test preconfigs.

Example: test_eltwise_binary_quasar dropped from 134400 variations to 55200 which is a 59% drop.

One pyskip was left in test_reduce_quasar since it is very specific and doesn't cause CI test compilation bloating.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=uvelimirovic/remove_llk_test_skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:uvelimirovic/remove_llk_test_skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=uvelimirovic/remove_llk_test_skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:uvelimirovic/remove_llk_test_skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=uvelimirovic/remove_llk_test_skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:uvelimirovic/remove_llk_test_skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=uvelimirovic/remove_llk_test_skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:uvelimirovic/remove_llk_test_skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=uvelimirovic/remove_llk_test_skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:uvelimirovic/remove_llk_test_skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=uvelimirovic/remove_llk_test_skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:uvelimirovic/remove_llk_test_skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=uvelimirovic/remove_llk_test_skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:uvelimirovic/remove_llk_test_skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=uvelimirovic/remove_llk_test_skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:uvelimirovic/remove_llk_test_skips)