### PR TITLE
Fix SD3.5 & Motif denoising perf regression (#46083)

### DIFF
--- a/models/tt_dit/pipelines/cfg.py
+++ b/models/tt_dit/pipelines/cfg.py
@@ -26,7 +26,6 @@ class CFGCombiner:
 
     def __init__(
         self,
-        /,
         devices: tuple[ttnn.MeshDevice] | tuple[ttnn.MeshDevice, ttnn.MeshDevice],
         *,
         via_host: bool = True,
@@ -71,7 +70,8 @@ class _SingleCombiner:
 
 class _HostCombiner:
     def __init__(self, uncond_device: ttnn.MeshDevice, cond_device: ttnn.MeshDevice) -> None:
-        self._devices = (uncond_device, cond_device)
+        self._uncond_device = uncond_device
+        self._cond_device = cond_device
 
     def combine(self, predictions: Sequence[ttnn.Tensor], cfg_scale: float) -> tuple[ttnn.Tensor, ttnn.Tensor]:
         if len(predictions) != 2:
@@ -83,11 +83,11 @@ class _HostCombiner:
         received_uncond = uncond.cpu(blocking=False)
         received_cond = cond.cpu(blocking=False)
 
-        ttnn.synchronize_device(self._devices[0])
-        ttnn.synchronize_device(self._devices[1])
+        ttnn.synchronize_device(self._uncond_device)
+        ttnn.synchronize_device(self._cond_device)
 
-        received_uncond = received_uncond.to(self._devices[1])
-        received_cond = received_cond.to(self._devices[0])
+        received_uncond = received_uncond.to(self._cond_device)
+        received_cond = received_cond.to(self._uncond_device)
 
         combined0 = uncond + cfg_scale * (received_cond - uncond)
         combined1 = received_uncond + cfg_scale * (cond - received_uncond)

--- a/models/tt_dit/pipelines/cfg.py
+++ b/models/tt_dit/pipelines/cfg.py
@@ -18,17 +18,27 @@ from models.tt_dit.utils import tensor
 class CFGCombiner:
     """Classifier-free guidance combiner.
 
-    Operates either on a single device or on two devices using mesh sockets for communication.
-    Assumes that the unconditional prediction comes first - either in the first half of the batch
-    dimension (single-device case) or on the first device (multi-device case).
+    Operates either on a single device or on two devices. Assumes that the unconditional prediction
+    comes first - either in the first half of the batch dimension (single-device case) or on the
+    first device (multi-device case).
+
     """
 
-    def __init__(self, /, devices: tuple[ttnn.MeshDevice] | tuple[ttnn.MeshDevice, ttnn.MeshDevice]) -> None:
+    def __init__(
+        self,
+        /,
+        devices: tuple[ttnn.MeshDevice] | tuple[ttnn.MeshDevice, ttnn.MeshDevice],
+        *,
+        via_host: bool = True,
+    ) -> None:
         match devices:
             case (_,):
-                self._inner = _CombinerSingle()
+                self._inner = _SingleCombiner()
             case (uncond_device, cond_device):
-                self._inner = _CombinerParallel(uncond_device, cond_device)
+                if via_host:
+                    self._inner = _HostCombiner(uncond_device, cond_device)
+                else:
+                    self._inner = _SocketCombiner(uncond_device, cond_device)
             case _:
                 msg = "devices must be a tuple of one or two MeshDevices"
                 raise ValueError(msg)
@@ -38,7 +48,7 @@ class CFGCombiner:
         return self._inner.combine(predictions, cfg_scale)
 
 
-class _CombinerSingle:
+class _SingleCombiner:
     def combine(self, predictions: Sequence[ttnn.Tensor], cfg_scale: float) -> tuple[ttnn.Tensor]:
         if len(predictions) != 1:
             msg = f"expected 1 prediction tensor for single-device combiner, got {len(predictions)}"
@@ -59,7 +69,33 @@ class _CombinerSingle:
         return (combined,)
 
 
-class _CombinerParallel:
+class _HostCombiner:
+    def __init__(self, uncond_device: ttnn.MeshDevice, cond_device: ttnn.MeshDevice) -> None:
+        self._devices = (uncond_device, cond_device)
+
+    def combine(self, predictions: Sequence[ttnn.Tensor], cfg_scale: float) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        if len(predictions) != 2:
+            msg = f"expected 2 prediction tensors for host-based combiner, got {len(predictions)}"
+            raise ValueError(msg)
+
+        uncond, cond = predictions
+
+        received_uncond = uncond.cpu(blocking=False)
+        received_cond = cond.cpu(blocking=False)
+
+        ttnn.synchronize_device(self._devices[0])
+        ttnn.synchronize_device(self._devices[1])
+
+        received_uncond = received_uncond.to(self._devices[1])
+        received_cond = received_cond.to(self._devices[0])
+
+        combined0 = uncond + cfg_scale * (received_cond - uncond)
+        combined1 = received_uncond + cfg_scale * (cond - received_uncond)
+
+        return combined0, combined1
+
+
+class _SocketCombiner:
     def __init__(self, uncond_device: ttnn.MeshDevice, cond_device: ttnn.MeshDevice) -> None:
         self._devices = (uncond_device, cond_device)
         self._sockets = _create_sockets(uncond_device, cond_device)

--- a/models/tt_dit/pipelines/cfg.py
+++ b/models/tt_dit/pipelines/cfg.py
@@ -4,18 +4,15 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
 
+import torch
 import ttnn.experimental
 
 import ttnn
+from models.tt_dit.parallel.config import DiTParallelConfig
 from models.tt_dit.utils import tensor
-
-if TYPE_CHECKING:
-    import torch
-
-    from models.tt_dit.parallel.config import DiTParallelConfig
 
 
 class CFGCombiner:
@@ -36,13 +33,18 @@ class CFGCombiner:
                 msg = "devices must be a tuple of one or two MeshDevices"
                 raise ValueError(msg)
 
-    def combine(self, prediction: ttnn.Tensor, cfg_scale: float) -> ttnn.Tensor:
-        """Compute the CFG-combined noise prediction on one submesh device."""
-        return self._inner.combine(prediction, cfg_scale)
+    def combine(self, predictions: Sequence[ttnn.Tensor], cfg_scale: float) -> tuple[ttnn.Tensor, ...]:
+        """Compute the CFG-combined noise prediction on each submesh device."""
+        return self._inner.combine(predictions, cfg_scale)
 
 
 class _CombinerSingle:
-    def combine(self, prediction: ttnn.Tensor, cfg_scale: float) -> ttnn.Tensor:
+    def combine(self, predictions: Sequence[ttnn.Tensor], cfg_scale: float) -> tuple[ttnn.Tensor]:
+        if len(predictions) != 1:
+            msg = f"expected 1 prediction tensor for single-device combiner, got {len(predictions)}"
+            raise ValueError(msg)
+
+        prediction = predictions[0]
         n = prediction.shape[0]
 
         if n % 2 != 0:
@@ -52,33 +54,43 @@ class _CombinerSingle:
         split_pos = n // 2
         uncond = prediction[0:split_pos]
         cond = prediction[split_pos:]
-        return uncond + cfg_scale * (cond - uncond)
+        combined = uncond + cfg_scale * (cond - uncond)
+
+        return (combined,)
 
 
 class _CombinerParallel:
     def __init__(self, uncond_device: ttnn.MeshDevice, cond_device: ttnn.MeshDevice) -> None:
         self._devices = (uncond_device, cond_device)
         self._sockets = _create_sockets(uncond_device, cond_device)
-        self._recv_buffers: list[ttnn.Tensor | None] = [None, None]
+        self._recv_buffers: tuple[ttnn.Tensor, ttnn.Tensor] | None = None
 
-    def combine(self, local_pred: ttnn.Tensor, cfg_scale: float) -> ttnn.Tensor:
-        idx = 0 if local_pred.device() == self._devices[0] else 1
+    def combine(self, predictions: Sequence[ttnn.Tensor], cfg_scale: float) -> tuple[ttnn.Tensor, ttnn.Tensor]:
+        if len(predictions) != 2:
+            msg = f"expected 2 prediction tensors for socket-based combiner, got {len(predictions)}"
+            raise ValueError(msg)
 
-        remote_pred = self._recv_buffers[idx]
-        if remote_pred is None:
-            remote_pred = ttnn.allocate_tensor_on_device(local_pred.spec, self._devices[idx])
-            self._recv_buffers[idx] = remote_pred
+        if self._recv_buffers is None:
+            self._recv_buffers = (
+                ttnn.allocate_tensor_on_device(predictions[0].spec, self._devices[0]),
+                ttnn.allocate_tensor_on_device(predictions[1].spec, self._devices[1]),
+            )
 
-        # call in different order on each device to avoid deadlock
-        if idx == 0:
-            ttnn.experimental.send_async(local_pred, self._sockets[0].tx)
-            ttnn.experimental.recv_async(remote_pred, self._sockets[1].rx)
-        else:
-            ttnn.experimental.recv_async(remote_pred, self._sockets[0].rx)
-            ttnn.experimental.send_async(local_pred, self._sockets[1].tx)
+        uncond, cond = predictions
+        received_cond, received_uncond = self._recv_buffers
 
-        uncond, cond = (local_pred, remote_pred) if idx == 0 else (remote_pred, local_pred)
-        return uncond + cfg_scale * (cond - uncond)
+        # on device 0: send uncond, receive cond
+        ttnn.experimental.send_async(uncond, self._sockets[0].tx)
+        ttnn.experimental.recv_async(received_cond, self._sockets[1].rx)
+
+        # on device 1: receive uncond, send cond
+        ttnn.experimental.recv_async(received_uncond, self._sockets[0].rx)
+        ttnn.experimental.send_async(cond, self._sockets[1].tx)
+
+        combined0 = uncond + cfg_scale * (received_cond - uncond)
+        combined1 = received_uncond + cfg_scale * (cond - received_uncond)
+
+        return combined0, combined1
 
 
 @dataclass

--- a/models/tt_dit/pipelines/flux1/pipeline_flux1.py
+++ b/models/tt_dit/pipelines/flux1/pipeline_flux1.py
@@ -315,39 +315,47 @@ class Flux1Pipeline(PipelineAPIMixin):
         for i, t in enumerate(tqdm.tqdm(timesteps)):
             on_event(SectionStart(f"denoising_step_{i}"))
 
-            for idx, (device, tracer) in enumerate(zip(self._submesh_devices, self._tracers, strict=True)):
+            velocity_preds = []
+            for idx, tracer in enumerate(self._tracers):
                 timestep = ttnn.full(
                     [1, 1],
                     fill_value=t,
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.float32,
-                    device=device,
+                    device=self._submesh_devices[idx],
                 )
 
                 inputs = tracer.inputs
-                velocity_pred = tracer(
-                    cfg_enabled=self._cfg_enabled,
-                    submesh_idx=idx,
-                    latents=latents[idx],
-                    prompt=context[idx] if i == 0 else inputs["prompt"],
-                    pooled=pooled[idx] if i == 0 else inputs["pooled"],
-                    timestep=timestep,
-                    guidance=guidance[idx] if i == 0 and guidance else inputs["guidance"],
-                    spatial_rope=(latents_rope_cos[idx], latents_rope_sin[idx]) if i == 0 else inputs["spatial_rope"],
-                    prompt_rope=(prompt_rope_cos[idx], prompt_rope_sin[idx]) if i == 0 else inputs["prompt_rope"],
-                    spatial_sequence_length=latents_sequence_length,
-                    prompt_sequence_length=prompt_sequence_length,
-                    traced=traced,
+                velocity_preds.append(
+                    tracer(
+                        cfg_enabled=self._cfg_enabled,
+                        submesh_idx=idx,
+                        latents=latents[idx],
+                        prompt=context[idx] if i == 0 else inputs["prompt"],
+                        pooled=pooled[idx] if i == 0 else inputs["pooled"],
+                        timestep=timestep,
+                        guidance=guidance[idx] if i == 0 and guidance else inputs["guidance"],
+                        spatial_rope=(latents_rope_cos[idx], latents_rope_sin[idx])
+                        if i == 0
+                        else inputs["spatial_rope"],
+                        prompt_rope=(prompt_rope_cos[idx], prompt_rope_sin[idx]) if i == 0 else inputs["prompt_rope"],
+                        spatial_sequence_length=latents_sequence_length,
+                        prompt_sequence_length=prompt_sequence_length,
+                        traced=traced,
+                    )
                 )
 
                 # latents can be overwritten by trace execution, use the captured input instead,
                 # which is safe.
                 latents[idx] = tracer.inputs["latents"]
 
-                if self._cfg_enabled:
-                    velocity_pred = self._cfg_combiner.combine(velocity_pred, cfg_scale)
+            if self._cfg_enabled:
+                velocity_preds = self._cfg_combiner.combine(velocity_preds, cfg_scale)
 
-                latents[idx] = self._solvers[idx].step(step=i, latent=latents[idx], velocity_pred=velocity_pred)
+            latents = [
+                solver.step(step=i, latent=latents[idx], velocity_pred=velocity_preds[idx])
+                for idx, solver in enumerate(self._solvers)
+            ]
 
             self.synchronize_devices()  # Helps with accurate time profiling.
 

--- a/models/tt_dit/pipelines/flux1/pipeline_flux1.py
+++ b/models/tt_dit/pipelines/flux1/pipeline_flux1.py
@@ -342,6 +342,7 @@ class Flux1Pipeline(PipelineAPIMixin):
                         spatial_sequence_length=latents_sequence_length,
                         prompt_sequence_length=prompt_sequence_length,
                         traced=traced,
+                        tracer_blocking_execution=False,
                     )
                 )
 

--- a/models/tt_dit/pipelines/motif/pipeline_motif.py
+++ b/models/tt_dit/pipelines/motif/pipeline_motif.py
@@ -303,6 +303,7 @@ class MotifPipeline(PipelineAPIMixin):
                         pooled=pooled[idx],
                         timestep=timestep,
                         traced=traced,
+                        tracer_blocking_execution=False,
                     )
                 )
 

