### PR TITLE
[Fix] Incorrect truncation of page table

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -780,6 +780,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                         use_batched_prefill=False,
                         user_id=user_id,
                         padded_batch_size=None,
+                        use_full_prompt_len=True,
                     )
             else:
                 page_table_user = None
@@ -2658,6 +2659,7 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         use_batched_prefill=False,
         user_id=None,
         padded_batch_size=None,
+        use_full_prompt_len=False,
     ):
         block_size = get_block_size(kv_cache)
 
@@ -2679,7 +2681,10 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # prefill length (for example 32-token prompts become 128-token
             # kernels), so the page table must expose blocks for that padded
             # length even on the non-traced compile path.
-            target_prefill_len = prefill_seq_len if prefill_seq_len is not None else prefill_len
+            if use_full_prompt_len:
+                target_prefill_len = prefill_len
+            else:
+                target_prefill_len = prefill_seq_len if prefill_seq_len is not None else prefill_len
             num_blocks = num_blocks_in_seq(target_prefill_len, block_size)
             if page_table.shape[1] < num_blocks:
                 padding = torch.ones(1, num_blocks - page_table.shape[1], dtype=torch.int32) * -1


### PR DESCRIPTION
### Summary

Fixes https://github.com/tenstorrent/vllm/issues/415

TT truncated the page table to the uncached suffix length before the prefix-resume path needs the full prompt mapping. Fixed by keeping the full target len.

### Testing

* Bug reproduced locally on different model and HW, change tested to fix that.
* Test in the original setup by @ifabijanic-tt : "Fix works with both small repro cases and full length requests."

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=viktorpus/fix-apc)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:viktorpus/fix-apc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=viktorpus/fix-apc)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:viktorpus/fix-apc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=viktorpus/fix-apc)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:viktorpus/fix-apc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=viktorpus/fix-apc)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:viktorpus/fix-apc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=viktorpus/fix-apc)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:viktorpus/fix-apc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=viktorpus/fix-apc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:viktorpus/fix-apc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=viktorpus/fix-apc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:viktorpus/fix-apc)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=viktorpus/fix-apc)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:viktorpus/fix-apc)