### PR TITLE
[Bug fix] Handle indivisible shared-expert subblocks

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
@@ -24,10 +24,11 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
 @pytest.mark.parametrize(
     "seq_len_per_chip, emb_dim, hidden_dim",
     [
-        (4096, 7 * 1024, 2 * 1024),
-        (3200, 7 * 1024, 2 * 1024),
+        pytest.param(4096, 7 * 1024, 2 * 1024, id="4K"),
+        pytest.param(3200, 7 * 1024, 2 * 1024, id="3.2K"),
+        pytest.param(4096, 2880, 2880, id="gpt_oss_120b-4K"),
+        pytest.param(3200, 2880, 2880, id="gpt_oss_120b-3.2K"),
     ],
-    ids=["4K", "3.2K"],
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
@@ -20,6 +20,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import (
     TtSharedExpert,
     get_bh_program_configs,
     get_wh_program_configs,
+    uses_tuned_shared_expert_gate_program_config,
 )
 from models.tt_transformers.tt.ccl import get_num_links
 from tests.ttnn.utils_for_testing import assert_with_pcc
@@ -33,24 +34,31 @@ from tests.ttnn.utils_for_testing import assert_with_pcc
     ],
 )
 @pytest.mark.parametrize(
-    "gate_n_tiles, expected_gate_out_subblock_w",
+    "gate_n_tiles, expects_tuned_gate_program_config",
     [
-        pytest.param(64, 8, id="divisible-by-8"),
-        pytest.param(56, 8, id="legacy-divisible-shape"),
-        pytest.param(23, 1, id="gpt-oss-120b-shape"),
-        pytest.param(7, 7, id="small-prime-shape"),
+        pytest.param(64, True, id="divisible-by-8"),
+        pytest.param(56, True, id="legacy-divisible-shape"),
+        pytest.param(23, False, id="gpt-oss-120b-shape"),
+        pytest.param(7, False, id="small-prime-shape"),
     ],
 )
