### PR TITLE
[CI Disable] blackhole-post-commit: skip test_host_io_loopback DEVICE_PULL failures on bh_p300-viommu (data mismatch)

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
@@ -54,6 +54,8 @@ def create_fabric_router_config(max_payload_size):
 def test_host_io_loopback(mesh_device, tensor_size_bytes, fifo_size, num_iterations, h2d_mode):
     if not is_slow_dispatch():
         pytest.skip("Skipping test in fast dispatch mode")
+    if h2d_mode == ttnn.H2DMode.DEVICE_PULL and tensor_size_bytes == 64 and fifo_size in (128, 256, 512):
+        pytest.skip(reason="Disabled on blackhole P300-viommu (DEVICE_PULL mode, data mismatch for small tensor sizes): see #46810")
 
     ttnn.enable_asynchronous_slow_dispatch(mesh_device)
 


### PR DESCRIPTION
Disable deterministically failing test_host_io_loopback DEVICE_PULL small-tensor tests on blackhole-post-commit bh_p300-viommu

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py::test_host_io_loopback[blackhole-H2DMode.DEVICE_PULL-64-128-512] [bh_p300-viommu] | https://github.com/tenstorrent/tt-metal/actions/runs/27441737760/job/81130000607 | [16e79a78](https://github.com/tenstorrent/tt-metal/commit/16e79a784996b0608f809a186f5816dd07e86d39) | 2026-06-12 22:13 UTC |
| models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py::test_host_io_loopback[blackhole-H2DMode.DEVICE_PULL-64-256-512] [bh_p300-viommu] | https://github.com/tenstorrent/tt-metal/actions/runs/27441737760/job/81130000607 | [16e79a78](https://github.com/tenstorrent/tt-metal/commit/16e79a784996b0608f809a186f5816dd07e86d39) | 2026-06-12 22:13 UTC |
| models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py::test_host_io_loopback[blackhole-H2DMode.DEVICE_PULL-64-512-512] [bh_p300-viommu] | https://github.com/tenstorrent/tt-metal/actions/runs/27441737760/job/81130000607 | [16e79a78](https://github.com/tenstorrent/tt-metal/commit/16e79a784996b0608f809a186f5816dd07e86d39) | 2026-06-12 22:13 UTC |