--- a/models/tt_dit/pipelines/motif/pipeline_motif.py
+++ b/models/tt_dit/pipelines/motif/pipeline_motif.py
@@ -285,32 +285,38 @@ class MotifPipeline(PipelineAPIMixin):
             context = early_context if t >= negative_strategy_switch_time else late_context
             pooled = early_pooled if t >= negative_strategy_switch_time else late_pooled
 
-            for idx, (device, tracer) in enumerate(zip(self._devices, self._tracers, strict=True)):
+            velocity_preds = []
+            for idx, tracer in enumerate(self._tracers):
                 timestep = ttnn.full(
                     [1, 1],
                     fill_value=t * 1000,
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.float32,
-                    device=device,
+                    device=self._devices[idx],
                 )
 
-                velocity_pred = tracer(
-                    submesh_idx=idx,
-                    latents=latents[idx],
-                    prompt=context[idx],
-                    pooled=pooled[idx],
-                    timestep=timestep,
-                    traced=traced,
+                velocity_preds.append(
+                    tracer(
+                        submesh_idx=idx,
+                        latents=latents[idx],
+                        prompt=context[idx],
+                        pooled=pooled[idx],
+                        timestep=timestep,
+                        traced=traced,
+                    )
                 )
 
                 # latents can be overwritten by trace execution, use the captured input instead,
                 # which is safe.
                 latents[idx] = tracer.inputs["latents"]
 
-                if self._cfg_enabled:
-                    velocity_pred = self._combiner.combine(velocity_pred, cfg_scale)
+            if self._cfg_enabled:
+                velocity_preds = self._combiner.combine(velocity_preds, cfg_scale)
 
-                latents[idx] = self._solvers[idx].step(step=step, latent=latents[idx], velocity_pred=velocity_pred)
+            latents = [
+                solver.step(step=step, latent=latents[idx], velocity_pred=velocity_preds[idx])
+                for idx, solver in enumerate(self._solvers)
+            ]
 
             # Helps with accurate time profiling.
             self.synchronize_devices()

--- a/models/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
+++ b/models/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
@@ -480,40 +480,46 @@ class QwenImagePipeline(PipelineAPIMixin):
         for i, t in enumerate(tqdm.tqdm(timesteps)):
             on_event(SectionStart(f"denoising_step_{i}"))
 
-            for idx, (device, tracer) in enumerate(zip(self._submesh_devices, self._tracers, strict=True)):
+            velocity_preds = []
+            for idx, tracer in enumerate(self._tracers):
                 timestep = ttnn.full(
                     [1, 1],
                     fill_value=t,
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.float32,
-                    device=device,
+                    device=self._submesh_devices[idx],
                 )
 
-                velocity_pred = tracer(
-                    cfg_enabled=self._cfg_enabled,
-                    submesh_idx=idx,
-                    latents=latents[idx],
-                    prompt=context[idx] if i == 0 else tracer.inputs["prompt"],
-                    timestep=timestep,
-                    spatial_rope=(latents_rope_cos[idx], latents_rope_sin[idx])
-                    if i == 0
-                    else tracer.inputs["spatial_rope"],
-                    prompt_rope=(prompt_rope_cos[idx], prompt_rope_sin[idx])
-                    if i == 0
-                    else tracer.inputs["prompt_rope"],
-                    spatial_sequence_length=latents_sequence_length,
-                    prompt_sequence_length=prompt_sequence_length,
-                    traced=traced,
+                velocity_preds.append(
+                    tracer(
+                        cfg_enabled=self._cfg_enabled,
+                        submesh_idx=idx,
+                        latents=latents[idx],
+                        prompt=context[idx] if i == 0 else tracer.inputs["prompt"],
+                        timestep=timestep,
+                        spatial_rope=(latents_rope_cos[idx], latents_rope_sin[idx])
+                        if i == 0
+                        else tracer.inputs["spatial_rope"],
+                        prompt_rope=(prompt_rope_cos[idx], prompt_rope_sin[idx])
+                        if i == 0
+                        else tracer.inputs["prompt_rope"],
+                        spatial_sequence_length=latents_sequence_length,
+                        prompt_sequence_length=prompt_sequence_length,
+                        traced=traced,
+                    )
                 )
 
                 # latents can be overwritten by trace execution, use the captured input instead,
                 # which is safe.
                 latents[idx] = tracer.inputs["latents"]
 
-                if self._cfg_enabled:
-                    velocity_pred = self._cfg_combiner.combine(velocity_pred, cfg_scale)
+            if self._cfg_enabled:
+                velocity_preds = self._cfg_combiner.combine(velocity_preds, cfg_scale)
 
-                latents[idx] = self._solvers[idx].step(step=i, latent=latents[idx], velocity_pred=velocity_pred)
+            latents = [
+                solver.step(step=i, latent=latents[idx], velocity_pred=velocity_preds[idx])
+                for idx, solver in enumerate(self._solvers)
+            ]
 
             self.synchronize_devices()
 

--- a/models/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
+++ b/models/tt_dit/pipelines/qwenimage/pipeline_qwenimage.py
@@ -506,6 +506,7 @@ class QwenImagePipeline(PipelineAPIMixin):
                         spatial_sequence_length=latents_sequence_length,
                         prompt_sequence_length=prompt_sequence_length,
                         traced=traced,
+                        tracer_blocking_execution=False,
                     )
                 )
 

