### PR TITLE
ds_prefill(sp_release_pipeline) - rework Galaxy/loudbox prefill CI

### DIFF
--- a/.github/workflows/demo-sp-release.yaml
+++ b/.github/workflows/demo-sp-release.yaml
@@ -85,7 +85,7 @@ jobs:
       docker-image: ${{ needs.build-artifact.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.build-artifact.outputs.wheel-artifact-name }}
       build-artifact-name: ${{ needs.build-artifact.outputs.build-artifact-name }}
-      enabled-skus: bh_galaxy,wh_llmbox_perf,bh_quietbox_2
+      enabled-skus: bh_galaxy,bh_loudbox
       model: deepseek_prefill
       mlperf-read-only: ${{ inputs.mlperf-read-only != false }}
       job-prefix: "[DeepSeek Prefill] "

--- a/models/demos/deepseek_v3_d_p/tests/conftest.py
+++ b/models/demos/deepseek_v3_d_p/tests/conftest.py
@@ -759,3 +759,44 @@ def infinitebench_prompt(request):
         data = json.load(f)
 
     return data["subset"], data["prompt"]
+
+
+def pytest_collection_finish(session):
+    """Optional CI guardrail: warn (do NOT fail) when the number of selected
+    deepseek_v3_d_p tests differs from EXPECT_NUM_TESTS.
+
+    Inert unless EXPECT_NUM_TESTS is set, so it has zero effect on normal runs.
+    Intended for pipeline commands whose ``-k`` filter must resolve to a known
+    count — e.g. topology-gated tests that can silently collect 0 on the wrong
+    mesh. Emits a GitHub Actions ``::warning::`` annotation but never changes the
+    exit code, so the job still passes."""
+    expected_raw = os.getenv("EXPECT_NUM_TESTS")
+    if not expected_raw:
+        return
+    try:
+        expected = int(expected_raw)
+    except ValueError:
+        print(f"::warning title=Test count check::EXPECT_NUM_TESTS={expected_raw!r} is not an integer; skipping check")
+        return
+    actual = len(session.items)
+    if actual == expected:
+        return
+    invocation = " ".join(session.config.invocation_params.args)
+    msg = f"expected {expected} test(s) to be collected but got {actual} (pytest {invocation})"
+    annotation = f"::warning title=Unexpected test count::{msg}"
+
+    # The annotation must reach the step's live log stream for GitHub to parse it,
+    # so emit it with pytest's output capture suspended (a plain print() here can be
+    # swallowed by capturing and never appear in the runner log).
+    capman = session.config.pluginmanager.get_plugin("capturemanager")
+    if capman is not None:
+        with capman.global_and_fixture_disabled():
+            print(annotation, flush=True)
+    else:
+        print(annotation, flush=True)
+
+    # Also surface it on the GitHub job-summary page when available.
+    summary_path = os.getenv("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a") as fh:
+            fh.write(f"⚠️ **Unexpected test count** — {msg}\n")

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -696,6 +696,32 @@ def test_ds_moe(
     "mesh_device, device_params, num_links, topology",
     [
         pytest.param(
+            (8, 1),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(
+                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
+                ),
+            },
+            2 if is_blackhole() else 1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(8, 1), topology="linear"),
+            id="linear-8",
+        ),
+        pytest.param(
+            (4, 2),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_1D,
+                "fabric_router_config": create_fabric_router_config(
+                    max_payload_size=DeepSeekV3Config.FABRIC_PAYLOAD_SIZE
+                ),
+            },
+            2 if is_blackhole() else 1,
+            ttnn.Topology.Linear,
+            marks=pytest.mark.requires_mesh_topology(mesh_shape=(4, 2), topology="mesh-4x2"),
+            id="mesh-4x2",
+        ),
+        pytest.param(
             (8, 4),
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
@@ -6,6 +6,7 @@ import pytest
 
 from models.demos.deepseek_v3_d_p.utils.perf_utils import (
     _is_galaxy_env,
+    adjust_margin_for_ddr_speed,
     run_mla_perf_with_approximation,
     run_model_device_perf_test_with_merge,
 )
@@ -43,6 +44,9 @@ def test_deepseek_v3_mla_perf_loudbox():
 def test_deepseek_v3_mla_perf_galaxy():
     if not _is_galaxy_env():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
+
+    margin = adjust_margin_for_ddr_speed(0.03)
+
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4,
         expected_device_perf_ns_per_iteration=14_252_829,  # Recalibrated 2026-06-10 on bh-glx-110-c08u02; FABRIC_1D.
@@ -50,7 +54,7 @@ def test_deepseek_v3_mla_perf_galaxy():
         model_name="deepseek_v3_mla_glx_8x4",
         num_iterations=1,
         batch_size=1,
-        margin=0.03,
+        margin=margin,
         comments="seq100k_scaled_glx_8x4_ground_truth",
     )
 