-def test_shared_expert_program_configs_pick_divisible_out_subblocks(
+def test_shared_expert_program_configs_keep_only_tuned_gate_up_configs(
     program_config_builder,
     expected_down_out_subblock_w: int,
     gate_n_tiles: int,
-    expected_gate_out_subblock_w: int,
+    expects_tuned_gate_program_config: bool,
 ):
     gate, up, down = program_config_builder(per_core_M=1, gate_n_tiles=gate_n_tiles, down_n_tiles=8)
 
-    assert gate.out_subblock_w == expected_gate_out_subblock_w
-    assert up.out_subblock_w == expected_gate_out_subblock_w
+    assert uses_tuned_shared_expert_gate_program_config(gate_n_tiles) == expects_tuned_gate_program_config
+    if expects_tuned_gate_program_config:
+        assert gate is not None
+        assert up is not None
+        assert gate.out_subblock_w == 8
+        assert up.out_subblock_w == 8
+    else:
+        assert gate is None
+        assert up is None
     assert down.out_subblock_w == expected_down_out_subblock_w
 
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
@@ -16,9 +16,42 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
-from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
+from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import (
+    TtSharedExpert,
+    get_bh_program_configs,
+    get_wh_program_configs,
+)
 from models.tt_transformers.tt.ccl import get_num_links
 from tests.ttnn.utils_for_testing import assert_with_pcc
+
+
+@pytest.mark.parametrize(
+    "program_config_builder, expected_down_out_subblock_w",
+    [
+        pytest.param(get_wh_program_configs, 1, id="wormhole"),
+        pytest.param(get_bh_program_configs, 8, id="blackhole"),
+    ],
+)
+@pytest.mark.parametrize(
+    "gate_n_tiles, expected_gate_out_subblock_w",
+    [
+        pytest.param(64, 8, id="divisible-by-8"),
+        pytest.param(56, 8, id="legacy-divisible-shape"),
+        pytest.param(23, 1, id="gpt-oss-120b-shape"),
+        pytest.param(7, 7, id="small-prime-shape"),
+    ],
+)
+def test_shared_expert_program_configs_pick_divisible_out_subblocks(
+    program_config_builder,
+    expected_down_out_subblock_w: int,
+    gate_n_tiles: int,
+    expected_gate_out_subblock_w: int,
+):
+    gate, up, down = program_config_builder(per_core_M=1, gate_n_tiles=gate_n_tiles, down_n_tiles=8)
+
+    assert gate.out_subblock_w == expected_gate_out_subblock_w
+    assert up.out_subblock_w == expected_gate_out_subblock_w
+    assert down.out_subblock_w == expected_down_out_subblock_w
 
 
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py
@@ -16,50 +16,9 @@ from tracy import signpost
 
 import ttnn
 from models.demos.deepseek_v3_d_p.reference.tt.moe.expert import TorchExpert
-from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import (
-    TtSharedExpert,
-    get_bh_program_configs,
-    get_wh_program_configs,
-    uses_tuned_shared_expert_gate_program_config,
-)
+from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
 from models.tt_transformers.tt.ccl import get_num_links
 from tests.ttnn.utils_for_testing import assert_with_pcc
-
-
-@pytest.mark.parametrize(
-    "program_config_builder, expected_down_out_subblock_w",
-    [
-        pytest.param(get_wh_program_configs, 1, id="wormhole"),
-        pytest.param(get_bh_program_configs, 8, id="blackhole"),
-    ],
-)
-@pytest.mark.parametrize(
-    "gate_n_tiles, expects_tuned_gate_program_config",
-    [
-        pytest.param(64, True, id="divisible-by-8"),
-        pytest.param(56, True, id="legacy-divisible-shape"),
-        pytest.param(23, False, id="gpt-oss-120b-shape"),
-        pytest.param(7, False, id="small-prime-shape"),
-    ],
-)
-def test_shared_expert_program_configs_keep_only_tuned_gate_up_configs(
-    program_config_builder,
-    expected_down_out_subblock_w: int,
-    gate_n_tiles: int,
-    expects_tuned_gate_program_config: bool,
-):
-    gate, up, down = program_config_builder(per_core_M=1, gate_n_tiles=gate_n_tiles, down_n_tiles=8)
-
-    assert uses_tuned_shared_expert_gate_program_config(gate_n_tiles) == expects_tuned_gate_program_config
-    if expects_tuned_gate_program_config:
-        assert gate is not None
-        assert up is not None
-        assert gate.out_subblock_w == 8
-        assert up.out_subblock_w == 8
-    else:
-        assert gate is None
-        assert up is None
-    assert down.out_subblock_w == expected_down_out_subblock_w
 
 
 @pytest.mark.parametrize(

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -30,14 +30,23 @@ COMPUTE_KERNEL_CONFIG_HIFI2 = ttnn.WormholeComputeKernelConfig(
 )
 
 
+def largest_divisible_out_subblock_w(per_core_n: int, max_width: int = 8) -> int:
+    """Pick the widest allowed output subblock that still divides the per-core N tile count."""
+    for out_subblock_w in range(min(per_core_n, max_width), 0, -1):
+        if per_core_n % out_subblock_w == 0:
+            return out_subblock_w
+    return 1
+
+
 def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
     """Program configs for the gate / up / down matmuls on Blackhole."""
     grid = ttnn.CoreCoord(11, 9)
+    gate_out_subblock_w = largest_divisible_out_subblock_w(gate_n_tiles)
     gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
         in0_block_w=4,
         out_subblock_h=1,
-        out_subblock_w=8,
+        out_subblock_w=gate_out_subblock_w,
         per_core_M=per_core_M,
         per_core_N=gate_n_tiles,
         fuse_batch=False,
@@ -48,7 +57,7 @@ def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int
         compute_with_storage_grid_size=grid,
         in0_block_w=4,
         out_subblock_h=1,
-        out_subblock_w=8,
+        out_subblock_w=gate_out_subblock_w,
         per_core_M=per_core_M,
         per_core_N=gate_n_tiles,
         fuse_batch=False,
@@ -70,11 +79,12 @@ def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int
 def get_wh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
     """Program configs for the gate / up / down matmuls on Wormhole."""
     grid = ttnn.CoreCoord(8, 7)
+    gate_out_subblock_w = largest_divisible_out_subblock_w(gate_n_tiles)
     gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
         in0_block_w=4,
         out_subblock_h=1,
-        out_subblock_w=8,
+        out_subblock_w=gate_out_subblock_w,
         per_core_M=per_core_M,
         per_core_N=gate_n_tiles,
         fuse_batch=False,
@@ -85,7 +95,7 @@ def get_wh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int
         compute_with_storage_grid_size=grid,
         in0_block_w=4,
         out_subblock_h=1,
-        out_subblock_w=8,
+        out_subblock_w=gate_out_subblock_w,
         per_core_M=per_core_M,
         per_core_N=gate_n_tiles,
         fuse_batch=False,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -28,40 +28,30 @@ COMPUTE_KERNEL_CONFIG_HIFI2 = ttnn.WormholeComputeKernelConfig(
     fp32_dest_acc_en=False,
     packer_l1_acc=True,
 )
-
-
-def uses_tuned_shared_expert_gate_program_config(gate_n_tiles: int, tuned_out_subblock_w: int = 8) -> bool:
-    """Keep the hand-tuned gate/up matmul configs only on shapes they were tuned for."""
-    return gate_n_tiles % tuned_out_subblock_w == 0
-
-
 def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
     """Program configs for the gate / up / down matmuls on Blackhole."""
     grid = ttnn.CoreCoord(11, 9)
-    gate = None
-    up = None
-    if uses_tuned_shared_expert_gate_program_config(gate_n_tiles):
-        gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-            compute_with_storage_grid_size=grid,
-            in0_block_w=4,
-            out_subblock_h=1,
-            out_subblock_w=8,
-            per_core_M=per_core_M,
-            per_core_N=gate_n_tiles,
-            fuse_batch=False,
-            mcast_in0=False,
-            fused_activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
-        )
-        up = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-            compute_with_storage_grid_size=grid,
-            in0_block_w=4,
-            out_subblock_h=1,
-            out_subblock_w=8,
-            per_core_M=per_core_M,
-            per_core_N=gate_n_tiles,
-            fuse_batch=False,
-            mcast_in0=False,
-        )
+    gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=grid,
+        in0_block_w=4,
+        out_subblock_h=1,
+        out_subblock_w=8,
+        per_core_M=per_core_M,
+        per_core_N=gate_n_tiles,
+        fuse_batch=False,
+        mcast_in0=False,
+        fused_activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
+    )
+    up = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=grid,
+        in0_block_w=4,
+        out_subblock_h=1,
+        out_subblock_w=8,
+        per_core_M=per_core_M,
+        per_core_N=gate_n_tiles,
+        fuse_batch=False,
+        mcast_in0=False,
+    )
     down = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
         in0_block_w=1,
