### PR TITLE
#40182: float->int->float conversion cleanup 5/n

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -17,31 +17,15 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vInt in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-        sfpi::vInt in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        sfpi::vFloat result = 0.0f;
+        // The inputs are in 2's complement form
+        sfpi::vSMag in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+        sfpi::vSMag in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+        sfpi::vFloat result = 1.0f;
 
-        v_if(in0 != 0 && in0 == in1) { result = sfpi::vConst1; }
-        v_else {
-            // Workaround for BH limitations:
-            //   • sfpi::int32_to_float cannot correctly convert negative int32 values (see #33044)
-            //   • sfpi::setsgn is not functional on BH (see #19675)
-            // So we convert inputs to their absolute values, typecast to fp32 and reapply the original signs to the
-            // result
-            sfpi::vInt pos_in0;
-            v_if(in0 < 0) { pos_in0 = 0 - in0; }
-            v_else { pos_in0 = in0; }
-            v_endif;
-
-            sfpi::vInt pos_in1;
-            v_if(in1 < 0) { pos_in1 = 0 - in1; }
-            v_else { pos_in1 = in1; }
-            v_endif;
-
-            sfpi::vFloat float_in0 = sfpi::int32_to_float(pos_in0, sfpi::RoundMode::NearestEven);
-            sfpi::vFloat float_in1 = sfpi::int32_to_float(pos_in1, sfpi::RoundMode::NearestEven);
+        v_if(in0 == 0 || in0 != in1) {
+            sfpi::vFloat float_in0 = sfpi::convert<sfpi::vFloat>(in0, sfpi::RoundMode::NearestEven);
+            sfpi::vFloat float_in1 = sfpi::convert<sfpi::vFloat>(in1, sfpi::RoundMode::NearestEven);
             result = float_in0 * _sfpu_reciprocal_<2>(float_in1);
-            result = sfpi::copysgn(result, in0 ^ in1);
         }
         v_endif;
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32.h
@@ -17,14 +17,14 @@ inline void calculate_div_int32(const uint dst_index_in0, const uint dst_index_i
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vInt in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-        sfpi::vInt in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-        sfpi::vFloat result = 0.0f;
+        // The inputs are in 2's complement form
+        sfpi::vSMag in0 = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+        sfpi::vSMag in1 = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+        sfpi::vFloat result = 1.0f;
 
-        v_if(in0 != 0 && in0 == in1) { result = sfpi::vConst1; }
-        v_else {
-            sfpi::vFloat float_in0 = sfpi::int32_to_float(in0, sfpi::RoundMode::NearestEven);
-            sfpi::vFloat float_in1 = sfpi::int32_to_float(in1, sfpi::RoundMode::NearestEven);
+        v_if(in0 == 0 || in0 != in1) {
+            sfpi::vFloat float_in0 = sfpi::convert<sfpi::vFloat>(in0, sfpi::RoundMode::NearestEven);
+            sfpi::vFloat float_in1 = sfpi::convert<sfpi::vFloat>(in1, sfpi::RoundMode::NearestEven);
             result = float_in0 * _sfpu_reciprocal_<2>(float_in1);
         }
         v_endif;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
This is the final conversion of the old `int32_to_float` API to the newer `convert<TYPE>` API.  This was a little confusing because the FPU data format is 2s complement in this case and we need sign-mag to do the conversion to float.

The `v_if` turns out to be necessary, because otherwise there's test failures.  I suspect inaccurate approx reciprocal.  (It's not an optimization, because the v_if body is always executed, even when no vector element needs it (and I suspect that case to be rare anyway).

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/div-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/div-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/div-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/div-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/div-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/div-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/div-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/div-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/div-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/div-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/div-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/div-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/div-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/div-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/div-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/div-40182)