@@ -62,6 +66,9 @@ def test_kimi_mla_chunked_perf_galaxy():
     640 matmul/SDPA configs end to end. Ground-truth 8x4 measurement (no 2x4 approximation)."""
     if not _is_galaxy_env():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
+
+    margin = adjust_margin_for_ddr_speed(0.03)
+
     run_model_device_perf_test_with_merge(
         command=_CMD_CHUNKED_8X4,
         expected_device_perf_ns_per_iteration=7_118_649,
@@ -69,7 +76,7 @@ def test_kimi_mla_chunked_perf_galaxy():
         model_name="kimi_mla_chunked_glx_8x4",
         num_iterations=1,
         batch_size=1,
-        margin=0.03,
+        margin=margin,
         # Time only the forward: ops between the MLA_START/MLA_END signposts, excluding one-time
         # weight-load tilize/typecast at construction (dispatched before MLA_START).
         between_signposts=("MLA_START", "MLA_END"),

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -15,16 +15,14 @@ Sum of per-op approximation approximates one glx column's MoE block kernel time;
 the 8x4 ground-truth test is the reference the approximation is compared against.
 """
 
-import logging
-
 import pytest
 
 from models.demos.deepseek_v3_d_p.utils.perf_utils import (
     _is_galaxy_env,
+    adjust_margin_for_ddr_speed,
     run_model_device_perf_test_with_merge,
     run_moe_perf_with_approximation,
 )
-from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import get_ddr_speed
 
 _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe"
 
@@ -61,13 +59,7 @@ def test_deepseek_v3_moe_perf_galaxy():
     if not _is_galaxy_env():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
 
-    margin = 0.03
-    ddr_speed = get_ddr_speed()
-    if ddr_speed is not None and ddr_speed < 16000:
-        logging.warning(f"DDR speed is {ddr_speed} (expected 16000), increasing margin from {margin} to {margin * 2}")
-        margin *= 2
-    elif ddr_speed is not None and ddr_speed > 16000:
-        logging.warning(f"DDR speed is {ddr_speed} (above expected 16000), baselines may need updating")
+    margin = adjust_margin_for_ddr_speed(0.03)
 
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4,

