### PR TITLE
Cleanup: move transpose int-FPU selection into LLK init

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -4,12 +4,18 @@
 
 #pragma once
 
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_unary_datacopy.h"
 
 /*************************************************************************
  * LLK ELTWISE UNARY DATACOPY
  *************************************************************************/
+
+inline constexpr bool is_int_fpu_data_format(const std::uint32_t data_format) {
+    return (masked_data_format(data_format) == to_underlying(DataFormat::Int8)) ||
+           (data_format == to_underlying(DataFormat::Int32));
+}
 
 template <
     DataCopyType type,
@@ -33,7 +39,7 @@ inline void llk_math_eltwise_unary_datacopy_block(
     std::uint32_t start_dst_index, std::uint32_t ntiles, std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
-    for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
+    for (std::uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
         LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
         _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
@@ -59,8 +65,19 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
     // tilize workaround. 8bit datums in input format do not require the tilize workaround on blackhole.
     const std::uint32_t src_format = get_operand_src_format(operand_id);
     const bool is_input_8bit_format = IS_8BIT_FORMAT(src_format);
-    _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en, pack_mode>(
-        num_faces, dst_format, is_input_8bit_format);
+    if constexpr (type == DataCopyType::A2D && src_b_bcast_type == BroadcastType::NONE && is_fp32_dest_acc_en) {
+        const bool needs_int_fpu = is_int_fpu_en || is_int_fpu_data_format(src_format);
+        if (needs_int_fpu) {
+            _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, true, pack_mode>(
+                num_faces, dst_format, is_input_8bit_format);
+        } else {
+            _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, false, pack_mode>(
+                num_faces, dst_format, is_input_8bit_format);
+        }
+    } else {
+        _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en, pack_mode>(
+            num_faces, dst_format, is_input_8bit_format);
+    }
 }
 
 template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_math_unary_datacopy_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "llk_math_common_api.h"
 #include "llk_math_eltwise_unary_datacopy.h"
 #include "llk_math_fast_tilize.h"
@@ -11,6 +12,11 @@
 /*************************************************************************
  * LLK ELTWISE UNARY DATACOPY
  *************************************************************************/
+
+inline constexpr bool is_int_fpu_data_format(const std::uint32_t data_format) {
+    return (masked_data_format(data_format) == to_underlying(DataFormat::Int8)) ||
+           (data_format == to_underlying(DataFormat::Int32));
+}
 
 template <
     DataCopyType type,
@@ -34,7 +40,7 @@ inline void llk_math_eltwise_unary_datacopy_block(
     std::uint32_t start_dst_index, std::uint32_t ntiles, std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
 
-    for (uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
+    for (std::uint32_t dst_index = start_dst_index; dst_index < start_dst_index + ntiles; dst_index++) {
         LLK_ASSERT((dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()), "");
 
         _llk_math_eltwise_unary_datacopy_<type, DST_SYNC_MODE, is_fp32_dest_acc_en, src_b_bcast_type, unpack_to_dest>(
@@ -57,8 +63,20 @@ inline void llk_math_eltwise_unary_datacopy_init(const std::uint32_t operand) {
     const std::uint32_t operand_id = get_operand_id(operand);
     const std::uint32_t num_faces = get_operand_num_faces(operand_id);
     const std::uint32_t dst_format = get_operand_dst_format(operand_id);
-    _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en>(
-        num_faces, dst_format);
+    if constexpr (type == DataCopyType::A2D && src_b_bcast_type == BroadcastType::NONE && is_fp32_dest_acc_en) {
+        const std::uint32_t src_format = get_operand_src_format(operand_id);
+        const bool needs_int_fpu = is_int_fpu_en || is_int_fpu_data_format(src_format);
+        if (needs_int_fpu) {
+            _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, true>(
+                num_faces, dst_format);
+        } else {
+            _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, false>(
+                num_faces, dst_format);
+        }
+    } else {
+        _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en>(
+            num_faces, dst_format);
+    }
 }
 
 template <BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>

--- a/tt_metal/hw/inc/api/compute/transpose.h
+++ b/tt_metal/hw/inc/api/compute/transpose.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "api/compute/common.h"
 #include "api/compute/sentinel/compute_kernel_sentinel.h"
 #include "sanitizer/api.h"
@@ -34,18 +35,13 @@ namespace ckernel {
  * | icb      | The identifier of the circular buffer (CB) containing input | uint32_t | 0 to 31     | True     |
  */
 // clang-format on
-ALWI void transpose_init(uint32_t icb, uint32_t call_line = __builtin_LINE()) {
+ALWI void transpose_init(std::uint32_t icb, std::uint32_t call_line = __builtin_LINE()) {
     LLK_SAN_FUNCTION();
     state_configure(icb, call_line);
 #if defined(TRISC_MATH) || defined(TRISC_UNPACK)
-    const std::uint32_t src_format = get_operand_src_format(icb);
     const std::uint32_t dst_format = get_operand_dst_format(icb);
 
 #ifndef ARCH_QUASAR
-    // Low-nibble compare intentionally matches both signed Int8 (14) and unsigned UInt8
-    // (30 -> low nibble 0xE): both 8-bit integer formats need the int-FPU (ELWADD) A2D
-    // reconstruct path.
-    const bool is_8bit_int = (src_format & 0xf) == (std::uint32_t)DataFormat::Int8;
     const bool enable_unpack_to_dest = (dst_format == (std::uint32_t)DataFormat::Float32) ||
                                        (dst_format == (std::uint32_t)DataFormat::UInt32) ||
                                        (dst_format == (std::uint32_t)DataFormat::Int32);
@@ -54,17 +50,6 @@ ALWI void transpose_init(uint32_t icb, uint32_t call_line = __builtin_LINE()) {
             true, false, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
         MATH((llk_math_transpose_dest_init<false, true>()));
-    } else if (is_8bit_int) {
-        // 8-bit integer (Int8/UInt8) transpose needs the int-FPU (ELWADD) A2D reconstruct path,
-        // selected here via is_int_fpu_en. Ideally the LLK layer would infer this path from the
-        // data format instead of selecting it here in the Compute API layer.
-        // TODO: #46832.
-        UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
-        MATH((llk_math_eltwise_unary_datacopy_init<
-              DataCopyType::A2D,
-              DST_ACCUM_MODE,
-              BroadcastType::NONE,
-              true /*is_int_fpu_en*/>(icb)));
     } else {
         UNPACK((llk_unpack_A_init<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE>(true, true, icb)));
         MATH((llk_math_eltwise_unary_datacopy_init<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE>(icb)));
@@ -102,7 +87,7 @@ ALWI void transpose_init(uint32_t icb, uint32_t call_line = __builtin_LINE()) {
  * | dst_tile_index | The index of the tile in DST REG for the result B       | uint32_t | Must be less than the acquired size of DST REG | True     |
  */
 // clang-format on
-ALWI void transpose_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
+ALWI void transpose_tile(std::uint32_t icb, std::uint32_t itile, std::uint32_t idst) {
     LLK_SAN_FUNCTION();
 #if defined(TRISC_MATH) || defined(TRISC_UNPACK)
     const std::uint32_t dst_format = get_operand_dst_format(icb);
@@ -115,7 +100,8 @@ ALWI void transpose_tile(uint32_t icb, uint32_t itile, uint32_t idst) {
         UNPACK(
             (llk_unpack_A<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, UnpackToDestEn>(icb, itile)));
         UNPACK((llk_unpack_set_srcb_dummy_valid()));
-        MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(idst, icb)));
+        MATH((llk_math_eltwise_unary_datacopy<DataCopyType::A2D, DST_ACCUM_MODE, BroadcastType::NONE, UnpackToDestEn>(
+            idst, icb)));
         MATH((llk_math_transpose_dest<false, true>(idst)));
     } else {
         UNPACK((llk_unpack_A<BroadcastType::NONE, false>(icb, itile)));

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_math_wrappers.h
@@ -24,6 +24,11 @@ inline constexpr PackMode llk_test_pack_mode_v = untilize ? PackMode::Untilize
                                                  : tilize ? PackMode::Tilize
                                                           : PackMode::Default;
 
+inline constexpr bool llk_test_is_int_fpu_data_format(const std::uint32_t data_format)
+{
+    return (masked_data_format(data_format) == to_underlying(DataFormat::Int8)) || (data_format == to_underlying(DataFormat::Int32));
+}
+
 #ifdef ARCH_WORMHOLE
 
 template <
@@ -39,6 +44,39 @@ inline void _llk_math_eltwise_unary_datacopy_init_wrapper_(
         pack_mode == PackMode::Default || pack_mode == PackMode::Untilize || pack_mode == PackMode::Tilize,
         "Wormhole B0 LLK tests: math datacopy init wrapper accepts PackMode::Default, PackMode::Untilize, or PackMode::Tilize (tilize is ignored on WH)");
     _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en>(num_faces, dst_format);
+}
+
+template <
+    DataCopyType type,
+    bool is_fp32_dest_acc_en,
+    BroadcastType src_b_bcast_type      = BroadcastType::NONE,
+    bool is_int_fpu_en                  = false,
+    [[maybe_unused]] PackMode pack_mode = PackMode::Default>
+inline void _llk_math_eltwise_unary_datacopy_init_inferred_wrapper_(
+    const std::uint32_t num_faces                         = 4,
+    const std::uint32_t src_format                        = 255,
+    const std::uint32_t dst_format                        = 255,
+    [[maybe_unused]] const bool skip_bh_tilize_workaround = false)
+{
+    static_assert(
+        pack_mode == PackMode::Default || pack_mode == PackMode::Untilize || pack_mode == PackMode::Tilize,
+        "Wormhole B0 LLK tests: math datacopy init wrapper accepts PackMode::Default, PackMode::Untilize, or PackMode::Tilize (tilize is ignored on WH)");
+    if constexpr (type == DataCopyType::A2D && src_b_bcast_type == BroadcastType::NONE && is_fp32_dest_acc_en)
+    {
+        const bool needs_int_fpu = is_int_fpu_en || llk_test_is_int_fpu_data_format(src_format);
+        if (needs_int_fpu)
+        {
+            _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, true>(num_faces, dst_format);
+        }
+        else
+        {
+            _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, false>(num_faces, dst_format);
+        }
+    }
+    else
+    {
+        _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en>(num_faces, dst_format);
+    }
 }
 
 template <DataCopyType type, DstSync Dst, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>
@@ -85,6 +123,39 @@ inline void _llk_math_eltwise_unary_datacopy_init_wrapper_(
         "Blackhole LLK tests: math datacopy init wrapper supports PackMode::Default or PackMode::Tilize");
     _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en, pack_mode>(
         num_faces, dst_format, skip_bh_tilize_workaround);
+}
+
+template <
+    DataCopyType type,
+    bool is_fp32_dest_acc_en,
+    BroadcastType src_b_bcast_type = BroadcastType::NONE,
+    bool is_int_fpu_en             = false,
+    PackMode pack_mode             = PackMode::Default>
+inline void _llk_math_eltwise_unary_datacopy_init_inferred_wrapper_(
+    const std::uint32_t num_faces = 4, const std::uint32_t src_format = 255, const std::uint32_t dst_format = 255, const bool skip_bh_tilize_workaround = false)
+{
+    static_assert(
+        pack_mode == PackMode::Default || pack_mode == PackMode::Tilize,
+        "Blackhole LLK tests: math datacopy init wrapper supports PackMode::Default or PackMode::Tilize");
+    if constexpr (type == DataCopyType::A2D && src_b_bcast_type == BroadcastType::NONE && is_fp32_dest_acc_en)
+    {
+        const bool needs_int_fpu = is_int_fpu_en || llk_test_is_int_fpu_data_format(src_format);
+        if (needs_int_fpu)
+        {
+            _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, true, pack_mode>(
+                num_faces, dst_format, skip_bh_tilize_workaround);
+        }
+        else
+        {
+            _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, false, pack_mode>(
+                num_faces, dst_format, skip_bh_tilize_workaround);
+        }
+    }
+    else
+    {
+        _llk_math_eltwise_unary_datacopy_init_<type, is_fp32_dest_acc_en, src_b_bcast_type, is_int_fpu_en, pack_mode>(
+            num_faces, dst_format, skip_bh_tilize_workaround);
+    }
 }
 
 template <DataCopyType type, DstSync Dst, bool is_fp32_dest_acc_en, BroadcastType src_b_bcast_type = BroadcastType::NONE, bool unpack_to_dest = false>

--- a/tt_metal/tt-llk/tests/sources/transpose_wh_int8_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_wh_int8_test.cpp
@@ -3,9 +3,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Faithful reproduction of the compute-API transpose_tile i8 path
-// (tt_metal/hw/inc/api/compute/transpose.h, the dedicated `else if (is_8bit_int)`
-// branch in transpose_init):
+// Faithful reproduction of the compute-API transpose_tile i8 path:
 // the full 32x32 transpose is performed in the UNPACKER (transpose_of_faces +
 // within_face_16x16_transpose / haloize), and the math thread only does the
 // A2D datacopy that reconstructs the Int8 register datum into DEST. There is no
@@ -60,27 +58,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 
-    // Int8/UInt8 both unpack into the Int8 register format and need the integer FPU datapath
-    // (is_int_fpu_en => ELWADD move) to reconstruct the integer value in DEST under FP32 dest mode.
-    const bool is_int8 = (masked_data_format(formats.math) == to_underlying(DataFormat::Int8));
-    if (is_int8)
-    {
-        _llk_math_eltwise_unary_datacopy_init_wrapper_<
-            DataCopyType::A2D,
-            is_fp32_dest_acc_en,
-            BroadcastType::NONE,
-            true /* is_int_fpu_en */,
-            PackMode::Default>(params.num_faces, formats.math);
-    }
-    else
-    {
-        _llk_math_eltwise_unary_datacopy_init_wrapper_<
-            DataCopyType::A2D,
-            is_fp32_dest_acc_en,
-            BroadcastType::NONE,
-            false /* is_int_fpu_en */,
-            PackMode::Default>(params.num_faces, formats.math);
-    }
+    // Mirror the LLK datacopy init inference boundary without hard-forcing
+    // is_int_fpu_en=true in the test source.
+    _llk_math_eltwise_unary_datacopy_init_inferred_wrapper_<
+        DataCopyType::A2D,
+        is_fp32_dest_acc_en,
+        BroadcastType::NONE,
+        false /* is_int_fpu_en */,
+        PackMode::Default>(params.num_faces, formats.unpack_A_src, formats.math);
 
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);


### PR DESCRIPTION
PR Category
Cleanup

Summary

The current transpose API still carried a local Int8 / UInt8 special case so the compute layer could force is_int_fpu_en for the A2D datacopy init path.

This moves that format decision into the Wormhole and Blackhole LLK datacopy init wrappers instead. For A2D, no-broadcast, FP32-dest datacopy init, the wrapper now enables the int-FPU path when the source format matches the existing math configure rule: masked Int8-register formats or Int32. The transpose compute path can call the normal datacopy init again, including after the recent transpose.h API rename.

The LLK test wrapper now has an inferred init entrypoint so transpose_wh_int8_test.cpp exercises the inference path instead of hard-forcing is_int_fpu_en in the test source.

Notes for reviewers

- Failure mechanism: transpose needed the ELWADD A2D reconstruct path for Int8 / UInt8 under FP32 dest mode, but that choice was still owned by the compute API boundary.
- Semantic change: infer the int-FPU datacopy init path from the source format at the LLK datacopy init boundary for the A2D, no-broadcast, FP32-dest case.
- Preserved invariant: explicit is_int_fpu_en callers still force the int-FPU path, and non-A2D or broadcast datacopy init paths continue to use the template parameter directly.

Validation

- git diff --check
- CHIP_ARCH=wormhole python -m pytest python_tests/test_transpose_dest.py -k test_transpose_dest_int8 --compile-producer -q
  - result: 2 passed, 26 deselected
- CHIP_ARCH=blackhole python -m pytest python_tests/test_transpose_dest.py -k test_transpose_dest_int8 --compile-producer -q
  - result: 2 passed, 26 deselected
