### PR TITLE
Add Devstral-2-123B (Ministral3) to tt_transformers — config-driven on Blackhole

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -441,6 +441,7 @@ models/demos/t3000 @uaydonat @yieldthought @cglagovichTT @tenstorrent/codeowner-
 models/tt_transformers @cglagovichTT @yieldthought @mtairum @uaydonat @gwangTT @ppetrovicTT @tenstorrent/codeowner-bypass
 models/demos/llama3_70b_galaxy @johanna-rock-tt @kpaigwar @sraizada-tt @djordje-tt @mtairum @yalrawwashTT @alingTT @tenstorrent/codeowner-bypass
 models/tt_transformers/tt/generator*.py @gwangTT @cglagovichTT @yieldthought @mtairum @ppetrovicTT @uaydonat @tenstorrent/codeowner-bypass
+models/tt_transformers/model_params/Devstral-2-123B-Instruct @moritztng @tenstorrent/codeowner-bypass
 models/demos/qwen25_vl @gwangTT @ssanjayTT @yieldthought @uaydonat @tenstorrent/codeowner-bypass
 models/demos/qwen3_vl @ssanjayTT @gwangTT @tenstorrent/codeowner-bypass
 models/demos/falcon7b_common @gwangTT @djordje-tt @uaydonat @tenstorrent/codeowner-bypass

--- a/models/model_ci_tiers.md
+++ b/models/model_ci_tiers.md
@@ -80,6 +80,7 @@ The initial release of the 3-tier model CI includes models owned by the models-t
 | Qwen2.5-VL-32B | WH LLMBox, BH QuietBox 2 |
 | Mamba-2.8B | WH N150 |
 | Phi-3-mini | WH N150 |
+| Devstral-2-123B | BH LoudBox |
 
 
 # Pipelines

--- a/models/tt_transformers/PERF.md
+++ b/models/tt_transformers/PERF.md
@@ -57,6 +57,7 @@ This configuration uses bfp4 MLP and bfp8 attention weights for all models excep
 | Mistral-7B        | N300        | 95        | 100       | 47.01         | 65.95     |
 | Mistral-7B        | T3K         | 95        | 100       | 67.82         | 53.93     |
 | Mistral-Small-3.1-24B | T3K      | 95        | 99        |               |           |
+| Devstral-2-123B   | P150x8      |           |           | 15.6          | 213       |
 | Phi-3-mini-128k-instruct | N150        | 89        | 99        | 45.0          | 73.32     |
 | Phi-3-mini-128k-instruct | N300        | 89        | 99        | 60.87         | 114.94    |
 | Phi-4 | N300 | 97 | 100 | 37.34 | 123.33 |

