### PR TITLE
[skip ci] Skip Mochi transformer tests on Wormhole due to fabric sync timeout

### DIFF
--- a/models/tt_dit/tests/models/mochi/test_transformer_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_transformer_mochi.py
@@ -11,6 +11,7 @@ from diffusers import MochiTransformer3DModel as TorchMochiTransformer3DModel
 from loguru import logger
 
 import ttnn
+from models.common.utility_functions import skip_for_wormhole_b0
 from models.tt_transformers.tt.common import get_rot_transformation_mat
 
 from ....models.transformers.transformer_mochi import MochiTransformer3DModel, MochiTransformerBlock


### PR DESCRIPTION
Temporarily skip test_mochi_transformer_block and test_mochi_transformer_model on Wormhole hardware due to fabric router sync timeout errors. The tests are failing with ethernet handshake failures during fabric firmware initialization. This affects the 4x8sp0tp1 and 4x8sp1tp0 configurations specifically on Galaxy hardware.