### PR TITLE
[Feature] ring_mla: single-slot KV-cache gather for indexed chunked prefill

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_reader.cpp
@@ -111,6 +111,9 @@ void kernel_main() {
     std::array<uint32_t, num_inputs> input_batch_head_count;
     std::array<uint32_t, num_inputs> input_tile_id_start;
     std::array<uint32_t, num_inputs> input_tile_id_end;
+    // Phase-1 input page base: nonzero only for single-slot gather (skip to the sliced input slot).
+    // The slice is always emitted into output slot 0, whatever the output batch size.
+    std::array<uint32_t, num_inputs> input_batch_base;
 
     for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
         input_tensor_Wt[input_idx] = get_arg_val<uint32_t>(arg_idx++);
@@ -120,6 +123,7 @@ void kernel_main() {
         input_batch_head_count[input_idx] = get_arg_val<uint32_t>(arg_idx++);
         input_tile_id_start[input_idx] = get_arg_val<uint32_t>(arg_idx++);
         input_tile_id_end[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        input_batch_base[input_idx] = get_arg_val<uint32_t>(arg_idx++);
     }
 
     auto inputs_tuple = make_tensor_accessor_tuple(inputs_args, arg_idx);
@@ -141,9 +145,11 @@ void kernel_main() {
     CircularBuffer cb_output(cb_output_id);
 
     // Push out our local slice
+    // For a single-slot gather this starts at the sliced batch slot; otherwise 0 (full batch).
     uint32_t output_tile_id_start = 0;
     // Read local slice to our buffers, before sending them over
     for (uint32_t input_idx = 0; input_idx < num_inputs; input_idx++) {
+        output_tile_id_start = input_batch_base[input_idx];
         uint32_t tiles_read = input_tile_id_start[input_idx];
         uint32_t tiles_to_read = input_tile_id_end[input_idx];
         for (uint32_t bh_idx = 0; bh_idx < input_batch_head_count[input_idx]; bh_idx++) {

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/kernels/ring_attention_all_gather_writer.cpp
@@ -70,6 +70,9 @@ void kernel_main() {
         input_batch_head_count[input_idx] = get_arg_val<uint32_t>(arg_idx++);
         input_tile_id_start[input_idx] = get_arg_val<uint32_t>(arg_idx++);
         input_tile_id_end[input_idx] = get_arg_val<uint32_t>(arg_idx++);
+        // input_batch_base: reader-only (phase-1 input offset). The writer always targets output
+        // slot 0, so it reads the arg here only for alignment.
+        (void)get_arg_val<uint32_t>(arg_idx++);
     }
 
     auto outputs_tuple = make_tensor_accessor_tuple(outputs_args, arg_idx);

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.cpp
@@ -102,7 +102,8 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
     std::optional<ttnn::experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
     const CoreCoord core_grid_offset,
-    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy) {
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy,
+    std::optional<uint32_t> input_batch_slice_idx) {
     using tt::tt_metal::CBDescriptor;
     using tt::tt_metal::CBFormatDescriptor;
     using tt::tt_metal::KernelDescriptor;
@@ -418,9 +419,11 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
             const auto input_tensor_num_pages = input_tensor[i].buffer()->num_pages();
             const auto input_tensor_shape = input_tensor[i].padded_shape();
             const auto output_tensor_shape = output_tensor[i].padded_shape();
-            const uint32_t batch_head_size = input_tensor_shape[0] * input_tensor_shape[1];
+            const uint32_t num_heads = input_tensor_shape[1];
+            // single_batch_head_num_pages is always pages-per-(batch,head); independent of slicing.
+            const uint32_t full_batch_head_size = input_tensor_shape[0] * num_heads;
 
-            uint32_t single_batch_head_num_pages = input_tensor_num_pages / batch_head_size;
+            uint32_t single_batch_head_num_pages = input_tensor_num_pages / full_batch_head_size;
             const uint32_t base_pages_per_worker = single_batch_head_num_pages / num_links;
             const uint32_t remainder = single_batch_head_num_pages % num_links;
             const uint32_t input_tile_id_start = (link * base_pages_per_worker) + std::min(link, remainder);
@@ -433,13 +436,30 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
             TT_ASSERT(!(input_tensor_shape[3] % tt::constants::TILE_WIDTH));
             TT_ASSERT(!(output_tensor_shape[3] % tt::constants::TILE_WIDTH));
 
+            // Single-slot gather: read only slot `input_batch_slice_idx`'s `num_heads` blocks (from
+            // `input_batch_base`); the writer emits them to output slot 0. A batch-1 output suffices,
+            // but a full-batch output also works (only slot 0 written). std::nullopt => full batch.
+            uint32_t batch_head_size = full_batch_head_size;
+            uint32_t input_batch_base = 0;
+            if (input_batch_slice_idx.has_value()) {
+                TT_FATAL(
+                    *input_batch_slice_idx < input_tensor_shape[0],
+                    "input_batch_slice_idx={} out of range for input batch={}",
+                    *input_batch_slice_idx,
+                    input_tensor_shape[0]);
+                batch_head_size = num_heads;
+                input_batch_base = ring_attention_all_gather_async_detail::input_batch_base_pages(
+                    *input_batch_slice_idx, num_heads, input_tensor_Ht, input_tensor_Wt);
+            }
+
             tensor_descriptor_args.push_back(input_tensor_Wt);      // 0 == input_tensor_Wt
             tensor_descriptor_args.push_back(input_tensor_Ht);      // 1 == input_tensor_Ht
             tensor_descriptor_args.push_back(output_tensor_Wt);     // 2 == output_tensor_Wt
             tensor_descriptor_args.push_back(output_tensor_Ht);     // 3 == output_tensor_Ht
-            tensor_descriptor_args.push_back(batch_head_size);      // 4 == batch_head_size
+            tensor_descriptor_args.push_back(batch_head_size);      // 4 == batch_head_size (bh-loop count)
             tensor_descriptor_args.push_back(input_tile_id_start);  // 5 == input_tile_id_start
             tensor_descriptor_args.push_back(input_tile_id_end);    // 6 == input_tile_id_end
+            tensor_descriptor_args.push_back(input_batch_base);     // 7 == input_batch_base (phase-1 input page offset)
         }
 
         KernelDescriptor::RTArgList reader_forward_rt_args;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/ring_attention_all_gather_async/device/ring_attention_all_gather_async_multi_core_with_workers_program_factory.hpp
@@ -8,6 +8,7 @@
 #include "ttnn/device_operation.hpp"
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include <cstdint>
 #include <optional>
 #include <vector>
 
@@ -29,6 +30,21 @@ struct RingAttentionAllGatherAsyncMultiCoreWithWorkersProgramFactory {
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn {
+
+namespace ring_attention_all_gather_async_detail {
+
+// All-gather reader runtime-arg layout: [0]=dim, [1]=ring_size, [2]=out_ready_sem,
+// followed by one tensor-descriptor block per gathered input.
+constexpr uint32_t kReaderRuntimeArgHeaderCount = 3;
+constexpr uint32_t kTensorDescriptorFieldCount = 8;
+constexpr uint32_t kInputBatchBaseFieldOffset = 7;
+
+inline uint32_t input_batch_base_pages(
+    uint32_t batch_idx, uint32_t num_heads, uint32_t tensor_height_tiles, uint32_t tensor_width_tiles) {
+    return batch_idx * num_heads * tensor_height_tiles * tensor_width_tiles;
+}
+
+}  // namespace ring_attention_all_gather_async_detail
 
 // Append all kernels, CBs, semaphores, and runtime args required by the
 // ring-attention all-gather worker pipeline to `desc`.
@@ -54,6 +70,10 @@ void ring_attention_all_gather_async_multi_core_with_workers_helper(
     const std::optional<tt::tt_metal::SubDeviceId>& sub_device_id,
     std::optional<ttnn::experimental::ccl::AllGatherFusedOpSignaler>& fused_op_signaler,
     CoreCoord core_grid_offset = CoreCoord(0, 0),
-    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR);
+    ttnn::ccl::CoreAllocationStrategy core_allocation_strategy = ttnn::ccl::CoreAllocationStrategy::ROW_MAJOR,
+    // When set, gather only this batch slot (dim-0 index) of `input_tensor` into slot 0 of
+    // `output_tensor` — lets a consumer keep a full KV cache as input with a batch-1 gathered buffer
+    // (a full-batch output also works; only slot 0 is written). std::nullopt => full batch (default).
+    std::optional<uint32_t> input_batch_slice_idx = std::nullopt);
 
 }  // namespace ttnn

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_reader.cpp
@@ -371,9 +371,11 @@ void kernel_main() {
     const auto gathered_k_reader = TensorAccessor(gathered_k_args, gathered_k_addr);
 
     const uint32_t kv_batch_dim = indexed_kv_cache ? kv_cache_batch_idx + 1 : B;
+    // The fused all-gather wrote the active slot to gathered slot 0, so address it as batch-1.
+    const uint32_t gathered_kv_batch_dim = indexed_kv_cache ? 1 : B;
     const auto input_q_tile_logical = TensorTileShape(B, NH, q_local_padded_Nt, DHt);
     const auto input_k_tile_logical = TensorTileShape(kv_batch_dim, NHK, kv_local_padded_Nt, DHt);
-    const auto gathered_k_input_tile_logical = TensorTileShape(kv_batch_dim, NHK, padded_Nt, DHt);
+    const auto gathered_k_input_tile_logical = TensorTileShape(gathered_kv_batch_dim, NHK, padded_Nt, DHt);
     const auto joint_input_tile_logical = TensorTileShape(B, NH, Lt, DHt);
 
     const auto q_generator = PaddedAddrGenerator(q_reader, input_q_tile_logical);
@@ -382,7 +384,7 @@ void kernel_main() {
     const auto local_v_reader = TensorAccessor(v_args, v_addr);
     const auto input_v_tile_logical = TensorTileShape(kv_batch_dim, NHV, kv_local_padded_Nt, vDHt);
     const auto gathered_v_reader = TensorAccessor(gathered_v_args, gathered_v_addr);
-    const auto gathered_v_input_tile_logical = TensorTileShape(kv_batch_dim, NHV, padded_Nt, vDHt);
+    const auto gathered_v_input_tile_logical = TensorTileShape(gathered_kv_batch_dim, NHV, padded_Nt, vDHt);
     const auto local_v_generator = PaddedAddrGenerator(local_v_reader, input_v_tile_logical);
     const auto gathered_v_generator = PaddedAddrGenerator(gathered_v_reader, gathered_v_input_tile_logical);
     [[maybe_unused]] const auto v_generators =
@@ -524,14 +526,17 @@ void kernel_main() {
                 Slice k_slice;
                 uint32_t end_seq_tile;
                 const uint32_t nk = nq / q_heads_per_k;
+                // Local KV reads the indexed cache slot; gathered KV is at slot 0 of the scratch buffer.
                 const uint32_t kv_batch = indexed_kv_cache ? kv_cache_batch_idx : nb;
+                const uint32_t gathered_kv_batch = indexed_kv_cache ? 0 : nb;
                 if (ring_iter == 0) {
                     const uint32_t local_k_start_tile = k_chunk * Sk_chunk_t;
                     k_slice = Slice(kv_batch, nk, local_k_start_tile, local_k_start_tile + Sk_chunk_t, 0, DHt);
                     end_seq_tile = ring_iter_valid_kv_tiles;
                 } else {
                     const uint32_t gathered_start_tile = ring_id * kv_local_padded_Nt + k_chunk * Sk_chunk_t;
-                    k_slice = Slice(kv_batch, nk, gathered_start_tile, gathered_start_tile + Sk_chunk_t, 0, DHt);
+                    k_slice =
+                        Slice(gathered_kv_batch, nk, gathered_start_tile, gathered_start_tile + Sk_chunk_t, 0, DHt);
                     end_seq_tile = ring_id * kv_local_padded_Nt + ring_iter_valid_kv_tiles;
                 }
                 if constexpr (has_joint_k) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_device_operation.cpp
@@ -29,7 +29,9 @@ namespace {
 
 void validate_ring_joint_all_gather_on_program_cache_miss(
     const ttnn::experimental::prim::RingAttentionAllGatherAsyncParams& operation_attributes,
-    const ttnn::experimental::prim::RingAttentionAllGatherAsyncInputs& tensor_args) {
+    const ttnn::experimental::prim::RingAttentionAllGatherAsyncInputs& tensor_args,
+    // Single-slot gather writes one cache slot to gathered slot 0, so allow a batch-1 output.
+    bool allow_single_slot_output) {
     const auto& input_tensors = tensor_args.input_tensor;
     TT_FATAL(
         !input_tensors.empty(), "Error, Input tensor size should be greater than 0 but has {}", input_tensors.size());
@@ -106,6 +108,14 @@ void validate_ring_joint_all_gather_on_program_cache_miss(
                         output_shape[d],
                         expected_output_shape[d],
                         operation_attributes.ring_size);
+                } else if (allow_single_slot_output && d == 0) {
+                    // Single-slot gather targets gathered slot 0: batch-1 expected, full-batch also ok.
+                    TT_FATAL(
+                        output_shape[d] == 1 || output_shape[d] == expected_output_shape[d],
+                        "Output tensor {} batch dim must be 1 (single-slot gather) or {}: got {}",
+                        i,
+                        expected_output_shape[d],
+                        output_shape[d]);
                 } else {
                     TT_FATAL(
                         output_shape[d] == expected_output_shape[d],
@@ -209,7 +219,7 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
     }
 
     validate_ring_joint_all_gather_on_program_cache_miss(
-        args.all_gather_operation_attributes, args.all_gather_tensor_args);
+        args.all_gather_operation_attributes, args.all_gather_tensor_args, args.has_indexed_kv_cache());
 
     // Check that SDPA coregrid does not overlap with AllGather coregrid
     TT_FATAL(args.program_config.has_value(), "Program config must be provided");
@@ -389,16 +399,18 @@ void RingJointSDPADeviceOperation::validate_on_program_cache_miss(
             "mode requires Q batch size 1. Got Q batch size {}",
             B);
         // kv_cache_batch_idx bounds are value checks → validate_runtime_patched_scalars (runs on hits too).
+        // Single-slot gather writes cache slot kv_cache_batch_idx to gathered slot 0: a batch-1 buffer
+        // is the efficient shape; a full-batch buffer is also accepted (only slot 0 is used).
         TT_FATAL(
-            k_shape[0] == K_cache_batch,
-            "Gathered K cache batch must match input K cache batch. Got gathered K: {}, input K: {}",
-            k_shape[0],
-            K_cache_batch);
+            k_shape[0] == 1 || k_shape[0] == K_cache_batch,
+            "Gathered K batch must be 1 (single-slot gather) or match input K cache batch {}. Got gathered K: {}",
+            K_cache_batch,
+            k_shape[0]);
         TT_FATAL(
-            v_shape[0] == V_cache_batch,
-            "Gathered V cache batch must match input V cache batch. Got gathered V: {}, input V: {}",
-            v_shape[0],
-            V_cache_batch);
+            v_shape[0] == 1 || v_shape[0] == V_cache_batch,
+            "Gathered V batch must be 1 (single-slot gather) or match input V cache batch {}. Got gathered V: {}",
+            V_cache_batch,
+            v_shape[0]);
     } else {
         TT_FATAL(k_shape[0] == B, "K batch size must match Q. Got Q: {}, K: {}", B, k_shape[0]);
         TT_FATAL(v_shape[0] == B, "V batch size must match Q. Got Q: {}, V: {}", B, v_shape[0]);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -8,6 +8,7 @@
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
 
 #include <algorithm>
+#include <array>
 #include <bit>
 #include <cstddef>
 #include <cstdint>
@@ -31,6 +32,8 @@
 using namespace tt::tt_metal;
 
 namespace {
+
+namespace ag_rt = ttnn::ring_attention_all_gather_async_detail;
 
 // Host-side summary of which ring-loop iterations do useful SDPA work. Bits are indexed by ring_iter,
 // not ring_id; kernels still advance their sync/ring-id sequence on every iter before checking the mask.
@@ -111,6 +114,11 @@ struct RingWritePlan {
 constexpr uint32_t kReaderKernelIndex = 0;
 constexpr uint32_t kWriterKernelIndex = 1;
 constexpr uint32_t kComputeKernelIndex = 2;
+
+// The helper appends 4 kernels after the 3 SDPA kernels above, in order: reader_forward (3),
+// writer_forward (4), reader_backward (5), writer_backward (6) (helper desc.kernels.push_back order).
+constexpr uint32_t kAllGatherReaderForwardKernelIndex = 3;
+constexpr uint32_t kAllGatherReaderBackwardKernelIndex = 5;
 
 // Compute runtime args 0/1 are global_q_start/global_q_end (see ring_joint_sdpa.cpp kernel_main).
 // A core with global_q_start == global_q_end got no Q chunks at emplace time and is idle.
@@ -456,6 +464,40 @@ void apply_ring_joint_scalar_runtime_args(
     const RingJointRuntimeArgLayout layout = get_runtime_arg_layout(args, tensor_args);
     const uint32_t num_cores = layout.grid_size.x * layout.grid_size.y;
     const uint32_t kv_cache_batch_idx = args.kv_cache_batch_idx.value_or(0);
+
+    // Re-patch the fused all-gather readers to gather the single cache slot `kv_cache_batch_idx`.
+    // input_batch_base is uniform across all gather cores/links, so patch every core that runs the
+    // reader. Mirrors the helper's create-time arithmetic so miss and hit paths agree.
+    if (patch_indexed_kv_cache) {
+        const Tensor& input_k = tensor_args.input_k;
+        const bool v_shares_k = tensor_args.has_latent_v();
+        const uint32_t num_ag_inputs = v_shares_k ? 1u : (tensor_args.input_v.has_value() ? 2u : 1u);
+        const std::array<const Tensor*, 2> ag_inputs = {
+            &input_k, tensor_args.input_v.has_value() ? &tensor_args.input_v.value() : &input_k};
+        const auto patch_all_gather_reader = [&](uint32_t kernel_id) {
+            auto& grid_args = GetRuntimeArgs(program, kernel_id);  // [x][y] per-core args
+            for (auto& col_args : grid_args) {
+                for (auto& core_args : col_args) {
+                    for (uint32_t in = 0; in < num_ag_inputs; ++in) {
+                        const auto& shape = ag_inputs[in]->padded_shape();
+                        const uint32_t num_heads = shape[1];
+                        const uint32_t Ht = shape[2] / tt::constants::TILE_WIDTH;
+                        const uint32_t Wt = shape[3] / tt::constants::TILE_WIDTH;
+                        const uint32_t input_batch_base =
+                            ag_rt::input_batch_base_pages(kv_cache_batch_idx, num_heads, Ht, Wt);
+                        const uint32_t idx = ag_rt::kReaderRuntimeArgHeaderCount +
+                                             in * ag_rt::kTensorDescriptorFieldCount +
+                                             ag_rt::kInputBatchBaseFieldOffset;
+                        if (core_args.size() > idx) {  // skip cores that don't run this kernel
+                            write_runtime_arg(core_args, idx, input_batch_base, "all_gather_reader.input_batch_base");
+                        }
+                    }
+                }
+            }
+        };
+        patch_all_gather_reader(kAllGatherReaderForwardKernelIndex);
+        patch_all_gather_reader(kAllGatherReaderBackwardKernelIndex);
+    }
 
     for (uint32_t i = 0; i < num_cores; ++i) {
         const CoreCoord core = {i % layout.grid_size.x, i / layout.grid_size.x};
@@ -2112,10 +2154,10 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         all_gather_input_tensors.push_back(input_tensor_v);
         all_gather_output_tensors.push_back(gathered_input_tensor_v);
     }
-    // Append the all-gather portion to `desc`. The helper assigns sequential
-    // semaphore IDs starting at `desc.semaphores.size()` (current count) and
-    // returns kernel indices into `desc.kernels`. Runtime args are auto-patched
-    // by the descriptor framework on cache hits, so no override path is needed.
+    // Append the all-gather portion to `desc`. Buffer addresses are auto-patched on cache hits; the
+    // indexed-mode input_batch_base scalar is re-patched in apply_ring_joint_scalar_runtime_args.
+    // The trailing kv_cache_batch_idx makes the gather collect only that cache slot (std::nullopt =>
+    // full batch).
     ring_attention_all_gather_async_multi_core_with_workers_helper(
         desc,
         all_gather_input_tensors,
@@ -2132,7 +2174,8 @@ tt::tt_metal::ProgramDescriptor RingJointSDPAProgramFactory::create_descriptor(
         args.all_gather_operation_attributes.sub_device_id,
         all_gather_fused_op_signaler,
         args.ccl_core_grid_offset,
-        args.all_gather_operation_attributes.core_allocation_strategy);
+        args.all_gather_operation_attributes.core_allocation_strategy,
+        args.kv_cache_batch_idx);
 
     return desc;
 }


### PR DESCRIPTION
### PR Category
Feature

### Summary
In indexed mode the fused all-gather in `ring_joint_sdpa` previously replicated the whole KV cache batch into the gathered scratch buffer. This adds a single-slot path: gather only the active cache slot (`kv_cache_batch_idx`) into slot 0 of the gathered buffer, so a chunked-prefill consumer can keep a full KV cache as input while the gathered scratch buffer is only one slot wide.

- **all_gather helper/kernels** — optional `input_batch_slice_idx` makes the reader read input slot `kv_cache_batch_idx` and the writer emit it to output slot 0. The gathered buffer may be batch-1 (memory-efficient) or full-batch (only slot 0 is written; the writer carries no batch offset, so both work). Shared reader arg-layout constants / `input_batch_base_pages()` live in the helper header.
- **ring_joint_sdpa_program_factory** — re-patches the all-gather readers' `input_batch_base` on every dispatch (program is shared across batch indices); passes `kv_cache_batch_idx` into the helper.
- **ring_joint_sdpa_device_operation** — accepts a batch-1 or full-batch gathered buffer in single-slot mode.
- **ring_joint_reader** — addresses the gathered scratch buffer at slot 0.

### Notes for reviewers
- The key correctness point: the writer always targets output slot 0 regardless of output batch, so dropping the old `output_tensor_shape[0] == 1` constraint is safe and lets the ND-sharded indexed path (full `cache_batch` gathered buffer) keep working.
- Verified on a 4×p150b Blackhole box: `tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py` passes (`CI=true`: 22 passed, 48 skipped — perf/multi-mesh gated; the 4 indexed/`kv_actual_isl` accuracy+determinism tests included).
- Blackhole e2e `sdpa` workflow dispatched on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/ring_mla_indexed_kv_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/ring_mla_indexed_kv_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/ring_mla_indexed_kv_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/ring_mla_indexed_kv_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/ring_mla_indexed_kv_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/ring_mla_indexed_kv_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/ring_mla_indexed_kv_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/ring_mla_indexed_kv_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/ring_mla_indexed_kv_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/ring_mla_indexed_kv_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/ring_mla_indexed_kv_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/ring_mla_indexed_kv_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/ring_mla_indexed_kv_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/ring_mla_indexed_kv_cache)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/ring_mla_indexed_kv_cache)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/ring_mla_indexed_kv_cache)