### PR TITLE
[LLK][Quasar] Match SFPU sfpmem enum to ISA, fix UINT8 mislabel

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
+++ b/tt_metal/tt-llk/tests/python_tests/quasar/test_sfpu_fill_quasar.py
@@ -104,14 +104,13 @@ SFPU_FILL_FLOAT_FORMATS = [
     for out_fmt in _FILL_FLOAT_OUTPUTS
 ]
 
-# Fill int path: _calculate_fill_int_ with p_sfpu::sfpmem::INT32/UINT16/UINT8.
+# Fill int path: _calculate_fill_int_ with p_sfpu::sfpmem::INT32/UINT16/INT8.
 # Quasar integer formats and their SFPMEM store modes:
-#   Int32  → sfpmem::INT32  (32-bit sign-magnitude)
-#   Int16  → sfpmem::UINT16 (INT16 = Quasar hardware code 9, maps to SFPMEM::UINT16)
-#   Int8   → sfpmem::UINT8  (8-bit)
-#   UInt8  → sfpmem::UINT8  (8-bit unsigned)
-# Note: UInt16 (Quasar code 130) is invalid on Quasar; Int16 (code 9) is the correct
-# 16-bit integer format. FILL_INT_FORMAT bakes the format into each compiled variant.
+#   Int32        → sfpmem::INT32  (32-bit sign-magnitude)
+#   Int16        → sfpmem::UINT16 (16-bit truncate)
+#   Int8 / UInt8 → sfpmem::INT8   (0b0101, sign-magnitude 8-bit; true UINT8 0b1011 is unvalidated
+#                  on the emulator — see ckernel_sfpu_fill.h)
+# FILL_INT_FORMAT bakes the format into each compiled variant.
 SFPU_FILL_INT_FORMATS = input_output_formats(
     [DataFormat.Int32, DataFormat.Int16, DataFormat.Int8, DataFormat.UInt8],
     same=True,

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_instr_params.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/ckernel_instr_params.h
@@ -336,15 +336,25 @@ struct p_sfpu
 
     struct sfpmem
     {
+        // SFPLOAD/SFPSTORE InstrMod format-select codes (Tensix SFPU ISA, SFPLOAD/SFPSTORE table).
+        // Signed integers are sign-magnitude in HW; the ISA names them SMAG<N> — this enum uses
+        // INT<N> (INT32 = ISA SMAG32, INT16 = SMAG16, INT8 = SMAG8).
         constexpr static std::uint32_t DEFAULT =
             0b0000; // format is determined by combination of SrcB exponent width of ALU_FORMAT_SPEC_REG and also ACC_CTRL_SFPU_Fp32
-        constexpr static std::uint32_t FP16A  = 0b0001; // stored data will be interpreted as fp16 (fp16_a) format
-        constexpr static std::uint32_t FP16B  = 0b0010; // stored data will be interpreted as bfloat (fp16_b) format
-        constexpr static std::uint32_t FP32   = 0b0011; // stored data will be interpreted as fp32 format
-        constexpr static std::uint32_t INT32  = 0b0100; // stored data will be interpreted as int32 (sign + magnitude) format
-        constexpr static std::uint32_t UINT8  = 0b0101; // stored data will be interpreted as unsigned int8 format
-        constexpr static std::uint32_t UINT16 = 0b0110; // stored data will be interpreted as unsigned int16 format
-                                                        // TODO - Luka: add the other formats
+        constexpr static std::uint32_t FP16A      = 0b0001; // fp16 (fp16_a)
+        constexpr static std::uint32_t FP16B      = 0b0010; // bfloat (fp16_b)
+        constexpr static std::uint32_t FP32       = 0b0011; // fp32 (MOD_FP32 in the register file)
+        constexpr static std::uint32_t INT32      = 0b0100; // signed int32, sign-magnitude (ISA SMAG32)
+        constexpr static std::uint32_t INT8       = 0b0101; // signed int8, sign-magnitude (ISA SMAG8)
+        constexpr static std::uint32_t UINT16     = 0b0110; // unsigned int16
+        constexpr static std::uint32_t HI16       = 0b0111; // half-word access, value in the upper 16 bits
+        constexpr static std::uint32_t INT16      = 0b1000; // signed int16, sign-magnitude (ISA SMAG16)
+        constexpr static std::uint32_t LO16       = 0b1001; // half-word access, value in the lower 16 bits
+        constexpr static std::uint32_t STACK_MODE = 0b1010; // SMAG32 via the SFPU stack pointer
+        constexpr static std::uint32_t UINT8      = 0b1011; // unsigned int8
+        constexpr static std::uint32_t LO16_ONLY  = 0b1110; // write only LREG[15:0], preserve the MSBs
+        constexpr static std::uint32_t HI16_ONLY  = 0b1111; // write only LREG[31:16], preserve the LSBs
+        // 0b1100 / 0b1101 are reserved in the ISA.
     };
 
     struct mad_mode

--- a/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_fill.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/common/inc/experimental/ckernel_sfpu_fill.h
@@ -41,9 +41,11 @@ inline void _calculate_fill_(const float value)
 
 // Broadcast an integer constant to all elements of Dest using an explicit SFPMEM store mode.
 // FMT → sfpmem mode:
-//   Int32        → sfpmem::INT32  (32-bit sign-magnitude, loads both halves)
-//   Int16        → sfpmem::UINT16 (16-bit; INT16 = Quasar hw code 9)
-//   Int8 / UInt8 → sfpmem::UINT8  (8-bit)
+//   Int32        → sfpmem::INT32  (32-bit sign-magnitude)
+//   Int16        → sfpmem::UINT16 (16-bit truncate)
+//   Int8 / UInt8 → sfpmem::INT8   (0b0101, sign-magnitude 8-bit). The ISA-correct unsigned-8 mode
+//                  is sfpmem::UINT8 (0b1011), but it is unproven on the emulator (cf. the UINT16
+//                  datapath bug), so the established INT8/0b0101 path is kept for both.
 // Note: Always use SFPLOADI_MOD0_LOWER to place the value at LReg bits [15:0].
 // SFPLOADI_MOD0_USHORT (mode 2) shifts the value 10 bits left inside the LReg,
 // causing for example SFPMEM::UINT16 reading [15:0] to produce value<<10 instead of value.
@@ -56,7 +58,7 @@ inline void _calculate_fill_int_(const std::uint32_t value)
 
     constexpr std::uint32_t SFPMEM_MODE = (FMT == DataFormat::Int32)   ? p_sfpu::sfpmem::INT32
                                           : (FMT == DataFormat::Int16) ? p_sfpu::sfpmem::UINT16
-                                                                       : p_sfpu::sfpmem::UINT8;
+                                                                       : p_sfpu::sfpmem::INT8;
 
     if constexpr (FMT == DataFormat::Int32)
     {

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_sfpu_common.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_eltwise_sfpu_common.h
@@ -195,7 +195,10 @@ inline constexpr std::uint32_t _sfpu_sfpmem_type_()
     }
     else if constexpr (FMT == DataFormat::UInt8)
     {
-        return ckernel::p_sfpu::sfpmem::UINT8;
+        // INT8 (0b0101) preserves the previously-validated behavior. The ISA-correct unsigned-8
+        // mode is sfpmem::UINT8 (0b1011), but it is unproven on the emulator (cf. the UINT16
+        // datapath bug) — switch once validated.
+        return ckernel::p_sfpu::sfpmem::INT8;
     }
     else if constexpr (FMT == DataFormat::UInt16)
     {
@@ -233,7 +236,8 @@ inline std::uint32_t _sfpu_sfpmem_type_(DataFormat fmt)
         case DataFormat::Int32:
             return ckernel::p_sfpu::sfpmem::INT32;
         case DataFormat::UInt8:
-            return ckernel::p_sfpu::sfpmem::UINT8;
+            return ckernel::p_sfpu::sfpmem::INT8; // see template overload: INT8 (0b0101) preserves
+                                                  // behavior; true UINT8 (0b1011) unvalidated on emulator
         case DataFormat::UInt16:
             return ckernel::p_sfpu::sfpmem::UINT16;
         default:


### PR DESCRIPTION
- [x] All SFPU tests passed emulation

## What

Complete the Quasar `p_sfpu::sfpmem` enum so it matches the Tensix SFPU ISA `SFPLOAD`/`SFPSTORE` `instr_mod0` format-select table, and fix a latent encoding bug.

## The bug

The enum entry named `UINT8` was `0b0101`. Per the ISA `SFPLOAD`/`SFPSTORE` table (and `assembly.yaml`), `0b0101` is **signed INT8 (SMAG8)** — the true `UINT8` code is `0b1011`. So every unsigned-8 SFPU store/load issued through `sfpmem::UINT8` was actually using the signed sign-magnitude 8-bit mode, silently dropping bit 7 (`value & 0x7F`) for unsigned values ≥ 128.

## Changes

- Rename the `0b0101` entry to `INT8` (ISA `SMAG8`) and add the true `UINT8 = 0b1011`.
- Add the remaining ISA codes that were missing: `HI16` (`0b0111`), `INT16` (`0b1000`, ISA `SMAG16`), `LO16` (`0b1001`), `STACK_MODE` (`0b1010`), `LO16_ONLY` (`0b1110`), `HI16_ONLY` (`0b1111`). The enum now covers all 13 named codes (`0b1100`/`0b1101` are ISA-reserved).
- Document the `INT<N>` ↔ ISA `SMAG<N>` naming (signed integers are sign-magnitude in HW).
- Repoint the existing `UInt8` callers — `_sfpu_sfpmem_type_` (compile-time template + runtime switch) and `ckernel_sfpu_fill.h` — from `sfpmem::UINT8` to `sfpmem::INT8`. This is **byte-identical** to the previous `0b0101`, so there is **no behavior change**; it only fixes the label. Flipping these to the ISA-correct `UINT8` (`0b1011`) is intentionally deferred until validated on the Quasar emulator.

## Risk

Behavior-preserving: the only enum value that changed (`UINT8`: `0b0101` → `0b1011`) has no remaining code referencing it — all prior `sfpmem::UINT8` uses now point at `INT8` (the same `0b0101` bits). The other additions are new, unused enum constants. No emitted SFPU instruction changes.

## Source

Tensix SFPU ISA — `SFPLOAD`/`SFPSTORE` `instr_mod0` format-select table; cross-checked against `tt_llk_quasar/instructions/assembly.yaml` (`description` block).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=njokovic/qsr-sfpmem-enum-isa)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:njokovic/qsr-sfpmem-enum-isa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=njokovic/qsr-sfpmem-enum-isa)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:njokovic/qsr-sfpmem-enum-isa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=njokovic/qsr-sfpmem-enum-isa)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:njokovic/qsr-sfpmem-enum-isa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njokovic/qsr-sfpmem-enum-isa)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:njokovic/qsr-sfpmem-enum-isa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=njokovic/qsr-sfpmem-enum-isa)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:njokovic/qsr-sfpmem-enum-isa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njokovic/qsr-sfpmem-enum-isa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njokovic/qsr-sfpmem-enum-isa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=njokovic/qsr-sfpmem-enum-isa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:njokovic/qsr-sfpmem-enum-isa)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=njokovic/qsr-sfpmem-enum-isa)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:njokovic/qsr-sfpmem-enum-isa)