### PR TITLE
Increase Wan2.2 encoder perf threshold for CI

### DIFF
--- a/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
+++ b/models/tt_dit/tests/models/wan2_2/test_performance_wan.py
@@ -76,10 +76,10 @@ def t2v_metrics(mesh_device, height):
             }
         else:
             expected_metrics = {
-                "encoder": 0.1,
+                "encoder": 0.2,
                 "denoising": 370.0,
                 "vae": 7.0,
-                "total": 375.0,
+                "total": 375.2,
             }
     elif tuple(mesh_device.shape) == (2, 2):
         assert height == 480, "2x2 is only supported for 480p"

--- a/tests/pipeline_reorg/galaxy_perf_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_perf_tests.yaml
@@ -51,6 +51,7 @@
 - name: Galaxy DiT Wan2.2 model perf tests
   cmd: |
     export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
+    export TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES=0
     pytest models/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "wh_4x8_sp1tp0 and resolution_720p and t2v" --timeout=1200
   model: wan2-2
   skus:

--- a/tests/pipeline_reorg/galaxy_perf_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_perf_tests.yaml
@@ -51,7 +51,6 @@
 - name: Galaxy DiT Wan2.2 model perf tests
   cmd: |
     export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
-    export TT_METAL_PINNED_MEMORY_CACHE_LIMIT_BYTES=0
     pytest models/tt_dit/tests/models/wan2_2/test_performance_wan.py -k "wh_4x8_sp1tp0 and resolution_720p and t2v" --timeout=1200
   model: wan2-2
   skus:


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
This pull request makes a minor update to the expected metrics in the `t2v_metrics` test to reflect new values for the "encoder" and "total" metrics. This ensures the test accurately validates the current model output.

- Updated the expected value for the "encoder" metric from 0.1 to 0.2, and for the "total" metric from 375.0 to 375.2 in the `t2v_metrics` test function in `test_performance_wan.py`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=drohani_wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:drohani_wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=drohani_wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:drohani_wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=drohani_wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:drohani_wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=drohani_wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:drohani_wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=drohani_wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:drohani_wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=drohani_wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:drohani_wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=drohani_wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:drohani_wan)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=drohani_wan)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:drohani_wan)