### PR TITLE
Adds Noc::set_read_trid to Device 2.0 NoC API

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/reader_writer_one_packet_stateful_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/reader_writer_one_packet_stateful_2_0.cpp
@@ -3,18 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/endpoints.h"
 #include "experimental/kernel_args.h"
 #include "api/debug/dprint.h"
 
 // L1 to L1 send (one packet, stateful + transaction-ID).
-//
-// NOTE: This kernel intentionally stays on the legacy NOC free functions
-// because the new Noc/UnicastEndpoint API does not yet expose a combined
-// "with_state + with_trid" form. The new API provides:
-//   - stateful only:        set_async_read_state + async_read_with_state
-//   - transaction-id only:  async_read<TxnIdMode::ENABLED>
-// but not the union of the two that this test exercises. Once the new API
-// surface adds a stateful+trid combined call, migrate this kernel to it.
 void kernel_main() {
     constexpr uint32_t l1_local_addr = get_arg(args::l1_addr);
     constexpr uint32_t test_id = get_arg(args::test_id);
@@ -25,40 +18,58 @@ void kernel_main() {
     const uint32_t num_of_transactions = num_transactions_raw < 16 ? num_transactions_raw : 15;
     const uint32_t bytes_per_transaction = get_arg(args::bytes_per_transaction);
 
-    // Runtime arguments
-    uint32_t sub0_receiver_x_coord = packed_sub0_core_coordinates >> 16;
-    uint32_t sub0_receiver_y_coord = packed_sub0_core_coordinates & 0xFFFF;
-    uint32_t sub1_sender_x_coord = packed_sub1_core_coordinates >> 16;
-    uint32_t sub1_sender_y_coord = packed_sub1_core_coordinates & 0xFFFF;
+    const uint32_t sub0_receiver_x_coord = packed_sub0_core_coordinates >> 16;
+    const uint32_t sub0_receiver_y_coord = packed_sub0_core_coordinates & 0xFFFF;
+    const uint32_t sub1_sender_x_coord = packed_sub1_core_coordinates >> 16;
+    const uint32_t sub1_sender_y_coord = packed_sub1_core_coordinates & 0xFFFF;
 
-    uint64_t sub0_dst_noc_addr = get_noc_addr(sub0_receiver_x_coord, sub0_receiver_y_coord, l1_local_addr);
-    uint64_t sub1_src_noc_addr = get_noc_addr(sub1_sender_x_coord, sub1_sender_y_coord, l1_local_addr);
+    Noc noc(noc_index);
+    UnicastEndpoint endpoint;
 
     {
         DeviceZoneScopedN("RISCV0");
 
-        uint32_t tmp_local_addr = l1_local_addr;
+        uint32_t local_addr = l1_local_addr;
+        uint32_t sub1_offset = 0;
 
         // Send out reads with transaction ids
         // Avoid using transaction id 0 in case fast dispatch breaks it in the future
-        noc_async_read_one_packet_set_state(sub1_src_noc_addr, bytes_per_transaction);
-        for (uint32_t i = 1; i <= num_of_transactions; i++) {  // Using 1-(num_of_transactions) as the transaction ids
-            noc_async_read_set_trid(i);
-            noc_async_read_one_packet_with_state_with_trid(
-                sub1_src_noc_addr, bytes_per_transaction * (i - 1), tmp_local_addr, i);
-            tmp_local_addr += bytes_per_transaction;
+        noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+            endpoint,
+            bytes_per_transaction,
+            {.noc_x = sub1_sender_x_coord, .noc_y = sub1_sender_y_coord, .addr = l1_local_addr});
+        for (uint32_t i = 1; i <= num_of_transactions; i++) {
+            noc.async_read_with_state<NocOptions::TXN_ID, NOC_MAX_BURST_SIZE>(
+                endpoint,
+                endpoint,
+                bytes_per_transaction,
+                {.noc_x = sub1_sender_x_coord, .noc_y = sub1_sender_y_coord, .addr = l1_local_addr + sub1_offset},
+                {.addr = local_addr},
+                NocOptVals{.trid = i});
+            local_addr += bytes_per_transaction;
+            sub1_offset += bytes_per_transaction;
         }
 
-        tmp_local_addr = l1_local_addr;
+        local_addr = l1_local_addr;
+        uint32_t sub0_offset = 0;
 
-        noc_async_write_one_packet_set_state(sub0_dst_noc_addr, bytes_per_transaction);
-        // Wait for reads with transaction ids to finish
-        for (uint32_t i = 1; i <= num_of_transactions; i++) {  // Using 1-(num_of_transactions) as the transaction ids
-            noc_async_read_barrier_with_trid(i);
-            noc_async_write_one_packet_with_state(tmp_local_addr, tmp_local_addr);
-            tmp_local_addr += bytes_per_transaction;
+        // Wait for reads with transaction ids to finish, then write
+        noc.set_async_write_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+            endpoint,
+            bytes_per_transaction,
+            {.noc_x = sub0_receiver_x_coord, .noc_y = sub0_receiver_y_coord, .addr = l1_local_addr});
+        for (uint32_t i = 1; i <= num_of_transactions; i++) {
+            noc.async_read_barrier<NocOptions::TXN_ID>(NocOptVals{.trid = i});
+            noc.async_write_with_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
+                endpoint,
+                endpoint,
+                bytes_per_transaction,
+                {.addr = local_addr},
+                {.noc_x = sub0_receiver_x_coord, .noc_y = sub0_receiver_y_coord, .addr = l1_local_addr + sub0_offset});
+            local_addr += bytes_per_transaction;
+            sub0_offset += bytes_per_transaction;
         }
-        noc_async_write_barrier();
+        noc.async_write_barrier();
     }
 
     DeviceTimestampedData("Test id", test_id);

--- a/tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/writer_reader_one_packet_stateful_2_0.cpp
+++ b/tests/tt_metal/tt_metal/data_movement/transaction_id/kernels/writer_reader_one_packet_stateful_2_0.cpp
@@ -9,11 +9,9 @@
 //
 // NOTE: This kernel intentionally stays on the legacy NOC free functions
 // because the new Noc/UnicastEndpoint API does not yet expose a combined
-// "with_state + with_trid" form. The new API provides:
-//   - stateful only:        set_async_write_state + async_write_with_state
-//   - transaction-id only:  async_write<TxnIdMode::ENABLED>
-// but not the union of the two that this test exercises. Once the new API
-// surface adds a stateful+trid combined call, migrate this kernel to it.
+// "with_state + with_trid" form on the write side: async_write_with_state
+// static_asserts against NocOptions::TXN_ID. Once the new API surface adds
+// a stateful+trid write, migrate this kernel to it.
 void kernel_main() {
     constexpr uint32_t l1_local_addr = get_arg(args::l1_addr);
     constexpr uint32_t test_id = get_arg(args::test_id);

--- a/tt_metal/hw/inc/api/dataflow/noc.h
+++ b/tt_metal/hw/inc/api/dataflow/noc.h
@@ -590,6 +590,15 @@ public:
         return ncrisc_noc_read_with_transaction_id_flushed(noc_id_, trid);
     }
 
+    /**
+     * @brief Sets the sticky NOC_PACKET_TAG register so subsequent reads on this Noc inherit `trid`.
+     *
+     * Pair with async_read_barrier<NocOptions::TXN_ID> to wait on just this batch.
+     *
+     * @param trid Transaction ID to set; 0 clears the tag.
+     */
+    void set_read_trid(uint32_t trid) const { noc_async_read_set_trid(trid, noc_id_); }
+
     /** @brief Waits for all outstanding read transactions to complete.
      *
      * This blocking call waits for all the outstanding enqueued read transactions

--- a/ttnn/cpp/ttnn/operations/pool/device/kernels/experimental_device_api.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/device/kernels/experimental_device_api.hpp
@@ -78,7 +78,7 @@ FORCE_INLINE void read_with_state(Noc noc, const Dst& dst, uint32_t src_addr) {
 // Noc's read cmd_buf.  Trid persists across set_read_state / read_with_state (those write
 // different cmd_buf registers).  Pair with async_read_barrier_with_trid to wait on just
 // this batch of reads.  Pass trid=0 to clear (untagged reads = no per-trid accounting).
-FORCE_INLINE void set_read_trid(Noc noc, uint32_t trid) { noc_async_read_set_trid(trid, noc.get_noc_id()); }
+FORCE_INLINE void set_read_trid(Noc noc, uint32_t trid) { noc.set_read_trid(trid); }
 
 // Block until reads tagged `trid` on this noc are flushed.  Other in-flight reads with
 // different trids continue independently.


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

  Relates to #45003.

  Add Noc::set_read_trid(uint32_t) to the Device 2.0 NoC API and migrate the lone legacy noc_async_read_set_trid call in pool/device/kernels/experimental_device_api.hpp to noc.set_read_trid(trid). Also migrate the reader_writer_one_packet_stateful_2_0.cpp test kernel (under tests/tt_metal/.../transaction_id/kernels/) to the new method — its companion writer_reader_one_packet_stateful_2_0.cpp stays on legacy because the Device 2.0 API does not yet expose a stateful+trid write.

### Notes for reviewers

  Noc::set_read_trid is a thin wrapper over the noc_async_read_set_trid primitive, which does a NOC_PACKET_TAG register write. The kernel migration in reader_writer_one_packet_stateful_2_0.cpp preserves the
  test's transaction pattern; only the issuing API changes.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/noc_set_read_trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/noc_set_read_trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/noc_set_read_trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/noc_set_read_trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/noc_set_read_trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/noc_set_read_trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/noc_set_read_trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/noc_set_read_trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/noc_set_read_trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/noc_set_read_trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/noc_set_read_trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/noc_set_read_trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/noc_set_read_trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/noc_set_read_trid)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/noc_set_read_trid)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/noc_set_read_trid)