### PR TITLE
[Quasar] Add comp (compare-to-zero) SFPU kernel - LLK

### DIFF
--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -4,81 +4,152 @@
 #pragma once
 
 #include <cstdint>
+#include <type_traits>
 
-#include "ckernel_addrmod.h"
+#include "ckernel_defs.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
 #include "llk_defs.h"
-#include "llk_math_eltwise_sfpu_common.h"
-#include "lltt.h"
 #include "sfpi.h"
 
 namespace ckernel {
 namespace sfpu {
-// fp16b bit patterns (upper 16 bits of the corresponding fp32), loaded as
-// SFPLOADI immediates in MOD0_FLOATB mode.
-constexpr std::uint32_t FP16B_ONE = 0x3F80;   // 1.0f
-constexpr std::uint32_t FP16B_ZERO = 0x0000;  // 0.0f
-
-// imm12_math[11]: makes SFPSETCC read the source as FP32/SMAG32 (sign-magnitude) rather than
-// two's-complement INT32. SFPLOAD only ever produces FP32, SMAG32, or UINT32 in the LREG (signed
-// integers load as sign-magnitude SMAG32, never 2's-complement), so this bit is set for every
-// format we handle — both float and integer. The sign tests (SFPSETCC modes 0/4) read the sign
-// bit regardless of this bit; it only governs the zero test, where SMAG32==0 correctly treats
-// sign-magnitude ±0 as zero (2's-complement would miss -0 = 0x80000000).
-constexpr std::uint32_t SFPSETCC_IMM_FP32 = 0x800;
 
 /**
- * @brief Whether FMT is read/written as an integer (vs float) — drives the 1/0 result encoding.
+ * @brief sfpi container type for an *integer* dst_reg[0] format (vInt→SMAG32, vSMag16→SMAG16,
+ * vUInt16→UINT16).
  *
- * Also gates the sfpmem mode: integers take their explicit width from the canonical
- * @ref _sfpu_sfpmem_type_<FMT>() selector (Int32→INT32, Int16→INT16, Int8→INT8, UInt8→UINT8,
- * UInt16→UINT16), while floats use sfpmem::DEFAULT (the explicit fp16 modes decode the fp16b
- * boolean result as NaN).
- *
- * @note Int8/UInt8 use their native Quasar dest format (SMAG8 / UINT8) — these are real
- *       register-file formats, so the 8-bit datapath round-trips natively. UInt16 is the exception:
- *       it is not a Quasar register-file format at all (absent from the unpacker / SrcA-B / dest /
- *       packer encodings — see VALID_QUASAR_SRC/DEST_REG_FORMATS; Int8/UInt8 are present, hence
- *       native). It is therefore routed through the Int16/SMAG16 container — unpack and pack run in
- *       Int16 (the known-good 16-bit bit-passthrough path) and only the SFPU accesses the
- *       unsigned-16 semantics via sfpmem::UINT16. The caller must keep the unpack/pack/math formats
- *       at Int16 and select FMT=UInt16 only to pick that sfpmem mode.
- *
- * @tparam FMT: SFPU DataFormat (sfpu_math): Int32 / Int16 / Int8 signed, UInt16 / UInt8 unsigned.
+ * @note Floats (all widths share @c vFloat) and the 8-bit formats (no sfpi dst_reg conversion; raw
+ *       SFPLOAD path) are handled in @ref zero_comp_traits, not here.
  */
 template <DataFormat FMT>
-inline constexpr bool _zero_comp_is_int_() {
-    return FMT == DataFormat::Int32 || FMT == DataFormat::Int16 || FMT == DataFormat::Int8 ||
-           FMT == DataFormat::UInt16 || FMT == DataFormat::UInt8;
-}
+struct dst_container {
+    using type = sfpi::vInt;
+};  // Int32
+template <>
+struct dst_container<DataFormat::Int16> {
+    using type = sfpi::vSMag16;
+};
+template <>
+struct dst_container<DataFormat::UInt16> {
+    using type = sfpi::vUInt16;
+};
 
 /**
- * @brief Number of instructions in the recorded replay body for a comparison mode.
+ * @brief Per-DataFormat load/store and 0/1 encoding for the comparison-to-zero result.
  *
- * Format-independent (Int32 and float bodies have identical instruction counts): eqz/nez predicate
- * with a single SFPSETCC (7). The strict ltz/gtz AND a second SFPSETCC (8). gtez/ltez are the
- * lane-wise complements of ltz/gtz — they predicate the same strictly-signed lanes but default the
- * result to 1 and write 0 — so they share the strict body's length (8).
+ * @c load reads the element as raw @c vInt bits for the shared predicate (see @ref _zero_comp_pred_);
+ * @c store writes @c zero/@c one back in FMT's native encoding. The 16/32-bit and float formats use
+ * the sfpi @c dst_reg[0] container; the 8-bit formats use a raw explicit-mode SFPLOAD/SFPSTORE.
  *
- * @tparam COMP_MODE: Comparison-to-zero mode selecting the body to record.
- * @return Recorded body length in instructions.
+ * @tparam FMT: SFPU DataFormat (sfpu_math). Int32 / Int16 / Int8 signed, UInt16 / UInt8 unsigned, or
+ *         any IEEE float width (Float32/Float16/Float16_b all share the float path).
+ *
+ * @todo Once sfpi adds an 8-bit dst_reg[0] conversion (vSMag8/vUInt8), add Int8→vSMag8 /
+ *       UInt8→vUInt8 to dst_container and drop the is_raw8 raw-SFPLOAD branches so 8-bit follows the
+ *       same container path as the other formats.
+ */
+template <DataFormat FMT>
+struct zero_comp_traits {
+    static constexpr bool is_float = (FMT == DataFormat::Float32);
+    static constexpr bool is_raw8 = (FMT == DataFormat::Int8 || FMT == DataFormat::UInt8);
+
+    // Result encoding: float formats emit 0.0f/1.0f, every integer format emits integer 0/1.
+    using result_t = std::conditional_t<is_float, sfpi::vFloat, sfpi::vInt>;
+
+    // dst_reg[0] container carrying FMT's width/encoding (unused on the 8-bit raw path): vFloat for
+    // every float width, else the per-format integer container.
+    using container_t = std::conditional_t<is_float, sfpi::vFloat, typename dst_container<FMT>::type>;
+
+    // sfpmem mode for the raw 8-bit SFPLOAD/SFPSTORE path.
+    static constexpr std::uint32_t sfpmem8 =
+        (FMT == DataFormat::UInt8) ? ckernel::p_sfpu::sfpmem::UINT8 : ckernel::p_sfpu::sfpmem::INT8;
+
+    static inline __attribute__((always_inline)) sfpi::vInt load() {
+        if constexpr (is_raw8) {
+            return sfpi::vInt(__builtin_rvtt_sfpload(0, sfpmem8, sfpi::SFPLOAD_ADDR_MODE_NOINC));
+        } else {
+            container_t c = sfpi::dst_reg[0];
+            return sfpi::as<sfpi::vInt>(c);
+        }
+    }
+    // result_t(0)/result_t(1): vInt(0/1), or vFloat(0/1) which the vFloat(float) ctor folds to 0.0f/1.0f.
+    static inline __attribute__((always_inline)) result_t zero() { return result_t(0); }
+    static inline __attribute__((always_inline)) result_t one() { return result_t(1); }
+    static inline __attribute__((always_inline)) void store(result_t r) {
+        if constexpr (is_raw8) {
+            __builtin_rvtt_sfpstore(r.get(), 0, sfpmem8, ckernel::ADDR_MOD_6);
+        } else {
+            sfpi::dst_reg[0].mode<>(ckernel::ADDR_MOD_6) = sfpi::as<container_t>(r);
+        }
+    }
+};
+
+/**
+ * @brief Lanes of @c v that receive the written (non-default) result for COMP_MODE, tested against zero.
+ *
+ * Two tests, both reading identically across every format (Quasar loads signed integers as
+ * sign-magnitude and floats as IEEE, both with the sign in bit 31): the magnitude @c setsgn(v,0)
+ * (sign bit cleared, so ±0 -> 0) and the sign via a native @c v<0 / @c v>=0 compare (the bit-31
+ * test). Clearing the sign makes the magnitude-zero test hold for both +0 (0x00000000) and -0
+ * (0x80000000), so -0 counts as zero, matching IEEE (-0.0 == 0); "negative" is @c v<0 &&
+ * magnitude-nonzero, excluding -0.
+ *
+ * gtez/ltez return their strict complement (ltz/gtz) predicate; the loop defaults those lanes' result
+ * to 1 and writes 0 here (see @ref _zero_comp_writes_zero_).
+ *
+ * @note Do NOT use @c abs(vInt) for the magnitude — that is two's-complement abs and leaves
+ *       sign-magnitude -0 (0x80000000) unchanged (nonzero), breaking eqz(-0). @c setsgn(v,0) is the
+ *       correct, format-agnostic primitive.
+ *
+ * @tparam COMP_MODE: Comparison-to-zero mode, values =
+ *         <equal_zero/not_equal_zero/less_than_zero/greater_than_zero/greater_than_equal_zero/less_than_equal_zero>
  */
 template <SfpuType COMP_MODE>
-inline constexpr std::uint32_t _zero_comp_replay_len_() {
-    if constexpr (
-        COMP_MODE == SfpuType::less_than_zero || COMP_MODE == SfpuType::greater_than_zero ||
-        COMP_MODE == SfpuType::greater_than_equal_zero || COMP_MODE == SfpuType::less_than_equal_zero) {
-        return 8;
+inline __attribute__((always_inline)) sfpi::vBool _zero_comp_pred_(sfpi::vInt v) {
+    static_assert(
+        COMP_MODE == SfpuType::equal_zero || COMP_MODE == SfpuType::not_equal_zero ||
+            COMP_MODE == SfpuType::less_than_zero || COMP_MODE == SfpuType::greater_than_zero ||
+            COMP_MODE == SfpuType::less_than_equal_zero || COMP_MODE == SfpuType::greater_than_equal_zero,
+        "_zero_comp_pred_: COMP_MODE must be one of the six comparison-to-zero SfpuType modes "
+        "(equal_zero/not_equal_zero/less_than_zero/greater_than_zero/less_than_equal_zero/greater_than_equal_zero)");
+    const sfpi::vInt mag = sfpi::setsgn(v, 0);  // sign bit cleared -> magnitude (±0 -> 0)
+    if constexpr (COMP_MODE == SfpuType::equal_zero) {
+        return mag == 0;  // ±0
+    } else if constexpr (COMP_MODE == SfpuType::not_equal_zero) {
+        return mag != 0;
+    } else if constexpr (COMP_MODE == SfpuType::less_than_zero) {
+        return (v < 0) && (mag != 0);  // sign set and nonzero -> excludes -0.0
+    } else if constexpr (COMP_MODE == SfpuType::greater_than_zero) {
+        return (v >= 0) && (mag != 0);  // sign clear and nonzero
+    } else if constexpr (COMP_MODE == SfpuType::greater_than_equal_zero) {
+        return (v < 0) && (mag != 0);   // strict-negative (ltz) lanes; loop defaults 1 and writes 0 here -> gtez
+    } else {                            // less_than_equal_zero
+        return (v >= 0) && (mag != 0);  // strict-positive (gtz) lanes; loop defaults 1 and writes 0 here -> ltez
     }
-    return 7;
 }
 
 /**
- * @brief Program ADDR_MOD_6 (dest.incr=2) so the replayed SFPSTORE advances the dest counter.
+ * @brief Whether COMP_MODE's loop defaults the result to 1 and writes 0 on its predicate (vs the
+ * default 0 / write 1).
  *
- * Quasar's shared SFPU init only programs ADDR_MOD_7 (incr=0); this is additive and leaves
- * ADDR_MOD_7 in place for the body's SFPLOAD.
+ * gtez/ltez are the lane-wise complement of ltz/gtz, so @ref _zero_comp_pred_ returns their strict
+ * (ltz/gtz) predicate and the loop inverts the default+write — costing one fewer SFPU op than an
+ * explicit OR-combine. ±0 (magnitude 0) is in neither strict set, so it keeps the default 1 (true)
+ * for both, matching IEEE.
+ */
+template <SfpuType COMP_MODE>
+inline constexpr bool _zero_comp_writes_zero_() {
+    return COMP_MODE == SfpuType::greater_than_equal_zero || COMP_MODE == SfpuType::less_than_equal_zero;
+}
+
+/**
+ * @brief Program the dest-increment addr mod shared by every comparison-to-zero instantiation.
+ *
+ * @c ADDR_MOD_6 (dest.incr=2) lets the body's SFPSTORE advance the dest counter, so
+ * @ref _calculate_zero_comp_ needs no dst_reg++. It is HW state shared across every COMP_MODE/FMT
+ * instantiation, so programming it once here (rather than per @ref _calculate_zero_comp_ call) keeps
+ * it out of the per-tile loop body.
  *
  * @note Call once after @ref _llk_math_eltwise_sfpu_init_ and before @ref _calculate_zero_comp_.
  */
@@ -92,180 +163,46 @@ inline void _init_zero_comp_() {
 }
 
 /**
- * @brief Predicate (SFPSETCC) the lanes of LREG0 satisfying SETCC_MOD1.
- *
- * Reads LREG0 as FP32/SMAG32 (see @ref SFPSETCC_IMM_FP32) — correct for both float and the
- * sign-magnitude integers SFPLOAD produces.
- *
- * @tparam SETCC_MOD1: SFPSETCC mod1 predicate, e.g. sfpi::SFPSETCC_MOD1_LREG_EQ0.
- */
-template <std::uint32_t SETCC_MOD1>
-inline __attribute__((always_inline)) void _zero_comp_setcc_() {
-    TTI_SFPSETCC(SFPSETCC_IMM_FP32, p_sfpu::LREG0, SETCC_MOD1);
-}
-
-/**
- * @brief Load the boolean result (0 or 1) into the result register LREG1 in FMT's encoding.
- *
- * Integer formats use SFPLOADI SHORT (INT16), which sign-extends the immediate into the full LREG
- * (1 -> 0x0000_0001) for a clean result at any store width. SHORT is used rather than USHORT
- * (UINT16) because USHORT left-shifts the immediate by 10 inside the LREG.
- *
- * @tparam FMT: SFPU DataFormat (sfpu_math); integer → integer 0/1, float → fp16b 0.0/1.0.
- * @tparam VALUE: false → 0, true → 1.
- */
-template <DataFormat FMT, bool VALUE>
-inline __attribute__((always_inline)) void _zero_comp_loadi_bool_() {
-    if constexpr (_zero_comp_is_int_<FMT>()) {
-        TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_SHORT, VALUE ? 1 : 0);
-    } else {
-        TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_FLOATB, VALUE ? FP16B_ONE : FP16B_ZERO);
-    }
-}
-
-/**
- * @brief Result value every lane is defaulted to before COMP_MODE's predication runs.
- *
- * eqz/nez/ltz/gtz default to 0 and write 1 into the matching lanes. gtez/ltez invert this: they
- * default to 1 and write 0 into the strictly-signed lanes (the complement of ltz/gtz).
- *
- * @tparam COMP_MODE: Comparison-to-zero mode.
- * @return true (lane default 1) for gtez/ltez, false (lane default 0) otherwise.
- */
-template <SfpuType COMP_MODE>
-inline constexpr bool _zero_comp_default_() {
-    return COMP_MODE == SfpuType::greater_than_equal_zero || COMP_MODE == SfpuType::less_than_equal_zero;
-}
-
-/**
- * @brief Predicate the lanes satisfying COMP_MODE and write the result into them.
- *
- * Successive SFPSETCC calls AND-combine and SFPLOADI writes only the currently predicated lanes;
- * FMT selects the 1/0 encoding (via @ref _zero_comp_loadi_bool_), not the SFPSETCC sequence.
- * eqz/nez use a single test and write 1. The strict ltz/gtz AND a sign test with NE0 (excluding
- * ±0) and write 1. gtez/ltez are the lane-wise complements of ltz/gtz: the body defaults every
- * lane to 1 (see @ref _zero_comp_default_), so they predicate the same strictly-signed lanes and
- * write 0, leaving every other lane at 1. This folds the opposite-signed zero into the true set
- * for free — the NE0 test already excludes ±0 from the strict set, so the complement includes it.
- *
- * @tparam FMT: SFPU DataFormat (sfpu_math).
- * @tparam COMP_MODE: Comparison-to-zero mode, values =
- *         <equal_zero/not_equal_zero/less_than_zero/greater_than_zero/greater_than_equal_zero/less_than_equal_zero>
- */
-template <DataFormat FMT, SfpuType COMP_MODE>
-struct zero_comp_fill;
-
-template <DataFormat FMT>
-struct zero_comp_fill<FMT, SfpuType::equal_zero> {
-    static inline __attribute__((always_inline)) void apply() {
-        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_EQ0>();  // == 0
-        _zero_comp_loadi_bool_<FMT, true>();
-    }
-};
-
-template <DataFormat FMT>
-struct zero_comp_fill<FMT, SfpuType::not_equal_zero> {
-    static inline __attribute__((always_inline)) void apply() {
-        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_NE0>();  // != 0
-        _zero_comp_loadi_bool_<FMT, true>();
-    }
-};
-
-template <DataFormat FMT>
-struct zero_comp_fill<FMT, SfpuType::less_than_zero> {
-    static inline __attribute__((always_inline)) void apply() {
-        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_LT0>();  // negative (sign set, incl -0)
-        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_NE0>();  // AND nonzero -> strictly < 0
-        _zero_comp_loadi_bool_<FMT, true>();
-    }
-};
-
-template <DataFormat FMT>
-struct zero_comp_fill<FMT, SfpuType::greater_than_zero> {
-    static inline __attribute__((always_inline)) void apply() {
-        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_GTE0>();  // positive (sign clear, incl +0)
-        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_NE0>();   // AND nonzero -> strictly > 0
-        _zero_comp_loadi_bool_<FMT, true>();
-    }
-};
-
-template <DataFormat FMT>
-struct zero_comp_fill<FMT, SfpuType::greater_than_equal_zero> {
-    static inline __attribute__((always_inline)) void apply() {
-        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_LT0>();  // negative (sign set, incl -0)
-        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_NE0>();  // AND nonzero -> strictly < 0
-        _zero_comp_loadi_bool_<FMT, false>();               // write 0 there; the >= 0 lanes keep the default 1
-    }
-};
-
-template <DataFormat FMT>
-struct zero_comp_fill<FMT, SfpuType::less_than_equal_zero> {
-    static inline __attribute__((always_inline)) void apply() {
-        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_GTE0>();  // positive (sign clear, incl +0)
-        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_NE0>();   // AND nonzero -> strictly > 0
-        _zero_comp_loadi_bool_<FMT, false>();                // write 0 there; the <= 0 lanes keep the default 1
-    }
-};
-
-/**
- * @brief Compute the comparison-to-zero boolean (1/0) for one SFP-row pair.
- *
- * Load x, default every result lane to COMP_MODE's wide value (0, or 1 for the gtez/ltez
- * complement — see @ref _zero_comp_default_), predicate the lanes that satisfy COMP_MODE and write
- * the opposite value into them (see @ref zero_comp_fill), then store unconditionally. FMT selects
- * the sfpmem mode, the SFPSETCC interpretation, and the 1/0 encoding. The SFPSTORE uses ADDR_MOD_6
- * (dest.incr=2) so each replay advances the dest counter by one SFP-row pair while the load/store
- * offsets stay constant, letting the recorded instructions re-issue unchanged across iterations.
- *
- * @tparam FMT: SFPU DataFormat (sfpu_math): Int32, Int16, Int8, UInt16, UInt8, or a float format.
- * @tparam COMP_MODE: Comparison-to-zero mode, values =
- *         <equal_zero/not_equal_zero/less_than_zero/greater_than_zero/greater_than_equal_zero/less_than_equal_zero>
- */
-template <DataFormat FMT, SfpuType COMP_MODE>
-inline __attribute__((always_inline)) void _zero_comp_body_() {
-    // Integers take their explicit width from the canonical selector (Int32→INT32, Int16→INT16,
-    // UInt16→UINT16). Floats must use DEFAULT: the comp result is written as an fp16b 1.0 bit
-    // pattern, and the explicit fp16 sfpmem modes (FP16A/FP16B) decode that store back as NaN —
-    // only the implied/DEFAULT format round-trips it correctly.
-    constexpr std::uint32_t sfpmem = _zero_comp_is_int_<FMT>() ? _sfpu_sfpmem_type_<FMT>() : p_sfpu::sfpmem::DEFAULT;
-
-    TTI_SFPLOAD(p_sfpu::LREG0, sfpmem, ADDR_MOD_7, 0 /* done */, 0 /* dest_reg */);  // load x from dest
-    _zero_comp_loadi_bool_<FMT, _zero_comp_default_<COMP_MODE>()>();  // result lanes default to COMP_MODE's wide value
-    TTI_SFPENCC(sfpi::SFPENCC_IMM12_BOTH, sfpi::SFPENCC_MOD1_EI_RI);  // enable CC + result=1: all lanes active
-
-    zero_comp_fill<FMT, COMP_MODE>::apply();
-
-    TTI_SFPENCC(sfpi::SFPENCC_IMM12_NEITHER, sfpi::SFPENCC_MOD1_EI_RI);  // disable CC, all lanes unconditional
-    TTI_SFPSTORE(p_sfpu::LREG1, sfpmem, ADDR_MOD_6, 0 /* done */, 0 /* dest_reg */);  // store result; dest += 2 rows
-}
-
-/**
  * @brief Element-wise comparison-to-zero over a tile, written as 1/0 booleans.
  *
- * Records the per-row-pair body once into replay slots 0..len-1 (NoExec: the record pass does
- * not run the SFPU), then replays it ITERATIONS times. ADDR_MOD_6's dest.incr=2 on the SFPSTORE
- * advances the dest counter per replay, so the loop processes one SFP-row pair per iteration.
+ * Defaults each result lane and writes the opposite into the lanes matching COMP_MODE (eqz/nez/ltz/gtz
+ * default 0 and write 1; gtez/ltez default 1 and write 0 — see @ref _zero_comp_writes_zero_), in FMT's
+ * native encoding (see @ref zero_comp_traits). The body's SFPSTORE rides @c ADDR_MOD_6 (dest.incr=2,
+ * programmed in @ref _init_zero_comp_) to advance the dest counter, so the loop needs no dst_reg++.
  *
  * @tparam APPROXIMATION_MODE: Unused (no approx path); retained for dispatcher signature symmetry.
- * @tparam FMT: SFPU DataFormat (sfpu_math): Int32, Int16, Int8, UInt16, UInt8, or a float format.
- * @tparam COMP_MODE: Comparison-to-zero mode, values =
- *         <equal_zero/not_equal_zero/less_than_zero/greater_than_zero/greater_than_equal_zero/less_than_equal_zero>
+ * @tparam FMT: SFPU DataFormat (sfpu_math): Int32/Int16/Int8/UInt16/UInt8, or Float32 for any float
+ *         width — the caller must pass Float32 for Float16/Float16_b too, whose DEFAULT sfpmem mode
+ *         resolves the actual width from the dest format config. Anything else is a compile error.
+ * @tparam COMP_MODE: Comparison-to-zero mode.
  * @tparam ITERATIONS: Number of SFP-row pairs to process (8 for a 32×16 face).
- * @note Requires @ref _init_zero_comp_ to have programmed ADDR_MOD_6 (dest.incr=2).
+ * @note Requires @ref _init_zero_comp_ to have programmed @c ADDR_MOD_6.
  */
 template <bool APPROXIMATION_MODE, DataFormat FMT, SfpuType COMP_MODE, int ITERATIONS = SFPU_ITERATIONS>
 inline void _calculate_zero_comp_() {
-    constexpr std::uint32_t replay_len = _zero_comp_replay_len_<COMP_MODE>();
+    constexpr bool is_int_fmt = FMT == DataFormat::Int32 || FMT == DataFormat::Int16 || FMT == DataFormat::Int8 ||
+                                FMT == DataFormat::UInt16 || FMT == DataFormat::UInt8;
+    constexpr bool is_float_fmt =
+        FMT == DataFormat::Float32 || FMT == DataFormat::Float16 || FMT == DataFormat::Float16_b;
+    static_assert(
+        is_int_fmt || is_float_fmt,
+        "_calculate_zero_comp_: unsupported FMT (expected an integer format or an IEEE float width)");
 
-    // Record the per-row-pair body once into replay slots 0..replay_len-1 (NoExec: the
-    // record pass does not run the SFPU); each replay re-issues it while ADDR_MOD_6
-    // advances the dest counter, so the loop processes one SFP-row pair per iteration.
-    lltt::record(0, replay_len);
-    _zero_comp_body_<FMT, COMP_MODE>();
+    using traits = zero_comp_traits<FMT>;
+
+    // gtez/ltez default to 1 and write 0 on their (strict-sign) predicate; the other modes default
+    // to 0 and write 1 (see @ref _zero_comp_writes_zero_).
+    constexpr bool writes_zero = _zero_comp_writes_zero_<COMP_MODE>();
 
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
-        lltt::replay(0, replay_len);
+        sfpi::vInt bits = traits::load();
+
+        typename traits::result_t result = writes_zero ? traits::one() : traits::zero();
+        v_if(_zero_comp_pred_<COMP_MODE>(bits)) { result = writes_zero ? traits::zero() : traits::one(); }
+        v_endif;
+
+        traits::store(result);
     }
 }
 

--- a/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
+++ b/tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h
@@ -1,0 +1,273 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "ckernel_addrmod.h"
+#include "ckernel_trisc_common.h"
+#include "cmath_common.h"
+#include "llk_defs.h"
+#include "llk_math_eltwise_sfpu_common.h"
+#include "lltt.h"
+#include "sfpi.h"
+
+namespace ckernel {
+namespace sfpu {
+// fp16b bit patterns (upper 16 bits of the corresponding fp32), loaded as
+// SFPLOADI immediates in MOD0_FLOATB mode.
+constexpr std::uint32_t FP16B_ONE = 0x3F80;   // 1.0f
+constexpr std::uint32_t FP16B_ZERO = 0x0000;  // 0.0f
+
+// imm12_math[11]: makes SFPSETCC read the source as FP32/SMAG32 (sign-magnitude) rather than
+// two's-complement INT32. SFPLOAD only ever produces FP32, SMAG32, or UINT32 in the LREG (signed
+// integers load as sign-magnitude SMAG32, never 2's-complement), so this bit is set for every
+// format we handle — both float and integer. The sign tests (SFPSETCC modes 0/4) read the sign
+// bit regardless of this bit; it only governs the zero test, where SMAG32==0 correctly treats
+// sign-magnitude ±0 as zero (2's-complement would miss -0 = 0x80000000).
+constexpr std::uint32_t SFPSETCC_IMM_FP32 = 0x800;
+
+/**
+ * @brief Whether FMT is read/written as an integer (vs float) — drives the 1/0 result encoding.
+ *
+ * Also gates the sfpmem mode: integers take their explicit width from the canonical
+ * @ref _sfpu_sfpmem_type_<FMT>() selector (Int32→INT32, Int16→INT16, Int8→INT8, UInt8→UINT8,
+ * UInt16→UINT16), while floats use sfpmem::DEFAULT (the explicit fp16 modes decode the fp16b
+ * boolean result as NaN).
+ *
+ * @note Int8/UInt8 use their native Quasar dest format (SMAG8 / UINT8) — these are real
+ *       register-file formats, so the 8-bit datapath round-trips natively. UInt16 is the exception:
+ *       it is not a Quasar register-file format at all (absent from the unpacker / SrcA-B / dest /
+ *       packer encodings — see VALID_QUASAR_SRC/DEST_REG_FORMATS; Int8/UInt8 are present, hence
+ *       native). It is therefore routed through the Int16/SMAG16 container — unpack and pack run in
+ *       Int16 (the known-good 16-bit bit-passthrough path) and only the SFPU accesses the
+ *       unsigned-16 semantics via sfpmem::UINT16. The caller must keep the unpack/pack/math formats
+ *       at Int16 and select FMT=UInt16 only to pick that sfpmem mode.
+ *
+ * @tparam FMT: SFPU DataFormat (sfpu_math): Int32 / Int16 / Int8 signed, UInt16 / UInt8 unsigned.
+ */
+template <DataFormat FMT>
+inline constexpr bool _zero_comp_is_int_() {
+    return FMT == DataFormat::Int32 || FMT == DataFormat::Int16 || FMT == DataFormat::Int8 ||
+           FMT == DataFormat::UInt16 || FMT == DataFormat::UInt8;
+}
+
+/**
+ * @brief Number of instructions in the recorded replay body for a comparison mode.
+ *
+ * Format-independent (Int32 and float bodies have identical instruction counts): eqz/nez predicate
+ * with a single SFPSETCC (7). The strict ltz/gtz AND a second SFPSETCC (8). gtez/ltez are the
+ * lane-wise complements of ltz/gtz — they predicate the same strictly-signed lanes but default the
+ * result to 1 and write 0 — so they share the strict body's length (8).
+ *
+ * @tparam COMP_MODE: Comparison-to-zero mode selecting the body to record.
+ * @return Recorded body length in instructions.
+ */
+template <SfpuType COMP_MODE>
+inline constexpr std::uint32_t _zero_comp_replay_len_() {
+    if constexpr (
+        COMP_MODE == SfpuType::less_than_zero || COMP_MODE == SfpuType::greater_than_zero ||
+        COMP_MODE == SfpuType::greater_than_equal_zero || COMP_MODE == SfpuType::less_than_equal_zero) {
+        return 8;
+    }
+    return 7;
+}
+
+/**
+ * @brief Program ADDR_MOD_6 (dest.incr=2) so the replayed SFPSTORE advances the dest counter.
+ *
+ * Quasar's shared SFPU init only programs ADDR_MOD_7 (incr=0); this is additive and leaves
+ * ADDR_MOD_7 in place for the body's SFPLOAD.
+ *
+ * @note Call once after @ref _llk_math_eltwise_sfpu_init_ and before @ref _calculate_zero_comp_.
+ */
+inline void _init_zero_comp_() {
+    addr_mod_t{
+        .srca = {.incr = 0},
+        .srcb = {.incr = 0},
+        .dest = {.incr = 2},
+    }
+        .set(ADDR_MOD_6, csr_read<CSR::TRISC_ID>());
+}
+
+/**
+ * @brief Predicate (SFPSETCC) the lanes of LREG0 satisfying SETCC_MOD1.
+ *
+ * Reads LREG0 as FP32/SMAG32 (see @ref SFPSETCC_IMM_FP32) — correct for both float and the
+ * sign-magnitude integers SFPLOAD produces.
+ *
+ * @tparam SETCC_MOD1: SFPSETCC mod1 predicate, e.g. sfpi::SFPSETCC_MOD1_LREG_EQ0.
+ */
+template <std::uint32_t SETCC_MOD1>
+inline __attribute__((always_inline)) void _zero_comp_setcc_() {
+    TTI_SFPSETCC(SFPSETCC_IMM_FP32, p_sfpu::LREG0, SETCC_MOD1);
+}
+
+/**
+ * @brief Load the boolean result (0 or 1) into the result register LREG1 in FMT's encoding.
+ *
+ * Integer formats use SFPLOADI SHORT (INT16), which sign-extends the immediate into the full LREG
+ * (1 -> 0x0000_0001) for a clean result at any store width. SHORT is used rather than USHORT
+ * (UINT16) because USHORT left-shifts the immediate by 10 inside the LREG.
+ *
+ * @tparam FMT: SFPU DataFormat (sfpu_math); integer → integer 0/1, float → fp16b 0.0/1.0.
+ * @tparam VALUE: false → 0, true → 1.
+ */
+template <DataFormat FMT, bool VALUE>
+inline __attribute__((always_inline)) void _zero_comp_loadi_bool_() {
+    if constexpr (_zero_comp_is_int_<FMT>()) {
+        TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_SHORT, VALUE ? 1 : 0);
+    } else {
+        TTI_SFPLOADI(p_sfpu::LREG1, sfpi::SFPLOADI_MOD0_FLOATB, VALUE ? FP16B_ONE : FP16B_ZERO);
+    }
+}
+
+/**
+ * @brief Result value every lane is defaulted to before COMP_MODE's predication runs.
+ *
+ * eqz/nez/ltz/gtz default to 0 and write 1 into the matching lanes. gtez/ltez invert this: they
+ * default to 1 and write 0 into the strictly-signed lanes (the complement of ltz/gtz).
+ *
+ * @tparam COMP_MODE: Comparison-to-zero mode.
+ * @return true (lane default 1) for gtez/ltez, false (lane default 0) otherwise.
+ */
+template <SfpuType COMP_MODE>
+inline constexpr bool _zero_comp_default_() {
+    return COMP_MODE == SfpuType::greater_than_equal_zero || COMP_MODE == SfpuType::less_than_equal_zero;
+}
+
+/**
+ * @brief Predicate the lanes satisfying COMP_MODE and write the result into them.
+ *
+ * Successive SFPSETCC calls AND-combine and SFPLOADI writes only the currently predicated lanes;
+ * FMT selects the 1/0 encoding (via @ref _zero_comp_loadi_bool_), not the SFPSETCC sequence.
+ * eqz/nez use a single test and write 1. The strict ltz/gtz AND a sign test with NE0 (excluding
+ * ±0) and write 1. gtez/ltez are the lane-wise complements of ltz/gtz: the body defaults every
+ * lane to 1 (see @ref _zero_comp_default_), so they predicate the same strictly-signed lanes and
+ * write 0, leaving every other lane at 1. This folds the opposite-signed zero into the true set
+ * for free — the NE0 test already excludes ±0 from the strict set, so the complement includes it.
+ *
+ * @tparam FMT: SFPU DataFormat (sfpu_math).
+ * @tparam COMP_MODE: Comparison-to-zero mode, values =
+ *         <equal_zero/not_equal_zero/less_than_zero/greater_than_zero/greater_than_equal_zero/less_than_equal_zero>
+ */
+template <DataFormat FMT, SfpuType COMP_MODE>
+struct zero_comp_fill;
+
+template <DataFormat FMT>
+struct zero_comp_fill<FMT, SfpuType::equal_zero> {
+    static inline __attribute__((always_inline)) void apply() {
+        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_EQ0>();  // == 0
+        _zero_comp_loadi_bool_<FMT, true>();
+    }
+};
+
+template <DataFormat FMT>
+struct zero_comp_fill<FMT, SfpuType::not_equal_zero> {
+    static inline __attribute__((always_inline)) void apply() {
+        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_NE0>();  // != 0
+        _zero_comp_loadi_bool_<FMT, true>();
+    }
+};
+
+template <DataFormat FMT>
+struct zero_comp_fill<FMT, SfpuType::less_than_zero> {
+    static inline __attribute__((always_inline)) void apply() {
+        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_LT0>();  // negative (sign set, incl -0)
+        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_NE0>();  // AND nonzero -> strictly < 0
+        _zero_comp_loadi_bool_<FMT, true>();
+    }
+};
+
+template <DataFormat FMT>
+struct zero_comp_fill<FMT, SfpuType::greater_than_zero> {
+    static inline __attribute__((always_inline)) void apply() {
+        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_GTE0>();  // positive (sign clear, incl +0)
+        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_NE0>();   // AND nonzero -> strictly > 0
+        _zero_comp_loadi_bool_<FMT, true>();
+    }
+};
+
+template <DataFormat FMT>
+struct zero_comp_fill<FMT, SfpuType::greater_than_equal_zero> {
+    static inline __attribute__((always_inline)) void apply() {
+        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_LT0>();  // negative (sign set, incl -0)
+        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_NE0>();  // AND nonzero -> strictly < 0
+        _zero_comp_loadi_bool_<FMT, false>();               // write 0 there; the >= 0 lanes keep the default 1
+    }
+};
+
+template <DataFormat FMT>
+struct zero_comp_fill<FMT, SfpuType::less_than_equal_zero> {
+    static inline __attribute__((always_inline)) void apply() {
+        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_GTE0>();  // positive (sign clear, incl +0)
+        _zero_comp_setcc_<sfpi::SFPSETCC_MOD1_LREG_NE0>();   // AND nonzero -> strictly > 0
+        _zero_comp_loadi_bool_<FMT, false>();                // write 0 there; the <= 0 lanes keep the default 1
+    }
+};
+
+/**
+ * @brief Compute the comparison-to-zero boolean (1/0) for one SFP-row pair.
+ *
+ * Load x, default every result lane to COMP_MODE's wide value (0, or 1 for the gtez/ltez
+ * complement — see @ref _zero_comp_default_), predicate the lanes that satisfy COMP_MODE and write
+ * the opposite value into them (see @ref zero_comp_fill), then store unconditionally. FMT selects
+ * the sfpmem mode, the SFPSETCC interpretation, and the 1/0 encoding. The SFPSTORE uses ADDR_MOD_6
+ * (dest.incr=2) so each replay advances the dest counter by one SFP-row pair while the load/store
+ * offsets stay constant, letting the recorded instructions re-issue unchanged across iterations.
+ *
+ * @tparam FMT: SFPU DataFormat (sfpu_math): Int32, Int16, Int8, UInt16, UInt8, or a float format.
+ * @tparam COMP_MODE: Comparison-to-zero mode, values =
+ *         <equal_zero/not_equal_zero/less_than_zero/greater_than_zero/greater_than_equal_zero/less_than_equal_zero>
+ */
+template <DataFormat FMT, SfpuType COMP_MODE>
+inline __attribute__((always_inline)) void _zero_comp_body_() {
+    // Integers take their explicit width from the canonical selector (Int32→INT32, Int16→INT16,
+    // UInt16→UINT16). Floats must use DEFAULT: the comp result is written as an fp16b 1.0 bit
+    // pattern, and the explicit fp16 sfpmem modes (FP16A/FP16B) decode that store back as NaN —
+    // only the implied/DEFAULT format round-trips it correctly.
+    constexpr std::uint32_t sfpmem = _zero_comp_is_int_<FMT>() ? _sfpu_sfpmem_type_<FMT>() : p_sfpu::sfpmem::DEFAULT;
+
+    TTI_SFPLOAD(p_sfpu::LREG0, sfpmem, ADDR_MOD_7, 0 /* done */, 0 /* dest_reg */);  // load x from dest
+    _zero_comp_loadi_bool_<FMT, _zero_comp_default_<COMP_MODE>()>();  // result lanes default to COMP_MODE's wide value
+    TTI_SFPENCC(sfpi::SFPENCC_IMM12_BOTH, sfpi::SFPENCC_MOD1_EI_RI);  // enable CC + result=1: all lanes active
+
+    zero_comp_fill<FMT, COMP_MODE>::apply();
+
+    TTI_SFPENCC(sfpi::SFPENCC_IMM12_NEITHER, sfpi::SFPENCC_MOD1_EI_RI);  // disable CC, all lanes unconditional
+    TTI_SFPSTORE(p_sfpu::LREG1, sfpmem, ADDR_MOD_6, 0 /* done */, 0 /* dest_reg */);  // store result; dest += 2 rows
+}
+
+/**
+ * @brief Element-wise comparison-to-zero over a tile, written as 1/0 booleans.
+ *
+ * Records the per-row-pair body once into replay slots 0..len-1 (NoExec: the record pass does
+ * not run the SFPU), then replays it ITERATIONS times. ADDR_MOD_6's dest.incr=2 on the SFPSTORE
+ * advances the dest counter per replay, so the loop processes one SFP-row pair per iteration.
+ *
+ * @tparam APPROXIMATION_MODE: Unused (no approx path); retained for dispatcher signature symmetry.
+ * @tparam FMT: SFPU DataFormat (sfpu_math): Int32, Int16, Int8, UInt16, UInt8, or a float format.
+ * @tparam COMP_MODE: Comparison-to-zero mode, values =
+ *         <equal_zero/not_equal_zero/less_than_zero/greater_than_zero/greater_than_equal_zero/less_than_equal_zero>
+ * @tparam ITERATIONS: Number of SFP-row pairs to process (8 for a 32×16 face).
+ * @note Requires @ref _init_zero_comp_ to have programmed ADDR_MOD_6 (dest.incr=2).
+ */
+template <bool APPROXIMATION_MODE, DataFormat FMT, SfpuType COMP_MODE, int ITERATIONS = SFPU_ITERATIONS>
+inline void _calculate_zero_comp_() {
+    constexpr std::uint32_t replay_len = _zero_comp_replay_len_<COMP_MODE>();
+
+    // Record the per-row-pair body once into replay slots 0..replay_len-1 (NoExec: the
+    // record pass does not run the SFPU); each replay re-issues it while ADDR_MOD_6
+    // advances the dest counter, so the loop processes one SFP-row pair per iteration.
+    lltt::record(0, replay_len);
+    _zero_comp_body_<FMT, COMP_MODE>();
+
+#pragma GCC unroll 8
+    for (int d = 0; d < ITERATIONS; d++) {
+        lltt::replay(0, replay_len);
+    }
+}
+
+}  // namespace sfpu
+}  // namespace ckernel

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -53,9 +53,9 @@ using namespace ckernel::sfpu;
 /**
  * @brief Whether OPERATION is one of the six comparison-to-zero modes.
  *
- * The comp family needs a dedicated init (@ref _init_zero_comp_) and a runtime
- * format switch (@ref call_zero_comp_operation_quasar), unlike the float-only
- * unary ops, so the dispatchers special-case it.
+ * The comp family needs a runtime format switch (@ref call_zero_comp_operation_quasar)
+ * to pick the integer-vs-float compare path, unlike the float-only unary ops, so the
+ * dispatcher special-cases it.
  *
  * @param op The SFPU operation type to classify.
  */
