### PR TITLE
Clarify paged KV cache dtype contracts

### DIFF
--- a/models/common/modules/attention/attention_1d.py
+++ b/models/common/modules/attention/attention_1d.py
@@ -795,6 +795,13 @@ class Attention1D(LightweightModule):
         k_fill_sliced = k_fill[:, :, :page_len, :] if page_len < k_fill.shape[2] else k_fill
         v_fill_sliced = v_fill[:, :, :page_len, :] if page_len < v_fill.shape[2] else v_fill
 
+        if k_fill_sliced.dtype != keys.dtype or v_fill_sliced.dtype != values.dtype:
+            raise ValueError(
+                "paged KV cache prefill requires K/V fill tensors to already match the cache dtype: "
+                f"k_fill={k_fill_sliced.dtype}, keys={keys.dtype}, "
+                f"v_fill={v_fill_sliced.dtype}, values={values.dtype}"
+            )
+
         ttnn.experimental.paged_fill_cache(keys, k_fill_sliced, fill_page_table, batch_idx=user_id)
         ttnn.experimental.paged_fill_cache(values, v_fill_sliced, fill_page_table, batch_idx=user_id)
 

--- a/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
+++ b/tests/ttnn/unit_tests/operations/transformers/test_paged_cache_flexible_geometry.py
@@ -697,6 +697,39 @@ def test_paged_fill_cache_legacy_no_override(device):
     )
 
 
