### PR TITLE
[Feature] CONTIGUOUS_1D (shard-contiguous) shard-to-bank distribution for the DRAM-core prefetcher recv-contig path

### DIFF
--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -533,3 +533,42 @@ INSTANTIATE_TEST_SUITE_P(
         )       // Combine
 );
 // clang-format on
+
+// Device-free check of the shard->core placement formula for both 1D strategies.
+// 8 single-page shards over 2 cores (R = 4 shards per core). Round-robin spreads
+// consecutive shards across cores; CONTIGUOUS_1D (block) packs a contiguous run per core.
+TEST(BufferDistributionSpecContiguous, BlockVsRoundRobinPlacement) {
+    const tt::tt_metal::Shape tensor_in_pages{8, 1};
+    const tt::tt_metal::Shape shard_in_pages{1, 1};
+    const CoreRangeSet grid(CoreRange({0, 0}, {1, 0}));  // 2 cores
+
+    BufferDistributionSpec round_robin(
+        tensor_in_pages, shard_in_pages, grid, ShardOrientation::ROW_MAJOR, ShardDistributionStrategy::ROUND_ROBIN_1D);
+    BufferDistributionSpec block(
+        tensor_in_pages, shard_in_pages, grid, ShardOrientation::ROW_MAJOR, ShardDistributionStrategy::CONTIGUOUS_1D);
+
+    ASSERT_EQ(round_robin.num_cores(), 2u);
+    ASSERT_EQ(block.num_cores(), 2u);
+
+    const auto round_robin_map = round_robin.compute_page_mapping().core_host_page_indices;
+    const auto block_map = block.compute_page_mapping().core_host_page_indices;
+
+    // Round-robin: core c holds shards c, c + num_cores, ...
+    EXPECT_EQ(round_robin_map[0], (std::vector<uint32_t>{0, 2, 4, 6}));
+    EXPECT_EQ(round_robin_map[1], (std::vector<uint32_t>{1, 3, 5, 7}));
+
+    // Block: core c holds the contiguous run c*R .. c*R + R - 1.
+    EXPECT_EQ(block_map[0], (std::vector<uint32_t>{0, 1, 2, 3}));
+    EXPECT_EQ(block_map[1], (std::vector<uint32_t>{4, 5, 6, 7}));
+}
+
+// CONTIGUOUS_1D requires a uniform shards-per-core; an indivisible count must fatal.
+TEST(BufferDistributionSpecContiguous, BlockRequiresUniformShardsPerCore) {
+    const tt::tt_metal::Shape tensor_in_pages{7, 1};  // 7 shards over 2 cores -> not uniform
+    const tt::tt_metal::Shape shard_in_pages{1, 1};
+    const CoreRangeSet grid(CoreRange({0, 0}, {1, 0}));  // 2 cores
+
+    BufferDistributionSpec block(
+        tensor_in_pages, shard_in_pages, grid, ShardOrientation::ROW_MAJOR, ShardDistributionStrategy::CONTIGUOUS_1D);
+    EXPECT_ANY_THROW((void)block.compute_page_mapping());
+}

