### PR TITLE
Packed-query speculative verify for Gemma4 batch-1 decode [Feature][Performance]

### DIFF
--- a/models/demos/gemma4/tests/unit/test_packed_verify.py
+++ b/models/demos/gemma4/tests/unit/test_packed_verify.py
@@ -1,0 +1,110 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Packed-query verify (spec decode) vs the sequential and batch-dim verifies.
+
+The packed verify folds the K+1 candidates into the query-heads dim of ONE
+batch=1 forward (head-major packed SDPA with an additive mask) and writes the
+new KV loop-free through the persistent staging + paged_fill_cache path. Greedy
+argmax must match the sequential single-token verify chain position-for-position
+(up to the same near-tie caveat as the batch-dim verify); the loop-free KV write
+must also leave the cache state correct across iterations (a chain of packed
+verifies, with rollovers across page boundaries, keeps matching sequential).
+
+Requires HF_MODEL (target). The drafter is irrelevant here.
+"""
+
+import math
+import os
+
+import pytest
+import torch
+from loguru import logger
+
+from ...tests.test_factory import parametrize_mesh_with_fabric
+
+
+@parametrize_mesh_with_fabric()
+def test_packed_verify_matches_sequential(mesh_device, reset_seeds):
+    model_path = os.getenv("HF_MODEL")
+    if not model_path:
+        pytest.skip("set HF_MODEL (target) to run")
+
+    from models.demos.gemma4.demo.text_demo_v2 import create_tt_page_table
+    from models.demos.gemma4.tt.generator import Gemma4Generator
+    from models.demos.gemma4.tt.spec_decode import SpeculativeDecoder
+    from models.tt_transformers.tt.common import PagedAttentionConfig, preprocess_inputs_prefill
+
+    max_seq_len = 1024
+    block_size = 64
+    paged_attention_config = PagedAttentionConfig(
+        block_size=block_size, max_num_blocks=math.ceil(max_seq_len / block_size)
+    )
+    generator, tt_kv_cache, tokenizer = Gemma4Generator.from_pretrained(
+        mesh_device=mesh_device,
+        model_path=model_path,
+        max_batch_size=1,
+        max_seq_len=max_seq_len,
+        num_layers=None,
+        paged_attention_config=paged_attention_config,
+        bounded_sliding_kv_cache=False,
+    )
+    target = generator.model[0]
+    page_table = create_tt_page_table(1, paged_attention_config)
+    prompt = "The capital of France is"
+    in_pt, encoded, decoding_pos, prefill_lens = preprocess_inputs_prefill(
+        [prompt], tokenizer, generator.model_args, True, 24, max_prefill_len=max_seq_len
+    )
+    in_pt = torch.stack(in_pt).view(1, -1)
+    anchor_token = int(encoded[0][prefill_lens[0] - 1])
+    anchor_pos = prefill_lens[0] - 1
+
+    # assistant_model unused — only the verify paths run.
+    spec = SpeculativeDecoder(
+        target_model=target,
+        assistant_model=None,
+        mesh_device=mesh_device,
+        tt_kv_cache=tt_kv_cache,
+        page_table_torch=page_table,
+        stop_tokens=tokenizer.stop_tokens,
+        draft_len=4,
+    )
+    P = spec.draft_len + 1
+
+    def _prefill():
+        generator.prefill_forward_text(in_pt, page_table=page_table, kv_cache=tt_kv_cache, prompt_lens=decoding_pos)
+
+    # ── Reference: sequential single-token verify chain (batch=1 takes the
+    # plain verify path — packing only engages for multi-token calls).
+    _prefill()
+    seq = []
+    tok, pos = anchor_token, anchor_pos
+    for _ in range(3 * P):  # several iterations ⇒ exercises staging rollovers
+        logits, h = spec._verify([tok], [pos])
+        h.deallocate(True)
+        tok = int(torch.argmax(logits[0]))
+        seq.append(tok)
+        pos += 1
+
+    # ── Packed: chain of packed verifies committing the matched chain tokens.
+    _prefill()
+    spec._pv_a_prev = -1
+    packed = []
+    pos = anchor_pos
+    chain = [anchor_token] + seq
+    it = 0
+    while len(packed) < 3 * P:
+        tokens = chain[it * P : it * P + P]  # the already-verified greedy chain
+        positions = [pos + j for j in range(P)]
+        lh, h = spec._verify(tokens, positions)
+        h.deallocate(True)
+        packed.extend(int(torch.argmax(lh[j])) for j in range(P))
+        pos += P
+        it += 1
+    packed = packed[: len(seq)]
+
+    logger.info(f"sequential: {seq}")
+    logger.info(f"packed:     {packed}")
+    n_match = sum(1 for a, b in zip(seq, packed) if a == b)
+    logger.info(f"match {n_match}/{len(seq)}")
+    assert packed == seq, f"packed verify diverges from sequential: packed={packed} seq={seq}"

--- a/models/demos/gemma4/tt/attention/__init__.py
+++ b/models/demos/gemma4/tt/attention/__init__.py
@@ -17,7 +17,7 @@ from models.demos.gemma4.config import MeshConfig, Mode
 
 from .weights import AttentionWeights, load_attention_weights
 from .kv_cache import init_kv_cache
-from .decode import decode_forward
+from .decode import decode_forward, packed_decode_forward
 from .prefill import prefill_forward
 
 
@@ -117,6 +117,11 @@ class Gemma4Attention:
         else:
             self.kv_cache = None
 
+        # Persistent hot-block staging for the packed-verify loop-free KV write.
+        # Allocated lazily by the spec-decode driver (see tt/spec_decode.py);
+        # None means packed_decode_forward falls back to the per-position loop.
+        self.kv_staging = None
+
     def __call__(
         self,
         hidden_states,
@@ -132,6 +137,7 @@ class Gemma4Attention:
         position_idx_cache=None,
         valid_seq_len=None,
         sequential_kv_write=False,
+        packed=None,
     ):
         """
         Attention forward pass — dispatches to on-device decode or prefill.
@@ -147,9 +153,35 @@ class Gemma4Attention:
             shared_kv: optional (tt_k, tt_v) from source layer for KV sharing (prefill only)
             keep_kv: if True, keep K/V alive for sharing with later layers (prefill only)
             is_kv_shared: if True, this layer shares KV from source (skip K/V proj + cache update)
+            packed: optional packed-verify dict (decode only) — keys packed_p,
+                position_idx, kv_write_idxs, attn_mask, rope_packed, embed_idx,
+                hot_pt; routes to packed_decode_forward (P positions, one pass)
         """
         cache = kv_cache or self.kv_cache
         cos_cache, sin_cache = rope_mats
+
+        if is_decode and packed is not None:
+            return packed_decode_forward(
+                hidden_states=hidden_states,
+                cos_cache=cos_cache,
+                sin_cache=sin_cache,
+                weights=self.weights,
+                kv_cache=cache,
+                config=self.config,
+                mesh_config=self.mesh_config,
+                mesh_device=self.mesh_device,
+                position_idx=packed["position_idx"],
+                kv_write_idxs=packed.get("kv_write_idxs"),
+                attn_mask=packed["attn_mask"],
+                packed_p=packed["packed_p"],
+                page_table=page_table,
+                ccl_manager=self.ccl_manager,
+                is_kv_shared=is_kv_shared,
+                rope_packed=packed.get("rope_packed"),
+                kv_staging=self.kv_staging,
+                embed_idx=packed.get("embed_idx"),
+                hot_pt=packed.get("hot_pt"),
+            )
 
         if is_decode:
             return decode_forward(

--- a/models/demos/gemma4/tt/attention/decode.py
+++ b/models/demos/gemma4/tt/attention/decode.py
@@ -7,6 +7,8 @@ Decode-mode attention forward pass for Gemma4.
 Uses HF-style ttnn.experimental.rotary_embedding (no transformation matrices).
 """
 