@@ -92,10 +92,10 @@ void init_unary_sfpu_operation_quasar()
  * @brief Apply a comparison-to-zero SFPU op in-place on one Dest tile.
  *
  * Unlike the float-only unary ops, comp needs the SFPU math format at runtime to
- * pick the sfpmem load/store mode and the 1/0 result encoding (see
- * `ckernel_sfpu_comp.h`). Integer formats select their explicit width; all float
- * widths share the width-agnostic `Float32` instantiation (SFPLOAD/SFPSTORE
- * DEFAULT resolves the actual width from the HW format config).
+ * pick the integer load/store width and the integer-vs-float compare path (see
+ * `ckernel_sfpu_comp.h`). Int32/Int16/Int8/UInt16/UInt8 select their explicit
+ * sfpmem width; all float widths share the width-agnostic `Float32` instantiation,
+ * whose sfpi compare path resolves the actual width from the HW format config.
  *
  * @tparam OPERATION The comparison-to-zero `SfpuType` (compile-time constant).
  * @tparam ITERATIONS Number of SFPU loop iterations.
@@ -103,9 +103,11 @@ void init_unary_sfpu_operation_quasar()
  * @param sfpu_format SFPU math format selecting the sfpmem mode / result encoding.
  * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op.
  */
-template <SfpuType OPERATION, int ITERATIONS = SFPU_ITERATIONS>
+template <SfpuType OPERATION, bool is_fp32_dest_acc_en, int ITERATIONS = SFPU_ITERATIONS>
 void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_format)
 {
+    static_assert(is_zero_comp_op(OPERATION), "call_zero_comp_operation_quasar: OPERATION must be a comparison-to-zero SfpuType");
+
     switch (sfpu_format)
     {
         case DataFormat::Int32:
@@ -115,17 +117,29 @@ void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_fo
             _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::Int16, OPERATION, ITERATIONS>, dst_index);
             break;
         case DataFormat::Int8:
-            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::Int8, OPERATION, ITERATIONS>, dst_index);
+        {
+            constexpr DataFormat sfpu_fmt = is_fp32_dest_acc_en ? DataFormat::Int32 : DataFormat::Int8;
+            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, sfpu_fmt, OPERATION, ITERATIONS>, dst_index);
             break;
