### PR TITLE
[feature] Harden reflection support to metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -66,7 +66,7 @@ using test_helpers::MakeShardedTensorParameter;
 using test_helpers::ScopedSlowDispatchOverride;
 
 // ============================================================================
-// Compile-time: ProgramSpec and its subcomponents are hashable via ttsl reflection
+// Reflection: ProgramSpec and its subcomponents are hashable via ttsl reflection
 // ============================================================================
 //
 // ttsl::hash (tt_stl/reflection.hpp) hashes a plain aggregate by reflecting over its fields
@@ -122,6 +122,18 @@ static_assert(hashable_v<DFBAdvancedOptions>, "DFBAdvancedOptions must be hashab
 static_assert(hashable_v<SemaphoreAdvancedOptions>, "SemaphoreAdvancedOptions must be hashable via ttsl reflection");
 static_assert(
     hashable_v<TensorParameterAdvancedOptions>, "TensorParameterAdvancedOptions must be hashable via ttsl reflection");
+
+TEST(ProgramSpecReflectionTest, IsHashable) {
+    const ProgramSpec spec = MakeMinimalValidProgramSpec();
+
+    // Deterministic: hashing the same spec twice yields the same value.
+    EXPECT_EQ(ttsl::hash::hash_objects_with_default_seed(spec), ttsl::hash::hash_objects_with_default_seed(spec));
+
+    // Sensitive: changing a field changes the hash.
+    ProgramSpec modified = spec;
+    modified.name += "_v2";
+    EXPECT_NE(ttsl::hash::hash_objects_with_default_seed(spec), ttsl::hash::hash_objects_with_default_seed(modified));
+}
 
 // ============================================================================
 // Test Fixtures

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -35,6 +35,7 @@
 
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program.hpp>
+#include <tt_stl/reflection.hpp>
 #include "impl/host_api/temp_quasar_api.hpp"  // for QuasarComputeConfig
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
@@ -63,6 +64,64 @@ using test_helpers::MakeMinimalValidProgramSpec;
 using test_helpers::MakeMinimalWorkUnit;
 using test_helpers::MakeShardedTensorParameter;
 using test_helpers::ScopedSlowDispatchOverride;
+
+// ============================================================================
+// Compile-time: ProgramSpec and its subcomponents are hashable via ttsl reflection
+// ============================================================================
+//
+// ttsl::hash (tt_stl/reflection.hpp) hashes a plain aggregate by reflecting over its fields
+// and recursing into each one. These checks pin that the whole ProgramSpec tree stays
+// hashable: if a future change adds a field ttsl::hash can't handle (or makes one of these
+// structs non-aggregate), the build breaks here rather than at some distant call site.
+//
+// This can't be a requires-expression. ttsl::hash::hash_object is an unconstrained template
+// whose "unsupported type" case is a static_assert in the function *body*, so the call is
+// always well-formed and unhashability only surfaces once the body is instantiated. hash_one
+// is never called; taking its address ODR-uses it, which forces that instantiation — and the
+// recursion through T's fields — at compile time.
+template <typename T>
+ttsl::hash::hash_t hash_one(const T& value) {
+    return ttsl::hash::hash_objects_with_default_seed(value);
+}
+template <typename T>
+inline constexpr bool hashable_v = (static_cast<void>(&hash_one<T>), true);
+
+// Top-level specs
+static_assert(hashable_v<ProgramSpec>, "ProgramSpec must be hashable via ttsl reflection");
+static_assert(hashable_v<WorkUnitSpec>, "WorkUnitSpec must be hashable via ttsl reflection");
+static_assert(hashable_v<KernelSpec>, "KernelSpec must be hashable via ttsl reflection");
+static_assert(hashable_v<DataflowBufferSpec>, "DataflowBufferSpec must be hashable via ttsl reflection");
+static_assert(hashable_v<RemoteDataflowBufferSpec>, "RemoteDataflowBufferSpec must be hashable via ttsl reflection");
+static_assert(hashable_v<SemaphoreSpec>, "SemaphoreSpec must be hashable via ttsl reflection");
+static_assert(hashable_v<TensorParameter>, "TensorParameter must be hashable via ttsl reflection");
+
+// KernelSpec subcomponents
+static_assert(hashable_v<KernelSpec::SourceCode>, "KernelSpec::SourceCode must be hashable via ttsl reflection");
+static_assert(
+    hashable_v<KernelSpec::CompilerOptions>, "KernelSpec::CompilerOptions must be hashable via ttsl reflection");
+static_assert(
+    hashable_v<KernelSpec::RuntimeArgSchema>, "KernelSpec::RuntimeArgSchema must be hashable via ttsl reflection");
+static_assert(hashable_v<DFBBinding>, "DFBBinding must be hashable via ttsl reflection");
+static_assert(hashable_v<SemaphoreBinding>, "SemaphoreBinding must be hashable via ttsl reflection");
+static_assert(hashable_v<TensorBinding>, "TensorBinding must be hashable via ttsl reflection");
+
+// Kernel hardware configs
+static_assert(
+    hashable_v<DataMovementHardwareConfig>, "DataMovementHardwareConfig must be hashable via ttsl reflection");
+static_assert(
+    hashable_v<DataMovementHardwareConfig::Gen1Config>,
+    "DataMovementHardwareConfig::Gen1Config must be hashable via ttsl reflection");
+static_assert(
+    hashable_v<DataMovementHardwareConfig::Gen2Config>,
+    "DataMovementHardwareConfig::Gen2Config must be hashable via ttsl reflection");
+static_assert(hashable_v<ComputeHardwareConfig>, "ComputeHardwareConfig must be hashable via ttsl reflection");
+
+// Per-spec advanced options
+static_assert(hashable_v<KernelAdvancedOptions>, "KernelAdvancedOptions must be hashable via ttsl reflection");
+static_assert(hashable_v<DFBAdvancedOptions>, "DFBAdvancedOptions must be hashable via ttsl reflection");
+static_assert(hashable_v<SemaphoreAdvancedOptions>, "SemaphoreAdvancedOptions must be hashable via ttsl reflection");
+static_assert(
+    hashable_v<TensorParameterAdvancedOptions>, "TensorParameterAdvancedOptions must be hashable via ttsl reflection");
 
 // ============================================================================
 // Test Fixtures

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
@@ -289,4 +289,56 @@ TEST(TableMiscTest, IntKeyStringValue) {
     EXPECT_FALSE(t.get(3));
 }
 
+// ---- contains ----------------------------------------------------------------
+
+TEST(TableTest, ContainsReturnsTrueForPresentKey) {
+    StrIntTable t{{"a", 1}, {"b", 2}};
+    EXPECT_TRUE(t.contains("a"));
+    EXPECT_TRUE(t.contains("b"));
+}
+
+TEST(TableTest, ContainsReturnsFalseForAbsentKey) {
+    StrIntTable t{{"a", 1}};
+    EXPECT_FALSE(t.contains("missing"));
+    EXPECT_FALSE(t.contains(""));
+}
+
+TEST(TableTest, ContainsOnEmptyTable) {
+    StrIntTable t;
+    EXPECT_FALSE(t.contains("anything"));
+}
+
+TEST(TableTest, ContainsReflectsInsertAndErase) {
+    StrIntTable t;
+    EXPECT_FALSE(t.contains("a"));
+    t.insert({"a", 1});
+    EXPECT_TRUE(t.contains("a"));
+    t.erase("a");
+    EXPECT_FALSE(t.contains("a"));
+}
+
+TEST(TableTest, ContainsWorksOnConstTable) {
+    const StrIntTable t{{"a", 1}, {"b", 2}};
+    EXPECT_TRUE(t.contains("a"));
+    EXPECT_FALSE(t.contains("z"));
+}
+
+TEST(TableTest, ContainsDoesNotMutateTable) {
+    StrIntTable t{{"a", 1}, {"b", 2}};
+    const auto size_before = t.size();
+    t.contains("a");
+    t.contains("missing");
+    EXPECT_EQ(t.size(), size_before);
+}
+
+TEST(TableMiscTest, ContainsWithIntKey) {
+    m2::Table<int, std::string> t;
+    t[1] = "one";
+    t.emplace(2, "two");
+    EXPECT_TRUE(t.contains(1));
+    EXPECT_TRUE(t.contains(2));
+    EXPECT_FALSE(t.contains(3));
+    EXPECT_FALSE(t.contains(0));
+}
+
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
@@ -397,7 +397,7 @@ TEST(TableHashTest, DifferentSizeChangesHash) {
 
 TEST(TableHashTest, HashIsOrderIndependent) {
     // Two tables that compare equal but were built in opposite order must hash equally:
-    // to_hash() folds the per-entry hashes in sorted order, so insertion order drops out
+    // std::hash<Table> folds the per-entry hashes in sorted order, so insertion order drops out
     // (consistent with operator==, which ignores order).
     StrIntTable a;
     a["x"] = 1;

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
@@ -344,11 +344,6 @@ TEST(TableMiscTest, ContainsWithIntKey) {
 }
 
 // ---- reflection-based hashing (tt_stl/reflection.hpp) ------------------------
-//
-// Table opts into ttsl reflection through attribute_names / attribute_values(),
-// so ttsl::hash can hash it and it can be nested inside other reflected types.
-// The hash is taken over the underlying entries vector, so it follows insertion
-// order — unlike operator==, which is order independent (see HashFollowsInsertionOrder).
 
 // Canonical hash entry point (matches how reflected structs hash themselves).
 template <typename T>
@@ -400,10 +395,10 @@ TEST(TableHashTest, DifferentSizeChangesHash) {
     EXPECT_NE(hash_of(small), hash_of(big));
 }
 
-TEST(TableHashTest, HashFollowsInsertionOrder) {
-    // Two tables that compare equal but were built in opposite order. Because the
-    // reflected hash is taken over the underlying entries vector, the hashes
-    // differ even though operator== treats the tables as equal.
+TEST(TableHashTest, HashIsOrderIndependent) {
+    // Two tables that compare equal but were built in opposite order must hash equally:
+    // to_hash() folds the per-entry hashes in sorted order, so insertion order drops out
+    // (consistent with operator==, which ignores order).
     StrIntTable a;
     a["x"] = 1;
     a["y"] = 2;
@@ -411,7 +406,7 @@ TEST(TableHashTest, HashFollowsInsertionOrder) {
     b["y"] = 2;
     b["x"] = 1;
     ASSERT_EQ(a, b);
-    EXPECT_NE(hash_of(a), hash_of(b));
+    EXPECT_EQ(hash_of(a), hash_of(b));
 }
 
 TEST(TableHashTest, NonStringKeyValueHashes) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
@@ -14,12 +14,43 @@
 #include <iterator>
 #include <map>
 #include <span>
+#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
+#include <tt_stl/reflection.hpp>
+
 #include <tt-metalium/experimental/metal2_host_api/utility/table.hpp>
+
+// ttsl JSON specializations for Table<K,V>.
+// These live here (not in table.hpp) to avoid pulling reflection.hpp into a public API header.
+namespace ttsl::json {
+
+template <typename K, typename V>
+struct to_json_t<tt::tt_metal::experimental::Table<K, V>> {
+    nlohmann::json operator()(const tt::tt_metal::experimental::Table<K, V>& table) {
+        nlohmann::json json_object = nlohmann::json::object();
+        for (const auto& [key, value] : table) {
+            json_object[to_json(key).dump()] = to_json(value);
+        }
+        return json_object;
+    }
+};
+
+template <typename K, typename V>
+struct from_json_t<tt::tt_metal::experimental::Table<K, V>> {
+    tt::tt_metal::experimental::Table<K, V> operator()(const nlohmann::json& json_object) {
+        tt::tt_metal::experimental::Table<K, V> table;
+        for (const auto& [key, value] : json_object.items()) {
+            table.insert({from_json<K>(nlohmann::json::parse(key)), from_json<V>(value)});
+        }
+        return table;
+    }
+};
+
+}  // namespace ttsl::json
 
 namespace {
 
@@ -339,6 +370,73 @@ TEST(TableMiscTest, ContainsWithIntKey) {
     EXPECT_TRUE(t.contains(2));
     EXPECT_FALSE(t.contains(3));
     EXPECT_FALSE(t.contains(0));
+}
+
+// ---- ttsl reflection: operator<< -------------------------------------------
+
+TEST(TableTest, StreamOutputEmptyTable) {
+    StrIntTable t;
+    std::ostringstream os;
+    os << t;
+    EXPECT_EQ(os.str(), "{}");
+}
+
+TEST(TableTest, StreamOutputContainsKeyAndValue) {
+    StrIntTable t{{"hello", 42}};
+    std::ostringstream os;
+    os << t;
+    const std::string s = os.str();
+    EXPECT_NE(s.find("hello"), std::string::npos);
+    EXPECT_NE(s.find("42"), std::string::npos);
+}
+
+// ---- ttsl reflection: hash --------------------------------------------------
+
+TEST(TableTest, HashIsConsistent) {
+    StrIntTable t{{"a", 1}, {"b", 2}};
+    EXPECT_EQ(ttsl::hash::detail::hash_object(t), ttsl::hash::detail::hash_object(t));
+}
+
+TEST(TableTest, HashIsOrderIndependent) {
+    StrIntTable a{{"a", 1}, {"b", 2}};
+    StrIntTable b;
+    b["b"] = 2;
+    b["a"] = 1;  // inserted in opposite order
+    EXPECT_EQ(ttsl::hash::detail::hash_object(a), ttsl::hash::detail::hash_object(b));
+}
+
+TEST(TableTest, HashDistinguishesDifferentValues) {
+    StrIntTable a{{"a", 1}, {"b", 2}};
+    StrIntTable b{{"a", 1}, {"b", 99}};
+    EXPECT_NE(ttsl::hash::detail::hash_object(a), ttsl::hash::detail::hash_object(b));
+}
+
+TEST(TableTest, HashDistinguishesDifferentKeys) {
+    StrIntTable a{{"a", 1}};
+    StrIntTable b{{"z", 1}};
+    EXPECT_NE(ttsl::hash::detail::hash_object(a), ttsl::hash::detail::hash_object(b));
+}
+
+TEST(TableTest, HashEmptyTableIsZero) {
+    StrIntTable t;
+    EXPECT_EQ(ttsl::hash::detail::hash_object(t), 0u);
+}
+
+// ---- ttsl reflection: to_json / from_json -----------------------------------
+
+TEST(TableTest, JsonRoundtrip) {
+    StrIntTable original{{"a", 1}, {"b", 2}, {"c", 3}};
+    const auto json = ttsl::json::to_json(original);
+    const auto deserialized = ttsl::json::from_json<StrIntTable>(json);
+    EXPECT_EQ(original, deserialized);
+}
+
+TEST(TableTest, JsonEmptyTableRoundtrip) {
+    StrIntTable original;
+    const auto json = ttsl::json::to_json(original);
+    const auto deserialized = ttsl::json::from_json<StrIntTable>(json);
+    EXPECT_EQ(original, deserialized);
+    EXPECT_TRUE(deserialized.empty());
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
@@ -350,11 +350,6 @@ TEST(TableMiscTest, ContainsWithIntKey) {
 // The hash is taken over the underlying entries vector, so it follows insertion
 // order — unlike operator==, which is order independent (see HashFollowsInsertionOrder).
 
-// Compile-time: Table advertises the reflection attribute hooks hash_object uses.
-static_assert(
-    ttsl::reflection::detail::supports_compile_time_attributes_v<StrIntTable>,
-    "Table must expose attribute_names / attribute_values() for ttsl reflection");
-
 // Canonical hash entry point (matches how reflected structs hash themselves).
 template <typename T>
 ttsl::hash::hash_t hash_of(const T& object) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
@@ -15,11 +15,13 @@
 #include <map>
 #include <span>
 #include <string>
+#include <tuple>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
 #include <tt-metalium/experimental/metal2_host_api/utility/table.hpp>
+#include <tt_stl/reflection.hpp>
 
 namespace {
 
@@ -326,8 +328,8 @@ TEST(TableTest, ContainsWorksOnConstTable) {
 TEST(TableTest, ContainsDoesNotMutateTable) {
     StrIntTable t{{"a", 1}, {"b", 2}};
     const auto size_before = t.size();
-    t.contains("a");
-    t.contains("missing");
+    EXPECT_TRUE(t.contains("a"));
+    EXPECT_FALSE(t.contains("missing"));
     EXPECT_EQ(t.size(), size_before);
 }
 
@@ -339,6 +341,109 @@ TEST(TableMiscTest, ContainsWithIntKey) {
     EXPECT_TRUE(t.contains(2));
     EXPECT_FALSE(t.contains(3));
     EXPECT_FALSE(t.contains(0));
+}
+
+// ---- reflection-based hashing (tt_stl/reflection.hpp) ------------------------
+//
+// Table opts into ttsl reflection through attribute_names / attribute_values(),
+// so ttsl::hash can hash it and it can be nested inside other reflected types.
+// The hash is taken over the underlying entries vector, so it follows insertion
+// order — unlike operator==, which is order independent (see HashFollowsInsertionOrder).
+
+// Compile-time: Table advertises the reflection attribute hooks hash_object uses.
+static_assert(
+    ttsl::reflection::detail::supports_compile_time_attributes_v<StrIntTable>,
+    "Table must expose attribute_names / attribute_values() for ttsl reflection");
+
+// Canonical hash entry point (matches how reflected structs hash themselves).
+template <typename T>
+ttsl::hash::hash_t hash_of(const T& object) {
+    return ttsl::hash::hash_objects_with_default_seed(object);
+}
+
+// A reflected struct that holds a Table, to exercise Table as a nested field
+// (its real use in the Metal 2.0 host API). Must live at namespace scope because
+// a local class can't have the static attribute_names member.
+struct TaggedTable {
+    int tag = 0;
+    StrIntTable table;
+
+    static constexpr auto attribute_names = std::forward_as_tuple("tag", "table");
+    auto attribute_values() const { return std::forward_as_tuple(tag, table); }
+};
+
+TEST(TableHashTest, HashIsDeterministic) {
+    StrIntTable t{{"a", 1}, {"b", 2}};
+    EXPECT_EQ(hash_of(t), hash_of(t));  // same object hashes identically every time
+}
+
+TEST(TableHashTest, EqualTablesHashEqual) {
+    StrIntTable a{{"a", 1}, {"b", 2}, {"c", 3}};
+    StrIntTable b{{"a", 1}, {"b", 2}, {"c", 3}};
+    ASSERT_EQ(a, b);
+    EXPECT_EQ(hash_of(a), hash_of(b));
+}
+
+TEST(TableHashTest, EmptyTables) {
+    EXPECT_EQ(hash_of(StrIntTable{}), hash_of(StrIntTable{}));
+    EXPECT_NE(hash_of(StrIntTable{}), hash_of(StrIntTable{{"a", 1}}));
+}
+
+TEST(TableHashTest, DifferentValueChangesHash) {
+    StrIntTable base{{"a", 1}, {"b", 2}};
+    StrIntTable diff{{"a", 1}, {"b", 99}};
+    EXPECT_NE(hash_of(base), hash_of(diff));
+}
+
+TEST(TableHashTest, DifferentKeyChangesHash) {
+    EXPECT_NE(hash_of(StrIntTable{{"a", 1}}), hash_of(StrIntTable{{"z", 1}}));
+}
+
+TEST(TableHashTest, DifferentSizeChangesHash) {
+    StrIntTable small{{"a", 1}};
+    StrIntTable big{{"a", 1}, {"b", 2}};
+    EXPECT_NE(hash_of(small), hash_of(big));
+}
+
+TEST(TableHashTest, HashFollowsInsertionOrder) {
+    // Two tables that compare equal but were built in opposite order. Because the
+    // reflected hash is taken over the underlying entries vector, the hashes
+    // differ even though operator== treats the tables as equal.
+    StrIntTable a;
+    a["x"] = 1;
+    a["y"] = 2;
+    StrIntTable b;
+    b["y"] = 2;
+    b["x"] = 1;
+    ASSERT_EQ(a, b);
+    EXPECT_NE(hash_of(a), hash_of(b));
+}
+
+TEST(TableHashTest, NonStringKeyValueHashes) {
+    // Reflection recurses into K and V, so any hashable key/value type works.
+    m2::Table<int, std::string> a;
+    a[1] = "one";
+    a[2] = "two";
+    m2::Table<int, std::string> same;
+    same[1] = "one";
+    same[2] = "two";
+    EXPECT_EQ(hash_of(a), hash_of(same));
+    EXPECT_NE(hash_of(a), hash_of(m2::Table<int, std::string>{{1, "one"}}));
+}
+
+TEST(TableHashTest, NestedInReflectedStruct) {
+    TaggedTable a{.tag = 7, .table = {{"a", 1}, {"b", 2}}};
+    TaggedTable b{.tag = 7, .table = {{"a", 1}, {"b", 2}}};
+    EXPECT_EQ(hash_of(a), hash_of(b));
+
+    TaggedTable diff_tag{.tag = 8, .table = {{"a", 1}, {"b", 2}}};
+    EXPECT_NE(hash_of(a), hash_of(diff_tag));
+
+    TaggedTable diff_table{.tag = 7, .table = {{"a", 1}, {"b", 3}}};
+    EXPECT_NE(hash_of(a), hash_of(diff_table));
+
+    // The Table is reachable as a named attribute of the enclosing reflected type.
+    EXPECT_STREQ(std::get<1>(TaggedTable::attribute_names), "table");
 }
 
 }  // namespace

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_table.cpp
@@ -14,43 +14,12 @@
 #include <iterator>
 #include <map>
 #include <span>
-#include <sstream>
 #include <string>
 #include <unordered_map>
 #include <utility>
 #include <vector>
 
-#include <tt_stl/reflection.hpp>
-
 #include <tt-metalium/experimental/metal2_host_api/utility/table.hpp>
-
-// ttsl JSON specializations for Table<K,V>.
-// These live here (not in table.hpp) to avoid pulling reflection.hpp into a public API header.
-namespace ttsl::json {
-
-template <typename K, typename V>
-struct to_json_t<tt::tt_metal::experimental::Table<K, V>> {
-    nlohmann::json operator()(const tt::tt_metal::experimental::Table<K, V>& table) {
-        nlohmann::json json_object = nlohmann::json::object();
-        for (const auto& [key, value] : table) {
-            json_object[to_json(key).dump()] = to_json(value);
-        }
-        return json_object;
-    }
-};
-
-template <typename K, typename V>
-struct from_json_t<tt::tt_metal::experimental::Table<K, V>> {
-    tt::tt_metal::experimental::Table<K, V> operator()(const nlohmann::json& json_object) {
-        tt::tt_metal::experimental::Table<K, V> table;
-        for (const auto& [key, value] : json_object.items()) {
-            table.insert({from_json<K>(nlohmann::json::parse(key)), from_json<V>(value)});
-        }
-        return table;
-    }
-};
-
-}  // namespace ttsl::json
 
 namespace {
 
@@ -370,73 +339,6 @@ TEST(TableMiscTest, ContainsWithIntKey) {
     EXPECT_TRUE(t.contains(2));
     EXPECT_FALSE(t.contains(3));
     EXPECT_FALSE(t.contains(0));
-}
-
-// ---- ttsl reflection: operator<< -------------------------------------------
-
-TEST(TableTest, StreamOutputEmptyTable) {
-    StrIntTable t;
-    std::ostringstream os;
-    os << t;
-    EXPECT_EQ(os.str(), "{}");
-}
-
-TEST(TableTest, StreamOutputContainsKeyAndValue) {
-    StrIntTable t{{"hello", 42}};
-    std::ostringstream os;
-    os << t;
-    const std::string s = os.str();
-    EXPECT_NE(s.find("hello"), std::string::npos);
-    EXPECT_NE(s.find("42"), std::string::npos);
-}
-
-// ---- ttsl reflection: hash --------------------------------------------------
-
-TEST(TableTest, HashIsConsistent) {
-    StrIntTable t{{"a", 1}, {"b", 2}};
-    EXPECT_EQ(ttsl::hash::detail::hash_object(t), ttsl::hash::detail::hash_object(t));
-}
-
-TEST(TableTest, HashIsOrderIndependent) {
-    StrIntTable a{{"a", 1}, {"b", 2}};
-    StrIntTable b;
-    b["b"] = 2;
-    b["a"] = 1;  // inserted in opposite order
-    EXPECT_EQ(ttsl::hash::detail::hash_object(a), ttsl::hash::detail::hash_object(b));
-}
-
-TEST(TableTest, HashDistinguishesDifferentValues) {
-    StrIntTable a{{"a", 1}, {"b", 2}};
-    StrIntTable b{{"a", 1}, {"b", 99}};
-    EXPECT_NE(ttsl::hash::detail::hash_object(a), ttsl::hash::detail::hash_object(b));
-}
-
-TEST(TableTest, HashDistinguishesDifferentKeys) {
-    StrIntTable a{{"a", 1}};
-    StrIntTable b{{"z", 1}};
-    EXPECT_NE(ttsl::hash::detail::hash_object(a), ttsl::hash::detail::hash_object(b));
-}
-
-TEST(TableTest, HashEmptyTableIsZero) {
-    StrIntTable t;
-    EXPECT_EQ(ttsl::hash::detail::hash_object(t), 0u);
-}
-
-// ---- ttsl reflection: to_json / from_json -----------------------------------
-
-TEST(TableTest, JsonRoundtrip) {
-    StrIntTable original{{"a", 1}, {"b", 2}, {"c", 3}};
-    const auto json = ttsl::json::to_json(original);
-    const auto deserialized = ttsl::json::from_json<StrIntTable>(json);
-    EXPECT_EQ(original, deserialized);
-}
-
-TEST(TableTest, JsonEmptyTableRoundtrip) {
-    StrIntTable original;
-    const auto json = ttsl::json::to_json(original);
-    const auto deserialized = ttsl::json::from_json<StrIntTable>(json);
-    EXPECT_EQ(original, deserialized);
-    EXPECT_TRUE(deserialized.empty());
 }
 
 }  // namespace

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
@@ -11,6 +11,7 @@
 #include <iterator>
 #include <optional>
 #include <ranges>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
@@ -218,6 +219,10 @@ public:
         }
         return true;
     }
+
+    // This is to support ttnn hashing, this allows the Table to be hased as it's underlying storage.
+    static constexpr auto attribute_names = std::forward_as_tuple("entries");
+    auto attribute_values() const { return std::forward_as_tuple(entries_); }
 
 private:
     Storage entries_;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
@@ -10,10 +10,13 @@
 #include <initializer_list>
 #include <iterator>
 #include <optional>
+#include <ostream>
 #include <ranges>
 #include <type_traits>
 #include <utility>
 #include <vector>
+
+#include <functional>
 
 #include <tt_stl/assert.hpp>
 #include <tt_stl/optional_reference.hpp>
@@ -141,6 +144,34 @@ public:
 
     // Returns true if `key` is present in the table, false otherwise.
     [[nodiscard]] bool contains(const K& key) const { return find(key) != end(); }
+
+    // XOR-based order-independent hash (XOR is commutative → insertion order
+    // doesn't affect the result).  Picked up automatically by ttsl::hash::hash_object.
+    // Requires K and V to be std::hash-able.
+    [[nodiscard]] std::size_t to_hash() const noexcept {
+        std::size_t h = 0;
+        for (const auto& [k, v] : entries_) {
+            std::size_t kh = std::hash<K>{}(k);
+            std::size_t vh = std::hash<V>{}(v);
+            // Boost-style combine for the pair, then XOR for order-independence.
+            std::size_t pair_h = kh ^ (vh + 0x9e3779b9u + (kh << 6) + (kh >> 2));
+            h ^= pair_h;
+        }
+        return h;
+    }
+
+    // Stream output matching std::map's format in reflection.hpp: {k: v, k: v}.
+    friend std::ostream& operator<<(std::ostream& os, const Table& t) {
+        os << "{";
+        for (auto it = t.entries_.begin(); it != t.entries_.end(); ++it) {
+            os << it->first << ": " << it->second;
+            if (std::next(it) != t.entries_.end()) {
+                os << ", ";
+            }
+        }
+        os << "}";
+        return os;
+    }
 
     // Inserts an entry only if its key is absent. Returns {iterator to the entry,
     // true} when inserted, or {iterator to the existing entry, false} otherwise.

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <initializer_list>
 #include <iterator>
 #include <numeric>
@@ -19,10 +20,10 @@
 #include <tt_stl/assert.hpp>
 #include <tt_stl/optional_reference.hpp>
 
-// Forward declarations of the ttsl::hash entry points used by Table::to_hash(), so this header
-// need not pull in the (heavy) <tt_stl/reflection.hpp>. The definitions live there; any
-// translation unit that actually hashes a Table must include reflection.hpp so to_hash() can be
-// instantiated. These signatures must stay in sync with reflection.hpp.
+// Forward declarations of the ttsl::hash entry points used by the std::hash<Table> specialization
+// below, so this header need not pull in the (heavy) <tt_stl/reflection.hpp>. The definitions live
+// there; any translation unit that actually hashes a Table must include reflection.hpp so the
+// specialization can be instantiated. These signatures must stay in sync with reflection.hpp.
 namespace ttsl::hash {
 
 using hash_t = std::uint64_t;
@@ -236,13 +237,24 @@ public:
         return true;
     }
 
-    ttsl::hash::hash_t to_hash() const {
+private:
+    Storage entries_;
+};
+
+}  // namespace tt::tt_metal::experimental
+
+// Makes Table hashable via std::hash, and therefore via ttsl::hash, which dispatches to it. Like
+// operator==, the result ignores the entries' storage order. A translation unit that hashes a Table
+// must include <tt_stl/reflection.hpp> so this specialization can be instantiated.
+template <typename K, typename V>
+struct std::hash<tt::tt_metal::experimental::Table<K, V>> {
+    std::size_t operator()(const tt::tt_metal::experimental::Table<K, V>& table) const {
         using ttsl::hash::hash_t;
 
         // Hash each entry on its own, recursing through K and V via ttsl::hash.
         std::vector<hash_t> entry_hashes;
-        entry_hashes.reserve(entries_.size());
-        for (const auto& entry : entries_) {
+        entry_hashes.reserve(table.size());
+        for (const auto& entry : table) {
             entry_hashes.push_back(ttsl::hash::hash_objects(hash_t{0}, entry));
         }
 
@@ -255,9 +267,4 @@ public:
                 return seed;
             });
     }
-
-private:
-    Storage entries_;
 };
-
-}  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
@@ -5,19 +5,35 @@
 #pragma once
 
 #include <algorithm>
-#include <concepts>
 #include <cstddef>
+#include <cstdint>
 #include <initializer_list>
 #include <iterator>
+#include <numeric>
 #include <optional>
 #include <ranges>
-#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>
 
 #include <tt_stl/assert.hpp>
 #include <tt_stl/optional_reference.hpp>
+
+// Forward declarations of the ttsl::hash entry points used by Table::to_hash(), so this header
+// need not pull in the (heavy) <tt_stl/reflection.hpp>. The definitions live there; any
+// translation unit that actually hashes a Table must include reflection.hpp so to_hash() can be
+// instantiated. These signatures must stay in sync with reflection.hpp.
+namespace ttsl::hash {
+
+using hash_t = std::uint64_t;
+
+template <typename... Types>
+hash_t hash_objects(hash_t seed, const Types&... args) noexcept;  // NOLINT(readability-redundant-declaration)
+
+template <typename T>
+void hash_combine(std::size_t& seed, const T& value);  // NOLINT(readability-redundant-declaration)
+
+}  // namespace ttsl::hash
 
 namespace tt::tt_metal::experimental {
 
@@ -220,9 +236,25 @@ public:
         return true;
     }
 
-    // This is to support ttnn hashing, this allows the Table to be hased as it's underlying storage.
-    static constexpr auto attribute_names = std::forward_as_tuple("entries");
-    auto attribute_values() const { return std::forward_as_tuple(entries_); }
+    ttsl::hash::hash_t to_hash() const {
+        using ttsl::hash::hash_t;
+
+        // Hash each entry on its own, recursing through K and V via ttsl::hash.
+        std::vector<hash_t> entry_hashes;
+        entry_hashes.reserve(entries_.size());
+        for (const auto& entry : entries_) {
+            entry_hashes.push_back(ttsl::hash::hash_objects(hash_t{0}, entry));
+        }
+
+        // Fold the per-entry hashes in sorted order, so the result is independent of the entries'
+        // storage order — consistent with operator==, which ignores order.
+        std::ranges::sort(entry_hashes);
+        return std::accumulate(
+            entry_hashes.begin(), entry_hashes.end(), std::size_t{0}, [](std::size_t seed, hash_t entry_hash) {
+                ttsl::hash::hash_combine(seed, entry_hash);
+                return seed;
+            });
+    }
 
 private:
     Storage entries_;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
@@ -139,6 +139,9 @@ public:
         return const_iterator{std::ranges::find(entries_, key, &Storage::value_type::first)};
     }
 
+    // Returns true if `key` is present in the table, false otherwise.
+    [[nodiscard]] bool contains(const K& key) const { return find(key) != end(); }
+
     // Inserts an entry only if its key is absent. Returns {iterator to the entry,
     // true} when inserted, or {iterator to the existing entry, false} otherwise.
     std::pair<iterator, bool> insert(const value_type& entry) {

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
@@ -10,13 +10,10 @@
 #include <initializer_list>
 #include <iterator>
 #include <optional>
-#include <ostream>
 #include <ranges>
 #include <type_traits>
 #include <utility>
 #include <vector>
-
-#include <functional>
 
 #include <tt_stl/assert.hpp>
 #include <tt_stl/optional_reference.hpp>
@@ -144,34 +141,6 @@ public:
 
     // Returns true if `key` is present in the table, false otherwise.
     [[nodiscard]] bool contains(const K& key) const { return find(key) != end(); }
-
-    // XOR-based order-independent hash (XOR is commutative → insertion order
-    // doesn't affect the result).  Picked up automatically by ttsl::hash::hash_object.
-    // Requires K and V to be std::hash-able.
-    [[nodiscard]] std::size_t to_hash() const noexcept {
-        std::size_t h = 0;
-        for (const auto& [k, v] : entries_) {
-            std::size_t kh = std::hash<K>{}(k);
-            std::size_t vh = std::hash<V>{}(v);
-            // Boost-style combine for the pair, then XOR for order-independence.
-            std::size_t pair_h = kh ^ (vh + 0x9e3779b9u + (kh << 6) + (kh >> 2));
-            h ^= pair_h;
-        }
-        return h;
-    }
-
-    // Stream output matching std::map's format in reflection.hpp: {k: v, k: v}.
-    friend std::ostream& operator<<(std::ostream& os, const Table& t) {
-        os << "{";
-        for (auto it = t.entries_.begin(); it != t.entries_.end(); ++it) {
-            os << it->first << ": " << it->second;
-            if (std::next(it) != t.entries_.end()) {
-                os << ", ";
-            }
-        }
-        os << "}";
-        return os;
-    }
 
     // Inserts an entry only if its key is absent. Returns {iterator to the entry,
     // true} when inserted, or {iterator to the existing entry, false} otherwise.

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -1112,7 +1112,7 @@ ProgramRunArgs MergeProgramRunArgs(ProgramRunArgs base, std::span<const ProgramR
         for (const auto& [name, arg] : other.tensor_args) {
             if (!skip_validation) {
                 TT_FATAL(
-                    base.tensor_args.find(name) == base.tensor_args.end(),
+                    !base.tensor_args.contains(name),
                     "MergeProgramRunArgs: TensorParameter '{}' is specified in more than one ProgramRunArgs.",
                     name);
             }


### PR DESCRIPTION
## PR Category
Feature

## Summary
- Adds `contains(const K& key) const` method to `Table<K,V>` utility (metal2_host_api)
- Adds reflection support to allow the Table to be hashable using ttsl reflection utilites.
- Added tests to assert `ProgramSpec` is hashable using reflection. 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/table-contains)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/table-contains)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/table-contains)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/table-contains)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/table-contains)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/table-contains)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/table-contains)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/table-contains)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/table-contains)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/table-contains)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/table-contains)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/table-contains)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/table-contains)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/table-contains)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/table-contains)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/table-contains)