### PR TITLE
[Bug fix] Pop waited CB pages in sharded unary writers

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp
@@ -14,4 +14,5 @@ void kernel_main() {
     CircularBuffer cb_out(cb_id_out);
 
     cb_out.wait_front(num_units);
+    cb_out.pop_front(num_units);
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary.cpp
@@ -19,6 +19,7 @@ void kernel_main() {
 
 #if DST_SHARDED
     cb_dst.wait_front(num_pages);
+    cb_dst.pop_front(num_pages);
 #else
     constexpr uint32_t onepage = 1;
     constexpr auto dst_args = TensorAccessorArgs<0, 0>();


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This narrows #46791 to two sharded writer paths where the kernel waits on output CB pages and returns without releasing them.

- `ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp` now pairs `cb_out.wait_front(num_units)` with `cb_out.pop_front(num_units)`.
- `ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary.cpp` now pairs the `DST_SHARDED` `cb_dst.wait_front(num_pages)` with `cb_dst.pop_front(num_pages)`.

I left the other `#46791` findings out of this PR because that report mixes direct local omissions with kernels that appear to keep CB entries alive as scratch or persistent state.

Relates to #46791

### Notes for reviewers
- Failure mechanism: both kernels consume sharded output pages from a CB and exit with the waited pages still outstanding.
- Preserved invariant: this change only balances the CB lifecycle in those two writer paths. It does not change the interleaved write loops or host-side program setup.
- Source reachability:
  - `writer_unary_sharded.cpp` is used by sharded data-movement program factories such as `tilize_multi_core_sharded_program_factory.cpp` and `untilize_multi_core_input_and_output_shard_type_and_shard_spec_identical_program_factory.cpp`.
  - `writer_unary.cpp` runs with `DST_SHARDED=1` from `ttnn/cpp/ttnn/operations/eltwise/unary/device/unary_program_factory.cpp`.
- Validation:
  - fresh Python-binding build with distributed disabled
  - mock-device path execution through sharded `ttnn.tilize(..., use_multicore=True)` and sharded unary `ttnn.abs(...)`
  - the same mock loop still passes after locally removing the two new `pop_front(...)` lines again, so I am treating this as a CB-lifecycle/source-consistency fix, not as a reproduced runtime failure on the current mock path
  - I kept the validation claim at path execution plus preserved sharded metadata. I did not claim full numeric proof from the mock path.
