### PR TITLE
Convert to vFloat before storing as SrcB format

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -17,7 +17,8 @@ inline void cast_fp32_to_fp16a() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        x = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        sfpi::dst_reg[0] = x;
         dst_reg++;
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -17,7 +17,8 @@ inline void cast_fp32_to_fp16a() {
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        x = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        sfpi::dst_reg[0] = x;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -20,7 +20,8 @@ inline void _cast_fp32_to_fp16a_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        x                = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        sfpi::dst_reg[0] = x;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -180,7 +180,8 @@ sfpi_inline void _calculate_stochastic_round_()
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
+        x                = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
+        sfpi::dst_reg[0] = x;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_cast_fp32_to_fp16a.h
@@ -19,7 +19,8 @@ inline void _cast_fp32_to_fp16a_(const int iterations)
     for (int d = 0; d < iterations; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        x                = sfpi::convert<sfpi::vFloat16a>(x, sfpi::RoundMode::NearestEven);
+        sfpi::dst_reg[0] = x;
         sfpi::dst_reg++;
     }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_rounding_ops.h
@@ -188,7 +188,8 @@ sfpi_inline void _calculate_stochastic_round_()
     for (int d = 0; d < ITERATIONS; d++)
     {
         sfpi::vFloat x   = sfpi::dst_reg[0];
-        sfpi::dst_reg[0] = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
+        x                = sfpi::convert<sfpi::vFloat16b>(x, sfpi::RoundMode::Stochastic);
+        sfpi::dst_reg[0] = x;
         sfpi::dst_reg++;
     }
 }


### PR DESCRIPTION
### PR Category
Bug Fix

### Summary
vFloat16a/b are loaded using the fp16a/b MOD0 value, but stored using the SrcB mod value.  That's inconsistent and should be fixed.

These direct stores of `convert<vFloat16b>` results need to store as vFloat to continue using the SrcB-specified format.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/layout-46513)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/layout-46513)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/layout-46513)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/layout-46513)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/layout-46513)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/layout-46513)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/layout-46513)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/layout-46513)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/layout-46513)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/layout-46513)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/layout-46513)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/layout-46513)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/layout-46513)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/layout-46513)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/layout-46513)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/layout-46513)