### PR TITLE
[Cleanup] Route ZERO_RELU through direct HW mode

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_defs.h
@@ -127,25 +127,6 @@ struct ReluConfig
         return threshold;
     }
 
-    // Encoding written to the HW STACC_RELU_ApplyRelu (RELU_MODE) field.
-    // ZERO_RELU is folded into MIN_THRESHOLD_RELU (HW mode 2) with whatever threshold the
-    // ReluConfig was constructed with (always 0 via the public ::zero() factory). HW does
-    // support apply_relu=1 (sign-bit-exact ZERO_RELU) directly, but tt-sim does not yet
-    // model that path; see tenstorrent/ttsim#9 and tt-metal#45720 for the follow-up to
-    // route ZERO_RELU through HW mode 1 once tt-sim supports it.
-    constexpr std::uint32_t get_hw_mode() const
-    {
-        switch (mode)
-        {
-            case ReluType::NO_RELU:
-                return 0;
-            case ReluType::MAX_THRESHOLD_RELU:
-                return 3;
-            default:
-                return 2;
-        }
-    }
-
 private:
     constexpr ReluConfig(ReluType m, std::uint32_t t = 0) : mode(m), threshold(t)
     {

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -137,11 +137,12 @@ inline void set_dst_write_addr(const std::uint32_t tile_index)
  *
  * Writes the relu mode and threshold carried by the config to the STACC_RELU config register.
  *
- * @param relu_config: Relu configuration supplying the hardware mode and threshold to apply.
+ * @param relu_config: Relu configuration supplying the mode and threshold to apply.
  */
 TT_ALWAYS_INLINE void _llk_pack_relu_config_(const ckernel::ReluConfig& relu_config)
 {
-    const std::uint32_t val = (relu_config.get_threshold() << STACC_RELU_ReluThreshold_SHAMT) | (relu_config.get_hw_mode() << STACC_RELU_ApplyRelu_SHAMT);
+    const std::uint32_t mode = static_cast<std::uint32_t>(relu_config.get_mode());
+    const std::uint32_t val  = (relu_config.get_threshold() << STACC_RELU_ReluThreshold_SHAMT) | (mode << STACC_RELU_ApplyRelu_SHAMT);
     TTI_SETDMAREG(0, val & 0xffff, 0, LO_16(p_gpr_pack::TMP0));
     TTI_SETDMAREG(0, val >> 16, 0, HI_16(p_gpr_pack::TMP0));
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK | p_stall::THCON);

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack_common.h
@@ -143,8 +143,8 @@ TT_ALWAYS_INLINE void _llk_pack_relu_config_(const ckernel::ReluConfig& relu_con
 {
     const std::uint32_t mode = static_cast<std::uint32_t>(relu_config.get_mode());
     const std::uint32_t val  = (relu_config.get_threshold() << STACC_RELU_ReluThreshold_SHAMT) | (mode << STACC_RELU_ApplyRelu_SHAMT);
-    TTI_SETDMAREG(0, val & 0xffff, 0, LO_16(p_gpr_pack::TMP0));
-    TTI_SETDMAREG(0, val >> 16, 0, HI_16(p_gpr_pack::TMP0));
+    TT_SETDMAREG(0, val & 0xffff, 0, LO_16(p_gpr_pack::TMP0));
+    TT_SETDMAREG(0, val >> 16, 0, HI_16(p_gpr_pack::TMP0));
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK | p_stall::THCON);
     TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, STACC_RELU_ApplyRelu_ADDR32);
     TTI_NOP;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_defs.h
@@ -127,25 +127,6 @@ struct ReluConfig
         return threshold;
     }
 
