### PR TITLE
Disable Sequential/Parallel fusion behind TT_METAL_ENABLE_PARALLEL_SEQUENTIAL until ProgramSpec is exposed to Python

### DIFF
--- a/models/experimental/ops/descriptors/fusion/fusion.py
+++ b/models/experimental/ops/descriptors/fusion/fusion.py
@@ -78,10 +78,11 @@ from models.experimental.ops.descriptors.fusion.common import (
 # behind an opt-in environment variable so accidental callers fail loudly rather
 # than silently depending on unfinished infrastructure.
 _ENABLE_ENV_VAR = "TT_METAL_ENABLE_PARALLEL_SEQUENTIAL"
+_ENABLE_TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
 
 
 def _check_fusion_enabled() -> None:
-    if not os.environ.get(_ENABLE_ENV_VAR):
+    if os.environ.get(_ENABLE_ENV_VAR, "").strip().lower() not in _ENABLE_TRUTHY_VALUES:
         raise RuntimeError(
             "Sequential/Parallel fusion is not yet production-ready and requires ProgramSpec to be "
             f"exposed to Python before general use. Set {_ENABLE_ENV_VAR}=1 to opt in."

--- a/models/experimental/ops/descriptors/fusion/fusion.py
+++ b/models/experimental/ops/descriptors/fusion/fusion.py
@@ -84,8 +84,7 @@ _ENABLE_TRUTHY_VALUES = frozenset({"1", "true", "yes", "on"})
 def _check_fusion_enabled() -> None:
     if os.environ.get(_ENABLE_ENV_VAR, "").strip().lower() not in _ENABLE_TRUTHY_VALUES:
         raise RuntimeError(
-            "Sequential/Parallel fusion is not yet production-ready and requires ProgramSpec to be "
-            f"exposed to Python before general use. Set {_ENABLE_ENV_VAR}=1 to opt in."
+            f"Sequential/Parallel fusion is disabled until ProgramSpec is exposed to Python. Set {_ENABLE_ENV_VAR}=1 to opt in."
         )
 
 

--- a/models/experimental/ops/descriptors/fusion/fusion.py
+++ b/models/experimental/ops/descriptors/fusion/fusion.py
@@ -870,6 +870,13 @@ class Sequential:
     """
 
     def __init__(self, *items, **named_items):
+        import os
+
+        if not os.environ.get("TTNN_ENABLE_PARALLEL_SEQUENTIAL"):
+            raise RuntimeError(
+                "Sequential/Parallel fusion is not yet production-ready and requires ProgramSpec to be "
+                "exposed to Python before general use. Set TTNN_ENABLE_PARALLEL_SEQUENTIAL=1 to opt in."
+            )
         all_items = list(items)
         for item in named_items.values():
             all_items.append(item)
@@ -1043,6 +1050,13 @@ class Parallel:
     """
 
     def __init__(self, *items, **named_items):
+        import os
+
+        if not os.environ.get("TTNN_ENABLE_PARALLEL_SEQUENTIAL"):
+            raise RuntimeError(
+                "Sequential/Parallel fusion is not yet production-ready and requires ProgramSpec to be "
+                "exposed to Python before general use. Set TTNN_ENABLE_PARALLEL_SEQUENTIAL=1 to opt in."
+            )
         all_items = list(items)
         for item in named_items.values():
             all_items.append(item)

--- a/models/experimental/ops/descriptors/fusion/fusion.py
+++ b/models/experimental/ops/descriptors/fusion/fusion.py
@@ -70,6 +70,25 @@ from models.experimental.ops.descriptors.fusion.common import (
 
 
 # =============================================================================
+# Production-readiness guard
+# =============================================================================
+
+# Sequential/Parallel fusion is not yet production-ready: it requires ProgramSpec
+# to be exposed to Python before general use. Until then, construction is gated
+# behind an opt-in environment variable so accidental callers fail loudly rather
+# than silently depending on unfinished infrastructure.
+_ENABLE_ENV_VAR = "TTNN_ENABLE_PARALLEL_SEQUENTIAL"
+
+
+def _check_fusion_enabled() -> None:
+    if not os.environ.get(_ENABLE_ENV_VAR):
+        raise RuntimeError(
+            "Sequential/Parallel fusion is not yet production-ready and requires ProgramSpec to be "
+            f"exposed to Python before general use. Set {_ENABLE_ENV_VAR}=1 to opt in."
+        )
+
+
+# =============================================================================
 # Fusion Build Cache — LRU-bounded
 # =============================================================================
 
@@ -870,13 +889,7 @@ class Sequential:
     """
 
     def __init__(self, *items, **named_items):
-        import os
-
-        if not os.environ.get("TTNN_ENABLE_PARALLEL_SEQUENTIAL"):
-            raise RuntimeError(
-                "Sequential/Parallel fusion is not yet production-ready and requires ProgramSpec to be "
-                "exposed to Python before general use. Set TTNN_ENABLE_PARALLEL_SEQUENTIAL=1 to opt in."
-            )
+        _check_fusion_enabled()
         all_items = list(items)
         for item in named_items.values():
             all_items.append(item)
@@ -1050,13 +1063,7 @@ class Parallel:
     """
 
     def __init__(self, *items, **named_items):
-        import os
-
-        if not os.environ.get("TTNN_ENABLE_PARALLEL_SEQUENTIAL"):
-            raise RuntimeError(
-                "Sequential/Parallel fusion is not yet production-ready and requires ProgramSpec to be "
-                "exposed to Python before general use. Set TTNN_ENABLE_PARALLEL_SEQUENTIAL=1 to opt in."
-            )
+        _check_fusion_enabled()
         all_items = list(items)
         for item in named_items.values():
             all_items.append(item)

--- a/models/experimental/ops/descriptors/fusion/fusion.py
+++ b/models/experimental/ops/descriptors/fusion/fusion.py
@@ -77,7 +77,7 @@ from models.experimental.ops.descriptors.fusion.common import (
 # to be exposed to Python before general use. Until then, construction is gated
 # behind an opt-in environment variable so accidental callers fail loudly rather
 # than silently depending on unfinished infrastructure.
-_ENABLE_ENV_VAR = "TTNN_ENABLE_PARALLEL_SEQUENTIAL"
+_ENABLE_ENV_VAR = "TT_METAL_ENABLE_PARALLEL_SEQUENTIAL"
 
 
 def _check_fusion_enabled() -> None:

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/conftest.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/conftest.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+# Opt in to Sequential/Parallel fusion for this test suite.
+# See models/experimental/ops/descriptors/fusion/fusion.py for context.
+os.environ.setdefault("TTNN_ENABLE_PARALLEL_SEQUENTIAL", "1")

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/conftest.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/conftest.py
@@ -9,9 +9,9 @@ import pytest
 def _enable_parallel_sequential(monkeypatch):
     """Opt this suite in to Sequential/Parallel fusion.
 
-    Sequential/Parallel are gated behind ``TTNN_ENABLE_PARALLEL_SEQUENTIAL`` until
+    Sequential/Parallel are gated behind ``TT_METAL_ENABLE_PARALLEL_SEQUENTIAL`` until
     ProgramSpec is exposed to Python (see fusion.py). This autouse fixture enables
     them only for the duration of each test in this directory and reverts after,
     so the guard stays active for every other test sharing the same process.
     """
-    monkeypatch.setenv("TTNN_ENABLE_PARALLEL_SEQUENTIAL", "1")
+    monkeypatch.setenv("TT_METAL_ENABLE_PARALLEL_SEQUENTIAL", "1")

--- a/tests/ttnn/unit_tests/operations/fused/parallel_sequential/conftest.py
+++ b/tests/ttnn/unit_tests/operations/fused/parallel_sequential/conftest.py
@@ -2,8 +2,16 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-import os
+import pytest
 
-# Opt in to Sequential/Parallel fusion for this test suite.
-# See models/experimental/ops/descriptors/fusion/fusion.py for context.
-os.environ.setdefault("TTNN_ENABLE_PARALLEL_SEQUENTIAL", "1")
+
+@pytest.fixture(autouse=True)
+def _enable_parallel_sequential(monkeypatch):
+    """Opt this suite in to Sequential/Parallel fusion.
+
+    Sequential/Parallel are gated behind ``TTNN_ENABLE_PARALLEL_SEQUENTIAL`` until
+    ProgramSpec is exposed to Python (see fusion.py). This autouse fixture enables
+    them only for the duration of each test in this directory and reverts after,
+    so the guard stays active for every other test sharing the same process.
+    """
+    monkeypatch.setenv("TTNN_ENABLE_PARALLEL_SEQUENTIAL", "1")


### PR DESCRIPTION
## Summary

`Sequential`/`Parallel` kernel fusion (`models/experimental/ops/descriptors/fusion`) is not yet production-ready: it depends on `ProgramSpec` being exposed to Python before it is safe for general use. This PR blocks construction by default so no new callers can accidentally depend on the unfinished infrastructure, while keeping the existing test suite green.

## Implementation

**Guard (`fusion.py`).** A module-level helper raises unless an opt-in env var is set:

```python
_ENABLE_ENV_VAR = "TT_METAL_ENABLE_PARALLEL_SEQUENTIAL"

def _check_fusion_enabled() -> None:
    if not os.environ.get(_ENABLE_ENV_VAR):
        raise RuntimeError(
            "Sequential/Parallel fusion is not yet production-ready and requires ProgramSpec to be "
            f"exposed to Python before general use. Set {_ENABLE_ENV_VAR}=1 to opt in."
        )
```

`_check_fusion_enabled()` is called as the first line of both `Sequential.__init__` and `Parallel.__init__`. The guard lives at construction time (not import time), so simply importing the symbols is harmless — only attempting to *build* a fused op trips it. A single shared helper (rather than two inline copies) keeps the call sites from drifting. The `TT_METAL_` prefix matches the project's other runtime env vars (e.g. `TT_METAL_FUSION_BUILD_CACHE_MAX_ENTRIES`).

**Test opt-in (`parallel_sequential/conftest.py`).** The fusion test suite opts back in via an **autouse fixture** scoped to that directory:

```python
@pytest.fixture(autouse=True)
def _enable_parallel_sequential(monkeypatch):
    monkeypatch.setenv("TT_METAL_ENABLE_PARALLEL_SEQUENTIAL", "1")
```

This sets the var per-test and reverts on teardown via `monkeypatch`. It deliberately does **not** set the var process-wide: in CI the `operations/fused` suite is sharded across processes (`pytest --splits 2 --group N`), and the guard must stay active for every test outside this directory that shares a process. A directory-scoped conftest is loaded by pytest for any invocation that collects these tests — the broad `operations/fused` sweep, a single file, or a single `::test` node — so there is no way to run a fusion test without the opt-in firing first. All `Sequential`/`Parallel` imports in the tests are deferred inside test bodies, i.e. they execute after the fixture has set the var.

## Why an env var (vs. removing `__all__`, `pytest.skip`, etc.)

- Callers fail **loudly** with an actionable message instead of silently running unfinished code.
- Trivially reversible: delete the guard + conftest once ProgramSpec lands. No GitHub issue exists for that work yet; the error message is the pointer.
- Existing fusion tests keep running unmodified — they just opt in.

## Verification

- Guard raises `RuntimeError` for both `Sequential()` and `Parallel()` when the var is unset.
- With the var set, construction passes the guard and proceeds to normal arg validation (`ValueError` on empty/`<2` items) — confirming the guard is the *only* thing gated.
- Ran the real fusion tests under the **exact** CI command (`pytest tests/ttnn/unit_tests/operations/fused --splits 2 --group 1 --splitting-algorithm least_duration -m "not disable_fast_runtime_mode"`) with the env var unset in the shell → tests that construct fused ops pass (the fixture opts them in).
- **No leak:** a probe test placed as a sibling under `operations/fused/` asserts the var is unset; it passes in the same pytest session as fusion tests in both orderings, proving the fixture reverts and the guard stays active outside the suite.
- `parallel_sequential` collects into both split groups (each a separate process); the conftest loads in each.
- No other CI path reaches the guard: the l2-nightly `tests/ttnn/nightly/.../operations/fused` tree contains no `parallel_sequential` subdir, and ttsim explicitly skips `test_parallel_sequential.py`.

## Merge ordering

This branch is based on `main`, where `models/demos/deepseek_v3/tt/mla/mla1d.py` still constructs `Parallel()` on the live decode path. **#46890 (revert that to sequential `ttnn.rms_norm`) must merge first**, otherwise DeepSeek decode CI will hit this guard. Tracked manually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/disable_parallel_sequential)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/disable_parallel_sequential)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rmillerTT/disable_parallel_sequential)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rmillerTT/disable_parallel_sequential)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/disable_parallel_sequential)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/disable_parallel_sequential)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/disable_parallel_sequential)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/disable_parallel_sequential)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rmillerTT/disable_parallel_sequential)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rmillerTT/disable_parallel_sequential)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/disable_parallel_sequential)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/disable_parallel_sequential)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/disable_parallel_sequential)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/disable_parallel_sequential)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/disable_parallel_sequential)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/disable_parallel_sequential)