--- a/models/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
+++ b/models/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
@@ -309,34 +309,44 @@ class StableDiffusion3Pipeline(PipelineAPIMixin):
         for i, t in enumerate(tqdm.tqdm(timesteps)):
             on_event(SectionStart(f"denoising_step_{i}"))
 
-            for idx, (device, tracer) in enumerate(zip(self.submesh_devices, self._tracers, strict=True)):
+            velocity_preds = []
+            for idx, tracer in enumerate(self._tracers):
                 timestep = ttnn.full(
                     [1, 1, 1, 1],
                     fill_value=t,
                     layout=ttnn.TILE_LAYOUT,
                     dtype=ttnn.float32,
-                    device=device,
+                    device=self.submesh_devices[idx],
                 )
 
-                velocity_pred = tracer(
-                    cfg_enabled=self._cfg_enabled,
-                    submesh_idx=idx,
-                    latents=latents[idx],
-                    prompt_embed=context[idx] if i == 0 else tracer.inputs["prompt_embed"],
-                    pooled_projections=pooled[idx] if i == 0 else tracer.inputs["pooled_projections"],
-                    timestep=timestep,
-                    N=latents_sequence_length,
-                    traced=traced,
+                velocity_preds.append(
+                    tracer(
+                        cfg_enabled=self._cfg_enabled,
+                        submesh_idx=idx,
+                        latents=latents[idx],
+                        prompt_embed=context[idx] if i == 0 else tracer.inputs["prompt_embed"],
+                        pooled_projections=pooled[idx] if i == 0 else tracer.inputs["pooled_projections"],
+                        timestep=timestep,
+                        N=latents_sequence_length,
+                        traced=traced,
+                        tracer_blocking_execution=False,
+                    )
                 )
 
                 # latents can be overwritten by trace execution, use the captured input instead,
                 # which is safe.
                 latents[idx] = tracer.inputs["latents"]
 
-                if self._cfg_enabled:
-                    velocity_pred = self._cfg_combiner.combine(velocity_pred, guidance_scale)
+            if self._cfg_enabled:
+                velocity_preds = self._cfg_combiner.combine(velocity_preds, guidance_scale)
 
-                latents[idx] = self._solvers[idx].step(step=i, latent=latents[idx], velocity_pred=velocity_pred)
+            for device in self.submesh_devices:
+                ttnn.synchronize_device(device)
+
+            latents = [
+                solver.step(step=i, latent=latents[idx], velocity_pred=velocity_preds[idx])
+                for idx, solver in enumerate(self._solvers)
+            ]
 
             on_event(SectionEnd(f"denoising_step_{i}"))
         on_event(SectionEnd("denoising"))

--- a/models/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
+++ b/models/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
@@ -329,6 +329,7 @@ class StableDiffusion3Pipeline(PipelineAPIMixin):
                         timestep=timestep,
                         N=latents_sequence_length,
                         traced=traced,
+                        tracer_blocking_execution=False,
                     )
                 )
 