--- a/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/distribution_spec/test_buffer_distribution_spec.cpp
@@ -536,39 +536,39 @@ INSTANTIATE_TEST_SUITE_P(
 
 // Device-free check of the shard->core placement formula for both 1D strategies.
 // 8 single-page shards over 2 cores (R = 4 shards per core). Round-robin spreads
-// consecutive shards across cores; CONTIGUOUS_1D (block) packs a contiguous run per core.
-TEST(BufferDistributionSpecContiguous, BlockVsRoundRobinPlacement) {
+// consecutive shards across cores; CONTIGUOUS_1D (shard-contiguous) packs a contiguous run per core.
+TEST(BufferDistributionSpecContiguous, ShardContiguousVsRoundRobinPlacement) {
     const tt::tt_metal::Shape tensor_in_pages{8, 1};
     const tt::tt_metal::Shape shard_in_pages{1, 1};
     const CoreRangeSet grid(CoreRange({0, 0}, {1, 0}));  // 2 cores
 
     BufferDistributionSpec round_robin(
         tensor_in_pages, shard_in_pages, grid, ShardOrientation::ROW_MAJOR, ShardDistributionStrategy::ROUND_ROBIN_1D);
-    BufferDistributionSpec block(
+    BufferDistributionSpec shard_contiguous(
         tensor_in_pages, shard_in_pages, grid, ShardOrientation::ROW_MAJOR, ShardDistributionStrategy::CONTIGUOUS_1D);
 
     ASSERT_EQ(round_robin.num_cores(), 2u);
-    ASSERT_EQ(block.num_cores(), 2u);
+    ASSERT_EQ(shard_contiguous.num_cores(), 2u);
 
     const auto round_robin_map = round_robin.compute_page_mapping().core_host_page_indices;
-    const auto block_map = block.compute_page_mapping().core_host_page_indices;
+    const auto shard_contiguous_map = shard_contiguous.compute_page_mapping().core_host_page_indices;
 
     // Round-robin: core c holds shards c, c + num_cores, ...
     EXPECT_EQ(round_robin_map[0], (std::vector<uint32_t>{0, 2, 4, 6}));
     EXPECT_EQ(round_robin_map[1], (std::vector<uint32_t>{1, 3, 5, 7}));
 
-    // Block: core c holds the contiguous run c*R .. c*R + R - 1.
-    EXPECT_EQ(block_map[0], (std::vector<uint32_t>{0, 1, 2, 3}));
-    EXPECT_EQ(block_map[1], (std::vector<uint32_t>{4, 5, 6, 7}));
+    // Shard-contiguous: core c holds the contiguous run c*R .. c*R + R - 1.
+    EXPECT_EQ(shard_contiguous_map[0], (std::vector<uint32_t>{0, 1, 2, 3}));
+    EXPECT_EQ(shard_contiguous_map[1], (std::vector<uint32_t>{4, 5, 6, 7}));
 }
 
 // CONTIGUOUS_1D requires a uniform shards-per-core; an indivisible count must fatal.
-TEST(BufferDistributionSpecContiguous, BlockRequiresUniformShardsPerCore) {
+TEST(BufferDistributionSpecContiguous, ShardContiguousRequiresUniformShardsPerCore) {
     const tt::tt_metal::Shape tensor_in_pages{7, 1};  // 7 shards over 2 cores -> not uniform
     const tt::tt_metal::Shape shard_in_pages{1, 1};
     const CoreRangeSet grid(CoreRange({0, 0}, {1, 0}));  // 2 cores
 
-    BufferDistributionSpec block(
+    BufferDistributionSpec shard_contiguous(
         tensor_in_pages, shard_in_pages, grid, ShardOrientation::ROW_MAJOR, ShardDistributionStrategy::CONTIGUOUS_1D);
-    EXPECT_ANY_THROW((void)block.compute_page_mapping());
+    EXPECT_ANY_THROW((void)shard_contiguous.compute_page_mapping());
 }

--- a/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_tensor_nd_sharding.cpp
@@ -408,6 +408,18 @@ INSTANTIATE_TEST_SUITE_P(
             .memory_layout = TensorMemoryLayout::BLOCK_SHARDED,
             .shard_shape_2d = Shape2D{32, 32},
         },
+        // CONTIGUOUS_1D has no legacy equivalent: the same params convert to BLOCK_SHARDED under GRID_2D (above), so
+        // without an explicit guard this would silently fabricate a garbled legacy spec. It must instead stay
+        // ND_SHARDED with no 2D shard spec.
+        NdToLegacyShardingParams{
+            .shape = Shape({2, 32 * 2, 32 * 2}),
+            .shard_shape_nd = Shape({1, 32, 32}),
+            .layout = Layout::TILE,
+            .grid_size = CoreCoord{3, 4},
+            .shard_distribution_strategy = ShardDistributionStrategy::CONTIGUOUS_1D,
+            .memory_layout = TensorMemoryLayout::ND_SHARDED,
+            .shard_shape_2d = std::nullopt,
+        },
         NdToLegacyShardingParams{
             .shape = Shape({2, 2, 4}),
             .shard_shape_nd = Shape({1, 1, 2}),

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
@@ -494,11 +494,11 @@ TEST_P(ShardedAccessorTestsReshardOnDevice, SingleCoreReshard) {
 std::vector<InputOutputBufferParams> get_sharded_accessor_test_params() {
     std::vector<InputOutputBufferParams> base_params{
         // Shard-contiguous (CONTIGUOUS_1D) distribution with shards_per_core == 2 (32 shards over 16 cores), so
-        // shard-contiguous
-        // and round-robin map shards to banks differently. Swept across all arg configs, this exercises
-        // both the compile-time shard-contiguous path (ArgConfig::IsShardContiguous bit, when num_banks is a CTA) and
-        // the runtime shard-contiguous path (flag packed in the top bit of the runtime num_banks word, when num_banks
-        // is a CRTA). The output buffer stays round-robin to also cover a mixed-distribution reshard.
+        // shard-contiguous and round-robin map shards to banks differently. Swept across all arg configs, this
+        // exercises both the compile-time shard-contiguous path (flag packed in the top bit of the compile-time
+        // num_banks word, when num_banks is a CTA) and the runtime shard-contiguous path (same flag in the runtime
+        // num_banks word, when num_banks is a CRTA). The output buffer stays round-robin to also cover a
+        // mixed-distribution reshard.
         InputOutputBufferParams{
             .tensor_shape = tt::tt_metal::Shape{8, 64, 64},
             .layout = Layout::TILE,

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
@@ -493,6 +493,32 @@ TEST_P(ShardedAccessorTestsReshardOnDevice, SingleCoreReshard) {
 
 std::vector<InputOutputBufferParams> get_sharded_accessor_test_params() {
     std::vector<InputOutputBufferParams> base_params{
+        // Block (CONTIGUOUS_1D) distribution with shards_per_core == 2 (32 shards over 16 cores), so block
+        // and round-robin map shards to banks differently. Swept across all arg configs, this exercises
+        // both the compile-time block path (ArgConfig::IsBlockDistribution bit, when num_banks is a CTA) and
+        // the runtime block path (flag packed in the top bit of the runtime num_banks word, when num_banks
+        // is a CRTA). The output buffer stays round-robin to also cover a mixed-distribution reshard.
+        InputOutputBufferParams{
+            .tensor_shape = tt::tt_metal::Shape{8, 64, 64},
+            .layout = Layout::TILE,
+            .dtype = DataType::UINT16,
+            .input_buffer_type = BufferType::L1,
+            .output_buffer_type = BufferType::L1,
+
+            .input_shard_spec =
+                NdShardSpec{
+                    .shard_shape = tt::tt_metal::Shape{1, 32, 32},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                    .orientation = ShardOrientation::ROW_MAJOR,
+                    .shard_distribution_strategy = ShardDistributionStrategy::CONTIGUOUS_1D,
+                },
+            .output_shard_spec =
+                NdShardSpec{
+                    .shard_shape = tt::tt_metal::Shape{2, 32, 32},
+                    .grid = CoreRangeSet(CoreRange({0, 0}, {3, 3})),
+                    .orientation = ShardOrientation::ROW_MAJOR,
+                },
+        },
         InputOutputBufferParams{
             .tensor_shape = tt::tt_metal::Shape{4, 64, 96},
             .layout = Layout::TILE,

--- a/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/test_tensor_accessor_on_device.cpp
@@ -493,10 +493,11 @@ TEST_P(ShardedAccessorTestsReshardOnDevice, SingleCoreReshard) {
 
 std::vector<InputOutputBufferParams> get_sharded_accessor_test_params() {
     std::vector<InputOutputBufferParams> base_params{
-        // Block (CONTIGUOUS_1D) distribution with shards_per_core == 2 (32 shards over 16 cores), so block
+        // Shard-contiguous (CONTIGUOUS_1D) distribution with shards_per_core == 2 (32 shards over 16 cores), so
+        // shard-contiguous
         // and round-robin map shards to banks differently. Swept across all arg configs, this exercises
-        // both the compile-time block path (ArgConfig::IsBlockDistribution bit, when num_banks is a CTA) and
-        // the runtime block path (flag packed in the top bit of the runtime num_banks word, when num_banks
+        // both the compile-time shard-contiguous path (ArgConfig::IsShardContiguous bit, when num_banks is a CTA) and
+        // the runtime shard-contiguous path (flag packed in the top bit of the runtime num_banks word, when num_banks
         // is a CRTA). The output buffer stays round-robin to also cover a mixed-distribution reshard.
         InputOutputBufferParams{
             .tensor_shape = tt::tt_metal::Shape{8, 64, 64},

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -58,10 +58,41 @@ def bank_receivers_strided(bank_idx: int, recv_per_bank: int, num_dram_banks: in
     return ttnn.CoreRangeSet(cores)
 
 
-def make_recv_contig_weight(device, pt_weight, num_dram_banks: int, ring_size: int, dtype):
+def bank_receivers_contiguous(bank_idx: int, recv_per_bank: int, ring_cols: int):
+    """Contiguous receiver arc matching BufferDistributionSpec CONTIGUOUS_1D (block)
+    placement: bank b -> ring positions [b*recv_per_bank .. (b+1)*recv_per_bank - 1].
+
+    Under CONTIGUOUS_1D shard distribution, shard s lands on bank
+    (s // recv_per_bank) at bank-local slab (s % recv_per_bank). Pairing that with
+    this GCB topology means shard index == ring position (no permutation), and each
+    bank feeds a contiguous arc of the ring instead of a strided set.
+    """
+    cores = []
+    for s in range(recv_per_bank):
+        ring_pos = bank_idx * recv_per_bank + s
+        col = ring_pos % ring_cols
+        row = ring_pos // ring_cols
+        cores.append(ttnn.CoreRange(ttnn.CoreCoord(col, row), ttnn.CoreCoord(col, row)))
+    return ttnn.CoreRangeSet(cores)
+
+
+def make_recv_contig_weight(
+    device,
+    pt_weight,
+    num_dram_banks: int,
+    ring_size: int,
+    dtype,
+    distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+):
     """Allocate ``pt_weight`` ((1, 1, K, N)) as a DRAM-sharded ND tensor in
-    receiver-contiguous layout: ``num_shards = ring_size`` distributed round-robin
-    across ``num_dram_banks`` DRAM cores, each shard ``(K, N // ring_size)``.
+    receiver-contiguous layout: ``num_shards = ring_size`` distributed across
+    ``num_dram_banks`` DRAM cores, each shard ``(K, N // ring_size)``.
+
+    ``distribution_strategy`` selects how shards map to banks: ROUND_ROBIN_1D
+    (shard s -> bank s % num_dram_banks) or CONTIGUOUS_1D (shard s -> bank
+    s // recv_per_bank). The GCB sender->receiver pairing must match (use
+    ``bank_receivers_strided`` for round-robin, ``bank_receivers_contiguous`` for
+    block) so that shard index == ring position.
 
     With ``ring_size > num_dram_banks`` (bank b stacks ``ring_size //
     num_dram_banks`` slabs vertically), the prefetcher manager auto-detects this
@@ -79,7 +110,7 @@ def make_recv_contig_weight(device, pt_weight, num_dram_banks: int, ring_size: i
         ttnn.Shape([K, n_per_recv]),
         dram_core_range_set,
         ttnn.ShardOrientation.ROW_MAJOR,
-        ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+        distribution_strategy,
     )
     mem_config = ttnn.MemoryConfig(ttnn.BufferType.DRAM, nd_shard)
     return ttnn.as_tensor(pt_weight, device=device, dtype=dtype, memory_config=mem_config, layout=ttnn.TILE_LAYOUT)

--- a/tests/ttnn/unit_tests/operations/prefetcher_common.py
+++ b/tests/ttnn/unit_tests/operations/prefetcher_common.py
@@ -59,7 +59,7 @@ def bank_receivers_strided(bank_idx: int, recv_per_bank: int, num_dram_banks: in
 
 
 def bank_receivers_contiguous(bank_idx: int, recv_per_bank: int, ring_cols: int):
-    """Contiguous receiver arc matching BufferDistributionSpec CONTIGUOUS_1D (block)
+    """Contiguous receiver arc matching BufferDistributionSpec CONTIGUOUS_1D (shard-contiguous)
     placement: bank b -> ring positions [b*recv_per_bank .. (b+1)*recv_per_bank - 1].
 
     Under CONTIGUOUS_1D shard distribution, shard s lands on bank
@@ -92,7 +92,7 @@ def make_recv_contig_weight(
     (shard s -> bank s % num_dram_banks) or CONTIGUOUS_1D (shard s -> bank
     s // recv_per_bank). The GCB sender->receiver pairing must match (use
     ``bank_receivers_strided`` for round-robin, ``bank_receivers_contiguous`` for
-    block) so that shard index == ring position.
+    shard-contiguous) so that shard index == ring position.
 
     With ``ring_size > num_dram_banks`` (bank b stacks ``ring_size //
     num_dram_banks`` slabs vertically), the prefetcher manager auto-detects this

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
@@ -482,7 +482,7 @@ def test_bench_dram_core_repeats(device, op_name, shape):
 @pytest.mark.parametrize(
     "distribution",
     [ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D, ttnn.ShardDistributionStrategy.CONTIGUOUS_1D],
-    ids=["round_robin", "block"],
+    ids=["round_robin", "shard_contiguous"],
 )
 def test_bench_dram_core_repeats_recv_contig(device, op_name, shape, distribution):
     """Same matmul trace-replay bench as test_bench_dram_core_repeats, but the weight
@@ -491,7 +491,7 @@ def test_bench_dram_core_repeats_recv_contig(device, op_name, shape, distributio
     Parametrized on the shard distribution to A/B the ring-routing effect:
       - round_robin: bank b feeds the STRIDED ring set [b, b+num_banks, ...] (column b
         of receivers_per_y) -- each bank's writes fan out across the whole ring.
-      - block (CONTIGUOUS_1D): bank b feeds the CONTIGUOUS arc [b*R, b*R+R-1] (row b of
+      - shard-contiguous (CONTIGUOUS_1D): bank b feeds the CONTIGUOUS arc [b*R, b*R+R-1] (row b of
         receivers_per_y) -- each bank's writes stay on a local ring segment.
     The matmul topology (receiver cores, ring order, program config) is identical; only
     the shard->bank placement and the GCB pairing change, so PCC holds for both. Compare
@@ -565,7 +565,7 @@ def test_bench_dram_core_repeats_recv_contig(device, op_name, shape, distributio
 
     # Receiver-contiguous weight: NdShardSpec, num_shards = ring_size, each shard (K_padded, n_per_recv).
     n_per_recv = _N // ring_size
-    is_block = distribution == ttnn.ShardDistributionStrategy.CONTIGUOUS_1D
+    is_shard_contiguous = distribution == ttnn.ShardDistributionStrategy.CONTIGUOUS_1D
     tt_weight = _make_recv_contig_weight(
         device, pt_weight, num_dram_banks, ring_size, _DTYPE, distribution_strategy=distribution
     )
@@ -595,8 +595,8 @@ def test_bench_dram_core_repeats_recv_contig(device, op_name, shape, distributio
     # bank_to_receivers pairing must match the BDS placement so ring position r receives
     # shard r (full K, N-cols [r*npr, ...)):
     #   round_robin -> STRIDED: bank b feeds [b, b+num_banks, ...] = column b of receivers_per_y.
-    #   block       -> CONTIGUOUS arc: bank b feeds [b*R, b*R+R-1] = row b of receivers_per_y.
-    if is_block:
+    #   shard-contiguous -> CONTIGUOUS arc: bank b feeds [b*R, b*R+R-1] = row b of receivers_per_y.
+    if is_shard_contiguous:
         bank_to_receivers = [
             (
                 b,
@@ -707,10 +707,10 @@ def test_bench_dram_core_repeats_recv_contig(device, op_name, shape, distributio
     per_matmul_us = elapsed / trace_repeats * 1e6
     tflops = _flops_per_matmul(_K) * trace_repeats / elapsed / 1e12
     # Effective weight-streaming bandwidth: the full weight (K_padded x N) crosses the
-    # ring once per matmul. This is the metric block distribution aims to improve.
+    # ring once per matmul. This is the metric shard-contiguous distribution aims to improve.
     weight_bytes = k_padded * _N * _DTYPE_BYTES
     gbps = weight_bytes * trace_repeats / elapsed / 1e9
-    dist_id = "block" if is_block else "round_robin"
+    dist_id = "shard_contiguous" if is_shard_contiguous else "round_robin"
     logger.info(
         f"[dram_core_rc][{op_name}] dist={dist_id} dual_senders={dual_senders} trace_elapsed={elapsed * 1e3:.2f}ms "
         f"repeats={trace_repeats} per_matmul={per_matmul_us:.2f}us -> {tflops:.4f} TFLOP/s, {gbps:.1f} GB/s"

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_bench.py
@@ -479,9 +479,23 @@ def test_bench_dram_core_repeats(device, op_name, shape):
     indirect=True,
 )
 @pytest.mark.parametrize("op_name,shape", LLAMA_SHAPES)
-def test_bench_dram_core_repeats_recv_contig(device, op_name, shape):
+@pytest.mark.parametrize(
+    "distribution",
+    [ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D, ttnn.ShardDistributionStrategy.CONTIGUOUS_1D],
+    ids=["round_robin", "block"],
+)
+def test_bench_dram_core_repeats_recv_contig(device, op_name, shape, distribution):
     """Same matmul trace-replay bench as test_bench_dram_core_repeats, but the weight
     is in **receiver-contiguous** DRAM layout (NdShardSpec, num_shards = ring_size).
+
+    Parametrized on the shard distribution to A/B the ring-routing effect:
+      - round_robin: bank b feeds the STRIDED ring set [b, b+num_banks, ...] (column b
+        of receivers_per_y) -- each bank's writes fan out across the whole ring.
+      - block (CONTIGUOUS_1D): bank b feeds the CONTIGUOUS arc [b*R, b*R+R-1] (row b of
+        receivers_per_y) -- each bank's writes stay on a local ring segment.
+    The matmul topology (receiver cores, ring order, program config) is identical; only
+    the shard->bank placement and the GCB pairing change, so PCC holds for both. Compare
+    the logged GB/s across the two ids for the same shape.
 
     Why this is matmul-correct: in a gather_in0 matmul, ring core r computes output
     N-cols [r*per_core_N, (r+1)*per_core_N) and therefore needs weight[all K, those
@@ -551,7 +565,10 @@ def test_bench_dram_core_repeats_recv_contig(device, op_name, shape):
 
     # Receiver-contiguous weight: NdShardSpec, num_shards = ring_size, each shard (K_padded, n_per_recv).
     n_per_recv = _N // ring_size
-    tt_weight = _make_recv_contig_weight(device, pt_weight, num_dram_banks, ring_size, _DTYPE)
+    is_block = distribution == ttnn.ShardDistributionStrategy.CONTIGUOUS_1D
+    tt_weight = _make_recv_contig_weight(
+        device, pt_weight, num_dram_banks, ring_size, _DTYPE, distribution_strategy=distribution
+    )
 
     K_per_shard = k_padded // ring_size
     act_mem_config = ttnn.create_sharded_memory_config(
@@ -575,24 +592,36 @@ def test_bench_dram_core_repeats_recv_contig(device, op_name, shape):
         num_global_cb_receivers=num_receivers_per_bank,
     )
 
-    # STRIDED bank_to_receivers: bank b feeds ring positions [b, b+num_banks, ...], i.e. the
-    # b-th receiver of each sorted y-row (column b of receivers_per_y). This matches the BDS
-    # round-robin placement so ring position r receives shard r (full K, N-cols [r*npr,...)).
-    bank_to_receivers = [
-        (
-            b,
-            ttnn.CoreRangeSet(
-                [
-                    ttnn.CoreRange(
-                        ttnn.CoreCoord(*receivers_per_y[s][b]),
-                        ttnn.CoreCoord(*receivers_per_y[s][b]),
-                    )
-                    for s in range(num_receivers_per_bank)
-                ]
-            ),
-        )
-        for b in range(num_dram_banks)
-    ]
+    # bank_to_receivers pairing must match the BDS placement so ring position r receives
+    # shard r (full K, N-cols [r*npr, ...)):
+    #   round_robin -> STRIDED: bank b feeds [b, b+num_banks, ...] = column b of receivers_per_y.
+    #   block       -> CONTIGUOUS arc: bank b feeds [b*R, b*R+R-1] = row b of receivers_per_y.
+    if is_block:
+        bank_to_receivers = [
+            (
+                b,
+                ttnn.CoreRangeSet(
+                    [
+                        ttnn.CoreRange(ttnn.CoreCoord(*receivers_per_y[b][s]), ttnn.CoreCoord(*receivers_per_y[b][s]))
+                        for s in range(num_receivers_per_bank)
+                    ]
+                ),
+            )
+            for b in range(num_dram_banks)
+        ]
+    else:
+        bank_to_receivers = [
+            (
+                b,
+                ttnn.CoreRangeSet(
+                    [
+                        ttnn.CoreRange(ttnn.CoreCoord(*receivers_per_y[s][b]), ttnn.CoreCoord(*receivers_per_y[s][b]))
+                        for s in range(num_receivers_per_bank)
+                    ]
+                ),
+            )
+            for b in range(num_dram_banks)
+        ]
     dual_senders = os.environ.get("BENCH_DUAL_SENDERS", "0") == "1"
     # Centralized recv-contig GCB builder: validates the (program_config, weight, bank_to_receivers)
     # triple (num_shards == ring_size, K % ring_size == 0, per_core_N == per-receiver N) and sizes/builds
@@ -677,9 +706,14 @@ def test_bench_dram_core_repeats_recv_contig(device, op_name, shape):
 
     per_matmul_us = elapsed / trace_repeats * 1e6
     tflops = _flops_per_matmul(_K) * trace_repeats / elapsed / 1e12
+    # Effective weight-streaming bandwidth: the full weight (K_padded x N) crosses the
+    # ring once per matmul. This is the metric block distribution aims to improve.
+    weight_bytes = k_padded * _N * _DTYPE_BYTES
+    gbps = weight_bytes * trace_repeats / elapsed / 1e9
+    dist_id = "block" if is_block else "round_robin"
     logger.info(
-        f"[dram_core_rc][{op_name}] dual_senders={dual_senders} trace_elapsed={elapsed * 1e3:.2f}ms "
-        f"repeats={trace_repeats} per_matmul={per_matmul_us:.2f}us -> {tflops:.4f} TFLOP/s"
+        f"[dram_core_rc][{op_name}] dist={dist_id} dual_senders={dual_senders} trace_elapsed={elapsed * 1e3:.2f}ms "
+        f"repeats={trace_repeats} per_matmul={per_matmul_us:.2f}us -> {tflops:.4f} TFLOP/s, {gbps:.1f} GB/s"
     )
 
 

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -436,10 +436,8 @@ def test_validator_dram_sender_recv_contig_block(device, K, N, dtype, recv_per_b
         dual_senders=dual_senders,
         distribution_strategy=ttnn.ShardDistributionStrategy.CONTIGUOUS_1D,
     )
-    with dram_core_prefetcher_session(device, dual_senders_per_bank=dual_senders):
-        ttnn.experimental.queue_dram_core_prefetcher_request(
-            device, [(tt_weight, ring_size)] * num_layers, global_cb=gcb
-        )
+    with tensor_prefetcher_session(device, dual_senders_per_bank=dual_senders):
+        ttnn.experimental.queue_tensor_prefetcher_request(device, [(tt_weight, ring_size)] * num_layers, global_cb=gcb)
         ttnn.experimental.test_dram_prefetcher_validator(
             device,
             tt_weight,

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -344,10 +344,10 @@ def _setup_weight_and_gcb_recv_contig(
     triggers the manager's recv-contig detection.
 
     The weight's shard distribution and the GCB sender->receiver pairing must
-    agree: round-robin shards pair with strided arcs, block (CONTIGUOUS_1D)
+    agree: round-robin shards pair with strided arcs, shard-contiguous (CONTIGUOUS_1D)
     shards pair with contiguous arcs. Either pairing yields shard index == ring
     position, so the validator's per-receiver column slice is unchanged."""
-    is_block = distribution_strategy == ttnn.ShardDistributionStrategy.CONTIGUOUS_1D
+    is_shard_contiguous = distribution_strategy == ttnn.ShardDistributionStrategy.CONTIGUOUS_1D
     tile_bytes = _bytes_per_tile(dtype)
     num_dram_banks = device.dram_grid_size().x
     ring_size = num_dram_banks * recv_per_bank
@@ -367,7 +367,7 @@ def _setup_weight_and_gcb_recv_contig(
         device, pt_weight, num_dram_banks, ring_size, dtype, distribution_strategy=distribution_strategy
     )
 
-    if is_block:
+    if is_shard_contiguous:
         bank_to_receivers = [
             (b, _bank_receivers_contiguous(b, recv_per_bank, ring_cols=ring_cols)) for b in range(num_dram_banks)
         ]
@@ -422,9 +422,11 @@ def test_validator_dram_sender_recv_contig(device, K, N, dtype, recv_per_bank, n
     ],
     ids=["multi_ksub", "ff1", "single_r4", "ff1_dual"],
 )
-def test_validator_dram_sender_recv_contig_block(device, K, N, dtype, recv_per_bank, num_layers, dual_senders):
-    """Block (CONTIGUOUS_1D) recv-contig: adjacent shards share a bank, so each bank
-    feeds a contiguous ring arc. Exercises the block shard->bank placement (host BDS)
+def test_validator_dram_sender_recv_contig_shard_contiguous(
+    device, K, N, dtype, recv_per_bank, num_layers, dual_senders
+):
+    """Shard-contiguous (CONTIGUOUS_1D) recv-contig: adjacent shards share a bank, so each bank
+    feeds a contiguous ring arc. Exercises the shard-contiguous shard->bank placement (host BDS)
     and the distribution-aware TensorAccessor the validator reads the source through."""
     tt_weight, gcb, num_iters_total, push_page_size, ring_size = _setup_weight_and_gcb_recv_contig(
         device,

--- a/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_prefetcher_BH_validator.py
@@ -23,6 +23,7 @@ from tests.ttnn.unit_tests.operations.prefetcher_common import (
     bytes_per_tile as _bytes_per_tile,
     ring_grid_cols as _ring_grid_cols,
     bank_receivers_strided as _bank_receivers_strided,
+    bank_receivers_contiguous as _bank_receivers_contiguous,
     make_recv_contig_weight as _make_recv_contig_weight,
     tensor_prefetcher_session,
 )
@@ -328,10 +329,25 @@ def test_validator_worker_sender(device, K, N, dtype, recv_per_bank, num_layers)
         device.remove_sub_device_manager(sub_device_manager)
 
 
-def _setup_weight_and_gcb_recv_contig(device, K, N, dtype, recv_per_bank, num_layers, dual_senders=False):
+def _setup_weight_and_gcb_recv_contig(
+    device,
+    K,
+    N,
+    dtype,
+    recv_per_bank,
+    num_layers,
+    dual_senders=False,
+    distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+):
     """Build a DRAM-sender GCB + NdShardSpec-allocated weight for the
     receiver-contiguous DRAM-core path. num_shards = ring_size > num_dram_banks
-    triggers the manager's recv-contig detection."""
+    triggers the manager's recv-contig detection.
+
+    The weight's shard distribution and the GCB sender->receiver pairing must
+    agree: round-robin shards pair with strided arcs, block (CONTIGUOUS_1D)
+    shards pair with contiguous arcs. Either pairing yields shard index == ring
+    position, so the validator's per-receiver column slice is unchanged."""
+    is_block = distribution_strategy == ttnn.ShardDistributionStrategy.CONTIGUOUS_1D
     tile_bytes = _bytes_per_tile(dtype)
     num_dram_banks = device.dram_grid_size().x
     ring_size = num_dram_banks * recv_per_bank
@@ -347,12 +363,19 @@ def _setup_weight_and_gcb_recv_contig(device, K, N, dtype, recv_per_bank, num_la
     pt_weight = torch.zeros(1, 1, K_padded, N)
     pt_weight[:, :, :K, :] = torch.randn(1, 1, K, N)
 
-    tt_weight = _make_recv_contig_weight(device, pt_weight, num_dram_banks, ring_size, dtype)
+    tt_weight = _make_recv_contig_weight(
+        device, pt_weight, num_dram_banks, ring_size, dtype, distribution_strategy=distribution_strategy
+    )
 
-    bank_to_receivers = [
-        (b, _bank_receivers_strided(b, recv_per_bank, num_dram_banks, ring_cols=ring_cols))
-        for b in range(num_dram_banks)
-    ]
+    if is_block:
+        bank_to_receivers = [
+            (b, _bank_receivers_contiguous(b, recv_per_bank, ring_cols=ring_cols)) for b in range(num_dram_banks)
+        ]
+    else:
+        bank_to_receivers = [
+            (b, _bank_receivers_strided(b, recv_per_bank, num_dram_banks, ring_cols=ring_cols))
+            for b in range(num_dram_banks)
+        ]
     gcb_size = _GCB_DEPTH_PAGES * push_page_size
     gcb = ttnn.experimental.create_global_circular_buffer_with_dram_senders(
         device, bank_to_receivers, gcb_size, dual_senders_per_bank=dual_senders
@@ -380,6 +403,43 @@ def test_validator_dram_sender_recv_contig(device, K, N, dtype, recv_per_bank, n
     )
     with tensor_prefetcher_session(device, dual_senders_per_bank=dual_senders):
         ttnn.experimental.queue_tensor_prefetcher_request(device, [(tt_weight, ring_size)] * num_layers, global_cb=gcb)
+        ttnn.experimental.test_dram_prefetcher_validator(
+            device,
+            tt_weight,
+            num_layers=num_layers,
+            print_stride=max(1, ring_size // 4),
+            global_cb=gcb,
+        )
+
+
+@pytest.mark.parametrize(
+    "K,N,dtype,recv_per_bank,num_layers,dual_senders",
+    [
+        (2048, 3584, ttnn.bfloat8_b, 2, 1, False),  # ring=16, contiguous arcs
+        (4096, 14336, ttnn.bfloat8_b, 8, 1, False),  # FF1 ring=64
+        (2048, 7168, ttnn.bfloat8_b, 4, 1, False),  # ring=32, single-sender nr=4
+        (4096, 14336, ttnn.bfloat8_b, 8, 1, True),  # FF1 ring=64, dual-sender split 4/4
+    ],
+    ids=["multi_ksub", "ff1", "single_r4", "ff1_dual"],
+)
+def test_validator_dram_sender_recv_contig_block(device, K, N, dtype, recv_per_bank, num_layers, dual_senders):
+    """Block (CONTIGUOUS_1D) recv-contig: adjacent shards share a bank, so each bank
+    feeds a contiguous ring arc. Exercises the block shard->bank placement (host BDS)
+    and the distribution-aware TensorAccessor the validator reads the source through."""
+    tt_weight, gcb, num_iters_total, push_page_size, ring_size = _setup_weight_and_gcb_recv_contig(
+        device,
+        K,
+        N,
+        dtype,
+        recv_per_bank,
+        num_layers,
+        dual_senders=dual_senders,
+        distribution_strategy=ttnn.ShardDistributionStrategy.CONTIGUOUS_1D,
+    )
+    with dram_core_prefetcher_session(device, dual_senders_per_bank=dual_senders):
+        ttnn.experimental.queue_dram_core_prefetcher_request(
+            device, [(tt_weight, ring_size)] * num_layers, global_cb=gcb
+        )
         ttnn.experimental.test_dram_prefetcher_validator(
             device,
             tt_weight,

--- a/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
+++ b/tt_metal/api/tt-metalium/buffer_distribution_spec.hpp
@@ -16,7 +16,10 @@ namespace detail {
 // TODO: These functions in the detail namespace are sharding utility functions and should be moved to a separate
 // header.
 UncompressedBufferPageMapping compute_page_mapping(
-    const Shape& tensor_shape, const Shape& shard_shape, const std::vector<CoreCoord>& cores);
+    const Shape& tensor_shape,
+    const Shape& shard_shape,
+    const std::vector<CoreCoord>& cores,
+    ShardDistributionStrategy shard_distribution_strategy = ShardDistributionStrategy::ROUND_ROBIN_1D);
 
 // Squeezes tensor and shard shapes to minimize rank while preserving sharding semantics.
 // The returned shapes are guaranteed to have the same rank.
@@ -57,6 +60,8 @@ public:
     size_t num_shards_per_core(size_t core_idx) const;
     size_t num_dev_pages_per_core(size_t core_idx) const;
 
+    ShardDistributionStrategy shard_distribution_strategy() const { return shard_distribution_strategy_; }
+
     struct CoreGroups {
         CoreRangeSet cores_with_data;
         CoreRangeSet cores_in_group_1;
@@ -71,7 +76,8 @@ public:
     std::tuple<uint32_t, CoreRangeSet, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t> core_groups_tuple() const;
 
     UncompressedBufferPageMapping compute_page_mapping() const {
-        return detail::compute_page_mapping(tensor_shape_in_pages_, shard_shape_in_pages_, cores_);
+        return detail::compute_page_mapping(
+            tensor_shape_in_pages_, shard_shape_in_pages_, cores_, shard_distribution_strategy_);
     }
 
 private:
@@ -87,6 +93,7 @@ private:
     Shape shard_shape_in_pages_;
 
     std::vector<CoreCoord> cores_;
+    ShardDistributionStrategy shard_distribution_strategy_ = ShardDistributionStrategy::ROUND_ROBIN_1D;
 
     // Precomputed data
     CoreGroups core_groups_;

--- a/tt_metal/api/tt-metalium/buffer_types.hpp
+++ b/tt_metal/api/tt-metalium/buffer_types.hpp
@@ -28,6 +28,10 @@ enum class ShardDistributionStrategy {
     ROUND_ROBIN_1D = 0,
     // Distribute a 2D grid of shards to a 2D grid of cores with one to one mapping.
     GRID_2D = 1,
+    // Distribute shards contiguously over a linearized list of cores: adjacent shards go to the
+    // same core until it is full. Shard s lands on core (s / shards_per_core) at slot
+    // (s % shards_per_core). Requires a uniform shards_per_core (num_shards % num_cores == 0).
+    CONTIGUOUS_1D = 2,
 };
 
 enum class BufferType {

--- a/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
@@ -23,12 +23,6 @@ enum class ArgConfig : uint8_t {
     RuntimeTensorShape = 1 << 4,
     RuntimeShardShape = 1 << 5,
     RuntimeBankCoords = 1 << 6,
-    // Shards are distributed contiguously across banks (shard-contiguous; ShardDistributionStrategy::CONTIGUOUS_1D)
-    // rather than round-robin. This bit is the *compile-time* default, used only when num_banks is also
-    // compile-time. When num_banks is runtime (RuntimeNumBanks), the shard-contiguous flag instead rides in the top
-    // bit of the runtime num_banks word (see ShardContiguousBit), so it can vary per dispatch without
-    // recompiling. Either way the flag carries no extra args/slots; it only changes the shard->bank math.
-    IsShardContiguous = 1 << 7,
     Runtime = RuntimeRank | RuntimeNumBanks | RuntimeTensorShape | RuntimeShardShape | RuntimeBankCoords
 };
 
@@ -36,10 +30,11 @@ using ArgsConfig = Flags<ArgConfig>;
 constexpr ArgsConfig operator|(ArgConfig a, ArgConfig b) noexcept { return ArgsConfig(a) | b; }
 constexpr ArgsConfig operator|(ArgConfig a, ArgsConfig b) noexcept { return ArgsConfig(a) | b; }
 
-// When num_banks is a common runtime arg, its CRTA word doubles as the carrier for the shard-contiguous distribution
-// flag: the value lives in the low bits and the shard-contiguous flag in the top bit. num_banks is tiny (number of
-// DRAM/L1 banks), so this never collides with a real bank count. This lets the distribution strategy vary
-// at runtime without adding a CRTA slot or a new ArgConfig bit, gated on RuntimeNumBanks being set.
+// The num_banks word (whether it is a compile-time arg or a common runtime arg) doubles as the carrier for the
+// shard-contiguous distribution flag: the bank count lives in the low bits and the shard-contiguous flag in the top
+// bit. num_banks is tiny (number of DRAM/L1 banks), so this never collides with a real bank count. This lets the
+// distribution strategy be selected -- at compile time or per dispatch -- without adding an arg/slot or an ArgConfig
+// bit.
 //
 // pack/unpack are the single source of truth for this layout, so the host encoder and the device decoders
 // cannot drift. Callers must ensure num_banks < ShardContiguousBit (always true for real bank counts).

--- a/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
@@ -23,6 +23,9 @@ enum class ArgConfig : uint8_t {
     RuntimeTensorShape = 1 << 4,
     RuntimeShardShape = 1 << 5,
     RuntimeBankCoords = 1 << 6,
+    // Shards are distributed block-contiguously across banks (ShardDistributionStrategy::CONTIGUOUS_1D)
+    // rather than round-robin. Affects only the on-device shard->bank math; carries no extra args.
+    IsBlockDistribution = 1 << 7,
     Runtime = RuntimeRank | RuntimeNumBanks | RuntimeTensorShape | RuntimeShardShape | RuntimeBankCoords
 };
 

--- a/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
@@ -24,7 +24,10 @@ enum class ArgConfig : uint8_t {
     RuntimeShardShape = 1 << 5,
     RuntimeBankCoords = 1 << 6,
     // Shards are distributed block-contiguously across banks (ShardDistributionStrategy::CONTIGUOUS_1D)
-    // rather than round-robin. Affects only the on-device shard->bank math; carries no extra args.
+    // rather than round-robin. This bit is the *compile-time* default, used only when num_banks is also
+    // compile-time. When num_banks is runtime (RuntimeNumBanks), the block flag instead rides in the top
+    // bit of the runtime num_banks word (see BlockDistributionBit), so it can vary per dispatch without
+    // recompiling. Either way the flag carries no extra args/slots; it only changes the shard->bank math.
     IsBlockDistribution = 1 << 7,
     Runtime = RuntimeRank | RuntimeNumBanks | RuntimeTensorShape | RuntimeShardShape | RuntimeBankCoords
 };
@@ -32,5 +35,21 @@ enum class ArgConfig : uint8_t {
 using ArgsConfig = Flags<ArgConfig>;
 constexpr ArgsConfig operator|(ArgConfig a, ArgConfig b) noexcept { return ArgsConfig(a) | b; }
 constexpr ArgsConfig operator|(ArgConfig a, ArgsConfig b) noexcept { return ArgsConfig(a) | b; }
+
+// When num_banks is a common runtime arg, its CRTA word doubles as the carrier for the block-distribution
+// flag: the value lives in the low bits and the block flag in the top bit. num_banks is tiny (number of
+// DRAM/L1 banks), so this never collides with a real bank count. This lets the distribution strategy vary
+// at runtime without adding a CRTA slot or a new ArgConfig bit, gated on RuntimeNumBanks being set.
+//
+// pack/unpack are the single source of truth for this layout, so the host encoder and the device decoders
+// cannot drift. Callers must ensure num_banks < BlockDistributionBit (always true for real bank counts).
+inline constexpr uint32_t BlockDistributionBit = 1u << 31;
+constexpr uint32_t pack_num_banks(uint32_t num_banks, bool is_block_distribution) {
+    return num_banks | (is_block_distribution ? BlockDistributionBit : 0u);
+}
+constexpr uint32_t unpack_num_banks(uint32_t packed_num_banks) { return packed_num_banks & ~BlockDistributionBit; }
+constexpr bool unpack_is_block_distribution(uint32_t packed_num_banks) {
+    return (packed_num_banks & BlockDistributionBit) != 0;
+}
 
 }  // namespace tensor_accessor

--- a/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
@@ -23,12 +23,12 @@ enum class ArgConfig : uint8_t {
     RuntimeTensorShape = 1 << 4,
     RuntimeShardShape = 1 << 5,
     RuntimeBankCoords = 1 << 6,
-    // Shards are distributed block-contiguously across banks (ShardDistributionStrategy::CONTIGUOUS_1D)
+    // Shards are distributed contiguously across banks (shard-contiguous; ShardDistributionStrategy::CONTIGUOUS_1D)
     // rather than round-robin. This bit is the *compile-time* default, used only when num_banks is also
-    // compile-time. When num_banks is runtime (RuntimeNumBanks), the block flag instead rides in the top
-    // bit of the runtime num_banks word (see BlockDistributionBit), so it can vary per dispatch without
+    // compile-time. When num_banks is runtime (RuntimeNumBanks), the shard-contiguous flag instead rides in the top
+    // bit of the runtime num_banks word (see ShardContiguousBit), so it can vary per dispatch without
     // recompiling. Either way the flag carries no extra args/slots; it only changes the shard->bank math.
-    IsBlockDistribution = 1 << 7,
+    IsShardContiguous = 1 << 7,
     Runtime = RuntimeRank | RuntimeNumBanks | RuntimeTensorShape | RuntimeShardShape | RuntimeBankCoords
 };
 
@@ -36,20 +36,20 @@ using ArgsConfig = Flags<ArgConfig>;
 constexpr ArgsConfig operator|(ArgConfig a, ArgConfig b) noexcept { return ArgsConfig(a) | b; }
 constexpr ArgsConfig operator|(ArgConfig a, ArgsConfig b) noexcept { return ArgsConfig(a) | b; }
 
-// When num_banks is a common runtime arg, its CRTA word doubles as the carrier for the block-distribution
-// flag: the value lives in the low bits and the block flag in the top bit. num_banks is tiny (number of
+// When num_banks is a common runtime arg, its CRTA word doubles as the carrier for the shard-contiguous distribution
+// flag: the value lives in the low bits and the shard-contiguous flag in the top bit. num_banks is tiny (number of
 // DRAM/L1 banks), so this never collides with a real bank count. This lets the distribution strategy vary
 // at runtime without adding a CRTA slot or a new ArgConfig bit, gated on RuntimeNumBanks being set.
 //
 // pack/unpack are the single source of truth for this layout, so the host encoder and the device decoders
-// cannot drift. Callers must ensure num_banks < BlockDistributionBit (always true for real bank counts).
-inline constexpr uint32_t BlockDistributionBit = 1u << 31;
-constexpr uint32_t pack_num_banks(uint32_t num_banks, bool is_block_distribution) {
-    return num_banks | (is_block_distribution ? BlockDistributionBit : 0u);
+// cannot drift. Callers must ensure num_banks < ShardContiguousBit (always true for real bank counts).
+inline constexpr uint32_t ShardContiguousBit = 1u << 31;
+constexpr uint32_t pack_num_banks(uint32_t num_banks, bool is_shard_contiguous) {
+    return num_banks | (is_shard_contiguous ? ShardContiguousBit : 0u);
 }
-constexpr uint32_t unpack_num_banks(uint32_t packed_num_banks) { return packed_num_banks & ~BlockDistributionBit; }
-constexpr bool unpack_is_block_distribution(uint32_t packed_num_banks) {
-    return (packed_num_banks & BlockDistributionBit) != 0;
+constexpr uint32_t unpack_num_banks(uint32_t packed_num_banks) { return packed_num_banks & ~ShardContiguousBit; }
+constexpr bool unpack_is_shard_contiguous(uint32_t packed_num_banks) {
+    return (packed_num_banks & ShardContiguousBit) != 0;
 }
 
 }  // namespace tensor_accessor

--- a/tt_metal/hw/inc/api/tensor/pages_address_iterator.h
+++ b/tt_metal/hw/inc/api/tensor/pages_address_iterator.h
@@ -159,7 +159,7 @@ private:
                 (page_coord[i] % accessor.dspec().shard_shape()[i]) * accessor.dspec().shard_strides()[i];
         }
 
-        // Calculate bank mapping (round-robin or block-contiguous, per the distribution strategy)
+        // Calculate bank mapping (round-robin or shard-contiguous, per the distribution strategy)
         {
             const auto bank_shard = accessor.shard_to_bank(flattened_shard_id);
             current_page_mapping.bank_id = bank_shard.bank_id;
@@ -246,7 +246,7 @@ private:
             page_offset_within_shard += (page_coord[i] % dspec.shard_shape()[i]) * dspec.shard_strides()[i];
         }
 
-        // Recalculate bank mapping (round-robin or block-contiguous, per the distribution strategy)
+        // Recalculate bank mapping (round-robin or shard-contiguous, per the distribution strategy)
         {
             const auto bank_shard = accessor.shard_to_bank(flattened_shard_id);
             current_page_mapping.bank_id = bank_shard.bank_id;

--- a/tt_metal/hw/inc/api/tensor/pages_address_iterator.h
+++ b/tt_metal/hw/inc/api/tensor/pages_address_iterator.h
@@ -159,15 +159,18 @@ private:
                 (page_coord[i] % accessor.dspec().shard_shape()[i]) * accessor.dspec().shard_strides()[i];
         }
 
-        // Calculate bank mapping
-        current_page_mapping.bank_id = flattened_shard_id % accessor.dspec().num_banks();
-        bank_shard_id = flattened_shard_id / accessor.dspec().num_banks();
+        // Calculate bank mapping (round-robin or block-contiguous, per the distribution strategy)
+        {
+            const auto bank_shard = accessor.shard_to_bank(flattened_shard_id);
+            current_page_mapping.bank_id = bank_shard.bank_id;
+            bank_shard_id = bank_shard.shard_in_bank;
+        }
         current_page_mapping.bank_page_offset =
             bank_shard_id * accessor.dspec().shard_volume() + page_offset_within_shard;
 
         // Calculate NOC address and shard ID
         current_noc_addr = accessor.get_noc_addr(current_page_mapping, 0, noc);
-        current_shard_id = current_page_mapping.bank_id + bank_shard_id * accessor.dspec().num_banks();
+        current_shard_id = flattened_shard_id;
     }
 
     // Efficiently increment page coordinate and update derived state
@@ -243,14 +246,17 @@ private:
             page_offset_within_shard += (page_coord[i] % dspec.shard_shape()[i]) * dspec.shard_strides()[i];
         }
 
-        // Recalculate bank mapping
-        current_page_mapping.bank_id = flattened_shard_id % dspec.num_banks();
-        bank_shard_id = flattened_shard_id / dspec.num_banks();
+        // Recalculate bank mapping (round-robin or block-contiguous, per the distribution strategy)
+        {
+            const auto bank_shard = accessor.shard_to_bank(flattened_shard_id);
+            current_page_mapping.bank_id = bank_shard.bank_id;
+            bank_shard_id = bank_shard.shard_in_bank;
+        }
         current_page_mapping.bank_page_offset = bank_shard_id * dspec.shard_volume() + page_offset_within_shard;
 
         // Recalculate NOC address and shard ID
         current_noc_addr = accessor.get_noc_addr(current_page_mapping, 0, noc);
-        current_shard_id = current_page_mapping.bank_id + bank_shard_id * dspec.num_banks();
+        current_shard_id = flattened_shard_id;
     }
 };
 

--- a/tt_metal/hw/inc/api/tensor/shard_pages_address_iterator.h
+++ b/tt_metal/hw/inc/api/tensor/shard_pages_address_iterator.h
@@ -56,10 +56,11 @@ public:
         }
 
         // Calculate NOC address for the final position
+        const auto bank_shard = accessor.shard_to_bank(shard_id);
         PageMapping current_page_mapping{
-            .bank_id = shard_id % accessor.dspec().num_banks(),
+            .bank_id = bank_shard.bank_id,
             .bank_page_offset =
-                (shard_id / accessor.dspec().num_banks() * accessor.dspec().shard_volume()) + current_page_id_in_shard};
+                (bank_shard.shard_in_bank * accessor.dspec().shard_volume()) + current_page_id_in_shard};
         current_noc_addr = accessor.get_noc_addr(current_page_mapping, 0, noc);
         ASSERT(current_page_id_in_shard <= accessor.dspec().shard_volume());
         update_current_page();

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -318,15 +318,33 @@ private:
         size_t shard_in_bank = 0;  // index of the shard within its bank
     };
 
-    // Maps a flattened shard id to its bank and its slot within that bank, honoring the
-    // distribution strategy. Round-robin spreads consecutive shards across banks; block
-    // (CONTIGUOUS_1D) packs shards_per_core consecutive shards into one bank before advancing.
+    // Round-robin spreads consecutive shards across banks; block (CONTIGUOUS_1D) packs shards_per_bank
+    // consecutive shards into one bank before advancing.
+    FORCE_INLINE BankShard block_mapping(size_t flattened_shard_id) const {
+        const size_t shards_per_bank = dspec().num_shards() / dspec().num_banks();
+        return {flattened_shard_id / shards_per_bank, flattened_shard_id % shards_per_bank};
+    }
+    FORCE_INLINE BankShard round_robin_mapping(size_t flattened_shard_id) const {
+        return {flattened_shard_id % dspec().num_banks(), flattened_shard_id / dspec().num_banks()};
+    }
+
+    // Maps a flattened shard id to its bank and its slot within that bank, honoring the distribution
+    // strategy. When num_banks is compile-time, the strategy is too (DSpec::is_block) and the branch is
+    // resolved at compile time, keeping these accessors byte-identical to round-robin-only builds. When
+    // num_banks is runtime, the block flag rides in the runtime num_banks word and is read per dispatch.
+    // NOTE: keep the nested `if constexpr` rather than a single `is_block_distribution() ? ...` ternary --
+    // the ternary would ODR-use (instantiate) both mappings even for static round-robin accessors, losing
+    // that byte-identical guarantee.
     FORCE_INLINE BankShard shard_to_bank(size_t flattened_shard_id) const {
-        if constexpr (DSpec::is_block) {
-            const size_t shards_per_bank = dspec().num_shards() / dspec().num_banks();
-            return {flattened_shard_id / shards_per_bank, flattened_shard_id % shards_per_bank};
+        if constexpr (DSpec::has_static_num_banks) {
+            if constexpr (DSpec::is_block) {
+                return block_mapping(flattened_shard_id);
+            } else {
+                return round_robin_mapping(flattened_shard_id);
+            }
         } else {
-            return {flattened_shard_id % dspec().num_banks(), flattened_shard_id / dspec().num_banks()};
+            return dspec().is_block_distribution() ? block_mapping(flattened_shard_id)
+                                                   : round_robin_mapping(flattened_shard_id);
         }
     }
 

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -318,9 +318,9 @@ private:
         size_t shard_in_bank = 0;  // index of the shard within its bank
     };
 
-    // Round-robin spreads consecutive shards across banks; block (CONTIGUOUS_1D) packs shards_per_bank
+    // Round-robin spreads consecutive shards across banks; shard-contiguous (CONTIGUOUS_1D) packs shards_per_bank
     // consecutive shards into one bank before advancing.
-    FORCE_INLINE BankShard block_mapping(size_t flattened_shard_id) const {
+    FORCE_INLINE BankShard shard_contiguous_mapping(size_t flattened_shard_id) const {
         const size_t shards_per_bank = dspec().num_shards() / dspec().num_banks();
         return {flattened_shard_id / shards_per_bank, flattened_shard_id % shards_per_bank};
     }
@@ -329,22 +329,22 @@ private:
     }
 
     // Maps a flattened shard id to its bank and its slot within that bank, honoring the distribution
-    // strategy. When num_banks is compile-time, the strategy is too (DSpec::is_block) and the branch is
+    // strategy. When num_banks is compile-time, the strategy is too (DSpec::is_shard_contiguous) and the branch is
     // resolved at compile time, keeping these accessors byte-identical to round-robin-only builds. When
-    // num_banks is runtime, the block flag rides in the runtime num_banks word and is read per dispatch.
-    // NOTE: keep the nested `if constexpr` rather than a single `is_block_distribution() ? ...` ternary --
+    // num_banks is runtime, the shard-contiguous flag rides in the runtime num_banks word and is read per dispatch.
+    // NOTE: keep the nested `if constexpr` rather than a single `resolve_shard_contiguous() ? ...` ternary --
     // the ternary would ODR-use (instantiate) both mappings even for static round-robin accessors, losing
     // that byte-identical guarantee.
     FORCE_INLINE BankShard shard_to_bank(size_t flattened_shard_id) const {
         if constexpr (DSpec::has_static_num_banks) {
-            if constexpr (DSpec::is_block) {
-                return block_mapping(flattened_shard_id);
+            if constexpr (DSpec::is_shard_contiguous) {
+                return shard_contiguous_mapping(flattened_shard_id);
             } else {
                 return round_robin_mapping(flattened_shard_id);
             }
         } else {
-            return dspec().is_block_distribution() ? block_mapping(flattened_shard_id)
-                                                   : round_robin_mapping(flattened_shard_id);
+            return dspec().resolve_shard_contiguous() ? shard_contiguous_mapping(flattened_shard_id)
+                                                      : round_robin_mapping(flattened_shard_id);
         }
     }
 
@@ -537,7 +537,7 @@ TensorAccessor(const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args, size_t)
             TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::NumBanksCT>::type,
         /* IsInterleaved */ !TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_sharded,
         /* IsDram */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_dram,
-        /* IsBlock */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_block_distribution>>;
+        /* IsShardContiguous */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_shard_contiguous>>;
 
 // CTAD deduction guide for the Metal 2.0 binding-token ctor.
 // Mirrors the (args, size_t) guide above. The token's ADDR_CRTA_OFFSET marks the
@@ -565,7 +565,8 @@ TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA
             TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::NumBanksCT>::type,
         /* IsInterleaved */ !TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_sharded,
         /* IsDram */ TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_dram,
-        /* IsBlock */ TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_block_distribution>>;
+        /* IsShardContiguous */
+        TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_shard_contiguous>>;
 
 template <std::size_t CTA_OFFSET, std::size_t CRTA_OFFSET>
 TensorAccessor(const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args, size_t, uint32_t)
@@ -589,7 +590,7 @@ TensorAccessor(const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args, size_t, 
             TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::NumBanksCT>::type,
         /* IsInterleaved */ !TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_sharded,
         /* IsDram */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_dram,
-        /* IsBlock */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_block_distribution>>;
+        /* IsShardContiguous */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_shard_contiguous>>;
 
 template <
     uint32_t RankCT,
@@ -599,7 +600,7 @@ template <
     typename BankCoordsWrapper,
     bool IsInterleaved,
     bool IsDram,
-    bool IsBlock>
+    bool IsShardContiguous>
 TensorAccessor(
     tensor_accessor::DistributionSpec<
         RankCT,
@@ -609,7 +610,7 @@ TensorAccessor(
         BankCoordsWrapper,
         IsInterleaved,
         IsDram,
-        IsBlock>,
+        IsShardContiguous>,
     size_t,
     uint32_t)
     -> TensorAccessor<tensor_accessor::DistributionSpec<
@@ -620,7 +621,7 @@ TensorAccessor(
         BankCoordsWrapper,
         IsInterleaved,
         IsDram,
-        IsBlock>>;
+        IsShardContiguous>>;
 
 namespace tensor_accessor::detail {
 template <typename... Args, uint32_t... Indexes>

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -144,9 +144,10 @@ public:
     FORCE_INLINE
     std::uint64_t get_shard_noc_addr(
         const uint32_t shard_id, const uint32_t offset = 0, uint8_t noc = noc_index) const {
+        const auto bank_shard = shard_to_bank(shard_id);
         PageMapping page_mapping{
-            .bank_id = shard_id % dspec().num_banks(),
-            .bank_page_offset = shard_id / dspec().num_banks() * dspec().shard_volume(),
+            .bank_id = bank_shard.bank_id,
+            .bank_page_offset = bank_shard.shard_in_bank * dspec().shard_volume(),
         };
         return get_noc_addr(page_mapping, offset, noc);
     }
@@ -215,13 +216,10 @@ public:
             page_offset_within_shard += (page_coord[i] % dspec().shard_shape()[i]) * dspec().shard_strides()[i];
         }
 
-        // NOTE: This assumes shards are round-robin assigned across banks
-        uint32_t bank_id = flattened_shard_id % dspec().num_banks();
-        uint32_t bank_shard_id = flattened_shard_id / dspec().num_banks();
+        const auto bank_shard = shard_to_bank(flattened_shard_id);
+        uint32_t bank_page_offset = (bank_shard.shard_in_bank * dspec().shard_volume()) + page_offset_within_shard;
 
-        uint32_t bank_page_offset = (bank_shard_id * dspec().shard_volume()) + page_offset_within_shard;
-
-        return {bank_id, bank_page_offset};
+        return {bank_shard.bank_id, bank_page_offset};
     }
 
     // Locality APIs
@@ -248,7 +246,7 @@ public:
 
     FORCE_INLINE
     bool is_local_shard(const uint32_t shard_id, uint8_t noc = noc_index) const {
-        uint32_t bank_id = shard_id % dspec().num_banks();
+        uint32_t bank_id = shard_to_bank(shard_id).bank_id;
 
         const auto& packed_xy_coords = dspec().packed_xy_coords();
         auto bank_x = get_bank_x(packed_xy_coords[bank_id]);
@@ -315,6 +313,23 @@ private:
         return bank_start + bank_base_address + (page_mapping.bank_page_offset * aligned_page_size) + offset;
     }
 
+    struct BankShard {
+        size_t bank_id = 0;
+        size_t shard_in_bank = 0;  // index of the shard within its bank
+    };
+
+    // Maps a flattened shard id to its bank and its slot within that bank, honoring the
+    // distribution strategy. Round-robin spreads consecutive shards across banks; block
+    // (CONTIGUOUS_1D) packs shards_per_core consecutive shards into one bank before advancing.
+    FORCE_INLINE BankShard shard_to_bank(size_t flattened_shard_id) const {
+        if constexpr (DSpec::is_block) {
+            const size_t shards_per_bank = dspec().num_shards() / dspec().num_banks();
+            return {flattened_shard_id / shards_per_bank, flattened_shard_id % shards_per_bank};
+        } else {
+            return {flattened_shard_id % dspec().num_banks(), flattened_shard_id / dspec().num_banks()};
+        }
+    }
+
     PageMapping get_bank_and_offset_from_page_id(uint32_t page_id) const {
         size_t flattened_shard_id = 0;
         size_t page_offset_within_shard = 0;
@@ -327,13 +342,10 @@ private:
             page_offset_within_shard += (page_coord % dspec().shard_shape()[i]) * dspec().shard_strides()[i];
         }
 
-        // NOTE: This assumes shards are round-robin assigned across banks
-        size_t bank_id = flattened_shard_id % dspec().num_banks();
-        size_t bank_shard_id = flattened_shard_id / dspec().num_banks();
+        const auto bank_shard = shard_to_bank(flattened_shard_id);
+        size_t bank_page_offset = (bank_shard.shard_in_bank * dspec().shard_volume()) + page_offset_within_shard;
 
-        size_t bank_page_offset = (bank_shard_id * dspec().shard_volume()) + page_offset_within_shard;
-
-        return {bank_id, bank_page_offset};
+        return {bank_shard.bank_id, bank_page_offset};
     }
 
     FORCE_INLINE
@@ -506,7 +518,8 @@ TensorAccessor(const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args, size_t)
             TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::BankCoordsCTAOffset,
             TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::NumBanksCT>::type,
         /* IsInterleaved */ !TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_sharded,
-        /* IsDram */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_dram>>;
+        /* IsDram */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_dram,
+        /* IsBlock */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_block_distribution>>;
 
 // CTAD deduction guide for the Metal 2.0 binding-token ctor.
 // Mirrors the (args, size_t) guide above. The token's ADDR_CRTA_OFFSET marks the
@@ -533,7 +546,8 @@ TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA
             TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::BankCoordsCTAOffset,
             TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::NumBanksCT>::type,
         /* IsInterleaved */ !TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_sharded,
-        /* IsDram */ TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_dram>>;
+        /* IsDram */ TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_dram,
+        /* IsBlock */ TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>::is_block_distribution>>;
 
 template <std::size_t CTA_OFFSET, std::size_t CRTA_OFFSET>
 TensorAccessor(const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args, size_t, uint32_t)
@@ -556,7 +570,8 @@ TensorAccessor(const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args, size_t, 
             TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::BankCoordsCTAOffset,
             TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::NumBanksCT>::type,
         /* IsInterleaved */ !TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_sharded,
-        /* IsDram */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_dram>>;
+        /* IsDram */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_dram,
+        /* IsBlock */ TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::is_block_distribution>>;
 
 template <
     uint32_t RankCT,
@@ -565,7 +580,8 @@ template <
     typename ShardShapeWrapper,
     typename BankCoordsWrapper,
     bool IsInterleaved,
-    bool IsDram>
+    bool IsDram,
+    bool IsBlock>
 TensorAccessor(
     tensor_accessor::DistributionSpec<
         RankCT,
@@ -574,7 +590,8 @@ TensorAccessor(
         ShardShapeWrapper,
         BankCoordsWrapper,
         IsInterleaved,
-        IsDram>,
+        IsDram,
+        IsBlock>,
     size_t,
     uint32_t)
     -> TensorAccessor<tensor_accessor::DistributionSpec<
@@ -584,7 +601,8 @@ TensorAccessor(
         ShardShapeWrapper,
         BankCoordsWrapper,
         IsInterleaved,
-        IsDram>>;
+        IsDram,
+        IsBlock>>;
 
 namespace tensor_accessor::detail {
 template <typename... Args, uint32_t... Indexes>

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
@@ -29,10 +29,6 @@ struct TensorAccessorArgs {
     static constexpr bool tensor_shape_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeTensorShape);
     static constexpr bool shard_shape_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeShardShape);
     static constexpr bool bank_coords_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeBankCoords);
-    // Compile-time default for shard-contiguous distribution (CONTIGUOUS_1D) vs. round-robin. Used
-    // directly when num_banks is compile-time. When num_banks is runtime, the live value is read from the
-    // runtime num_banks word instead (see resolve_shard_contiguous()). Carries no extra args/slots.
-    static constexpr bool is_shard_contiguous = args_config.test(tensor_accessor::ArgConfig::IsShardContiguous);
 
     // Impossible to have runtime rank without runtime tensor and shard shapes since then impossible to calculate CTA
     // offsets in compile time
@@ -59,13 +55,22 @@ struct TensorAccessorArgs {
         }
     }();
 
-    static constexpr uint32_t NumBanksCT = [] {
+    // Raw compile-time num_banks word: the bank count in the low bits and the shard-contiguous flag in the top bit
+    // (see arg_config.hpp). NumBanksCT / is_shard_contiguous are the unpacked views used everywhere else.
+    static constexpr uint32_t NumBanksRawCT = [] {
         if constexpr (!is_sharded || num_banks_is_crta) {
             return 0;
         } else {
             return get_compile_time_arg_val(NumBanksCTAOffset);
         }
     }();
+
+    static constexpr uint32_t NumBanksCT = tensor_accessor::unpack_num_banks(NumBanksRawCT);
+
+    // Shard-contiguous distribution (CONTIGUOUS_1D) vs. round-robin. When num_banks is compile-time this is read from
+    // the top bit of the compile-time num_banks word; when num_banks is runtime, the live value is read from the
+    // runtime num_banks word instead (see resolve_shard_contiguous()). Carries no extra args/slots.
+    static constexpr bool is_shard_contiguous = tensor_accessor::unpack_is_shard_contiguous(NumBanksRawCT);
 
     static constexpr uint32_t PhysicalNumBanksCT = (NumBanksCT + 1) / 2;
 
@@ -118,8 +123,9 @@ public:
     }
 
     // Whether shards are distributed contiguously (shard-contiguous, CONTIGUOUS_1D) vs. round-robin. When num_banks is
-    // compile-time this is the constexpr config bit; when num_banks is runtime it is read from the top bit
-    // of the runtime num_banks word, so it can vary per dispatch without recompiling.
+    // compile-time this is the constexpr is_shard_contiguous (top bit of the compile-time num_banks word); when
+    // num_banks is runtime it is read from the top bit of the runtime num_banks word, so it can vary per dispatch
+    // without recompiling.
     constexpr bool resolve_shard_contiguous() const {
         if constexpr (!num_banks_is_crta) {
             return is_shard_contiguous;

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
@@ -29,10 +29,10 @@ struct TensorAccessorArgs {
     static constexpr bool tensor_shape_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeTensorShape);
     static constexpr bool shard_shape_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeShardShape);
     static constexpr bool bank_coords_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeBankCoords);
-    // Compile-time default for block-contiguous shard distribution (CONTIGUOUS_1D) vs. round-robin. Used
+    // Compile-time default for shard-contiguous distribution (CONTIGUOUS_1D) vs. round-robin. Used
     // directly when num_banks is compile-time. When num_banks is runtime, the live value is read from the
-    // runtime num_banks word instead (see get_is_block_distribution()). Carries no extra args/slots.
-    static constexpr bool is_block_distribution = args_config.test(tensor_accessor::ArgConfig::IsBlockDistribution);
+    // runtime num_banks word instead (see resolve_shard_contiguous()). Carries no extra args/slots.
+    static constexpr bool is_shard_contiguous = args_config.test(tensor_accessor::ArgConfig::IsShardContiguous);
 
     // Impossible to have runtime rank without runtime tensor and shard shapes since then impossible to calculate CTA
     // offsets in compile time
@@ -112,19 +112,19 @@ public:
         if constexpr (!num_banks_is_crta) {
             return NumBanksCT;
         } else {
-            // The runtime num_banks word packs the block-distribution flag in its top bit; strip it off.
+            // The runtime num_banks word packs the shard-contiguous flag in its top bit; strip it off.
             return tensor_accessor::unpack_num_banks(get_common_arg_val<uint32_t>(num_banks_crta_offset()));
         }
     }
 
-    // Whether shards are block-contiguously distributed (CONTIGUOUS_1D) vs. round-robin. When num_banks is
+    // Whether shards are distributed contiguously (shard-contiguous, CONTIGUOUS_1D) vs. round-robin. When num_banks is
     // compile-time this is the constexpr config bit; when num_banks is runtime it is read from the top bit
     // of the runtime num_banks word, so it can vary per dispatch without recompiling.
-    constexpr bool get_is_block_distribution() const {
+    constexpr bool resolve_shard_contiguous() const {
         if constexpr (!num_banks_is_crta) {
-            return is_block_distribution;
+            return is_shard_contiguous;
         } else {
-            return tensor_accessor::unpack_is_block_distribution(get_common_arg_val<uint32_t>(num_banks_crta_offset()));
+            return tensor_accessor::unpack_is_shard_contiguous(get_common_arg_val<uint32_t>(num_banks_crta_offset()));
         }
     }
 

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
@@ -29,6 +29,9 @@ struct TensorAccessorArgs {
     static constexpr bool tensor_shape_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeTensorShape);
     static constexpr bool shard_shape_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeShardShape);
     static constexpr bool bank_coords_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeBankCoords);
+    // Block-contiguous shard distribution (CONTIGUOUS_1D) vs. round-robin. Carries no extra args; only
+    // changes the shard->bank math in the accessor. Lives in args_config, so no CTA/CRTA offset impact.
+    static constexpr bool is_block_distribution = args_config.test(tensor_accessor::ArgConfig::IsBlockDistribution);
 
     // Impossible to have runtime rank without runtime tensor and shard shapes since then impossible to calculate CTA
     // offsets in compile time

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
@@ -29,8 +29,9 @@ struct TensorAccessorArgs {
     static constexpr bool tensor_shape_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeTensorShape);
     static constexpr bool shard_shape_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeShardShape);
     static constexpr bool bank_coords_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeBankCoords);
-    // Block-contiguous shard distribution (CONTIGUOUS_1D) vs. round-robin. Carries no extra args; only
-    // changes the shard->bank math in the accessor. Lives in args_config, so no CTA/CRTA offset impact.
+    // Compile-time default for block-contiguous shard distribution (CONTIGUOUS_1D) vs. round-robin. Used
+    // directly when num_banks is compile-time. When num_banks is runtime, the live value is read from the
+    // runtime num_banks word instead (see get_is_block_distribution()). Carries no extra args/slots.
     static constexpr bool is_block_distribution = args_config.test(tensor_accessor::ArgConfig::IsBlockDistribution);
 
     // Impossible to have runtime rank without runtime tensor and shard shapes since then impossible to calculate CTA
@@ -111,7 +112,19 @@ public:
         if constexpr (!num_banks_is_crta) {
             return NumBanksCT;
         } else {
-            return get_common_arg_val<uint32_t>(num_banks_crta_offset());
+            // The runtime num_banks word packs the block-distribution flag in its top bit; strip it off.
+            return tensor_accessor::unpack_num_banks(get_common_arg_val<uint32_t>(num_banks_crta_offset()));
+        }
+    }
+
+    // Whether shards are block-contiguously distributed (CONTIGUOUS_1D) vs. round-robin. When num_banks is
+    // compile-time this is the constexpr config bit; when num_banks is runtime it is read from the top bit
+    // of the runtime num_banks word, so it can vary per dispatch without recompiling.
+    constexpr bool get_is_block_distribution() const {
+        if constexpr (!num_banks_is_crta) {
+            return is_block_distribution;
+        } else {
+            return tensor_accessor::unpack_is_block_distribution(get_common_arg_val<uint32_t>(num_banks_crta_offset()));
         }
     }
 

--- a/tt_metal/hw/inc/internal/tensor/dspec.h
+++ b/tt_metal/hw/inc/internal/tensor/dspec.h
@@ -46,7 +46,7 @@ template <
     typename BankCoordsWrapper = ArrayDynamicWrapper,
     bool IsInterleaved = false,
     bool IsDram = false,
-    bool IsBlock = false>
+    bool IsShardContiguous = false>
 struct DistributionSpec {
     static constexpr bool has_static_rank = RankCT != 0;
     static constexpr bool has_static_num_banks = NumBanksCT != 0;
@@ -57,8 +57,8 @@ struct DistributionSpec {
     static constexpr bool is_static = shapes_static && bank_coords_static;
     static constexpr bool is_interleaved = IsInterleaved;
     static constexpr bool is_dram = IsDram;
-    // Block-contiguous shard->bank placement (ShardDistributionStrategy::CONTIGUOUS_1D) vs. round-robin.
-    static constexpr bool is_block = IsBlock;
+    // Shard-contiguous shard->bank placement (ShardDistributionStrategy::CONTIGUOUS_1D) vs. round-robin.
+    static constexpr bool is_shard_contiguous = IsShardContiguous;
 
     static constexpr auto rank_ct = RankCT;
     static constexpr auto num_banks_ct = NumBanksCT;
@@ -79,7 +79,7 @@ struct DistributionSpec {
     DistributionSpec(const DistributionSpec& other) :
         rank_rt(other.rank_rt),
         num_banks_rt(other.num_banks_rt),
-        is_block_rt(other.is_block_rt),
+        is_shard_contiguous_rt(other.is_shard_contiguous_rt),
         tensor_shape_rt(other.tensor_shape_rt),
         shard_shape_rt(other.shard_shape_rt),
         bank_coords_rt(other.bank_coords_rt),
@@ -113,7 +113,7 @@ struct DistributionSpec {
     DistributionSpec(DistributionSpec&& other) noexcept :
         rank_rt(other.rank_rt),
         num_banks_rt(other.num_banks_rt),
-        is_block_rt(other.is_block_rt),
+        is_shard_contiguous_rt(other.is_shard_contiguous_rt),
         tensor_shape_rt(std::move(other.tensor_shape_rt)),
         shard_shape_rt(std::move(other.shard_shape_rt)),
         bank_coords_rt(std::move(other.bank_coords_rt)),
@@ -152,8 +152,8 @@ struct DistributionSpec {
         TensorShape&& tensor_shape_arr,
         ShardShape&& shard_shape_arr = {},
         BankCoords&& bank_coords_arr = {},
-        bool is_block_param = IsBlock) :
-        is_block_rt(is_block_param),
+        bool is_shard_contiguous_param = IsShardContiguous) :
+        is_shard_contiguous_rt(is_shard_contiguous_param),
         tensor_shape_rt(std::forward<TensorShape>(tensor_shape_arr)),
         shard_shape_rt(std::forward<ShardShape>(shard_shape_arr)),
         bank_coords_rt(std::forward<BankCoords>(bank_coords_arr)) {
@@ -181,8 +181,8 @@ struct DistributionSpec {
         uint32_t* tensor_shape_ptr = nullptr,
         uint32_t* shard_shape_ptr = nullptr,
         uint16_t* bank_coords_ptr = nullptr,
-        bool is_block_param = IsBlock) :
-        is_block_rt(is_block_param),
+        bool is_shard_contiguous_param = IsShardContiguous) :
+        is_shard_contiguous_rt(is_shard_contiguous_param),
         tensor_shape_rt(init_tensor_shape(tensor_shape_ptr, rank_rt_param)),
         shard_shape_rt(init_shard_shape(shard_shape_ptr, rank_rt_param)),
         bank_coords_rt(init_bank_coords(bank_coords_ptr, num_banks_rt_param)) {
@@ -236,7 +236,7 @@ struct DistributionSpec {
             Args::tensor_shape_is_crta ? (uint32_t*)get_common_arg_addr(args.tensor_shape_crta_offset()) : nullptr,
             Args::shard_shape_is_crta ? (uint32_t*)get_common_arg_addr(args.shard_shape_crta_offset()) : nullptr,
             Args::bank_coords_is_crta ? (uint16_t*)get_common_arg_addr(args.bank_coords_crta_offset()) : nullptr,
-            args.get_is_block_distribution()) {
+            args.resolve_shard_contiguous()) {
         static_assert(
             !Args::rank_is_crta or Args::tensor_shape_is_crta,
             "Tensor shape must be CRTA if rank is not known at compile time!");
@@ -262,10 +262,10 @@ struct DistributionSpec {
 
     FORCE_INLINE constexpr uint32_t num_banks() const {getter_helper(has_static_num_banks, num_banks_ct, num_banks_rt)}
 
-    // Block (CONTIGUOUS_1D) vs. round-robin shard->bank placement. Compile-time (IsBlock) when num_banks is
-    // compile-time; otherwise the runtime value carried alongside the runtime num_banks word.
-    FORCE_INLINE
-        constexpr bool is_block_distribution() const {getter_helper(has_static_num_banks, IsBlock, is_block_rt)}
+    // Shard-contiguous (CONTIGUOUS_1D) vs. round-robin shard->bank placement. Compile-time (IsShardContiguous) when
+    // num_banks is compile-time; otherwise the runtime value carried alongside the runtime num_banks word.
+    FORCE_INLINE constexpr bool resolve_shard_contiguous() const {
+        getter_helper(has_static_num_banks, IsShardContiguous, is_shard_contiguous_rt)}
 
     FORCE_INLINE constexpr const
         auto& tensor_shape() const {getter_helper(tensor_shape_static, TensorShapeWrapper::elements, tensor_shape_rt)}
@@ -289,7 +289,7 @@ struct DistributionSpec {
     // === Sharding Layout ===
     FORCE_INLINE constexpr const auto& shard_grid() const {getter_helper(shapes_static, shard_grid_ct, shard_grid_rt)}
 
-    // Total number of shards = product of the shard grid. Used by the block (CONTIGUOUS_1D)
+    // Total number of shards = product of the shard grid. Used by the shard-contiguous (CONTIGUOUS_1D)
     // shard->bank math to derive shards_per_core = num_shards / num_banks.
     FORCE_INLINE constexpr size_t num_shards() const {
         size_t n = 1;
@@ -357,7 +357,7 @@ private:
     void swap(DistributionSpec& other) noexcept {
         std::swap(rank_rt, other.rank_rt);
         std::swap(num_banks_rt, other.num_banks_rt);
-        std::swap(is_block_rt, other.is_block_rt);
+        std::swap(is_shard_contiguous_rt, other.is_shard_contiguous_rt);
         std::swap(tensor_shape_rt, other.tensor_shape_rt);
         std::swap(shard_shape_rt, other.shard_shape_rt);
         std::swap(bank_coords_rt, other.bank_coords_rt);
@@ -480,8 +480,8 @@ private:
 
     uint32_t rank_rt = 0;
     uint32_t num_banks_rt = 0;
-    // Runtime block-distribution flag; only consulted when num_banks is runtime (!has_static_num_banks).
-    bool is_block_rt = false;
+    // Runtime shard-contiguous flag; only consulted when num_banks is runtime (!has_static_num_banks).
+    bool is_shard_contiguous_rt = false;
 
     Shape tensor_shape_rt = {};
     Shape shard_shape_rt = {};

--- a/tt_metal/hw/inc/internal/tensor/dspec.h
+++ b/tt_metal/hw/inc/internal/tensor/dspec.h
@@ -45,7 +45,8 @@ template <
     typename ShardShapeWrapper = ArrayDynamicWrapper,
     typename BankCoordsWrapper = ArrayDynamicWrapper,
     bool IsInterleaved = false,
-    bool IsDram = false>
+    bool IsDram = false,
+    bool IsBlock = false>
 struct DistributionSpec {
     static constexpr bool has_static_rank = RankCT != 0;
     static constexpr bool has_static_num_banks = NumBanksCT != 0;
@@ -56,6 +57,8 @@ struct DistributionSpec {
     static constexpr bool is_static = shapes_static && bank_coords_static;
     static constexpr bool is_interleaved = IsInterleaved;
     static constexpr bool is_dram = IsDram;
+    // Block-contiguous shard->bank placement (ShardDistributionStrategy::CONTIGUOUS_1D) vs. round-robin.
+    static constexpr bool is_block = IsBlock;
 
     static constexpr auto rank_ct = RankCT;
     static constexpr auto num_banks_ct = NumBanksCT;
@@ -271,6 +274,17 @@ struct DistributionSpec {
 
     // === Sharding Layout ===
     FORCE_INLINE constexpr const auto& shard_grid() const {getter_helper(shapes_static, shard_grid_ct, shard_grid_rt)}
+
+    // Total number of shards = product of the shard grid. Used by the block (CONTIGUOUS_1D)
+    // shard->bank math to derive shards_per_core = num_shards / num_banks.
+    FORCE_INLINE constexpr size_t num_shards() const {
+        size_t n = 1;
+        const auto& grid = shard_grid();
+        for (uint32_t i = 0; i < rank(); ++i) {
+            n *= grid[i];
+        }
+        return n;
+    }
 
     FORCE_INLINE constexpr const
         auto& shard_grid_strides() const {getter_helper(shapes_static, shard_grid_strides_ct, shard_grid_strides_rt)}

--- a/tt_metal/hw/inc/internal/tensor/dspec.h
+++ b/tt_metal/hw/inc/internal/tensor/dspec.h
@@ -79,6 +79,7 @@ struct DistributionSpec {
     DistributionSpec(const DistributionSpec& other) :
         rank_rt(other.rank_rt),
         num_banks_rt(other.num_banks_rt),
+        is_block_rt(other.is_block_rt),
         tensor_shape_rt(other.tensor_shape_rt),
         shard_shape_rt(other.shard_shape_rt),
         bank_coords_rt(other.bank_coords_rt),
@@ -112,6 +113,7 @@ struct DistributionSpec {
     DistributionSpec(DistributionSpec&& other) noexcept :
         rank_rt(other.rank_rt),
         num_banks_rt(other.num_banks_rt),
+        is_block_rt(other.is_block_rt),
         tensor_shape_rt(std::move(other.tensor_shape_rt)),
         shard_shape_rt(std::move(other.shard_shape_rt)),
         bank_coords_rt(std::move(other.bank_coords_rt)),
@@ -147,7 +149,11 @@ struct DistributionSpec {
         typename BankCoords = BankCoords,
         typename = std::enable_if_t<!std::is_same_v<std::decay_t<TensorShape>, DistributionSpec>>>
     constexpr DistributionSpec(
-        TensorShape&& tensor_shape_arr, ShardShape&& shard_shape_arr = {}, BankCoords&& bank_coords_arr = {}) :
+        TensorShape&& tensor_shape_arr,
+        ShardShape&& shard_shape_arr = {},
+        BankCoords&& bank_coords_arr = {},
+        bool is_block_param = IsBlock) :
+        is_block_rt(is_block_param),
         tensor_shape_rt(std::forward<TensorShape>(tensor_shape_arr)),
         shard_shape_rt(std::forward<ShardShape>(shard_shape_arr)),
         bank_coords_rt(std::forward<BankCoords>(bank_coords_arr)) {
@@ -174,7 +180,9 @@ struct DistributionSpec {
         uint32_t num_banks_rt_param = 0,
         uint32_t* tensor_shape_ptr = nullptr,
         uint32_t* shard_shape_ptr = nullptr,
-        uint16_t* bank_coords_ptr = nullptr) :
+        uint16_t* bank_coords_ptr = nullptr,
+        bool is_block_param = IsBlock) :
+        is_block_rt(is_block_param),
         tensor_shape_rt(init_tensor_shape(tensor_shape_ptr, rank_rt_param)),
         shard_shape_rt(init_shard_shape(shard_shape_ptr, rank_rt_param)),
         bank_coords_rt(init_bank_coords(bank_coords_ptr, num_banks_rt_param)) {
@@ -227,7 +235,8 @@ struct DistributionSpec {
             args.get_num_banks(),
             Args::tensor_shape_is_crta ? (uint32_t*)get_common_arg_addr(args.tensor_shape_crta_offset()) : nullptr,
             Args::shard_shape_is_crta ? (uint32_t*)get_common_arg_addr(args.shard_shape_crta_offset()) : nullptr,
-            Args::bank_coords_is_crta ? (uint16_t*)get_common_arg_addr(args.bank_coords_crta_offset()) : nullptr) {
+            Args::bank_coords_is_crta ? (uint16_t*)get_common_arg_addr(args.bank_coords_crta_offset()) : nullptr,
+            args.get_is_block_distribution()) {
         static_assert(
             !Args::rank_is_crta or Args::tensor_shape_is_crta,
             "Tensor shape must be CRTA if rank is not known at compile time!");
@@ -252,6 +261,11 @@ struct DistributionSpec {
     FORCE_INLINE constexpr uint32_t rank() const {getter_helper(has_static_rank, rank_ct, rank_rt)}
 
     FORCE_INLINE constexpr uint32_t num_banks() const {getter_helper(has_static_num_banks, num_banks_ct, num_banks_rt)}
+
+    // Block (CONTIGUOUS_1D) vs. round-robin shard->bank placement. Compile-time (IsBlock) when num_banks is
+    // compile-time; otherwise the runtime value carried alongside the runtime num_banks word.
+    FORCE_INLINE
+        constexpr bool is_block_distribution() const {getter_helper(has_static_num_banks, IsBlock, is_block_rt)}
 
     FORCE_INLINE constexpr const
         auto& tensor_shape() const {getter_helper(tensor_shape_static, TensorShapeWrapper::elements, tensor_shape_rt)}
@@ -343,6 +357,7 @@ private:
     void swap(DistributionSpec& other) noexcept {
         std::swap(rank_rt, other.rank_rt);
         std::swap(num_banks_rt, other.num_banks_rt);
+        std::swap(is_block_rt, other.is_block_rt);
         std::swap(tensor_shape_rt, other.tensor_shape_rt);
         std::swap(shard_shape_rt, other.shard_shape_rt);
         std::swap(bank_coords_rt, other.bank_coords_rt);
@@ -465,6 +480,8 @@ private:
 
     uint32_t rank_rt = 0;
     uint32_t num_banks_rt = 0;
+    // Runtime block-distribution flag; only consulted when num_banks is runtime (!has_static_num_banks).
+    bool is_block_rt = false;
 
     Shape tensor_shape_rt = {};
     Shape shard_shape_rt = {};

--- a/tt_metal/impl/buffers/buffer_distribution_spec.cpp
+++ b/tt_metal/impl/buffers/buffer_distribution_spec.cpp
@@ -30,6 +30,11 @@ struct PageMappingIntermData {
     uint32_t* actual_shard_size = nullptr;
     size_t core_id = 0;
     size_t shard_id = 0;
+
+    // Block (CONTIGUOUS_1D) placement: adjacent shards fill one core's slots before advancing.
+    // When false, the default round-robin placement is used.
+    bool block_placement = false;
+    size_t shards_per_core = 0;  // only meaningful when block_placement is true
 };
 
 void iterate_within_shard(PageMappingIntermData& params, size_t dim, size_t src_offset, size_t dst_offset) {
@@ -47,8 +52,16 @@ void iterate_within_shard(PageMappingIntermData& params, size_t dim, size_t src_
 
 void iterate_over_shards(PageMappingIntermData& params, size_t dim, size_t src_offset) {
     if (dim == params.rank) {
-        params.core_id = params.shard_id % params.num_cores;
-        size_t dst_offset = (params.shard_id / params.num_cores) * params.shard_volume;
+        size_t dst_offset = 0;
+        if (params.block_placement) {
+            // Contiguous: shards_per_core consecutive shards fill one core's slots [0..shards_per_core)
+            // before advancing to the next core.
+            params.core_id = params.shard_id / params.shards_per_core;
+            dst_offset = (params.shard_id % params.shards_per_core) * params.shard_volume;
+        } else {
+            params.core_id = params.shard_id % params.num_cores;
+            dst_offset = (params.shard_id / params.num_cores) * params.shard_volume;
+        }
 
         iterate_within_shard(params, 0, src_offset, dst_offset);
 
@@ -103,7 +116,8 @@ BufferDistributionSpec::BufferDistributionSpec(
     const tt::tt_metal::Shape& shard_shape_in_pages,
     const CoreRangeSet& core_range_set,
     ShardOrientation shard_orientation,
-    ShardDistributionStrategy shard_distribution_strategy) {
+    ShardDistributionStrategy shard_distribution_strategy) :
+    shard_distribution_strategy_(shard_distribution_strategy) {
     TT_FATAL(tensor_shape_in_pages.rank() >= 1, "Tensor rank must be at least 1!");
     TT_FATAL(shard_shape_in_pages.rank() >= 1, "Shard rank must be at least 1!");
     TT_FATAL(shard_shape_in_pages.volume() != 0, "Shard shape must have non zero volume!");
@@ -141,7 +155,10 @@ std::vector<CoreCoord> BufferDistributionSpec::compute_core_list(
     const CoreRangeSet& core_range_set,
     ShardOrientation shard_orientation,
     ShardDistributionStrategy shard_distribution_strategy) {
-    if (shard_distribution_strategy == ShardDistributionStrategy::ROUND_ROBIN_1D) {
+    if (shard_distribution_strategy == ShardDistributionStrategy::ROUND_ROBIN_1D ||
+        shard_distribution_strategy == ShardDistributionStrategy::CONTIGUOUS_1D) {
+        // Both 1D strategies linearize the core grid identically; they differ only in how shards
+        // are assigned to that list (round-robin vs. block), which is handled in iterate_over_shards.
         return corerange_to_cores(
             core_range_set, core_range_set.num_cores(), shard_orientation == ShardOrientation::ROW_MAJOR);
     }
@@ -247,7 +264,10 @@ void BufferDistributionSpec::init_precomputed_data() {
 
 namespace detail {
 UncompressedBufferPageMapping compute_page_mapping(
-    const Shape& tensor_shape, const Shape& shard_shape, const std::vector<CoreCoord>& cores) {
+    const Shape& tensor_shape,
+    const Shape& shard_shape,
+    const std::vector<CoreCoord>& cores,
+    ShardDistributionStrategy shard_distribution_strategy) {
     UncompressedBufferPageMapping page_mapping;
     page_mapping.all_cores = cores;
 
@@ -262,6 +282,14 @@ UncompressedBufferPageMapping compute_page_mapping(
 
     size_t num_shards_per_core = (num_shards + cores.size() - 1) / cores.size();
     size_t shard_pages = shard_shape.volume();
+
+    const bool block_placement = shard_distribution_strategy == ShardDistributionStrategy::CONTIGUOUS_1D;
+    TT_FATAL(
+        !block_placement || num_shards % cores.size() == 0,
+        "CONTIGUOUS_1D distribution requires a uniform shards-per-core: num_shards ({}) must be divisible by "
+        "num_cores ({}).",
+        num_shards,
+        cores.size());
 
     page_mapping.core_host_page_indices.resize(cores.size());
     for (size_t i = 0; i < cores.size(); i++) {
@@ -291,6 +319,8 @@ UncompressedBufferPageMapping compute_page_mapping(
         .actual_shard_size = actual_shard_size.data(),
         .core_id = 0,
         .shard_id = 0,
+        .block_placement = block_placement,
+        .shards_per_core = num_shards_per_core,
     };
     CMAKE_UNIQUE_NAMESPACE::iterate_over_shards(params, 0, 0);
 

--- a/tt_metal/impl/buffers/buffer_distribution_spec.cpp
+++ b/tt_metal/impl/buffers/buffer_distribution_spec.cpp
@@ -31,10 +31,10 @@ struct PageMappingIntermData {
     size_t core_id = 0;
     size_t shard_id = 0;
 
-    // Block (CONTIGUOUS_1D) placement: adjacent shards fill one core's slots before advancing.
+    // Shard-contiguous (CONTIGUOUS_1D) placement: adjacent shards fill one core's slots before advancing.
     // When false, the default round-robin placement is used.
-    bool block_placement = false;
-    size_t shards_per_core = 0;  // only meaningful when block_placement is true
+    bool shard_contiguous_placement = false;
+    size_t shards_per_core = 0;  // only meaningful when shard_contiguous_placement is true
 };
 
 void iterate_within_shard(PageMappingIntermData& params, size_t dim, size_t src_offset, size_t dst_offset) {
@@ -53,7 +53,7 @@ void iterate_within_shard(PageMappingIntermData& params, size_t dim, size_t src_
 void iterate_over_shards(PageMappingIntermData& params, size_t dim, size_t src_offset) {
     if (dim == params.rank) {
         size_t dst_offset = 0;
-        if (params.block_placement) {
+        if (params.shard_contiguous_placement) {
             // Contiguous: shards_per_core consecutive shards fill one core's slots [0..shards_per_core)
             // before advancing to the next core.
             params.core_id = params.shard_id / params.shards_per_core;
@@ -158,7 +158,7 @@ std::vector<CoreCoord> BufferDistributionSpec::compute_core_list(
     if (shard_distribution_strategy == ShardDistributionStrategy::ROUND_ROBIN_1D ||
         shard_distribution_strategy == ShardDistributionStrategy::CONTIGUOUS_1D) {
         // Both 1D strategies linearize the core grid identically; they differ only in how shards
-        // are assigned to that list (round-robin vs. block), which is handled in iterate_over_shards.
+        // are assigned to that list (round-robin vs. shard-contiguous), which is handled in iterate_over_shards.
         return corerange_to_cores(
             core_range_set, core_range_set.num_cores(), shard_orientation == ShardOrientation::ROW_MAJOR);
     }
@@ -283,9 +283,9 @@ UncompressedBufferPageMapping compute_page_mapping(
     size_t num_shards_per_core = (num_shards + cores.size() - 1) / cores.size();
     size_t shard_pages = shard_shape.volume();
 
-    const bool block_placement = shard_distribution_strategy == ShardDistributionStrategy::CONTIGUOUS_1D;
+    const bool shard_contiguous_placement = shard_distribution_strategy == ShardDistributionStrategy::CONTIGUOUS_1D;
     TT_FATAL(
-        !block_placement || num_shards % cores.size() == 0,
+        !shard_contiguous_placement || num_shards % cores.size() == 0,
         "CONTIGUOUS_1D distribution requires a uniform shards-per-core: num_shards ({}) must be divisible by "
         "num_cores ({}).",
         num_shards,
@@ -319,7 +319,7 @@ UncompressedBufferPageMapping compute_page_mapping(
         .actual_shard_size = actual_shard_size.data(),
         .core_id = 0,
         .shard_id = 0,
-        .block_placement = block_placement,
+        .shard_contiguous_placement = shard_contiguous_placement,
         .shards_per_core = num_shards_per_core,
     };
     CMAKE_UNIQUE_NAMESPACE::iterate_over_shards(params, 0, 0);

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -56,11 +56,11 @@ void append_sharded_args(
         args.push_back(rank);
     }
     if (add_num_banks) {
-        // When num_banks is a runtime arg, its top bit carries the shard-contiguous flag so the strategy
-        // can vary per dispatch without recompiling (no extra CRTA slot). Compile-time num_banks instead
-        // relies on the ArgConfig::IsShardContiguous bit.
-        const bool pack_shard_contiguous = is_runtime && buffer_distribution_spec.shard_distribution_strategy() ==
-                                                             ShardDistributionStrategy::CONTIGUOUS_1D;
+        // The num_banks word (compile-time or runtime) carries the shard-contiguous flag in its top bit, so the
+        // distribution strategy needs no extra arg/slot and no ArgConfig bit. pack/unpack (arg_config.hpp) are the
+        // single source of truth for this layout.
+        const bool pack_shard_contiguous =
+            buffer_distribution_spec.shard_distribution_strategy() == ShardDistributionStrategy::CONTIGUOUS_1D;
         TT_FATAL(
             n_banks < tensor_accessor::ShardContiguousBit,
             "num_banks {} is too large to pack the shard-contiguous flag",
@@ -151,14 +151,6 @@ void TensorAccessorArgs::update_args_config() {
 
     if (buffer_->buffer_distribution_spec().has_value()) {
         args_config_.set(tensor_accessor::ArgConfig::Sharded);
-        // Shard-contiguous distribution is baked into the compile-time config bit only when num_banks is compile-time.
-        // When num_banks is runtime, the flag rides in the runtime num_banks word instead, so the same
-        // binary serves both strategies; leave the config bit clear to keep the IsShardContiguous template fixed.
-        const bool is_shard_contiguous = buffer_->buffer_distribution_spec()->shard_distribution_strategy() ==
-                                         ShardDistributionStrategy::CONTIGUOUS_1D;
-        args_config_.set(
-            tensor_accessor::ArgConfig::IsShardContiguous,
-            is_shard_contiguous && !args_config_.test(tensor_accessor::ArgConfig::RuntimeNumBanks));
     } else {
         args_config_ = tensor_accessor::ArgConfig::None;
     }

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -56,16 +56,16 @@ void append_sharded_args(
         args.push_back(rank);
     }
     if (add_num_banks) {
-        // When num_banks is a runtime arg, its top bit carries the block-distribution flag so the strategy
+        // When num_banks is a runtime arg, its top bit carries the shard-contiguous flag so the strategy
         // can vary per dispatch without recompiling (no extra CRTA slot). Compile-time num_banks instead
-        // relies on the ArgConfig::IsBlockDistribution bit.
-        const bool pack_block = is_runtime && buffer_distribution_spec.shard_distribution_strategy() ==
-                                                  ShardDistributionStrategy::CONTIGUOUS_1D;
+        // relies on the ArgConfig::IsShardContiguous bit.
+        const bool pack_shard_contiguous = is_runtime && buffer_distribution_spec.shard_distribution_strategy() ==
+                                                             ShardDistributionStrategy::CONTIGUOUS_1D;
         TT_FATAL(
-            n_banks < tensor_accessor::BlockDistributionBit,
-            "num_banks {} is too large to pack the block-distribution flag",
+            n_banks < tensor_accessor::ShardContiguousBit,
+            "num_banks {} is too large to pack the shard-contiguous flag",
             n_banks);
-        args.push_back(tensor_accessor::pack_num_banks(static_cast<uint32_t>(n_banks), pack_block));
+        args.push_back(tensor_accessor::pack_num_banks(static_cast<uint32_t>(n_banks), pack_shard_contiguous));
     }
     if (add_tensor_shape) {
         args.insert(args.end(), tensor_shape.cbegin(), tensor_shape.cend());
@@ -151,14 +151,14 @@ void TensorAccessorArgs::update_args_config() {
 
     if (buffer_->buffer_distribution_spec().has_value()) {
         args_config_.set(tensor_accessor::ArgConfig::Sharded);
-        // Block distribution is baked into the compile-time config bit only when num_banks is compile-time.
+        // Shard-contiguous distribution is baked into the compile-time config bit only when num_banks is compile-time.
         // When num_banks is runtime, the flag rides in the runtime num_banks word instead, so the same
-        // binary serves both strategies; leave the config bit clear to keep the IsBlock template fixed.
-        const bool is_block = buffer_->buffer_distribution_spec()->shard_distribution_strategy() ==
-                              ShardDistributionStrategy::CONTIGUOUS_1D;
+        // binary serves both strategies; leave the config bit clear to keep the IsShardContiguous template fixed.
+        const bool is_shard_contiguous = buffer_->buffer_distribution_spec()->shard_distribution_strategy() ==
+                                         ShardDistributionStrategy::CONTIGUOUS_1D;
         args_config_.set(
-            tensor_accessor::ArgConfig::IsBlockDistribution,
-            is_block && !args_config_.test(tensor_accessor::ArgConfig::RuntimeNumBanks));
+            tensor_accessor::ArgConfig::IsShardContiguous,
+            is_shard_contiguous && !args_config_.test(tensor_accessor::ArgConfig::RuntimeNumBanks));
     } else {
         args_config_ = tensor_accessor::ArgConfig::None;
     }

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -142,6 +142,10 @@ void TensorAccessorArgs::update_args_config() {
 
     if (buffer_->buffer_distribution_spec().has_value()) {
         args_config_.set(tensor_accessor::ArgConfig::Sharded);
+        args_config_.set(
+            tensor_accessor::ArgConfig::IsBlockDistribution,
+            buffer_->buffer_distribution_spec()->shard_distribution_strategy() ==
+                ShardDistributionStrategy::CONTIGUOUS_1D);
     } else {
         args_config_ = tensor_accessor::ArgConfig::None;
     }

--- a/tt_metal/impl/buffers/tensor_accessor_args.cpp
+++ b/tt_metal/impl/buffers/tensor_accessor_args.cpp
@@ -56,7 +56,16 @@ void append_sharded_args(
         args.push_back(rank);
     }
     if (add_num_banks) {
-        args.push_back(n_banks);
+        // When num_banks is a runtime arg, its top bit carries the block-distribution flag so the strategy
+        // can vary per dispatch without recompiling (no extra CRTA slot). Compile-time num_banks instead
+        // relies on the ArgConfig::IsBlockDistribution bit.
+        const bool pack_block = is_runtime && buffer_distribution_spec.shard_distribution_strategy() ==
+                                                  ShardDistributionStrategy::CONTIGUOUS_1D;
+        TT_FATAL(
+            n_banks < tensor_accessor::BlockDistributionBit,
+            "num_banks {} is too large to pack the block-distribution flag",
+            n_banks);
+        args.push_back(tensor_accessor::pack_num_banks(static_cast<uint32_t>(n_banks), pack_block));
     }
     if (add_tensor_shape) {
         args.insert(args.end(), tensor_shape.cbegin(), tensor_shape.cend());
@@ -142,10 +151,14 @@ void TensorAccessorArgs::update_args_config() {
 
     if (buffer_->buffer_distribution_spec().has_value()) {
         args_config_.set(tensor_accessor::ArgConfig::Sharded);
+        // Block distribution is baked into the compile-time config bit only when num_banks is compile-time.
+        // When num_banks is runtime, the flag rides in the runtime num_banks word instead, so the same
+        // binary serves both strategies; leave the config bit clear to keep the IsBlock template fixed.
+        const bool is_block = buffer_->buffer_distribution_spec()->shard_distribution_strategy() ==
+                              ShardDistributionStrategy::CONTIGUOUS_1D;
         args_config_.set(
             tensor_accessor::ArgConfig::IsBlockDistribution,
-            buffer_->buffer_distribution_spec()->shard_distribution_strategy() ==
-                ShardDistributionStrategy::CONTIGUOUS_1D);
+            is_block && !args_config_.test(tensor_accessor::ArgConfig::RuntimeNumBanks));
     } else {
         args_config_ = tensor_accessor::ArgConfig::None;
     }

--- a/tt_metal/impl/tensor/spec/tensor_spec.cpp
+++ b/tt_metal/impl/tensor/spec/tensor_spec.cpp
@@ -283,6 +283,13 @@ std::optional<MemoryConfig> TensorSpec::populate_legacy_shard_spec_from_nd() con
     const auto& nd_shard_spec = mem_config.nd_shard_spec().value();
     const auto& nd_shard_shape = nd_shard_spec.shard_shape;
 
+    // CONTIGUOUS_1D has no legacy equivalent: its shard->bank placement (adjacent shards packed onto the same bank)
+    // is not expressible as any legacy WIDTH/HEIGHT/BLOCK_SHARDED layout. Don't fabricate a (garbled) legacy spec --
+    // leave the tensor ND-sharding-only.
+    if (nd_shard_spec.shard_distribution_strategy == ShardDistributionStrategy::CONTIGUOUS_1D) {
+        return std::nullopt;
+    }
+
     // Trying to flatten ND shard shape into 2D
     std::array<uint32_t, 2> shard_shape = {1, nd_shard_shape[-1]};
     size_t cur_tensor_volume = padded_shape()[-1];

--- a/tt_metal/impl/tensor/tensor_types.cpp
+++ b/tt_metal/impl/tensor/tensor_types.cpp
@@ -60,6 +60,7 @@ std::ostream& operator<<(std::ostream& os, const tt::tt_metal::NdShardSpec& spec
     switch (spec.shard_distribution_strategy) {
         case ShardDistributionStrategy::ROUND_ROBIN_1D: os << "ShardDistributionStrategy::ROUND_ROBIN_1D"; break;
         case ShardDistributionStrategy::GRID_2D: os << "ShardDistributionStrategy::GRID_2D"; break;
+        case ShardDistributionStrategy::CONTIGUOUS_1D: os << "ShardDistributionStrategy::CONTIGUOUS_1D"; break;
     }
     os << "\"";
 

--- a/ttnn/core/tensor/flatbuffer/tensor_spec.fbs
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec.fbs
@@ -44,6 +44,7 @@ enum ShardOrientation : ubyte {
 enum ShardDistributionStrategy : ubyte {
     ROUND_ROBIN_1D = 0,
     GRID_2D = 1,
+    CONTIGUOUS_1D = 2,
 }
 
 enum ShardModeDeprecated : ubyte {

--- a/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_spec_flatbuffer.cpp
@@ -128,6 +128,8 @@ flatbuffer::ShardDistributionStrategy to_flatbuffer(tt::tt_metal::ShardDistribut
         case tt::tt_metal::ShardDistributionStrategy::ROUND_ROBIN_1D:
             return flatbuffer::ShardDistributionStrategy::ROUND_ROBIN_1D;
         case tt::tt_metal::ShardDistributionStrategy::GRID_2D: return flatbuffer::ShardDistributionStrategy::GRID_2D;
+        case tt::tt_metal::ShardDistributionStrategy::CONTIGUOUS_1D:
+            return flatbuffer::ShardDistributionStrategy::CONTIGUOUS_1D;
     }
     TT_THROW("Unsupported ShardDistributionStrategy to flatbuffer.");
 }
@@ -137,6 +139,8 @@ tt::tt_metal::ShardDistributionStrategy from_flatbuffer(flatbuffer::ShardDistrib
         case flatbuffer::ShardDistributionStrategy::ROUND_ROBIN_1D:
             return tt::tt_metal::ShardDistributionStrategy::ROUND_ROBIN_1D;
         case flatbuffer::ShardDistributionStrategy::GRID_2D: return tt::tt_metal::ShardDistributionStrategy::GRID_2D;
+        case flatbuffer::ShardDistributionStrategy::CONTIGUOUS_1D:
+            return tt::tt_metal::ShardDistributionStrategy::CONTIGUOUS_1D;
     }
     TT_THROW("Unsupported ShardDistributionStrategy from flatbuffer.");
 }

--- a/ttnn/cpp/ttnn-nanobind/tensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/tensor.cpp
@@ -105,7 +105,12 @@ void tensor_mem_config_module_types(nb::module_& m_tensor) {
         .value(
             "GRID_2D",
             ShardDistributionStrategy::GRID_2D,
-            "Distribute a 2D grid of shards to a 2D grid of cores with one to one mapping.");
+            "Distribute a 2D grid of shards to a 2D grid of cores with one to one mapping.")
+        .value(
+            "CONTIGUOUS_1D",
+            ShardDistributionStrategy::CONTIGUOUS_1D,
+            "Distribute shards contiguously over a linearized list of cores: adjacent shards go to the same "
+            "core (shard s -> core s/shards_per_core, slot s%shards_per_core). Requires uniform shards-per-core.");
 
     tt_serializable_class<tt::tt_metal::CoreCoord>(m_tensor, "CoreCoord", R"doc(
         Class defining core coordinate

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
@@ -143,14 +143,14 @@ DramPrefetcherValidatorDeviceOperation::ProgramFactory::create_at(
     // Layout detection: ND_SHARDED tensors with `num_shards == ring_size` are
     // the receiver-contiguous DRAM-core layout. Under ROUND_ROBIN_1D shard
     // distribution, the natural GCB pairing is strided (bank b feeds ring
-    // positions b, b + num_senders, ...). Under CONTIGUOUS_1D (block) shard
-    // distribution, bank b owns a contiguous block of shards, so it feeds the
+    // positions b, b + num_senders, ...). Under CONTIGUOUS_1D (shard-contiguous) shard
+    // distribution, bank b owns a contiguous run of shards, so it feeds the
     // contiguous ring arc b*R .. b*R+R-1 (same pairing as legacy WIDTH_SHARDED).
     const bool is_recv_contig =
         source_tensor.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED &&
         tensor_buffer->buffer_distribution_spec().has_value() &&
         tensor_buffer->buffer_distribution_spec()->num_shards() == ring_size;
-    const bool is_block_recv_contig =
+    const bool is_shard_contiguous_recv_contig =
         is_recv_contig && tensor_buffer->buffer_distribution_spec()->shard_distribution_strategy() ==
                               tt::tt_metal::ShardDistributionStrategy::CONTIGUOUS_1D;
 
@@ -208,9 +208,10 @@ DramPrefetcherValidatorDeviceOperation::ProgramFactory::create_at(
                 receivers_per_bank);
             // ring_pos formula differs by layout:
             //   round-robin recv-contig + strided GCB: bank b's slot k -> ring_pos = b + k * num_dram_banks
-            //   block recv-contig and legacy K-row-major: bank b's slot k -> ring_pos = b * receivers_per_bank + k
+            //   shard-contiguous recv-contig and legacy K-row-major: bank b's slot k -> ring_pos = b *
+            //   receivers_per_bank + k
             // With dual senders, k is the bank-local receiver index across both senders.
-            const bool strided_pairing = is_recv_contig && !is_block_recv_contig;
+            const bool strided_pairing = is_recv_contig && !is_shard_contiguous_recv_contig;
             const uint32_t ring_pos = strided_pairing ? (bank_id + bank_local_recv * num_dram_banks)
                                                       : (bank_id * receivers_per_bank + bank_local_recv);
             const uint32_t n_col_start = ring_pos * n_per_recv_tiles;

--- a/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/test/prefetcher_consumer/dram_prefetcher_validator.cpp
@@ -143,12 +143,16 @@ DramPrefetcherValidatorDeviceOperation::ProgramFactory::create_at(
     // Layout detection: ND_SHARDED tensors with `num_shards == ring_size` are
     // the receiver-contiguous DRAM-core layout. Under ROUND_ROBIN_1D shard
     // distribution, the natural GCB pairing is strided (bank b feeds ring
-    // positions b, b + num_senders, ...). Legacy WIDTH_SHARDED keeps the
-    // row-major GCB (bank b -> contiguous block of ring positions).
+    // positions b, b + num_senders, ...). Under CONTIGUOUS_1D (block) shard
+    // distribution, bank b owns a contiguous block of shards, so it feeds the
+    // contiguous ring arc b*R .. b*R+R-1 (same pairing as legacy WIDTH_SHARDED).
     const bool is_recv_contig =
         source_tensor.memory_config().memory_layout() == tt::tt_metal::TensorMemoryLayout::ND_SHARDED &&
         tensor_buffer->buffer_distribution_spec().has_value() &&
         tensor_buffer->buffer_distribution_spec()->num_shards() == ring_size;
+    const bool is_block_recv_contig =
+        is_recv_contig && tensor_buffer->buffer_distribution_spec()->shard_distribution_strategy() ==
+                              tt::tt_metal::ShardDistributionStrategy::CONTIGUOUS_1D;
 
     const CoreRangeSet receiver_cores = global_cb.receiver_cores();
 
@@ -203,11 +207,12 @@ DramPrefetcherValidatorDeviceOperation::ProgramFactory::create_at(
                 bank_local_recv,
                 receivers_per_bank);
             // ring_pos formula differs by layout:
-            //   legacy K-row-major: bank b's slot k -> ring_pos = b * receivers_per_bank + k
-            //   recv-contig + strided GCB: bank b's slot k -> ring_pos = b + k * num_dram_banks
+            //   round-robin recv-contig + strided GCB: bank b's slot k -> ring_pos = b + k * num_dram_banks
+            //   block recv-contig and legacy K-row-major: bank b's slot k -> ring_pos = b * receivers_per_bank + k
             // With dual senders, k is the bank-local receiver index across both senders.
-            const uint32_t ring_pos = is_recv_contig ? (bank_id + bank_local_recv * num_dram_banks)
-                                                     : (bank_id * receivers_per_bank + bank_local_recv);
+            const bool strided_pairing = is_recv_contig && !is_block_recv_contig;
+            const uint32_t ring_pos = strided_pairing ? (bank_id + bank_local_recv * num_dram_banks)
+                                                      : (bank_id * receivers_per_bank + bank_local_recv);
             const uint32_t n_col_start = ring_pos * n_per_recv_tiles;
             std::vector<uint32_t> rt_args = {
                 bank_id,


### PR DESCRIPTION
### PR Category
Feature

### Summary
**Terminology:** "shard-contiguous" / `CONTIGUOUS_1D` here is a `ShardDistributionStrategy` — an
ND-sharding *placement* of shards onto banks.

The DRAM-core prefetcher's receiver-contiguous (recv-contig) path distributes a
weight's `ring_size` shards round-robin across DRAM banks (shard `s` → bank
`s % num_banks`). As a result each bank feeds a *strided* set of GCB-ring
receivers, so its writes traverse the whole ring.

This adds a new `ShardDistributionStrategy::CONTIGUOUS_1D` (shard-contiguous) distribution where
adjacent shards land on the *same* bank (shard `s` → bank `s / R`, slot `s % R`,
`R = ring_size / num_banks`). Each bank then feeds a **contiguous arc** of the ring,
localizing NoC traffic and improving ring routing. Receiver `r` still consumes
shard `r` in both modes, so no output permutation is needed — only the physical
shard→bank placement and the GCB sender→receiver pairing change (together).

The strategy is generic (lives in `BufferDistributionSpec` / `NdShardSpec`), opt-in,
and leaves all existing round-robin tensors untouched.

### Notes for reviewers
The change spans three layers that must agree — flipping any one alone delivers data
to the wrong receiver:

1. **Host placement** (`buffer_distribution_spec.cpp`): shard-contiguous branch in
   `iterate_over_shards`; `CONTIGUOUS_1D` routed through the linear `compute_core_list`
   (note: previously any non-`ROUND_ROBIN_1D` fell into the GRID_2D path); a uniform
   shards-per-core guard.
2. **Device addressing** (`tensor_accessor.h` + friends): the round-robin `% num_banks`
   math was hardcoded in four accessor sites plus the page iterators. These now route
   through one shared `shard_to_bank()` helper. The distribution can be selected either
   at compile time or at runtime, in both cases with **no new arg slots and no new
   `ArgConfig` bit**:
   - **Compile-time** (default): the `ArgConfig::IsShardContiguous` flag in the existing
     `args_config` word picks the strategy; `shard_to_bank()` resolves the branch with
     `if constexpr`, so round-robin-only builds stay byte-identical.
   - **Runtime** (when `num_banks` is a common runtime arg, `RuntimeNumBanks`): the
     shard-contiguous flag instead rides in the **top bit of the runtime `num_banks` word** —
     the same kernel binary then serves either strategy, chosen per dispatch without
     recompiling. `pack_num_banks` / `unpack_num_banks` in `arg_config.hpp` are the single
     source of truth for this layout, so host and device can't drift; `num_banks` is tiny,
     so its top bit never collides with a real bank count.

   `shards_per_core` is derived on-device from the shard grid (`num_shards()`), so nothing
   new is plumbed over the wire beyond that one flag bit (in either word).
3. **Verification op** (`dram_prefetcher_validator.cpp`): shard-contiguous recv-contig uses the
   contiguous `ring_pos` formula (the DRISC sender kernel reads slabs bank-locally and
   is unchanged).

Verification:
- `test_validator_dram_sender_recv_contig_shard_contiguous[*]` — shard-contiguous variants of the
  verification op (incl. dual-sender). The validator kernel hangs on any byte
  mismatch, so passing == byte-exact delivery, proving placement / GCB-arc / ring_pos
  / TensorAccessor are mutually consistent. Round-robin variants still pass (no
  regression).
- `BufferDistributionSpecContiguous.*` — device-free unit tests for the placement
  formula and the uniformity guard.
- `ShardedAccessorTestsReshardOnDevice` — a `CONTIGUOUS_1D` reshard param
  (`shards_per_core == 2`) added to the generic on-device TensorAccessor sweep.
  Swept across every arg config, it byte-exact-validates **both** the compile-time
  shard-contiguous path (config bit, when `num_banks` is a CTA) and the runtime
  shard-contiguous path (flag packed in the runtime `num_banks` word, when `num_banks`
  is a CRTA).

First cut requires uniform receivers-per-bank (always true for the recv-contig ring);
production model weights stay on round-robin until this is validated at the model level.

### Bench result (single-card P150, 8 recv/bank)
`test_bench_dram_core_repeats_recv_contig` is parametrized on the distribution and
logs effective weight-streaming GB/s. Shard-contiguous vs round-robin, same shape:

| Shape | round_robin | shard_contiguous | Δ |
|---|---|---|---|
| 1B_FF1 (K2048 N8192) | 138.5 GB/s | 122.3 | −12% |
| 1B_QKV (K2048 N3072) | 47.1 | 60.0 | +27% |
| 1B_FF2 (K8192 N2048) | 80.1 | 136.1 | +70% |
| 3B_FF1 (K3072 N8192) | 124.3 | 156.3 | +26% |

Shard-contiguous (one contiguous ring arc per bank) wins on 3 of 4 shapes — most for
deep-K shapes — and regresses ~12% on 1B_FF1. Multi-card fabric rings (where contiguous
arcs avoid long hops) are expected to benefit more; not measured here.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/drisccontiguous)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/drisccontiguous)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/drisccontiguous)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/drisccontiguous)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/drisccontiguous)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/drisccontiguous)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/drisccontiguous)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/drisccontiguous)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/drisccontiguous)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/drisccontiguous)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/drisccontiguous)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/drisccontiguous)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/drisccontiguous)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/drisccontiguous)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/drisccontiguous)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/drisccontiguous)
