### PR TITLE
Add version warning banner and SEO tags for old docs pages

### DIFF
--- a/docs/source/common/_static/tt_theme.css
+++ b/docs/source/common/_static/tt_theme.css
@@ -469,3 +469,31 @@ https://github.com/readthedocs/sphinx_rtd_theme/issues/1301
 .py.property {
   display: block !important;
 }
+
+/* Version warning banner for old docs */
+#tt-version-warning {
+  background-color: #fff3cd;
+  border-bottom: 2px solid #ffc107;
+  color: #664d03;
+  padding: 0.75rem 1.25rem;
+  font-family: var(--font-main);
+  font-size: 0.95rem;
+  text-align: center;
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+}
+
+#tt-version-warning a {
+  color: #664d03;
+  font-weight: bold;
+  text-decoration: underline;
+}
+
+#tt-version-warning a:hover {
+  color: #332600;
+}
+
+#tt-version-warning strong {
+  font-weight: bold;
+}

--- a/docs/source/common/_templates/layout.html
+++ b/docs/source/common/_templates/layout.html
@@ -1,5 +1,47 @@
 {%- extends "!layout.html" %}
 
+{%- block extrahead %}
+{{ super() }}
+<script>
+(function() {
+    var parts = window.location.pathname.split('/');
+    // URL pattern: /tt-metal/{version}/{project}/...
+    var version = parts[2] || '';
+    if (version && version !== 'latest') {
+        // Add noindex to keep old versions out of search results
+        var noindex = document.createElement('meta');
+        noindex.name = 'robots';
+        noindex.content = 'noindex';
+        document.head.appendChild(noindex);
+        // Add canonical pointing to latest
+        var canonical = document.createElement('link');
+        canonical.rel = 'canonical';
+        canonical.href = window.location.href.replace('/tt-metal/' + version + '/', '/tt-metal/latest/');
+        document.head.appendChild(canonical);
+    }
+})();
+</script>
+{%- endblock %}
+
+{%- block content %}
+<div id="tt-version-warning" style="display:none"></div>
+<script>
+(function() {
+    var parts = window.location.pathname.split('/');
+    var version = parts[2] || '';
+    if (version && version !== 'latest') {
+        var latestUrl = window.location.href.replace('/tt-metal/' + version + '/', '/tt-metal/latest/');
+        var banner = document.getElementById('tt-version-warning');
+        banner.innerHTML =
+            'You are viewing documentation for an older version (<strong>' + version + '</strong>). ' +
+            '<a href="' + latestUrl + '">Click here for the latest version.</a>';
+        banner.style.display = 'block';
+    }
+})();
+</script>
+{{ super() }}
+{%- endblock %}
+
 {%- block sidebartitle %}
 
 {# the logo helper function was removed in Sphinx 6 and deprecated since Sphinx 4 #}

--- a/docs/source/common/_templates/layout.html
+++ b/docs/source/common/_templates/layout.html
@@ -5,8 +5,9 @@
 <script>
 (function() {
     var parts = window.location.pathname.split('/');
-    // URL pattern: /tt-metal/{version}/{project}/...
-    var version = parts[2] || '';
+    // Only applies to the hosted docs layout: /tt-metal/{version}/{project}/...
+    // Skips local builds (make html/server) where this prefix is absent.
+    var version = parts[1] === 'tt-metal' ? (parts[2] || '') : '';
     if (version && version !== 'latest') {
         // Add noindex to keep old versions out of search results
         var noindex = document.createElement('meta');
@@ -28,7 +29,9 @@
 <script>
 (function() {
     var parts = window.location.pathname.split('/');
-    var version = parts[2] || '';
+    // Only applies to the hosted docs layout: /tt-metal/{version}/{project}/...
+    // Skips local builds (make html/server) where this prefix is absent.
+    var version = parts[1] === 'tt-metal' ? (parts[2] || '') : '';
     if (version && version !== 'latest') {
         var latestUrl = window.location.href.replace('/tt-metal/' + version + '/', '/tt-metal/latest/');
         var banner = document.getElementById('tt-version-warning');

--- a/docs/source/common/_templates/layout.html
+++ b/docs/source/common/_templates/layout.html
@@ -14,10 +14,11 @@
         noindex.name = 'robots';
         noindex.content = 'noindex';
         document.head.appendChild(noindex);
-        // Add canonical pointing to latest
+        // Add canonical pointing to latest (clean URL, no query/fragment)
         var canonical = document.createElement('link');
         canonical.rel = 'canonical';
-        canonical.href = window.location.href.replace('/tt-metal/' + version + '/', '/tt-metal/latest/');
+        canonical.href = (window.location.origin + window.location.pathname)
+            .replace('/tt-metal/' + version + '/', '/tt-metal/latest/');
         document.head.appendChild(canonical);
     }
 })();
@@ -33,11 +34,19 @@
     // Skips local builds (make html/server) where this prefix is absent.
     var version = parts[1] === 'tt-metal' ? (parts[2] || '') : '';
     if (version && version !== 'latest') {
-        var latestUrl = window.location.href.replace('/tt-metal/' + version + '/', '/tt-metal/latest/');
+        var latestUrl = (window.location.origin + window.location.pathname)
+            .replace('/tt-metal/' + version + '/', '/tt-metal/latest/');
         var banner = document.getElementById('tt-version-warning');
-        banner.innerHTML =
-            'You are viewing documentation for an older version (<strong>' + version + '</strong>). ' +
-            '<a href="' + latestUrl + '">Click here for the latest version.</a>';
+        // Build with DOM nodes/textContent so URL-derived data is never parsed as HTML (avoids DOM XSS).
+        banner.textContent = 'You are viewing documentation for an older version (';
+        var versionEl = document.createElement('strong');
+        versionEl.textContent = version;
+        banner.appendChild(versionEl);
+        banner.appendChild(document.createTextNode('). '));
+        var link = document.createElement('a');
+        link.href = latestUrl;
+        link.textContent = 'Click here for the latest version.';
+        banner.appendChild(link);
         banner.style.display = 'block';
     }
 })();

--- a/docs/source/common/_templates/versions.html
+++ b/docs/source/common/_templates/versions.html
@@ -20,7 +20,9 @@ async function loadVersions() {
         const response = await fetch(VERSIONS_URL);
         const data = await response.json();
         const versionList = document.getElementById('version-list');
-        const projectCode = location.pathname.split('/')[3];
+        const pathParts = location.pathname.split('/');
+        // Hosted layout: /tt-metal/{version}/{project}/...; local builds: /{project}/...
+        const projectCode = pathParts[1] === 'tt-metal' ? pathParts[3] : pathParts[1];
 
         data.versions.forEach(version => {
             const dd = document.createElement('dd');
@@ -38,7 +40,9 @@ async function loadVersions() {
 loadVersions();
 
 function getCurrentVersion() {
-    return window.location.pathname.split('/')[2];
+    const parts = window.location.pathname.split('/');
+    // Hosted layout: /tt-metal/{version}/...; local builds fall back to 'latest'.
+    return parts[1] === 'tt-metal' ? parts[2] : 'latest';
 }
 document.getElementById('current-version').textContent = getCurrentVersion();
 


### PR DESCRIPTION
### Problem
When searching Google for terms like `ttnn all_gather`, the top results link to stale versioned docs (e.g. `/v0.55.0/`) instead of the latest documentation at `/latest/`.

### What this PR does
1. **Version warning banner** — A sticky yellow banner at the top of every non-latest docs page: *"You are viewing documentation for an older version (vX.Y.Z). Click here for the latest version."* Hidden on `/latest/` pages and local builds.
2. **`<meta name="robots" content="noindex">`** — Injected on versioned pages so Google drops them from search results over time.
3. **`<link rel="canonical">`** — Points versioned pages to their `/latest/` equivalent, telling Google which URL to rank.

This matches the approach used by PyTorch docs (`noindex` + `canonical` on old versions), combined with a user-facing banner for discoverability.

### Files changed
- **`docs/source/common/_templates/layout.html`** — `extrahead` block injects SEO meta tags (`noindex`, `canonical`); `content` block adds the warning banner. Both use safe DOM construction (no innerHTML) to avoid XSS. Guarded by `parts[1] === 'tt-metal'` so local `make html` builds are unaffected.
- **`docs/source/common/_static/tt_theme.css`** — Sticky banner styling (yellow warning theme, high z-index).
- **`docs/source/common/_templates/versions.html`** — Fix version dropdown to handle both hosted (`/tt-metal/{version}/{project}/...`) and local build URL layouts.

### How it works
Client-side JavaScript parses the URL path. On hosted docs, the path follows `/tt-metal/{version}/{project}/...` — if version is not `latest`, the banner is shown and SEO tags are injected. Local builds (where `parts[1] !== 'tt-metal'`) are skipped entirely. No server-side or Sphinx config changes needed.

<img width="1512" height="537" alt="Screenshot 2026-06-12 at 9 41 50 AM" src="https://github.com/user-attachments/assets/000784d6-f1a3-4ba3-9b33-15b2825444ee" />