### PR TITLE
[skip ci] Skip additional UMD unit tests in blackhole upstream CI tests

### DIFF
--- a/.github/workflows/upstream-tests.yaml
+++ b/.github/workflows/upstream-tests.yaml
@@ -33,6 +33,13 @@ on:
         type: boolean
         default: false
         description: "Enable Link Time Optimization (LTO)"
+      update-latest-via-branch:
+        required: false
+        type: boolean
+        default: false
+        description: >-
+          Update :latest tags when running from a non-main branch.
+          Ignored on main; scheduled runs on main always update :latest.
   schedule:
     - cron: "0 12 * * *"
 
@@ -550,12 +557,14 @@ jobs:
           echo "images-to-push=$images_to_push_json" >> "$GITHUB_OUTPUT"
   push-latest:
     # Push images based on the dynamic matrix calculated by calculate-to-publish
-    # This job will only run if calculate-to-publish has images to push
+    # This job will only run if calculate-to-publish has images to push.
+    # On non-main branches, :latest is only updated when update-latest-via-branch is set.
     if: >-
       ${{
         !cancelled() &&
         needs.calculate-to-publish.result == 'success' &&
-        needs.calculate-to-publish.outputs.images-to-push != '[]'
+        needs.calculate-to-publish.outputs.images-to-push != '[]' &&
+        (github.ref == 'refs/heads/main' || inputs.update-latest-via-branch)
       }}
     needs:
       - calculate-to-publish

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -24,7 +24,7 @@ test_suite_bh_single_pcie_metal_unit_tests() {
 test_suite_bh_umd_unit_tests() {
     ./build/test/umd/blackhole/unit_tests
     # Filter out the tests that are failing due to local soc descriptor/YAML files, see: https://github.com/tenstorrent/tt-umd/issues/1304
-    gtest_filter="-TestTTVisibleDevices.DifferentConstructors:-AllArchs/IsCoreOfTypeTest.*"
+    gtest_filter="-TestTTVisibleDevices.DifferentConstructors:AllArchs/IsCoreOfTypeTest.*"
     ./build/test/umd/api/api_tests --gtest_filter="$gtest_filter"
 }
 

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -23,8 +23,8 @@ test_suite_bh_single_pcie_metal_unit_tests() {
 # Function test run BH UMD tests, should be any topology
 test_suite_bh_umd_unit_tests() {
     ./build/test/umd/blackhole/unit_tests
-    # Filter out the test that is failing due to local YAML files, see: https://github.com/tenstorrent/tt-metal/issues/24359
-    gtest_filter="-TestTTVisibleDevices.DifferentConstructors"
+    # Filter out the tests that are failing due to local soc descriptor/YAML files, see: https://github.com/tenstorrent/tt-umd/issues/1304
+    gtest_filter="-TestTTVisibleDevices.DifferentConstructors:-AllArchs/IsCoreOfTypeTest.*"
     ./build/test/umd/api/api_tests --gtest_filter="$gtest_filter"
 }
 


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Skipping umd tests that cannot run in upstream container due to issue: https://github.com/tenstorrent/tt-umd/issues/1304
Also gate publishing the `:latest` tag on an additional input when running upstream CI on branches

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
[![](https://github.com/tenstorrent/tt-metal/actions/workflows/upstream-tests.yaml/badge.svg?branch=williamly/upstream-bh-umd-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/upstream-tests.yaml?query=branch:williamly/upstream-bh-umd-skips)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=williamly/upstream-bh-umd-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:williamly/upstream-bh-umd-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=williamly/upstream-bh-umd-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:williamly/upstream-bh-umd-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=williamly/upstream-bh-umd-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:williamly/upstream-bh-umd-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=williamly/upstream-bh-umd-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:williamly/upstream-bh-umd-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=williamly/upstream-bh-umd-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:williamly/upstream-bh-umd-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=williamly/upstream-bh-umd-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:williamly/upstream-bh-umd-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=williamly/upstream-bh-umd-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:williamly/upstream-bh-umd-skips)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=williamly/upstream-bh-umd-skips)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:williamly/upstream-bh-umd-skips)