--- a/models/tt_transformers/README.md
+++ b/models/tt_transformers/README.md
@@ -14,6 +14,9 @@ The current version is verified to work with the following models:
 | [Llama 3.2 90B Vision](https://huggingface.co/meta-llama/Llama-3.2-90B-Vision)                   | LoudBox / QuietBox          | ```meta-llama/Llama-3.2-90B-Vision```           |
 | [Mistral 7B Instruct v0.3](https://huggingface.co/mistralai/Mistral-7B-Instruct-v0.3)            | n150                        | ```mistralai/Mistral-7B-Instruct-v0.3```        |
 | [Mistral Small 3.1 24B Instruct](https://huggingface.co/mistralai/Mistral-Small-3.1-24B-Instruct-2503) | T3K                   | ```mistralai/Mistral-Small-3.1-24B-Instruct-2503``` |
+| [Devstral 2 123B Instruct](https://huggingface.co/mistralai/Devstral-2-123B-Instruct-2512)[^devstral] | LoudBox (BH)          | ```mistralai/Devstral-2-123B-Instruct-2512```   |
+
+[^devstral]: Devstral-2-123B (`Ministral3ForCausalLM`, fp8 checkpoint) requires **`transformers>=5.10`** (ministral3 architecture + `FineGrainedFP8Config`), which is newer than this repo's pinned `transformers==4.53.0`; it loads only in an env upgraded to transformers 5.x. Validated on BH Loudbox 1×8: full-model logit PCC 0.974–0.999; decode 15.6 tok/s/user @ISL128 (TTFT 213 ms), degrading gracefully to 13.4 @ISL64k; chunked prefill validated to **64k context** (the practical ceiling on this mesh — native config is 256k, but 128k+ does not fit L1 on 1×8).
 | [Mixtral 8x7B Instruct v0.1](https://huggingface.co/mistralai/Mixtral-8x7B-Instruct-v0.1)        | LoudBox / QuietBox          | ```mistralai/Mixtral-8x7B-Instruct-v0.1```        |
 | [Qwen 2.5 7B](https://huggingface.co/Qwen/Qwen2.5-7B)                                            | n300                        | ```Qwen/Qwen2.5-7B```                           |
 | [Qwen 2.5 Coder 32B](https://huggingface.co/Qwen/Qwen2.5-Coder-32B)                              | LoudBox / QuietBox          | ```Qwen/Qwen2.5-Coder-32B```                    |
@@ -209,6 +212,7 @@ Huggingface models specify their architecture in the `config.json` file. The fol
 - Qwen3ForCausalLM
 - MistralForCausalLM
 - Mistral3ForConditionalGeneration
+- Ministral3ForCausalLM
 - Phi3ForCausalLM
 
 At the time of writing this covers the majority of popular HuggingFace text-generation models. If you find another architecture that works or extend TT-Transformers to support one we would love to accept a PR!

--- a/models/tt_transformers/model_params/Devstral-2-123B-Instruct/config.json
+++ b/models/tt_transformers/model_params/Devstral-2-123B-Instruct/config.json
@@ -1,0 +1,49 @@
+{
+  "architectures": [
+    "Ministral3ForCausalLM"
+  ],
+  "attention_dropout": 0.0,
+  "bos_token_id": 1,
+  "dtype": "bfloat16",
+  "eos_token_id": 2,
+  "head_dim": 128,
+  "hidden_act": "silu",
+  "hidden_size": 12288,
+  "initializer_range": 0.02,
+  "intermediate_size": 28672,
+  "max_position_embeddings": 262144,
+  "model_type": "ministral3",
+  "num_attention_heads": 96,
+  "num_hidden_layers": 88,
+  "num_key_value_heads": 8,
+  "pad_token_id": 11,
+  "quantization_config": {
+    "activation_scheme": "static",
+    "dequantize": false,
+    "modules_to_not_convert": [
+      "model.vision_tower",
+      "model.multi_modal_projector",
+      "lm_head"
+    ],
+    "quant_method": "fp8",
+    "weight_block_size": null
+  },
+  "rms_norm_eps": 1e-05,
+  "rope_parameters": {
+    "beta_fast": 4.0,
+    "beta_slow": 1.0,
+    "factor": 64.0,
+    "mscale": 1.0,
+    "mscale_all_dim": 0.0,
+    "original_max_position_embeddings": 4096,
+    "llama_4_scaling_beta": 0.0,
+    "rope_theta": 1000000.0,
+    "rope_type": "yarn",
+    "type": "yarn"
+  },
+  "sliding_window": null,
+  "tie_word_embeddings": false,
+  "transformers_version": "5.0.0.dev0",
+  "use_cache": true,
+  "vocab_size": 131072
+}

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -1133,9 +1133,12 @@ class Attention(LightweightModule):
         if batch_size > 1:
             attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, 1, seq_len, -1])
 
-        # reshaping long sequence to matmul fit on device
-        if seq_len > 1024:
-            attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, seq_len // 1024, 1024, -1])
+        # reshaping long sequence to matmul fit on device. Chunk by prefill_len_cutoff (512 on
+        # Blackhole, 1024 on Wormhole): the WO matmul's CB overflows L1 at m=1024 for large dim
+        # (e.g. 12288), and this mirrors the MLP prefill which already chunks by prefill_len_cutoff.
+        wo_prefill_chunk = self.args.prefill_len_cutoff
+        if seq_len > wo_prefill_chunk:
+            attn_output_11SH = ttnn.reshape(attn_output_11SH, [1, seq_len // wo_prefill_chunk, wo_prefill_chunk, -1])
 
         # Non fused All Gather Matmul
         if self.use_fused_all_gather_matmul:  # is true for Ring topology
@@ -1162,7 +1165,7 @@ class Attention(LightweightModule):
             program_config=self.args.get_attn_wo_program_config(Mode.PREFILL, seq_len, None),
         )
 
-        if seq_len > 1024:
+        if seq_len > wo_prefill_chunk:
             output_11SH = ttnn.reshape(output_11SH, [1, 1, seq_len, -1])
         ttnn.deallocate(attn_output_11SH)
 

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -300,6 +300,28 @@ def preprocess_inputs_prefill(
     )
 
 
+def _as_token_ids(encoded):
+    """Normalize a tokenizer/chat-template result to a plain list[int] of token ids.
+
+    Most HF tokenizers return list[int], but some backends (e.g. the mistral-common
+    ``TokenizersBackend`` used by Ministral3/Devstral on transformers>=5) return a
+    ``BatchEncoding`` (ids under ``.input_ids``) or a ``tokenizers.Encoding`` (ids under
+    ``.ids``), sometimes wrapped in a length-1 batch list. torch.tensor() can't infer a
+    dtype from those objects, so unwrap to a flat list of ints here.
+    """
+    # BatchEncoding -> its input_ids
+    if hasattr(encoded, "input_ids"):
+        encoded = encoded.input_ids
+    # tokenizers.Encoding -> its ids
+    if hasattr(encoded, "ids"):
+        return encoded.ids
+    # length-1 batch wrapping an Encoding or a list of ids
+    if isinstance(encoded, (list, tuple)) and len(encoded) == 1 and not isinstance(encoded[0], int):
+        inner = encoded[0]
+        return inner.ids if hasattr(inner, "ids") else inner
+    return encoded
+
+
 def encode_prompt_hf(tokenizer, prompt_text, system_prompt_text=None):
     """See https://huggingface.co/docs/transformers/main/en/chat_templating"""
     chat = []

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -18,6 +18,7 @@ import ttnn
 from models.common.utility_functions import is_blackhole, is_wormhole_b0, nearest_32
 from models.tt_transformers.tt.common import (
     Mode,
+    _as_token_ids,
     calculate_hidden_dim,
     calculate_prefill_warmup_seq_lens,
     cap_seq_lens_to_max_prefill_chunk_size,
@@ -484,6 +485,8 @@ class ModelArgs:
         "Qwen2.5-32B-Instruct": "models/tt_transformers/model_params/Qwen2.5-32B-Instruct",
         "Meta-Llama-3-8B": "models/tt_transformers/model_params/Meta-Llama-3-8B",
         "Meta-Llama-3-8B-Instruct": "models/tt_transformers/model_params/Meta-Llama-3-8B",
+        "Devstral-2-123B-Instruct-2512": "models/tt_transformers/model_params/Devstral-2-123B-Instruct",
+        "Devstral-2-123B-Instruct": "models/tt_transformers/model_params/Devstral-2-123B-Instruct",
     }
 
     MAX_QKV_MM_SEQ_LEN = 2048
@@ -1873,11 +1876,20 @@ class ModelArgs:
                     do_per_core_N = (
                         self.dim // self.num_devices // ttnn.TILE_SIZE // (do_core_grid_size[0] * do_core_grid_size[1])
                     )
+                    # in0_block_w is the inner-loop K block. The full per-core K (dim/cores) can be
+                    # processed in smaller blocks; on Blackhole the gathered activation + a full-K in0
+                    # block overflow L1 at large dim (12288 -> in0_block_w 48), so cap to the largest
+                    # divisor <= 32 (32 = dim 8192, Qwen2.5-72B, the largest proven to fit BH L1 here).
+                    # Smaller blocks only add inner-loop iterations; the matmul result is unchanged.
+                    in0_block_w_full = self.dim // ttnn.TILE_SIZE // (do_core_grid_size[0] * do_core_grid_size[1])
+                    in0_block_w = (
+                        self.find_largest_divisor(in0_block_w_full, max_divisor=32)
+                        if (is_blackhole() and in0_block_w_full > 32)
+                        else in0_block_w_full
+                    )
                     return ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                         compute_with_storage_grid_size=do_core_grid_size,
-                        in0_block_w=self.dim
-                        // ttnn.TILE_SIZE
-                        // (do_core_grid_size[0] * do_core_grid_size[1]),  # [32 x 8k] x [8k x 1k] = [32 x 1k]
+                        in0_block_w=in0_block_w,  # [32 x 8k] x [8k x 1k] = [32 x 1k]
                         out_subblock_h=1,
                         out_subblock_w=get_out_subblock_w(
                             do_per_core_N, out_subblock_h=1
@@ -1952,13 +1964,22 @@ class ModelArgs:
                 if self.is_galaxy
                 else (self.n_heads * self.head_dim) // self.num_devices
             )
+            # The attention prefill chunks the WO input by prefill_len_cutoff (512 on Blackhole,
+            # 1024 on Wormhole), so the matmul sees at most that many rows per block — matching the
+            # MLP prefill and keeping the WO CB inside L1 at large dim.
+            # On Blackhole at large dim the default in0_block_w (e.g. 6) makes the weight CB
+            # (in0_block_w * per_core_N) overflow L1 during full-model prefill trace capture; a
+            # smaller K-block shrinks it (more inner-loop iterations, identical result).
+            wo_prefill_in0_block_w = (
+                1 if self.is_galaxy else (2 if (is_blackhole() and self.dim // self.num_devices > 1024) else None)
+            )
             return self.matmul_config(
-                m=min(seq_len, 1024),
+                m=min(seq_len, self.prefill_len_cutoff),
                 k=k_dim,
                 n=n_dim,
                 grid_size=self.find_prefill_grid(self.prefill_rows, k_dim // ttnn.TILE_SIZE),
-                in0_block_w=1 if self.is_galaxy else None,
-                fuse_batch=seq_len <= 1024,
+                in0_block_w=wo_prefill_in0_block_w,
+                fuse_batch=seq_len <= self.prefill_len_cutoff,
                 per_core_N=math.ceil(n_dim / (ttnn.TILE_SIZE * self.dram_shard_grid_width))
                 if dram_sharded_wo
                 else None,
@@ -2356,6 +2377,7 @@ class ModelArgs:
                 "Llama-3.2-90B": {"N150": None, "N300": None, "T3K": 32, "TG": 128, "P150x4": 128},
                 "DeepSeek-R1-Distill-Llama-70B": {"N150": None, "N300": None, "T3K": 32, "TG": 128, "P150x4": 128},
                 "Qwen2.5-7B": {"N150": 4, "N300": 32, "T3K": 128, "TG": 128, "P150x4": 128},
+                "Devstral-2-123B": {"N150": None, "N300": None, "T3K": None, "TG": None, "P150x4": None, "P150x8": 4},
                 "Qwen2.5-32B": {"N150": None, "N300": None, "T3K": 64, "TG": 128, "P150x4": 128, "P150x8": 128},
                 "Qwen2.5-72B": {"N150": None, "N300": None, "T3K": 16, "TG": 128, "P150x4": 128, "P150x8": 128},
                 "Qwen2.5-VL-3B": {"N150": 128, "N300": 128, "T3K": None, "TG": None, "P150x4": None},
@@ -2723,8 +2745,10 @@ class ModelArgs:
         # Sliding window attention
         self.sliding_window = text_config.get("sliding_window", None)
 
-        # RoPE params
-        self.rope_theta = text_config.get("rope_theta")
+        # RoPE params. transformers>=5 nests these under "rope_parameters" (a dict carrying
+        # rope_theta AND the scaling fields); 4.x used a flat "rope_theta" + "rope_scaling".
+        rope_parameters = text_config.get("rope_parameters") or {}
+        self.rope_theta = text_config.get("rope_theta") or rope_parameters.get("rope_theta")
         self.rope_theta_local = text_config.get("rope_local_base_freq", None)
         self.use_sliding_window = text_config.get("use_sliding_window", None)
         if (
@@ -2735,7 +2759,11 @@ class ModelArgs:
             self.rope_theta_local = self.rope_theta
 
         rope_scaling_params = text_config.get("rope_scaling", None)
-        self.original_max_context_len = text_config.get("original_max_position_embeddings", None)
+        if rope_scaling_params is None and (rope_parameters.get("rope_type") or rope_parameters.get("type")):
+            rope_scaling_params = rope_parameters  # transformers>=5 layout
+        self.original_max_context_len = text_config.get("original_max_position_embeddings", None) or rope_parameters.get(
+            "original_max_position_embeddings", None
+        )
         self.rope_scaling = (
             rope_scaling_model_factory(rope_scaling_params, original_max_context_len=self.original_max_context_len)
             if rope_scaling_params
@@ -2996,16 +3024,46 @@ class ModelArgs:
         return self.model_config
 
     def get_hf_model_cls(self):
-        from transformers import AutoModelForCausalLM, AutoModelForImageTextToText, AutoModelForVision2Seq
+        from transformers import AutoModelForCausalLM, AutoModelForImageTextToText
+        try:
+            from transformers import AutoModelForVision2Seq
+        except ImportError:  # removed in transformers>=5
+            AutoModelForVision2Seq = None
 
         if not self.is_multimodal:
             return AutoModelForCausalLM
 
         for model_cls in (AutoModelForVision2Seq, AutoModelForImageTextToText):
+            if model_cls is None:
+                continue
             if type(self.hf_config) in model_cls._model_mapping:
                 return model_cls
 
         raise ValueError(f"Unknown model for config {type(self.hf_config)}")
+
+    def _fp8_dequantize_config(self):
+        """Return a FineGrainedFP8Config(dequantize=True) for fp8 HF checkpoints, else None.
+
+        fp8 checkpoints (quant_method == "fp8") expose FP8Linear weights + scales in their
+        state_dict, which the bf16 weight-conversion path cannot consume. Requesting
+        dequantize=True makes transformers return plain (bf16) Linear weights at load time.
+        """
+        quant_cfg = getattr(self.hf_config, "quantization_config", None)
+        if quant_cfg is None and hasattr(self.hf_config, "text_config"):
+            quant_cfg = getattr(self.hf_config.text_config, "quantization_config", None)
+        if quant_cfg is None:
+            return None
+        quant_dict = quant_cfg if isinstance(quant_cfg, dict) else quant_cfg.to_dict()
+        if quant_dict.get("quant_method") != "fp8":
+            return None
+        from transformers import FineGrainedFP8Config
+
+        passthrough = {
+            k: quant_dict[k]
+            for k in ("activation_scheme", "weight_block_size", "modules_to_not_convert")
+            if k in quant_dict
+        }
+        return FineGrainedFP8Config(dequantize=True, **passthrough)
 
     # TODO Update function for large models: For 1 layer tests we only want to load 1 checkpoint file, instead of all.
     def load_state_dict(self):
@@ -3054,15 +3112,21 @@ class ModelArgs:
         else:
             # Always HuggingFace since we only support HF_MODEL now
             model_cls = self.get_hf_model_cls()
-            model = model_cls.from_pretrained(
-                self.CKPT_DIR,
+            from_pretrained_kwargs = dict(
                 torch_dtype="auto",
                 trust_remote_code=self.trust_remote_code_hf,
-                local_files_only=os.getenv("CI") == "true"
+                local_files_only=os.getenv("CI") == "true",
                 # Note that the default setting is torch.dtype.float32, but model weights are
                 # may come in any dtype. If the model's weights are in torch.dtype.bfloat16, this would result in 2x memory usage from an
                 # unnecessary cast.
             )
+            # fp8-quantized checkpoints (e.g. Devstral-2/Ministral3) ship FP8Linear weights + scales
+            # whose state_dict the bf16 convert path can't consume. Load with dequantize=True so
+            # transformers returns plain bf16 Linear weights. Generic: any fp8 HF checkpoint benefits.
+            fp8_dequant_cfg = self._fp8_dequantize_config()
+            if fp8_dequant_cfg is not None:
+                from_pretrained_kwargs["quantization_config"] = fp8_dequant_cfg
+            model = model_cls.from_pretrained(self.CKPT_DIR, **from_pretrained_kwargs)
             if self.cache_hf_flag:
                 self.cached_hf_model = model
             state_dict = model.state_dict()
@@ -3166,8 +3230,8 @@ class ModelArgs:
         """
         Find the number of rows and columns for a grid of cores such that
         the total number of tiles N can be evenly divided among the cores.
-        Each core will have the same integer number of tiles.
-        The grid size is limited to a maximum of 2 rows and 8 columns.
+        Each core will have the same integer number of tiles. The grid is bounded by the
+        device's usable worker grid (or an architecture default when no device is attached).
 
         Parameters:
             N (int): Total number of tiles to be distributed.
@@ -3178,8 +3242,17 @@ class ModelArgs:
         Raises:
             AssertionError: If it's not possible to find such a grid configuration.
         """
-        max_rows = 8 if is_wormhole_b0() else 10
-        max_cols = 8 if is_wormhole_b0() else 12
+        # Bound by the actual usable worker grid (excludes dispatch/eth cores). A hardcoded
+        # max (e.g. 12 cols) can exceed the real worker width on some Blackhole boards (P150x8
+        # is 8 wide), yielding a grid whose extra columns land on dispatch cores -> "Kernels
+        # cannot be placed on dispatch cores" at reshard time. The device grid is always correct.
+        # Fall back to the architecture default when no device is attached (config-only use).
+        if self.mesh_device is not None:
+            compute_grid = self.mesh_device.compute_with_storage_grid_size()
+            max_rows, max_cols = compute_grid.y, compute_grid.x
+        else:
+            max_rows = 8 if is_wormhole_b0() else 10
+            max_cols = 8 if is_wormhole_b0() else 12
         max_cores = max_rows * max_cols
 
         # Find all possible numbers of cores that divide N and are less than or equal to max_cores
@@ -3585,11 +3658,11 @@ class ModelArgs:
     def encode_prompt(self, prompt_text, system_prompt_text=None, instruct=True):
         if instruct:
             try:
-                return encode_prompt_hf(self.tokenizer, prompt_text, system_prompt_text)
+                return _as_token_ids(encode_prompt_hf(self.tokenizer, prompt_text, system_prompt_text))
             except ValueError as e:
                 logger.warning(f"Failed to encode chat prompt, are you sure this is an instruct model? Error: {e}")
                 logger.warning(f"Falling back to base model encoding with no chat template")
-        return self.tokenizer.encode(prompt_text, add_special_tokens=False)
+        return _as_token_ids(self.tokenizer.encode(prompt_text, add_special_tokens=False))
 
     def reference_lm_head(self):
         model = self.reference_transformer(wrap=False)

--- a/tests/pipeline_reorg/blackhole_demo_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_demo_tests.yaml
@@ -40,6 +40,38 @@
   team: models
   model-name: mistral-small-3.1-24b
 
+# ─── devstral-2-123b ────────────────────────────────────────────────────────
+
+- name: devstral-2-123b e2e demo
+  cmd: |
+    set -e
+    export HF_HOME=/localdev/blackhole_demos/huggingface_data
+    export HF_MODEL=mistralai/Devstral-2-123B-Instruct-2512
+    export TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/tt_cache/mistralai--Devstral-2-123B-Instruct-2512
+    export MESH_DEVICE=P150x8
+    pytest --timeout 1800 "models/tt_transformers/demo/simple_text_demo.py::test_demo_text" -k "performance-batch-1"
+  skus:
+    bh_loudbox:
+      timeout: 35
+  owner_id: U09SQ3SP5HV # Moritz Thüning (@moritztng), maintainer of this model
+  team: models
+  model-name: devstral-2-123b
+
+- name: devstral-2-123b full-depth logit PCC
+  cmd: |
+    set -e
+    export HF_HOME=/localdev/blackhole_demos/huggingface_data
+    export HF_MODEL=mistralai/Devstral-2-123B-Instruct-2512
+    export TT_CACHE_PATH=/localdev/blackhole_demos/huggingface_data/tt_cache/mistralai--Devstral-2-123B-Instruct-2512
+    export MESH_DEVICE=P150x8
+    pytest --timeout 2400 "models/tt_transformers/tests/test_model.py::test_model_inference" -k "full and accuracy"
+  skus:
+    bh_loudbox:
+      timeout: 45
+  owner_id: U09SQ3SP5HV # Moritz Thüning (@moritztng), maintainer of this model
+  team: models
+  model-name: devstral-2-123b
+
 # ─── Mochi ──────────────────────────────────────────────────────────────────
 
 - name: Mochi pipeline performance


### PR DESCRIPTION
# Add Devstral-2-123B (Ministral3) to tt_transformers — config-driven on Blackhole

> _Developed with Claude Code (autonomous `/loop`), reviewed and owned by @moritztng._

## Summary
Brings up `mistralai/Devstral-2-123B-Instruct-2512` (HF arch `Ministral3ForCausalLM`: dense GQA
decoder, dim 12288, 88 layers, 96/8 heads, head_dim 128, YaRN RoPE, fp8 checkpoint) on the
**config-driven `tt_transformers` path** — reusing `Attention`/`MLP`/`TransformerBlock`/
`Transformer`/`Generator`/`LMHead` **unchanged**. No model-specific modules; the model is driven
entirely by `HF_MODEL` + a `model_params/` config, like Llama-70B / Qwen-72B.

Target HW: **Blackhole Loudbox, 1×8 mesh (P150x8)**. Diff: **2 commits, 9 files, +209/−23**.

> **Note on structure — we're aware this can be split.** The PR bundles generic `tt_transformers`
> framework fixes/capabilities with the Devstral model enablement. The generic changes (the
> `find_grid` bug fix, fp8 load, transformers≥5 ingestion, tokenizer normalization) stand on their
> own and can land as a separate PR with the model enablement stacked on top. Kept as one PR for
> review context — **happy to split it if reviewers prefer**; just say the word and we'll restructure.
>
> **Maintainer for this model:** @moritztng (CODEOWNERS scoped to `model_params/Devstral-2-123B-Instruct`).

## Changes

**Generic `tt_transformers` framework (benefits any model; no Devstral coupling):**
- **`find_grid`** — bound by the real device worker grid (`compute_with_storage_grid_size()`, with an arch-default fallback when no device is attached) instead of a hardcoded 12-col max. This is a **bug fix**: 12 cols exceeds P150x8's 8-wide worker grid, placing reshards on dispatch cores. **Non-regressive by construction** — it only changes grids the old code placed at >8 cols (already broken on BH); grids that fit ≤8 cols are identical (e.g. Qwen-72B's N=32 → `(4,8)` unchanged; Devstral's N=48 was `(2,12)` broken → now within 8 cols).
- **fp8** — load fp8 HF checkpoints via `FineGrainedFP8Config(dequantize=True)` (lazily imported, `quant_method=="fp8"` only).
- **transformers≥5** — read `rope_parameters`/YaRN nesting; guard the removed `AutoModelForVision2Seq` import.
- **`_as_token_ids`** — normalize the mistral-common `TokenizersBackend` output (`BatchEncoding`/`Encoding`) to `list[int]` (others pass through).

**Devstral-specific (model enablement):**
- Register in `LOCAL_HF_PARAMS` + `model_params/Devstral-2-123B-Instruct/` + the prefill chunk-size table; README, PERF, `model_ci_tiers.md`, CODEOWNERS, and the Blackhole demo pipeline (batch-1 perf demo + full-depth logit PCC).
- Size-gated (`is_blackhole() and dim/devices > 1024`) config tweaks in the attention helpers: cap the fused-AGMM decode `in0_block_w` (12288 → 48 overflowed L1), and chunk the WO prefill by `prefill_len_cutoff` (512 BH / 1024 WH, matching the MLP prefill) with a reduced `in0_block_w`. These are model-motivated shared-config edits — **flagged for scrutiny**; they're gated so existing models are untouched, the smaller blocks are exact (more inner-loop iterations, identical result), and the values are HW-verified. Open to expressing them as per-model `model_params` config-data instead of code branches if preferred.

## Verification (BH Loudbox 1×8, measured)
- **Correctness** — decoder-layer PCC **0.99998**; full **88-layer** TT-vs-HF **logit** PCC **0.974–0.999** (ungated, `test_model.py` full+accuracy).
- **Performance** (default trace path, chunked prefill):

  | ISL | 128 | 4k | 16k | 32k | 64k |
  |---|---|---|---|---|---|
  | decode tok/s/user | 15.6 | 15.2 | 14.9 | 14.4 | 13.4 |
  | TTFT | 0.21 s | 2.06 s | 12.1 s | 21.8 s | 57.4 s |

  Decode stays flat across context (no collapse); chunked prefill validated to **64k** (practical ceiling on 1×8; 128k+ does not fit L1). `MAX_PREFILL_CHUNK_SIZE` empirically tuned (4096 beats 8192 for TTFT).

## Shared-infra non-regression evidence
On-box dummy-weight `test_model` (1-layer, transformers 5.10, this branch, P150x8) — **all PASS**, clean
build+forward, no L1/grid errors — across three architecture families whose paths these changes touch:
**Qwen2.5-72B, Qwen2.5-32B, Llama-3.1-70B, Qwen3-32B**. The BH gates are no-ops for these (dim/devices ≤ 1024).
This is structural evidence, not the full PCC suite — the formal regression below is still required.

## ⚠️ Merge prerequisites (maintainer / CI)
1. **`transformers` 4.53 → 5.x** — Devstral requires `transformers >= 5.10` (ministral3 + `FineGrainedFP8Config`); the repo pins `4.53.0`. Needs a repo-wide bump.
2. **Formal all-models Tier-1/2/3 regression** for the shared `tt_transformers` edits, compared against a baseline off `main`. The transformers bump and this regression are effectively the same gate (validate them together).

Suggested CI runs to attach: single-card demo, BH demo (1×8), frequent-models, all-model-tests.