+import os
+
 import ttnn
 
 from .operations import (
@@ -19,8 +21,33 @@ from .operations import (
     concat_heads,
     effective_block_size,
     split_qkv_heads_decode,
+    split_qkv_heads_prefill,
 )
 from .weights import AttentionWeights
+
+# Cache for the L1 height-sharded ``MemoryConfig`` that
+# ``nlp_create_qkv_heads_decode`` produces. The spec only depends on shape
+# constants (B, num_heads_local, head_dim, qkv_dim, kv_replicated/global flags)
+# — all fixed for a given model+batch. By caching across calls we avoid the
+# per-layer probe decode-split that exists ONLY to discover this spec.
+# Populated on the first (un-traced compile) call; inside trace capture the
+# probe is skipped entirely.
+_Q_SHARDED_MEM_CACHE: dict = {}
+
+
+def _q_sharded_mem_key(B, qkv_dim, config, weights, tp):
+    """Hashable key for the q_sharded_mem cache. Captures every input that
+    affects ``nlp_create_qkv_heads_decode``'s output shard spec."""
+    return (
+        int(B),
+        int(qkv_dim),
+        int(config.num_attention_heads),
+        int(config.num_key_value_heads),
+        int(config.head_dim),
+        bool(weights.is_global),
+        bool(weights.kv_replicated),
+        int(tp),
+    )
 
 
 def decode_forward(
@@ -289,4 +316,436 @@ def decode_forward(
     tt_out = apply_output_projection(tt_out, weights)
     tt_out = apply_allreduce(tt_out, mesh_config, ccl_manager, config.hidden_size)
 
+    return tt_out
+
+
+# ── Packed-query verify decode ─────────────────────────────────────────────
+# Verifies P speculative positions per user in ONE attention pass by packing
+# the P positions into the query-heads dim (H_local*P packed heads) and
+# running a single non-causal SDPA with an additive mask that bakes in the
+# per-position causal upper bound (and the sliding-window lower bound on
+# sliding layers). Ported from the gemma4_cody packed-verify path.
+
+
+def _packed_sdpa_grid(config, mesh_device):
+    """SDPA grid for the packed verify — mirrors the single-token decode's
+    choice: small grid for global layers (head_dim=512 needs more L1/core),
+    full device grid for sliding layers."""
+    if config.head_dim >= 512:
+        return ttnn.CoreCoord(8, 4)
+    device_grid = mesh_device.compute_with_storage_grid_size()
+    return ttnn.CoreCoord(device_grid.x, device_grid.y)
+
+
+def _verify_head_splits(B, H_local, nkv_local, P, head_dim, grid=None):
+    """How many QUERY-HEAD-wise sub-ops to split the packed-verify SDPA into.
+
+    The packed verify folds ``H_local*P`` query rows onto ``nkv_local`` KV
+    groups; the per-core SDPA-decode CBs (Q, QK scores, and the flash
+    cross-core reduction buffer) scale with the packed query-head tile count
+    ``PNHt = H_local*P/32``. Global-attention layers (head_dim=512 ⇒ DHt 16,
+    single local KV head at high TP) can overflow the 1.5 MB L1 even at the
+    default k_chunk; we split the packed-head dim across ``n`` full-grid ops +
+    a concat, carrying ``H_local/n`` heads each. Sliding layers (head_dim 256)
+    fit and are left as one op.
+
+    Enabled ONLY when ``nkv_local == 1``: then every query head maps to the
+    lone KV head, so each sub-op can SHARE the full (paged) K/V cache +
+    page_table with NO cache slicing — any head subset is GQA-correct. With >1
+    local KV head a head split would need per-op cache slicing; such configs
+    are left unsplit.
+
+    ``GEMMA4_PV_SDPA_HEAD_SPLITS`` overrides the count (clamped to the largest
+    valid split <= the request)."""
+    if nkv_local != 1:
+        return 1
+    # Valid splits: whole heads per op AND 32-tile-aligned query-row slices.
+    valid = [d for d in range(1, H_local + 1) if H_local % d == 0 and ((H_local // d) * P) % 32 == 0]
+    if not valid:
+        return 1
+    env = os.environ.get("GEMMA4_PV_SDPA_HEAD_SPLITS")
+    if env:
+        want = max(1, min(int(env), H_local))
+        return max(d for d in valid if d <= want)
+    if (H_local * P) * head_dim <= 8192:  # not heavy (sliding) — one op fits
+        return 1
+    # Mirror sdpa_decode_program_factory's core allocation (num_kv_heads == 1)
+    # and CB tile counts; keep grid / max_cores_per_head_batch / k_chunk in sync
+    # with the packed sdpa_program_config. Budget in 2 KB tiles with margin
+    # under the 768-tile (1.5 MB) L1 cap.
+    if grid is None:
+        grid = 32 if head_dim >= 512 else 64
+    max_cores_per_head, k_chunk = 16, 64
+    cores_per_head = max(1, min(grid, max_cores_per_head * B) // max(1, B))
+    DHt, Sk = head_dim // 32, max(1, k_chunk // 32)
+    BUDGET_TILES = 720
+
+    def per_core_tiles(n):
+        pnht = (H_local * P) // (32 * n)
+        return (
+            2 * pnht * DHt  # Q-in + tilized-Q
+            + 5 * pnht * DHt  # 3 out-im + out-stats + out-final
+            + 2 * pnht * Sk  # attn-mask + QK-im
+            + 11 * pnht  # softmax stats CBs
+            + 4 * Sk * DHt  # K + V (double-buffered)
+            + 3  # scale / identity
+            + (pnht * DHt + 2 * pnht) * (cores_per_head - 1)  # cross-core flash reduction
+        )
+
+    for d in valid:  # ascending ⇒ smallest split that fits the budget
+        if per_core_tiles(d) <= BUDGET_TILES:
+            return d
+    return valid[-1]
+
+
+def _packed_verify_sdpa(
+    q_packed, k, v, layer_page_table, attn_mask, scale, pc, n_splits, B, H_local, P, head_dim, block_size, num_kv_heads
+):
+    """Run the packed-verify decode-SDPA, optionally head-split into
+    ``n_splits`` full-grid ops + a concat (see ``_verify_head_splits``).
+    Splitting SHARES the (paged) K/V cache + page_table across sub-ops unsliced
+    — valid only for a single local KV head — and slices only Q and the
+    additive mask on the packed query-head dim. Does NOT free its inputs.
+    Returns [1, B, H_local*P, head_dim]."""
+
+    def _call(q, m):
+        if layer_page_table is not None:
+            return ttnn.transformer.paged_scaled_dot_product_attention_decode(
+                q,
+                k,
+                v,
+                page_table_tensor=layer_page_table,
+                is_causal=False,
+                attn_mask=m,
+                scale=scale,
+                sliding_window_size=None,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                program_config=pc,
+                block_size=block_size,
+                num_kv_heads=num_kv_heads,
+            )
+        return ttnn.transformer.scaled_dot_product_attention_decode(
+            q,
+            k,
+            v,
+            is_causal=False,
+            attn_mask=m,
+            scale=scale,
+            sliding_window_size=None,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            program_config=pc,
+        )
+
+    if n_splits <= 1:
+        return _call(q_packed, attn_mask)
+    s_k = attn_mask.shape[3] if attn_mask is not None else None
+    rows_per = (H_local // n_splits) * P  # packed query rows per sub-op (32-aligned)
+    parts = []
+    for s in range(n_splits):
+        r0, r1 = s * rows_per, (s + 1) * rows_per
+        q_i = ttnn.slice(q_packed, [0, 0, r0, 0], [1, B, r1, head_dim])
+        m_i = ttnn.slice(attn_mask, [0, 0, r0, 0], [B, 1, r1, s_k]) if attn_mask is not None else None
+        out_i = _call(q_i, m_i)
+        ttnn.deallocate(q_i)
+        if m_i is not None:
+            ttnn.deallocate(m_i)
+        parts.append(out_i)
+    out = ttnn.concat(parts, dim=2)  # [1, B, H_local*P, head_dim]
+    for p in parts:
+        ttnn.deallocate(p)
+    return out
+
+
+def _packed_fill_kv_loopfree_embed(cache, staging, new_seq, embed_idx, hot_pt):
+    """Loop-free packed KV-cache write via PERSISTENT STAGING and a
+    transpose-free ``ttnn.embedding`` row-gather merge — replaces the
+    per-position ``paged_update_cache`` loop, and never reads the committed
+    cache on the hot path.
+
+    ``staging`` is this layer's resident hot-block copy
+    ``[1, nkv, S2, head_dim]`` (S2 = max_batch * PV_HOT_BLOCKS * block_size),
+    slot-indexed: slot ``s`` owns seq ``[s*BLK*bs, (s+1)*BLK*bs)`` and already
+    holds the committed prefix of its hot block(s) — seeded at the first
+    verify, maintained step-to-step by the spec-decode driver. ``new_seq`` is
+    the freshly projected/normed/RoPE'd K (or V) ``[1, nkv, n_new, head_dim]``
+    (user-major / position-minor rows, n_new tile-aligned — caller pads).
+
+    Per step (all fixed-shape ⇒ trace-safe; cost scales with S2, never with
+    max_num_blocks):
+      1. merge: ``ttnn.embedding`` row-gathers the flattened
+         ``concat([staging, new_seq])`` — committed positions copy from staging
+         (identity, or shifted one block on a rollover), the P new positions
+         pull from ``new_seq``. ``embed_idx`` ([1, nkv*S2] u32) bakes the
+         per-head row offset in: ``embed_idx[h*S2 + j] = h*(S2+n_new) +
+         merge_idx[j]``.
+      2. ``assign`` the merged hot blocks back into ``staging`` (persists for
+         the next step — no cache read needed next time).
+      3. one ``paged_fill_cache`` writes each slot's hot block(s) to its
+         physical page(s) named by ``hot_pt`` (-1 = skip ⇒ idle slots / the
+         unused spill block are left untouched).
+    """
+    dram = ttnn.DRAM_MEMORY_CONFIG
+    nkv = staging.shape[1]
+    S2 = staging.shape[2]
+    head_dim = staging.shape[3]
+    src_seq = S2 + new_seq.shape[2]
+
+    # ① merge resident staging with this step's new K/V — no committed-cache read.
+    new_dram = ttnn.to_memory_config(new_seq, dram)
+    src = ttnn.concat([staging, new_dram], dim=2, memory_config=dram)  # [1, nkv, src_seq, hd] TILE
+    ttnn.deallocate(new_dram)
+    # Flatten (nkv, seq) into the row axis and gather rows by embed_idx. The
+    # reshape is metadata-only (src_seq and S2 are tile-aligned); embedding
+    # reads bf16/TILE weights, output is [1, nkv*S2, hd].
+    src2d = ttnn.reshape(src, (nkv * src_seq, head_dim))
+    merged = ttnn.embedding(embed_idx, src2d, layout=ttnn.TILE_LAYOUT)  # [1, nkv*S2, hd]
+    ttnn.deallocate(src)
+    merged = ttnn.reshape(merged, (1, nkv, S2, head_dim))
+
+    # ② persist updated hot blocks for next step, then ③ one fill launch.
+    ttnn.assign(merged, staging)
+    ttnn.experimental.paged_fill_cache(cache, merged, hot_pt, batch_idx=0)
+    ttnn.deallocate(merged)
+
+
+def packed_decode_forward(
+    hidden_states,
+    cos_cache,
+    sin_cache,
+    weights: AttentionWeights,
+    kv_cache,
+    config,
+    mesh_config,
+    mesh_device,
+    position_idx,
+    kv_write_idxs,
+    attn_mask,
+    packed_p,
+    page_table=None,
+    ccl_manager=None,
+    is_kv_shared=False,
+    rope_packed=None,
+    kv_staging=None,
+    embed_idx=None,
+    hot_pt=None,
+):
+    """Packed multi-token decode attention — P query positions/slot in one pass.
+
+    Hoists QKV projection, prefill-style split, per-head norm, and RoPE OUT of
+    any per-position loop: those run once on the full B*P tensor. The KV write
+    is loop-free when staging is provided (one paged_fill_cache per K/V), else
+    a per-position paged_update_cache fallback.
+
+    Args:
+        hidden_states: [1, 1, B*P, hidden_size]. Rows user-major / position-
+            minor — row u*P+p is slot u's p-th packed token.
+        cos_cache, sin_cache: 2D RoPE caches [max_seq_len, head_dim].
+        position_idx: [1, B*P] uint32 — RoPE position per row (cur_pos_u + p).
+        kv_write_idxs: list of P int32 [B] device tensors — the cache write
+            position for each packed position p (fallback per-p loop only).
+        attn_mask: [B, 1, H_local*P, S_k] head-major additive mask baking in
+            the per-position causal upper bound and (sliding layers) the
+            window lower bound. S_k must be a multiple of k_chunk (64).
+        packed_p: P, the number of packed positions per slot.
+        rope_packed: optional pre-gathered (cos_bp, sin_bp) for this layer
+            type — identical for all layers of a type, so the caller gathers
+            once per type per step.
+        kv_staging: optional [k_staging, v_staging] persistent hot-block
+            buffers (loop-free write path; see _packed_fill_kv_loopfree_embed).
+        embed_idx: [1, nkv_local*S2] uint32 merge gather index (loop-free path).
+        hot_pt: [1, max_batch*PV_HOT_BLOCKS] int32 physical fill pages, -1=skip.
+
+    Returns:
+        [1, 1, B*P, hidden_size] — attention output for every packed position.
+    """
+    P = packed_p
+    tp = mesh_config.tp if mesh_config else 1
+    B = hidden_states.shape[2] // P
+    H_local = config.num_attention_heads // tp
+    head_dim = config.head_dim
+    nkv_local = 1 if weights.kv_replicated else config.num_key_value_heads // tp
+    if config.cache_position_modulo is not None:
+        raise NotImplementedError("packed verify does not support bounded sliding KV caches")
+    if kv_cache is None:
+        raise ValueError("packed_decode_forward requires a KV cache (it attends through the paged cache)")
+    l1 = ttnn.L1_MEMORY_CONFIG
+
+    # ── ① QKV projection (one call on the full B*P, output kept on L1) ──────
+    xqkv = apply_qkv_projection(hidden_states, weights, memory_config=l1)
+    qkv_dim = xqkv.shape[-1]
+
+    # ── ② L1 height-sharded MemoryConfig for the fallback paged_update_cache ─
+    # ``paged_update_cache`` needs the layout ``nlp_create_qkv_heads_decode``
+    # emits; the spec depends only on shape constants, so probe once and cache.
+    cache_key = _q_sharded_mem_key(B, qkv_dim, config, weights, tp)
+    q_sharded_mem = _Q_SHARDED_MEM_CACHE.get(cache_key)
+    if q_sharded_mem is None and kv_staging is None and not is_kv_shared:
+        probe = ttnn.slice(xqkv, [0, 0, 0, 0], [1, 1, B, qkv_dim])
+        q_probe, k_probe, v_probe = split_qkv_heads_decode(
+            probe, config, weights.is_global, tp=tp, kv_replicated=weights.kv_replicated
+        )
+        q_sharded_mem = q_probe.memory_config()
+        _Q_SHARDED_MEM_CACHE[cache_key] = q_sharded_mem
+        for t in (q_probe, k_probe, v_probe, probe):
+            ttnn.deallocate(t)
+
+    # ── ②b Prefill-style split → L1 Q/K/V on B*P ────────────────────────────
+    tt_q, tt_k, tt_v = split_qkv_heads_prefill(
+        xqkv, config, weights.is_global, tp=tp, kv_replicated=weights.kv_replicated, memory_config=l1
+    )
+    # Q: [1, H_local, B*P, head_dim], K/V: [1, nkv_local, B*P, head_dim]
+    ttnn.deallocate(xqkv)
+
+    # ── ③ Per-head norms (one call each on B*P, kept on L1) ─────────────────
+    tt_q = apply_per_head_norm(tt_q, weights.q_norm_weight, config.rms_norm_eps, with_scale=True, memory_config=l1)
+    if not is_kv_shared:
+        tt_k = apply_per_head_norm(tt_k, weights.k_norm_weight, config.rms_norm_eps, with_scale=True, memory_config=l1)
+        tt_v = apply_per_head_norm(tt_v, None, config.rms_norm_eps, with_scale=False, memory_config=l1)
+
+    # ── ④ RoPE on B*P, prefill mode (kernel iterates along S=B*P) ───────────
+    if rope_packed is not None:
+        cos_bp, sin_bp = rope_packed
+        owns_rope = False
+    else:
+        cos_bp = ttnn.unsqueeze_to_4D(ttnn.embedding(position_idx, cos_cache, layout=ttnn.TILE_LAYOUT))
+        sin_bp = ttnn.unsqueeze_to_4D(ttnn.embedding(position_idx, sin_cache, layout=ttnn.TILE_LAYOUT))
+        owns_rope = True
+    tt_q = apply_rope(tt_q, cos_bp, sin_bp, token_index=None, memory_config=l1)
+    if not is_kv_shared:
+        tt_k = apply_rope(tt_k, cos_bp, sin_bp, token_index=None, memory_config=l1)
+    if owns_rope:
+        ttnn.deallocate(cos_bp)
+        ttnn.deallocate(sin_bp)
+
+    if is_kv_shared:
+        ttnn.deallocate(tt_k)
+        ttnn.deallocate(tt_v)
+
+    # ── ⑤ KV write — loop-free persistent staging (primary) ────────────────
+    if not is_kv_shared and kv_staging is not None and embed_idx is not None:
+        # Park Q off L1 (idle until the SDPA pack ⑥); merge intermediates live
+        # in DRAM and Q never re-enters L1 before the SDPA call.
+        tt_q = ttnn.to_memory_config(tt_q, ttnn.DRAM_MEMORY_CONFIG)
+        k_cache_w, v_cache_w = kv_cache
+        k_stg, v_stg = kv_staging
+        if k_stg.shape[1] != k_cache_w.shape[1]:
+            raise ValueError("staging nkv must match cache nkv (HMA-shared caches unsupported)")
+        # Pad new rows up to a tile boundary so the merge concat + flatten
+        # reshape stay metadata-only; embed_idx is built against the padded
+        # src_seq, so padded rows are never gathered.
+        n_new = tt_k.shape[2]
+        pad = (-n_new) % 32
+        if pad:
+            k_pad = ttnn.pad(tt_k, [(0, 0), (0, 0), (0, pad), (0, 0)], value=0.0)
+            v_pad = ttnn.pad(tt_v, [(0, 0), (0, 0), (0, pad), (0, 0)], value=0.0)
+            ttnn.deallocate(tt_k)
+            ttnn.deallocate(tt_v)
+            tt_k, tt_v = k_pad, v_pad
+        _packed_fill_kv_loopfree_embed(k_cache_w, k_stg, tt_k, embed_idx, hot_pt)
+        _packed_fill_kv_loopfree_embed(v_cache_w, v_stg, tt_v, embed_idx, hot_pt)
+        ttnn.deallocate(tt_k)
+        ttnn.deallocate(tt_v)
+
+    # ── ⑤ FALLBACK per-p paged_update_cache loop ────────────────────────────
+    elif not is_kv_shared:
+        tt_q = ttnn.to_memory_config(tt_q, ttnn.DRAM_MEMORY_CONFIG)
+        k_cache_w, v_cache_w = kv_cache
+        eff_bs = effective_block_size(k_cache_w, head_dim, nkv_local)
+        # Convert the prefill-style [1, nkv, B*P, hd] to decode layout
+        # [1, B*P, nkv, hd] (DRAM — the full tensors stay resident across the
+        # loop; only the per-p reshard occupies L1).
+        tt_k_bp = ttnn.permute(tt_k, (0, 2, 1, 3), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        tt_v_bp = ttnn.permute(tt_v, (0, 2, 1, 3), memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        ttnn.deallocate(tt_k)
+        ttnn.deallocate(tt_v)
+        tt_k_view = ttnn.reshape(tt_k_bp, (1, B, P, nkv_local, head_dim))
+        tt_v_view = ttnn.reshape(tt_v_bp, (1, B, P, nkv_local, head_dim))
+        for p in range(P):
+            k_p = ttnn.slice(tt_k_view, [0, 0, p, 0, 0], [1, B, p + 1, nkv_local, head_dim])
+            k_p = ttnn.reshape(k_p, (1, B, nkv_local, head_dim))
+            v_p = ttnn.slice(tt_v_view, [0, 0, p, 0, 0], [1, B, p + 1, nkv_local, head_dim])
+            v_p = ttnn.reshape(v_p, (1, B, nkv_local, head_dim))
+            k_p = ttnn.to_memory_config(k_p, q_sharded_mem)
+            v_p = ttnn.to_memory_config(v_p, q_sharded_mem)
+            if page_table is not None:
+                ttnn.experimental.paged_update_cache(
+                    k_cache_w,
+                    k_p,
+                    update_idxs_tensor=kv_write_idxs[p],
+                    page_table=page_table,
+                    block_size=eff_bs,
+                    num_kv_heads=nkv_local,
+                )
+                ttnn.experimental.paged_update_cache(
+                    v_cache_w,
+                    v_p,
+                    update_idxs_tensor=kv_write_idxs[p],
+                    page_table=page_table,
+                    block_size=eff_bs,
+                    num_kv_heads=nkv_local,
+                )
+            else:
+                ttnn.experimental.paged_update_cache(k_cache_w, k_p, update_idxs_tensor=kv_write_idxs[p])
+                ttnn.experimental.paged_update_cache(v_cache_w, v_p, update_idxs_tensor=kv_write_idxs[p])
+            ttnn.deallocate(k_p)
+            ttnn.deallocate(v_p)
+        ttnn.deallocate(tt_k_bp)
+        ttnn.deallocate(tt_v_bp)
+
+    k_cache_use, v_cache_use = kv_cache
+
+    # ── ⑥ Head-major pack Q → [1, B, H_local*P, head_dim] → SDPA ────────────
+    # ROW_MAJOR on purpose: P (< 32) never lands on a tile axis, so the
+    # split/merge reshapes are free views and the rank-5 permute is one strided
+    # copy; in TILE the same reshapes re-tile AND pad P→32. The head-major
+    # order (h*P+p) is load-bearing: SDPA maps packed query head i → KV head
+    # i // group, so a KV group must be a contiguous head block.
+    tt_q = ttnn.to_layout(tt_q, ttnn.ROW_MAJOR_LAYOUT)
+    tt_q = ttnn.reshape(tt_q, (1, H_local, B, P, head_dim))
+    tt_q = ttnn.permute(tt_q, (0, 2, 1, 3, 4))  # [1, B, H_local, P, hd]
+    tt_q = ttnn.reshape(tt_q, (1, B, H_local * P, head_dim))
+    q_packed = ttnn.to_layout(tt_q, ttnn.TILE_LAYOUT, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    ttnn.deallocate(tt_q)
+
+    sdpa_program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=_packed_sdpa_grid(config, mesh_device),
+        q_chunk_size=32,
+        k_chunk_size=64,
+        exp_approx_mode=False,
+        max_cores_per_head_batch=16,
+    )
+    _grid = sdpa_program_config.compute_with_storage_grid_size
+    n_sdpa_splits = _verify_head_splits(B, H_local, nkv_local, P, head_dim, grid=_grid.x * _grid.y)
+    eff_bs_sdpa = effective_block_size(k_cache_use, head_dim, nkv_local)
+    tt_sdpa = _packed_verify_sdpa(
+        q_packed,
+        k_cache_use,
+        v_cache_use,
+        page_table,
+        attn_mask,
+        1.0,
+        sdpa_program_config,
+        n_sdpa_splits,
+        B,
+        H_local,
+        P,
+        head_dim,
+        eff_bs_sdpa,
+        nkv_local,
+    )
+    ttnn.deallocate(q_packed)
+
+    # ── ⑦ Unpack head-major SDPA output → concat heads + o_proj + AR ────────
+    tt_sdpa = ttnn.to_layout(tt_sdpa, ttnn.ROW_MAJOR_LAYOUT, memory_config=l1)  # DRAM TILE → L1 RM
+    tt_sdpa = ttnn.reshape(tt_sdpa, (1, B, H_local, P, head_dim))
+    tt_sdpa = ttnn.permute(tt_sdpa, (0, 1, 3, 2, 4))  # [1, B, P, H_local, head_dim]
+    tt_sdpa = ttnn.reshape(tt_sdpa, (1, B * P, H_local, head_dim))
+    tt_sdpa = ttnn.to_layout(tt_sdpa, ttnn.TILE_LAYOUT, memory_config=l1)
+
+    # Decode-layout concat: transpose batch/heads then nlp_concat_heads.
+    tt_sdpa = ttnn.transpose(tt_sdpa, 1, 2)
+    tt_out = ttnn.experimental.nlp_concat_heads(tt_sdpa, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+    ttnn.deallocate(tt_sdpa)
+    tt_out = apply_output_projection(tt_out, weights)
+    tt_out = apply_allreduce(tt_out, mesh_config, ccl_manager, config.hidden_size)
     return tt_out

--- a/models/demos/gemma4/tt/attention/kv_cache.py
+++ b/models/demos/gemma4/tt/attention/kv_cache.py
@@ -13,6 +13,12 @@ import torch
 import ttnn
 from models.demos.gemma4.utils.general_utils import get_cache_file_name
 
+# Hot cache blocks held in staging per decode slot for the loop-free packed KV
+# write: a P-token speculative tail (P <= block_size) straddles at most 2 pages,
+# so each slot reserves 2 staging blocks (cur_pos block + spill). Must match the
+# spec-decode driver's staging bookkeeping (see tt/spec_decode.py).
+PV_HOT_BLOCKS = 2
+
 
 def init_kv_cache(
     mesh_device,
@@ -96,3 +102,45 @@ def init_kv_cache(
     )
 
     return [k_cache, v_cache]
+
+
+def init_kv_staging(
+    mesh_device,
+    config,
+    max_batch_size,
+    block_size,
+    blk=PV_HOT_BLOCKS,
+    cache_dtype=ttnn.bfloat16,
+):
+    """Per-layer staging buffers for the loop-free packed-verify KV write.
+
+    Holds, per decode slot, the ``blk`` "hot" cache blocks it is currently
+    appending into (the partial block at cur_pos + one spill block). The
+    packed-verify write merges this resident copy with the step's new K/V and
+    re-fills the committed cache from it — so the committed cache is never read
+    on the hot path (see ``decode.py::_packed_fill_kv_loopfree_embed``).
+
+    Shape ``[1, num_local_kv_heads, max_batch_size*blk*block_size, head_dim]``
+    in TILE/DRAM — same seq layout as the ``paged_fill_cache`` input. Slot ``s``
+    owns seq positions ``[s*blk*block_size, (s+1)*blk*block_size)``; block-slot
+    0 is the cur_pos block, block-slot 1 the spill block.
+
+    Returns ``[k_staging, v_staging]``.
+    """
+    is_mesh = hasattr(mesh_device, "shape")
+    tp = mesh_device.shape[1] if is_mesh else 1
+    num_local_kv_heads = 1 if config.num_key_value_heads < tp else config.num_key_value_heads // tp
+    stage_shape = [1, num_local_kv_heads, max_batch_size * blk * block_size, config.head_dim]
+    mesh_mapper = ttnn.ReplicateTensorToMesh(mesh_device) if is_mesh else None
+
+    def _zeros():
+        return ttnn.as_tensor(
+            torch.zeros(stage_shape),
+            device=mesh_device,
+            layout=ttnn.TILE_LAYOUT,
+            dtype=cache_dtype,
+            mesh_mapper=mesh_mapper,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    return [_zeros(), _zeros()]

--- a/models/demos/gemma4/tt/attention/operations.py
+++ b/models/demos/gemma4/tt/attention/operations.py
@@ -40,9 +40,13 @@ PREFILL_CHUNK_SIZE = int(os.environ.get("GEMMA4_PREFILL_CHUNK_SIZE", "8192"))
 PREFILL_SLIDING_CHUNK_SIZE = int(os.environ.get("GEMMA4_PREFILL_SLIDING_CHUNK_SIZE", "30720"))
 
 
-def apply_qkv_projection(hidden_states, weights: AttentionWeights):
-    """Fused QKV matmul (no bias for Gemma4)."""
-    return ttnn.linear(hidden_states, weights.wqkv)
+def apply_qkv_projection(hidden_states, weights: AttentionWeights, memory_config=None):
+    """Fused QKV matmul (no bias for Gemma4).
+
+    ``memory_config`` lets the packed-verify decode keep the projection output
+    resident on L1; ``None`` keeps the op default (DRAM) for existing callers.
+    """
+    return ttnn.linear(hidden_states, weights.wqkv, memory_config=memory_config)
 
 
 def split_qkv_heads_decode(xqkv_fused, config, is_global: bool, tp: int = 1, kv_replicated: bool = False):
@@ -69,11 +73,19 @@ def split_qkv_heads_decode(xqkv_fused, config, is_global: bool, tp: int = 1, kv_
     )
 
 
-def split_qkv_heads_prefill(xqkv_fused, config, is_global: bool, tp: int = 1, kv_replicated: bool = False):
+def split_qkv_heads_prefill(
+    xqkv_fused, config, is_global: bool, tp: int = 1, kv_replicated: bool = False, memory_config=ttnn.DRAM_MEMORY_CONFIG
+):
     """
     Split fused QKV into separate head tensors for prefill mode.
     When TP > 1, uses local head counts (global / tp).
     When kv_replicated (num_kv_heads < TP), each device has 1 KV head (GQA-assigned).
+
+    ``memory_config`` defaults to DRAM (true prefill: seq_len can be thousands of
+    tokens and would not fit L1). The packed-verify decode caller overrides it to
+    L1 so the split output — and the downstream activation stream — stays
+    resident on L1 (the op only emits sharded output for sharded input, so an L1
+    interleaved input yields L1 interleaved output).
     """
     num_local_heads = config.num_attention_heads // tp
     num_local_kv_heads = 1 if kv_replicated else config.num_key_value_heads // tp
@@ -82,16 +94,20 @@ def split_qkv_heads_prefill(xqkv_fused, config, is_global: bool, tp: int = 1, kv
         num_heads=num_local_heads,
         num_kv_heads=num_local_kv_heads,
         transpose_k_heads=False,
-        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        memory_config=memory_config,
     )
 
 
-def apply_per_head_norm(tensor, weight, eps, with_scale=True):
+def apply_per_head_norm(tensor, weight, eps, with_scale=True, memory_config=None):
     """
     Apply RMSNorm per-head on the head_dim dimension.
 
     Input: [1, num_heads, S, head_dim]
     Process: reshape to [1, 1, num_heads*S, head_dim] -> rms_norm -> reshape back
+
+    ``memory_config`` is forwarded to ``rms_norm``; pass L1 to keep the normed
+    activation resident on L1 (packed-verify decode path). ``None`` keeps the
+    op's default (follows the input's layout).
     """
     orig_shape = tensor.shape
     num_heads = orig_shape[1]
@@ -100,14 +116,14 @@ def apply_per_head_norm(tensor, weight, eps, with_scale=True):
 
     flat = ttnn.reshape(tensor, (1, 1, num_heads * seq_or_batch, head_dim))
     if with_scale and weight is not None:
-        normed = ttnn.rms_norm(flat, weight=weight, epsilon=eps)
+        normed = ttnn.rms_norm(flat, weight=weight, epsilon=eps, memory_config=memory_config)
     else:
-        normed = ttnn.rms_norm(flat, epsilon=eps)
+        normed = ttnn.rms_norm(flat, epsilon=eps, memory_config=memory_config)
 
     return ttnn.reshape(normed, orig_shape)
 
 
-def apply_rope(tensor, cos_cache, sin_cache, token_index=None):
+def apply_rope(tensor, cos_cache, sin_cache, token_index=None, memory_config=None):
     """
     Apply HF-style rotary position embedding.
 
@@ -120,13 +136,15 @@ def apply_rope(tensor, cos_cache, sin_cache, token_index=None):
         sin_cache: [1, 1, max_seq_len, head_dim] - full sin cache
         token_index: int or None. If int (decode), slices into cache at that position.
                      If None (prefill), applies to full sequence.
+        memory_config: forwarded to the rotary op; the packed-verify decode passes
+                     L1 to keep the rotated tensor resident on L1.
 
     Note: rotary_embedding pads dim 2 to TILE_HEIGHT (32) in decode mode.
     We reshape+slice to restore the original logical shape, following the
     tt_transformers _hf_rope_decode pattern.
     """
     orig_shape = tensor.shape
-    result = ttnn.experimental.rotary_embedding(tensor, cos_cache, sin_cache, token_index)
+    result = ttnn.experimental.rotary_embedding(tensor, cos_cache, sin_cache, token_index, memory_config=memory_config)
 
     # In decode mode (token_index provided), dim 2 gets padded to 32.
     # Reshape to indicate logical vs padded size, then slice back.

--- a/models/demos/gemma4/tt/layer.py
+++ b/models/demos/gemma4/tt/layer.py
@@ -209,6 +209,7 @@ class Gemma4DecoderLayer:
         position_idx_cache=None,
         valid_seq_len=None,
         sequential_kv_write=False,
+        packed=None,
     ):
         """
         Decoder layer forward pass.
@@ -244,6 +245,7 @@ class Gemma4DecoderLayer:
             position_idx_cache=position_idx_cache,
             valid_seq_len=valid_seq_len,
             sequential_kv_write=sequential_kv_write,
+            packed=packed,
         )
 
         if isinstance(attn_output, torch.Tensor):

--- a/models/demos/gemma4/tt/model.py
+++ b/models/demos/gemma4/tt/model.py
@@ -495,6 +495,7 @@ class Gemma4Model:
         page_tables_per_layer=None,
         return_hidden=False,
         sequential_kv_write=False,
+        packed=None,
     ):
         """
         Forward pass through decoder layers + final norm + lm_head + softcapping.
@@ -524,6 +525,11 @@ class Gemma4Model:
                 The vLLM hybrid kv-cache manager produces this list so
                 sliding-window layers can index a smaller paged pool than
                 full-attention layers (KV cache groups).
+            packed: optional packed-verify dict (decode only). Carries the
+                P-position packed attention inputs; layer-type-specific entries
+                (attn_mask_full / attn_mask_sliding, embed_idx_full /
+                embed_idx_sliding, rope_packed per type) are selected per layer
+                here and routed to ``packed_decode_forward``.
         """
         seq_len = hidden_states.shape[2]
         caches = kv_caches or self.tt_kv_cache
@@ -608,6 +614,22 @@ class Gemma4Model:
                 keep_kv = True
 
             layer_page_table = page_tables_per_layer[i] if page_tables_per_layer is not None else page_table
+
+            layer_packed = None
+            if packed is not None:
+                lt = self.hf_config.layer_types[i]
+                sliding = lt == "sliding_attention"
+                rope_packed = packed.get("rope_packed") or {}
+                layer_packed = {
+                    "packed_p": packed["packed_p"],
+                    "position_idx": packed["position_idx"],
+                    "kv_write_idxs": packed.get("kv_write_idxs"),
+                    "attn_mask": packed["attn_mask_sliding"] if sliding else packed["attn_mask_full"],
+                    "rope_packed": rope_packed.get(lt),
+                    "embed_idx": packed.get("embed_idx_sliding") if sliding else packed.get("embed_idx_full"),
+                    "hot_pt": packed.get("hot_pt"),
+                }
+
             hidden_states = layer(
                 hidden_states,
                 rope_mats=layer_rope,
@@ -623,6 +645,7 @@ class Gemma4Model:
                 position_idx_cache=position_idx_cache,
                 valid_seq_len=prefill_valid_len,
                 sequential_kv_write=sequential_kv_write,
+                packed=layer_packed,
             )
 
             # For KV source layers during prefill, capture the K/V from the attention
@@ -817,6 +840,87 @@ class Gemma4Model:
             # serialized KV-write loop (KV is corrupted when False — timing only).
             sequential_kv_write=getattr(self, "_verify_seq_kv_write", True),
         )
+
+    def ttnn_packed_verify_forward(
+        self,
+        x,
+        position_idx,
+        attn_mask_full,
+        attn_mask_sliding,
+        packed_p,
+        page_table=None,
+        kv_cache=None,
+        kv_write_idxs=None,
+        embed_idx_full=None,
+        embed_idx_sliding=None,
+        hot_pt=None,
+    ):
+        """Packed-query speculative verify — all P candidates in ONE batch=1 pass.
+
+        Unlike ``ttnn_verify_forward`` (candidates in the batch dim, K+1
+        pseudo-users, sequential per-candidate KV writes), this packs the P =
+        K+1 positions into the query-heads dim: one QKV projection / norm /
+        RoPE over P rows, ONE non-causal SDPA per layer with an additive mask
+        that bakes in each packed row's causal upper bound (and the sliding
+        window on sliding layers), and a loop-free staging KV write (one
+        paged_fill_cache per K/V) when staging is provided.
+
+        Args:
+            x: [1, P] uint32 token ids ``[anchor, d1..dK]``.
+            position_idx: [1, P] uint32 positions (p..p+K), used for RoPE
+                gathers; also reused row-wise for the KV-write fallback.
+            attn_mask_full / attn_mask_sliding: [1, 1, H_local*P, S_k] bf16
+                TILE additive masks (S_k a multiple of 64).
+            packed_p: P.
+            kv_write_idxs: optional list of P int32 [1] tensors (per-position
+                fallback writes when staging isn't wired).
+            embed_idx_full / embed_idx_sliding: [1, nkv_local*S2] uint32 merge
+                gather indices (loop-free staging path; nkv differs per type).
+            hot_pt: [1, PV_HOT_BLOCKS] int32 physical fill pages (-1 = skip).
+
+        Returns:
+            (logits [1,1,P,vocab], hidden [1,1,P,hidden]) — same contract as
+            ``ttnn_verify_forward``.
+        """
+        input_embeds = self.embed_tokens(x)
+        if len(input_embeds.shape) == 3:
+            input_embeds = ttnn.unsqueeze_to_4D(input_embeds)
+        input_embeds = ttnn.to_layout(input_embeds, ttnn.TILE_LAYOUT)
+
+        # Pre-gather RoPE once per layer type (identical for all layers of a
+        # type — saves 2 embedding gathers per layer).
+        rope_packed = {}
+        for lt, (cos_2d, sin_2d) in self.rope_caches_2d.items():
+            cos_bp = ttnn.unsqueeze_to_4D(ttnn.embedding(position_idx, cos_2d, layout=ttnn.TILE_LAYOUT))
+            sin_bp = ttnn.unsqueeze_to_4D(ttnn.embedding(position_idx, sin_2d, layout=ttnn.TILE_LAYOUT))
+            rope_packed[lt] = (cos_bp, sin_bp)
+
+        packed = {
+            "packed_p": packed_p,
+            "position_idx": position_idx,
+            "kv_write_idxs": kv_write_idxs,
+            "attn_mask_full": attn_mask_full,
+            "attn_mask_sliding": attn_mask_sliding,
+            "rope_packed": rope_packed,
+            "embed_idx_full": embed_idx_full,
+            "embed_idx_sliding": embed_idx_sliding,
+            "hot_pt": hot_pt,
+        }
+
+        out = self(
+            hidden_states=input_embeds,
+            position_idx=position_idx,
+            page_table=page_table,
+            kv_caches=kv_cache,
+            is_decode=True,
+            token_index=None if self.rope_caches_2d else 0,
+            return_hidden=True,
+            packed=packed,
+        )
+        for cos_bp, sin_bp in rope_packed.values():
+            cos_bp.deallocate(True)
+            sin_bp.deallocate(True)
+        return out
 
     def compute_host_pli(self, token_id):
         """Compute per-layer input (PLI) on CPU for a single decode token.

--- a/models/demos/gemma4/tt/spec_decode.py
+++ b/models/demos/gemma4/tt/spec_decode.py
@@ -141,6 +141,19 @@ class SpeculativeDecoder:
         # scratch and corrupt it (manifests as a hang on a *re*-replay). seed()
         # writes into this buffer via ttnn.copy instead of cloning.
         self._anchor_buf = None
+        # Packed-query verify: all K+1 candidates in the query-heads dim of ONE
+        # batch=1 forward (one QKV/norm/RoPE over K+1 rows, one masked SDPA per
+        # layer, loop-free staging KV write) instead of K+1 pseudo-users with
+        # sequential per-candidate KV writes. This is the default multi-token
+        # verify; single-token calls (seed/reseed) keep the plain batch=1 path.
+        # (The fused single-trace paths keep the batch-dim verify.)
+        # S_k (mask key length) is padded to this bucket so the verify trace
+        # shape stays stable as the context grows; a new trace is captured when
+        # the bucket rolls.
+        self._pv_sk_bucket = 1024
+        self._pv_ready = False
+        self._pv_a_prev = -1  # last hot block index (-1 ⇒ staging unseeded)
+        self._pv_traces = {}  # (P, S_k) -> persistent trace inputs/outputs
 
     def _fused_shift_seed_row(self, accepted, K):
         if self._fused_shift_seed == "current":
@@ -276,9 +289,225 @@ class SpeculativeDecoder:
             t = ttnn.to_torch(logits)
         return t[..., : self.target.vocab_size]
 
+    # ── packed-query verify ──────────────────────────────────────────────
+    def _pv_setup(self):
+        """Lazy one-time setup for the packed verify: allocate per-layer hot-
+        block staging buffers (non-KV-shared layers only) and stash the shape
+        constants the host-side index/mask builders need."""
+        if self._pv_ready:
+            return
+        from models.demos.gemma4.tt.attention.kv_cache import PV_HOT_BLOCKS, init_kv_staging
+
+        target = self.target
+        # Paged cache shape: [max_blocks, nkv_local, block_size, head_dim].
+        self._pv_bs = int(self.tt_kv_cache[0][0].padded_shape[2])
+        self._pv_blk = PV_HOT_BLOCKS
+        self._pv_s2 = self._pv_blk * self._pv_bs
+        tp = self._tp
+        first_cfg = target.layers[0].self_attn.config
+        self._pv_h_local = first_cfg.num_attention_heads // tp
+        self._pv_window = target.hf_config.sliding_window
+        self._pv_nkv = {}  # layer_type -> nkv_local (staging/cache head count)
+        for i, layer in enumerate(target.layers):
+            cfg = layer.self_attn.config
+            if cfg.cache_position_modulo is not None:
+                raise NotImplementedError("packed verify does not support bounded sliding KV caches")
+            if i in target.kv_shared_layer_map:
+                continue  # shares source layer's cache+staging; skips KV writes
+            layer.self_attn.kv_staging = init_kv_staging(
+                self.mesh_device, cfg, max_batch_size=1, block_size=self._pv_bs, blk=self._pv_blk
+            )
+            lt = target.hf_config.layer_types[i]
+            self._pv_nkv[lt] = int(layer.self_attn.kv_staging[0].shape[1])
+        self._pv_pages = (
+            self.page_table_torch[0] if self.page_table_torch.dim() > 1 else self.page_table_torch
+        ).to(torch.int64)
+        self._pv_ready = True
+
+    def _pv_seed_staging(self, c):
+        """Seed every layer's staging block-slot 0 with the committed content of
+        the hot block at position ``c`` (read from the cache — the only
+        committed-cache read in the design, once per generation)."""
+        bs, S2 = self._pv_bs, self._pv_s2
+        a = c // bs
+        self._pv_a_prev = a
+        if c % bs == 0:
+            return  # fresh block — zeros are fine
+        blk_phys = int(self._pv_pages[a])
+        for i, layer in enumerate(self.target.layers):
+            if i in self.target.kv_shared_layer_map:
+                continue
+            staging = layer.self_attn.kv_staging
+            cache = self.tt_kv_cache[i]
+            for kv in (0, 1):
+                stg = staging[kv]
+                nkv, hd = stg.shape[1], stg.shape[3]
+                block = ttnn.slice(cache[kv], [blk_phys, 0, 0, 0], [blk_phys + 1, nkv, bs, hd])
+                tail = ttnn.slice(stg, [0, 0, bs, 0], [1, nkv, S2, hd])
+                rebuilt = ttnn.concat([block, tail], dim=2)
+                ttnn.assign(rebuilt, stg)
+                for t in (rebuilt, block, tail):
+                    ttnn.deallocate(t)
+
+    def _pv_host_inputs(self, c, P):
+        """Host tensors for one packed verify at anchor position ``c``.
+
+        Returns dict of torch tensors: pos [1,P]u32, masks [1,1,H*P,S_k] bf16
+        (full + sliding), embed_idx per layer type [1,nkv*S2]u32, hot_pt
+        [1,BLK]i32, and S_k.
+        """
+        bs, S2, BLK = self._pv_bs, self._pv_s2, self._pv_blk
+        a, off = c // bs, c % bs
+        roll = 1 if a == self._pv_a_prev + 1 else 0
+        H, W = self._pv_h_local, self._pv_window
+
+        pos = torch.arange(c, c + P, dtype=torch.int32).reshape(1, P)
+
+        # Additive masks, head-major rows h*P+p: causal upper bound c+p; sliding
+        # adds the window lower bound. S_k is bucket-padded for trace stability.
+        NEG = -1e9
+        S_k = ((c + P + self._pv_sk_bucket - 1) // self._pv_sk_bucket) * self._pv_sk_bucket
+        j = torch.arange(S_k)
+        rows_full = torch.empty(P, S_k)
+        rows_slide = torch.empty(P, S_k)
+        for p in range(P):
+            upper = c + p
+            rows_full[p] = torch.where(j <= upper, 0.0, NEG)
+            rows_slide[p] = torch.where((j <= upper) & (j > upper - W), 0.0, NEG)
+        mask_full = rows_full.repeat(H, 1).reshape(1, 1, H * P, S_k).to(torch.bfloat16)
+        mask_slide = rows_slide.repeat(H, 1).reshape(1, 1, H * P, S_k).to(torch.bfloat16)
+
+        # merge_idx over staging positions: committed prefix from staging
+        # (identity, or +bs on a rollover — the prefix came from the spill
+        # block), the P new rows from new_seq (concat index S2+p), stale tail
+        # identity. embed_idx bakes the per-head flattened row offset in
+        # (new_seq is padded to 32 rows in packed_decode_forward).
+        m = torch.arange(S2, dtype=torch.int64)
+        if roll:
+            m[:off] += bs
+        m[off : off + P] = S2 + torch.arange(P)
+        p_pad = ((P + 31) // 32) * 32
+        src_seq = S2 + p_pad
+        embed = {}
+        for lt, nkv in self._pv_nkv.items():
+            off_h = (torch.arange(nkv, dtype=torch.int64) * src_seq).unsqueeze(1)
+            embed[lt] = (m.unsqueeze(0) + off_h).reshape(1, nkv * S2).to(torch.int32)
+
+        hot = torch.full((1, BLK), -1, dtype=torch.int32)
+        hot[0, 0] = int(self._pv_pages[a])
+        if off + P > bs:
+            hot[0, 1] = int(self._pv_pages[a + 1])
+
+        return {"pos": pos, "mask_full": mask_full, "mask_slide": mask_slide, "embed": embed, "hot": hot, "S_k": S_k}
+
+    def _pv_from_torch(self, t, dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=True):
+        return ttnn.from_torch(
+            t,
+            device=self.mesh_device if device else None,
+            layout=layout,
+            dtype=dtype,
+            mesh_mapper=self._mapper,
+        )
+
+    def _pv_device_inputs(self, tokens, h):
+        """Device tensors for one packed verify from host dict ``h``."""
+        return {
+            "x": self._tokens_tensor(tokens),
+            "pos": self._pv_from_torch(h["pos"], ttnn.uint32),
+            "mask_full": self._pv_from_torch(h["mask_full"], ttnn.bfloat16, layout=ttnn.TILE_LAYOUT),
+            "mask_slide": self._pv_from_torch(h["mask_slide"], ttnn.bfloat16, layout=ttnn.TILE_LAYOUT),
+            "embed": {lt: self._pv_from_torch(e, ttnn.uint32) for lt, e in h["embed"].items()},
+            "hot": self._pv_from_torch(h["hot"], ttnn.int32),
+        }
+
+    def _pv_call(self, dev, P):
+        return self.target.ttnn_packed_verify_forward(
+            x=dev["x"],
+            position_idx=dev["pos"],
+            attn_mask_full=dev["mask_full"],
+            attn_mask_sliding=dev["mask_slide"],
+            packed_p=P,
+            page_table=dev.get("pt"),
+            kv_cache=self.tt_kv_cache,
+            embed_idx_full=dev["embed"].get("full_attention"),
+            embed_idx_sliding=dev["embed"].get("sliding_attention"),
+            hot_pt=dev["hot"],
+        )
+
+    def _verify_packed(self, tokens, positions):
+        """Packed verify (eager). Same contract as ``_verify``."""
+        self._pv_setup()
+        P = len(tokens)
+        c = positions[0]
+        if self._pv_a_prev < 0:
+            self._pv_seed_staging(c)
+        h = self._pv_host_inputs(c, P)
+        dev = self._pv_device_inputs(tokens, h)
+        dev["pt"] = self._page_table(1)
+        logits, hidden = self._pv_call(dev, P)
+        self._pv_a_prev = c // self._pv_bs
+        lh = self._logits_to_host(logits).reshape(P, -1)
+        logits.deallocate(True)
+        for t in (dev["x"], dev["pos"], dev["mask_full"], dev["mask_slide"], dev["hot"], dev["pt"]):
+            t.deallocate(True)
+        for e in dev["embed"].values():
+            e.deallocate(True)
+        return lh, hidden
+
+    def _verify_packed_traced(self, tokens, positions):
+        """Packed verify via trace, keyed by (P, S_k bucket). Persistent device
+        inputs are refreshed per step via copy_host_to_device_tensor; a new
+        trace is captured lazily when P or the S_k bucket changes."""
+        self._pv_setup()
+        P = len(tokens)
+        c = positions[0]
+        if self._pv_a_prev < 0:
+            self._pv_seed_staging(c)
+        h = self._pv_host_inputs(c, P)
+        key = (P, h["S_k"])
+        tr = self._pv_traces.get(key)
+        if tr is None:
+            dev = self._pv_device_inputs(tokens, h)
+            dev["pt"] = self._page_table(1)
+            # Compile run (warm program cache), then capture. Both runs write
+            # the SAME tokens to the SAME positions, so KV writes are idempotent.
+            logits, hidden = self._pv_call(dev, P)
+            ttnn.synchronize_device(self.mesh_device)
+            logits.deallocate(True)
+            hidden.deallocate(True)
+            tid = ttnn.begin_trace_capture(self.mesh_device, cq_id=0)
+            logits, hidden = self._pv_call(dev, P)
+            ttnn.end_trace_capture(self.mesh_device, tid, cq_id=0)
+            dev.update({"id": tid, "logits": logits, "hidden": hidden})
+            self._pv_traces[key] = dev
+        else:
+            ttnn.copy_host_to_device_tensor(self._host_tokens(tokens), tr["x"])
+            for src, dst in (
+                (self._pv_from_torch(h["pos"], ttnn.uint32, device=False), tr["pos"]),
+                (self._pv_from_torch(h["mask_full"], ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=False), tr["mask_full"]),
+                (self._pv_from_torch(h["mask_slide"], ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=False), tr["mask_slide"]),
+                (self._pv_from_torch(h["hot"], ttnn.int32, device=False), tr["hot"]),
+            ):
+                ttnn.copy_host_to_device_tensor(src, dst)
+            for lt, e in h["embed"].items():
+                ttnn.copy_host_to_device_tensor(self._pv_from_torch(e, ttnn.uint32, device=False), tr["embed"][lt])
+            ttnn.execute_trace(self.mesh_device, tr["id"], cq_id=0, blocking=False)
+        tr = self._pv_traces[key]
+        self._pv_a_prev = c // self._pv_bs
+        lh = self._logits_to_host(tr["logits"]).reshape(P, -1)
+        # Persistent hidden — caller must consume before the next replay.
+        return lh, tr["hidden"]
+
     # ── target forwards ───────────────────────────────────────────────────
     def _verify(self, tokens, positions):
         """Batched verify. Returns (logits_host [B,vocab], hidden_device [1,1,B,h])."""
+        # Packed-query verify: all K+1 candidates in one batch=1 pass (positions
+        # packed into the query-heads dim, loop-free staging KV write).
+        # Single-token calls (seed/reseed) keep the plain verify.
+        if len(tokens) > 1:
+            if self._use_trace:
+                return self._verify_packed_traced(tokens, positions)
+            return self._verify_packed(tokens, positions)
         # Tracing: BOTH the batch=1 verify (seed/reseed) and the batch=K+1
         # speculative verify capture + replay correctly. The per-candidate
         # sequential_kv_write loop (the race fix for the shared paged block) is
@@ -594,6 +823,7 @@ class SpeculativeDecoder:
         """
         if self._use_trace:
             return self._generate_fused_traced(anchor_token, anchor_pos, max_new_tokens)
+        self._pv_a_prev = -1  # re-seed packed-verify staging for the new anchor/request
         self._last_fused_setup_s = 0.0
         K = self.draft_len
         out, accepts = [], []
@@ -852,6 +1082,7 @@ class SpeculativeDecoder:
         """
         greedy = not temperature or temperature <= 0
         traced = self._use_trace
+        self._pv_a_prev = -1  # re-seed packed-verify staging for the new anchor/request
         out = []
         accepts = []
         # Own (and free) only what we allocate: a caller-provided anchor_hidden


### PR DESCRIPTION
### PR Category
Feature, Performance

### Summary

Stacked on top of #46508. Adds a **packed-query speculative verify** path for Gemma4.

Instead of verifying the `K+1` speculative candidates as `K+1` pseudo-users in the batch dim (the "batch-alias" approach, with sequential per-candidate KV writes), this packs the `P = K+1` positions into the **query-heads dimension** (`H_local*P` packed heads) and verifies them in **one forward pass**:

- **One pass for projection/norm/RoPE** — QKV projection, prefill-style head split, per-head RMSNorm, and RoPE all run once over the full `B*P` tensor rather than per-position.
- **One masked SDPA per layer** — a single non-causal `paged_scaled_dot_product_attention_decode` with an additive mask that bakes in each packed row's causal upper bound (and the sliding-window lower bound on sliding layers). Global-attention layers (head_dim 512) are optionally split head-wise across full-grid sub-ops to stay under the 1.5 MB L1 cap, sharing the paged K/V cache unsliced (valid for a single local KV head).
- **Loop-free KV write** — a persistent per-layer hot-block staging buffer is merged with the step's new K/V via a transpose-free `ttnn.embedding` row-gather and committed with a single `paged_fill_cache` per K/V. The committed cache is never read on the hot path, so write cost scales with the hot window (`PV_HOT_BLOCKS` blocks/slot), not `max_num_blocks`. A per-position `paged_update_cache` loop remains as a fallback when staging isn't wired.

The packed path becomes the default multi-token verify in `SpeculativeDecoder` (both eager and traced, keyed by `(P, S_k bucket)` so the trace shape stays stable as context grows). Single-token seed/reseed calls keep the plain batch=1 verify.

### Why this wins at scale (multi-batch + KV bandwidth)

Decode attention at long context is **KV-bandwidth-bound** — the cost is dominated by streaming the K/V cache from DRAM into SRAM.

- **Batch-alias verify** places the `K+1` candidates as separate batch rows, so each candidate independently re-reads the user's KV cache from DRAM. KV bandwidth scales as `(K+1) × seq_len` per user.
- **Packed verify** folds the `P = K+1` positions onto the query-heads dimension over a *single* row, so the user's KV cache is streamed DRAM→SRAM **once** and reused across all `P` packed query heads. KV bandwidth scales as `seq_len` per user — the read is **amortized across the P positions**.

This generalizes directly to **multi-batch verify**: with true batch `B` and `P` packed positions per user, packed KV reads scale as `B` (one read per user, reused across `P`) versus `B × P` for the batch-alias approach. Because the gap is in the bandwidth-bound term, the packed approach's advantage **grows with both batch size and sequence length** — so at larger batches and longer contexts it can deliver more throughput than the batch-alias approach. The current driver is wired for batch=1, but the attention/staging design carries straight over to `B > 1`.

### Notes for reviewers

Focus on the packed-verify decode path and the staging KV-write correctness:

```
models/demos/gemma4/tt/attention/decode.py        # packed_decode_forward + loop-free staging write
models/demos/gemma4/tt/attention/kv_cache.py      # init_kv_staging, PV_HOT_BLOCKS
models/demos/gemma4/tt/model.py                    # ttnn_packed_verify_forward
models/demos/gemma4/tt/spec_decode.py              # _verify_packed / _verify_packed_traced, staging bookkeeping
models/demos/gemma4/tests/unit/test_packed_verify.py
```

The current driver is limited to batch=1 and full (unbounded) sliding KV caches; `cache_position_modulo` (bounded sliding cache) raises `NotImplementedError`.

### Testing

`tests/unit/test_packed_verify.py` asserts the packed verify reproduces the sequential single-token verify chain position-for-position across several iterations (exercising staging rollovers across page boundaries). Requires `HF_MODEL` (target) set.

### Collaboration

Built in collaboration with [@CutieillFusion](https://github.com/CutieillFusion).