--- a/models/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
+++ b/models/tt_dit/pipelines/stable_diffusion_35_large/pipeline_stable_diffusion_35_large.py
@@ -329,7 +329,6 @@ class StableDiffusion3Pipeline(PipelineAPIMixin):
                         timestep=timestep,
                         N=latents_sequence_length,
                         traced=traced,
-                        tracer_blocking_execution=False,
                     )
                 )
 

--- a/models/tt_dit/tests/models/motif/test_performance_motif.py
+++ b/models/tt_dit/tests/models/motif/test_performance_motif.py
@@ -46,7 +46,7 @@ from models.tt_dit.pipelines.motif.pipeline_motif import MotifPipeline, MotifPip
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D, "l1_small_size": 32768, "trace_region_size": 50000000}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768, "trace_region_size": 50000000}],
     indirect=True,
 )
 def test_motif_pipeline_performance(

--- a/models/tt_dit/tests/models/motif/test_pipeline_motif.py
+++ b/models/tt_dit/tests/models/motif/test_pipeline_motif.py
@@ -21,7 +21,7 @@ from models.tt_dit.pipelines.motif.pipeline_motif import MotifPipeline, MotifPip
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D, "l1_small_size": 32768, "trace_region_size": 50000000}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768, "trace_region_size": 50000000}],
     indirect=True,
 )
 @pytest.mark.parametrize(("width", "height", "num_inference_steps"), [(1024, 1024, 20)])

