### PR TITLE
[tt-emule] get_tile_size returns CB tile size, not page size (tt-emule#111)

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -543,8 +543,11 @@ static std::string disk_cache_so_path(const std::string& cache_key) {
 //   1. `asm volatile("csrr %0, mhartid" : "=r"(V));` → `V = __processor_id;`
 //      (x86 assembler rejects RISC-V CSR instructions; the runner sets the
 //      __processor_id TLS before each kernel launch.)
-//   2. `asm volatile("fence" ::: "memory");` → `__sync_synchronize();`
-//      (Host memory barrier is the closest emulation-side equivalent.)
+//   2. `asm volatile("fence" ::: "memory");` or bare `asm volatile("fence");`
+//      → `__sync_synchronize();` (Host memory barrier is the closest
+//      emulation-side equivalent; the clobber list is optional — e.g. the
+//      embedding_backward compute kernel's ARCH_BLACKHOLE cache-flush fence
+//      omits it.)
 //   3. `reinterpret_cast<T*>(get_arg_val<uint32_t>(N))` →
 //      `reinterpret_cast<T*>((uintptr_t)__emule_local_l1_to_ptr(get_arg_val<uint32_t>(N)))`
 //      (Quasar kernels pass raw L1 firmware offsets as runtime args; x86 needs
@@ -564,7 +567,7 @@ static void preprocess_kernel_source_for_x86(const std::string& src_path, const 
         R"(asm\s+volatile\s*\(\s*"csrr\s+%0\s*,\s*mhartid"\s*:\s*"=r"\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)\s*\)\s*\)\s*;)");
     src = std::regex_replace(src, mhartid_re, "$1 = __processor_id;");
 
-    static const std::regex fence_re(R"(asm\s+volatile\s*\(\s*"fence"\s*:::\s*"memory"\s*\)\s*;)");
+    static const std::regex fence_re(R"(asm\s+volatile\s*\(\s*"fence"\s*(:::\s*"memory"\s*)?\)\s*;)");
     src = std::regex_replace(src, fence_re, "__sync_synchronize();");
 
     static const std::regex l1_arg_ptr_re(

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1148,7 +1148,10 @@ static std::map<std::string, std::string> build_kernel_defines(
         for (auto& cb_impl : cb_impls) {
             for (uint8_t idx : cb_impl->local_buffer_indices()) {
                 if (idx < EMULE_NUM_CBS) {
-                    tile_sizes[idx] = cb_impl->page_size(idx);
+                    // Calculate tile size from the CB's data format.
+                    const auto& tile = cb_impl->tile(idx);
+                    tile_sizes[idx] = tile.has_value() ? tile->get_tile_size(cb_impl->data_format(idx))
+                                                       : Tile().get_tile_size(cb_impl->data_format(idx));
                     cb_formats[idx] = static_cast<uint8_t>(cb_impl->data_format(idx));
                 }
             }


### PR DESCRIPTION
### PR Category
Bug fix in tt-emule for https://github.com/tenstorrent/tt-emule/issues/111

### Summary
- Rewrite bare asm volatile("fence") for x86. This broadens the rewriter's fence regex to also match the no-clobber form used by the embedding_backward kernel under `ARCH_BLACKHOLE`; without it the RISC-V fence reached the x86 assembler and failed to compile. Unblocks `embedding_bw` on blackhole (wormhole only needed the tile-size fix). Verified green on both arches + full gtest regression.
 - Make the `emulated_program_runner` derive the CB tile size from the CB's data format:`Tile::get_tile_size(cb_impl->data_format(idx))`. 
Previously, the tile size was derived via the CB's page size (`cb_impl->page_size(idx)`), baked into the `EMULE_TILE_SIZES` define that backs the kernel's `unpack_tile_size[]` / `get_tile_size()`. This is fine in the majority of cases because tiled CBs are allocated with page_size == tile_size, but errored out in a sub-tile-paged CB like `embedding_bw`'s index buffer (page 64 B vs bf16 tile 2048 B). The reader pulled 1 index per block instead of 32, which dropped PCC to ~0.02 on `tt-metal/tests/ttnn/unit_tests/operations/data_movement/test_backward_embedding.py::test_embedding_bw_with_program_cache`. 
 - See [tenstorrent/tt-emule#111](https://github.com/tenstorrent/tt-emule/issues/111).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=brapanan/emule-issue-111-tile-size-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:brapanan/emule-issue-111-tile-size-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=brapanan/emule-issue-111-tile-size-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:brapanan/emule-issue-111-tile-size-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=brapanan/emule-issue-111-tile-size-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:brapanan/emule-issue-111-tile-size-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=brapanan/emule-issue-111-tile-size-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:brapanan/emule-issue-111-tile-size-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=brapanan/emule-issue-111-tile-size-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:brapanan/emule-issue-111-tile-size-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=brapanan/emule-issue-111-tile-size-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:brapanan/emule-issue-111-tile-size-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=brapanan/emule-issue-111-tile-size-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:brapanan/emule-issue-111-tile-size-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=brapanan/emule-issue-111-tile-size-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:brapanan/emule-issue-111-tile-size-fix)