+        }
         case DataFormat::UInt16:
             _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::UInt16, OPERATION, ITERATIONS>, dst_index);
             break;
         case DataFormat::UInt8:
-            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::UInt8, OPERATION, ITERATIONS>, dst_index);
+        {
+            constexpr DataFormat sfpu_fmt = is_fp32_dest_acc_en ? DataFormat::Int32 : DataFormat::UInt8;
+            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, sfpu_fmt, OPERATION, ITERATIONS>, dst_index);
+            break;
+        }
+        case DataFormat::Float16:
+        case DataFormat::Float16_b:
+        case DataFormat::Float32:
+            // Float widths share the width-agnostic Float32 path: its sfpmem::DEFAULT access mode
+            // resolves the actual width from ALU_FORMAT_SPEC_REG / ACC_CTRL.
+            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::Float32, OPERATION, ITERATIONS>, dst_index);
             break;
         default:
-            // Float16 / Float16_b / Float32 — width-agnostic float path.
-            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::Float32, OPERATION, ITERATIONS>, dst_index);
+            LLK_ASSERT(false, "Unsupported Quasar comp-to-zero SFPU format");
             break;
     }
 }
@@ -140,7 +154,7 @@ void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_fo
  *        @ref call_zero_comp_operation_quasar), float-only ops ignore it.
  * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op.
  */
