### PR TITLE
[skip ci] upstream tests: symlink to the correct path for descriptor files + un-skip blackhole umd api tests

### DIFF
--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -630,6 +630,10 @@ jobs:
           if [[ "${{ inputs.skip-tt-train }}" != "true" ]]; then
             ARTIFACT_PATHS="$ARTIFACT_PATHS build/tt-train data"
           fi
+          if [[ "${{ inputs.build-umd-tests }}" == "true" ]]; then
+            ARTIFACT_PATHS+=" tt_metal/third_party/umd/tests/soc_descs"
+            ARTIFACT_PATHS+=" tt_metal/third_party/umd/tests/cluster_descriptor_examples"
+          fi
           tar -I 'zstd --adapt=min=9 -T0' -cvhf /work/ttm_any.tar.zst $ARTIFACT_PATHS
 
       - name: Set build artifact name

--- a/.github/workflows/build-artifact.yaml
+++ b/.github/workflows/build-artifact.yaml
@@ -630,10 +630,6 @@ jobs:
           if [[ "${{ inputs.skip-tt-train }}" != "true" ]]; then
             ARTIFACT_PATHS="$ARTIFACT_PATHS build/tt-train data"
           fi
-          if [[ "${{ inputs.build-umd-tests }}" == "true" ]]; then
-            ARTIFACT_PATHS+=" tt_metal/third_party/umd/tests/soc_descs"
-            ARTIFACT_PATHS+=" tt_metal/third_party/umd/tests/cluster_descriptor_examples"
-          fi
           tar -I 'zstd --adapt=min=9 -T0' -cvhf /work/ttm_any.tar.zst $ARTIFACT_PATHS
 
       - name: Set build artifact name

--- a/dockerfile/upstream_test_images/Dockerfile.template
+++ b/dockerfile/upstream_test_images/Dockerfile.template
@@ -29,6 +29,12 @@ COPY _tt-metal/build/ ./build/
 COPY _tt-metal/runtime/ ./runtime/
 COPY ttnn-*.whl ./
 
+# UMD api_tests embed UMD_TESTS_ROOT_PATH=/work/tt_metal/third_party/umd/tests at compile time.
+# The metal build runs at /work, but this image keeps sources under /home/user/tt-metal.
+# Point the baked-in path at the cloned soc_descs and cluster_descriptor_examples.
+RUN sudo mkdir -p /work/tt_metal/third_party/umd && \
+    sudo ln -sfn /home/user/tt-metal/tt_metal/third_party/umd/tests /work/tt_metal/third_party/umd/tests
+
 RUN uv pip install $(ls -1 *.whl)
 
 RUN TRACY_NO_INVARIANT_CHECK=1 TT_METAL_SKIP_ETH_CORES_WITH_RETRAIN=1 ./build/test/tt_metal/unit_tests_dispatch --gtest_filter="UnitMeshCQSingleCardBufferFixture.ShardedBufferLarge*ReadWrites" --gtest_list_tests

--- a/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
+++ b/dockerfile/upstream_test_images/run_upstream_tests_vanilla.sh
@@ -23,9 +23,7 @@ test_suite_bh_single_pcie_metal_unit_tests() {
 # Function test run BH UMD tests, should be any topology
 test_suite_bh_umd_unit_tests() {
     ./build/test/umd/blackhole/unit_tests
-    # Filter out the tests that are failing due to local soc descriptor/YAML files, see: https://github.com/tenstorrent/tt-umd/issues/1304
-    gtest_filter="-TestTTVisibleDevices.DifferentConstructors:AllArchs/IsCoreOfTypeTest.*"
-    ./build/test/umd/api/api_tests --gtest_filter="$gtest_filter"
+    ./build/test/umd/api/api_tests
 }
 
 # Function to run BH single PCIe small ML model tests


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix for https://github.com/tenstorrent/tt-umd/issues/1304

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Create a symlink from `/home/user/tt-metal/tt_metal/third_party/umd/tests` to `/work/tt_metal/third_party/umd/tests` inside the upstream container for the path expected by the umd api tests at compile time.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
Upstream tests P150: https://github.com/tenstorrent/tt-metal/actions/runs/27379570288/job/80920643588

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=williamly/umd-socdesc-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:williamly/umd-socdesc-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=williamly/umd-socdesc-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:williamly/umd-socdesc-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=williamly/umd-socdesc-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:williamly/umd-socdesc-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=williamly/umd-socdesc-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:williamly/umd-socdesc-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=williamly/umd-socdesc-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:williamly/umd-socdesc-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=williamly/umd-socdesc-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:williamly/umd-socdesc-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=williamly/umd-socdesc-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:williamly/umd-socdesc-upstream)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=williamly/umd-socdesc-upstream)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:williamly/umd-socdesc-upstream)