### PR TITLE
[tt-triage] Filter out callstacks for disabled cores

### DIFF
--- a/tools/triage/dispatcher_data.py
+++ b/tools/triage/dispatcher_data.py
@@ -81,6 +81,9 @@ class DispatcherCoreData:
     # Inspector/control-plane-sourced block type for this core. Used by callers to reason about
     # active-vs-idle ETH without re-consulting the cluster descriptor.
     block_type: BlockType | None = None
+    # Whether kernel_config.enables turned this specific risc on. False => idle by design (no kernel
+    # launched on it). None => unknown (read failed / corrupt), so callers must not hide the core.
+    risc_enabled_by_kernel: bool | None = None
     # Hint surfaced when find_kernel fails — explains the most likely cause (program cache off,
     # or workload destroyed despite cache being on) so callers can append it to "PC not in range" style errors.
     kernel_lookup_warning: str | None = None
@@ -303,6 +306,11 @@ class DispatcherData:
             return self.drisc_enabled()
         return True
 
+    def is_idle_in_default_view(self, location: OnChipCoordinate, risc_name: str) -> bool:
+        """Risc hidden unless --all-cores: finished (Go=DONE) or never enabled by the program."""
+        d = self.get_cached_core_data(location, risc_name)
+        return d.go_message == "DONE" or d.risc_enabled_by_kernel is False
+
     def get_cached_core_data(self, location: OnChipCoordinate, risc_name: str) -> DispatcherCoreData:
         key = (location, risc_name)
         with self.lock:
@@ -469,6 +477,7 @@ class DispatcherData:
         dispatch_mode = None
         brisc_noc_id = None
         enables = None
+        risc_enabled_by_kernel = None
         subordinate_sync = None
         watcher_enabled = None
 
@@ -520,6 +529,8 @@ class DispatcherData:
             enables = ""
             for i, sym in enumerate(symbols):
                 enables += sym if (enables_val & (1 << i)) else sym.lower()
+            # bit i set => processor i enabled; proc_type is this risc's processor index.
+            risc_enabled_by_kernel = bool(enables_val & (1 << proc_type))
         except Exception:
             log_check_location(
                 location,
@@ -662,6 +673,7 @@ class DispatcherData:
             subordinate_sync=subordinate_sync,
             watcher_enabled=watcher_enabled,
             block_type=block_type,
+            risc_enabled_by_kernel=risc_enabled_by_kernel,
             kernel_lookup_warning=kernel_lookup_warning,
         )
 

--- a/tools/triage/dump_aggregated_callstacks.py
+++ b/tools/triage/dump_aggregated_callstacks.py
@@ -8,7 +8,8 @@ Usage:
     dump_aggregated_callstacks [--all-cores] [--device-visualization]
 
 Options:
-    --all-cores                      Show all cores including ones with Go Message = DONE. By default, DONE cores are filtered out.
+    --all-cores                      Show all cores including ones with Go Message = DONE or riscs disabled by
+                                     kernel config. By default, both are filtered out.
     --device-visualization           Show device visualizations instead of plain coordinate lists in the Locations column.
 
 Description:
