### PR TITLE
[Feature] #46134: Enable Sharding support for Ternary TTS and TST reader kernels

### DIFF
--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
@@ -2037,12 +2037,10 @@ def test_ternary_resolve_mem_config_with_grid_size_two(device):
 def test_where_ttt_outer_bcast_with_height_sharding(
     device, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
 ):
-    # NOTE: TTT only enables native L1 sharding when all three inputs have identical shapes
-    # (see is_native_L1_sharding in ternary_op_utils.cpp). Because `true` outer-broadcasts on N,
-    # the shapes differ, so the op always drops the sharding request and runs the interleaved
-    # outer-bcast path (SRC_SHARDED_*=0) regardless of the *_sharded flags. This test verifies
-    # that fallback produces correct results (and a sharded output when requested) across cores.
-    torch.manual_seed(0)
+    # NOTE: Native L1 sharding is enabled only when all tensor inputs have identical shapes
+    # and identical memory configs (see is_native_L1_sharding in ternary_op_utils.cpp).
+    # When enabled, the whole shard is pre-populated into the CB (bulk reserve/push).
+    # Otherwise, per-tile NOC reads are performed via TensorAccessor (interleaved fallback).
     predicate_shape = (2, 7, 2 * 32, 4 * 32)
     true_shape = (1, 7, 2 * 32, 4 * 32)  # outer broadcast on N (2 -> 1); H/W identical
     false_shape = (2, 7, 2 * 32, 4 * 32)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
@@ -2027,3 +2027,491 @@ def test_ternary_resolve_mem_config_with_grid_size_two(device):
 
     output = ttnn.to_torch(output_tt)
     assert_with_pcc(torch_output, output)
