### PR TITLE
[Bug fix] Pop final input page in tiled reshape writer

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
@@ -29,6 +29,7 @@ void kernel_main() {
 
     // loop over output (reshaped) pages this core is responsible for
     bool first = true;
+    bool input_page_loaded = false;
     cb_reserve_back(cb_id_working, 1);
     const uint32_t working_write_addr = get_write_ptr(cb_id_working);
     for (uint32_t output_page_idx = start_output_page; output_page_idx < end_output_page; ++output_page_idx) {
@@ -41,6 +42,7 @@ void kernel_main() {
                 if (output_page_idx == end_output_page - 1 && seg_idx == Max_Map_Entries - 1) {
                     noc_async_write_barrier();
                     cb_pop_front(cb_id_input, 1);
+                    input_page_loaded = false;
                 }
                 continue;
             }
@@ -50,13 +52,16 @@ void kernel_main() {
                 input_base_addr = get_read_ptr(cb_id_input);
                 previous_input_page_idx = map_ptr[seg_idx].input_page_index;
                 first = false;
+                input_page_loaded = true;
 
             } else if (map_ptr[seg_idx].input_page_index != previous_input_page_idx) {
                 noc_async_write_barrier();
                 cb_pop_front(cb_id_input, 1);
+                input_page_loaded = false;
                 cb_wait_front(cb_id_input, 1);
                 input_base_addr = get_read_ptr(cb_id_input);
                 previous_input_page_idx = map_ptr[seg_idx].input_page_index;
+                input_page_loaded = true;
             }
             // TODO (maybe) pre calculate size and offsets in bytes on host
             const uint32_t output_addr = working_write_addr + map_ptr[seg_idx].output_page_offset * element_sz_bytes;
@@ -71,6 +76,10 @@ void kernel_main() {
         noc_async_write_barrier();
 
         cb_pop_front(cb_id_mapping, 1);
+    }
+    if (input_page_loaded) {
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_input, 1);
     }
     cb_push_back(cb_id_working, 1);
 }


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This narrows #46791 to `writer_reshape_tiled.cpp`, where the tiled reshape writer can carry the final input CB page to kernel exit without releasing it.

`ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp` now tracks whether an input page is still live and pops it before kernel exit when the map traversal did not already release it on a page transition or zero-sentinel tail.

I kept this separate from #46794 and #46801 because this is a different operator family and a different failure shape.

Relates to #46791

### Notes for reviewers
- Failure mechanism: the writer pops `cb_id_input` on page transitions and on one specific zero-sentinel tail case, but the host-side mapping does not guarantee that the final map slot is always a zero sentinel. A fully populated map page can therefore exit with the final input page still outstanding.
- Source proof:
  - `reshape_tiled_program_factory.cpp` zero-initializes the flattened mapping buffer, but it also computes `max_input_segments` from the maximum real page segment count and then copies each page's real segment list directly into that capacity.
  - when a page uses the full `max_input_segments` capacity, its last slot is a real segment rather than a zero sentinel.
- Preserved invariant: this change only balances the input CB lifecycle at kernel exit. It does not change the mapping traversal, output writes, or host-side mapping generation.
- Source reachability:
  - tiled `ttnn.reshape(...)` selects `ReshapeViewTiledProgramFactory` from `reshape_device_operation.cpp`
  - that factory selects `writer_reshape_tiled.cpp`
- Validation:
  - fresh Python-binding build with distributed disabled and simulation disabled
  - mock-device path execution through tiled `ttnn.reshape(...)`
  - I kept the validation claim at path execution. I did not claim full numeric correctness from the mock path.