--- a/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
+++ b/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
@@ -107,6 +107,7 @@ def test_qwenimage_pipeline_performance(
             prompts=[prompts[0]],
             num_inference_steps=num_inference_steps,
             traced=True,
+            encoder_traced=False,
         )
     images[0].save(f"qwenimage_{image_w}_{image_h}_warmup.png")
 
@@ -138,6 +139,7 @@ def test_qwenimage_pipeline_performance(
                     prompts=[prompts[prompt_idx]],
                     num_inference_steps=num_inference_steps,
                     traced=True,
+                    encoder_traced=False,
                     on_event=profiler_event_callback(benchmark_profiler, i),
                 )
 

--- a/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
+++ b/models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py
@@ -45,7 +45,7 @@ from ....pipelines.qwenimage.pipeline_qwenimage import QwenImagePipeline, QwenIm
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D, "trace_region_size": 47000000}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 47000000}],
     indirect=True,
 )
 def test_qwenimage_pipeline_performance(

--- a/models/tt_dit/tests/models/qwenimage/test_pipeline_qwenimage.py
+++ b/models/tt_dit/tests/models/qwenimage/test_pipeline_qwenimage.py
@@ -20,7 +20,7 @@ from ....pipelines.qwenimage.pipeline_qwenimage import QwenImagePipeline, QwenIm
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D, "trace_region_size": 47000000}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 47000000}],
     indirect=True,
 )
 @pytest.mark.parametrize(("width", "height", "num_inference_steps"), [(1024, 1024, 50)])

