### PR TITLE
ds_prefill - Remove insert OP from routed expert

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py
@@ -54,7 +54,7 @@ _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_prefill_block_loop.py"
         ),
         (
             f"pytest {_TEST_PATH} -k 'mesh-2x4-2link and layer3 and gate_device and no_ref and isl_6k4'",
-            58_750_603,  # Recalibrated 2026-06-10 on BH LoudBox 2x4; FABRIC_1D.
+            56_857_362,  # Recalibrated 2026-06-22 on BH LoudBox 2x4; FABRIC_1D. Direct-write FFN fusion (#46800) drops the per-expert insert DRAM round-trip (~3.2% faster).
             "deepseek_v3_prefill_block",
             "deepseek_v3_prefill_block_2x4_layer3_moe",
             1,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
@@ -8,20 +8,34 @@
 // block, packed one subblock at a time) and write tiles to the DRAM-
 // interleaved output tensor at this core's (mt, nt_d) tile region, looped
 // over `effective_chunks` chunks. Reads the device-side counts/idx
-// scratch CBs to compute effective_chunks. Output writes start at tile
-// row 0 — the FFN op writes to a per-expert output tensor; ttnn::insert
-// handles placement into any shared destination buffer. The activated
-// tiles are distributed across the M-row by the READER via L1 multicast —
-// there is no DRAM scratch round-trip or cross-core barrier.
+// scratch CBs to compute effective_chunks. The activated tiles are
+// distributed across the M-row by the READER via L1 multicast — there is
+// no DRAM scratch round-trip or cross-core barrier.
+//
+// Output placement has two modes (selected by the `direct_write` CT flag):
+//   * direct_write == 0: writes start at tile row 0. The FFN op writes to
+//     a per-expert output tensor; a separate ttnn::insert handles placement
+//     into any shared destination buffer.
+//   * direct_write == 1: this expert's output is written directly into a
+//     shared destination buffer at the expert's region offset. The kernel
+//     reads start[global_expert_id] from `start` (= expert_region_offsets)
+//     device-side and adds (start / TILE_HEIGHT) tile-rows to every output
+//     row — fusing what ttnn::insert would otherwise do as a separate op
+//     (no temp-buffer DRAM round-trip).
 
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/debug/assert.h"
+
+constexpr uint32_t TILE_HEIGHT = 32;
 
 void kernel_main() {
     const uint32_t output_addr = get_arg_val<uint32_t>(0);
     const uint32_t my_mt = get_arg_val<uint32_t>(1);
     const uint32_t my_nt_d = get_arg_val<uint32_t>(2);
+    // start (= expert_region_offsets) address. Only read when direct_write.
+    const uint32_t start_addr = get_arg_val<uint32_t>(3);
 
     constexpr uint32_t cb_out = get_compile_time_arg_val(1);
     constexpr uint32_t per_core_M = get_compile_time_arg_val(2);
@@ -35,20 +49,31 @@ void kernel_main() {
     constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(13);
     constexpr uint32_t cb_idx_scratch = get_compile_time_arg_val(14);
     constexpr uint32_t local_expert_id = get_compile_time_arg_val(15);
-    // M_tiles_full: total tile-row count of the output tensor. When the
+    // M_tiles_full: total tile-row count of the FFN *input* (x). When the
     // kernel runs more chunks than strictly needed (because
     // M_tiles_full % chunk_M_tiles != 0), the last chunk has writer
-    // destinations past M_tiles_full — we skip those writes here so we
-    // don't OOB-write the output buffer.
+    // destinations past M_tiles_full — we skip those source rows here.
     constexpr uint32_t M_tiles_full = get_compile_time_arg_val(16);
+    // direct_write: 0 -> write to per-expert output at row 0 (standalone FFN).
+    //               1 -> write into shared buffer at start[global_id]/TILE.
+    constexpr uint32_t direct_write = get_compile_time_arg_val(17);
+    // dst_M_tiles: tile-row count of the *destination* buffer. Equals
+    // M_tiles_full in non-direct mode; the shared buffer's row count in
+    // direct-write mode (used to bound destination writes).
+    constexpr uint32_t dst_M_tiles = get_compile_time_arg_val(18);
+    constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(19);
 
     constexpr uint32_t d_out_subblock_num_tiles = d_out_subblock_h * d_out_subblock_w;
     constexpr uint32_t d_in1_num_subblocks_M = per_core_M / d_out_subblock_h;
     constexpr uint32_t d_in1_num_subblocks_N = per_core_N_d / d_out_subblock_w;
 
-    constexpr uint32_t out_accessor_offset = 17;
+    constexpr uint32_t out_accessor_offset = 20;
     constexpr auto out_args = TensorAccessorArgs<out_accessor_offset>();
     const auto out_acc = TensorAccessor(out_args, output_addr, get_tile_size(cb_out));
+
+    constexpr uint32_t start_accessor_offset = out_args.next_compile_time_args_offset();
+    constexpr auto start_args = TensorAccessorArgs<start_accessor_offset>();
+    const auto start_acc = TensorAccessor(start_args, start_addr);
 
     const uint32_t out_tile_bytes = get_tile_size(cb_out);
 
@@ -69,6 +94,20 @@ void kernel_main() {
     const uint32_t effective_chunks_runtime = (count_tiles + chunk_M_tiles - 1) / chunk_M_tiles;
     const uint32_t effective_chunks = effective_chunks_runtime < num_chunks ? effective_chunks_runtime : num_chunks;
 
+    // Destination tile-row offset for direct-write mode. In direct-write
+    // mode the output buffer is a SHARED buffer and this expert's slice
+    // begins at start[global_expert_id] (token row); convert to tile rows.
+    // Mirrors ttnn::insert's writer: start_tile_row = start_value / TILE.
+    uint32_t row_offset_tiles = 0;
+    if constexpr (direct_write != 0) {
+        const uint32_t start_l1 = get_write_ptr(cb_start_scratch);
+        noc_async_read_page(0, start_acc, start_l1);
+        noc_async_read_barrier();
+        const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(start_l1);
+        const uint32_t start_value = start_ptr[global_expert_id];
+        row_offset_tiles = start_value / TILE_HEIGHT;
+    }
+
     for (uint32_t chunk = 0; chunk < effective_chunks; ++chunk) {
         const uint32_t row0 = chunk * chunk_M_tiles + my_mt * per_core_M;
         const uint32_t col0 = my_nt_d * per_core_N_d;
@@ -80,15 +119,12 @@ void kernel_main() {
                     for (uint32_t j = 0; j < d_out_subblock_w; ++j) {
                         const uint32_t row = row0 + sb_m * d_out_subblock_h + i;
                         const uint32_t col = col0 + sb_n * d_out_subblock_w + j;
-                        // Skip OOB writes:
-                        //   * col >= N_down_tiles_full: GRID_X=11 ceil_div
-                        //     produces phantom output cols past actual N.
-                        //   * row >= M_tiles_full: ceil_div of M produces a
-                        //     last-chunk tail past actual M when M_tiles_full
-                        //     doesn't divide chunk_M_tiles. The matmul still
-                        //     runs on those rows (reader zero-fills input),
-                        //     but the output isn't part of the result tensor.
-                        // Bounds:
+                        // `row` indexes the FFN *input* (x) tile-rows; the
+                        // destination tile-row adds the per-expert region
+                        // offset (0 in non-direct mode).
+                        const uint32_t dst_row = row_offset_tiles + row;
+                        // Bounds that decide whether this is a real output tile
+                        // for this expert:
                         //   * col < N_down_tiles_full: GRID_X=11 ceil_div
                         //     produces phantom output cols past actual N.
                         //   * row < M_tiles_full: ceil_div of M produces a
@@ -98,8 +134,20 @@ void kernel_main() {
                         //     rows extend past count_tiles when count_tiles
                         //     is not chunk-aligned.
                         if (col < N_down_tiles_full && row < M_tiles_full && row < count_tiles) {
-                            const uint32_t tile_idx = row * N_down_tiles_full + col;
-                            noc_async_write_page(tile_idx, out_acc, l1_read);
+                            // The destination tile-row must stay inside the
+                            // (possibly shared) output buffer. ttnn::insert
+                            // asserted the whole-slice fit
+                            // (start_tile_idx + num_tiles <= global_num_tiles);
+                            // assert the per-tile equivalent so an over-capacity
+                            // region offset fails loudly in watcher builds. The
+                            // guard below keeps Release builds safe (skip the OOB
+                            // write rather than corrupt DRAM, since ASSERT is a
+                            // no-op there).
+                            ASSERT(dst_row < dst_M_tiles);
+                            if (dst_row < dst_M_tiles) {
+                                const uint32_t tile_idx = dst_row * N_down_tiles_full + col;
+                                noc_async_write_page(tile_idx, out_acc, l1_read);
+                            }
                         }
                         l1_read += out_tile_bytes;
                     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
@@ -90,7 +90,7 @@ void kernel_main() {
     const volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(idx_l1);
     const uint32_t global_expert_id = idx_ptr[local_expert_id];
     const uint32_t count_value = counts_ptr[global_expert_id];
-    const uint32_t count_tiles = (count_value + 31) / 32;
+    const uint32_t count_tiles = (count_value + TILE_HEIGHT - 1) / TILE_HEIGHT;
     const uint32_t effective_chunks_runtime = (count_tiles + chunk_M_tiles - 1) / chunk_M_tiles;
     const uint32_t effective_chunks = effective_chunks_runtime < num_chunks ? effective_chunks_runtime : num_chunks;
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.cpp
@@ -101,8 +101,50 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
         op.local_expert_id,
         t.global_expert_idx_table.logical_shape()[-1]);
 
-    // optional_output: writer kernel computes per-core tile indices from
-    // x.padded_shape[-2]/TILE; a smaller output buffer would overflow.
+    // Direct-write mode: expert_region_offsets present => the writer places
+    // this expert's output into the SHARED optional_output buffer at the
+    // expert's region offset (fusing ttnn::insert). Requires optional_output.
+    const bool direct_write = t.expert_region_offsets.has_value();
+    if (direct_write) {
+        const auto& start = *t.expert_region_offsets;
+        // These mirror ttnn::insert's validate_index_tensor for the `start`
+        // tensor: by fusing insert into this op, the FFN now owns the
+        // region-offset vector the writer fetches device-side, so it must
+        // enforce the same invariants insert did. The writer does a single
+        // noc_async_read_page(page 0) and indexes start[global_id], which is
+        // only correct for a contiguous ROW_MAJOR single-page UINT32 vector.
+        TT_FATAL(start.storage_type() == tt::tt_metal::StorageType::DEVICE, "expert_region_offsets must be on device");
+        TT_FATAL(start.dtype() == tt::tt_metal::DataType::UINT32, "expert_region_offsets must be UINT32");
+        TT_FATAL(
+            start.layout() == tt::tt_metal::Layout::ROW_MAJOR,
+            "expert_region_offsets must be ROW_MAJOR layout, got {}",
+            start.layout());
+        TT_FATAL(is_dram_interleaved(start), "expert_region_offsets must be DRAM-interleaved");
+        const auto& start_shape = start.logical_shape();
+        const bool start_valid_1d = start_shape.rank() == 1;
+        const bool start_valid_2d = start_shape.rank() == 2 && start_shape[0] == 1;
+        TT_FATAL(
+            start_valid_1d || start_valid_2d,
+            "expert_region_offsets must be 1D or 2D with first dimension == 1, got shape {}",
+            start_shape);
+        TT_FATAL(
+            static_cast<uint32_t>(start_shape[-1]) <= MAX_GLOBAL_EXPERTS,
+            "expert_region_offsets length ({}) exceeds the maximum supported number of experts ({})",
+            start_shape[-1],
+            MAX_GLOBAL_EXPERTS);
+        // The writer reads start[global_id] and counts[global_id] from the same
+        // global-expert index space, so the two vectors must be the same length
+        // (mirrors ttnn::insert's start/counts last-dim check).
+        TT_FATAL(
+            start_shape[-1] == t.counts.logical_shape()[-1],
+            "expert_region_offsets length ({}) must equal counts length ({})",
+            start_shape[-1],
+            t.counts.logical_shape()[-1]);
+        TT_FATAL(
+            t.optional_output.has_value(),
+            "direct-write mode (expert_region_offsets set) requires optional_output (the shared destination buffer)");
+    }
+
     if (t.optional_output.has_value()) {
         const auto& out = *t.optional_output;
         TT_FATAL(out.storage_type() == tt::tt_metal::StorageType::DEVICE, "optional_output must be on device");
@@ -116,14 +158,36 @@ void UnifiedRoutedExpertFfnDeviceOperation::validate_on_program_cache_miss(
             "optional_output rank ({}) must match x rank ({})",
             out_shape.rank(),
             x_shape.rank());
-        for (int i = 0; i < static_cast<int>(out_shape.rank()); ++i) {
+        // Common to both modes: the N (emb) dim and all leading dims must match
+        // x — the writer's tile-row stride is out_shape[-1]/TILE, and leading
+        // dims index the same logical (1,..,1,M,N) tensor.
+        TT_FATAL(
+            out_shape[-1] == x_shape[-1],
+            "optional_output last dim ({}) must match x last dim ({})",
+            out_shape[-1],
+            x_shape[-1]);
+        for (int i = 0; i < static_cast<int>(out_shape.rank()) - 2; ++i) {
             TT_FATAL(
                 out_shape[i] == x_shape[i],
-                "optional_output padded_shape[{}] ({}) must match x padded_shape[{}] ({})",
+                "optional_output leading dim {} ({}) must match x ({})",
                 i,
                 out_shape[i],
-                i,
                 x_shape[i]);
+        }
+        // Mode-specific M (row) dim: direct-write targets the larger shared
+        // buffer (M >= x's M, tile-aligned; the writer bounds rows by
+        // dst_M_tiles); otherwise the output is per-expert and M must match x.
+        constexpr uint32_t TILE_H = tt::constants::TILE_HEIGHT;
+        if (direct_write) {
+            TT_FATAL(out_shape[-2] % TILE_H == 0, "optional_output M ({}) must be tile-aligned", out_shape[-2]);
+            TT_FATAL(
+                out_shape[-2] >= x_shape[-2],
+                "optional_output M ({}) must be >= x M ({}) in direct-write mode",
+                out_shape[-2],
+                x_shape[-2]);
+        } else {
+            TT_FATAL(
+                out_shape[-2] == x_shape[-2], "optional_output M ({}) must match x M ({})", out_shape[-2], x_shape[-2]);
         }
     }
 }
@@ -166,7 +230,8 @@ ttnn::Tensor unified_routed_expert_ffn(
     uint32_t local_expert_id,
     uint32_t chunk_M_tiles,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    const std::optional<ttnn::Tensor>& optional_output) {
+    const std::optional<ttnn::Tensor>& optional_output,
+    const std::optional<ttnn::Tensor>& expert_region_offsets) {
     using OperationType =
         ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn::UnifiedRoutedExpertFfnDeviceOperation;
     return ttnn::device_operation::launch<OperationType>(
@@ -181,7 +246,8 @@ ttnn::Tensor unified_routed_expert_ffn(
             .down_proj = down_proj,
             .counts = counts,
             .global_expert_idx_table = global_expert_idx_table,
-            .optional_output = optional_output});
+            .optional_output = optional_output,
+            .expert_region_offsets = expert_region_offsets});
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_device_operation.hpp
@@ -42,6 +42,7 @@ ttnn::Tensor unified_routed_expert_ffn(
     uint32_t local_expert_id,
     uint32_t chunk_M_tiles,
     const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    const std::optional<ttnn::Tensor>& optional_output);
+    const std::optional<ttnn::Tensor>& optional_output,
+    const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -43,6 +43,10 @@ constexpr uint32_t CB_IN0_DOWN_FULL = tt::CBIndex::c_12;
 // partials_up (up matmul) using the SAME shared x K-block — one x read
 // per K-block feeds both matmuls instead of two.
 constexpr uint32_t CB_PARTIALS_UP = tt::CBIndex::c_13;
+// Writer-only scratch for the device-side `start` (expert_region_offsets)
+// page in direct-write mode. Allocated unconditionally (negligible L1) so
+// the CB-index layout is stable across both write modes.
+constexpr uint32_t CB_START_SCRATCH = tt::CBIndex::c_14;
 }  // namespace
 
 UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnProgramFactory::create(
@@ -203,6 +207,19 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
     auto* idx_buffer = t.global_expert_idx_table.buffer();
     auto* out_buffer = tensor_return_value.buffer();
 
+    // Direct-write mode: when expert_region_offsets is supplied, the writer
+    // writes this expert's output straight into the shared output buffer at
+    // start[global_id]/TILE tile-rows (fusing ttnn::insert). Otherwise the
+    // writer targets tile row 0 of a per-expert buffer. The `start` accessor
+    // is appended unconditionally so the writer's CT-arg layout is stable;
+    // when not in direct-write mode it points at out_buffer and is never read.
+    const bool direct_write = t.expert_region_offsets.has_value();
+    auto* start_buffer = direct_write ? t.expert_region_offsets->buffer() : out_buffer;
+    // dst_M_tiles bounds destination writes. Equals M_tiles_full when the
+    // output matches x's shape; is the shared buffer's tile-row count in
+    // direct-write mode.
+    const uint32_t dst_M_tiles = tensor_return_value.padded_shape()[-2] / TILE;
+
     // -------------------------- semaphores --------------------------------
     // Weight-multicast semaphores for in1 (gate/up/down). Pattern: per
     // N-col group (gx fixed, gy=0..GRID_Y-1), one sender at gy=0 reads the
@@ -329,6 +346,20 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
             .set_page_size(CB_IDX_SCRATCH, idx_scratch_bytes);
     tt::tt_metal::CreateCircularBuffer(program, core_range_set, idx_cb_cfg);
 
+    // CB_START_SCRATCH holds the device-side `start` (expert_region_offsets)
+    // page for the writer in direct-write mode. Same sizing rationale as the
+    // counts scratch: expert_region_offsets is validated to have the same
+    // length as counts, so size it to the real per-call requirement (lands the
+    // tensor's page and holds every region-offset entry) rather than the old
+    // fixed MAX_GLOBAL_EXPERTS floor.
+    const uint32_t start_scratch_bytes = std::max<uint32_t>(
+        static_cast<uint32_t>(start_buffer->aligned_page_size()),
+        counts_num_entries * static_cast<uint32_t>(sizeof(uint32_t)));
+    tt::tt_metal::CircularBufferConfig start_cb_cfg =
+        tt::tt_metal::CircularBufferConfig(start_scratch_bytes, {{CB_START_SCRATCH, tt::DataFormat::UInt32}})
+            .set_page_size(CB_START_SCRATCH, start_scratch_bytes);
+    tt::tt_metal::CreateCircularBuffer(program, core_range_set, start_cb_cfg);
+
     // -------------------------- kernel build ------------------------------
     // Reader compile-time args. Order must exactly match the layout the reader
     // kernel reads via get_compile_time_arg_val(idx) and the TensorAccessor
@@ -403,8 +434,16 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         // chunk_M_tiles rows per core, of which only those < M_tiles_full
         // correspond to real output rows in the tensor.
         M_tiles_full,  // 16
+        // direct_write: 1 -> writer adds start[global_id]/TILE tile-rows and
+        // targets the shared output buffer (fuses ttnn::insert).
+        static_cast<uint32_t>(direct_write),  // 17
+        // dst_M_tiles: tile-row count of the destination buffer (= M_tiles_full
+        // for the per-expert output; the shared buffer's rows in direct mode).
+        dst_M_tiles,       // 18
+        CB_START_SCRATCH,  // 19
     };
     tt::tt_metal::TensorAccessorArgs(out_buffer).append_to(writer_ct_args);
+    tt::tt_metal::TensorAccessorArgs(start_buffer).append_to(writer_ct_args);
 
     auto writer_kernel_id = tt::tt_metal::CreateKernel(
         program,
@@ -607,10 +646,13 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
         //   0: output_addr
         //   1: my_mt
         //   2: my_nt_d
+        //   3: start_addr (expert_region_offsets in direct-write mode; else
+        //      out_buffer, unused by the kernel)
         std::vector<uint32_t> writer_args = {
             out_buffer->address(),
             my_mt,
             my_nt_d,
+            start_buffer->address(),
         };
         tt::tt_metal::SetRuntimeArgs(program, writer_kernel_id, core, writer_args);
     }
@@ -641,6 +683,8 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
     const uint32_t counts_addr = t.counts.buffer()->address();
     const uint32_t idx_addr = t.global_expert_idx_table.buffer()->address();
     const uint32_t out_addr = tensor_return_value.buffer()->address();
+    const uint32_t start_addr =
+        t.expert_region_offsets.has_value() ? t.expert_region_offsets->buffer()->address() : out_addr;
 
     for (const auto& core : cores) {
         auto& reader_args = tt::tt_metal::GetRuntimeArgs(program, reader_id, core);
@@ -653,6 +697,7 @@ void UnifiedRoutedExpertFfnProgramFactory::override_runtime_arguments(
 
         auto& writer_args = tt::tt_metal::GetRuntimeArgs(program, writer_id, core);
         writer_args[0] = out_addr;
+        writer_args[3] = start_addr;
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_types.hpp
@@ -70,6 +70,12 @@ struct UnifiedRoutedExpertFfnInputs {
     Tensor counts;
     Tensor global_expert_idx_table;
     std::optional<Tensor> optional_output;
+    // Direct-write mode: per-global-expert region start offsets (UINT32, the
+    // same `start` tensor ttnn::insert consumes). When present, the writer
+    // places this expert's output directly into `optional_output` (the shared
+    // buffer) at start[global_id]/TILE tile-rows, fusing the ttnn::insert step.
+    // Requires optional_output to also be set.
+    std::optional<Tensor> expert_region_offsets;
 };
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.cpp
@@ -8,7 +8,6 @@
 #include "tt-metalium/math.hpp"
 #include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/extract/extract.hpp"
-#include "ttnn/operations/experimental/deepseek_prefill/insert/insert.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/routed_expert_ffn/routed_expert_ffn.hpp"
 
 namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_expert_ffn {
@@ -22,7 +21,8 @@ ttnn::Tensor unified_routed_expert_ffn(
     const ttnn::Tensor& global_expert_idx_table,
     uint32_t local_expert_id,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config,
-    const std::optional<ttnn::Tensor>& output) {
+    const std::optional<ttnn::Tensor>& output,
+    const std::optional<ttnn::Tensor>& expert_region_offsets) {
     // Single-op fused per-expert FFN. One device Program runs gate matmul,
     // up matmul, silu, multiply, down matmul as four phases inside the same
     // kernel. The kernel reads counts[global_expert_idx_table[local_expert_id]]
@@ -72,7 +72,8 @@ ttnn::Tensor unified_routed_expert_ffn(
         chunk_M_tiles,
         compute_kernel_config.has_value() ? std::optional<ttnn::DeviceComputeKernelConfig>(*compute_kernel_config)
                                           : std::nullopt,
-        output);
+        output,
+        expert_region_offsets);
 }
 
 ttnn::Tensor unified_routed_expert_moe(
@@ -95,23 +96,27 @@ ttnn::Tensor unified_routed_expert_moe(
     TT_FATAL(experts_per_chip > 0, "Need at least one expert per chip");
 
     // Per-expert composite: extract this expert's tokens out of the shared
-    // dispatched buffer, run the unified FFN on them, and insert the result
-    // back into a fresh output buffer at the expert's region offset. Same
-    // loop applies regardless of `num_routed_experts` — the previously
-    // present "fused" path (FFN reading from / writing to the shared buffer
-    // via device-side region offsets) was removed because it only worked on
-    // non-production configurations (num_routed_experts <= 64).
+    // dispatched buffer, run the unified FFN on them, and have the FFN's
+    // writer place the result DIRECTLY into the shared output buffer at the
+    // expert's region offset (direct-write mode). This fuses what used to be
+    // a separate ttnn::insert op into the FFN writer — the FFN no longer
+    // writes a per-expert temp buffer that insert then copies into the shared
+    // buffer; it writes the shared buffer once. Same loop applies regardless
+    // of `num_routed_experts`.
     //
     // `tokens` from extract is a per-expert (max_dispatched_tokens_per_expert,
-    // emb) tensor with rows starting at 0. The FFN kernel always reads/writes
-    // from row 0 of its inputs; `ttnn::insert` handles placement into the
-    // shared output at expert_region_offsets[global_expert_id].
-    // Zero-initialized (not ttnn::empty): only `insert` writes each expert's
-    // valid token rows, so padding rows — tile-aligned slack within a region,
-    // regions of zero-count experts, and the tail of the buffer — would
-    // otherwise keep uninitialized DRAM garbage (incl. NaN/Inf bit patterns).
-    // The torch reference zeros these, and a NaN in padding would corrupt any
-    // downstream masked reduction/combine, so the buffer is zeroed up front.
+    // emb) tensor with rows starting at 0. The FFN reads from row 0 of its
+    // inputs; passing expert_region_offsets makes the writer add
+    // expert_region_offsets[global_expert_id]/TILE tile-rows so the output
+    // lands in this expert's slice of `expert_outputs`.
+    //
+    // Zero-initialized (not ttnn::empty): the FFN writer only writes each
+    // expert's valid token rows, so padding rows — tile-aligned slack within a
+    // region, regions of zero-count experts, and the tail of the buffer —
+    // would otherwise keep uninitialized DRAM garbage (incl. NaN/Inf bit
+    // patterns). The torch reference zeros these, and a NaN in padding would
+    // corrupt any downstream masked reduction/combine, so the buffer is zeroed
+    // up front.
     //
     // zeros_like (not zeros): dispatched_buffer is a TILE device tensor in a
     // device-fill-eligible dtype (bf8/bf16/fp32), so zeros_like takes the
@@ -132,7 +137,10 @@ ttnn::Tensor unified_routed_expert_moe(
             global_expert_idx_table,
             local_expert,
             max_dispatched_tokens_per_expert);
-        auto ffn_out = unified_routed_expert_ffn(
+        // Direct-write: output == expert_outputs (the shared buffer),
+        // expert_region_offsets supplied so the writer offsets into this
+        // expert's region. Returns the same expert_outputs handle.
+        expert_outputs = unified_routed_expert_ffn(
             tokens,
             gate_projs[local_expert],
             up_projs[local_expert],
@@ -141,9 +149,8 @@ ttnn::Tensor unified_routed_expert_moe(
             global_expert_idx_table,
             local_expert,
             compute_kernel_config,
-            std::nullopt);
-        expert_outputs = ttnn::insert(
-            expert_outputs, ffn_out, expert_region_offsets, expert_token_counts, global_expert_idx_table, local_expert);
+            expert_outputs,
+            expert_region_offsets);
     }
     return expert_outputs;
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn.hpp
@@ -38,8 +38,15 @@ namespace ttnn::operations::experimental::deepseek_prefill::unified_routed_exper
 //      actual token count.
 //   local_expert_id: index into global_expert_idx_table.
 //   compute_kernel_config: optional matmul math fidelity / accumulator config.
-//   output: optional pre-allocated (M_max, K=emb) DRAM-interleaved output
-//      tensor to write into. Must match x.dtype() and shape.
+//   output: optional pre-allocated DRAM-interleaved output tensor to write
+//      into. Must match x.dtype(); shape must match x unless
+//      expert_region_offsets is set (direct-write mode), in which case it is
+//      the larger shared destination buffer.
+//   expert_region_offsets: optional UINT32 per-global-expert region start
+//      offsets (the same `start` tensor ttnn::insert consumes). When set, the
+//      writer places this expert's output directly into `output` (the shared
+//      buffer) at start[global_id]/TILE tile-rows, fusing the ttnn::insert
+//      step (no temp-buffer DRAM round-trip). Requires `output` to be set.
 ttnn::Tensor unified_routed_expert_ffn(
     const ttnn::Tensor& x,
     const ttnn::Tensor& gate_proj,
@@ -49,14 +56,17 @@ ttnn::Tensor unified_routed_expert_ffn(
     const ttnn::Tensor& global_expert_idx_table,
     uint32_t local_expert_id,
     const std::optional<const ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt,
-    const std::optional<ttnn::Tensor>& output = std::nullopt);
+    const std::optional<ttnn::Tensor>& output = std::nullopt,
+    const std::optional<ttnn::Tensor>& expert_region_offsets = std::nullopt);
 
 // MoE-level composite: takes the dispatched buffer + ALL local experts'
 // weights and loops over local experts in C++, calling
-//   extract -> unified_routed_expert_ffn -> insert
-// per expert. NOT a single fused device op across experts (per-expert FFN
-// entries still appear in tt-perf-report); Python sees one call, the device
-// sees N.
+//   extract -> unified_routed_expert_ffn (direct-write)
+// per expert. The FFN writer places each expert's output directly into the
+// shared output buffer at its region offset (the old per-expert ttnn::insert
+// is fused into the FFN writer — no temp buffer, no second DRAM round-trip).
+// NOT a single fused device op across experts (per-expert FFN entries still
+// appear in tt-perf-report); Python sees one call, the device sees N.
 //
 // The unified FFN reads counts on-device so each expert's work scales to its
 // actual count. No host-side counts/idx read, no per-expert Python loop.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
@@ -76,9 +76,12 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         R"doc(
         MoE-level composite: takes the full dispatched buffer + ALL local
         experts' weights and loops over local experts in C++, launching one
-        ``unified_routed_expert_ffn`` device program per expert wrapped by
-        ``ttnn::extract`` (input slice) and ``ttnn::insert`` (output
-        placement). This is NOT a single fused device op across experts —
+        ``unified_routed_expert_ffn`` device program per expert preceded by
+        ``ttnn::extract`` (input slice). The FFN runs in direct-write mode:
+        its writer places each expert's output straight into the shared
+        output buffer at the expert's region offset, so NO separate
+        ``ttnn::insert`` op (and no per-expert temp-buffer DRAM round-trip)
+        is needed. This is NOT a single fused device op across experts —
         per-expert FFN entries still appear in tt-perf-report.
 
         The unified FFN reads device-resident counts/idx and bounds its

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/unified_routed_expert_ffn_nanobind.cpp
@@ -54,7 +54,15 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         Keyword Args:
             compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional)
             output (ttnn.Tensor, optional): pre-allocated output buffer.
-                Must match x.dtype() and x.shape().
+                Must match x.dtype() and x.shape() unless expert_region_offsets
+                is set (direct-write mode), in which case it is the larger
+                shared destination buffer.
+            expert_region_offsets (ttnn.Tensor, optional): UINT32
+                per-global-expert region start offsets. When set, the writer
+                places this expert's output directly into ``output`` at
+                start[global_id]/TILE tile-rows (direct-write mode), fusing the
+                ttnn::insert step. Requires ``output`` to be set. Defaults to
+                None (standalone per-expert output, rows start at 0).
 
         Returns:
             ttnn.Tensor: (M_max, K=emb).
@@ -69,7 +77,8 @@ void bind_unified_routed_expert_ffn(nb::module_& mod) {
         nb::arg("local_expert_id"),
         nb::kw_only(),
         nb::arg("compute_kernel_config") = nb::none(),
-        nb::arg("output") = nb::none());
+        nb::arg("output") = nb::none(),
+        nb::arg("expert_region_offsets") = nb::none());
 
     ttnn::bind_function<"unified_routed_expert_moe", "ttnn.experimental.deepseek_prefill.">(
         mod,


### PR DESCRIPTION
## Summary
The DeepSeek-V3 prefill MoE composite (unified_routed_expert_moe) ran, per local expert: `extract` -> unified FFN (writes a per-expert temp buffer) -> `insert` (copies temp to shared output at the expert's region offset). The insert was a full second DRAM round-trip of every expert's output tiles.

This PR adds a direct-write mode to the unified FFN: given `expert_region_offsets` + the shared output buffer, the FFN's writer kernel reads `start[global_expert_id]` device-side, converts it to a tile-row offset, and writes each output tile straight into the expert's slice of the shared buffer, fusing what insert did into the writer. The composite is now `extract` -> FFN (direct-write); the `insert` op is gone. The standalone FFN path (no region offsets) is unchanged.

## CIs
- https://github.com/tenstorrent/tt-metal/actions/runs/27942783312
-- Kimi failed due to known PCC issue.
- https://github.com/tenstorrent/tt-metal/actions/runs/27951272315
-- Only timeout issues, unrelated to these changes.