-    // Encoding written to the HW STACC_RELU_ApplyRelu (RELU_MODE) field.
-    // ZERO_RELU is folded into MIN_THRESHOLD_RELU (HW mode 2) with whatever threshold the
-    // ReluConfig was constructed with (always 0 via the public ::zero() factory). HW does
-    // support apply_relu=1 (sign-bit-exact ZERO_RELU) directly, but tt-sim does not yet
-    // model that path; see tenstorrent/ttsim#9 and tt-metal#45720 for the follow-up to
-    // route ZERO_RELU through HW mode 1 once tt-sim supports it.
-    constexpr std::uint32_t get_hw_mode() const
-    {
-        switch (mode)
-        {
-            case ReluType::NO_RELU:
-                return 0;
-            case ReluType::MAX_THRESHOLD_RELU:
-                return 3;
-            default:
-                return 2;
-        }
-    }
-
 private:
     constexpr ReluConfig(ReluType m, std::uint32_t t = 0) : mode(m), threshold(t)
     {

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
@@ -201,8 +201,8 @@ TT_ALWAYS_INLINE void _llk_pack_relu_config_(const ckernel::ReluConfig& relu_con
 {
     const std::uint32_t mode = static_cast<std::uint32_t>(relu_config.get_mode());
     const std::uint32_t val  = (relu_config.get_threshold() << STACC_RELU_ReluThreshold_SHAMT) | (mode << STACC_RELU_ApplyRelu_SHAMT);
-    TTI_SETDMAREG(0, val & 0xffff, 0, LO_16(p_gpr_pack::TMP0));
-    TTI_SETDMAREG(0, val >> 16, 0, HI_16(p_gpr_pack::TMP0));
+    TT_SETDMAREG(0, val & 0xffff, 0, LO_16(p_gpr_pack::TMP0));
+    TT_SETDMAREG(0, val >> 16, 0, HI_16(p_gpr_pack::TMP0));
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
     TTI_WRCFG(p_gpr_pack::TMP0, p_cfg::WRCFG_32b, STACC_RELU_ApplyRelu_ADDR32);
     TTI_NOP;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_common.h
@@ -193,14 +193,14 @@ inline void set_dst_write_addr(const std::uint32_t tile_index)
 /**
  * @brief Configure the packer relu mode and threshold.
  *
- * Decodes the relu config into a hardware relu mode (none / min-threshold / max-threshold) and
- * threshold value and writes it to the STACC_RELU config register.
+ * Writes the relu mode and threshold carried by the config to the STACC_RELU config register.
  *
- * @param relu_config: Relu configuration carrying the hardware relu mode and threshold value.
+ * @param relu_config: Relu configuration carrying the mode and threshold value.
  */
 TT_ALWAYS_INLINE void _llk_pack_relu_config_(const ckernel::ReluConfig& relu_config)
 {
-    const std::uint32_t val = (relu_config.get_threshold() << STACC_RELU_ReluThreshold_SHAMT) | (relu_config.get_hw_mode() << STACC_RELU_ApplyRelu_SHAMT);
+    const std::uint32_t mode = static_cast<std::uint32_t>(relu_config.get_mode());
+    const std::uint32_t val  = (relu_config.get_threshold() << STACC_RELU_ReluThreshold_SHAMT) | (mode << STACC_RELU_ApplyRelu_SHAMT);
     TTI_SETDMAREG(0, val & 0xffff, 0, LO_16(p_gpr_pack::TMP0));
     TTI_SETDMAREG(0, val >> 16, 0, HI_16(p_gpr_pack::TMP0));
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);


### PR DESCRIPTION
### PR Category
Cleanup
### Summary
Route `ReluConfig::zero()` through the direct HW `ZERO_RELU` mode in BH/WH `_llk_pack_relu_config_` now that tt-sim supports `apply_relu=1`.
This removes the temporary compatibility remap added while `tenstorrent/ttsim#9` was open, so BH/WH match Quasar and `_llk_pack_hw_configure_` by programming the `STACC_RELU_ApplyRelu` field directly.
Closes #45720
Refs tenstorrent/ttsim#9
### Notes for reviewers
Please focus on the BH/WH packer relu config path. `ReluConfig::zero()` now writes HW mode `1` instead of being folded into `MIN_THRESHOLD_RELU(0)`, preserving the sign-bit-exact ZERO_RELU behavior described in #45720.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/refactor_relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/refactor_relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/refactor_relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/refactor_relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/refactor_relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/refactor_relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/refactor_relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/refactor_relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/refactor_relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/refactor_relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/refactor_relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/refactor_relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/refactor_relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/refactor_relu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/refactor_relu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/refactor_relu)