@@ -78,30 +68,27 @@ def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int
 def get_wh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
     """Program configs for the gate / up / down matmuls on Wormhole."""
     grid = ttnn.CoreCoord(8, 7)
-    gate = None
-    up = None
-    if uses_tuned_shared_expert_gate_program_config(gate_n_tiles):
-        gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-            compute_with_storage_grid_size=grid,
-            in0_block_w=4,
-            out_subblock_h=1,
-            out_subblock_w=8,
-            per_core_M=per_core_M,
-            per_core_N=gate_n_tiles,
-            fuse_batch=False,
-            mcast_in0=False,
-            fused_activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
-        )
-        up = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-            compute_with_storage_grid_size=grid,
-            in0_block_w=4,
-            out_subblock_h=1,
-            out_subblock_w=8,
-            per_core_M=per_core_M,
-            per_core_N=gate_n_tiles,
-            fuse_batch=False,
-            mcast_in0=False,
-        )
+    gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=grid,
+        in0_block_w=4,
+        out_subblock_h=1,
+        out_subblock_w=8,
+        per_core_M=per_core_M,
+        per_core_N=gate_n_tiles,
+        fuse_batch=False,
+        mcast_in0=False,
+        fused_activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
+    )
+    up = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=grid,
+        in0_block_w=4,
+        out_subblock_h=1,
+        out_subblock_w=8,
+        per_core_M=per_core_M,
+        per_core_N=gate_n_tiles,
+        fuse_batch=False,
+        mcast_in0=False,
+    )
     down = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
         in0_block_w=1,
@@ -445,6 +432,7 @@ class TtSharedExpert(LightweightModule):
 
         gate_n_tiles = self.gate_proj.padded_shape[-1] // TILE
         down_n_tiles = self.down_proj.padded_shape[-1] // TILE
