### PR TITLE
[Cleanup] Migrate shared writer unary stick kernel file to Device 2.0

### DIFF
--- a/ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp
@@ -4,6 +4,9 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -16,6 +19,9 @@ void kernel_main() {
 
     const auto s0 = TensorAccessor(dst0_args, dst_addr);
 
+    Noc noc;
+    CircularBuffer cb_out0(cb_id_out0);
+
 #ifdef BACKWARDS
     uint32_t end_id = start_id - num_sticks;
     for (uint32_t i = start_id; i != end_id; --i) {
@@ -23,11 +29,9 @@ void kernel_main() {
     uint32_t end_id = start_id + num_sticks;
     for (uint32_t i = start_id; i < end_id; ++i) {
 #endif
-        cb_wait_front(cb_id_out0, 1);
-        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
-        uint64_t dst_noc_addr = s0.get_noc_addr(i);
-        noc_async_write(l1_read_addr, dst_noc_addr, stick_size);
-        noc_async_write_barrier();
-        cb_pop_front(cb_id_out0, 1);
+        cb_out0.wait_front(1);
+        noc.async_write(cb_out0, s0, stick_size, {.offset_bytes = 0}, {.page_id = i, .offset_bytes = 0});
+        noc.async_write_barrier();
+        cb_out0.pop_front(1);
     }
 }


### PR DESCRIPTION
## PR Category

Cleanup

## Summary

Relates to #45003. Migrates the shared dataflow kernel `ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_start_id.cpp` onto the Device 2.0 kernel API:

- `cb_wait_front` etc. mapped onto `CircularBuffer` object methods
- `noc_async_write()`, `noc_async_write_barrier()` changed to calls on the `Noc` class objects

## Notes for reviewers

Pure API swap, no behavioral changes expected

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/migrate_shared_writer_stick_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/migrate_shared_writer_stick_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/migrate_shared_writer_stick_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/migrate_shared_writer_stick_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/migrate_shared_writer_stick_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/migrate_shared_writer_stick_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/migrate_shared_writer_stick_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/migrate_shared_writer_stick_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/migrate_shared_writer_stick_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/migrate_shared_writer_stick_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/migrate_shared_writer_stick_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/migrate_shared_writer_stick_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/migrate_shared_writer_stick_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/migrate_shared_writer_stick_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/migrate_shared_writer_stick_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/migrate_shared_writer_stick_layout)