-template <SfpuType OPERATION, int ITERATIONS = SFPU_ITERATIONS>
+template <SfpuType OPERATION, bool is_fp32_dest_acc_en, int ITERATIONS = SFPU_ITERATIONS>
 void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_format = DataFormat::Float32)
 {
     if constexpr (OPERATION == SfpuType::abs)
@@ -189,7 +203,7 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_f
     }
     else if constexpr (is_zero_comp_op(OPERATION))
     {
-        call_zero_comp_operation_quasar<OPERATION, ITERATIONS>(dst_index, sfpu_format);
+        call_zero_comp_operation_quasar<OPERATION, is_fp32_dest_acc_en, ITERATIONS>(dst_index, sfpu_format);
     }
     else
     {

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations_quasar.h
@@ -16,6 +16,7 @@
 //    call_unary_sfpu_operation_quasar() (and to init_unary_sfpu_operation_quasar()
 //    if the op needs an init step).
 #include "experimental/ckernel_sfpu_abs.h"
+#include "llk_sfpu/ckernel_sfpu_comp.h"
 #include "llk_sfpu/ckernel_sfpu_square.h"
 #include "sfpu/ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_gelu.h"
@@ -50,6 +51,21 @@ using namespace ckernel::math;
 using namespace ckernel::sfpu;
 
 /**
+ * @brief Whether OPERATION is one of the six comparison-to-zero modes.
+ *
+ * The comp family needs a dedicated init (@ref _init_zero_comp_) and a runtime
+ * format switch (@ref call_zero_comp_operation_quasar), unlike the float-only
+ * unary ops, so the dispatchers special-case it.
+ *
+ * @param op The SFPU operation type to classify.
+ */
+inline constexpr bool is_zero_comp_op(SfpuType op)
+{
+    return op == SfpuType::equal_zero || op == SfpuType::not_equal_zero || op == SfpuType::less_than_zero || op == SfpuType::greater_than_zero ||
+           op == SfpuType::less_than_equal_zero || op == SfpuType::greater_than_equal_zero;
+}
+
+/**
  * @brief Run the per-operation init step for a Quasar unary SFPU op.
  *
  * @tparam OPERATION The SFPU operation type (compile-time `SfpuType` constant).
@@ -66,6 +82,52 @@ void init_unary_sfpu_operation_quasar()
     {
         _init_square_();
     }
+    else if constexpr (is_zero_comp_op(OPERATION))
+    {
+        _init_zero_comp_();
+    }
+}
+
+/**
+ * @brief Apply a comparison-to-zero SFPU op in-place on one Dest tile.
+ *
+ * Unlike the float-only unary ops, comp needs the SFPU math format at runtime to
+ * pick the sfpmem load/store mode and the 1/0 result encoding (see
+ * `ckernel_sfpu_comp.h`). Integer formats select their explicit width; all float
+ * widths share the width-agnostic `Float32` instantiation (SFPLOAD/SFPSTORE
+ * DEFAULT resolves the actual width from the HW format config).
+ *
+ * @tparam OPERATION The comparison-to-zero `SfpuType` (compile-time constant).
+ * @tparam ITERATIONS Number of SFPU loop iterations.
+ * @param dst_index Destination tile index operated on (already offset by DST_INDEX).
+ * @param sfpu_format SFPU math format selecting the sfpmem mode / result encoding.
+ * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op.
+ */
+template <SfpuType OPERATION, int ITERATIONS = SFPU_ITERATIONS>
+void call_zero_comp_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_format)
+{
+    switch (sfpu_format)
+    {
+        case DataFormat::Int32:
+            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::Int32, OPERATION, ITERATIONS>, dst_index);
+            break;
+        case DataFormat::Int16:
+            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::Int16, OPERATION, ITERATIONS>, dst_index);
+            break;
+        case DataFormat::Int8:
+            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::Int8, OPERATION, ITERATIONS>, dst_index);
+            break;
+        case DataFormat::UInt16:
+            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::UInt16, OPERATION, ITERATIONS>, dst_index);
+            break;
+        case DataFormat::UInt8:
+            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::UInt8, OPERATION, ITERATIONS>, dst_index);
+            break;
+        default:
+            // Float16 / Float16_b / Float32 — width-agnostic float path.
+            _llk_math_eltwise_unary_sfpu_params_(_calculate_zero_comp_<false, DataFormat::Float32, OPERATION, ITERATIONS>, dst_index);
+            break;
+    }
 }
 
 /**
@@ -74,10 +136,12 @@ void init_unary_sfpu_operation_quasar()
  * @tparam OPERATION The SFPU operation type (compile-time `SfpuType` constant).
  * @tparam ITERATIONS Number of SFPU loop iterations.
  * @param dst_index Destination tile index operated on (already offset by DST_INDEX).
+ * @param sfpu_format SFPU math format; only the comp family reads it (see
+ *        @ref call_zero_comp_operation_quasar), float-only ops ignore it.
  * @note Must be preceded by @ref init_unary_sfpu_operation_quasar for the same op.
  */
 template <SfpuType OPERATION, int ITERATIONS = SFPU_ITERATIONS>