+        use_default_matmul = gate_n_tiles % 8 != 0
         if is_blackhole():
             gate_program_config, up_program_config, down_program_config = get_bh_program_configs(
                 per_core_M, gate_n_tiles, down_n_tiles
@@ -456,17 +444,15 @@ class TtSharedExpert(LightweightModule):
 
         # 1) Compute gate and up projections
         gate_matmul_kwargs = {
+            "program_config": None if use_default_matmul else gate_program_config,
             "compute_kernel_config": self.compute_kernel_config,
             "sub_device_id": self.subdevice_id,
         }
         up_matmul_kwargs = {
+            "program_config": None if use_default_matmul else up_program_config,
             "compute_kernel_config": self.compute_kernel_config,
             "sub_device_id": self.subdevice_id,
         }
-        if gate_program_config is not None:
-            gate_matmul_kwargs["program_config"] = gate_program_config
-        if up_program_config is not None:
-            up_matmul_kwargs["program_config"] = up_program_config
 
         gate_out = ttnn.matmul(x, self.gate_proj, **gate_matmul_kwargs)
         up_out = ttnn.matmul(x, self.up_proj, **up_matmul_kwargs)

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -30,39 +30,38 @@ COMPUTE_KERNEL_CONFIG_HIFI2 = ttnn.WormholeComputeKernelConfig(
 )
 
 
-def largest_divisible_out_subblock_w(per_core_n: int, max_width: int = 8) -> int:
-    """Pick the widest allowed output subblock that still divides the per-core N tile count."""
-    for out_subblock_w in range(min(per_core_n, max_width), 0, -1):
-        if per_core_n % out_subblock_w == 0:
-            return out_subblock_w
-    return 1
+def uses_tuned_shared_expert_gate_program_config(gate_n_tiles: int, tuned_out_subblock_w: int = 8) -> bool:
+    """Keep the hand-tuned gate/up matmul configs only on shapes they were tuned for."""
+    return gate_n_tiles % tuned_out_subblock_w == 0
 
 
 def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
     """Program configs for the gate / up / down matmuls on Blackhole."""
     grid = ttnn.CoreCoord(11, 9)
-    gate_out_subblock_w = largest_divisible_out_subblock_w(gate_n_tiles)
-    gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=grid,
-        in0_block_w=4,
-        out_subblock_h=1,
-        out_subblock_w=gate_out_subblock_w,
-        per_core_M=per_core_M,
-        per_core_N=gate_n_tiles,
-        fuse_batch=False,
-        mcast_in0=False,
-        fused_activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
-    )
-    up = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=grid,
-        in0_block_w=4,
-        out_subblock_h=1,
-        out_subblock_w=gate_out_subblock_w,
-        per_core_M=per_core_M,
-        per_core_N=gate_n_tiles,
-        fuse_batch=False,
-        mcast_in0=False,
-    )
+    gate = None
+    up = None
+    if uses_tuned_shared_expert_gate_program_config(gate_n_tiles):
+        gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=grid,
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=8,
+            per_core_M=per_core_M,
+            per_core_N=gate_n_tiles,
+            fuse_batch=False,
+            mcast_in0=False,
+            fused_activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
+        )
+        up = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=grid,
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=8,
+            per_core_M=per_core_M,
+            per_core_N=gate_n_tiles,
+            fuse_batch=False,
+            mcast_in0=False,
+        )
     down = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
         in0_block_w=1,
@@ -79,28 +78,30 @@ def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int
 def get_wh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
     """Program configs for the gate / up / down matmuls on Wormhole."""
     grid = ttnn.CoreCoord(8, 7)
-    gate_out_subblock_w = largest_divisible_out_subblock_w(gate_n_tiles)
-    gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=grid,
-        in0_block_w=4,
-        out_subblock_h=1,
-        out_subblock_w=gate_out_subblock_w,
-        per_core_M=per_core_M,
-        per_core_N=gate_n_tiles,
-        fuse_batch=False,
-        mcast_in0=False,
-        fused_activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
-    )
-    up = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
-        compute_with_storage_grid_size=grid,
-        in0_block_w=4,
-        out_subblock_h=1,
-        out_subblock_w=gate_out_subblock_w,
-        per_core_M=per_core_M,
-        per_core_N=gate_n_tiles,
-        fuse_batch=False,
-        mcast_in0=False,
-    )
+    gate = None
+    up = None
+    if uses_tuned_shared_expert_gate_program_config(gate_n_tiles):
+        gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=grid,
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=8,
+            per_core_M=per_core_M,
+            per_core_N=gate_n_tiles,
+            fuse_batch=False,
+            mcast_in0=False,
+            fused_activation=ttnn.UnaryWithParam(ttnn.UnaryOpType.SILU),
+        )
+        up = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+            compute_with_storage_grid_size=grid,
+            in0_block_w=4,
+            out_subblock_h=1,
+            out_subblock_w=8,
+            per_core_M=per_core_M,
+            per_core_N=gate_n_tiles,
+            fuse_batch=False,
+            mcast_in0=False,
+        )
     down = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
         in0_block_w=1,
