### PR TITLE
[Bug fix] Pop lookup CB pages in paged cache writers

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp
@@ -78,6 +78,7 @@ void kernel_main() {
         uint32_t index_cb_ptr = cb_index.get_read_ptr();
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_ptr);
         const uint32_t update_idx = index_ptr[my_batch_idx];
+        cb_index.pop_front(1);
 
         if (update_idx == (uint32_t)-1) {
             // Passing update_idx = -1 tells us to skip update for this user
@@ -107,6 +108,7 @@ void kernel_main() {
                 const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
                 const uint32_t block_offset = block_row_tile * Wt;
                 cache_id = block_start_id + block_offset;
+                cb_page_table.pop_front(num_pages_to_read);
 
             } else {
                 const uint32_t cache_batch_tile_offset = my_batch_idx * cache_batch_num_tiles;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp
@@ -86,6 +86,7 @@ void kernel_main() {
         uint32_t index_cb_ptr = cb_index.get_read_ptr();
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_ptr);
         const uint32_t update_idx = index_ptr[my_batch_idx];
+        cb_index.pop_front(1);
 
         if (update_idx == (uint32_t)-1) {
             // Passing update_idx = -1 tells us to skip update for this user
@@ -115,6 +116,7 @@ void kernel_main() {
                 const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
                 const uint32_t block_offset = block_row_tile * Wt;
                 cache_id = block_start_id + block_offset;
+                cb_page_table.pop_front(num_pages_to_read);
 
             } else {
                 const uint32_t cache_batch_tile_offset = my_batch_idx * cache_batch_num_tiles;

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp
@@ -74,6 +74,7 @@ void kernel_main() {
         uint32_t index_cb_ptr = cb_index.get_read_ptr();
         volatile tt_l1_ptr uint32_t* index_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(index_cb_ptr);
         const uint32_t raw_update_idx = index_ptr[my_batch_idx];
+        cb_index.pop_front(1);
 
         if (raw_update_idx == (uint32_t)-1) {
             // Passing update_idx = -1 tells us to skip update for this user
@@ -96,6 +97,7 @@ void kernel_main() {
                 const uint32_t block_row_tile = (update_idx % block_size) / TILE_HEIGHT;
                 const uint32_t block_offset = block_row_tile * Wt;
                 cache_id = block_start_id + block_offset;
+                cb_page_table.pop_front(1);
 
             } else {
                 const uint32_t cache_batch_tile_offset = my_batch_idx * cache_batch_num_tiles;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This narrows #46791 to the paged-cache writer kernels that wait on index or page-table CB pages just long enough to read lookup metadata and then exit that lookup path without releasing the waited pages.

- `ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_update_cache_interleaved_start_id.cpp` now pops:
  - `cb_index` after reading `update_idxs_tensor`
  - `cb_page_table` after resolving the paged-cache block lookup
- `ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_fused_update_cache_interleaved_start_id.cpp` now pops the same two CBs on the corresponding lookup path.
- `ttnn/cpp/ttnn/operations/experimental/paged_cache/device/kernels/dataflow/writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp` now pops the same two CBs on the corresponding lookup path.

I kept this separate from #46794 because it is a different kernel family and a different host-visible op surface.

Relates to #46791

### Notes for reviewers
- Failure mechanism: these writer kernels wait on CB pages that hold lookup metadata, read the index or page-table entries once, and continue with the cache write path while those waited pages remain outstanding.
- Preserved invariant: this change only balances the lookup CB lifecycle. It does not change cache address calculation, skip-update behavior, or the write loops.
- Source reachability:
  - `writer_update_cache_interleaved_start_id.cpp` is selected by `paged_update_cache_program_factory.cpp`.
  - `writer_paged_fused_update_cache_interleaved_start_id.cpp` is selected by `paged_tiled_fused_update_cache_program_factory.cpp`.
  - `writer_paged_row_major_fused_update_cache_interleaved_start_id.cpp` is selected by `paged_row_major_fused_update_cache_program_factory.cpp`.
- Validation:
  - fresh Python-binding build with distributed disabled and simulation disabled
  - mock-device path execution for:
    - `ttnn.experimental.paged_update_cache(..., update_idxs_tensor=..., page_table=...)`
    - `ttnn.experimental.paged_fused_update_cache(..., update_idxs_tensor=..., page_table=...)` with tiled inputs
    - `ttnn.experimental.paged_fused_update_cache(..., update_idxs_tensor=..., page_table=...)` with row-major inputs
  - I kept the validation claim at successful path execution. I did not claim full numeric correctness from the mock path.
