### PR TITLE
DS Prefill :: FP8 uplift for dispatch

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
@@ -302,16 +302,15 @@ def test_ttnn_dispatch(
     # Run torch reference for all EP ranks at once
     torch_dispatched, torch_metadata = torch_dispatch_module(x, weights, indices, expert_offsets)
 
-    # Quantize the torch dispatch reference to fp8_e4m3fn so it carries the same precision as
-    # the TT dispatch output (which packs BF16->FP8 at the untilize stage). This isolates
-    # dispatch routing correctness from fp8 quantization noise in the PCC. Round-trip to float32
-    # since validate_dispatch_buffer_pcc expects a real float dtype (and matches the TT side below).
-    if use_fp8_output:
-        torch_dispatched = torch_dispatched.to(torch.float8_e4m3fn).to(torch.float32)
-
     # Convert TTNN outputs to torch for comparison
     mesh_composer = get_ep_mesh_composer(mesh_device)
     if use_fp8_output:
+        # Quantize the torch reference to fp8_e4m3fn so it carries the same precision as the TT
+        # dispatch output (which packs BF16->FP8 at the untilize stage), isolating routing
+        # correctness from fp8 quantization noise. Round-trip to float32 since
+        # validate_dispatch_buffer_pcc expects a real float dtype — matching the TT side below.
+        torch_dispatched = torch_dispatched.to(torch.float8_e4m3fn).to(torch.float32)
+
         # ttnn.to_torch returns a torch.float8_e4m3fn tensor for FP8_E4M3 device tensors; widen to fp32 for PCC.
         tt_out_dispatched = ttnn.to_torch(tt_dispatched, mesh_composer=mesh_composer)
         assert (

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
@@ -305,10 +305,12 @@ def test_ttnn_dispatch(
     # Convert TTNN outputs to torch for comparison
     mesh_composer = get_ep_mesh_composer(mesh_device)
     if use_fp8_output:
-        # Device returned uint8 bytes that decode as float8_e4m3fn — widen to fp32 for PCC.
+        # ttnn.to_torch returns a torch.float8_e4m3fn tensor for FP8_E4M3 device tensors; widen to fp32 for PCC.
         tt_out_dispatched = ttnn.to_torch(tt_dispatched, mesh_composer=mesh_composer)
-        assert tt_out_dispatched.dtype == torch.uint8, f"expected uint8 fp8 output, got {tt_out_dispatched.dtype}"
-        tt_out_dispatched = tt_out_dispatched.view(torch.float8_e4m3fn).to(torch.float32)
+        assert (
+            tt_out_dispatched.dtype == torch.float8_e4m3fn
+        ), f"expected float8_e4m3fn fp8 output, got {tt_out_dispatched.dtype}"
+        tt_out_dispatched = tt_out_dispatched.to(torch.float32)
     else:
         tt_out_dispatched = ttnn.to_torch(tt_dispatched, mesh_composer=mesh_composer, dtype=torch.float32)
     tt_out_metadata = ttnn.to_torch(tt_metadata, mesh_composer=mesh_composer)

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py
@@ -302,6 +302,13 @@ def test_ttnn_dispatch(
     # Run torch reference for all EP ranks at once
     torch_dispatched, torch_metadata = torch_dispatch_module(x, weights, indices, expert_offsets)
 
+    # Quantize the torch dispatch reference to fp8_e4m3fn so it carries the same precision as
+    # the TT dispatch output (which packs BF16->FP8 at the untilize stage). This isolates
+    # dispatch routing correctness from fp8 quantization noise in the PCC. Round-trip to float32
+    # since validate_dispatch_buffer_pcc expects a real float dtype (and matches the TT side below).
+    if use_fp8_output:
+        torch_dispatched = torch_dispatched.to(torch.float8_e4m3fn).to(torch.float32)
+
     # Convert TTNN outputs to torch for comparison
     mesh_composer = get_ep_mesh_composer(mesh_device)
     if use_fp8_output:

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
@@ -276,14 +276,6 @@ class TtDispatchModule(LightweightModule):
             num_untilizers_per_sender=self.num_untilizers_per_sender,
         )
 
-        if tt_dispatched_buffer.dtype == ttnn.uint8:
-            logger.warning(
-                """tt_dispatched_buffer dtype is uint8 but the actual content is fp8_e4m3fn. \
-                Workaround until fp8_e4m3fn is supported as a data type. \
-                Use custom kernels to typecast. See test_fp8_typecast.py
-                """
-            )
-
         tt_dispatched_buffer_shape = tt_dispatched_buffer.shape
         tt_dispatched_metadata_shape = tt_dispatch_metadata.shape
         logger.debug(f"[TtDispatchModule.forward] OUTPUT SHAPES:")

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_device_operation.cpp
@@ -93,8 +93,10 @@ DispatchDeviceOperation::spec_return_value_t DispatchDeviceOperation::compute_ou
     auto dispatch_buffer_shape = ttnn::Shape({1, 1, max_dispatch_buffer_token_size, hidden_dim});
     auto dispatch_metadata_shape = ttnn::Shape({1, 1, max_dispatch_buffer_token_size, metadata_len});
 
-    // FP8 dispatch uses UINT8 (1 byte/element) for DRAM allocation; actual content is Fp8_e4m3.
-    auto dispatch_buffer_dtype = operation_attributes.use_fp8_dispatch ? DataType::UINT8 : DataType::BFLOAT16;
+    // FP8 dispatch emits Fp8_e4m3 (1 byte/element); DataType::FP8_E4M3 maps directly to
+    // tt::DataFormat::Fp8_e4m3 via datatype_to_dataformat_converter, so downstream CBs created
+    // with detail::create_tensor_cb(output_tensor, ...) pick up the right dtype/page-size.
+    auto dispatch_buffer_dtype = operation_attributes.use_fp8_dispatch ? DataType::FP8_E4M3 : DataType::BFLOAT16;
 
     // Create TensorSpec objects with correct dtypes
     auto dispatch_buffer_spec = TensorSpec(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -37,9 +37,9 @@ uint32_t get_num_rows(const ttnn::Tensor& tensor) {
 }
 
 // ProgramDescriptor-flavored helper.  Pushes a CBDescriptor onto the desc
-// instead of calling CreateCircularBuffer.  Mirrors the legacy data_format
-// rewrite for the FP8 dispatch path (UINT8 dispatch buffers reinterpret as
-// Fp8_e4m3 in the CB until FP8 gets a dedicated dtype).
+// instead of calling CreateCircularBuffer.  The FP8 dispatch path allocates its
+// buffer as DataType::FP8_E4M3, which datatype_to_dataformat_converter maps
+// straight to tt::DataFormat::Fp8_e4m3 — no special-casing needed here.
 void create_tensor_cb(
     tt::tt_metal::ProgramDescriptor& desc,
     const CoreRangeSet& core_range_set,
@@ -51,11 +51,6 @@ void create_tensor_cb(
     auto num_pages = detail::get_num_pages(tensor);
     auto aligned_page_size = get_aligned_page_size(tensor);
     auto data_format = tt::tt_metal::datatype_to_dataformat_converter(tensor.dtype());
-    if (data_format == tt::DataFormat::UInt8) {
-        // TODO: remove once FP8 has a dedicated dtype. In this op, UINT8 tensors only appear
-        // on the FP8 dispatch path (DRAM is allocated as UINT8 but content is Fp8_e4m3).
-        data_format = tt::DataFormat::Fp8_e4m3;
-    }
 
     uint32_t cb_size = buffering_factor * aligned_page_size;
 
@@ -707,8 +702,8 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
         untilize_compute_kd.config = tt::tt_metal::ComputeConfigDescriptor{
             .math_fidelity = MathFidelity::HiFi4,
             // Blackhole requires the DEST register in 32-bit mode whenever any CB on the core uses
-            // an 8-bit float format (Fp8_e4m3). The FP8 dispatch path reinterprets UINT8 CBs as
-            // Fp8_e4m3, so fp32_dest_acc_en must be enabled there.
+            // an 8-bit float format (Fp8_e4m3). The FP8 dispatch path emits Fp8_e4m3 output, so
+            // fp32_dest_acc_en must be enabled there.
             .fp32_dest_acc_en = operation_attributes.use_fp8_dispatch,
             // 32-bit DEST halves pack_untilize block capacity: half-sync 32-bit allows only 4
             // tiles, but pack_untilize_block uses block_ct_dim=8. Full-sync 32-bit restores the
@@ -1369,12 +1364,6 @@ tt::tt_metal::WorkloadDescriptor DispatchProgramFactory::create_workload_descrip
 
     const bool is_tile_layout = tensor_args.input_tensor.layout() == tt::tt_metal::Layout::TILE;
     log_info(tt::LogOp, "Prefill dispatch: input tensor is {} layout", is_tile_layout ? "TILE" : "ROW_MAJOR");
-    if (operation_attributes.use_fp8_dispatch) {
-        log_warning(
-            tt::LogOp,
-            "Prefill dispatch: FP8 path — output buffer is allocated as UINT8 but content is Fp8_e4m3. "
-            "CBs reinterpret UINT8 tensors as Fp8_e4m3 (temporary, until FP8 has a dedicated dtype).");
-    }
 
     // Dispatch is mesh-coord-dependent (fabric routing + linearized mesh
     // coordinate are baked into kernel compile-time args), so we cannot

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
@@ -72,7 +72,7 @@ void bind_dispatch(nb::module_& mod) {
             use_l1_small_for_semaphores (bool, optional): Allocate the workload's
                 GlobalSemaphores in L1_SMALL instead of L1. Defaults to False.
             use_fp8_dispatch (bool, optional): Pack the dispatched buffer as Fp8_e4m3
-                (DRAM allocated as UINT8). Requires TILE input layout, not supported on
+                (DataType::FP8_E4M3). Requires TILE input layout, not supported on
                 Wormhole_B0. Defaults to False.
             num_untilizers_per_sender (int, optional): Number of untilize cores per
                 sender on the tile-layout path.


### PR DESCRIPTION
- FP8 has been added - there is no need to treat the output tensor as UINT8 - it can be treated as FP8_e4m3
- resolve https://github.com/tenstorrent/tt-metal/pull/43775/changes#r3208127632
- resolves issue - https://github.com/tenstorrent/tt-metal/issues/44708

### Deepseek CI - enough to test bh e2e since the full MoE pipeline still uses bf16 data format for dispatch buffer
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=nostojic/dispatch_fp8_uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:nostojic/dispatch_fp8_uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=nostojic/dispatch_fp8_uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:nostojic/dispatch_fp8_uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=nostojic/dispatch_fp8_uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:nostojic/dispatch_fp8_uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=nostojic/dispatch_fp8_uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:nostojic/dispatch_fp8_uplift)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_fp8_uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/dispatch_fp8_uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_fp8_uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/dispatch_fp8_uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nostojic/dispatch_fp8_uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nostojic/dispatch_fp8_uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/dispatch_fp8_uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/dispatch_fp8_uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/dispatch_fp8_uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/dispatch_fp8_uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/dispatch_fp8_uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/dispatch_fp8_uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/dispatch_fp8_uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/dispatch_fp8_uplift)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/dispatch_fp8_uplift)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/dispatch_fp8_uplift)