### PR TITLE
[CI Disable] t3000-unit-tests: skip TestValidateModuleConfigs tests on wh_llmbox (EagerLLMExecutor missing methods)

### DIFF
--- a/models/common/tests/test_executor_parity.py
+++ b/models/common/tests/test_executor_parity.py
@@ -153,10 +153,12 @@ class TestOutputSpecCapture:
 class TestValidateModuleConfigs:
     """Tests for the _validate_module_configs context manager."""
 
+    @pytest.mark.skip(reason="Disabled: see #46807")
     def test_validate_module_configs_method_exists(self):
         """Test that _validate_module_configs method exists on EagerLLMExecutor."""
         assert hasattr(EagerLLMExecutor, "_validate_module_configs")
 
+    @pytest.mark.skip(reason="Disabled: see #46807")
     def test_compile_accepts_validate_configs_flag(self):
         """Test that compile() accepts validate_configs parameter."""
         import inspect


### PR DESCRIPTION
Disable deterministically failing TestValidateModuleConfigs tests on t3000-unit-tests wh_llmbox (EagerLLMExecutor missing _validate_module_configs method and compile attribute)

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| models/common/tests/test_executor_parity.py::TestValidateModuleConfigs::test_validate_module_configs_method_exists [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27442163505/job/81119978381 | [22a02a8f](https://github.com/tenstorrent/tt-metal/commit/22a02a8f76d23cda34f5347224e6070a601ef885) | 2026-06-12 23:38 UTC |
| models/common/tests/test_executor_parity.py::TestValidateModuleConfigs::test_compile_accepts_validate_configs_flag [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27442163505/job/81119978381 | [22a02a8f](https://github.com/tenstorrent/tt-metal/commit/22a02a8f76d23cda34f5347224e6070a601ef885) | 2026-06-12 23:38 UTC |