-void call_unary_sfpu_operation_quasar(std::uint32_t dst_index)
+void call_unary_sfpu_operation_quasar(std::uint32_t dst_index, DataFormat sfpu_format = DataFormat::Float32)
 {
     if constexpr (OPERATION == SfpuType::abs)
     {
@@ -122,6 +186,10 @@ void call_unary_sfpu_operation_quasar(std::uint32_t dst_index)
     else if constexpr (OPERATION == SfpuType::square)
     {
         _llk_math_eltwise_unary_sfpu_params_(_calculate_square_<ITERATIONS>, dst_index);
+    }
+    else if constexpr (is_zero_comp_op(OPERATION))
+    {
+        call_zero_comp_operation_quasar<OPERATION, ITERATIONS>(dst_index, sfpu_format);
     }
     else
     {

--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -2123,6 +2123,12 @@ class UnarySFPUGolden:
     def __init__(self):
         self.ops = {
             MathOperation.Abs: self._abs,
+            MathOperation.EqualZero: self._equal_zero,
+            MathOperation.NotEqualZero: self._not_equal_zero,
+            MathOperation.LessThanZero: self._less_than_zero,
+            MathOperation.GreaterThanZero: self._greater_than_zero,
+            MathOperation.LessThanEqualZero: self._less_than_equal_zero,
+            MathOperation.GreaterThanEqualZero: self._greater_than_equal_zero,
             MathOperation.Atanh: self._atanh,
             MathOperation.Asinh: self._asinh,
             MathOperation.Acosh: self._acosh,
@@ -2347,6 +2353,30 @@ class UnarySFPUGolden:
     # Operation methods
     def _abs(self, x):
         return abs(x)
+
+    # Comparison-to-zero ops. The Quasar kernel builds the strict comparisons from
+    # SFPSETCC sign + magnitude tests (ltz = negative AND nonzero, gtz = positive AND
+    # nonzero), so ±0.0 is excluded from ltz/gtz and the semantics reduce to plain IEEE:
+    #   eqz/nez: magnitude tests (both +0.0 and -0.0 count as zero).
+    #   ltz/gtz: strict (x < 0 / x > 0); ltz(-0.0)=gtz(+0.0)=False.
+    #   lez/gez: x <= 0 / x >= 0, inclusive of ±0.0.
+    def _equal_zero(self, x):
+        return 1.0 if x == 0.0 else 0.0
+
+    def _not_equal_zero(self, x):
+        return 1.0 if x != 0.0 else 0.0
+
+    def _less_than_zero(self, x):
+        return 1.0 if x < 0.0 else 0.0
+
+    def _greater_than_zero(self, x):
+        return 1.0 if x > 0.0 else 0.0
+
+    def _less_than_equal_zero(self, x):
+        return 1.0 if x <= 0.0 else 0.0
+
+    def _greater_than_equal_zero(self, x):
+        return 1.0 if x >= 0.0 else 0.0
 
     def _atanh(self, x):
         return self._torch_unary(x, torch.atanh)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/llk_params.py
@@ -93,6 +93,14 @@ class MathOperation(Enum):
     Silu = OpSpec("silu", MathOpType.SFPU_UNARY)
     Sqrt = OpSpec("sqrt", MathOpType.SFPU_UNARY)
     Square = OpSpec("square", MathOpType.SFPU_UNARY)
+    # Comparison-to-zero unary SFPU ops. cpp_enum_value must exactly match the
+    # SfpuType enumerator name so SFPU_UNARY_OPERATION = SfpuType::{value} resolves.
+    EqualZero = OpSpec("equal_zero", MathOpType.SFPU_UNARY)
+    NotEqualZero = OpSpec("not_equal_zero", MathOpType.SFPU_UNARY)
+    LessThanZero = OpSpec("less_than_zero", MathOpType.SFPU_UNARY)
+    GreaterThanZero = OpSpec("greater_than_zero", MathOpType.SFPU_UNARY)
+    LessThanEqualZero = OpSpec("less_than_equal_zero", MathOpType.SFPU_UNARY)
+    GreaterThanEqualZero = OpSpec("greater_than_equal_zero", MathOpType.SFPU_UNARY)
     # Swiglu is technically a binary SFPU op (gate+up → out), but because
     # Quasar lacks the llk_math_eltwise_binary_sfpu_* dispatcher, its test
     # harness runs through the unary SFPU path. We therefore register it as

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -415,8 +415,7 @@ def is_invalid_quasar_sfpu_format_combination(
     # Sub-32-bit integer input cannot use a 32-bit dest: the packer input format must stay at the
     # narrow width (UInt16 collapses to Int16). Mirrors the data_format_inference guard.
     if (
-        in_fmt
-        in (DataFormat.Int16, DataFormat.UInt16, DataFormat.Int8, DataFormat.UInt8)
+        in_fmt in (DataFormat.Int16, DataFormat.UInt16)
         and dest_acc == DestAccumulation.Yes
     ):
         return True

--- a/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/param_config.py
@@ -412,6 +412,15 @@ def is_invalid_quasar_sfpu_format_combination(
     ):
         return True
 
+    # Sub-32-bit integer input cannot use a 32-bit dest: the packer input format must stay at the
+    # narrow width (UInt16 collapses to Int16). Mirrors the data_format_inference guard.
+    if (
+        in_fmt
+        in (DataFormat.Int16, DataFormat.UInt16, DataFormat.Int8, DataFormat.UInt8)
+        and dest_acc == DestAccumulation.Yes
+    ):
+        return True
+
     return False
 
 

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py
@@ -7,7 +7,7 @@ from typing import List
 
 import pytest
 import torch
-from helpers.format_config import DataFormat, FormatConfig
+from helpers.format_config import DataFormat, InputOutputFormat
 from helpers.golden_generators import UnarySFPUGolden, get_golden_generator
 from helpers.llk_params import (
     DataCopyType,
@@ -55,6 +55,32 @@ SFPU_UNARY_FORMATS = input_output_formats(
         DataFormat.Float32,
         DataFormat.Float16_b,
     ]
+)
+
+# The six comparison-to-zero modes. These run integer formats too (and UInt16 via
+# the Int16 container), so the sweep adds them to the float formats above.
+COMP_OPS = [
+    MathOperation.EqualZero,
+    MathOperation.NotEqualZero,
+    MathOperation.LessThanZero,
+    MathOperation.GreaterThanZero,
+    MathOperation.LessThanEqualZero,
+    MathOperation.GreaterThanEqualZero,
+]
+
+# Extra (integer) formats only the comp family sweeps. Int32/Int16/Int8 (signed) and UInt8
+# (unsigned) use their native Quasar dest format. UInt16 is the exception: it has no native Quasar
+# dest format, so the inference routes its data path through Int16 and sets FormatConfig.sfpu_math=
+# UInt16, the only stage the comp kernel reads as uint16.
+SFPU_COMP_EXTRA_FORMATS = input_output_formats(
+    [
+        DataFormat.Int32,
+        DataFormat.Int16,
+        DataFormat.Int8,
+        DataFormat.UInt16,
+        DataFormat.UInt8,
+    ],
+    same=True,
 )
 
 
@@ -321,7 +347,96 @@ def prepare_unary_inputs(
         return prepare_abs_inputs(src_A, src_B, input_format, output_format)
     if mathop == MathOperation.Square:
         return prepare_square_inputs(src_A, src_B, input_format, output_format)
+    if mathop in COMP_OPS:
+        # Unsigned formats need non-negative stimuli (a signed split would wrap under the unsigned
+        # dtype); signed formats use the sign-vs-magnitude builder.
+        if input_format in (DataFormat.UInt16, DataFormat.UInt8):
+            return prepare_comp_inputs_uint(src_A, src_B, input_format)
+        return prepare_comp_inputs(src_A, src_B, input_format, output_format)
     return prepare_inputs_for_operation(src_A, mathop, input_format, output_format)
+
+
+def prepare_comp_inputs(
+    src_A: torch.Tensor,
+    src_B: torch.Tensor,
+    input_format: DataFormat,
+    output_format: DataFormat,
+) -> torch.Tensor:
+    """
+    Prepare input tensor for comparison-to-zero operations.
+
+    Mixes positive, negative, exact +0.0/-0.0, and small-magnitude values so the
+    sign-vs-magnitude split (ltz/gtz are sign tests; eqz/nez are magnitude tests)
+    is exercised. Avoids NaN/subnormal stimuli, which SFPSETCC does not special-case
+    and on which Quasar and an IEEE golden could disagree.
+    """
+    input_torch_format = format_dict[input_format]
+
+    # Integer formats (Int32 / Int16, both signed): comparison-to-zero only depends on sign and
+    # zero-ness, not magnitude. The default integer stimuli are non-negative, so split src_B about
+    # its median to sign roughly half the lanes negative (spread across every face), then seed a few
+    # exact zeros/extremes to exercise all six modes.
+    if not input_torch_format.is_floating_point:
+        big = torch.iinfo(input_torch_format).max // 8
+        src_B_float = src_B.to(torch.float32)
+        signs = torch.where(src_B_float < src_B_float.median(), -1, 1)
+        values = (src_A.to(torch.int64) % big) * signs
+
+        flat = values.flatten()
+        for i, seed in enumerate([0, 1, -1, big, -big, 2]):
+            if i < flat.numel():
+                flat[i] = seed
+        return flat.reshape(values.shape).to(input_torch_format)
+
+    src_A_float = src_A.to(torch.float32)
+    src_B_float = src_B.to(torch.float32)
+
+    # Magnitudes in a comfortably-representable range, signed by src_B. src_B is non-negative under
+    # the default spec, so split it about its median to sign roughly half the lanes negative.
+    magnitudes = torch.clamp(torch.abs(src_A_float) * 0.5 + 0.5, 0.1, 100.0)
+    signs = torch.where(src_B_float < src_B_float.median(), -1.0, 1.0)
+    values = signs * magnitudes
+
+    flat = values.flatten()
+    # Seed exact zeros of both signs and a few small-magnitude values to pin
+    # down the sign-vs-magnitude behaviour at the origin.
+    if flat.numel() >= 8:
+        flat[0] = 0.0  # +0.0
+        flat[1] = -0.0  # -0.0
+        flat[2] = 1.0
+        flat[3] = -1.0
+        flat[4] = 0.5
+        flat[5] = -0.5
+        flat[6] = 2.0
+        flat[7] = -2.0
+    values = flat.reshape(values.shape)
+
+    return values.to(input_torch_format)
+
+
+def prepare_comp_inputs_uint(
+    src_A: torch.Tensor, src_B: torch.Tensor, input_format: DataFormat
+) -> torch.Tensor:
+    """
+    Non-negative stimuli for an unsigned comp path (UInt8 / UInt16).
+
+    UInt16 rides the Int16/SMAG16 container, so its values are kept in [0, 32767] where the bit
+    pattern is identical read as signed or unsigned. UInt8 uses its native UINT8 dest, so it spans
+    the full [0, 255] range (bit 7 set is exercised). Seeds exact zero and a couple of extremes so
+    every comparison mode is hit; the signed and unsigned goldens coincide on non-negative inputs.
+    """
+    # Signed-safe magnitude ceiling: half-range for UInt16 (Int16 container), full range for UInt8.
+    hi = 32767 if input_format == DataFormat.UInt16 else 255
+    values = (src_A.to(torch.int64).abs() % (hi + 1)) | (
+        src_B.to(torch.int64).abs() % 256
+    )  # mix in low bits from B for variety, stays non-negative
+    values = values % (hi + 1)
+
+    flat = values.flatten()
+    for i, seed in enumerate([0, 1, 2, hi, 100, 0]):
+        if i < flat.numel():
+            flat[i] = seed
+    return flat.reshape(values.shape).to(format_dict[input_format])
 
 
 # ---------------------------------------------------------------------------
@@ -351,24 +466,33 @@ OP_CONFIGS = [
     OpConfig(MathOperation.Tanh, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Sigmoid, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
     OpConfig(MathOperation.Silu, TENSOR_DIMS, DEST_SYNC_MODES, uniform_spec=True),
-]
+] + [OpConfig(op, TENSOR_DIMS, DEST_SYNC_MODES) for op in COMP_OPS]
 
 OP_CONFIG_BY_MATHOP = {cfg.mathop: cfg for cfg in OP_CONFIGS}
 
 
-def generate_sfpu_unary_combinations(formats_list: List[FormatConfig]):
+def formats_for_op(cfg: OpConfig) -> List[InputOutputFormat]:
+    """Float formats for every op, plus the integer/UInt16 formats only comp sweeps."""
+    if cfg.mathop in COMP_OPS:
+        return SFPU_UNARY_FORMATS + SFPU_COMP_EXTRA_FORMATS
+    return SFPU_UNARY_FORMATS
+
+
+def generate_sfpu_unary_combinations():
     """
-    Build the full unary-SFPU sweep across all ops: a uniform
-    formats × dest_acc × {Half, Full} dest-sync × {No, Yes} implied-math ×
-    {[32, 32], [64, 64]} matrix per op. (Consolidation dropped the redundant
-    [32, 64] dim and the per-op dest-sync quirks of the standalone tests.)
+    Build the full unary-SFPU sweep across all ops: per op, a
+    formats × dest_acc × dest-sync × implied-math × {[32, 32], [64, 64]} matrix.
+
+    Every op runs the same matrix over its own format set (from formats_for_op).
+    32-bit inputs always pair with dest_acc=Yes; 16-bit inputs sweep both dest_acc
+    modes. Invalid format/dest_acc combinations are dropped via the shared filter.
 
     Returns: list of (mathop, fmt, dest_acc, dest_sync, implied_math_format,
     input_dimensions) tuples.
     """
     combinations = []
     for cfg in OP_CONFIGS:
-        for fmt in formats_list:
+        for fmt in formats_for_op(cfg):
             in_fmt = fmt.input_format
 
             dest_acc_modes = (
@@ -403,9 +527,7 @@ def generate_sfpu_unary_combinations(formats_list: List[FormatConfig]):
 
 @pytest.mark.quasar
 @parametrize(
-    mathop_formats_dest_acc_sync_implied_math_input_dims=generate_sfpu_unary_combinations(
-        SFPU_UNARY_FORMATS
-    ),
+    mathop_formats_dest_acc_sync_implied_math_input_dims=generate_sfpu_unary_combinations(),
 )
 def test_eltwise_unary_sfpu_quasar(
     mathop_formats_dest_acc_sync_implied_math_input_dims,
@@ -413,7 +535,8 @@ def test_eltwise_unary_sfpu_quasar(
     """
     Consolidated unary-SFPU test on Quasar. One compile-time-selected op per
     variant (abs, exp, gelu, relu, reciprocal, sqrt, tanh, sigmoid, silu, rsqrt,
-    square), validated against the UnarySFPUGolden reference.
+    square, and the six compare-to-zero modes), validated against the
+    UnarySFPUGolden reference.
     """
     mathop, formats, dest_acc, dest_sync, implied_math_format, input_dimensions = (
         mathop_formats_dest_acc_sync_implied_math_input_dims[0]
@@ -437,15 +560,25 @@ def test_eltwise_unary_sfpu_quasar(
 
     num_faces = MAX_NUM_FACES
 
-    generate_golden = get_golden_generator(UnarySFPUGolden)
-    golden_tensor = generate_golden(
-        mathop,
-        src_A,
-        formats.output_format,
-        dest_acc,
-        formats.input_format,
-        input_dimensions,
-    )
+    if format_dict[formats.input_format].is_floating_point:
+        generate_golden = get_golden_generator(UnarySFPUGolden)
+        golden_tensor = generate_golden(
+            mathop,
+            src_A,
+            formats.output_format,
+            dest_acc,
+            formats.input_format,
+            input_dimensions,
+        )
+    else:
+        # Integer-input ops (Int32/Int16/UInt16 — currently only the comp family): apply the
+        # UnarySFPUGolden op element-wise instead of through its __call__. __call__ runs a
+        # float-only pipeline (float dst, tilize, FTZ) that would mangle integer values; applying
+        # the op per element keeps integers intact, and for an element-wise op row-major order
+        # already matches the packed result. A non-element-wise integer op would need its own path.
+        ops = UnarySFPUGolden().ops
+        op_res = [ops[mathop](x) for x in src_A.flatten().tolist()]
+        golden_tensor = torch.tensor(op_res, dtype=format_dict[formats.output_format])
 
     unpack_to_dest = (
         formats.input_format.is_32_bit() and dest_acc == DestAccumulation.Yes

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
@@ -107,7 +107,7 @@ SFPU_FILL_FLOAT_FORMATS = [
 # Fill int path: _calculate_fill_int_ with p_sfpu::sfpmem::INT32/UINT16/INT8/UINT8.
 # Quasar integer formats and their SFPMEM store modes:
 #   Int32 → sfpmem::INT32  (32-bit sign-magnitude)
-#   Int16 → sfpmem::UINT16 (16-bit truncate)
+#   Int16 → sfpmem::INT16 (16-bit truncate)
 #   Int8  → sfpmem::INT8   (0b0101, sign-magnitude 8-bit)
 #   UInt8 → sfpmem::UINT8  (0b1011, true unsigned 8-bit; validated on the emulator — see
 #           ckernel_sfpu_fill.h)

--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
@@ -104,12 +104,13 @@ SFPU_FILL_FLOAT_FORMATS = [
     for out_fmt in _FILL_FLOAT_OUTPUTS
 ]
 
-# Fill int path: _calculate_fill_int_ with p_sfpu::sfpmem::INT32/UINT16/INT8.
+# Fill int path: _calculate_fill_int_ with p_sfpu::sfpmem::INT32/UINT16/INT8/UINT8.
 # Quasar integer formats and their SFPMEM store modes:
-#   Int32        → sfpmem::INT32  (32-bit sign-magnitude)
-#   Int16        → sfpmem::UINT16 (16-bit truncate)
-#   Int8 / UInt8 → sfpmem::INT8   (0b0101, sign-magnitude 8-bit; true UINT8 0b1011 is unvalidated
-#                  on the emulator — see ckernel_sfpu_fill.h)
+#   Int32 → sfpmem::INT32  (32-bit sign-magnitude)
+#   Int16 → sfpmem::UINT16 (16-bit truncate)
+#   Int8  → sfpmem::INT8   (0b0101, sign-magnitude 8-bit)
+#   UInt8 → sfpmem::UINT8  (0b1011, true unsigned 8-bit; validated on the emulator — see
+#           ckernel_sfpu_fill.h)
 # FILL_INT_FORMAT bakes the format into each compiled variant.
 SFPU_FILL_INT_FORMATS = input_output_formats(
     [DataFormat.Int32, DataFormat.Int16, DataFormat.Int8, DataFormat.UInt8],

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -149,7 +149,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // so it is offset by params.DST_INDEX.
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        test_utils::call_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION>(params.DST_INDEX + i, sfpu_format);
+        test_utils::call_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION, is_fp32_dest_acc_en>(params.DST_INDEX + i, sfpu_format);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp
@@ -142,12 +142,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_eltwise_sfpu_init_();
     test_utils::init_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION>();
 
+    const DataFormat sfpu_format = static_cast<DataFormat>(formats.sfpu_math);
+
     // Apply the selected SFPU op in-place on Dest for each tile. Tile index must
     // match the one used by the producer (datacopy above, or UNPACK-to-Dest),
     // so it is offset by params.DST_INDEX.
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {
-        test_utils::call_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION>(params.DST_INDEX + i);
+        test_utils::call_unary_sfpu_operation_quasar<SFPU_UNARY_OPERATION>(params.DST_INDEX + i, sfpu_format);
     }
 
     _llk_math_set_dvalid_<p_cleardvalid::SFPU, dest_sync>();

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_fill.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_fill.h
@@ -8,6 +8,7 @@
 #include "ckernel_ops.h"
 #include "ckernel_trisc_common.h"
 #include "cmath_common.h"
+#include "llk_math_eltwise_sfpu_common.h" // _sfpu_sfpmem_type_<FMT>()
 #include "sfpi_constants.h"
 
 namespace ckernel
@@ -40,12 +41,8 @@ inline void _calculate_fill_(const float value)
 }
 
 // Broadcast an integer constant to all elements of Dest using an explicit SFPMEM store mode.
-// FMT → sfpmem mode:
-//   Int32        → sfpmem::INT32  (32-bit sign-magnitude)
-//   Int16        → sfpmem::UINT16 (16-bit truncate)
-//   Int8 / UInt8 → sfpmem::INT8   (0b0101, sign-magnitude 8-bit). The ISA-correct unsigned-8 mode
-//                  is sfpmem::UINT8 (0b1011), but it is unproven on the emulator (cf. the UINT16
-//                  datapath bug), so the established INT8/0b0101 path is kept for both.
+// The DataFormat → sfpmem mode is chosen by the canonical _sfpu_sfpmem_type_<FMT>() selector
+// (Int32→INT32, Int16→INT16, Int8→INT8, UInt8→UINT8).
 // Note: Always use SFPLOADI_MOD0_LOWER to place the value at LReg bits [15:0].
 // SFPLOADI_MOD0_USHORT (mode 2) shifts the value 10 bits left inside the LReg,
 // causing for example SFPMEM::UINT16 reading [15:0] to produce value<<10 instead of value.
@@ -56,9 +53,7 @@ inline void _calculate_fill_int_(const std::uint32_t value)
         FMT == DataFormat::Int32 || FMT == DataFormat::Int16 || FMT == DataFormat::Int8 || FMT == DataFormat::UInt8,
         "_calculate_fill_int_ only supports Int32, Int16, Int8, and UInt8 formats");
 
-    constexpr std::uint32_t SFPMEM_MODE = (FMT == DataFormat::Int32)   ? p_sfpu::sfpmem::INT32
-                                          : (FMT == DataFormat::Int16) ? p_sfpu::sfpmem::UINT16
-                                                                       : p_sfpu::sfpmem::INT8;
+    constexpr std::uint32_t SFPMEM_MODE = _sfpu_sfpmem_type_<FMT>();
 
     if constexpr (FMT == DataFormat::Int32)
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_defs.h
@@ -110,6 +110,12 @@ enum class SfpuType : std::uint32_t
     le_int,
     ge_int,
     mul_int,
+    equal_zero,
+    not_equal_zero,
+    less_than_zero,
+    greater_than_zero,
+    less_than_equal_zero,
+    greater_than_equal_zero,
 };
 
 enum class DstSync : std::uint8_t

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_sfpu_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_sfpu_common.h
@@ -170,8 +170,12 @@ inline constexpr std::uint32_t _sfpu_stochround_conversion_()
 /**
  * @brief Compile-time sfpmem type selector from a DataFormat.
  *
+ * Formats with no dedicated SFPU load/store mode (fp8, the MX block formats, 4-bit ints) map to
+ * sfpmem::DEFAULT — the implied/default format the producing engine left in the register-file
+ * format config (ISA: HW derives it from ALU_FORMAT_SPEC_REG / ACC_CTRL).
+ *
  * @tparam FMT: Data format to map
- * @return sfpmem type parameter for FMT.
+ * @return sfpmem type parameter for FMT, or sfpmem::DEFAULT for formats with no dedicated mode.
  * @note Runtime equivalent: @ref _sfpu_sfpmem_type_. Keep both in sync when adding a format.
  */
 template <DataFormat FMT>
@@ -193,12 +197,17 @@ inline constexpr std::uint32_t _sfpu_sfpmem_type_()
     {
         return ckernel::p_sfpu::sfpmem::INT32;
     }
+    else if constexpr (FMT == DataFormat::Int16)
+    {
+        return ckernel::p_sfpu::sfpmem::INT16;
+    }
+    else if constexpr (FMT == DataFormat::Int8)
+    {
+        return ckernel::p_sfpu::sfpmem::INT8;
+    }
     else if constexpr (FMT == DataFormat::UInt8)
     {
-        // INT8 (0b0101) preserves the previously-validated behavior. The ISA-correct unsigned-8
-        // mode is sfpmem::UINT8 (0b1011), but it is unproven on the emulator (cf. the UINT16
-        // datapath bug) — switch once validated.
-        return ckernel::p_sfpu::sfpmem::INT8;
+        return ckernel::p_sfpu::sfpmem::UINT8;
     }
     else if constexpr (FMT == DataFormat::UInt16)
     {
@@ -206,9 +215,9 @@ inline constexpr std::uint32_t _sfpu_sfpmem_type_()
     }
     else
     {
-        static_assert(
-            !std::is_same_v<decltype(FMT), DataFormat>,
-            "Unsupported DataFormat for sfpmem type determination"); // need the condition to depend on the template parameter... compiler things
+        // No dedicated SFPU mode (fp8, MX block formats, 4-bit ints): fall back to the implied/
+        // default register-file format. Matches the runtime overload's default case.
+        return ckernel::p_sfpu::sfpmem::DEFAULT;
     }
 }
 
@@ -235,9 +244,12 @@ inline std::uint32_t _sfpu_sfpmem_type_(DataFormat fmt)
             return ckernel::p_sfpu::sfpmem::FP32;
         case DataFormat::Int32:
             return ckernel::p_sfpu::sfpmem::INT32;
+        case DataFormat::Int16:
+            return ckernel::p_sfpu::sfpmem::INT16;
+        case DataFormat::Int8:
+            return ckernel::p_sfpu::sfpmem::INT8;
         case DataFormat::UInt8:
-            return ckernel::p_sfpu::sfpmem::INT8; // see template overload: INT8 (0b0101) preserves
-                                                  // behavior; true UINT8 (0b1011) unvalidated on emulator
+            return ckernel::p_sfpu::sfpmem::UINT8;
         case DataFormat::UInt16:
             return ckernel::p_sfpu::sfpmem::UINT16;
         default:


### PR DESCRIPTION
Adds the compare-to-zero (comp) unary-SFPU family for Quasar — `eqz`, `nez`, `gtz`, `gez`, `ltz`, `lez` — across float and integer formats, validated through the consolidated unary-SFPU test. Reference: `tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_comp.h`.

### What changed
- **`tt_metal/hw/ckernels/quasar/metal/llk_api/llk_sfpu/ckernel_sfpu_comp.h`** (new) — the comp kernel, in the metal LLK-API tree.
- **`tt_llk_quasar/llk_lib/llk_defs.h`** — 6 `SfpuType` enumerators (eqz, nez, gtz, gez, ltz, lez).
- **`tests/python_tests/helpers/golden_generators.py`** — 6 comparison goldens (plain IEEE) + dispatch.
- **`tests/python_tests/helpers/llk_params.py`** — 6 `MathOperation` entries.
- **`tests/helpers/include/sfpu_operations_quasar.h`** — comp wired into the shared unary-SFPU dispatcher (init + a format-aware calculate branch).
- **`tests/sources/quasar/eltwise_unary_sfpu_quasar_test.cpp`** — forwards the SFPU math format to the dispatcher so comp picks its sfpmem mode / result encoding.
- **`tests/python_tests/quasar/test_eltwise_unary_sfpu_quasar.py`** — comp folded into the consolidated unary-SFPU sweep.
- **`tests/python_tests/helpers/param_config.py`** — invalid-combo guard: 16-bit integer input (Int16/UInt16) can't use a 32-bit dest (`dest_acc=Yes`).

### Test consolidation
Comp has no standalone test files — it runs through the consolidated unary-SFPU test:
- The six comp ops, the integer/UInt16 formats (added per-op via `formats_for_op`), and an integer stimuli + element-wise golden path are folded into `test_eltwise_unary_sfpu_quasar.py`.
- Comp runs the **same** `formats × dest_acc × dest-sync × implied-math × dims` matrix as every other unary op, differing only in its format set; float comp therefore also exercises the FPU-datacopy path and the full dest_acc / implied-math axes.
- The comp dispatch lives in the shared `sfpu_operations_quasar.h` (an `_init_zero_comp_` init branch and a `call_zero_comp_operation_quasar` calculate branch that switches on the math format to select the integer vs width-agnostic float instantiation); the consolidated kernel forwards the SFPU math format to it.
- The 16-bit-int / 32-bit-dest restriction is enforced once in the shared `is_invalid_quasar_sfpu_format_combination` filter, mirroring `data_format_inference` (the packer has no `INT16 → INT32` conversion).

### Situations tested
Functional tests on the Quasar simulator pass (compile + run): 768 comp variants pass, and the non-comp unary coverage in the consolidated test is unchanged. Float goldens follow plain IEEE; integer goldens reuse the same element-wise comparison methods (comp-to-zero depends only on sign and zero-ness, so no sign-magnitude conversion is needed).

| Dimension | Coverage |
|-----------|----------|
| Ops (6) | EqualZero, NotEqualZero, GreaterThanZero, GreaterThanEqualZero, LessThanZero, LessThanEqualZero |
| Float formats | Float16, Float32, Float16_b |
| Integer formats | Int32, Int16, UInt16 (same-format in/out; UInt16 routed through the Int16 container), Int8, Uint8 |
| Tile dims | [32, 32] and [64, 64] |
| Dest-sync | SyncHalf and SyncFull |
| Implied-math | No and Yes |
| DestAccumulation | Yes and No for floats; Int32 → Yes only, Int16/UInt16 → No only (16-bit int can't use a 32-bit dest) |

> The Quasar `sfpmem` enum ISA-match + UINT8 fix that this branch also touches is reviewed separately in #46884
> - [x] Merged
> - [x] Waiting to merge  #47056
---
*Draft — auto-generated kernel; pending human review.*

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=njokovic/llk-comp-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:njokovic/llk-comp-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=njokovic/llk-comp-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:njokovic/llk-comp-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=njokovic/llk-comp-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:njokovic/llk-comp-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njokovic/llk-comp-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:njokovic/llk-comp-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=njokovic/llk-comp-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:njokovic/llk-comp-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njokovic/llk-comp-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njokovic/llk-comp-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=njokovic/llk-comp-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:njokovic/llk-comp-sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=njokovic/llk-comp-sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:njokovic/llk-comp-sfpu)