--- a/models/tt_dit/tests/models/sd35/test_performance_sd35.py
+++ b/models/tt_dit/tests/models/sd35/test_performance_sd35.py
@@ -69,7 +69,7 @@ def get_expected_metrics(mesh_device):
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D, "l1_small_size": 32768, "trace_region_size": 50000000}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768, "trace_region_size": 50000000}],
     indirect=True,
 )
 def test_sd35_new_pipeline_performance(

--- a/models/tt_dit/tests/models/sd35/test_pipeline_sd35.py
+++ b/models/tt_dit/tests/models/sd35/test_pipeline_sd35.py
@@ -45,7 +45,7 @@ from ....pipelines.stable_diffusion_35_large.pipeline_stable_diffusion_35_large 
 )
 @pytest.mark.parametrize(
     "device_params",
-    [{"fabric_config": ttnn.FabricConfig.FABRIC_2D, "l1_small_size": 32768, "trace_region_size": 50000000}],
+    [{"fabric_config": ttnn.FabricConfig.FABRIC_1D, "l1_small_size": 32768, "trace_region_size": 50000000}],
     indirect=True,
 )
 @pytest.mark.parametrize("traced", [True, False], ids=["yes_traced", "no_traced"])

--- a/models/tt_dit/utils/tracing.py
+++ b/models/tt_dit/utils/tracing.py
@@ -232,9 +232,6 @@ class Tracer:
             # actually compute outputs.
             for d, trace_id in zip(self._devices, trace_ids, strict=True):
                 ttnn.execute_trace(d, trace_id, cq_id=cq_id, blocking=blocking_execution)
