### PR TITLE
[Cleanup] Remove stale legacy CB API comments from rotary kernel

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/kernels/compute/rotary_embedding_llama_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama_fused_qk/device/kernels/compute/rotary_embedding_llama_sharded.cpp
@@ -67,22 +67,6 @@ void kernel_main() {
     mm_init(in_cb, trans_mat_cb, out_cb);
     binary_op_init_common(rotated_in_interm_cb, sin_cb, sin_interm_cb);  // General Init for all binary ops
 
-    /* Unnecessary CB APIs (comment out for code size)
-    // Get the trans_mat
-    constexpr uint32_t onetile = 1;
-    cb_reserve_back(trans_mat_cb, onetile);
-    cb_push_back(trans_mat_cb, onetile);
-    cb_wait_front(trans_mat_cb, onetile);
-
-    // Get the sin/cos matrices
-    // TODO: To parallelize across multiple batch, this should be in a batch loop
-    cb_reserve_back(sin_cb, Wt);
-    cb_reserve_back(cos_cb, Wt);
-
-    cb_push_back(sin_cb, Wt);
-    cb_push_back(cos_cb, Wt);
-    */
-
     for (uint32_t ht = 0; ht < Ht; ht++) {  // Over n_heads_t dimension
         rotated_in_interm_cb_obj.reserve_back(Wt);
         sin_interm_cb_obj.reserve_back(Wt);
@@ -142,13 +126,4 @@ void kernel_main() {
         sin_interm_cb_obj.pop_front(Wt);
         cos_interm_cb_obj.pop_front(Wt);
     }
-
-    /* Unnecessary CB APIs (comment out for code size)
-    // Done with the sin/cos matrices, so remove from CB
-    cb_pop_front(sin_cb, Wt);
-    cb_pop_front(cos_cb, Wt);
-
-    // Done with the transformation matrix, so remove from CB
-    cb_pop_front(trans_mat_cb, onetile);
-    */
 }


### PR DESCRIPTION
## PR Category

Cleanup

## Summary

Relates to https://github.com/tenstorrent/tt-metal/issues/45003.

Deletes two commented-out blocks of legacy free-function CB calls

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/rotary_emb_fused_qk_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/rotary_emb_fused_qk_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/rotary_emb_fused_qk_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/rotary_emb_fused_qk_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/rotary_emb_fused_qk_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/rotary_emb_fused_qk_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/rotary_emb_fused_qk_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/rotary_emb_fused_qk_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/rotary_emb_fused_qk_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/rotary_emb_fused_qk_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/rotary_emb_fused_qk_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/rotary_emb_fused_qk_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/rotary_emb_fused_qk_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/rotary_emb_fused_qk_cleanup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/rotary_emb_fused_qk_cleanup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/rotary_emb_fused_qk_cleanup)