### PR TITLE
[Feature] Sampling - Add support for <32 Users

### DIFF
--- a/tests/ttnn/unit_tests/operations/reduce/test_sampling.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sampling.py
@@ -213,6 +213,84 @@ def test_sampling_callback(shape, k, p, seed, k_dtype, device):
     assert device.cache_entries_counter.total > 0
 
 
+# Test to run with fewer than 32 users while still mapping one core per user. The kernels
+# still process a single padded 32-row tile, but only `num_users` core instances run, so the output
+# last dim is `num_users`. Each (num_users, grid) config is run with two sub_core_grids modes:
+#   - "explicit_grid": an explicit `grid_rows x grid_cols` CoreRangeSet with exactly `num_users`
+#     cores (one per user).
+#   - "full_grid": sub_core_grids=None, so the op auto-selects `num_users` cores from the device grid.
+@pytest.mark.parametrize(
+    "num_users, grid_rows, grid_cols",
+    [
+        (2, 1, 2),  # 1x2 grid
+        (7, 1, 7),  # 1x7 grid
+        (15, 3, 5),  # 3x5 grid
+    ],
+    ids=["2_users_1x2", "7_users_1x7", "15_users_3x5"],
+)
+@pytest.mark.parametrize("Wt", [2])  # last dim = 32 * Wt; Wt must be a power of 2
+@pytest.mark.parametrize("seed", [2024])
+@pytest.mark.parametrize("k_dtype", [ttnn.uint32, ttnn.int32])
+@pytest.mark.parametrize("grid_mode", ["explicit", "full_grid"], ids=["explicit_grid", "full_grid"])
+def test_sampling_sub_32_users(num_users, grid_rows, grid_cols, Wt, seed, k_dtype, grid_mode, device):
+    torch.manual_seed(seed)
+    shape = [1, 1, num_users, 32 * Wt]
+
+    # per-user k; p == 0 -> pure top-k, which lets us validate top-k membership of each pick.
+    k = [10 + 5 * (i % 5) for i in range(num_users)]
+    p = [0.0] * num_users
+
+    if grid_mode == "explicit":
+        # Exactly `num_users` cores laid out as grid_rows x grid_cols (one core per user).
+        sub_core_grids = ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_cols - 1, grid_rows - 1))}
+        )
+        assert sub_core_grids.num_cores() == num_users
+    else:
+        # Let the op auto-select `num_users` cores from the full device grid.
+        sub_core_grids = None
+
+    input_values = torch.randn(shape)
+    input_indices = torch.arange(0, shape[-1], dtype=torch.int32).expand(shape)
+    input_values_tensor = ttnn.from_torch(input_values, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
+    input_indices_tensor = ttnn.from_torch(input_indices, device=device, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    # k/p/temp carry one entry per user, so they are length `num_users`
+    k_tensor = ttnn.from_torch(torch.tensor(k), device=device, dtype=k_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
+    p_tensor = ttnn.from_torch(torch.tensor(p), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+    temp = ttnn.from_torch(torch.ones(num_users), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
+
+    output = ttnn.to_torch(
+        ttnn.sampling(
+            input_values_tensor,
+            input_indices_tensor,
+            k=k_tensor,
+            p=p_tensor,
+            temp=temp,
+            seed=seed,
+            sub_core_grids=sub_core_grids,
+        )
+    )
+    assert output.shape[-1] == num_users, f"Expected output last dim = {num_users}, got {output.shape}"
+
+    # Same seed -> identical output.
+    output_rerun = ttnn.to_torch(
+        ttnn.sampling(
+            input_values_tensor,
+            input_indices_tensor,
+            k=k_tensor,
+            p=p_tensor,
+            temp=temp,
+            seed=seed,
+            sub_core_grids=sub_core_grids,
+        )
+    )
+    assert torch.allclose(output, output_rerun), "Output is not deterministic for the same seed"
+
+    # With p == 0 this is pure top-k, so each user's pick must lie within its top-k set.
+    validate_statistics(input_values, output, k, p)
+
+
 @pytest.mark.parametrize(
     "shape",
     [

--- a/tests/ttnn/unit_tests/operations/reduce/test_sampling.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sampling.py
@@ -216,17 +216,18 @@ def test_sampling_callback(shape, k, p, seed, k_dtype, device):
 # Test to run with fewer than 32 users while still mapping one core per user. The kernels
 # still process a single padded 32-row tile, but only `num_users` core instances run, so the output
 # last dim is `num_users`. Each (num_users, grid) config is run with two sub_core_grids modes:
-#   - "explicit_grid": an explicit `grid_rows x grid_cols` CoreRangeSet with exactly `num_users`
-#     cores (one per user).
+#   - "explicit_grid": an explicit `grid_rows x grid_cols` CoreRangeSet with at least `num_users`
+#     cores. The grid may be over-provisioned (e.g. 13 users on a 3x5=15 core grid); only the first
+#     `num_users` cores are used and any extras are ignored.
 #   - "full_grid": sub_core_grids=None, so the op auto-selects `num_users` cores from the device grid.
 @pytest.mark.parametrize(
     "num_users, grid_rows, grid_cols",
     [
-        (2, 1, 2),  # 1x2 grid
-        (7, 1, 7),  # 1x7 grid
-        (15, 3, 5),  # 3x5 grid
+        (2, 1, 2),  # 1x2 grid, exactly sized
+        (7, 1, 7),  # 1x7 grid, exactly sized
+        (13, 3, 5),  # 3x5=15 core grid, over-provisioned for 13 users
     ],
-    ids=["2_users_1x2", "7_users_1x7", "15_users_3x5"],
+    ids=["2_users_1x2", "7_users_1x7", "13_users_3x5"],
 )
 @pytest.mark.parametrize("Wt", [2])  # last dim = 32 * Wt; Wt must be a power of 2
 @pytest.mark.parametrize("seed", [2024])
@@ -241,11 +242,11 @@ def test_sampling_sub_32_users(num_users, grid_rows, grid_cols, Wt, seed, k_dtyp
     p = [0.0] * num_users
 
     if grid_mode == "explicit":
-        # Exactly `num_users` cores laid out as grid_rows x grid_cols (one core per user).
+        # A grid_rows x grid_cols grid with at least `num_users` cores (may be over-provisioned).
         sub_core_grids = ttnn.CoreRangeSet(
             {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_cols - 1, grid_rows - 1))}
         )
-        assert sub_core_grids.num_cores() == num_users
+        assert sub_core_grids.num_cores() >= num_users
     else:
         # Let the op auto-select `num_users` cores from the full device grid.
         sub_core_grids = None

--- a/tests/ttnn/unit_tests/operations/reduce/test_sampling.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sampling.py
@@ -6,14 +6,7 @@ import torch
 import torch.nn.functional as F
 import pytest
 import ttnn
-import numpy as np
 from loguru import logger
-from tests.ttnn.unit_tests.operations.test_utils import (
-    get_compute_kernel_options,
-    compute_kernel_options,
-    compute_kernel_ids,
-    get_lib_dtype,
-)
 from models.common.utility_functions import is_wormhole_b0, is_blackhole
 
 

--- a/tests/ttnn/unit_tests/operations/reduce/test_sampling.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_sampling.py
@@ -14,7 +14,7 @@ from tests.ttnn.unit_tests.operations.test_utils import (
     compute_kernel_ids,
     get_lib_dtype,
 )
-from models.common.utility_functions import is_watcher_enabled
+from models.common.utility_functions import is_wormhole_b0, is_blackhole
 
 
 def check_determinism(input_values_tensor, input_indices_tensor, k, p, seed, sub_core_grids, device, k_dtype):
@@ -199,6 +199,11 @@ def run_sampling(shape, k, p, seed, device, sub_core_grids=None, *, k_dtype):
 @pytest.mark.parametrize("seed", [2024, 11, 123])
 @pytest.mark.parametrize("k_dtype", [ttnn.uint32, ttnn.int32])
 def test_sampling_callback(shape, k, p, seed, k_dtype, device):
+    # UINT32 k is only supported on Wormhole/Blackhole; other archs (e.g. Quasar) run the
+    # INT32-only path, so skip the UINT32 cases there.
+    if k_dtype == ttnn.uint32 and not (is_wormhole_b0() or is_blackhole()):
+        pytest.skip("UINT32 dtype is only supported on Wormhole/Blackhole")
+
     torch.manual_seed(seed)
     for i in range(2):
         run_sampling(shape, k, p, seed, device, k_dtype=k_dtype)
@@ -231,9 +236,14 @@ def test_sampling_callback(shape, k, p, seed, k_dtype, device):
 )
 @pytest.mark.parametrize("Wt", [2])  # last dim = 32 * Wt; Wt must be a power of 2
 @pytest.mark.parametrize("seed", [2024])
-@pytest.mark.parametrize("k_dtype", [ttnn.uint32, ttnn.int32])
+# input_indices and k are the two int-typed inputs (both accept UINT32, as well as INT32 on WH/BH)
+@pytest.mark.parametrize("index_dtype", [ttnn.uint32, ttnn.int32])
 @pytest.mark.parametrize("grid_mode", ["explicit", "full_grid"], ids=["explicit_grid", "full_grid"])
-def test_sampling_sub_32_users(num_users, grid_rows, grid_cols, Wt, seed, k_dtype, grid_mode, device):
+def test_sampling_sub_32_users(num_users, grid_rows, grid_cols, Wt, seed, index_dtype, grid_mode, device):
+    # UINT32 indices/k are only supported on Wormhole/Blackhole; other archs (e.g. Quasar) only support INT32 path
+    if index_dtype == ttnn.uint32 and not (is_wormhole_b0() or is_blackhole()):
+        pytest.skip("UINT32 index dtype is only supported on Wormhole/Blackhole")
+
     torch.manual_seed(seed)
     shape = [1, 1, num_users, 32 * Wt]
 
@@ -254,10 +264,12 @@ def test_sampling_sub_32_users(num_users, grid_rows, grid_cols, Wt, seed, k_dtyp
     input_values = torch.randn(shape)
     input_indices = torch.arange(0, shape[-1], dtype=torch.int32).expand(shape)
     input_values_tensor = ttnn.from_torch(input_values, device=device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT)
-    input_indices_tensor = ttnn.from_torch(input_indices, device=device, dtype=ttnn.int32, layout=ttnn.ROW_MAJOR_LAYOUT)
+    input_indices_tensor = ttnn.from_torch(
+        input_indices, device=device, dtype=index_dtype, layout=ttnn.ROW_MAJOR_LAYOUT
+    )
 
     # k/p/temp carry one entry per user, so they are length `num_users`
-    k_tensor = ttnn.from_torch(torch.tensor(k), device=device, dtype=k_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
+    k_tensor = ttnn.from_torch(torch.tensor(k), device=device, dtype=index_dtype, layout=ttnn.ROW_MAJOR_LAYOUT)
     p_tensor = ttnn.from_torch(torch.tensor(p), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
     temp = ttnn.from_torch(torch.ones(num_users), device=device, dtype=ttnn.bfloat16, layout=ttnn.ROW_MAJOR_LAYOUT)
 
@@ -306,6 +318,11 @@ def test_sampling_sub_32_users(num_users, grid_rows, grid_cols, Wt, seed, k_dtyp
     "sub_core_grids", [ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(8 - 1, 4 - 1))})]
 )
 def test_sampling_subcores_callback(shape, k, p, seed, k_dtype, device, sub_core_grids):
+    # UINT32 k is only supported on Wormhole/Blackhole; other archs (e.g. Quasar) run the
+    # INT32-only path, so skip the UINT32 cases there.
+    if k_dtype == ttnn.uint32 and not (is_wormhole_b0() or is_blackhole()):
+        pytest.skip("UINT32 dtype is only supported on Wormhole/Blackhole")
+
     torch.manual_seed(seed)
     for i in range(2):
         run_sampling(shape, k, p, seed, device, sub_core_grids, k_dtype=k_dtype)

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/reader_values_indices_tensor.cpp
@@ -61,8 +61,11 @@ void kernel_main() {
     constexpr uint32_t input_indices_page_size = get_compile_time_arg_val(5);
     constexpr uint32_t tile_height = get_compile_time_arg_val(6);
     constexpr bool use_32bit_index = get_compile_time_arg_val(7) == 1;
+    // Number of logical users (== number of running cores). Only this many input-index rows exist
+    // and are streamed in, even though the values tile is padded to a full tile_height.
+    constexpr uint32_t num_users = get_compile_time_arg_val(8);
 
-    constexpr auto s0_args = TensorAccessorArgs<8>();
+    constexpr auto s0_args = TensorAccessorArgs<9>();
     constexpr auto s1_args = TensorAccessorArgs<s0_args.next_compile_time_args_offset()>();
 
     // ublocks size defined in tiles
@@ -92,8 +95,9 @@ void kernel_main() {
         }
     }
 
-    // input indices RM
-    for (uint32_t j = 0; j < Ht * tile_height; ++j) {
+    // input indices RM — push one stick per running core/user. Previously hard-coded to
+    // Ht * tile_height (== 32); now `num_users` so fewer-than-32-user configs don't over-read.
+    for (uint32_t j = 0; j < num_users; ++j) {
         input_indices_cb.reserve_back(onetile);
         noc.async_read(s1, input_indices_cb, input_indices_page_size, {.page_id = j}, {.offset_bytes = 0});
         noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -67,6 +67,9 @@ void kernel_main() {
     // Local sort-index width must match the index CB format / fp32_dest_acc_en chosen by the host:
     // 32-bit (Int32) on Quasar, 16-bit (UInt16) on WH/BH.
     constexpr bool use_32bit_index = get_compile_time_arg_val(args_base + 16) == 1;
+    // Number of running cores / users. The final-indices CB holds one stick per user (no longer
+    // hard-coded to 32), so this kernel waits/pops exactly `num_users` sticks.
+    constexpr uint32_t num_users = get_compile_time_arg_val(args_base + 17);
     constexpr uint32_t k_chunk_size = num_cores * sizeof(uint32_t);     // 4 bytes per uint32_t
     constexpr uint32_t p_chunk_size = num_cores * sizeof(uint16_t);     // 2 bytes per uint16_t
     constexpr uint32_t temp_chunk_size = num_cores * sizeof(uint16_t);  // 2 bytes per uint16_t
@@ -130,7 +133,7 @@ void kernel_main() {
     CoreLocalMem<volatile uint16_t> rand_values(cb_rand.get_read_ptr());
     uint16_t rand = rand_values[0];
     // wait for compute kernel
-    cb_final_indices.wait_front(32);
+    cb_final_indices.wait_front(num_users);
     cb_local_values.wait_front(1);
     cb_local_indices.wait_front(1);
     // Read producer-written compute outputs from these CBs in L1.
@@ -231,7 +234,7 @@ void kernel_main() {
     cb_rand.pop_front(1);
     cb_local_values.pop_front(1);
     cb_local_indices.pop_front(1);
-    cb_final_indices.pop_front(32);
+    cb_final_indices.pop_front(num_users);
 
     const auto s_out = TensorAccessor(dst_args, dst_addr);
     // Write individual core result - output buffer should handle alignment

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
@@ -89,9 +89,12 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
         validate_reduce_op_tensor(input_values_tensor, "Sampling", "input_values", &sampling_grid_opts);
     }
     if (args.sub_core_grids.has_value()) {
+        // The grid may be over-provisioned: only the first `num_users` cores are used, any extras
+        // are ignored. It must supply at least `num_users` cores (one per user).
         TT_FATAL(
-            args.sub_core_grids.value().num_cores() == input_shape[0] * input_shape[1] * input_shape[2],
-            "Subcore grid expects num_users cores, but found {}!",
+            args.sub_core_grids.value().num_cores() >= num_users,
+            "Subcore grid must supply at least num_users ({}) cores, but found {}!",
+            num_users,
             args.sub_core_grids.value().num_cores());
     }
     if (preallocated_output_tensor.has_value()) {

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
@@ -59,7 +59,12 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
         "Input values and indices must have the same shape!");
     auto input_shape = input_values_tensor.logical_shape();
     TT_FATAL(input_shape.rank() == 4, "Sampling input_values must be rank-4; got rank {}", input_shape.rank());
-    TT_FATAL(input_shape[0] * input_shape[1] * input_shape[2] == 32, "Input must have 32 users!");
+
+    const uint32_t num_users = input_shape[0] * input_shape[1] * input_shape[2];
+    TT_FATAL(
+        num_users >= 1 && num_users <= 32,
+        "Sampling currently supports between 1 and 32 users (one core per user); got {}!",
+        num_users);
     TT_FATAL(
         input_shape[3] != 0 && input_shape[3] % 32 == 0,
         "Input inner dim ({}) must be non-zero and divisible by 32, pad if needed!",
@@ -133,9 +138,11 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
     TT_FATAL(k.layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR layout is supported for k!");
     TT_FATAL(p.layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR layout is supported for p!");
     TT_FATAL(temp.layout() == Layout::ROW_MAJOR, "Only ROW_MAJOR layout is supported for temp!");
-    TT_FATAL(k.logical_shape() == Shape({32}), "k must have shape [32]!");
-    TT_FATAL(p.logical_shape() == Shape({32}), "p must have shape [32]!");
-    TT_FATAL(temp.logical_shape() == Shape({32}), "temp must have shape [32]!");
+    // k/p/temp carry one entry per user, so they must match num_users (== N*C*H). Only num_users
+    // cores run and each reads its own entry, so no padding to 32 is required.
+    TT_FATAL(k.logical_shape() == Shape({num_users}), "k must have shape [{}] (one per user)!", num_users);
+    TT_FATAL(p.logical_shape() == Shape({num_users}), "p must have shape [{}] (one per user)!", num_users);
+    TT_FATAL(temp.logical_shape() == Shape({num_users}), "temp must have shape [{}] (one per user)!", num_users);
 }
 
 TensorSpec SamplingDeviceOperation::compute_output_specs(

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_device_operation.cpp
@@ -60,7 +60,18 @@ void SamplingDeviceOperation::validate_on_program_cache_miss(
     auto input_shape = input_values_tensor.logical_shape();
     TT_FATAL(input_shape.rank() == 4, "Sampling input_values must be rank-4; got rank {}", input_shape.rank());
 
-    const uint32_t num_users = input_shape[0] * input_shape[1] * input_shape[2];
+    // Users live in dim 2 (H): the output is sized [1,1,1,H] and the per-user inputs/cores are
+    // indexed by the user (row) index. dims 0 and 1 (N, C) must therefore be 1; otherwise
+    // num_users = N*C*H would exceed H and the writer would index past the H-sized output.
+    TT_FATAL(
+        input_shape[0] == 1 && input_shape[1] == 1,
+        "Sampling requires input dims 0 and 1 (N, C) to be 1; got [{}, {}, {}, {}]!",
+        input_shape[0],
+        input_shape[1],
+        input_shape[2],
+        input_shape[3]);
+    // N and C are guaranteed to be 1 by the check above, so the user count is just dim 2 (H).
+    const uint32_t num_users = input_shape[2];
     TT_FATAL(
         num_users >= 1 && num_users <= 32,
         "Sampling currently supports between 1 and 32 users (one core per user); got {}!",

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -62,9 +62,14 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     auto input_shape = input_values_tensor.logical_shape();
     const uint32_t tile_height = input_values_tensor.tensor_spec().tile().get_height();
     const uint32_t tile_width = input_values_tensor.tensor_spec().tile().get_width();
-    uint32_t Ht = (input_shape[0] * input_shape[1] * input_shape[2]) / tile_height;
+    // `num_users` is the logical user count (rows) in the range [1, 32], so the data still
+    // occupies a single padded row-tile (Ht == 1); only `num_users` cores actually run. Decoupling
+    // num_cores from Ht*tile_height is what lets <32 users work: the old `(.../tile_height)` would
+    // integer-divide to Ht == 0 (and num_cores == 0) for fewer than tile_height users.
+    const uint32_t num_users = input_shape[0] * input_shape[1] * input_shape[2];
+    uint32_t Ht = (num_users + tile_height - 1) / tile_height;  // == 1 for 1..32 users
     uint32_t Wt = input_shape[3] / tile_width;
-    auto num_cores = Ht * tile_height;
+    auto num_cores = num_users;
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     CoreRangeSet core_grid = tt::tt_metal::num_cores_to_corerangeset(num_cores, compute_with_storage_grid_size, true);
@@ -332,7 +337,8 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
         Wt,
         aligned_final_indices_rm_unit_size,
         tile_height,
-        static_cast<uint32_t>(use_32bit_index)};
+        static_cast<uint32_t>(use_32bit_index),
+        num_users};
     tt::tt_metal::TensorAccessorArgs(input_values_tensor).append_to(reader_compile_time_args);
     tt::tt_metal::TensorAccessorArgs(input_indices_tensor).append_to(reader_compile_time_args);
 
@@ -383,6 +389,7 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
                 tile_width,
                 num_cores,
                 static_cast<uint32_t>(use_32bit_index),
+                num_users,
             });
 
         KernelDescriptor writer_desc;

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -79,6 +79,18 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     }
     auto cores = corerange_to_cores(core_grid, num_cores, true);
 
+    // `sub_core_grids` may be over-provisioned (more cores than users); only the first `num_cores`
+    // cores actually run. Confine CB allocation and the reader kernel to exactly those cores so we
+    // don't place a reader (with unset runtime args) on the unused cores.
+    if (core_grid.num_cores() != num_cores) {
+        std::vector<CoreRange> active_core_ranges;
+        active_core_ranges.reserve(cores.size());
+        for (const auto& core : cores) {
+            active_core_ranges.emplace_back(core);
+        }
+        core_grid = CoreRangeSet(active_core_ranges);
+    }
+
     validate_reduce_op_program_grid(
         "Sampling",
         core_grid,

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/sampling_program_factory.cpp
@@ -62,11 +62,12 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
     auto input_shape = input_values_tensor.logical_shape();
     const uint32_t tile_height = input_values_tensor.tensor_spec().tile().get_height();
     const uint32_t tile_width = input_values_tensor.tensor_spec().tile().get_width();
-    // `num_users` is the logical user count (rows) in the range [1, 32], so the data still
-    // occupies a single padded row-tile (Ht == 1); only `num_users` cores actually run. Decoupling
-    // num_cores from Ht*tile_height is what lets <32 users work: the old `(.../tile_height)` would
-    // integer-divide to Ht == 0 (and num_cores == 0) for fewer than tile_height users.
-    const uint32_t num_users = input_shape[0] * input_shape[1] * input_shape[2];
+    // `num_users` is the logical user count (rows in dim 2) in the range [1, 32]; validation
+    // guarantees N == C == 1, so it is just input_shape[2]. The data still occupies a single padded
+    // row-tile (Ht == 1) and only `num_users` cores run. Decoupling num_cores from Ht*tile_height is
+    // what lets <32 users work: the old `(.../tile_height)` would integer-divide to Ht == 0 (and
+    // num_cores == 0) for fewer than tile_height users.
+    const uint32_t num_users = input_shape[2];
     uint32_t Ht = (num_users + tile_height - 1) / tile_height;  // == 1 for 1..32 users
     uint32_t Wt = input_shape[3] / tile_width;
     auto num_cores = num_users;
@@ -88,7 +89,7 @@ tt::tt_metal::ProgramDescriptor SamplingProgramFactory::create_descriptor(
         for (const auto& core : cores) {
             active_core_ranges.emplace_back(core);
         }
-        core_grid = CoreRangeSet(active_core_ranges);
+        core_grid = CoreRangeSet(std::move(active_core_ranges));
     }
 
     validate_reduce_op_program_grid(

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
@@ -97,7 +97,8 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
 
         Limitations:
             - Inputs must be 4D tensors with shape [N, C, H, W], and must be located on the device.
-            - The input tensors must represent exactly `32 users` based on their shape (i.e. N*C*H = 32).
+            - The input tensors represent ``num_users = N*C*H`` users, which must be in the range
+              ``[1, 32]``. The op runs one core per user, so ``num_users`` cores are used.
             - The last dimension of:attr:`input_values_tensor` must be padded to a multiple of 32
             - The number of tiles along the last dimension, ``Wt = W / 32``, must be a power of 2
               (i.e. ``W`` must be a power-of-2 multiple of 32: 32, 64, 128, 256, ...). The internal
@@ -105,9 +106,10 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
               non-power-of-2 ``Wt`` is rejected. Pad ``W`` up to the next power-of-2 multiple of 32
               (e.g. with ``-inf`` values and dummy indices) if needed.
             - The overall shape of :attr:`input_values_tensor` must match that of :attr:`input_indices_tensor`.
-            - :attr:`k`: Must contain 32 values, in the range  '(0,32]'.
-            - :attr:`p`, :attr:`temp`: Must contain 32 values in the range `[0.0, 1.0]`.
-            - :attr:`sub_core_grids` (if provided): number of cores must equal the number of users (which is constrained to 32).
+            - :attr:`k`: Must contain ``num_users`` values (one per user), in the range '(0,32]'.
+            - :attr:`p`, :attr:`temp`: Must contain ``num_users`` values (one per user); :attr:`p`
+              values must be in the range `[0.0, 1.0]`.
+            - :attr:`sub_core_grids` (if provided): number of cores must equal ``num_users`` (1 to 32).
         )doc";
 
     ttnn::bind_function<"sampling">(

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
@@ -109,7 +109,8 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
             - :attr:`k`: Must contain ``num_users`` values (one per user), in the range '(0,32]'.
             - :attr:`p`, :attr:`temp`: Must contain ``num_users`` values (one per user); :attr:`p`
               values must be in the range `[0.0, 1.0]`.
-            - :attr:`sub_core_grids` (if provided): number of cores must equal ``num_users`` (1 to 32).
+            - :attr:`sub_core_grids` (if provided): must supply at least ``num_users`` cores (1 to 32);
+              only the first ``num_users`` cores are used and any extras are ignored.
         )doc";
 
     ttnn::bind_function<"sampling">(

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/sampling_nanobind.cpp
@@ -97,18 +97,19 @@ void bind_reduction_sampling_operation(nb::module_& mod) {
 
         Limitations:
             - Inputs must be 4D tensors with shape [N, C, H, W], and must be located on the device.
-            - The input tensors represent ``num_users = N*C*H`` users, which must be in the range
-              ``[1, 32]``. The op runs one core per user, so ``num_users`` cores are used.
-            - The last dimension of:attr:`input_values_tensor` must be padded to a multiple of 32
+            - Input dims 0 and 1 (``N``, ``C``) must equal 1
+            - Input dim 2 (``H``) represents the number of users, which must be in
+              the range ``[1, 32]``. The op runs one core per user, so ``num_users`` cores are used.
+            - The last dimension of:attr:`input_values_tensor` (``W``) must be padded to a multiple of 32
             - The number of tiles along the last dimension, ``Wt = W / 32``, must be a power of 2
               (i.e. ``W`` must be a power-of-2 multiple of 32: 32, 64, 128, 256, ...). The internal
               top-k stage uses a bitonic merge tree that assumes a power-of-2 tile count; a
               non-power-of-2 ``Wt`` is rejected. Pad ``W`` up to the next power-of-2 multiple of 32
               (e.g. with ``-inf`` values and dummy indices) if needed.
             - The overall shape of :attr:`input_values_tensor` must match that of :attr:`input_indices_tensor`.
-            - :attr:`k`: Must contain ``num_users`` values (one per user), in the range '(0,32]'.
-            - :attr:`p`, :attr:`temp`: Must contain ``num_users`` values (one per user); :attr:`p`
-              values must be in the range `[0.0, 1.0]`.
+            - :attr:`k`: Must be a 1D tensor of shape ``[num_users]`` (one value per user), in the range '(0,32]'.
+            - :attr:`p`, :attr:`temp`: Must be 1D tensors of shape ``[num_users]`` (one value per user);
+              :attr:`p` values must be in the range `[0.0, 1.0]`.
             - :attr:`sub_core_grids` (if provided): must supply at least ``num_users`` cores (1 to 32);
               only the first ``num_users`` cores are used and any extras are ignored.
         )doc";


### PR DESCRIPTION
### Summary
Closes https://github.com/tenstorrent/tt-metal/issues/46371

Sampling historically required 32 user inputs, and could only be run on 32 cores. This PR eases the limitations so that `num_users` needs to be in the range of [1, 32], and if a sub core grid is provided, it just needs to provide at least `num_users` cores (of which, only the first `num_users` will actually be used).

PR also adds a test for sub-32 user sampling, testing both with and without an explicit core grid provided. The testcases are two users (to allow running on small emulation builds if need be), seven users, and thirteen users (testing over-provision a 3x5 grid instead of creating an explicit 13 user grid). 

For the new tests as well as all the existing tests that ran with UINT, skips were added to ensure they only run on WH/BH, since Quasar will TT_FATAL if/when these tests are run on it.

This PR also adds some validation and documentation for assumptions that were required for the inputs, but were not explicitly stated (mainly N=C=1, p/k are 1D).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=edwinlee/46371/sampling_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:edwinlee/46371/sampling_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=edwinlee/46371/sampling_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:edwinlee/46371/sampling_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=edwinlee/46371/sampling_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:edwinlee/46371/sampling_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=edwinlee/46371/sampling_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:edwinlee/46371/sampling_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=edwinlee/46371/sampling_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:edwinlee/46371/sampling_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=edwinlee/46371/sampling_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:edwinlee/46371/sampling_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=edwinlee/46371/sampling_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:edwinlee/46371/sampling_parallel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=edwinlee/46371/sampling_parallel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:edwinlee/46371/sampling_parallel)
- Frequent model and TTNN [running](https://github.com/tenstorrent/tt-metal/actions/runs/27438725234)