### PR TITLE
[skip ci] #MINFRA-814: re-enable mistral-small-3.1-24b e2e test on bh_quietbox_2

### DIFF
--- a/tests/pipeline_reorg/blackhole_demo_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_demo_tests.yaml
@@ -24,24 +24,21 @@
 # server hosts checkpoints in a layout that does not match the canonical hub cache.
 
 # ─── mistral-small-3.1-24b ──────────────────────────────────────────────────
-# TEMPORARILY DISABLED: bh_loudbox is being removed from CI (MINFRA-615). Mistral
-# still needs to be tested on QB2 (bh_quietbox_2) before this entry can be re-enabled
-# or migrated. Left commented (not deleted) so we don't lose track of it.
-#
-# - name: mistral-small-3.1-24b e2e tests
-#   cmd: |
-#     set -e
-#     export HF_HOME=/localdev/blackhole_demos/huggingface_data
-#     export HF_MODEL=mistralai/Mistral-Small-3.1-24B-Instruct-2503
-#     export TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/tt_cache/mistralai--Mistral-Small-3.1-24B-Instruct-2503
-#     export MESH_DEVICE=T3K
-#     pytest --timeout 600 models/experimental/mistral_24b/tests/pipeline_tests
-#   skus:
-#     bh_loudbox:
-#       timeout: 10
-#   owner_id: U03PUAKE719 # Miguel Tairum
-#   team: models
-#   model-name: mistral-small-3.1-24b
+
+- name: mistral-small-3.1-24b e2e tests
+  cmd: |
+    set -e
+    export HF_HOME=/localdev/blackhole_demos/huggingface_data
+    export HF_MODEL=mistralai/Mistral-Small-3.1-24B-Instruct-2503
+    export TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/tt_cache/mistralai--Mistral-Small-3.1-24B-Instruct-2503
+    export MESH_DEVICE=T3K
+    pytest --timeout 600 models/experimental/mistral_24b/tests/pipeline_tests
+  skus:
+    bh_quietbox_2:
+      timeout: 10
+  owner_id: U03PUAKE719 # Miguel Tairum
+  team: models
+  model-name: mistral-small-3.1-24b
 
 # ─── stable_diffusion_xl ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary
- Bring back the `mistral-small-3.1-24b e2e tests` entry in `tests/pipeline_reorg/blackhole_demo_tests.yaml` that was temporarily commented out by #46699 when `bh_loudbox` was removed from CI.
- Swap SKU `bh_loudbox` → `bh_quietbox_2` so the test runs on QB2 (qb-ge-2).
- `MESH_DEVICE=T3K` and `timeout: 10` are kept as-is.

## Test plan
- [ ] Reviewer: manually trigger `(Blackhole) Demo tests` via `workflow_dispatch` with `system-type=QuietBox 2 (2xP300)` and `model=mistral-small-3.1-24b`; confirm the job runs and passes.
- [ ] Reviewer: confirm next scheduled `blackhole-demo-tests` cron picks up the entry and the QB2 job appears in the matrix.

---
**Jira:** [MINFRA-814](https://tenstorrent.atlassian.net/browse/MINFRA-814)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mchiou/MINFRA-814-port-mistral-24b-to-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mchiou/MINFRA-814-port-mistral-24b-to-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mchiou/MINFRA-814-port-mistral-24b-to-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mchiou/MINFRA-814-port-mistral-24b-to-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mchiou/MINFRA-814-port-mistral-24b-to-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mchiou/MINFRA-814-port-mistral-24b-to-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mchiou/MINFRA-814-port-mistral-24b-to-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mchiou/MINFRA-814-port-mistral-24b-to-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mchiou/MINFRA-814-port-mistral-24b-to-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mchiou/MINFRA-814-port-mistral-24b-to-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mchiou/MINFRA-814-port-mistral-24b-to-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mchiou/MINFRA-814-port-mistral-24b-to-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mchiou/MINFRA-814-port-mistral-24b-to-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mchiou/MINFRA-814-port-mistral-24b-to-qb2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mchiou/MINFRA-814-port-mistral-24b-to-qb2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mchiou/MINFRA-814-port-mistral-24b-to-qb2)