### PR TITLE
[Bug fix] Reset NCRISC read-VC to firmware default at kernel exit

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/matmul/test_dram_sharded_then_1d_matmul.py
+++ b/tests/ttnn/nightly/unit_tests/operations/matmul/test_dram_sharded_then_1d_matmul.py
@@ -1,0 +1,311 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Regression test: a 1D-config matmul (modeling Llama lm_head) runs ~20% slower when it executes
+immediately after a DRAM-sharded-config matmul, because of a NOC virtual-channel (VC) state leak
+between the two kernels.  Both matmuls are individually correct and fast; only the back-to-back
+ordering is affected, which is why a single-op test would never catch this.
+
+Root cause: the DRAM-sharded matmul reader (reader_bmm_tile_layout_in1_sender_dram_sharded.cpp)
+calls set_async_read_state<NocOptions::CUSTOM_VC, ...> to write a per-bank virtual channel into
+NCRISC_RD_CMD_BUF NOC_CTRL without restoring it at kernel end.  Subsequent kernels that rely on
+NOC_CTRL being at the firmware default (VC=1, set in noc_init) -- such as the 1D matmul's reader
+reader_bmm_tile_layout_in1_sender_writer_padding.cpp in DM_DEDICATED_NOC mode -- inherit the
+stale VC and achieve ~20% lower DRAM read bandwidth.
+
+Fix: reset NOC_CTRL's static read VC to the firmware default (1) at every dedicated-NOC kernel
+exit (the *k.cc firmware exit blocks for WH/BH), so no kernel can leak a custom VC to the next.
+
+This test measures lm_head execution time solo vs immediately after a DRAM-sharded matmul
+and asserts the ratio does not exceed DEGRADATION_THRESHOLD.
+
+  Without fix: ratio ~1.20x  -> test FAILS
+  With fix:    ratio ~1.00x  -> test PASSES
+
+Important: the two phases are kept strictly separate so that DS never runs during the solo
+warm-up.  If DS were mixed into the warm-up the NOC VC state on the shared cores would
+already be corrupted when we measure solo, masking the degradation.
+"""
+
+import math
+import time
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_blackhole
+
+
+# ---------------------------------------------------------------------------
+# Shapes
+# ---------------------------------------------------------------------------
+
+SEQ = 32  # M: decode batch x sequence length
+DIM = 4096  # K: model hidden dimension
+DS_N = 4096  # N for DRAM-sharded (DS) matmul
+LM_HEAD_N = 131072  # N for lm_head 1D matmul (= 64 cores x 64 tiles x 32 elements)
+
+# ---------------------------------------------------------------------------
+# Compute grids
+# ---------------------------------------------------------------------------
+
+# DS matmul: 4x8 = 32 compute cores.  DIM % (TILE_SIZE * 32) = 4096 % 1024 = 0
+_DS_GRID_X = 8
+_DS_GRID_Y = 4
+_DS_NUM_CORES = _DS_GRID_X * _DS_GRID_Y  # 32
+
+# lm_head matmul: 8x8 = 64 compute cores.
+_LM_GRID_X = 8
+_LM_GRID_Y = 8
+_LM_NUM_CORES = _LM_GRID_X * _LM_GRID_Y  # 64
+
+# ---------------------------------------------------------------------------
+# Timing
+# ---------------------------------------------------------------------------
+
+_WARMUP_ITERS = 3  # kernel compilation + cache warm-up, not measured
+_MEASURE_ITERS = 7  # odd count so median is the middle value
+_DEGRADATION_THRESHOLD = 1.10  # lm_head after DS must be < 1.10x solo time
+
+
+# ---------------------------------------------------------------------------
+# Program / compute configs
+# ---------------------------------------------------------------------------
+
+
+def _ds_program_config():
+    per_core_N = DIM // (32 * _DS_NUM_CORES)  # 4
+    in0_block_w = DIM // (32 * _DS_NUM_CORES)  # 4
+    return ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+        in0_block_w=in0_block_w,
+        per_core_M=math.ceil(SEQ / 32),  # 1
+        per_core_N=per_core_N,
+        fused_activation=None,
+    )
+
+
+def _lm_head_program_config():
+    per_core_N = LM_HEAD_N // (32 * _LM_NUM_CORES)  # 64
+    return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
+        compute_with_storage_grid_size=(_LM_GRID_X, _LM_GRID_Y),
+        in0_block_w=2,
+        per_core_M=1,
+        per_core_N=per_core_N,
+        out_subblock_h=1,
+        out_subblock_w=8,
+        fuse_batch=True,
+        fused_activation=None,
+        mcast_in0=True,
+    )
+
+
+def _compute_config():
+    # Mirrors the real lm_head matmul: LoFi fidelity, BF16 activations x BFP8 weights.
+    cls = ttnn.WormholeComputeKernelConfig if not is_blackhole() else ttnn.types.BlackholeComputeKernelConfig
+    return cls(
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tensor helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_ds_tensors(device):
+    """
+    in0  (1,1,32,4096)   BF16  L1 width-sharded on 32 compute cores (4x8)
+    in1  (1,1,4096,4096) BFP8  DRAM width-sharded across DRAM banks
+    """
+    dram_grid_size = device.dram_grid_size()
+    dram_num_banks = dram_grid_size.x * dram_grid_size.y
+
+    n_padded = math.ceil(DS_N / (32 * dram_num_banks)) * (32 * dram_num_banks)
+    dram_grid = ttnn.CoreRangeSet(
+        {
+            ttnn.CoreRange(
+                ttnn.CoreCoord(0, 0),
+                ttnn.CoreCoord(dram_grid_size.x - 1, dram_grid_size.y - 1),
+            )
+        }
+    )
+    in1_mem = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        ttnn.ShardSpec(dram_grid, (DIM, n_padded // dram_num_banks), ttnn.ShardOrientation.ROW_MAJOR),
+    )
+    in0_mem = ttnn.create_sharded_memory_config(
+        shape=(SEQ, DIM // _DS_NUM_CORES),
+        core_grid=ttnn.CoreGrid(y=_DS_GRID_Y, x=_DS_GRID_X),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    in0 = ttnn.from_torch(
+        torch.randn(1, 1, SEQ, DIM, dtype=torch.bfloat16),
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=in0_mem,
+    )
+    in1 = ttnn.from_torch(
+        torch.randn(1, 1, DIM, DS_N, dtype=torch.bfloat16),
+        dtype=ttnn.DataType.BFLOAT8_B,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=in1_mem,
+    )
+    out_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1)
+    return in0, in1, out_mem
+
+
+def _make_lm_head_tensors(device):
+    """
+    in0  (1,1,32,4096)     BF16  L1 interleaved
+    in1  (1,1,4096,131072) BFP8  DRAM interleaved  (~537 MB)
+
+    torch_ref covers only the first _PCC_COLS columns to avoid a 4096x131072 CPU matmul.
+    """
+    torch_in0 = torch.randn(1, 1, SEQ, DIM, dtype=torch.bfloat16)
+    torch_in1 = torch.randn(1, 1, DIM, LM_HEAD_N, dtype=torch.bfloat16)
+    in0 = ttnn.from_torch(
+        torch_in0,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+    in1 = ttnn.from_torch(
+        torch_in1,
+        dtype=ttnn.DataType.BFLOAT8_B,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    out_mem = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+    # Reference only over a small slice — the full 4096x131072 matmul is too expensive on CPU.
+    _PCC_COLS = 1024
+    torch_ref = (torch_in0.float() @ torch_in1[..., :_PCC_COLS].float()).to(torch.bfloat16)
+    return in0, in1, out_mem, torch_ref, _PCC_COLS
+
+
+# ---------------------------------------------------------------------------
+# Test
+# ---------------------------------------------------------------------------
+
+
+def test_noc_vc_state_not_leaked_after_dram_sharded_matmul(device):
+    """Assert lm_head is not slowed down by residual NOC VC state from a DRAM-sharded matmul.
+
+    reader_bmm_tile_layout_in1_sender_dram_sharded.cpp programs a custom static read VC via
+    set_async_read_state<NocOptions::CUSTOM_VC, ...>.  The firmware must reset NOC_CTRL's static
+    read VC to the default (1) at dedicated-NOC kernel exit.  Without the reset, the subsequent
+    lm_head reader (reader_bmm_tile_layout_in1_sender_writer_padding.cpp) inherits the stale VC
+    and reads the ~537 MB weight at ~149 GB/s instead of ~178 GB/s -- a persistent 20% slowdown.
+
+    Measurement strategy:
+      Phase 1 -- warm up and measure lm_head with NO DS ever having run.
+                 NOC_CTRL is at firmware default (vc=1) on all cores.
+      Phase 2 -- warm up DS kernel, then measure lm_head immediately after each DS run.
+                 Without the fix, DS leaves vc=custom on its 32 cores (which overlap with
+                 lm_head's 64-core grid), degrading lm_head reads by ~20%.
+
+    Fails if:  median(phase2_lm_times) / median(phase1_lm_times) >= DEGRADATION_THRESHOLD
+    Passes if: the ratio is below the threshold (NOC_CTRL correctly reset by the fix).
+    """
+    grid = device.compute_with_storage_grid_size()
+    if grid.x < _LM_GRID_X or grid.y < _LM_GRID_Y:
+        pytest.skip(f"Device compute grid {grid.x}x{grid.y} smaller than required {_LM_GRID_X}x{_LM_GRID_Y}")
+
+    ds_cfg = _ds_program_config()
+    lm_cfg = _lm_head_program_config()
+    compute_cfg = _compute_config()
+
+    ds_in0, ds_in1, ds_out_mem = _make_ds_tensors(device)
+    lm_in0, lm_in1, lm_out_mem, lm_ref, pcc_cols = _make_lm_head_tensors(device)
+
+    def run_ds():
+        out = ttnn.matmul(
+            ds_in0,
+            ds_in1,
+            program_config=ds_cfg,
+            memory_config=ds_out_mem,
+            dtype=ttnn.DataType.BFLOAT16,
+            compute_kernel_config=compute_cfg,
+        )
+        out.deallocate(True)
+
+    def run_lm_head():
+        return ttnn.matmul(
+            lm_in0,
+            lm_in1,
+            program_config=lm_cfg,
+            memory_config=lm_out_mem,
+            dtype=ttnn.DataType.BFLOAT16,
+            compute_kernel_config=compute_cfg,
+        )
+
+    # PCC check against the first pcc_cols columns only (full-width reference is too expensive)
+    out_tt = run_lm_head()
+    out_torch = ttnn.to_torch(out_tt)[..., :pcc_cols]
+    out_tt.deallocate(True)
+    pcc = torch.corrcoef(torch.stack([lm_ref.flatten().float(), out_torch.flatten().float()]))[0, 1].item()
+    logger.info(f"lm_head PCC: {pcc:.6f}")
+    assert pcc > 0.97, f"lm_head PCC too low: {pcc:.6f}"
+
+    # -----------------------------------------------------------------------
+    # Phase 1: warm up lm_head kernel ONLY, then measure solo.
+    # DS never runs here, so NOC_CTRL stays at the firmware default (vc=1).
+    # -----------------------------------------------------------------------
+    for _ in range(_WARMUP_ITERS):
+        out = run_lm_head()
+        out.deallocate(True)
+    ttnn.device.synchronize_device(device)
+
+    solo_times = []
+    for _ in range(_MEASURE_ITERS):
+        t0 = time.perf_counter()
+        out = run_lm_head()
+        ttnn.device.synchronize_device(device)
+        solo_times.append(time.perf_counter() - t0)
+        out.deallocate(True)
+
+    # -----------------------------------------------------------------------
+    # Phase 2: warm up DS kernel, then measure lm_head after each DS run.
+    # DS leaves vc=custom on its 32 cores (without the fix), which are a
+    # subset of lm_head's 64-core grid -- degrading lm_head DRAM reads.
+    # -----------------------------------------------------------------------
+    for _ in range(_WARMUP_ITERS):
+        run_ds()
+    ttnn.device.synchronize_device(device)
+
+    seq_times = []
+    for _ in range(_MEASURE_ITERS):
+        run_ds()
+        ttnn.device.synchronize_device(device)  # DS completes; stale VC now in NOC_CTRL
+        t0 = time.perf_counter()
+        out = run_lm_head()
+        ttnn.device.synchronize_device(device)
+        seq_times.append(time.perf_counter() - t0)
+        out.deallocate(True)
+
+    solo_median = sorted(solo_times)[_MEASURE_ITERS // 2]
+    seq_median = sorted(seq_times)[_MEASURE_ITERS // 2]
+    ratio = seq_median / solo_median
+
+    logger.info(f"lm_head solo     median: {solo_median * 1e6:.0f} us")
+    logger.info(f"lm_head after DS median: {seq_median * 1e6:.0f} us")
+    logger.info(f"ratio: {ratio:.3f}x  (threshold: < {_DEGRADATION_THRESHOLD}x)")
+
+    assert ratio < _DEGRADATION_THRESHOLD, (
+        f"lm_head is {ratio:.2f}x slower after DRAM-sharded matmul "
+        f"(threshold {_DEGRADATION_THRESHOLD}x). "
+        f"NCRISC static read-VC not reset to the firmware default at dedicated-NOC kernel exit."
+    )

--- a/tt_metal/hw/firmware/src/tt-1xx/active_erisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/active_erisck.cc
@@ -49,6 +49,11 @@ void _start() {
             ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
             ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
             ASSERT(ncrisc_noc_packet_tags_cleared(NOC_INDEX), DebugAssertNCriscNOCPacketTagClearedTripped);
+            // Assert (watcher) then restore: a kernel that programmed a custom read VC must leave the read
+            // command buffer at the firmware default, since the next kernel's plain reads inherit NOC_CTRL.
+            // The reset is the always-on safety net; the assert blames the offending kernel before it runs.
+            ASSERT(ncrisc_noc_read_vc_is_default(NOC_INDEX), DebugAssertNCriscNOCReadVCNotDefaultTripped);
+            noc_reset_cmd_buf_vc_to_default(NOC_INDEX);
             WAYPOINT("NKFD");
         }
 

--- a/tt_metal/hw/firmware/src/tt-1xx/brisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/brisck.cc
@@ -89,6 +89,11 @@ uint32_t _start() {
             ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
             ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
             ASSERT(ncrisc_noc_packet_tags_cleared(NOC_INDEX), DebugAssertNCriscNOCPacketTagClearedTripped);
+            // Assert (watcher) then restore: a kernel that programmed a custom read VC must leave the read
+            // command buffer at the firmware default, since the next kernel's plain reads inherit NOC_CTRL.
+            // The reset is the always-on safety net; the assert blames the offending kernel before it runs.
+            ASSERT(ncrisc_noc_read_vc_is_default(NOC_INDEX), DebugAssertNCriscNOCReadVCNotDefaultTripped);
+            noc_reset_cmd_buf_vc_to_default(NOC_INDEX);
             WAYPOINT("NKFD");
         }
     }

--- a/tt_metal/hw/firmware/src/tt-1xx/drisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/drisck.cc
@@ -35,6 +35,11 @@ uint32_t _start() {
         ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
         ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
         ASSERT(ncrisc_noc_packet_tags_cleared(NOC_INDEX), DebugAssertNCriscNOCPacketTagClearedTripped);
+        // Assert (watcher) then restore: a kernel that programmed a custom read VC must leave the read
+        // command buffer at the firmware default, since the next kernel's plain reads inherit NOC_CTRL.
+        // The reset is the always-on safety net; the assert blames the offending kernel before it runs.
+        ASSERT(ncrisc_noc_read_vc_is_default(NOC_INDEX), DebugAssertNCriscNOCReadVCNotDefaultTripped);
+        noc_reset_cmd_buf_vc_to_default(NOC_INDEX);
         WAYPOINT("NKFD");
     }
     return measure_stack_usage();

--- a/tt_metal/hw/firmware/src/tt-1xx/idle_erisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/idle_erisck.cc
@@ -46,6 +46,11 @@ uint32_t _start() {
             ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
             ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
             ASSERT(ncrisc_noc_packet_tags_cleared(NOC_INDEX), DebugAssertNCriscNOCPacketTagClearedTripped);
+            // Assert (watcher) then restore: a kernel that programmed a custom read VC must leave the read
+            // command buffer at the firmware default, since the next kernel's plain reads inherit NOC_CTRL.
+            // The reset is the always-on safety net; the assert blames the offending kernel before it runs.
+            ASSERT(ncrisc_noc_read_vc_is_default(NOC_INDEX), DebugAssertNCriscNOCReadVCNotDefaultTripped);
+            noc_reset_cmd_buf_vc_to_default(NOC_INDEX);
             WAYPOINT("NKFD");
         }
     }

--- a/tt_metal/hw/firmware/src/tt-1xx/ncrisck.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/ncrisck.cc
@@ -83,6 +83,11 @@ uint32_t _start() {
         ASSERT(ncrisc_noc_nonposted_atomics_flushed(NOC_INDEX), DebugAssertNCriscNOCNonpostedAtomicsFlushedTripped);
         ASSERT(ncrisc_noc_posted_writes_sent(NOC_INDEX), DebugAssertNCriscNOCPostedWritesSentTripped);
         ASSERT(ncrisc_noc_packet_tags_cleared(NOC_INDEX), DebugAssertNCriscNOCPacketTagClearedTripped);
+        // Assert (watcher) then restore: a kernel that programmed a custom read VC must leave the read
+        // command buffer at the firmware default, since the next kernel's plain reads inherit NOC_CTRL.
+        // The reset is the always-on safety net; the assert blames the offending kernel before it runs.
+        ASSERT(ncrisc_noc_read_vc_is_default(NOC_INDEX), DebugAssertNCriscNOCReadVCNotDefaultTripped);
+        noc_reset_cmd_buf_vc_to_default(NOC_INDEX);
         WAYPOINT("NKFD");
     }
 #endif

--- a/tt_metal/hw/inc/hostdev/dev_msgs.h
+++ b/tt_metal/hw/inc/hostdev/dev_msgs.h
@@ -285,6 +285,7 @@ enum debug_assert_type_t {
     DebugAssertCrtaOutOfBounds = 9,
     DebugAssertHwFault = 10,
     DebugAssertNCriscNOCPacketTagClearedTripped = 11,
+    DebugAssertNCriscNOCReadVCNotDefaultTripped = 12,
 };
 
 enum debug_transaction_type_t { TransactionRead = 0, TransactionWrite = 1, TransactionAtomic = 2, TransactionNumTypes };

--- a/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/blackhole/noc_nonblocking_api.h
@@ -258,6 +258,36 @@ inline __attribute__((always_inline)) bool ncrisc_noc_packet_tags_cleared(uint32
            NOC_CMD_BUF_READ_REG(noc, NCRISC_AT_CMD_BUF, NOC_PACKET_TAG) == 0;
 }
 
+// True iff NCRISC_RD_CMD_BUF NOC_CTRL static VC equals the firmware default (1).
+// Static VC is the 3-bit field selected by NOC_CMD_STATIC_VC (bits [15:13]).
+// Plain reads (no CUSTOM_VC) inherit this field implicitly, so a kernel that
+// programmed a custom read VC must leave it back at the default for the next kernel.
+inline __attribute__((always_inline)) bool ncrisc_noc_read_vc_is_default(uint32_t noc) {
+    constexpr uint32_t static_vc_mask = NOC_CMD_STATIC_VC(0x7);
+    return (NOC_CMD_BUF_READ_REG(noc, NCRISC_RD_CMD_BUF, NOC_CTRL) & static_vc_mask) == NOC_CMD_STATIC_VC(1);
+}
+
+// Restore NOC_CTRL for the command buffers that can carry a persisted static VC
+// (read + write) back to the firmware default (static VC = 1, matching noc_init).
+// Cheap and safe: the next plain transaction overwrites NOC_CTRL regardless, so
+// this only matters for the stateful read/write APIs that set NOC_CTRL once and
+// reuse it. Atomic / wr_reg command buffers rewrite the full NOC_CTRL field on
+// every transaction and need no reset.
+inline __attribute__((always_inline)) void noc_reset_cmd_buf_vc_to_default(uint32_t noc) {
+    while (!noc_cmd_buf_ready(noc, NCRISC_RD_CMD_BUF));
+    NOC_CMD_BUF_WRITE_REG(
+        noc,
+        NCRISC_RD_CMD_BUF,
+        NOC_CTRL,
+        NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1));
+    while (!noc_cmd_buf_ready(noc, NCRISC_WR_CMD_BUF));
+    NOC_CMD_BUF_WRITE_REG(
+        noc,
+        NCRISC_WR_CMD_BUF,
+        NOC_CTRL,
+        NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1) | NOC_CMD_RESP_MARKED);
+}
+
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.
 inline __attribute__((always_inline)) void noc_cmd_buf_restore_state(
     uint32_t noc, uint32_t cmd_buf, const NocCmdBufState* state) {

--- a/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
+++ b/tt_metal/hw/inc/internal/tt-1xx/wormhole/noc_nonblocking_api.h
@@ -222,6 +222,36 @@ inline __attribute__((always_inline)) bool ncrisc_noc_packet_tags_cleared(uint32
            NOC_CMD_BUF_READ_REG(noc, NCRISC_AT_CMD_BUF, NOC_PACKET_TAG) == 0;
 }
 
+// True iff NCRISC_RD_CMD_BUF NOC_CTRL static VC equals the firmware default (1).
+// Static VC is the 3-bit field selected by NOC_CMD_STATIC_VC (bits [15:13]).
+// Plain reads (no CUSTOM_VC) inherit this field implicitly, so a kernel that
+// programmed a custom read VC must leave it back at the default for the next kernel.
+inline __attribute__((always_inline)) bool ncrisc_noc_read_vc_is_default(uint32_t noc) {
+    constexpr uint32_t static_vc_mask = NOC_CMD_STATIC_VC(0x7);
+    return (NOC_CMD_BUF_READ_REG(noc, NCRISC_RD_CMD_BUF, NOC_CTRL) & static_vc_mask) == NOC_CMD_STATIC_VC(1);
+}
+
+// Restore NOC_CTRL for the command buffers that can carry a persisted static VC
+// (read + write) back to the firmware default (static VC = 1, matching noc_init).
+// Cheap and safe: the next plain transaction overwrites NOC_CTRL regardless, so
+// this only matters for the stateful read/write APIs that set NOC_CTRL once and
+// reuse it. Atomic / wr_reg command buffers rewrite the full NOC_CTRL field on
+// every transaction and need no reset.
+inline __attribute__((always_inline)) void noc_reset_cmd_buf_vc_to_default(uint32_t noc) {
+    while (!noc_cmd_buf_ready(noc, NCRISC_RD_CMD_BUF));
+    NOC_CMD_BUF_WRITE_REG(
+        noc,
+        NCRISC_RD_CMD_BUF,
+        NOC_CTRL,
+        NOC_CMD_CPY | NOC_CMD_RD | NOC_CMD_RESP_MARKED | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1));
+    while (!noc_cmd_buf_ready(noc, NCRISC_WR_CMD_BUF));
+    NOC_CMD_BUF_WRITE_REG(
+        noc,
+        NCRISC_WR_CMD_BUF,
+        NOC_CTRL,
+        NOC_CMD_CPY | NOC_CMD_WR | NOC_CMD_VC_STATIC | NOC_CMD_STATIC_VC(1) | NOC_CMD_RESP_MARKED);
+}
+
 // Restores cmd_buf from state; waits for cmd_buf ready before writing.
 inline __attribute__((always_inline)) void noc_cmd_buf_restore_state(
     uint32_t noc, uint32_t cmd_buf, const NocCmdBufState* state) {

--- a/tt_metal/impl/debug/debug_helpers.hpp
+++ b/tt_metal/impl/debug/debug_helpers.hpp
@@ -129,6 +129,10 @@ inline std::string get_debug_assert_message(
             return "detected invalid NOC command buffer state before starting the next kernel "
                    "(write-capable NOC packet tags must be zero so implicit transaction ID users start with "
                    "transaction ID 0).";
+        case dev_msgs::DebugAssertNCriscNOCReadVCNotDefaultTripped:
+            return "detected invalid NOC command buffer state before starting the next kernel "
+                   "(NCRISC read command buffer left at a non-default NOC VC; restore the firmware "
+                   "default VC before kernel exit).";
         case dev_msgs::DebugAssertRtaOutOfBounds: return "accessed unique runtime arg index out of bounds.";
         case dev_msgs::DebugAssertCrtaOutOfBounds: return "accessed common runtime arg index out of bounds.";
         case dev_msgs::DebugAssertHwFault:


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
A kernel that programs a custom static read VC via `set_async_read_state` (e.g. the DRAM-sharded matmul reader) leaves it in `NCRISC_RD_CMD_BUF` `NOC_CTRL`. On tt-1xx, `noc_init` only re-runs at boot / on NOC-mode change, so the stale VC persists to the next dedicated-NOC kernel whose plain reads inherit `NOC_CTRL`, costing ~20% DRAM read bandwidth.

Reset `NOC_CTRL` static VC to the firmware default (1) for the read and write command buffers at every dedicated-NOC kernel exit, and assert (watcher builds) that the read command buffer is left at the default before the reset. Wired into all five `*k.cc` kernel-exit blocks for Wormhole and Blackhole.

### Notes for reviewers
- `noc_reset_cmd_buf_vc_to_default` is the always-on safety net; `ncrisc_noc_read_vc_is_default` + the new `DebugAssertNCriscNOCReadVCNotDefaultTripped` assert (compiled out unless watcher/lightweight asserts are on) runs first so it still blames the offending kernel.
- Reset covers read + write command buffers; atomic/wr_reg buffers self-churn `NOC_CTRL` per transaction and need no reset.
- Quasar already resets command buffers per kernel (`overlay_cmd_buff_init` at kernel entry), so it is not affected.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vvukomanovic/mutlicast-vc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vvukomanovic/mutlicast-vc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vvukomanovic/mutlicast-vc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vvukomanovic/mutlicast-vc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vvukomanovic/mutlicast-vc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vvukomanovic/mutlicast-vc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vvukomanovic/mutlicast-vc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vvukomanovic/mutlicast-vc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vvukomanovic/mutlicast-vc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vvukomanovic/mutlicast-vc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vvukomanovic/mutlicast-vc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vvukomanovic/mutlicast-vc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vvukomanovic/mutlicast-vc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vvukomanovic/mutlicast-vc-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vvukomanovic/mutlicast-vc-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vvukomanovic/mutlicast-vc-fix)