### PR TITLE
[Bug fix] Pop layernorm partial CB pages after gather

### DIFF
--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp
@@ -239,6 +239,8 @@ void kernel_main() {
             reduce_sender_sem.wait_min(block + 2);
             cb_ex_global_obj.push_back(num_tiles * num_tiles_scaler);
         }
+
+        cb_partial_obj.pop_front(block_h * num_tiles_scaler);
     };
 
     if constexpr (!rms_norm) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp
@@ -201,6 +201,8 @@ void kernel_main() {
             cb_reduce_first_stage_obj.wait_front(num_tiles_per_partial_result * num_tiles_to_read);
             reduce_second_stage_sem.up(noc, remote_coords_second_stage[0].x, remote_coords_second_stage[0].y, 1);
         }
+
+        cb_partial_obj.pop_front(num_tiles_per_partial_result * block_h);
     };
     global_reduce_receiver(cb_ex_partial2, cb_ex_external2, cb_ex2);
     noc.async_atomic_barrier();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp
@@ -210,6 +210,7 @@ void kernel_main() {
         // ---------------------------------------------------------------------------
 
         cb_ex_obj.wait_front(num_tiles_per_worker * num_tiles_scaler);
+        cb_partial_obj.pop_front(block_h * num_tiles_scaler);
 
         if constexpr (num_all_to_all_workers_first_stage > 1) {
             reduce_receiver_sem.wait(num_all_to_all_workers_first_stage - 1);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp
@@ -177,6 +177,7 @@ void kernel_main() {
                              1));  // push back partials from all cores -> compute can start reducing now
                     }
                 }
+                cb_partial_obj.pop_front(num_tiles_per_partial_result * block_h);
             };
     global_reduce_sender(cb_ex_partial2, cb_ex_external2, cb_ex2);
     noc.async_write_barrier();


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This narrows `#46791` to the sharded `layernorm` dataflow kernels that wait on local partial-reduction CB pages, use those pages through `get_read_ptr()` for the all-to-all gather/combine path, and then leave that local partial buffer outstanding.

- `ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln.cpp`
- `ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln.cpp`
- `ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp`
- `ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp`

Each file now releases the waited local partial pages with the matching `cb_partial_obj.pop_front(...)` once its gather/combine phase finishes.

I kept this separate from `#46794`, `#46801`, and `#46817` because this is a different kernel family and a different failure shape.

Relates to `#46791`

### Notes for reviewers
- Failure mechanism:
  - these kernels wait on local partial-result pages
  - take `cb_partial_obj.get_read_ptr()`
  - drive the gather/combine path from those local pages
  - and then exit that phase without releasing the waited pages
- Source proof:
  - regular sender:
    - `reader_mcast_sender_unary_sharded_ln.cpp`
      - `cb_partial_obj.wait_front(block_h * num_tiles_scaler)`
      - `cb_partial_obj.get_read_ptr()`
  - regular receiver:
    - `reader_mcast_receiver_unary_sharded_ln.cpp`
      - `cb_partial_obj.wait_front(block_h * num_tiles_scaler)`
      - `cb_partial_obj.get_read_ptr()`
  - pre-allgather sender:
    - `reader_mcast_sender_unary_sharded_ln_pre_allgather.cpp`
      - `cb_partial_obj.wait_front(num_tiles_per_partial_result * block_h)`
      - `cb_partial_obj.get_read_ptr()`
  - pre-allgather receiver:
    - `reader_mcast_receiver_unary_sharded_ln_pre_allgather.cpp`
      - `cb_partial_obj.wait_front(num_tiles_per_partial_result * block_h)`
      - `cb_partial_obj.get_read_ptr()`
- Preserved invariant:
  - this change only balances the local partial CB lifecycle
  - it does not change:
    - semaphore ordering
    - NOC gather topology
    - combine order
    - multicast staging
- Scope boundary:
  - I did not include the post-allgather pair
  - `reader_mcast_sender_unary_sharded_ln_post_allgather.cpp` already pairs:
    - `cb_stats_reduced_obj.wait_front(...)`
    - `cb_stats_reduced_obj.pop_front(...)`
  - `reader_mcast_receiver_unary_sharded_ln_post_allgather.cpp` only waits on a semaphore and pushes into `cb_ex_global`
- Validation:
  - fresh WSL worktree on latest `upstream/main`
  - fresh Python-binding configure succeeded
  - fresh no-simulation Python build linked:
    - `ttnn/_ttnn.so`
    - `ttnn/_ttnncpp.so`
  - I did not claim a green mock runtime rerun here because the available local mock path hit validation-environment drift outside this patch:
    - no-simulation runtime import still references `SimulationChip`
    - simulation-enabled rebuild moved into a local fabric / UMD API mismatch before the target rerun