+
+
+@pytest.mark.parametrize(
+    "shape, shard_strategy, shard_shape_row_major, shard_shape_col_major, core_grid",
+    [
+        # BLOCK sharding
+        (
+            (1, 1, 1024, 1024),
+            ttnn.ShardStrategy.BLOCK,
+            (1024 // 2, 1024 // 4),
+            (1024 // 2, 1024 // 4),
+            ttnn.CoreGrid(y=2, x=4),
+        ),
+        # HEIGHT sharding
+        (
+            (1, 1, 256, 256),
+            ttnn.ShardStrategy.HEIGHT,
+            (256 // 4, 256),
+            (256, 256 // 4),
+            ttnn.CoreGrid(y=4, x=1),
+        ),
+        # WIDTH sharding
+        (
+            (1, 1, 256, 256),
+            ttnn.ShardStrategy.WIDTH,
+            (256, 256 // 4),
+            (256 // 4, 256),
+            ttnn.CoreGrid(y=1, x=4),
+        ),
+    ],
+)
+@pytest.mark.parametrize("input_sharded", [True, False])
+@pytest.mark.parametrize("end_sharded", [True, False])
+@pytest.mark.parametrize("out_sharded", [True, False])
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_lerp_tts_no_bcast_with_sharding(
+    device,
+    shape,
+    shard_strategy,
+    shard_shape_row_major,
+    shard_shape_col_major,
+    core_grid,
+    input_sharded,
+    end_sharded,
+    out_sharded,
+    shard_orientation,
+):
+    torch.manual_seed(0)
+    weight = 0.5
+    torch_input = torch.rand(shape, dtype=torch.bfloat16)
+    torch_end = torch.rand(shape, dtype=torch.bfloat16)
+
+    if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
+        shard_shape = shard_shape_row_major
+    else:
+        shard_shape = shard_shape_col_major
+
+    sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=shard_shape,
+        core_grid=core_grid,
+        strategy=shard_strategy,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    torch_output = torch.lerp(torch_input, torch_end, weight)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if input_sharded:
+        input_tensor = ttnn.to_memory_config(input_tensor, sharded_mem_config)
+
+    end_tensor = ttnn.from_torch(
+        torch_end, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if end_sharded:
+        end_tensor = ttnn.to_memory_config(end_tensor, sharded_mem_config)
+
+    if out_sharded:
+        out_mem_config = sharded_mem_config
+    else:
+        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+
+    output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output, output_tensor)
+    assert output_tensor.shape == shape
+
+
+@pytest.mark.parametrize("input_sharded", [True, False])
+@pytest.mark.parametrize("out_sharded", [True, False])
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_lerp_tts_scalar_bcast_with_height_sharding(device, input_sharded, out_sharded, shard_orientation):
+    torch.manual_seed(0)
+    input_shape = (2, 7, 2 * 32, 4 * 32)
+    end_shape = (1, 7, 1, 1)
+    output_shape = (2, 7, 2 * 32, 4 * 32)
+    weight = 0.3
+
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+    torch_end = torch.rand(end_shape, dtype=torch.bfloat16)
+
+    if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
+        shard_shape = (2 * 32 * 2, 4 * 32)
+    else:
+        shard_shape = (4 * 32, 2 * 32 * 2)
+
+    height_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=shard_shape,
+        core_grid=ttnn.CoreGrid(y=1, x=7),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    torch_output = torch.lerp(torch_input, torch_end, weight)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if input_sharded:
+        input_tensor = ttnn.to_memory_config(input_tensor, height_sharded_mem_config)
+
+    end_tensor = ttnn.from_torch(
+        torch_end, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    if out_sharded:
+        out_mem_config = height_sharded_mem_config
+    else:
+        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+
+    output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output, output_tensor)
+    assert output_tensor.shape == output_shape
+
+
+@pytest.mark.parametrize("input_sharded", [True, False])
+@pytest.mark.parametrize("end_sharded", [True, False])
+@pytest.mark.parametrize("out_sharded", [True, False])
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_lerp_tts_outer_bcast_with_height_sharding(device, input_sharded, end_sharded, out_sharded, shard_orientation):
+    torch.manual_seed(0)
+    input_shape = (2, 7, 2 * 32, 4 * 32)
+    end_shape = (1, 7, 2 * 32, 4 * 32)
+    output_shape = (2, 7, 2 * 32, 4 * 32)
+    weight = 0.4
+
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+    torch_end = torch.rand(end_shape, dtype=torch.bfloat16)
+
+    if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
+        input_shard_shape = (2 * 32 * 2, 4 * 32)
+        end_shard_shape = (1 * 32 * 2, 4 * 32)
+    else:
+        input_shard_shape = (4 * 32, 2 * 32 * 2)
+        end_shard_shape = (4 * 32, 1 * 32 * 2)
+
+    input_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=input_shard_shape,
+        core_grid=ttnn.CoreGrid(y=1, x=7),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    end_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=end_shard_shape,
+        core_grid=ttnn.CoreGrid(y=1, x=7),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    torch_output = torch.lerp(torch_input, torch_end, weight)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if input_sharded:
+        input_tensor = ttnn.to_memory_config(input_tensor, input_sharded_mem_config)
+
+    end_tensor = ttnn.from_torch(
+        torch_end, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if end_sharded:
+        end_tensor = ttnn.to_memory_config(end_tensor, end_sharded_mem_config)
+
+    if out_sharded:
+        out_mem_config = input_sharded_mem_config
+    else:
+        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+
+    output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output, output_tensor)
+    assert output_tensor.shape == output_shape
+
+
+@pytest.mark.parametrize("input_sharded", [True, False])
+@pytest.mark.parametrize("end_sharded", [True, False])
+@pytest.mark.parametrize("out_sharded", [True, False])
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_lerp_tts_outer_bcast_with_width_sharding(device, input_sharded, end_sharded, out_sharded, shard_orientation):
+    torch.manual_seed(0)
+    input_shape = (1, 2, 2 * 32, 7 * 32)
+    end_shape = (1, 1, 2 * 32, 7 * 32)
+    output_shape = (1, 2, 2 * 32, 7 * 32)
+    weight = 0.6
+
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+    torch_end = torch.rand(end_shape, dtype=torch.bfloat16)
+
+    if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
+        input_shard_shape = (2 * 1 * 2 * 32, 32)
+        end_shard_shape = (1 * 1 * 2 * 32, 32)
+    else:
+        input_shard_shape = (32, 2 * 1 * 2 * 32)
+        end_shard_shape = (32, 1 * 1 * 2 * 32)
+
+    input_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=input_shard_shape,
+        core_grid=ttnn.CoreGrid(y=1, x=7),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    end_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=end_shard_shape,
+        core_grid=ttnn.CoreGrid(y=1, x=7),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    torch_output = torch.lerp(torch_input, torch_end, weight)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if input_sharded:
+        input_tensor = ttnn.to_memory_config(input_tensor, input_sharded_mem_config)
+
+    end_tensor = ttnn.from_torch(
+        torch_end, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if end_sharded:
+        end_tensor = ttnn.to_memory_config(end_tensor, end_sharded_mem_config)
+
+    if out_sharded:
+        out_mem_config = input_sharded_mem_config
+    else:
+        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+
+    output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output, output_tensor)
+    assert output_tensor.shape == output_shape
+
+
+@pytest.mark.parametrize("end_sharded", [True, False])
+@pytest.mark.parametrize("out_sharded", [True, False])
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_lerp_tts_row_col_bcast_with_height_sharding(device, end_sharded, out_sharded, shard_orientation):
+    torch.manual_seed(0)
+    input_shape = (1, 1, 1, 4 * 32)
+    end_shape = (1, 1, 4 * 32, 1)
+    output_shape = (1, 1, 4 * 32, 4 * 32)
+    weight = 0.5
+
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+    torch_end = torch.rand(end_shape, dtype=torch.bfloat16)
+
+    if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
+        out_shard_shape = (1 * 32, 4 * 32)
+        end_shard_shape = (1 * 32, 1 * 32)
+    else:
+        out_shard_shape = (4 * 32, 1 * 32)
+        end_shard_shape = (1 * 32, 1 * 32)
+
+    out_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=out_shard_shape,
+        core_grid=ttnn.CoreGrid(y=4, x=1),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    end_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=end_shard_shape,
+        core_grid=ttnn.CoreGrid(y=4, x=1),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    torch_output = torch.lerp(torch_input, torch_end, weight)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    end_tensor = ttnn.from_torch(
+        torch_end, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if end_sharded:
+        end_tensor = ttnn.to_memory_config(end_tensor, end_sharded_mem_config)
+
+    if out_sharded:
+        out_mem_config = out_sharded_mem_config
+    else:
+        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+
+    output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output, output_tensor)
+    assert output_tensor.shape == output_shape
+
+
+@pytest.mark.parametrize("end_sharded", [True, False])
+@pytest.mark.parametrize("out_sharded", [True, False])
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_lerp_tts_row_bcast_with_height_sharding(device, end_sharded, out_sharded, shard_orientation):
+    torch.manual_seed(0)
+    input_shape = (1, 1, 1, 4 * 32)
+    end_shape = (1, 1, 4 * 32, 4 * 32)
+    output_shape = (1, 1, 4 * 32, 4 * 32)
+    weight = 0.5
+
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+    torch_end = torch.rand(end_shape, dtype=torch.bfloat16)
+
+    if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
+        shard_shape = (1 * 32, 4 * 32)
+    else:
+        shard_shape = (4 * 32, 1 * 32)
+
+    height_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=shard_shape,
+        core_grid=ttnn.CoreGrid(y=4, x=1),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    torch_output = torch.lerp(torch_input, torch_end, weight)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    end_tensor = ttnn.from_torch(
+        torch_end, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if end_sharded:
+        end_tensor = ttnn.to_memory_config(end_tensor, height_sharded_mem_config)
+
+    if out_sharded:
+        out_mem_config = height_sharded_mem_config
+    else:
+        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+
+    output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output, output_tensor)
+    assert output_tensor.shape == output_shape
+
+
+@pytest.mark.parametrize("input_sharded", [True, False])
+@pytest.mark.parametrize("end_sharded", [True, False])
+@pytest.mark.parametrize("out_sharded", [True, False])
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_lerp_tts_col_bcast_with_height_sharding(device, input_sharded, end_sharded, out_sharded, shard_orientation):
+    torch.manual_seed(0)
+    input_shape = (1, 1, 4 * 32, 4 * 32)
+    end_shape = (1, 1, 4 * 32, 1)
+    output_shape = (1, 1, 4 * 32, 4 * 32)
+    weight = 0.5
+
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+    torch_end = torch.rand(end_shape, dtype=torch.bfloat16)
+
+    if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
+        input_shard_shape = (1 * 32, 4 * 32)
+        end_shard_shape = (1 * 32, 1 * 32)
+    else:
+        input_shard_shape = (4 * 32, 1 * 32)
+        end_shard_shape = (1 * 32, 1 * 32)
+
+    input_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=input_shard_shape,
+        core_grid=ttnn.CoreGrid(y=4, x=1),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    end_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=end_shard_shape,
+        core_grid=ttnn.CoreGrid(y=4, x=1),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    torch_output = torch.lerp(torch_input, torch_end, weight)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if input_sharded:
+        input_tensor = ttnn.to_memory_config(input_tensor, input_sharded_mem_config)
+
+    end_tensor = ttnn.from_torch(
+        torch_end, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if end_sharded:
+        end_tensor = ttnn.to_memory_config(end_tensor, end_sharded_mem_config)
+
+    if out_sharded:
+        out_mem_config = input_sharded_mem_config
+    else:
+        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+
+    output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output, output_tensor)
+    assert output_tensor.shape == output_shape
+
+
+@pytest.mark.parametrize("input_sharded", [True, False])
+@pytest.mark.parametrize("out_sharded", [True, False])
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_lerp_tts_scalar_bcast_with_width_sharding(device, input_sharded, out_sharded, shard_orientation):
+    torch.manual_seed(0)
+    input_shape = (1, 2, 2 * 32, 7 * 32)
+    end_shape = (1, 1, 1, 1)
+    output_shape = (1, 2, 2 * 32, 7 * 32)
+    weight = 0.7
+
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+    torch_end = torch.rand(end_shape, dtype=torch.bfloat16)
+
+    if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
+        shard_shape = (2 * 1 * 2 * 32, 32)
+    else:
+        shard_shape = (32, 2 * 1 * 2 * 32)
+
+    width_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=shard_shape,
+        core_grid=ttnn.CoreGrid(y=1, x=7),
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    torch_output = torch.lerp(torch_input, torch_end, weight)
+
+    input_tensor = ttnn.from_torch(
+        torch_input, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if input_sharded:
+        input_tensor = ttnn.to_memory_config(input_tensor, width_sharded_mem_config)
+
+    end_tensor = ttnn.from_torch(
+        torch_end, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+    if out_sharded:
+        out_mem_config = width_sharded_mem_config
+    else:
+        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+
+    output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_with_pcc(torch_output, output_tensor)
+    assert output_tensor.shape == output_shape

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
@@ -2112,6 +2112,8 @@ def test_lerp_tts_no_bcast_with_sharding(
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    if out_sharded:
+        assert output_tensor.memory_config().is_sharded()
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output, output_tensor)
@@ -2162,6 +2164,8 @@ def test_lerp_tts_scalar_bcast_with_height_sharding(device, input_sharded, out_s
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    if out_sharded:
+        assert output_tensor.memory_config().is_sharded()
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output, output_tensor)
@@ -2225,6 +2229,8 @@ def test_lerp_tts_outer_bcast_with_height_sharding(device, input_sharded, end_sh
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    if out_sharded:
+        assert output_tensor.memory_config().is_sharded()
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output, output_tensor)
@@ -2288,6 +2294,8 @@ def test_lerp_tts_outer_bcast_with_width_sharding(device, input_sharded, end_sha
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    if out_sharded:
+        assert output_tensor.memory_config().is_sharded()
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output, output_tensor)
@@ -2348,6 +2356,8 @@ def test_lerp_tts_row_col_bcast_with_height_sharding(device, end_sharded, out_sh
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    if out_sharded:
+        assert output_tensor.memory_config().is_sharded()
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output, output_tensor)
@@ -2398,6 +2408,8 @@ def test_lerp_tts_row_bcast_with_height_sharding(device, end_sharded, out_sharde
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    if out_sharded:
+        assert output_tensor.memory_config().is_sharded()
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output, output_tensor)
@@ -2461,6 +2473,8 @@ def test_lerp_tts_col_bcast_with_height_sharding(device, input_sharded, end_shar
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    if out_sharded:
+        assert output_tensor.memory_config().is_sharded()
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output, output_tensor)
@@ -2511,6 +2525,8 @@ def test_lerp_tts_scalar_bcast_with_width_sharding(device, input_sharded, out_sh
         out_mem_config = ttnn.DRAM_MEMORY_CONFIG
 
     output_tensor = ttnn.lerp(input_tensor, end_tensor, weight, memory_config=out_mem_config)
+    if out_sharded:
+        assert output_tensor.memory_config().is_sharded()
     output_tensor = ttnn.to_torch(output_tensor)
 
     assert_with_pcc(torch_output, output_tensor)

--- a/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
+++ b/tests/ttnn/unit_tests/operations/eltwise/test_ternary_sharding.py
@@ -2029,6 +2029,86 @@ def test_ternary_resolve_mem_config_with_grid_size_two(device):
     assert_with_pcc(torch_output, output)
 
 
+@pytest.mark.parametrize("predicate_sharded", [True, False])
+@pytest.mark.parametrize("true_sharded", [True, False])
+@pytest.mark.parametrize("false_sharded", [True, False])
+@pytest.mark.parametrize("out_sharded", [True, False])
+@pytest.mark.parametrize("shard_orientation", [ttnn.ShardOrientation.ROW_MAJOR, ttnn.ShardOrientation.COL_MAJOR])
+def test_where_ttt_outer_bcast_with_height_sharding(
+    device, predicate_sharded, true_sharded, false_sharded, out_sharded, shard_orientation
+):
+    # NOTE: TTT only enables native L1 sharding when all three inputs have identical shapes
+    # (see is_native_L1_sharding in ternary_op_utils.cpp). Because `true` outer-broadcasts on N,
+    # the shapes differ, so the op always drops the sharding request and runs the interleaved
+    # outer-bcast path (SRC_SHARDED_*=0) regardless of the *_sharded flags. This test verifies
+    # that fallback produces correct results (and a sharded output when requested) across cores.
+    torch.manual_seed(0)
+    predicate_shape = (2, 7, 2 * 32, 4 * 32)
+    true_shape = (1, 7, 2 * 32, 4 * 32)  # outer broadcast on N (2 -> 1); H/W identical
+    false_shape = (2, 7, 2 * 32, 4 * 32)
+    output_shape = (2, 7, 2 * 32, 4 * 32)
+
+    torch_predicate = torch.randint(0, 2, predicate_shape, dtype=torch.bfloat16)
+    torch_true = torch.rand(true_shape, dtype=torch.bfloat16)
+    torch_false = torch.rand(false_shape, dtype=torch.bfloat16)
+
+    if shard_orientation == ttnn.ShardOrientation.ROW_MAJOR:
+        pred_shard_shape = (2 * 32 * 2, 4 * 32)  # [128, 128]
+        true_shard_shape = (1 * 32 * 2, 4 * 32)  # [64, 128]
+    else:
+        pred_shard_shape = (4 * 32, 2 * 32 * 2)  # [128, 128] for COL_MAJOR
+        true_shard_shape = (4 * 32, 1 * 32 * 2)  # [128, 64] for COL_MAJOR
+
+    pred_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=pred_shard_shape,
+        core_grid=ttnn.CoreGrid(y=1, x=7),  # 7 cores: (0,0) to (0,6)
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    true_sharded_mem_config = ttnn.create_sharded_memory_config(
+        shape=true_shard_shape,
+        core_grid=ttnn.CoreGrid(y=1, x=7),  # 7 cores: (0,0) to (0,6)
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=shard_orientation,
+        use_height_and_width_as_shard_shape=True,
+    )
+
+    torch_output = torch.where(torch_predicate.bool(), torch_true, torch_false)
+
+    predicate_tensor = ttnn.from_torch(
+        torch_predicate, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if predicate_sharded:
+        predicate_tensor = ttnn.to_memory_config(predicate_tensor, pred_sharded_mem_config)
+
+    true_tensor = ttnn.from_torch(
+        torch_true, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if true_sharded:
+        true_tensor = ttnn.to_memory_config(true_tensor, true_sharded_mem_config)
+
+    false_tensor = ttnn.from_torch(
+        torch_false, layout=ttnn.TILE_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    if false_sharded:
+        false_tensor = ttnn.to_memory_config(false_tensor, pred_sharded_mem_config)
+
+    if out_sharded:
+        out_mem_config = pred_sharded_mem_config
+    else:
+        out_mem_config = ttnn.DRAM_MEMORY_CONFIG
+
+    output_tensor = ttnn.where(predicate_tensor, true_tensor, false_tensor, memory_config=out_mem_config)
+    if out_sharded:
+        assert output_tensor.memory_config().is_sharded()
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert torch_equal_nan(output_tensor, torch_output)
+    assert output_tensor.shape == output_shape
+
+
 @pytest.mark.parametrize(
     "shape, shard_strategy, shard_shape_row_major, shard_shape_col_major, core_grid",
     [

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_tst_tts.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nobcast_tst_tts.cpp
@@ -18,31 +18,51 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_in1 = get_compile_time_arg_val(1);
 
-    constexpr auto src0_args = TensorAccessorArgs<2, 0>();
-    constexpr auto src1_args =
-        TensorAccessorArgs<src0_args.next_compile_time_args_offset(), src0_args.next_common_runtime_args_offset()>();
-
     Noc noc;
     CircularBuffer cb0(cb_id_in0);
     CircularBuffer cb1(cb_id_in1);
 
+#if SRC_SHARDED_A
+    cb0.reserve_back(num_tiles);
+    cb0.push_back(num_tiles);
+#endif
+#if SRC_SHARDED_B
+    cb1.reserve_back(num_tiles);
+    cb1.push_back(num_tiles);
+#endif
+#if !SRC_SHARDED_A || !SRC_SHARDED_B
+    constexpr auto src0_args = TensorAccessorArgs<2, 0>();
+    constexpr auto src1_args =
+        TensorAccessorArgs<src0_args.next_compile_time_args_offset(), src0_args.next_common_runtime_args_offset()>();
+#if !SRC_SHARDED_A
     const uint32_t tile_bytes_0 = cb0.get_tile_size();
-    const uint32_t tile_bytes_1 = cb1.get_tile_size();
     const auto s0 = TensorAccessor(src0_args, src0_addr);
+#endif
+#if !SRC_SHARDED_B
+    const uint32_t tile_bytes_1 = cb1.get_tile_size();
     const auto s1 = TensorAccessor(src1_args, src1_addr);
+#endif
 
     constexpr uint32_t onetile = 1;
 
     for (uint32_t tile_id = start_id; tile_id < start_id + num_tiles; tile_id++) {
+#if !SRC_SHARDED_A
         cb0.reserve_back(onetile);
         noc.async_read(s0, cb0, tile_bytes_0, {.page_id = tile_id}, {.offset_bytes = 0});
-
+#endif
+#if !SRC_SHARDED_B
         cb1.reserve_back(onetile);
         noc.async_read(s1, cb1, tile_bytes_1, {.page_id = tile_id}, {.offset_bytes = 0});
+#endif
 
         noc.async_read_barrier();
 
+#if !SRC_SHARDED_A
         cb0.push_back(onetile);
+#endif
+#if !SRC_SHARDED_B
         cb1.push_back(onetile);
+#endif
     }
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nosubtilebcast_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_nosubtilebcast_ttt.cpp
@@ -120,6 +120,7 @@ void kernel_main() {
     uint32_t next_nd_shift_c = nD_stride_c - d_stride_c * D;
 
     uint32_t num_tiles_read = 0;
+    // Supports both nobcast and outer_bcast cases for TTT variant
     for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
         for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
             for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_scalar_ttt.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/ternary_reader_scalar_ttt.cpp
@@ -11,7 +11,7 @@
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {
-    // Standard first 5 arguments (same as ternary_reader_nobcast_ttt.cpp)
+    // Standard first 5 arguments (same as ternary_reader_nosubtilebcast_ttt.cpp)
     const uint32_t src0_addr = get_arg_val<uint32_t>(0);  // predicate address
     const uint32_t src1_addr = get_arg_val<uint32_t>(1);  // true tensor address
     const uint32_t src2_addr = get_arg_val<uint32_t>(2);  // false tensor address

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp
@@ -48,11 +48,17 @@ void kernel_main() {
     CircularBuffer cb_pred(predicate_cb);
     CircularBuffer cb_b(src_b_cb);
 
-#if !SRC_SHARDED_A
+#if SRC_SHARDED_A
+    cb_pred.reserve_back(srcA_num_tiles);
+    cb_pred.push_back(srcA_num_tiles);
+#else
     const uint32_t src0_tile_bytes = cb_pred.get_tile_size();
     const auto s0 = TensorAccessor(src0_args, src0_addr);
 #endif
-#if !SRC_SHARDED_B
+#if SRC_SHARDED_B
+    cb_b.reserve_back(srcB_num_tiles);
+    cb_b.push_back(srcB_num_tiles);
+#else
     const uint32_t src1_tile_bytes = cb_b.get_tile_size();
     const auto s1 = TensorAccessor(src1_args, src1_addr);
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp
@@ -48,17 +48,11 @@ void kernel_main() {
     CircularBuffer cb_pred(predicate_cb);
     CircularBuffer cb_b(src_b_cb);
 
-#if SRC_SHARDED_A
-    cb_pred.reserve_back(srcA_num_tiles);
-    cb_pred.push_back(srcA_num_tiles);
-#else
+#if !SRC_SHARDED_A
     const uint32_t src0_tile_bytes = cb_pred.get_tile_size();
     const auto s0 = TensorAccessor(src0_args, src0_addr);
 #endif
-#if SRC_SHARDED_B
-    cb_b.reserve_back(srcB_num_tiles);
-    cb_b.push_back(srcB_num_tiles);
-#else
+#if !SRC_SHARDED_B
     const uint32_t src1_tile_bytes = cb_b.get_tile_size();
     const auto s1 = TensorAccessor(src1_args, src1_addr);
 #endif

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_outer_bcast.cpp
@@ -48,25 +48,17 @@ void kernel_main() {
     CircularBuffer cb_pred(predicate_cb);
     CircularBuffer cb_b(src_b_cb);
 
-    // #if SRC_SHARDED_A
-    //     cb_pred.reserve_back(srcA_num_tiles);
-    //     cb_pred.push_back(srcA_num_tiles);
-    // #else
+#if !SRC_SHARDED_A
     const uint32_t src0_tile_bytes = cb_pred.get_tile_size();
     const auto s0 = TensorAccessor(src0_args, src0_addr);
-    // #endif
-    // #if SRC_SHARDED_B
-    //     cb_b.reserve_back(srcB_num_tiles);
-    //     cb_b.push_back(srcB_num_tiles);
-    // #else
+#endif
+#if !SRC_SHARDED_B
     const uint32_t src1_tile_bytes = cb_b.get_tile_size();
     const auto s1 = TensorAccessor(src1_args, src1_addr);
-    // #endif
+#endif
 
-    // #if !SRC_SHARDED_A || !SRC_SHARDED_B
     constexpr uint32_t onetile = 1;
-    constexpr bool has_sharding = 0;  // TODO: remove this when sharding support is added
-    // constexpr bool has_sharding = get_compile_time_arg_val(src2_args.next_compile_time_args_offset()) == 1;
+    constexpr bool has_sharding = get_compile_time_arg_val(src1_args.next_compile_time_args_offset()) == 1;
     const uint32_t HtWt = Ht * Wt;
 
     const uint32_t tiles_per_n = C * HtWt;
@@ -108,28 +100,25 @@ void kernel_main() {
                     for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
                         for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
                              ++tw, ++num_tiles_read) {
-                            // #if !SRC_SHARDED_A
-                            // read a tile from src_a
+#if !SRC_SHARDED_A
                             cb_pred.reserve_back(onetile);
                             noc.async_read(
                                 s0, cb_pred, src0_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
-                            // #endif
-                            // #if !SRC_SHARDED_B
-                            // read a tile from src_b
+#endif
+#if !SRC_SHARDED_B
                             cb_b.reserve_back(onetile);
                             noc.async_read(
                                 s1, cb_b, src1_tile_bytes, {.page_id = tile_offset_b + tw}, {.offset_bytes = 0});
-                            // #endif
-
-                            // #if !SRC_SHARDED_A || !SRC_SHARDED_B
+#endif
+#if !SRC_SHARDED_A || !SRC_SHARDED_B
                             noc.async_read_barrier();
-                            // #endif
-                            // #if !SRC_SHARDED_A
+#endif
+#if !SRC_SHARDED_A
                             cb_pred.push_back(onetile);
-                            // #endif
-                            // #if !SRC_SHARDED_B
+#endif
+#if !SRC_SHARDED_B
                             cb_b.push_back(onetile);
-                            // #endif
+#endif
                         }
                         if constexpr (!has_sharding) {
                             // next row of tiles should start at the first column
@@ -150,5 +139,4 @@ void kernel_main() {
         tile_offset += next_nd_shift;
         tile_offset_b += next_nd_shift_b;
     }
-    // #endif
 }

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_scalar_bcast.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/kernels/dataflow/tst_tts_reader_scalar_bcast.cpp
@@ -47,17 +47,17 @@ void kernel_main() {
     CircularBuffer cb_pred(predicate_cb);
     CircularBuffer cb_b(src_b_cb);
 
-    // #if !SRC_SHARDED_A
+#if !SRC_SHARDED_A
     const uint32_t src_tile_bytes = cb_pred.get_tile_size();
     const auto src = TensorAccessor(src_args, src0_addr);
-    // #endif
-    // #if !SRC_SHARDED_B
+#endif
+#if !SRC_SHARDED_B
     const uint32_t src_tile_bytes_b = cb_b.get_tile_size();
     const auto src_b = TensorAccessor(src_b_args, src1_addr);
-    // #endif
+#endif
 
     constexpr uint32_t onetile = 1;
-    constexpr bool has_sharding = false;  // TODO: add sharding support
+    constexpr bool has_sharding = get_compile_time_arg_val(src_b_args.next_compile_time_args_offset()) == 1;
     const uint32_t HtWt = Ht * Wt;
 
     const uint32_t tiles_per_n = C * HtWt;

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -197,8 +197,15 @@ void setup_reader_defines(
     }
 
     // Set sharding defines after dataflow defines
+    // SRC_SHARDED_A always maps to CB0 (predicate)
+    // SRC_SHARDED_B maps to CB1: value_true for TTT/TTS, value_false for TST
+    // SRC_SHARDED_C maps to CB2: value_false for TTT (unused for TTS/TST)
     reader_defines["SRC_SHARDED_A"] = (predicate_sharded && has_sharding) ? "1" : "0";
-    reader_defines["SRC_SHARDED_B"] = (value_true_sharded && has_sharding) ? "1" : "0";
+    if (variant == TernaryVariant::TST) {
+        reader_defines["SRC_SHARDED_B"] = (value_false_sharded && has_sharding) ? "1" : "0";
+    } else {
+        reader_defines["SRC_SHARDED_B"] = (value_true_sharded && has_sharding) ? "1" : "0";
+    }
     reader_defines["SRC_SHARDED_C"] = (value_false_sharded && has_sharding) ? "1" : "0";
 }
 

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -200,6 +200,7 @@ void setup_reader_defines(
     // SRC_SHARDED_A always maps to CB0 (predicate)
     // SRC_SHARDED_B maps to CB1: value_true for TTT/TTS, value_false for TST
     // SRC_SHARDED_C maps to CB2: value_false for TTT (unused for TTS/TST)
+    // SRC_SHARDED_* is 0 for unequal shaped sharded inputs, since has_sharding and is_native_L1_sharding are both false
     reader_defines["SRC_SHARDED_A"] = (predicate_sharded && has_sharding) ? "1" : "0";
     if (variant == TernaryVariant::TST) {
         reader_defines["SRC_SHARDED_B"] = (value_false_sharded && has_sharding) ? "1" : "0";

--- a/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/ternary/device/ternary_program_factory.cpp
@@ -298,43 +298,42 @@ std::optional<AllShardSpecs> get_shard_specs(
     const std::optional<TensorSpec>& true_spec,
     const std::optional<TensorSpec>& false_spec,
     const TensorSpec& output_spec) {
-    // Only support TTT variant
-    if (!true_spec.has_value() || !false_spec.has_value()) {
-        return std::nullopt;
-    }
-
     bool predicate_sharded = predicate_spec.memory_config().is_sharded();
-    bool true_sharded = true_spec->memory_config().is_sharded();
-    bool false_sharded = false_spec->memory_config().is_sharded();
+    bool true_sharded = true_spec.has_value() && true_spec->memory_config().is_sharded();
+    bool false_sharded = false_spec.has_value() && false_spec->memory_config().is_sharded();
     bool output_sharded = output_spec.memory_config().is_sharded();
 
-    if ((!predicate_sharded && !true_sharded && !false_sharded) && !output_sharded) {
+    if (!predicate_sharded && !true_sharded && !false_sharded && !output_sharded) {
         return std::nullopt;
     }
 
-    // Check if output is unevenly sharded. If so, fall back to tensor accessor mode instead of direct
-    // L1 sharding to avoid kernel deadlocks when cores have different shard sizes.
     if (!is_native_L1_sharding(predicate_spec, true_spec, false_spec, output_spec.memory_config()) ||
         is_uneven(output_spec)) {
-        // treat as interleaved
         return std::nullopt;
     }
 
     const auto& predicate_shape = predicate_spec.padded_shape();
-    const auto& true_shape = true_spec->padded_shape();
-    const auto& false_shape = false_spec->padded_shape();
     const auto& output_shape = output_spec.padded_shape();
 
-    // Output must have a shard spec
     TT_FATAL(get_shard_spec(output_spec).has_value(), "Output must have a shard spec");
+    const auto& output_shard = *get_shard_spec(output_spec);
+
+    auto derive_shard_spec = [&](const std::optional<TensorSpec>& spec, bool sharded) -> tt::tt_metal::ShardSpec {
+        if (sharded) {
+            return *get_shard_spec(*spec);
+        }
+        if (spec.has_value()) {
+            return adjust_to_shape(output_shard, output_shape, spec->padded_shape());
+        }
+        return output_shard;
+    };
+
     return AllShardSpecs{
         predicate_sharded ? *get_shard_spec(predicate_spec)
-                          : adjust_to_shape(*get_shard_spec(output_spec), output_shape, predicate_shape),
-        true_sharded ? *get_shard_spec(*true_spec)
-                     : adjust_to_shape(*get_shard_spec(output_spec), output_shape, true_shape),
-        false_sharded ? *get_shard_spec(*false_spec)
-                      : adjust_to_shape(*get_shard_spec(output_spec), output_shape, false_shape),
-        *get_shard_spec(output_spec)};
+                          : adjust_to_shape(output_shard, output_shape, predicate_shape),
+        derive_shard_spec(true_spec, true_sharded),
+        derive_shard_spec(false_spec, false_sharded),
+        output_shard};
 }
 
 // ShardShapeGenerator class
@@ -1187,6 +1186,7 @@ tt::tt_metal::ProgramDescriptor TernaryDeviceOperation::TernaryProgramFactory::c
         tt::tt_metal::TensorAccessorArgs(
             *value_true_tensor.value().buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
             .append_to(reader_compile_time_args, reader_common_runtime_args);
+        reader_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
 
     } else if (variant == TernaryVariant::TST) {
         // TST: c_0 = predicate, c_1 = value_false tensor
@@ -1197,6 +1197,7 @@ tt::tt_metal::ProgramDescriptor TernaryDeviceOperation::TernaryProgramFactory::c
         tt::tt_metal::TensorAccessorArgs(
             *value_false_tensor.value().buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
             .append_to(reader_compile_time_args, reader_common_runtime_args);
+        reader_compile_time_args.push_back(static_cast<uint32_t>(has_sharding));
     } else if (variant == TernaryVariant::TTT) {
         reader_compile_time_args.push_back((std::uint32_t)predicate_tensor_cb);
         reader_compile_time_args.push_back((std::uint32_t)value_true_tensor_cb);


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title --> Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
#46134

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
- Enable sharding support for Ternary TTS and TST variants - used by `ttnn.lerp` op which has a TTS variant

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kalaivani/ternary_tts_tst)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kalaivani/ternary_tts_tst)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kalaivani/ternary_tts_tst)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kalaivani/ternary_tts_tst)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kalaivani/ternary_tts_tst)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kalaivani/ternary_tts_tst)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kalaivani/ternary_tts_tst)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kalaivani/ternary_tts_tst)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kalaivani/ternary_tts_tst)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kalaivani/ternary_tts_tst)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kalaivani/ternary_tts_tst)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kalaivani/ternary_tts_tst)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kalaivani/ternary_tts_tst)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kalaivani/ternary_tts_tst)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kalaivani/ternary_tts_tst)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kalaivani/ternary_tts_tst)