### PR TITLE
RoundMode clarification (models) 5/6

### DIFF
--- a/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_rsqrt.h
+++ b/models/demos/deepseek_v3_b1/kernel_includes/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_add_rsqrt.h
@@ -23,7 +23,7 @@ inline void calculate_add_rsqrt(uint32_t param0) {
         sfpi::vFloat y = _calculate_sqrt_body_<APPROXIMATION_MODE, true, FAST_APPROX>(x_plus_addend);
 
         if constexpr (!fp32_dest_acc_en) {
-            y = sfpi::convert<sfpi::vFloat16b>(y, RoundMode::NearestEven);
+            y = sfpi::convert<sfpi::vFloat16b>(y, RoundMode::Nearest);
         }
         sfpi::dst_reg[0] = y;
         sfpi::dst_reg++;

--- a/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
@@ -39,7 +39,7 @@ static inline float bf16_to_float(uint16_t bf) {
     return bits_to_float(u32);
 }
 
-// Convert float32 to bf16 bit-pattern using round-to-nearest-even
+// Convert float32 to bf16 bit-pattern using round-to-nearest
 static inline uint16_t float_to_bf16_rne(float x) {
     uint32_t u = float_to_bits(x);
 
@@ -147,7 +147,7 @@ void calculate_sampling_recip_scalar() {
         out = ckernel::sfpu::_sfpu_reciprocal_<1>(in);
     }
     if constexpr (!(DST_ACCUM_MODE || APPROX)) {
-        out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::NearestEven);
+        out = sfpi::convert<sfpi::vFloat16b>(out, sfpi::RoundMode::Nearest);
     }
     sfpi::dst_reg[0] = out;
 }


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
A user noticed that WH & BH round to nearest with ties away from zero, not to nearest even.
I've updated SFPI in a backwards compatible manner and will deprecate the old names later.
https://github.com/tenstorrent/sfpi/releases/tag/7.58.0

TL;DR; use `RoundMode::Nearest` and get what the arch provides.

This updates the files in `models`

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/nearest5)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/nearest5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/nearest5)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/nearest5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/nearest5)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/nearest5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/nearest5)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/nearest5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/nearest5)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/nearest5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/nearest5)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/nearest5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/nearest5)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/nearest5)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/nearest5)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/nearest5)