### PR TITLE
RoundMode clarification (docs) 6/6

### DIFF
--- a/METALIUM_GUIDE.md
+++ b/METALIUM_GUIDE.md
@@ -495,8 +495,8 @@ inline void calculate_sine() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         vFloat v = dst_reg[0] * FRAC_1_PI;
-        vInt whole_v = float_to_int16(v, RoundMode::NearestEven);
-        v -= int32_to_float(whole_v, RoundMode::NearestEven);
+        vSMag16 whole_v = convert<vSMag16>(v, RoundMode::Nearest);
+        v -= convert<vFloat>(whole_v, RoundMode::Nearest);
         v = sfpu_sinpi<APPROXIMATION_MODE>(v);
 
         v_if(whole_v & 1) { v = -v; }

--- a/docs/source/tt-metalium/tt_metal/apis/kernel_apis/sfpu/llk.rst
+++ b/docs/source/tt-metalium/tt_metal/apis/kernel_apis/sfpu/llk.rst
@@ -355,15 +355,19 @@ Returns the count of leading (left-most) zeros of ''v'' ignoring the sign bit.
 .. code-block:: c++
 
     template<typename ToType, typename FromType>
-    ToType convert (FromType in, RoundMode rounding = RoundMode::Stochastic)
+    ToType convert (FromType in, RoundMode rounding = RoundMode::NearestStochastic)
     template<typename ToType, typename FromType>
-    ToType convert (FromType in, unsigned descale, RoundMode rounding = RoundMode::Stochastic)
+    ToType convert (FromType in, unsigned descale, RoundMode rounding = RoundMode::NearestStochastic)
 
-Returns the rounded value performing round-to-even when ''rounding''
-is ''RoundMode::NearestEven'', stochastic rounding when ''rounding'' is
-''RoundMode::Stochastic'', and round-to-zero when it is
-''RoundMode::Zero'' (not available on WormHole).  Not all
-conversions are supported, and a compilation error will occur if not available.
+Not all conversions are supported, and a compilation error will occur
+if not available.  The following rounding modes are available:
+
+  * ``NearestEven`` - round to nearest, ties to even mantissa (Quasar)
+  * ``NearestAway`` - round to nearest, ties away from zero (Wormhole, Blackhole)
+  * ``NearestStochastic`` - round to nearest, ties randomly up or down
+  * ``Stochastic`` - deprecated alias for ``NearestStochastic``
+  * ``Zero`` - round towards zero (Blackhole and Quasar)
+  * ``Nearest`` - ``NearestEven``, if available, else ``NearestAway``
 
 Immediate Floating Point Values
 -------------------------------


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
A user noticed that WH & BH round to nearest with ties away from zero, not to nearest even.
I've updated SFPI in a backwards compatible manner and will deprecate the old names later.
https://github.com/tenstorrent/sfpi/releases/tag/7.58.0

TL;DR; use `RoundMode::Nearest` and get what the arch provides.

This updates the documentation

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/nearest6)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/nearest6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/nearest6)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/nearest6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/nearest6)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/nearest6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/nearest6)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/nearest6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/nearest6)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/nearest6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/nearest6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/nearest6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/nearest6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/nearest6)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/nearest6)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/nearest6)