### PR TITLE
RoundMode clarification (tt_metal/tt-llk) 2/6

### DIFF
--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -20,7 +20,7 @@ inline void _cast_fp32_to_fp16a_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        x                = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        x                = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::Nearest);
         sfpi::dst_reg[0] = x;
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_log.h
@@ -48,7 +48,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
     ////////////////////////////
     auto exp = sfpi::convert<sfpi::vSMag>(sfpi::exexp(in));
 
-    sfpi::vFloat expf      = sfpi::convert<sfpi::vFloat>(exp, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat expf      = sfpi::convert<sfpi::vFloat>(exp, sfpi::RoundMode::Nearest);
     sfpi::vFloat vConstLn2 = sfpi::vConstFloatPrgm0;
     sfpi::vFloat result    = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
 
@@ -79,7 +79,7 @@ sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base)
 
     // Convert exponent to float
     auto exp          = sfpi::convert<sfpi::vSMag>(sfpi::exexp(base));
-    sfpi::vFloat expf = sfpi::convert<sfpi::vFloat>(exp, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat expf = sfpi::convert<sfpi::vFloat>(exp, sfpi::RoundMode::Nearest);
 
     // De-normalize to original range
     sfpi::vFloat vConstLn2  = 0.692871f;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -180,7 +180,7 @@ sfpi_inline void _calculate_stochastic_round_()
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        x                = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
+        x                = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::NearestStochastic);
         sfpi::dst_reg[0] = x;
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -112,7 +112,7 @@ inline void _calculate_rsqrt_compat_(const int iterations)
         v_endif;
         if constexpr (!(fp32_dest_acc_en || APPROXIMATION_MODE))
         {
-            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
+            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::Nearest);
         }
         sfpi::dst_reg[0] = out;
         sfpi::dst_reg++;
@@ -145,7 +145,7 @@ inline void _calculate_reciprocal_compat_(const int iterations)
         v_endif;
         if constexpr (!(fp32_dest_acc_en || APPROXIMATION_MODE))
         {
-            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
+            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::Nearest);
         }
         sfpi::dst_reg[0] = out;
         sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -19,7 +19,7 @@ inline void _cast_fp32_to_fp16a_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        x                = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        x                = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::Nearest);
         sfpi::dst_reg[0] = x;
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_log.h
@@ -48,7 +48,7 @@ sfpi_inline void _calculate_log_body_(const std::uint32_t log_base_scale_factor,
     ////////////////////////////
     auto exp = sfpi::convert<sfpi::vSMag>(exexp(in));
 
-    sfpi::vFloat expf      = sfpi::convert<sfpi::vFloat>(exp, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat expf      = sfpi::convert<sfpi::vFloat>(exp, sfpi::RoundMode::Nearest);
     sfpi::vFloat vConstLn2 = sfpi::vConstFloatPrgm0;
     sfpi::vFloat result    = expf * vConstLn2 + series_result; // exp correction: ln(1+x) + exp*ln(2)
 
@@ -79,7 +79,7 @@ sfpi_inline sfpi::vFloat _calculate_log_body_no_init_(sfpi::vFloat base)
 
     // Convert exponent to float
     auto exp          = sfpi::convert<sfpi::vSMag>(exexp(base));
-    sfpi::vFloat expf = sfpi::convert<sfpi::vFloat>(exp, sfpi::RoundMode::NearestEven);
+    sfpi::vFloat expf = sfpi::convert<sfpi::vFloat>(exp, sfpi::RoundMode::Nearest);
 
     // De-normalize to original range
     sfpi::vFloat vConstLn2  = 0.692871f;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -95,7 +95,7 @@ inline void _calculate_reciprocal_internal_(const int iterations)
         else
         {
             out = _sfpu_reciprocal_<1>(in);
-            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
+            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::Nearest);
             }
             sfpi::dst_reg[0] = out;
             sfpi::dst_reg++;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -188,7 +188,7 @@ sfpi_inline void _calculate_stochastic_round_()
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        x                = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
+        x                = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::NearestStochastic);
         sfpi::dst_reg[0] = x;
         sfpi::dst_reg++;
     }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rsqrt_compat.h
@@ -112,7 +112,7 @@ inline void _calculate_rsqrt_compat_(const int iterations)
         v_endif;
         if constexpr (!(fp32_dest_acc_en || APPROXIMATION_MODE))
         {
-            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
+            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::Nearest);
         }
         sfpi::dst_reg[0] = out;
         sfpi::dst_reg++;
@@ -145,7 +145,7 @@ inline void _calculate_reciprocal_compat_(const int iterations)
         v_endif;
         if constexpr (!(fp32_dest_acc_en || APPROXIMATION_MODE))
         {
-            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
+            out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::Nearest);
         }
         sfpi::dst_reg[0] = out;
         sfpi::dst_reg++;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
A user noticed that WH & BH round to nearest with ties away from zero, not to nearest even.
I've updated SFPI in a backwards compatible manner and will deprecate the old names later.
https://github.com/tenstorrent/sfpi/releases/tag/7.58.0

TL;DR; use `RoundMode::Nearest` and get what the arch provides.

This updates the files in `tt_metal/tt-llk`

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/nearest2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/nearest2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/nearest2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/nearest2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/nearest2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/nearest2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/nearest2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/nearest2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/nearest2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/nearest2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/nearest2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/nearest2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/nearest2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/nearest2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/nearest2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/nearest2)