-            for d in self._devices:
-                ttnn.synchronize_device(d)
-            ttnn.distributed_context_barrier()
 
     def _execute(
         self,
@@ -261,9 +258,6 @@ class Tracer:
 
         for d, trace_id in zip(self._devices, trace_ids, strict=True):
             ttnn.execute_trace(d, trace_id, cq_id=cq_id, blocking=blocking)
-        for d in self._devices:
-            ttnn.synchronize_device(d)
-        ttnn.distributed_context_barrier()
 
     @property
     def trace_captured(self) -> bool:


### PR DESCRIPTION
Fixes #46083. Also fixes #46081, #46082, #46969, #46970, #47406 and a T3k QwenImage perf regression `total_encoding_time is outside of the tolerance range. Expected: 0.35, Actual: 0.505226` due to running encoder traced in the perf test.

## Problem

After the pipeline refactor, denoising time roughly doubled for both SD3.5 and Motif. The regression was tied to the switch to `FABRIC_2D` and per-step device synchronization.

## Changes

- Remove device synchronization in `Tracer`
- Switch CFG communication via host: `CFGCombiner` now defaults to a host-based communication instead of device-to-device socket communication. This makes it possible to switch back to `FABRIC_1D`.
- Performance/pipeline tests for SD3.5, Motif, and QwenImage revert their `fabric_config` from `FABRIC_2D` back to `FABRIC_1D`.

### CI Failures

- Galaxy Wan2.2 perf: preexisting
- Galaxy Mochi perf: preexisting

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=friedrich/pipeline-refactor-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:friedrich/pipeline-refactor-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=friedrich/pipeline-refactor-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:friedrich/pipeline-refactor-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=friedrich/pipeline-refactor-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:friedrich/pipeline-refactor-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=friedrich/pipeline-refactor-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:friedrich/pipeline-refactor-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=friedrich/pipeline-refactor-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:friedrich/pipeline-refactor-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=friedrich/pipeline-refactor-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:friedrich/pipeline-refactor-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=friedrich/pipeline-refactor-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:friedrich/pipeline-refactor-fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=friedrich/pipeline-refactor-fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:friedrich/pipeline-refactor-fixes)