### PR TITLE
[LTX] Fix VAE decode L1 OOM on un-swept meshes (BH QB 2x2)

### DIFF
--- a/models/tt_dit/tests/models/ltx/test_ltx_dit_vae_bh_qb.py
+++ b/models/tt_dit/tests/models/ltx/test_ltx_dit_vae_bh_qb.py
@@ -1,0 +1,42 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+"""BH QB (4-chip 2x2) smoke test: load real 22B LTX weights via FSDP and run the
+full DiT denoise + VAE decode using dummy (zero) prompt embeddings. Bypasses the
+gated Gemma text encoder (gemma_path=None) so it needs only the LTX checkpoint."""
+import os
+
+import pytest
+
+import ttnn
+from models.tt_dit.pipelines.ltx.pipeline_ltx import LTXPipeline
+from models.tt_dit.utils.test import line_params
+
+
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
+    [[(2, 2), (2, 2), 0, 1, 2, False, line_params, ttnn.Topology.Linear, True]],
+    ids=["2x2sp0tp1"],
+    indirect=["mesh_device", "device_params"],
+)
+def test_ltx_dit_vae_warmup(mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, topology, is_fsdp):
+    sub = mesh_device.create_submesh(ttnn.MeshShape(*mesh_shape))
+    ckpt = os.environ.get("LTX_CHECKPOINT", "Lightricks/LTX-2.3:ltx-2.3-22b-dev.safetensors")
+    nf = int(os.environ.get("NUM_FRAMES", "25"))
+    h = int(os.environ.get("HEIGHT", "256"))
+    w = int(os.environ.get("WIDTH", "256"))
+    LTXPipeline.create_pipeline(
+        mesh_device=sub,
+        checkpoint_name=ckpt,
+        gemma_path=None,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+        dynamic_load=dynamic_load,
+        is_fsdp=is_fsdp,
+        topology=topology,
+        num_frames=nf,
+        height=h,
+        width=w,
+        run_warmup=True,
+    )
+    print("DIT+VAE WARMUP OK", flush=True)