@@ -454,20 +455,21 @@ class TtSharedExpert(LightweightModule):
             )
 
         # 1) Compute gate and up projections
-        gate_out = ttnn.matmul(
-            x,
-            self.gate_proj,
-            program_config=gate_program_config,
-            compute_kernel_config=self.compute_kernel_config,
-            sub_device_id=self.subdevice_id,
-        )
-        up_out = ttnn.matmul(
-            x,
-            self.up_proj,
-            program_config=up_program_config,
-            compute_kernel_config=self.compute_kernel_config,
-            sub_device_id=self.subdevice_id,
-        )
+        gate_matmul_kwargs = {
+            "compute_kernel_config": self.compute_kernel_config,
+            "sub_device_id": self.subdevice_id,
+        }
+        up_matmul_kwargs = {
+            "compute_kernel_config": self.compute_kernel_config,
+            "sub_device_id": self.subdevice_id,
+        }
+        if gate_program_config is not None:
+            gate_matmul_kwargs["program_config"] = gate_program_config
+        if up_program_config is not None:
+            up_matmul_kwargs["program_config"] = up_program_config
+
+        gate_out = ttnn.matmul(x, self.gate_proj, **gate_matmul_kwargs)
+        up_out = ttnn.matmul(x, self.up_proj, **up_matmul_kwargs)
 
         # 2) Multiply gate and up projection
         ttnn.multiply_(gate_out, up_out, sub_core_grids=self.subdevice_cores)

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -28,6 +28,11 @@ COMPUTE_KERNEL_CONFIG_HIFI2 = ttnn.WormholeComputeKernelConfig(
     fp32_dest_acc_en=False,
     packer_l1_acc=True,
 )
+
+GPT_OSS_SHARED_EXPERT_EMB_DIM = 2880
+GPT_OSS_SHARED_EXPERT_HIDDEN_DIM = 2880
+
+
 def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
     """Program configs for the gate / up / down matmuls on Blackhole."""
     grid = ttnn.CoreCoord(11, 9)
@@ -432,7 +437,9 @@ class TtSharedExpert(LightweightModule):
 
         gate_n_tiles = self.gate_proj.padded_shape[-1] // TILE
         down_n_tiles = self.down_proj.padded_shape[-1] // TILE
-        use_default_matmul = gate_n_tiles % 8 != 0
+        use_default_matmul = (
+            self.emb_dim == GPT_OSS_SHARED_EXPERT_EMB_DIM and self.hidden_dim == GPT_OSS_SHARED_EXPERT_HIDDEN_DIM
+        )
         if is_blackhole():
             gate_program_config, up_program_config, down_program_config = get_bh_program_configs(
                 per_core_M, gate_n_tiles, down_n_tiles


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
- `TtSharedExpert` hardcodes tuned gate/up program configs with `out_subblock_w=8` on Wormhole and Blackhole.
- GPT OSS 120B drives the shared-expert gate/up path through a shape that is not covered by those tuned configs.
- This patch keeps the existing tuned gate/up configs unchanged for the existing DeepSeek shared-expert shape and routes the GPT OSS shared-expert shape through the default matmul config by passing `program_config=None`.
- The down matmul config stays explicit and unchanged.
- The PCC matrix now includes the GPT OSS 120B shared-expert `4K` and `3.2K` shapes.

### Notes for reviewers
- Runtime change is limited to `models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py`.
- Regression update is limited to `models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py`.
- Existing program config getters are unchanged.
- The fallback no longer uses a divisibility heuristic; it is scoped to the GPT OSS shared-expert shape covered by the added tests.

### Validation
- `python3 -m py_compile models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py models/demos/deepseek_v3_d_p/tests/pcc/test_shared_expert.py`
- `git diff --check`

I did not claim a mesh-backed PCC rerun from this machine.

Closes #46730
