### PR TITLE
Replace Parallel(q_norm, kv_norm) with sequential ttnn.rms_norm in DeepSeek MLA decode

### DIFF
--- a/models/demos/deepseek_v3/tt/mla/mla1d.py
+++ b/models/demos/deepseek_v3/tt/mla/mla1d.py
@@ -11,7 +11,6 @@ import torch
 from loguru import logger
 from transformers.configuration_utils import PretrainedConfig
 
-import models.experimental.ops.descriptors as descriptors
 import ttnn
 from models.common.utility_functions import nearest_y
 from models.demos.deepseek_v3.tt.ccl import CCL
@@ -49,7 +48,6 @@ from models.demos.deepseek_v3.utils.run_config import (
     RunPrefillConfig,
     WeightConfig,
 )
-from models.experimental.ops.descriptors.fusion import Parallel
 from models.tt_transformers.tt.common import PagedAttentionConfig
 
 
@@ -2281,21 +2279,10 @@ class MLA1D(AbstractModule):
         cfg: RunDecodeConfig,
         rope_tensors: dict,
     ) -> tuple[ttnn.Tensor, ttnn.Tensor]:
-        # Parallel Q and KV Norms — persistent Parallel (reuse OpDescriptors + update).
         # Q: 1,1,32,1536, width sharded 4x4 [32,96]
         # KV: 1,1,32,512, width sharded 2x8 [32,32]
-        fused = cfg.get("fused_qkv_norm")
-        if fused is None:
-            q_pc = RMSNorm._get_pc(tt_q.memory_config())
-            kv_pc = RMSNorm._get_pc(tt_kv_nope.memory_config())
-            fused = Parallel(
-                q=descriptors.rms_norm(program_config=q_pc, **cfg["q_norm"]),
-                kv=descriptors.rms_norm(program_config=kv_pc, **cfg["kv_norm"]),
-            )
-            cfg["fused_qkv_norm"] = fused
-        fused.q.update(tt_q)
-        fused.kv.update(tt_kv_nope)
-        tt_q, tt_kv_nope = fused.run()
+        tt_q = RMSNorm.forward_decode(tt_q, cfg["q_norm"])
+        tt_kv_nope = RMSNorm.forward_decode(tt_kv_nope, cfg["kv_norm"])
         # Q: 1,1,32,1536, width sharded 8x2 [32,96]
 
         # KV RoPE


### PR DESCRIPTION
## Summary

- Removes the `Parallel()` fusion of Q and KV RMSNorms in `_fwd_decode_norm_and_rope` in `models/demos/deepseek_v3/tt/mla/mla1d.py`
- Reverts to the two sequential `RMSNorm.forward_decode()` calls (i.e. plain `ttnn.rms_norm`)
- Removes all Parallel-related scaffolding: `cfg["fused_qkv_norm"]` persistent state, `_get_pc` calls at setup time, `fused.q.update` / `fused.kv.update` / `fused.run()` pattern
- Removes the now-unused `import models.experimental.ops.descriptors as descriptors` and `from models.experimental.ops.descriptors.fusion import Parallel` imports

## Motivation

`Parallel`/`Sequential` fusion infrastructure requires ProgramSpec to be exposed to Python before it is production-ready. Until that work is done, callers should use plain `ttnn` ops directly.

## Test plan

- [ ] Run DeepSeek V3 decode CI (all-model-tests / blackhole-post-commit deepseek blitz)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/deepseek_mla_ttnn_rms)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/deepseek_mla_ttnn_rms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rmillerTT/deepseek_mla_ttnn_rms)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rmillerTT/deepseek_mla_ttnn_rms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/deepseek_mla_ttnn_rms)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/deepseek_mla_ttnn_rms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/deepseek_mla_ttnn_rms)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/deepseek_mla_ttnn_rms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rmillerTT/deepseek_mla_ttnn_rms)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rmillerTT/deepseek_mla_ttnn_rms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/deepseek_mla_ttnn_rms)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/deepseek_mla_ttnn_rms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/deepseek_mla_ttnn_rms)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/deepseek_mla_ttnn_rms)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/deepseek_mla_ttnn_rms)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/deepseek_mla_ttnn_rms)