--- a/models/tt_dit/tests/models/ltx/test_vae_ltx.py
+++ b/models/tt_dit/tests/models/ltx/test_vae_ltx.py
@@ -752,3 +752,32 @@ def test_ltx_video_decoder_2k(
     generic blockings — correct, but not yet perf-tuned. See conv3d.py.
     """
     _run_ltx_decoder_parity(mesh_device, h_axis, w_axis, num_links, num_frames, height, width, mean=mean, std=std)
+
+
+@pytest.mark.parametrize("num_frames, height, width", [(25, 256, 256)], ids=["25f_256x256"])
+@pytest.mark.parametrize(
+    "mesh_device, h_axis, w_axis, num_links",
+    [((2, 2), 1, 0, 2)],
+    ids=["2x2_h1_w0"],
+    indirect=["mesh_device"],
+)
+@pytest.mark.parametrize("device_params", _LTX_VAE_FABRIC_DEVICE_PARAMS, indirect=True)
+def test_ltx_video_decoder_qb_2x2(
+    mesh_device: ttnn.MeshDevice,
+    num_frames: int,
+    height: int,
+    width: int,
+    h_axis: int,
+    w_axis: int,
+    num_links: int,
+):
+    """Full LTXVideoDecoder on a BH QB 2x2 (4-chip) mesh — h_factor=w_factor=2.
+
+    The 2x2 mesh has no exact ``_BLOCKINGS`` sweep, so every decoder conv3d takes
+    the channel-keyed ``_DEFAULT_BLOCKINGS`` fallback. Regression guard for the
+    square-channel res convs ((1024,1024)/(512,512)/(256,256)/(128,1024)): without
+    a fallback entry they hit the hardcoded full-C_in default, whose vol2col/weight
+    CBs grow to ~3.7 MB and overflow the 1.5 MB L1 (see conv3d.py). Mesh axes match
+    the pipeline mapping (height on tp_axis=1, width on sp_axis=0).
+    """
+    _run_ltx_decoder_parity(mesh_device, h_axis, w_axis, num_links, num_frames, height, width)

--- a/models/tt_dit/utils/conv3d.py
+++ b/models/tt_dit/utils/conv3d.py
@@ -467,7 +467,16 @@ _DEFAULT_BLOCKINGS = {
     # LTX-2.3 22B VAE decoder + latent upsampler conservative fallbacks. These
     # channel combos all have swept exact _BLOCKINGS entries for 2x4/4x8 1080p;
     # they remain here as the cross-mesh/cross-resolution fallback (the hardcoded
-    # full-Cin default OOMs at these widths).
+    # full-Cin default OOMs at these widths). This set covers every (in,out) the
+    # decoder builds, so meshes without an exact _BLOCKINGS sweep (e.g. BH QB 2x2,
+    # h_factor=w_factor=2) still fit L1. C_in_block=128 keeps the two big conv3d
+    # CBs (vol2col_tiled + weight_tiled, each ~ matmul_K_t*tile = kernel_vol*C_in_block/32*tile)
+    # to ~221 KB apiece; the hardcoded full-Cin default makes the 1024-wide res
+    # conv's CBs ~1.77 MB each (3.7 MB total > 1.5 MB L1).
+    (128, 1024, (3, 3, 3)): (128, 32, 1, 4, 4),  # conv_in
+    (1024, 1024, (3, 3, 3)): (128, 32, 1, 4, 4),  # s0_res
+    (512, 512, (3, 3, 3)): (128, 32, 1, 4, 4),  # s1_res / s2_res
+    (256, 256, (3, 3, 3)): (128, 32, 1, 4, 4),  # s3_res
     (1024, 4096, (3, 3, 3)): (256, 32, 1, 1, 1),  # s0_up
     (512, 4096, (3, 3, 3)): (256, 32, 1, 1, 1),  # s1_up
     (256, 512, (3, 3, 3)): (256, 32, 1, 4, 4),  # s3_chg


### PR DESCRIPTION
## Problem

The LTX-2.3 22B VAE decoder OOMs L1 during `ttnn.experimental.conv3d` on any mesh **without an exact `_BLOCKINGS` sweep** — notably the BH QB 4-chip **2x2** mesh (`h_factor=w_factor=2`). Four square-channel res convs the decoder builds — `(1024,1024)`, `(512,512)`, `(256,256)`, `(128,1024)` (all `(3,3,3)`) — had no `_DEFAULT_BLOCKINGS` channel fallback, so they fell to the hardcoded `(in_channels, 32, 1, 1, 1)` default.

conv3d CB footprint is driven by `C_in_block`, **not** by spatial dims: with the full `C_in_block` the `vol2col_tiled` + `weight_tiled` CBs each grow to `ceil(kernel_vol*C_in_block/32)*tile`. For `1024->1024` that's `matmul_K_t=864` → ~1.77 MB each → ~3.7 MB total, over the 1.5 MB L1:

```
TT_THROW: Statically allocated circular buffers grow to 3711744 B which is beyond max L1 size of 1572864 B
```

This is **mesh-size independent** — more chips don't help, because spatial parallelism doesn't shrink these CBs.

## Fix

Add the four missing channel-keyed fallbacks to `_DEFAULT_BLOCKINGS` with `C_in_block=128` (each big CB ~221 KB, ~600 KB peak). Fallback-only change: production **2x4 / 4x8** meshes still hit their perf-tuned exact `_BLOCKINGS`, so no perf regression; the affected combos previously OOM'd via the hardcoded default at any resolution.

## Verification (bh-qbge-06, 4x Blackhole p300c)

- **Full pipeline warmup** (22B FSDP + DiT denoise + VAE decode), 2x2 @ 256x256/25f → `DIT+VAE WARMUP OK`
- **Decoder parity** 2x2 @ 256x256/25f → PCC 99.96%
- **1x1 resnet-block unit tests** for the same channel combos → PCC 99.999%

Adds `test_ltx_video_decoder_qb_2x2` (fast, checkpoint-free) as a regression guard, plus the end-to-end `test_ltx_dit_vae_bh_qb` pipeline warmup test.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ltx-bh-qb-vae-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ltx-bh-qb-vae-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ltx-bh-qb-vae-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ltx-bh-qb-vae-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ltx-bh-qb-vae-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ltx-bh-qb-vae-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ltx-bh-qb-vae-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ltx-bh-qb-vae-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ltx-bh-qb-vae-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ltx-bh-qb-vae-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ltx-bh-qb-vae-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ltx-bh-qb-vae-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ltx-bh-qb-vae-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ltx-bh-qb-vae-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ltx-bh-qb-vae-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ltx-bh-qb-vae-fix)