### PR TITLE
Migrate binary_ng dataflow kernels to Device 2.0 NoC API

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast.cpp
@@ -45,8 +45,8 @@ void kernel_main() {
 
 #if SRC_SHARDED
 #if !SRC_BCAST
-    cb_reserve_back(cb_id_src, src_num_tiles);
-    cb_push_back(cb_id_src, src_num_tiles);
+    cb_src.reserve_back(src_num_tiles);
+    cb_src.push_back(src_num_tiles);
 #endif
 #else
     const uint32_t src_tile_bytes = cb_src.get_tile_size();
@@ -54,8 +54,8 @@ void kernel_main() {
 #endif
 #if SRC_SHARDED_B
 #if !SRC_BCAST_B
-    cb_reserve_back(cb_id_src_b, src_num_tiles_b);
-    cb_push_back(cb_id_src_b, src_num_tiles_b);
+    cb_src_b.reserve_back(src_num_tiles_b);
+    cb_src_b.push_back(src_num_tiles_b);
 #endif
 #else
     const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_col_bcast.cpp
@@ -7,6 +7,8 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 namespace {
@@ -172,7 +174,12 @@ void kernel_main() {
                                 const uint32_t row_l1_addr =
                                     l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
 
-                                noc_async_read(addr_a, scratch_l1_addr, element_size);
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(scratch_l1_addr),
+                                    element_size,
+                                    {.page_id = row_idx_a},
+                                    {});
                                 noc.async_read_barrier();
 
                                 copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
@@ -182,8 +189,12 @@ void kernel_main() {
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_b = row_block_b + k * s_h_b;
-                                const uint64_t addr_b = src_b.get_noc_addr(row_idx_b) + current_chunk_offset;
-                                noc_async_read(addr_b, curr_l1_b, current_read_len_b);
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    current_read_len_b,
+                                    {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
+                                    {});
                                 curr_l1_b += current_chunk_bytes;
                             }
                             noc.async_read_barrier();
@@ -193,8 +204,12 @@ void kernel_main() {
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                const uint64_t addr_a = src.get_noc_addr(row_idx_a) + current_chunk_offset;
-                                noc_async_read(addr_a, curr_l1_a, current_read_len_a);
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    current_read_len_a,
+                                    {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
+                                    {});
                                 curr_l1_a += current_chunk_bytes;
                             }
                             noc.async_read_barrier();
@@ -207,7 +222,12 @@ void kernel_main() {
                                 const uint32_t row_l1_addr =
                                     l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;
 
-                                noc_async_read(addr_b, scratch_l1_addr, element_size);
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(scratch_l1_addr),
+                                    element_size,
+                                    {.page_id = row_idx_b},
+                                    {});
                                 noc.async_read_barrier();
 
                                 copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast.cpp
@@ -7,6 +7,8 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
 
 void kernel_main() {
     uint32_t index = 0;
@@ -135,8 +137,12 @@ void kernel_main() {
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                const uint64_t addr_a = src.get_noc_addr(row_idx_a) + current_chunk_offset;
-                                noc_async_read(addr_a, curr_l1_a, current_read_len_a);
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    current_read_len_a,
+                                    {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
+                                    {});
                                 curr_l1_a += current_chunk_bytes;
                             }
                             noc.async_read_barrier();
@@ -144,8 +150,12 @@ void kernel_main() {
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_b = row_block_b + k * s_h_b;
-                                const uint64_t addr_b = src_b.get_noc_addr(row_idx_b) + current_chunk_offset;
-                                noc_async_read(addr_b, curr_l1_b, current_read_len_b);
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    current_read_len_b,
+                                    {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
+                                    {});
                                 curr_l1_b += current_chunk_bytes;
                             }
                             noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_bcast.cpp
@@ -7,6 +7,8 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
@@ -140,14 +142,22 @@ void kernel_main() {
                             const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
 
 #if SRC_BCAST
-                            const uint64_t addr_a = src.get_noc_addr(row_block_a) + current_chunk_offset;
-                            noc_async_read(addr_a, l1_write_addr_src, current_read_len_a);
+                            noc.async_read(
+                                src,
+                                CoreLocalMem<uint32_t>(l1_write_addr_src),
+                                current_read_len_a,
+                                {.page_id = row_block_a, .offset_bytes = current_chunk_offset},
+                                {});
 
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_b = row_block_b + k * s_h_b;
-                                const uint64_t addr_b = src_b.get_noc_addr(row_idx_b) + current_chunk_offset;
-                                noc_async_read(addr_b, curr_l1_b, current_read_len_b);
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    current_read_len_b,
+                                    {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
+                                    {});
                                 curr_l1_b += current_chunk_bytes;
                             }
                             noc.async_read_barrier();
@@ -156,13 +166,21 @@ void kernel_main() {
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                const uint64_t addr_a = src.get_noc_addr(row_idx_a) + current_chunk_offset;
-                                noc_async_read(addr_a, curr_l1_a, current_read_len_a);
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    current_read_len_a,
+                                    {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
+                                    {});
                                 curr_l1_a += current_chunk_bytes;
                             }
 
-                            const uint64_t addr_b = src_b.get_noc_addr(row_block_b) + current_chunk_offset;
-                            noc_async_read(addr_b, l1_write_addr_src_b, current_read_len_b);
+                            noc.async_read(
+                                src_b,
+                                CoreLocalMem<uint32_t>(l1_write_addr_src_b),
+                                current_read_len_b,
+                                {.page_id = row_block_b, .offset_bytes = current_chunk_offset},
+                                {});
 
                             noc.async_read_barrier();
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_row_col_mixed_bcast.cpp
@@ -7,6 +7,8 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 namespace {
@@ -172,15 +174,24 @@ void kernel_main() {
                                 const uint32_t row_l1_addr =
                                     l1_write_addr_src + static_cast<uint32_t>(k) * current_chunk_bytes;
 
-                                noc_async_read(addr_a, scratch_l1_addr, element_size);
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(scratch_l1_addr),
+                                    element_size,
+                                    {.page_id = row_idx_a},
+                                    {});
                                 noc.async_read_barrier();
 
                                 copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
                             }
 
-                            const uint64_t addr_b = src_b.get_noc_addr(row_block_b) + current_chunk_offset;
-                            noc_async_read(addr_b, l1_write_addr_src_b, current_read_len_b);
+                            noc.async_read(
+                                src_b,
+                                CoreLocalMem<uint32_t>(l1_write_addr_src_b),
+                                current_read_len_b,
+                                {.page_id = row_block_b, .offset_bytes = current_chunk_offset},
+                                {});
                             noc.async_read_barrier();
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src_b, current_chunk_elements, limit);
 #else
@@ -194,15 +205,24 @@ void kernel_main() {
                                 const uint32_t row_l1_addr =
                                     l1_write_addr_src_b + static_cast<uint32_t>(k) * current_chunk_bytes;
 
-                                noc_async_read(addr_b, scratch_l1_addr, element_size);
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(scratch_l1_addr),
+                                    element_size,
+                                    {.page_id = row_idx_b},
+                                    {});
                                 noc.async_read_barrier();
 
                                 copy_one_element<element_size>(row_l1_addr, scratch_l1_addr);
                                 FILL_TILE_WITH_FIRST_COLUMN_RM(row_l1_addr, current_chunk_elements);
                             }
 
-                            const uint64_t addr_a = src.get_noc_addr(row_block_a) + current_chunk_offset;
-                            noc_async_read(addr_a, l1_write_addr_src, current_read_len_a);
+                            noc.async_read(
+                                src,
+                                CoreLocalMem<uint32_t>(l1_write_addr_src),
+                                current_read_len_a,
+                                {.page_id = row_block_a, .offset_bytes = current_chunk_offset},
+                                {});
                             noc.async_read_barrier();
                             FILL_TILE_WITH_FIRST_ROW_RM(l1_write_addr_src, current_chunk_elements, limit);
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_bcast.cpp
@@ -7,6 +7,8 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 namespace {
@@ -167,7 +169,12 @@ void kernel_main() {
                             const uint32_t src_low_bits = static_cast<uint32_t>(addr_a & (alignment_a - 1));
                             const uint32_t scratch_l1_addr = l1_write_addr_src + src_low_bits;
 
-                            noc_async_read(addr_a, scratch_l1_addr, element_size);
+                            noc.async_read(
+                                src,
+                                CoreLocalMem<uint32_t>(scratch_l1_addr),
+                                element_size,
+                                {.page_id = row_block_a},
+                                {});
                             noc.async_read_barrier();
 
                             copy_one_element<element_size>(l1_write_addr_src, scratch_l1_addr);
@@ -176,8 +183,12 @@ void kernel_main() {
                             uint32_t curr_l1_b = l1_write_addr_src_b;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_b = row_block_b + k * s_h_b;
-                                const uint64_t addr_b = src_b.get_noc_addr(row_idx_b) + current_chunk_offset;
-                                noc_async_read(addr_b, curr_l1_b, current_read_len_b);
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    current_read_len_b,
+                                    {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
+                                    {});
                                 curr_l1_b += current_chunk_bytes;
                             }
                             noc.async_read_barrier();
@@ -188,8 +199,12 @@ void kernel_main() {
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                const uint64_t addr_a = src.get_noc_addr(row_idx_a) + current_chunk_offset;
-                                noc_async_read(addr_a, curr_l1_a, current_read_len_a);
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    current_read_len_a,
+                                    {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
+                                    {});
                                 curr_l1_a += current_chunk_bytes;
                             }
                             noc.async_read_barrier();
@@ -198,7 +213,12 @@ void kernel_main() {
                             const uint32_t src_low_bits = static_cast<uint32_t>(addr_b & (alignment_b - 1));
                             const uint32_t scratch_l1_addr = l1_write_addr_src_b + src_low_bits;
 
-                            noc_async_read(addr_b, scratch_l1_addr, element_size);
+                            noc.async_read(
+                                src_b,
+                                CoreLocalMem<uint32_t>(scratch_l1_addr),
+                                element_size,
+                                {.page_id = row_block_b},
+                                {});
                             noc.async_read_barrier();
 
                             copy_one_element<element_size>(l1_write_addr_src_b, scratch_l1_addr);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_scalar_op.cpp
@@ -7,6 +7,8 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
@@ -123,8 +125,12 @@ void kernel_main() {
                             uint32_t curr_l1_a = l1_write_addr_src;
                             for (uint32_t k = 0; k < limit; ++k) {
                                 const uint32_t row_idx_a = row_block_a + k * s_h_a;
-                                const uint64_t addr_a = src.get_noc_addr(row_idx_a) + current_chunk_offset;
-                                noc_async_read(addr_a, curr_l1_a, current_read_len);
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    current_read_len,
+                                    {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
+                                    {});
                                 curr_l1_a += current_chunk_bytes;
                             }
                             noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast.cpp
@@ -45,8 +45,8 @@ void kernel_main() {
 
 #if SRC_SHARDED
 #if !SRC_BCAST
-    cb_reserve_back(cb_id_src, src_num_tiles);
-    cb_push_back(cb_id_src, src_num_tiles);
+    cb_src.reserve_back(src_num_tiles);
+    cb_src.push_back(src_num_tiles);
 #endif
 #else
     const uint32_t src_tile_bytes = cb_src.get_tile_size();
@@ -54,8 +54,8 @@ void kernel_main() {
 #endif
 #if SRC_SHARDED_B
 #if !SRC_BCAST_B
-    cb_reserve_back(cb_id_src_b, src_num_tiles_b);
-    cb_push_back(cb_id_src_b, src_num_tiles_b);
+    cb_src_b.reserve_back(src_num_tiles_b);
+    cb_src_b.push_back(src_num_tiles_b);
 #endif
 #else
     const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp
@@ -7,6 +7,8 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
 
 void kernel_main() {
     uint32_t index = 0;
@@ -80,8 +82,12 @@ void kernel_main() {
                             uint32_t l1_read_addr = cb_out.get_read_ptr();
                             for (uint32_t row = 0; row < limit; ++row) {
                                 const uint32_t row_abs_idx = row_block_base_row + row;
-                                const uint64_t dst_noc_addr = dst.get_noc_addr(row_abs_idx) + current_chunk_offset;
-                                noc_async_write(l1_read_addr, dst_noc_addr, current_write_len);
+                                noc.async_write(
+                                    CoreLocalMem<uint32_t>(l1_read_addr),
+                                    dst,
+                                    current_write_len,
+                                    {},
+                                    {.page_id = row_abs_idx, .offset_bytes = current_chunk_offset});
                                 l1_read_addr += current_chunk_bytes;
                             }
 


### PR DESCRIPTION
### Ticket
Closes #46788

### Problem description
Finish migrating `eltwise/binary_ng` dataflow kernels off the legacy free-function data-movement APIs onto the Device 2.0 object-oriented NoC API, per the [Device 2.0 Data Movement migration guide](https://github.com/tenstorrent/tt-metal/blob/main/docs/source/tt-metalium/tt_metal/apis/kernel_apis/data_movement/device_api_migration_guide.md). Several reader/writer kernels still used `noc_async_read`/`noc_async_write` on raw `uint64` addresses and a couple still called `cb_reserve_back`/`cb_push_back` free functions even though a `CircularBuffer`/`Noc` wrapper was already in scope.

### What's changed
Migrated 9 dataflow kernels (the remaining legacy ones; the `*_no_bcast` tile-path kernels and `fill_tile_utils.hpp` were already migrated on `main`):

- **7 row-major kernels** (`reader_interleaved_rm_{col,row,scalar,row_col_mixed}_bcast`, `reader_interleaved_rm_no_bcast`, `reader_interleaved_rm_scalar_op`, `writer_interleaved_rm_no_bcast`): replaced raw `noc_async_read`/`noc_async_write` with the object-oriented form:
  ```cpp
  noc.async_read(src, CoreLocalMem<uint32_t>(l1), len,
                 {.page_id = row, .offset_bytes = chunk_off}, {});
  ```
  Behavior-preserving: the `TensorAccessor` src-args path computes `get_noc_addr(page_id, offset_bytes)` which adds `offset` as raw bytes — identical to the prior `get_noc_addr(row) + chunk_offset`; `CoreLocalMem<uint32_t>(l1)` resolves to `l1 + 0`. Scratch single-element reads keep their explicit `get_noc_addr()` where the low-bits alignment arithmetic needs it — only the transfer is swapped. Added `api/tensor/noc_traits.h` + `api/core_local_mem.h` includes.
- **2 tile kernels** (`reader_interleaved_{col,scalar}_bcast`): `cb_reserve_back`/`cb_push_back` → `cb.reserve_back()`/`cb.push_back()`.

**Intentionally left as-is:**
- `get_tile_size(cb_id)` in the rm kernels — its result feeds a `constexpr element_size` used as a template argument (`copy_one_element<element_size>`), and `CircularBuffer::get_tile_size()` is not `constexpr`. It's a CB-metadata query, not a movement op.
- Compute (TRISC) kernels' free-function `cb_*` calls — standard mechanism there, not legacy holdovers.

This follows the pattern in #46707's [device-2.0 kernel commit](https://github.com/tenstorrent/tt-metal/pull/46707/changes/7a5678f03d148e89052efc3d6c2540f1869c28d1).

### Verification
- `grep 'cb_.*('` / `grep 'noc_.*('` over the dataflow kernels: no legacy free-functions remain.
- Local on Blackhole p150b (kernels JIT-build cleanly under `-Werror`):
  - Smoke test of all 9 migrated paths (rm no-bcast, rm row/col/scalar/mixed bcast, tile no/col/scalar bcast) — numerically correct vs torch.
  - `test_binary_ng_program_cache.py`: 15 passed
  - `test_binary_ng_typecast.py`: 1543 passed
  - `test_binary_ng_bcast_fp32_dest_acc.py`: 55 passed
  - `test_binary_bcast.py` (3848 tests, row-major heavy): running

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vsureshTT/binary_ng_D2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vsureshTT/binary_ng_D2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vsureshTT/binary_ng_D2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vsureshTT/binary_ng_D2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vsureshTT/binary_ng_D2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vsureshTT/binary_ng_D2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vsureshTT/binary_ng_D2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vsureshTT/binary_ng_D2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vsureshTT/binary_ng_D2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vsureshTT/binary_ng_D2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vsureshTT/binary_ng_D2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vsureshTT/binary_ng_D2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vsureshTT/binary_ng_D2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vsureshTT/binary_ng_D2_migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vsureshTT/binary_ng_D2_migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vsureshTT/binary_ng_D2_migration)