+def test_paged_fill_cache_rejects_input_dtype_mismatch(device):
+    """paged_fill_cache is a raw tile-copy path; callers must cast to cache dtype first."""
+    torch.manual_seed(14)
+    cache_torch = torch.randn([8, 1, 32, 32]).bfloat16().float()
+    input_torch = torch.randn([1, 1, 32, 32]).bfloat16().float()
+    page_table_torch = torch.tensor([[1, 0, 0, 0, 0, 0, 0, 0]], dtype=torch.int32)
+
+    cache_tt = ttnn.from_torch(cache_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
+    input_tt = ttnn.from_torch(input_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    page_table_tt = ttnn.from_torch(page_table_torch, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
+
+    with pytest.raises(RuntimeError, match="must match cache tensor dtype"):
+        ttnn.experimental.paged_fill_cache(cache_tt, input_tt, page_table_tt, batch_idx=0)
+
+
+def test_paged_fill_cache_accepts_bfloat8_input_for_bfloat8_cache(device):
+    torch.manual_seed(15)
+    cache_torch = torch.randn([8, 1, 32, 32]).bfloat16().float()
+    input_torch = torch.randn([1, 1, 32, 32]).bfloat16().float()
+    page_table_torch = torch.tensor([[1, 0, 0, 0, 0, 0, 0, 0]], dtype=torch.int32)
+
+    cache_tt = ttnn.from_torch(cache_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
+    input_tt = ttnn.from_torch(input_torch, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat8_b)
+    page_table_tt = ttnn.from_torch(page_table_torch, device=device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.int32)
+
+    ttnn.experimental.paged_fill_cache(cache_tt, input_tt, page_table_tt, batch_idx=0)
+
+    got_cache = _read_paged_cache(cache_tt)
+    expected_input = input_tt.cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch()
+    eq, msg = comp_equal(got_cache[1:2], expected_input)
+    assert eq, f"bfloat8 paged_fill_cache raw copy mismatch: {msg}"
+
+
 @pytest.mark.parametrize("num_kv_heads", [1, 8])
 def test_paged_fill_cache_override_view_full_into_sliding_buffer(num_kv_heads, device):
     """Cache allocated as sliding ``(128, 256)``, filled via override with full

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fill_cache/paged_fill_cache_device_operation.cpp
@@ -29,11 +29,20 @@ void PagedFillCacheDeviceOperation::validate_on_program_cache_miss(
     const auto& input_tensor = tensor_args.input_tensor;
     const auto& page_table_tensor = tensor_args.page_table;
 
-    // Data type validation
+    // paged_fill_cache is a raw tile-copy fill path: it does not convert input
+    // K/V into the cache dtype. Callers must cast prefill K/V to the destination
+    // cache dtype before calling this op.
     TT_FATAL(
-        input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16 ||
+        cache_tensor.dtype() == DataType::FLOAT32 || cache_tensor.dtype() == DataType::BFLOAT16 ||
             cache_tensor.dtype() == DataType::BFLOAT8_B || cache_tensor.dtype() == DataType::BFLOAT4_B,
-        "Data type of input tensor for fill cache must be FLOAT32, BFLOAT16, or BFLOAT8_b");
+        "Data type of cache tensor for paged_fill_cache must be FLOAT32, BFLOAT16, BFLOAT8_B, or BFLOAT4_B and is {}",
+        cache_tensor.dtype());
+    TT_FATAL(
+        input_tensor.dtype() == cache_tensor.dtype(),
+        "Input tensor dtype ({}) must match cache tensor dtype ({}) for paged_fill_cache; cast prefill K/V to the "
+        "cache dtype before filling the paged cache.",
+        input_tensor.dtype(),
+        cache_tensor.dtype());
 
     TT_FATAL(
         input_tensor.memory_config().memory_layout() == TensorMemoryLayout::INTERLEAVED,

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.cpp
@@ -203,7 +203,8 @@ void PagedFusedUpdateCacheDeviceOperation::validate_on_program_cache_miss(
         // Data type validation
         TT_FATAL(
             input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16,
-            "Data type of input tensor for update cache must be FLOAT32 or BFLOAT16");
+            "Data type of input tensor for update cache must be FLOAT32 or BFLOAT16; decode update repacks into the "
+            "cache dtype and should not receive low-precision packed input");
 
         TT_FATAL(operation_attributes.batch_offset == 0, "batch_offset must be 0");
     }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/fused_update_cache/paged_fused_update_cache_device_operation.cpp
@@ -203,8 +203,8 @@ void PagedFusedUpdateCacheDeviceOperation::validate_on_program_cache_miss(
         // Data type validation
         TT_FATAL(
             input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16,
-            "Data type of input tensor for update cache must be FLOAT32 or BFLOAT16; decode update repacks into the "
-            "cache dtype and should not receive low-precision packed input");
+            "Data type of input tensor for paged_fused_update_cache must be FLOAT32 or BFLOAT16; decode update "
+            "repacks into the cache dtype and should not receive low-precision packed input");
 
         TT_FATAL(operation_attributes.batch_offset == 0, "batch_offset must be 0");
     }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
@@ -293,7 +293,7 @@ void PagedUpdateCacheDeviceOperation::validate_on_program_cache_miss(
     // Data type validation
     TT_FATAL(
         input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16,
-        "Data type of input tensor for update cache must be FLOAT32 or BFLOAT16; decode update repacks into the "
+        "Data type of input tensor for paged_update_cache must be FLOAT32 or BFLOAT16; decode update repacks into the "
         "cache dtype and should not receive low-precision packed input");
 
     TT_FATAL(operation_attributes.batch_offset == 0, "batch_offset must be 0");

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/device/update_cache/paged_update_cache_device_operation.cpp
@@ -293,7 +293,8 @@ void PagedUpdateCacheDeviceOperation::validate_on_program_cache_miss(
     // Data type validation
     TT_FATAL(
         input_tensor.dtype() == DataType::FLOAT32 || input_tensor.dtype() == DataType::BFLOAT16,
-        "Data type of input tensor for update cache must be FLOAT32 or BFLOAT16");
+        "Data type of input tensor for update cache must be FLOAT32 or BFLOAT16; decode update repacks into the "
+        "cache dtype and should not receive low-precision packed input");
 
     TT_FATAL(operation_attributes.batch_offset == 0, "batch_offset must be 0");
 }

--- a/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/paged_cache/paged_cache_nanobind.cpp
@@ -35,6 +35,10 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
          input is height-sharded with the kv-heads dim padded to TILE_HEIGHT so the
          logical count can't be inferred from the tensor.
          ``num_kv_heads * block_size * head_dim`` must be preserved across views.
+         Input tensors must be FLOAT32 or BFLOAT16 even when the destination cache is
+         BFLOAT8_B/BFLOAT4_B. This op updates one token row inside an existing cache
+         tile and owns the final repack into the cache dtype; do not pre-cast decode
+         K/V updates to the low-precision cache dtype.
          ``cache_position_modulo`` (optional, paged mode only) makes the kernel
          compute ``update_idx %= cache_position_modulo`` before resolving the
          page_table entry — i.e. treats the cache as a circular buffer of that
@@ -117,6 +121,9 @@ void bind_experimental_paged_cache_operations(nb::module_& mod) {
         ``head_dim`` is read from ``input_tensor.padded_shape[-1]``. ``block_size``
         defaults to ``cache_tensor.padded_shape[2]``; pass the kwarg to override it (see
         ``paged_update_cache`` for details). Per-block byte count must be preserved.
+        ``paged_fill_cache`` does not perform dtype conversion; it copies prefill K/V
+        tiles into the cache. ``input_tensor.dtype`` must match ``cache_tensor.dtype``.
+        Cast prefill K/V to the cache dtype before calling this op.
         ``cache_position_modulo`` (optional) treats the cache as a circular buffer of
         that many tokens: each tile write computes ``seq_tile_id %=
         cache_position_modulo / TILE_HEIGHT`` before the page_table lookup. Lets


### PR DESCRIPTION
## Summary
- Require `paged_fill_cache` input tensors to match the destination cache dtype, since the op is a raw tile-copy fill path and does not convert K/V.
- Document the prefill/decode dtype split: prefill fill inputs must be cast to cache dtype, while decode update inputs remain BF16/FLOAT32 because update repacks into the cache dtype.
- Add a common `Attention1D` paged-prefill dtype check and focused coverage for BF16 input into a BFP8 paged cache failing validation plus BFP8 input into a BFP8 cache succeeding.

## Manually Triggered CI
- [![Custom test dispatch](https://github.com/tenstorrent/tt-metal/actions/workflows/test-dispatch.yaml/badge.svg?branch=yieldthought%2Fpaged-cache-dtype-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/test-dispatch.yaml?query=branch%3Ayieldthought%2Fpaged-cache-dtype-contract)
  - Focused paged-cache dtype regression: https://github.com/tenstorrent/tt-metal/actions/runs/27405558776
  - TTNN ops docs check for paged-cache docstrings: https://github.com/tenstorrent/tt-metal/actions/runs/27405558863
  - Focused Attention1D paged prefill/decode transition: https://github.com/tenstorrent/tt-metal/actions/runs/27405714496
- [![Single-card TTNN frequent](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yieldthought%2Fpaged-cache-dtype-contract)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch%3Ayieldthought%2Fpaged-cache-dtype-contract)
  - Single-card TTNN frequent pipeline: https://github.com/tenstorrent/tt-metal/actions/runs/27405558845
