### PR TITLE
fix: short-circuit golden generation when compiling LLK kernels

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -283,7 +283,20 @@ def register_golden(cls):
 
 
 def get_golden_generator(cls):
-    """Retrieve the registered golden class instance."""
+    """Retrieve the registered golden class instance.
+
+    In compile-only (PRODUCE) mode the golden values are never used: tests skip
+    before any comparison against device results, so return a dummy generator and
+    skip the (potentially expensive) golden computation. Doing the check here,
+    rather than monkeypatching the module attribute, makes it robust to how tests
+    import this function (most do ``from helpers.golden_generators import
+    get_golden_generator``, which binds the name at import time).
+    """
+    from .test_config import BuildMode, TestConfig
+
+    if TestConfig.BUILD_MODE == BuildMode.PRODUCE:
+        return DummyGoldenGenerator()
+
     if cls not in golden_registry:
         raise KeyError(f"Golden class {cls.__name__} is not registered.")
     return golden_registry[cls]

--- a/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_generator/generator.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/stimuli_generator/generator.py
@@ -355,6 +355,24 @@ def generate_stimuli(
     num_elements_A = input_dimensions_A[0] * input_dimensions_A[1]
     num_elements_B = input_dimensions_B[0] * input_dimensions_B[1]
 
+    # In compile-only (PRODUCE) mode the generated values are never written to the
+    # device: TestConfig.run() skips right after building the ELFs, before any
+    # stimuli reach L1. Only the tile counts above are consumed (as compile/runtime
+    # parameters), and those are pure dimension math. So skip the expensive random
+    # generation (and the golden computation it feeds), but still return correctly
+    # shaped/typed zero tensors so callers that reshape/tilize the stimuli before
+    # the skip keep working.
+    from ..test_config import BuildMode, TestConfig
+
+    if TestConfig.BUILD_MODE == BuildMode.PRODUCE:
+        srcA_tensor = torch.zeros(
+            num_elements_A, dtype=_get_dtype_for_format(stimuli_format_A)
+        )
+        srcB_tensor = torch.zeros(
+            num_elements_B, dtype=_get_dtype_for_format(stimuli_format_B)
+        )
+        return srcA_tensor, tile_cnt_A, srcB_tensor, tile_cnt_B
+
     srcA_tensor = _generate_source_tensor(
         stimuli_format=stimuli_format_A,
         num_elements=num_elements_A,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -59,7 +59,6 @@ from .format_config import (
 from .golden_generators import (
     GeneratorProxy,
     ProxyMode,
-    dummy_golden_generator,
     get_golden_proxied,
 )
 from .llk_params import (
@@ -502,7 +501,9 @@ class TestConfig:
 
         if compile_producer:
             TestConfig.BUILD_MODE = BuildMode.PRODUCE
-            golden_generators_module.get_golden_generator = dummy_golden_generator
+            # Goldens are short-circuited inside get_golden_generator() when
+            # BUILD_MODE == PRODUCE, and generate_stimuli() skips tensor generation,
+            # so no golden/stimuli values are computed during compile-only runs.
 
         if compile_consumer:
             TestConfig.BUILD_MODE = BuildMode.CONSUME


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=filip/short-circuit-golden-when-compiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:filip/short-circuit-golden-when-compiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=filip/short-circuit-golden-when-compiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:filip/short-circuit-golden-when-compiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=filip/short-circuit-golden-when-compiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:filip/short-circuit-golden-when-compiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=filip/short-circuit-golden-when-compiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:filip/short-circuit-golden-when-compiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=filip/short-circuit-golden-when-compiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:filip/short-circuit-golden-when-compiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=filip/short-circuit-golden-when-compiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:filip/short-circuit-golden-when-compiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=filip/short-circuit-golden-when-compiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:filip/short-circuit-golden-when-compiling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=filip/short-circuit-golden-when-compiling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:filip/short-circuit-golden-when-compiling)