@@ -189,11 +190,9 @@ def _collect_aggregated(
         try:
             if not callstack_provider.dispatcher_data.risc_enabled(risc_name):
                 return None
-            # Filter DONE cores, like dump_callstacks.py does
-            if not show_all_cores:
-                d = callstack_provider.dispatcher_data.get_cached_core_data(location, risc_name)
-                if d.go_message == "DONE":
-                    return None
+            # Filter DONE / not-enabled-by-design cores, like dump_callstacks.py does
+            if not show_all_cores and callstack_provider.dispatcher_data.is_idle_in_default_view(location, risc_name):
+                return None
 
             return callstack_provider.get_cached_callstacks(location, risc_name)
         except TimeoutDeviceRegisterError:

--- a/tools/triage/dump_aggregated_callstacks.py
+++ b/tools/triage/dump_aggregated_callstacks.py
@@ -8,8 +8,7 @@ Usage:
     dump_aggregated_callstacks [--all-cores] [--device-visualization]
 
 Options:
-    --all-cores                      Show all cores including ones with Go Message = DONE or riscs disabled by
-                                     kernel config. By default, both are filtered out.
+    --all-cores                      Show all cores, including those with Go Message = DONE and RISCs not enabled by the running program. By default, both are filtered out.
     --device-visualization           Show device visualizations instead of plain coordinate lists in the Locations column.
 
 Description:

--- a/tools/triage/dump_callstacks.py
+++ b/tools/triage/dump_callstacks.py
@@ -8,13 +8,13 @@ Usage:
     dump_callstacks [--all-cores]
 
 Options:
-    --all-cores        Show all cores including ones with Go Message = DONE or riscs disabled by
-                       kernel config By default, both are filtered out.
+    --all-cores        Show all cores, including those with Go Message = DONE and RISCs not enabled
+                       by the running program. By default, both are filtered out.
 
 Description:
-    Dumps callstacks for all devices in the system and for every supported risc processor.
-    By default, filters out cores with DONE status and riscs not enabled by the running program
-    and shows essential fields.
+    Dumps callstacks for all devices in the system and for every supported RISC processor.
+    By default, shows essential fields and filters out cores with Go Message = DONE and RISCs not
+    enabled by the running program (kernel_config.enables).
     Use --all-cores to see all cores, and -v/-vv to show more columns.
 
     Color output is automatically enabled when stdout is a TTY (terminal) and can be overridden

--- a/tools/triage/dump_callstacks.py
+++ b/tools/triage/dump_callstacks.py
@@ -8,11 +8,13 @@ Usage:
     dump_callstacks [--all-cores]
 
 Options:
-    --all-cores        Show all cores including ones with Go Message = DONE. By default, DONE cores are filtered out.
+    --all-cores        Show all cores including ones with Go Message = DONE or riscs disabled by
+                       kernel config By default, both are filtered out.
 
 Description:
     Dumps callstacks for all devices in the system and for every supported risc processor.
-    By default, filters out cores with DONE status and shows essential fields.
+    By default, filters out cores with DONE status and riscs not enabled by the running program
+    and shows essential fields.
     Use --all-cores to see all cores, and -v/-vv to show more columns.
 
     Color output is automatically enabled when stdout is a TTY (terminal) and can be overridden
@@ -46,11 +48,9 @@ def dump_callstacks(
     try:
         if not callstack_provider.dispatcher_data.risc_enabled(risc_name):
             return None
-        # Skip DONE cores unless --all-cores is specified
-        if not show_all_cores:
-            dispatcher_core_data = callstack_provider.dispatcher_data.get_cached_core_data(location, risc_name)
-            if dispatcher_core_data.go_message == "DONE":
-                return None
+        # Skip DONE / not-enabled-by-design cores unless --all-cores is specified
+        if not show_all_cores and callstack_provider.dispatcher_data.is_idle_in_default_view(location, risc_name):
+            return None
         return callstack_provider.get_cached_callstacks(location, risc_name)
     except TimeoutDeviceRegisterError:
         raise


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Closes https://github.com/tenstorrent/tt-exalens/issues/1077 

`dump_(aggregated_)callstacks.py`'s default view filters out cores that have the dispatch message == `DONE`. Some operations only use some cores (i.e. data movement ops BRISC/NCRISC) so some cores are idle by design and stuck in firmware. Dumping callstacks when those ops hang produce a ton of noise so we're filtering out cores disabled by the kernel in that default view, they can still be seen if `--all-cores` is passed 

Confirmed with runtime that `kernel_config.enables` is the signal we should use.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=onenezic/callstacks-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:onenezic/callstacks-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=onenezic/callstacks-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:onenezic/callstacks-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=onenezic/callstacks-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:onenezic/callstacks-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=onenezic/callstacks-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:onenezic/callstacks-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=onenezic/callstacks-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:onenezic/callstacks-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=onenezic/callstacks-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:onenezic/callstacks-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=onenezic/callstacks-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:onenezic/callstacks-filter)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=onenezic/callstacks-filter)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:onenezic/callstacks-filter)