### PR TITLE
Integer typecast clamp coverage in copy_ops and exact float→uint16 device golden

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py
@@ -45,9 +45,12 @@ def _make_host_typecast_torch_input(shape, output_dtype, seed):
 
 
 def _host_typecast_golden(torch_tensor, output_dtype):
-    """Golden for host-resident typecast; fp32→uint8 clamps on host (not wrap)."""
+    """Golden for host-resident typecast; host paths differ from device for some dtypes."""
     if output_dtype == ttnn.uint8:
         return torch.clamp(torch_tensor, 0, 255).to(torch.uint8)
+    if output_dtype == ttnn.uint16:
+        # Host fp32→uint16 truncates; device float_to_uint16 rounds in float32 first.
+        return torch.clamp(torch_tensor.to(torch.int32), min=0, max=65535)
     return eltwise_typecast(torch_tensor, tt_input_dtype=ttnn.float32, tt_output_dtype=output_dtype)
 
 
@@ -511,9 +514,8 @@ def test_typecast_host_tensor(output_dtype, preferred_layout, device):
     """
     Test that typecast works on host tensors (fixes issue #16279).
 
-    Host-resident fp32→uint8 clamps to [0, 255] (not wrap); fp32→uint32 uses
-    non-negative inputs so relu-style golden matches. Other integer outputs use
-    widened bounds and eltwise_typecast goldens.
+    Host-resident fp32→uint8 clamps to [0, 255] (not wrap); fp32→uint16 truncates (device
+    rounds); fp32→uint32 uses non-negative inputs so relu-style golden matches.
     """
     shape = [32, 2048]
     torch_tensor = _make_host_typecast_torch_input(shape, output_dtype, seed=2005)

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py
@@ -10,6 +10,7 @@ import ttnn
 
 from tests.ttnn.python_api_testing.sweep_tests.ttnn_pytorch_ops import eltwise_typecast
 from tests.ttnn.python_api_testing.typecast_test_helpers import (
+    INTEGER_OUTPUT_DTYPES,
     assert_integer_typecast_equal,
     make_typecast_test_input,
     typecast_test_input_bounds,
@@ -19,29 +20,21 @@ from tests.ttnn.unit_tests.operations.test_utils import get_ttnn_torch_dtype
 
 pytestmark = pytest.mark.use_module_device
 
-_INTEGER_OUTPUT_DTYPES = {ttnn.uint8, ttnn.uint16, ttnn.uint32, ttnn.int32}
-_TTNN_TO_TORCH_INPUT_DTYPE = {
-    ttnn.bfloat16: torch.bfloat16,
-    ttnn.float32: torch.float32,
-}
 
-
-def _make_typecast_torch_input(shape, input_dtype, output_dtype, seed):
-    torch.manual_seed(seed)
-    pt_dtype = _TTNN_TO_TORCH_INPUT_DTYPE[input_dtype]
-    if output_dtype in _INTEGER_OUTPUT_DTYPES:
+def _make_typecast_torch_input(shape, input_dtype, output_dtype):
+    pt_dtype = tt_dtype_to_torch_dtype[input_dtype]
+    if output_dtype in INTEGER_OUTPUT_DTYPES:
         in_low, in_high = typecast_test_input_bounds(input_dtype, output_dtype)
         return make_typecast_test_input(shape, pt_dtype, in_low, in_high)
     return torch.randn(shape, dtype=pt_dtype)
 
 
-def _make_host_typecast_torch_input(shape, output_dtype, seed):
+def _make_host_typecast_torch_input(shape, output_dtype):
     """Host typecast inputs; uint32 stays non-negative (host matches relu-style golden)."""
-    torch.manual_seed(seed)
     in_low, in_high = typecast_test_input_bounds(ttnn.float32, output_dtype)
     if output_dtype == ttnn.uint32:
         in_low = 0
-    return make_typecast_test_input(shape, torch.float32, in_low, in_high)
+    return make_typecast_test_input(shape, tt_dtype_to_torch_dtype[ttnn.float32], in_low, in_high)
 
 
 def _host_typecast_golden(torch_tensor, output_dtype):
@@ -331,7 +324,8 @@ def test_typecast_community(device):
 
 def run_typecast_row_major_test(shape, memory_config, input_dtype, output_dtype, device):
     """Test typecast operation on row-major device tensors."""
-    torch_input = _make_typecast_torch_input(shape, input_dtype, output_dtype, seed=54321)
+    torch.manual_seed(54321)
+    torch_input = _make_typecast_torch_input(shape, input_dtype, output_dtype)
 
     # Create row-major tensor on device
     input_tensor = ttnn.from_torch(torch_input, input_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
@@ -350,7 +344,7 @@ def run_typecast_row_major_test(shape, memory_config, input_dtype, output_dtype,
 
     torch_output = ttnn.to_torch(output_tensor)
 
-    if output_dtype in _INTEGER_OUTPUT_DTYPES:
+    if output_dtype in INTEGER_OUTPUT_DTYPES:
         torch_expected = eltwise_typecast(torch_input, tt_input_dtype=input_dtype, tt_output_dtype=output_dtype)
         assert_integer_typecast_equal(torch_expected, torch_output)
     else:
@@ -518,7 +512,8 @@ def test_typecast_host_tensor(output_dtype, preferred_layout, device):
     rounds); fp32→uint32 uses non-negative inputs so relu-style golden matches.
     """
     shape = [32, 2048]
-    torch_tensor = _make_host_typecast_torch_input(shape, output_dtype, seed=2005)
+    torch.manual_seed(2005)
+    torch_tensor = _make_host_typecast_torch_input(shape, output_dtype)
 
     # Create host tensor
     ttnn_tensor_host = ttnn.from_torch(torch_tensor, dtype=ttnn.float32, layout=preferred_layout)
@@ -537,7 +532,7 @@ def test_typecast_host_tensor(output_dtype, preferred_layout, device):
     torch_output = ttnn.to_torch(ttnn_tensor_typecast)
     assert torch_output.shape == tuple(shape)
 
-    if output_dtype in _INTEGER_OUTPUT_DTYPES:
+    if output_dtype in INTEGER_OUTPUT_DTYPES:
         torch_expected = _host_typecast_golden(torch_tensor, output_dtype)
         assert_integer_typecast_equal(torch_expected, torch_output)
     elif output_dtype == ttnn.bfloat16:

--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py
@@ -8,10 +8,47 @@ import torch
 
 import ttnn
 
+from tests.ttnn.python_api_testing.sweep_tests.ttnn_pytorch_ops import eltwise_typecast
+from tests.ttnn.python_api_testing.typecast_test_helpers import (
+    assert_integer_typecast_equal,
+    make_typecast_test_input,
+    typecast_test_input_bounds,
+)
 from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc, assert_with_ulp, tt_dtype_to_torch_dtype
 from tests.ttnn.unit_tests.operations.test_utils import get_ttnn_torch_dtype
 
 pytestmark = pytest.mark.use_module_device
+
+_INTEGER_OUTPUT_DTYPES = {ttnn.uint8, ttnn.uint16, ttnn.uint32, ttnn.int32}
+_TTNN_TO_TORCH_INPUT_DTYPE = {
+    ttnn.bfloat16: torch.bfloat16,
+    ttnn.float32: torch.float32,
+}
+
+
+def _make_typecast_torch_input(shape, input_dtype, output_dtype, seed):
+    torch.manual_seed(seed)
+    pt_dtype = _TTNN_TO_TORCH_INPUT_DTYPE[input_dtype]
+    if output_dtype in _INTEGER_OUTPUT_DTYPES:
+        in_low, in_high = typecast_test_input_bounds(input_dtype, output_dtype)
+        return make_typecast_test_input(shape, pt_dtype, in_low, in_high)
+    return torch.randn(shape, dtype=pt_dtype)
+
+
+def _make_host_typecast_torch_input(shape, output_dtype, seed):
+    """Host typecast inputs; uint32 stays non-negative (host matches relu-style golden)."""
+    torch.manual_seed(seed)
+    in_low, in_high = typecast_test_input_bounds(ttnn.float32, output_dtype)
+    if output_dtype == ttnn.uint32:
+        in_low = 0
+    return make_typecast_test_input(shape, torch.float32, in_low, in_high)
+
+
+def _host_typecast_golden(torch_tensor, output_dtype):
+    """Golden for host-resident typecast; fp32→uint8 clamps on host (not wrap)."""
+    if output_dtype == ttnn.uint8:
+        return torch.clamp(torch_tensor, 0, 255).to(torch.uint8)
+    return eltwise_typecast(torch_tensor, tt_input_dtype=ttnn.float32, tt_output_dtype=output_dtype)
 
 
 def run_copy_test(N, C, H, W, layout, device):
@@ -264,7 +301,6 @@ def test_typecast_output_tensor(device):
     h = w = 32
     from_dtype = ttnn.bfloat16
     to_dtype = ttnn.uint32
-    gold_tensor = ttnn.ones([h, w], to_dtype, ttnn.TILE_LAYOUT, device, ttnn.L1_MEMORY_CONFIG)
     bfloat16_tensor = ttnn.ones([h, w], from_dtype, ttnn.TILE_LAYOUT, device, ttnn.L1_MEMORY_CONFIG)
     uint32_preallocated = ttnn.empty([h, w], to_dtype, ttnn.TILE_LAYOUT, device, ttnn.L1_MEMORY_CONFIG)
 
@@ -274,11 +310,12 @@ def test_typecast_output_tensor(device):
     ttnn.typecast(bfloat16_tensor, to_dtype, memory_config=ttnn.L1_MEMORY_CONFIG, output_tensor=uint32_preallocated)
     assert len(pages_before) == len(ttnn._ttnn.reports.get_buffer_pages(device))
 
-    torch_gold = ttnn.to_torch(gold_tensor)
+    torch_input = torch.ones([h, w], dtype=torch.bfloat16)
+    torch_expected = eltwise_typecast(torch_input, tt_input_dtype=from_dtype, tt_output_dtype=to_dtype)
     torch_output_ttnn = ttnn.to_torch(output_ttnn)
     torch_output_ttnn_preallocated = ttnn.to_torch(uint32_preallocated)
-    torch.equal(torch_gold, torch_output_ttnn)
-    torch.equal(torch_gold, torch_output_ttnn_preallocated)
+    assert_integer_typecast_equal(torch_expected, torch_output_ttnn)
+    assert_integer_typecast_equal(torch_expected, torch_output_ttnn_preallocated)
 
 
 def test_typecast_community(device):
@@ -291,12 +328,10 @@ def test_typecast_community(device):
 
 def run_typecast_row_major_test(shape, memory_config, input_dtype, output_dtype, device):
     """Test typecast operation on row-major device tensors."""
-    torch.manual_seed(54321)
-    torch_dtype = torch.bfloat16
-    input = torch.randn(shape, dtype=torch_dtype)
+    torch_input = _make_typecast_torch_input(shape, input_dtype, output_dtype, seed=54321)
 
     # Create row-major tensor on device
-    input_tensor = ttnn.from_torch(input, input_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    input_tensor = ttnn.from_torch(torch_input, input_dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
 
     # Verify input is row-major
     assert input_tensor.layout == ttnn.ROW_MAJOR_LAYOUT, "Input tensor should be in ROW_MAJOR_LAYOUT"
@@ -310,21 +345,13 @@ def run_typecast_row_major_test(shape, memory_config, input_dtype, output_dtype,
     assert output_tensor.layout == ttnn.ROW_MAJOR_LAYOUT, "Output should maintain ROW_MAJOR_LAYOUT"
     assert output_tensor.memory_config() == memory_config, "Output memory config should match"
 
-    # Convert original input to output dtype for comparison
     torch_output = ttnn.to_torch(output_tensor)
 
-    # Map ttnn dtype to torch dtype for conversion
-    torch_output_dtype = get_ttnn_torch_dtype(output_dtype)
-
-    # Convert original input to match output dtype for comparison
-    torch_expected = input.to(torch_output_dtype)
-
-    if output_dtype == ttnn.int32:
-        # For integer types, use exact equality (typecast from float to int may have rounding)
-        assert torch.equal(
-            torch_expected, torch_output
-        ), f"Integer typecast mismatch: expected {torch_expected}, got {torch_output}"
+    if output_dtype in _INTEGER_OUTPUT_DTYPES:
+        torch_expected = eltwise_typecast(torch_input, tt_input_dtype=input_dtype, tt_output_dtype=output_dtype)
+        assert_integer_typecast_equal(torch_expected, torch_output)
     else:
+        torch_expected = torch_input.to(get_ttnn_torch_dtype(output_dtype))
         assert_with_ulp(torch_expected, torch_output, ulp_threshold=2)
 
 
@@ -484,17 +511,15 @@ def test_typecast_host_tensor(output_dtype, preferred_layout, device):
     """
     Test that typecast works on host tensors (fixes issue #16279).
 
-    This test reproduces the scenario from the bug report and tests various dtypes:
-    - Create a host tensor from torch (no device parameter)
-    - Call typecast on the host tensor
-    - Verify it works without throwing an error
+    Host-resident fp32→uint8 clamps to [0, 255] (not wrap); fp32→uint32 uses
+    non-negative inputs so relu-style golden matches. Other integer outputs use
+    widened bounds and eltwise_typecast goldens.
     """
-    torch.manual_seed(2005)
     shape = [32, 2048]
-    torch_tensor = torch.rand(shape, dtype=torch.float32)
+    torch_tensor = _make_host_typecast_torch_input(shape, output_dtype, seed=2005)
 
     # Create host tensor
-    ttnn_tensor_host = ttnn.from_torch(torch_tensor, layout=preferred_layout)
+    ttnn_tensor_host = ttnn.from_torch(torch_tensor, dtype=ttnn.float32, layout=preferred_layout)
 
     # Verify input is on host
     assert ttnn_tensor_host.storage_type() == ttnn.StorageType.HOST
@@ -507,11 +532,12 @@ def test_typecast_host_tensor(output_dtype, preferred_layout, device):
     assert ttnn_tensor_typecast.dtype == output_dtype
     assert ttnn_tensor_typecast.storage_type() == ttnn.StorageType.HOST
 
-    # Convert back to torch and verify the shape
     torch_output = ttnn.to_torch(ttnn_tensor_typecast)
     assert torch_output.shape == tuple(shape)
 
-    # Verify values are reasonable
-    torch_dtype = tt_dtype_to_torch_dtype[output_dtype]
-    torch_expected = torch_tensor.to(torch_dtype)
-    torch.equal(torch_expected, torch_output)
+    if output_dtype in _INTEGER_OUTPUT_DTYPES:
+        torch_expected = _host_typecast_golden(torch_tensor, output_dtype)
+        assert_integer_typecast_equal(torch_expected, torch_output)
+    elif output_dtype == ttnn.bfloat16:
+        torch_expected = torch_tensor.to(tt_dtype_to_torch_dtype[output_dtype])
+        assert_with_ulp(torch_expected, torch_output, ulp_threshold=2)

--- a/tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py
+++ b/tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py
@@ -223,9 +223,14 @@ def _simulate_bfp_quantization(x, man_bits):
     return result.view(torch.float32).reshape(orig_shape).to(torch.bfloat16)
 
 
+def _float_to_uint16_clamp(x):
+    # Device float_to_uint16 converts to float32 before std::round; match in float32.
+    return torch.clamp(torch.floor(x.float() + 0.5).to(torch.int32), min=0, max=65535)
+
+
 def eltwise_typecast(x, *args, tt_input_dtype, tt_output_dtype, **kwargs):
     if tt_input_dtype == ttnn.bfloat16 and tt_output_dtype == ttnn.uint16:
-        return torch.clamp(x.to(torch.int32), min=0, max=65535)  # due to no uint16 support
+        return _float_to_uint16_clamp(x)
     elif tt_input_dtype == ttnn.uint16 and tt_output_dtype == ttnn.bfloat16:
         return x.to(torch.bfloat16)
     elif tt_input_dtype == ttnn.int32 and tt_output_dtype == ttnn.bfloat16:
@@ -237,7 +242,7 @@ def eltwise_typecast(x, *args, tt_input_dtype, tt_output_dtype, **kwargs):
     elif tt_input_dtype == ttnn.float32 and tt_output_dtype == ttnn.bfloat16:
         return x.to(torch.bfloat16)
     elif tt_input_dtype == ttnn.float32 and tt_output_dtype == ttnn.uint16:
-        return torch.clamp(x.to(torch.int32), min=0, max=65535)  # due to no uint16 support
+        return _float_to_uint16_clamp(x)
     elif tt_input_dtype == ttnn.uint16 and tt_output_dtype == ttnn.float32:
         return x.to(torch.float32)
     elif tt_input_dtype == ttnn.float32 and tt_output_dtype == ttnn.int32:

--- a/tests/ttnn/python_api_testing/typecast_test_helpers.py
+++ b/tests/ttnn/python_api_testing/typecast_test_helpers.py
@@ -101,11 +101,4 @@ def assert_integer_typecast_equal(expected, actual):
 
 
 def uses_exact_integer_typecast_check(tt_input_dtype, tt_output_dtype):
-    if tt_output_dtype in (ttnn.int32, ttnn.uint32, ttnn.uint8):
-        return True
-    return tt_output_dtype == ttnn.uint16 and tt_input_dtype in (
-        ttnn.int32,
-        ttnn.uint16,
-        ttnn.uint32,
-        ttnn.uint8,
-    )
+    return tt_output_dtype in _INTEGER_OUTPUT_DTYPES

--- a/tests/ttnn/python_api_testing/typecast_test_helpers.py
+++ b/tests/ttnn/python_api_testing/typecast_test_helpers.py
@@ -7,8 +7,8 @@ import ttnn
 
 from tests.ttnn.utils_for_testing import assert_equal
 
-_INTEGER_OUTPUT_DTYPES = {ttnn.uint8, ttnn.uint16, ttnn.uint32, ttnn.int32}
-_UNSIGNED_INPUT_DTYPES = {ttnn.uint8, ttnn.uint16, ttnn.uint32}
+INTEGER_OUTPUT_DTYPES = frozenset({ttnn.uint8, ttnn.uint16, ttnn.uint32, ttnn.int32})
+_UNSIGNED_INPUT_DTYPES = frozenset({ttnn.uint8, ttnn.uint16, ttnn.uint32})
 
 # Signed 32-bit extrema: min = -2^(32-1), max = 2^(32-1) - 1 (exponent is 31, not 32).
 _INT32_MIN = -(2**31)
@@ -58,7 +58,7 @@ def typecast_test_input_bounds(tt_input_dtype, tt_output_dtype):
       high = out_max + slack (80000 for uint16-scale outputs).
     - Unsigned input + uint8 output → [0, min(512, input_max)]; wider outputs → [0, min(80000, input_max)].
     """
-    if tt_output_dtype not in _INTEGER_OUTPUT_DTYPES:
+    if tt_output_dtype not in INTEGER_OUTPUT_DTYPES:
         return 0, 100
 
     out_min = _DTYPE_MIN[tt_output_dtype]
@@ -100,5 +100,5 @@ def assert_integer_typecast_equal(expected, actual):
     assert_equal(expected.to(torch.int64), actual.to(torch.int64))
 
 
-def uses_exact_integer_typecast_check(tt_input_dtype, tt_output_dtype):
-    return tt_output_dtype in _INTEGER_OUTPUT_DTYPES
+def uses_exact_integer_typecast_check(_tt_input_dtype, tt_output_dtype):
+    return tt_output_dtype in INTEGER_OUTPUT_DTYPES


### PR DESCRIPTION
### Issue
https://github.com/tenstorrent/tt-metal/issues/46237

## Summary

- Updates nightly `test_copy_ops.py` typecast tests to use shared clamp-aware helpers, widened inputs, and exact integer assertions.
- Fixes the shared `eltwise_typecast` golden for **device** `bf16`/`fp32` → `uint16` so existing eltwise tests can use elementwise equality instead of PCC for those paths.
- Adds a **host-specific** `uint16` golden in `test_copy_ops.py` because host-resident typecast truncates while device typecast rounds.

## Changes Done

### `tests/ttnn/nightly/unit_tests/operations/data_movement/test_copy_ops.py`

**Reason:** Tests used in-range inputs, naive goldens, and weak or missing numerical checks.

| Test | Before | After |
|------|--------|-------|
| `run_typecast_row_major_test` / `test_typecast_row_major` | `torch.randn`; naive `.to(dtype)`; `torch.equal` only for `int32` | `typecast_test_input_bounds` + `make_typecast_test_input`; `eltwise_typecast` golden; `assert_integer_typecast_equal` for all integer outputs |
| `test_typecast_host_tensor` | `torch.rand([0,1))`; shape/dtype/storage only — **no numerical assert** | Widened fp32 inputs; host/device-aware golden; `assert_integer_typecast_equal` |
| `test_typecast_output_tensor` | `torch.equal` called but **result never asserted** | `eltwise_typecast` golden + `assert_integer_typecast_equal` on both normal and preallocated output paths |

**Host-specific goldens** (host path ≠ device path):

| Conversion | Host behavior | Golden |
|------------|---------------|--------|
| `fp32 → uint8` | Clamps to `[0, 255]` (no wrap) | `torch.clamp(..., 0, 255).to(uint8)` |
| `fp32 → uint16` | **Truncates** | `torch.clamp(x.to(int32), 0, 65535)` |
| `fp32 → uint32` | Relu-style; negatives mismatch | Force non-negative inputs (`in_low = 0`) |
| Other integer outputs on host | Same as device | `eltwise_typecast` |

### `tests/ttnn/python_api_testing/sweep_tests/ttnn_pytorch_ops.py`

**Reason:** Device `float_to_uint16()` (in `ttnn/.../common/common.cpp`) converts to float32, applies `std::round`, then clamps to `[0, 65535]`. The old test golden truncated via `.to(int32)`, causing ±1 mismatches on device and forcing PCC in eltwise tests.

Used for `bf16 → uint16` and `fp32 → uint16` in `eltwise_typecast`. Block-float → `uint16` paths (`bf8_b`, `bf4_b`) are unchanged (quantize then truncate; already matched device exactly).

---

### `tests/ttnn/python_api_testing/typecast_test_helpers.py`

**Why:** `test_run_eltwise_typecast_op` already branches on `uses_exact_integer_typecast_check()` — no test file edit needed once the golden and predicate are fixed.
- Before `bf16`/`fp32`/`bf8_b`/`bf4_b` → `uint16` fell through to **PCC**.
- All integer output dtypes now use **`assert_integer_typecast_equal`**.

PCC remains in `test_run_eltwise_typecast_op` only for **block-float output** paths (e.g. `bf16 → bfp8_b`), which are not integer typecasts.

### Pipeline status

- [x] Sanity test
- [x] (Runtime) Sanity Tests
- [x] BHPC
- [x] Nightly for DM category

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=virdhatchanu/typecast_3)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:virdhatchanu/typecast_3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=virdhatchanu/typecast_3)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:virdhatchanu/typecast_3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=virdhatchanu/typecast_3)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:virdhatchanu/typecast_3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=virdhatchanu/typecast_3)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:virdhatchanu/typecast_3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=virdhatchanu/typecast_3)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:virdhatchanu/typecast_3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=virdhatchanu/typecast_3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:virdhatchanu/typecast_3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=virdhatchanu/typecast_3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:virdhatchanu/typecast_3)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=virdhatchanu/typecast_3)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:virdhatchanu/typecast_3)