### PR TITLE
RoundMode clarification (ttnn) 1/6

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_gpt/device/kernels/swiglu_sfpu.h
@@ -101,7 +101,7 @@ inline void calculate_swiglu(const uint gate_tile_idx, const uint up_tile_idx, c
 
         // Round to bf16 if not in fp32 dest accumulation mode
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::convert<sfpi::vFloat16b>(result, RoundMode::NearestEven);
+            result = sfpi::convert<sfpi::vFloat16b>(result, RoundMode::Nearest);
         }
 
         sfpi::dst_reg[out_tile_idx * dst_tile_size] = result;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -243,7 +243,7 @@ void calculate_recip_first_column() {
             // }
             // v_endif;
             if constexpr (!(DST_ACCUM_MODE || APPROX)) {
-                out = sfpi::convert<sfpi::vFloat16b>(out, RoundMode::NearestEven);
+                out = sfpi::convert<sfpi::vFloat16b>(out, RoundMode::Nearest);
             }
             sfpi::dst_reg[0] = out;
             sfpi::dst_reg += 2;
@@ -259,7 +259,7 @@ void calculate_recip_first_column() {
                 out = ckernel::sfpu::_sfpu_reciprocal_<2>(in);
             } else {
                 out = ckernel::sfpu::_sfpu_reciprocal_<1>(in);
-                out = sfpi::convert<sfpi::vFloat16b>(out, RoundMode::NearestEven);
+                out = sfpi::convert<sfpi::vFloat16b>(out, RoundMode::Nearest);
             }
             sfpi::dst_reg[0] = out;
             sfpi::dst_reg += 2;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
A user noticed that WH & BH round to nearest with ties away from zero, not to nearest even.
I've updated SFPI in a backwards compatible manner and will deprecate the old names later.
https://github.com/tenstorrent/sfpi/releases/tag/7.58.0

TL;DR; use `RoundMode::Nearest` and get what the arch provides.

This updates the files in `ttnn`

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/nearest1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/nearest1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/nearest1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/nearest1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/nearest1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/nearest1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/nearest1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/nearest1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/nearest1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/nearest1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/nearest1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/nearest1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/nearest1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/nearest1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/nearest1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/nearest1)