--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -15,6 +15,8 @@ Sum of per-op approximation approximates one glx column's MoE block kernel time;
 the 8x4 ground-truth test is the reference the approximation is compared against.
 """
 
+import logging
+
 import pytest
 
 from models.demos.deepseek_v3_d_p.utils.perf_utils import (
@@ -22,6 +24,7 @@ from models.demos.deepseek_v3_d_p.utils.perf_utils import (
     run_model_device_perf_test_with_merge,
     run_moe_perf_with_approximation,
 )
+from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import get_ddr_speed
 
 _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe"
 
@@ -57,6 +60,15 @@ def test_deepseek_v3_moe_perf_galaxy():
     """8x4 galaxy ground truth — the reference the loudbox approximation targets."""
     if not _is_galaxy_env():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
+
+    margin = 0.03
+    ddr_speed = get_ddr_speed()
+    if ddr_speed is not None and ddr_speed < 16000:
+        logging.warning(f"DDR speed is {ddr_speed} (expected 16000), increasing margin from {margin} to {margin * 2}")
+        margin *= 2
+    elif ddr_speed is not None and ddr_speed > 16000:
+        logging.warning(f"DDR speed is {ddr_speed} (above expected 16000), baselines may need updating")
+
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4,
         expected_device_perf_ns_per_iteration=41_294_210,
@@ -64,6 +76,6 @@ def test_deepseek_v3_moe_perf_galaxy():
         model_name="deepseek_v3_moe_glx_8x4",
         num_iterations=1,
         batch_size=1,
-        margin=0.03,
+        margin=margin,
         comments="seq3200_glx_8x4_ground_truth",
     )

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -416,7 +416,7 @@ def test_ds_mla(
     )
 
 
-@pytest.mark.parametrize("mesh_device", [(8, 4)], ids=["8x4"], indirect=True)
+@pytest.mark.parametrize("mesh_device", [(8, 4), (2, 4)], ids=["8x4", "2x4"], indirect=True)
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -428,8 +428,14 @@ def test_ds_mla(
             "fabric_config": ttnn.FabricConfig.FABRIC_1D_RING,
             "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
         },
+        {
+            "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+            "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+            "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+            "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+        },
     ],
-    ids=["line", "ring"],
+    ids=["line", "ring", "fabric2d"],
     indirect=True,
 )
 @pytest.mark.parametrize("use_pretrained", [False], ids=["random"])

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -439,7 +439,7 @@ def test_ds_mla(
     indirect=True,
 )
 @pytest.mark.parametrize("use_pretrained", [False], ids=["random"])
-@pytest.mark.parametrize("scale_down_sl", [False], ids=["max_sl"])
+@pytest.mark.parametrize("scale_down_sl", [False, True], ids=["max_sl", "scaled_sl"])
 @pytest.mark.parametrize(
     "seq_len",
     [5 * 1024, 25 * 1024],

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -11,6 +11,7 @@ Uses HF DeepseekV3Model layer as the reference: creates a model with random weig
 extracts those weights into our TT state_dict format, and compares forward passes.
 """
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -125,7 +126,13 @@ def run_model(
 
     # --- Cache setup ---
     is_dense = layer_idx < config.first_k_dense_replace
-    cache_dir = Path(f"/tmp/{variant.name}_prefill_block/{layer_type}_{sp_factor}x{tp_factor}mesh_{isl_total}isl")
+    cache_root = os.environ.get("TT_DS_PREFILL_HOST_REF_CACHE", "/tmp")
+    balanced_tag = "balanced" if is_balanced else "non_balanced"
+    gate_tag = gate_fallback_mode.value if gate_fallback_mode else "no_gate_fallback"
+    cache_dir = Path(
+        f"{cache_root}/{variant.name}_prefill_block/"
+        f"{layer_type}_{sp_factor}x{tp_factor}mesh_{isl_total}isl_{balanced_tag}_{gate_tag}"
+    )
     cache_dir.mkdir(parents=True, exist_ok=True)
 
     init_checker(cache_dir)

--- a/models/demos/deepseek_v3_d_p/utils/perf_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/perf_utils.py
@@ -12,8 +12,28 @@ from loguru import logger
 from tracy.common import PROFILER_ARTIFACTS_DIR
 from tracy.process_model_log import get_latest_ops_log_filename
 
+from models.demos.deepseek_v3_d_p.utils.smbus_telemetry import get_ddr_speed
 from models.perf.device_perf_utils import check_device_perf, prep_device_perf_report, run_device_perf
 from models.tt_transformers.tests.test_utils import merge_device_rows
+
+
+def adjust_margin_for_ddr_speed(margin: float, expected_speed: int = 16000) -> float:
+    """Return *margin* adjusted for the actual DDR speed reported by tt-smi.
+
+    - DDR speed < *expected_speed*  → double the margin (slower memory, looser threshold).
+    - DDR speed > *expected_speed*  → warn that baselines may need updating, keep margin.
+    - DDR speed == *expected_speed* or unavailable → keep margin unchanged.
+    """
+    ddr_speed = get_ddr_speed()
+    if ddr_speed is not None and ddr_speed < expected_speed:
+        logger.warning(
+            f"DDR speed is {ddr_speed} (expected {expected_speed}), increasing margin from {margin} to {margin * 2}"
+        )
+        return margin * 2
+    if ddr_speed is not None and ddr_speed > expected_speed:
+        logger.warning(f"DDR speed is {ddr_speed} (above expected {expected_speed}), baselines may need updating")
+    return margin
+
 
 # TP-collective ops: depend on TP=4 topology/bandwidth → take from 2x4
 # Everything else: depends on SP=8 tokens-per-chip and 8 experts/device → take from 8x1

--- a/models/demos/deepseek_v3_d_p/utils/smbus_telemetry.py
+++ b/models/demos/deepseek_v3_d_p/utils/smbus_telemetry.py
@@ -1,0 +1,24 @@
+import json
+import subprocess
+
+
+def get_smbus_telemetry():
+    result = subprocess.run(
+        ["tt-smi", "-s", "--snapshot_no_tty"],
+        capture_output=True,
+        text=True,
+        timeout=15,
+    )
+    if result.returncode == 0:
+        return json.loads(result.stdout)
+    return None
+
+
+def get_ddr_speed():
+    data = get_smbus_telemetry()
+    if data and data.get("device_info"):
+        smbus_telem = data["device_info"][0].get("smbus_telem", {})
+        ddr_speed_hex = smbus_telem.get("DDR_SPEED") or smbus_telem.get("SMBUS_TX_DDR_SPEED")
+        if ddr_speed_hex:
+            return int(ddr_speed_hex, 16)
+    return None

--- a/models/demos/deepseek_v3_d_p/utils/smbus_telemetry.py
+++ b/models/demos/deepseek_v3_d_p/utils/smbus_telemetry.py
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
 import json
 import subprocess
 

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -163,9 +163,19 @@ INFINITEBENCH_SUBSETS = {
     "longbook_qa_eng": "longbook_qa_eng.jsonl",
 }
 
-INFINITEBENCH_CACHE_DIR = Path(
-    os.environ.get("TT_DS_PREFILL_INFINITEBENCH_CACHE", "/tmp/deepseek_v3_transformer_inputs")
-)
+
+def _default_infinitebench_cache_dir() -> str:
+    # Prefer a test-specific override, then HF_HOME/infinitebench, then a temp dir.
+    explicit = os.environ.get("TT_DS_PREFILL_INFINITEBENCH_CACHE")
+    if explicit:
+        return explicit
+    hf_home = os.environ.get("HF_HOME")
+    if hf_home:
+        return os.path.join(hf_home, "infinitebench")
+    return "/tmp/deepseek_v3_transformer_inputs"
+
+
+INFINITEBENCH_CACHE_DIR = Path(_default_infinitebench_cache_dir())
 
 
 # --- HF model helpers ---

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -19,28 +19,30 @@
 
 - name: "(Galaxy) DeepSeek Prefill e2e tests"
   cmd: |
-    ll /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill-fresh
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-block-golden pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and with_determinism and iter5 and dense and smoke and random" -vvv --tb=short --timeout=900
-    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-block-golden pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and with_determinism and iter5 and moe and smoke and random" -vvv --tb=short --timeout=900
+    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
+    export HF_HOME=/mnt/MLPerf/huggingface/hub
+    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and no_determinism and iter5 and dense and pcc" -vvv --tb=short
+    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and no_determinism and iter5 and moe and pcc" -vvv --tb=short
+    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and with_determinism and iter5 and dense and smoke and random" -vvv --tb=short
+    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and with_determinism and iter5 and moe and smoke and random" -vvv --tb=short
     EXPECT_NUM_TESTS=1 \
     TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache-prefill-fresh \
-    HF_HOME=/mnt/MLPerf/huggingface/hub \
     TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden-32a3e8b6/ \
     pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py -k "ds_prefill and pretrained and e256_device_fp32 and fabric2d-mesh-8x4 and 61_layers and balanced and right_pad and smoke and no_determinism and iter25 and 25600 and longbook" -vvv --tb=short --timeout=1800
     # to replace test_prefill_transformer.py with add kimi and deepseek runners tests
   model: deepseek_prefill
   skus:
     bh_galaxy:
-      timeout: 30
-  owner_id: U08RL15T4N8
+      timeout: 20
+  owner_id: U08RL15T4N8 # David Popov
   team: models
 
 - name: "(Galaxy) DeepSeek Prefill Perf tests"
   cmd: |
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-block-golden pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer0" -vvv --tb=short
-    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-block-golden pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer3" -vvv --tb=short
+    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer0" -vvv --tb=short
+    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer3" -vvv --tb=short
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_deepseek_v3_moe_perf_galaxy -vvv --tb=short
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_galaxy -vvv --tb=short
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_kimi_mla_chunked_perf_galaxy -vvv --tb=short
@@ -48,7 +50,7 @@
   skus:
     bh_galaxy:
       timeout: 30
-  owner_id: U08RL15T4N8
+  owner_id: U08RL15T4N8 # David Popov
   team: models
 
 - name: "(bh loudbox) DeepSeek Prefill modules"
@@ -63,7 +65,7 @@
   skus:
     bh_loudbox:
       timeout: 75
-  owner_id: U08E1JCMAJF
+  owner_id: U08RL15T4N8 # David Popov
   team: models
 
 # ============================================================================

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -35,7 +35,7 @@
   skus:
     bh_galaxy:
       timeout: 20
-  owner_id: U08RL15T4N8 # David Popov
+  owner_id: U0ACLAM77PS # Kosta Grujcic
   team: models
 
 - name: "(Galaxy) DeepSeek Prefill Perf tests"
@@ -50,7 +50,7 @@
   skus:
     bh_galaxy:
       timeout: 30
-  owner_id: U08RL15T4N8 # David Popov
+  owner_id: U0ACLAM77PS # Kosta Grujcic
   team: models
 
 - name: "(bh loudbox) DeepSeek Prefill modules"
@@ -65,7 +65,7 @@
   skus:
     bh_loudbox:
       timeout: 75
-  owner_id: U08RL15T4N8 # David Popov
+  owner_id: U0ACLAM77PS # Kosta Grujcic
   team: models
 
 # ============================================================================

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -21,9 +21,10 @@
   cmd: |
     ll /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill-fresh
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and with_determinism and iter5 and dense and smoke and random" -vvv --tb=short --timeout=900
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and with_determinism and iter5 and moe and smoke and random" -vvv --tb=short --timeout=900
-    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache-prefill-fresh \
+    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-block-golden pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and with_determinism and iter5 and dense and smoke and random" -vvv --tb=short --timeout=900
+    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-block-golden pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and with_determinism and iter5 and moe and smoke and random" -vvv --tb=short --timeout=900
+    EXPECT_NUM_TESTS=1 \
+    TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache-prefill-fresh \
     HF_HOME=/mnt/MLPerf/huggingface/hub \
     TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden-32a3e8b6/ \
     pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py -k "ds_prefill and pretrained and e256_device_fp32 and fabric2d-mesh-8x4 and 61_layers and balanced and right_pad and smoke and no_determinism and iter25 and 25600 and longbook" -vvv --tb=short --timeout=1800
@@ -38,8 +39,8 @@
 - name: "(Galaxy) DeepSeek Prefill Perf tests"
   cmd: |
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer0" -vvv --tb=short
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer3" -vvv --tb=short
+    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-block-golden pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer0" -vvv --tb=short
+    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-block-golden pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer3" -vvv --tb=short
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_deepseek_v3_moe_perf_galaxy -vvv --tb=short
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_galaxy -vvv --tb=short
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_kimi_mla_chunked_perf_galaxy -vvv --tb=short

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -43,6 +43,7 @@
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
     export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
     export HF_HOME=/mnt/MLPerf/huggingface/hub
+    export MESH_DEVICE=TG
     EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer0" -vvv --tb=short
     EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer3" -vvv --tb=short
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_deepseek_v3_moe_perf_galaxy -vvv --tb=short

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -17,14 +17,15 @@
 # Galaxy DeepSeek Prefill Tests
 # ============================================================================
 
-- name: "(Galaxy) DeepSeek Prefill module tests"
+- name: "(Galaxy) DeepSeek Prefill e2e tests"
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=TG
-    uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py -k "mesh-8x4"
     export DEEPSEEK_V3_MLA_REF_CACHE=/mnt/MLPerf/deepseek-prefill-cache/test_mla_output
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "8x4 and random and max_sl and check_pcc and balanced and ring" -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and pcc and balanced and not non_balanced and fabric2d" -vvv --tb=short --timeout=900
+
+    uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and pcc and balanced and not non_balanced and fabric2d and with_determinism and iter5" -vvv --tb=short --timeout=900
+    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py -k "ds_prefill and pretrained and e256_device_fp32 and fabric2d-mesh-8x4 and 61_layers and balanced and right_pad and smoke and no_determinism and iter25 and 25600 and longbook" -vvv --tb=short --timeout=1800
+    # to replace test_prefill_transformer.py with add kimi and deepseek runners tests
   model: deepseek_prefill
   skus:
     bh_galaxy:
@@ -32,7 +33,7 @@
   owner_id: U08RL15T4N8
   team: models
 
-- name: "(Galaxy) DeepSeek Prefill PERF"
+- name: "(Galaxy) DeepSeek Prefill Perf tests"
   cmd: |
     export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=TG
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
@@ -47,43 +48,18 @@
   owner_id: U08RL15T4N8
   team: models
 
-- name: "t3k_DeepSeek_PREFILL"
+- name: "(bh loudbox) DeepSeek Prefill modules"
   cmd: |
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch.py -vvv --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-"
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_combine.py -vvv  --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-"
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_reduce.py -vvv --tb=short -k "2048 and (linear-4x1 or mesh-4x2 or mesh-2x4)"
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ttnn_dispatch_combine.py -vvv --tb=short -k "random and (linear-8-1link or mesh-4x2 or mesh-2x4) and not fabric2d-"
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -vvv --tb=short -k "mesh-4x2 and not fabric2d-"
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and single_run and pcc_check and not fabric2d' -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and random and scaled_sl and check_pcc and line" -vvv --tb=short
-  model: deepseek_prefill
-  skus:
-    wh_llmbox_perf:
-      timeout: 45
-  owner_id: U08E1JCMAJF
-  team: models
 
-- name: bh_lb_DeepSeek_PREFILL
-  cmd: |
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64 and ((mesh-4x2 or mesh-2x4 or linear-8) or not (moe_gate_prefill2d or moe_routing_setup or ttnn_moe))"
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '4x2 and pcc_check and fabric2d' -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_rope_prefill.py -k '4x2' -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and random and scaled_sl and check_pcc and fabric2d" -vvv --tb=short
+    # deepseek and kimi chunked prefill on 2x4 mesh
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "production and 50k+5k and cpu and 2x4 and not 32x4" -vvv --tb=short
+    # deepseek and kimi moe blocks
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "linear-8 and pcc-device" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "linear-8 and 5k and not 25k" -vvv --tb=short
   model: deepseek_prefill
   skus:
     bh_loudbox:
       timeout: 75
-  owner_id: U08E1JCMAJF
-  team: models
-
-- name: bh_qb_DeepSeek_PREFILL
-  cmd: |
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/ -vvv --tb=short -k "not matmul_pcc and not perf-host-64 and (mesh-2x2 or not (moe_gate_prefill2d or moe_routing_setup or ttnn_moe))"
-    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_ring_joint_mla.py -k '2x2 and pcc_check and fabric2d' -vvv --tb=short
-  model: deepseek_prefill
-  skus:
-    bh_quietbox_2:
-      timeout: 40
   owner_id: U08E1JCMAJF
   team: models
 

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -61,6 +61,8 @@
     # deepseek and kimi prefill on 2x4 mesh
     EXPECT_NUM_TESTS=2 pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and not 32x4 and random and scaled_sl and check_pcc and 100k and fabric2d" -vvv --tb=short
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_kimi_mla -k "2x4 and random and scaled_sl and check_pcc and seq5k and fabric2d" -vvv --tb=short
+    EXPECT_NUM_TESTS=1 python -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k 'maxedge-1u and kimi and cpu and 2x4 and fabric2d'
+    EXPECT_NUM_TESTS=1 python -m pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k 'maxedge-1u and ds and cpu and 2x4 and fabric2d'
     # deepseek and kimi moe blocks
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "linear-8 and pcc-device" -vvv --tb=short --timeout=1800
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "linear-8 and 5k and not 25k" -vvv --tb=short --timeout=1800

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -69,7 +69,7 @@
   model: deepseek_prefill
   skus:
     bh_loudbox:
-      timeout: 20
+      timeout: 30
   owner_id: U0ACLAM77PS # Kosta Grujcic
   team: models
 

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -19,12 +19,11 @@
 
 - name: "(Galaxy) DeepSeek Prefill e2e tests"
   cmd: |
-    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=TG
     export DEEPSEEK_V3_MLA_REF_CACHE=/mnt/MLPerf/deepseek-prefill-cache/test_mla_output
 
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and pcc and balanced and not non_balanced and fabric2d and with_determinism and iter5" -vvv --tb=short --timeout=900
-    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py -k "ds_prefill and pretrained and e256_device_fp32 and fabric2d-mesh-8x4 and 61_layers and balanced and right_pad and smoke and no_determinism and iter25 and 25600 and longbook" -vvv --tb=short --timeout=1800
+    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and smoke and balanced and not non_balanced and fabric2d and with_determinism and iter5" -vvv --tb=short --timeout=900
+    TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill-fresh HF_HOME=/mnt/MLPerf/huggingface/hub TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-prefill-golden-32a3e8b6/ pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py -k "ds_prefill and pretrained and e256_device_fp32 and fabric2d-mesh-8x4 and 61_layers and balanced and right_pad and smoke and no_determinism and iter25 and 25600 and longbook" -vvv --tb=short --timeout=1800
     # to replace test_prefill_transformer.py with add kimi and deepseek runners tests
   model: deepseek_prefill
   skus:
@@ -35,7 +34,6 @@
 
 - name: "(Galaxy) DeepSeek Prefill Perf tests"
   cmd: |
-    export DEEPSEEK_V3_HF_MODEL=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528 DEEPSEEK_V3_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/CI MESH_DEVICE=TG
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
     pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4" -vvv --tb=short
     pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_deepseek_v3_moe_perf_galaxy -vvv --tb=short
@@ -52,10 +50,10 @@
   cmd: |
 
     # deepseek and kimi chunked prefill on 2x4 mesh
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "production and 50k+5k and cpu and 2x4 and not 32x4" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "production and 50k+5k and cpu and 2x4 and not 32x4" -vvv --tb=short --timeout=1800
     # deepseek and kimi moe blocks
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "linear-8 and pcc-device" -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "linear-8 and 5k and not 25k" -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "linear-8 and pcc-device" -vvv --tb=short --timeout=1800
+    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "linear-8 and 5k and not 25k" -vvv --tb=short --timeout=1800
   model: deepseek_prefill
   skus:
     bh_loudbox:

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -60,7 +60,7 @@
   cmd: |
     # deepseek and kimi prefill on 2x4 mesh
     EXPECT_NUM_TESTS=2 pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and not 32x4 and random and scaled_sl and check_pcc and 100k and fabric2d" -vvv --tb=short
-    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_kimi_mla -k "2x4 and random and check_pcc and seq5k and fabric2d" -vvv --tb=short
+    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_kimi_mla -k "2x4 and random and scaled_sl and check_pcc and seq5k and fabric2d" -vvv --tb=short
     # deepseek and kimi moe blocks
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "linear-8 and pcc-device" -vvv --tb=short --timeout=1800
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "linear-8 and 5k and not 25k" -vvv --tb=short --timeout=1800

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -19,11 +19,14 @@
 
 - name: "(Galaxy) DeepSeek Prefill e2e tests"
   cmd: |
-    export DEEPSEEK_V3_MLA_REF_CACHE=/mnt/MLPerf/deepseek-prefill-cache/test_mla_output
-
+    ll /mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill-fresh
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and smoke and balanced and not non_balanced and fabric2d and with_determinism and iter5" -vvv --tb=short --timeout=900
-    TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-Cache-prefill-fresh HF_HOME=/mnt/MLPerf/huggingface/hub TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache/DeepSeek-R1-0528-prefill-golden-32a3e8b6/ pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py -k "ds_prefill and pretrained and e256_device_fp32 and fabric2d-mesh-8x4 and 61_layers and balanced and right_pad and smoke and no_determinism and iter25 and 25600 and longbook" -vvv --tb=short --timeout=1800
+    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and with_determinism and iter5 and dense and smoke and random" -vvv --tb=short --timeout=900
+    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/test_prefill_block.py::test_ds_prefill_block -k "8x4 and non_balanced and fabric2d and with_determinism and iter5 and moe and smoke and random" -vvv --tb=short --timeout=900
+    EXPECT_NUM_TESTS=1 TT_DS_PREFILL_TTNN_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-Cache-prefill-fresh \
+    HF_HOME=/mnt/MLPerf/huggingface/hub \
+    TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden-32a3e8b6/ \
+    pytest models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py -k "ds_prefill and pretrained and e256_device_fp32 and fabric2d-mesh-8x4 and 61_layers and balanced and right_pad and smoke and no_determinism and iter25 and 25600 and longbook" -vvv --tb=short --timeout=1800
     # to replace test_prefill_transformer.py with add kimi and deepseek runners tests
   model: deepseek_prefill
   skus:
@@ -35,10 +38,11 @@
 - name: "(Galaxy) DeepSeek Prefill Perf tests"
   cmd: |
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
-    pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4" -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_deepseek_v3_moe_perf_galaxy -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_galaxy -vvv --tb=short
-    pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_kimi_mla_chunked_perf_galaxy -vvv --tb=short
+    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer0" -vvv --tb=short
+    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer3" -vvv --tb=short
+    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_deepseek_v3_moe_perf_galaxy -vvv --tb=short
+    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_galaxy -vvv --tb=short
+    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_kimi_mla_chunked_perf_galaxy -vvv --tb=short
   model: deepseek_prefill
   skus:
     bh_galaxy:
@@ -50,10 +54,10 @@
   cmd: |
 
     # deepseek and kimi chunked prefill on 2x4 mesh
-    pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "production and 50k+5k and cpu and 2x4 and not 32x4" -vvv --tb=short --timeout=1800
+    EXPECT_NUM_TESTS=2 pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "production and 50k+5k and cpu and 2x4 and not 32x4" -vvv --tb=short --timeout=1800
     # deepseek and kimi moe blocks
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "linear-8 and pcc-device" -vvv --tb=short --timeout=1800
-    pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "linear-8 and 5k and not 25k" -vvv --tb=short --timeout=1800
+    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "linear-8 and pcc-device" -vvv --tb=short --timeout=1800
+    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "linear-8 and 5k and not 25k" -vvv --tb=short --timeout=1800
   model: deepseek_prefill
   skus:
     bh_loudbox:

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -41,6 +41,8 @@
 - name: "(Galaxy) DeepSeek Prefill Perf tests"
   cmd: |
     uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt
+    export DEEPSEEK_V3_HF_MODEL=/mnt/models/deepseek-ai/DeepSeek-R1-0528
+    export HF_HOME=/mnt/MLPerf/huggingface/hub
     EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer0" -vvv --tb=short
     EXPECT_NUM_TESTS=1 TT_DS_PREFILL_HOST_REF_CACHE=/mnt/MLPerf/tt_dnn-models/deepseek-ai/DeepSeek-R1-0528-prefill-golden pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4 and fabric2d and layer3" -vvv --tb=short
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_deepseek_v3_moe_perf_galaxy -vvv --tb=short

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -58,16 +58,16 @@
 
 - name: "(bh loudbox) DeepSeek Prefill modules"
   cmd: |
-
-    # deepseek and kimi chunked prefill on 2x4 mesh
-    EXPECT_NUM_TESTS=2 pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill -k "production and 50k+5k and cpu and 2x4 and not 32x4" -vvv --tb=short --timeout=1800
+    # deepseek and kimi prefill on 2x4 mesh
+    EXPECT_NUM_TESTS=2 pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla -k "2x4 and not 32x4 and random and scaled_sl and check_pcc and 100k and fabric2d" -vvv --tb=short
+    EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/test_mla.py::test_kimi_mla -k "2x4 and random and check_pcc and seq5k and fabric2d" -vvv --tb=short
     # deepseek and kimi moe blocks
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_ds_moe -k "linear-8 and pcc-device" -vvv --tb=short --timeout=1800
     EXPECT_NUM_TESTS=1 pytest models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe -k "linear-8 and 5k and not 25k" -vvv --tb=short --timeout=1800
   model: deepseek_prefill
   skus:
     bh_loudbox:
-      timeout: 75
+      timeout: 20
   owner_id: U0ACLAM77PS # Kosta Grujcic
   team: models
 


### PR DESCRIPTION
## Summary
- Rework `demo_sp_release_tests.yaml`: replace the old Galaxy module/PERF + t3k/qb jobs with e2e + perf suites driven by prefill golden caches; add a bh_loudbox modules job (chunked prefill + DS/Kimi MoE). Drops the wormhole (`wh_llmbox_perf`) and `bh_quietbox_2` jobs.
- `demo-sp-release.yaml`: `enabled-skus` → `bh_galaxy,bh_loudbox`.
- Add `EXPECT_NUM_TESTS` guardrail in `conftest.py`: warns (never fails) when a `-k` filter collects an unexpected test count — catches topology-gated tests silently collecting 0.
- `test_ttnn_moe.py`: add `linear-8` and `mesh-4x2` params for `test_ds_moe`/`test_kimi_moe`.
- `test_prefill_block.py`: cache dir honors `TT_DS_PREFILL_HOST_REF_CACHE` and keys on balanced/gate tags.
- Update prefill owner_id David → Kosta.

## Test plan
- `/deepseek-pipelines` (all 4 CI workflows)

### DeepSeek Prefill CI
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=mbezulj/2606-sp-release-tests-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:mbezulj/2606-sp-release-tests-prefill) Galaxy
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=mbezulj/2606-sp-release-tests-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:mbezulj/2606-sp-release-tests-prefill) T3K
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=mbezulj/2606-sp-release-tests-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:mbezulj/2606-sp-release-tests-prefill) Single Card
⚠️ [DeepSeek Prefill Tests / [DeepSeek Prefill] (bh loudbox) DeepSeek Prefill modules 
FAILED models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py::test_kimi_moe[blackhole-kimi-linear-8-kimi-5k-pcc] - AssertionError: One or more comparisons failed. See logs for details. @ddjekicTT  has a PR to fix it
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=mbezulj/2606-sp-release-tests-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:mbezulj/2606-sp-release-tests-prefill) Blackhole
⚠️ [blackhole-e2e-tests (LoudBox (8xP150), bh_loudbox) / bh_lb_DeepSeek_PREFILL [bh_loudbox]](https://github.com/tenstorrent/tt-metal/actions/runs/27760325724/job/82142222154#logs) hits a 93min timeout. Needs a fix,  unrelated to this PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mbezulj/2606-sp-release-tests-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mbezulj/2606-sp-release-tests-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mbezulj/2606-sp-release-tests-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mbezulj/2606-sp-release-tests-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mbezulj/2606-sp-release-tests-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mbezulj/2606-sp-release-tests-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mbezulj/2606-sp-release-tests-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mbezulj/2606-sp-release-tests-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mbezulj/2606-sp-release-tests-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mbezulj/2606-sp-release-tests-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mbezulj/2606-sp-release-tests-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mbezulj/2606-sp-release-tests-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mbezulj/2606-sp-release-tests-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mbezulj/2606-sp-release-tests-prefill)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mbezulj/2606-sp-release-tests-prefill)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mbezulj/2606-sp-release-tests-prefill)