### PR TITLE
[Draft] slice: extract tile create_descriptor into a standalone builder

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_descriptor_builders.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_descriptor_builders.cpp
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp"
+
+#include <optional>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/operations/data_movement/slice/slice.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim {
+
+// Body moved verbatim from SliceTileProgramFactory::create_descriptor. The slice
+// factory now delegates here; the pybind and mesh_partition call this directly.
+tt::tt_metal::ProgramDescriptor build_slice_tile_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input;
+    tt::tt_metal::IDevice* device = input.device();
+
+    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+
+    tt::tt_metal::Buffer* src0_buffer = input.buffer();
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    const auto& input_shape = input.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+
+    // --- CB Descriptor ---
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = 2;
+
+    tt::tt_metal::ProgramDescriptor program_descriptor;
+
+    tt::tt_metal::CBDescriptor cb_desc;
+    cb_desc.total_size = num_input_tiles * single_tile_size;
+    cb_desc.core_ranges = all_cores;
+    cb_desc.format_descriptors.push_back(tt::tt_metal::CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(src0_cb_index),
+        .data_format = cb_data_format,
+        .page_size = single_tile_size});
+    program_descriptor.cbs.push_back(std::move(cb_desc));
+
+    // --- Reader Kernel Descriptor ---
+    // CB index via named compile-time arg (essential for fusion CB remapping).
+    std::vector<uint32_t> reader_compile_time_args = {num_dims};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+
+    // Reader common runtime args: [src_addr, num_unpadded_per_dim..., num_padded_per_dim...]
+    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
+    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
+    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
+    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    accumulated_total_per_dim[0] = num_total_Xt;
+    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+
+    std::vector<uint32_t> reader_common_args(1 + (num_dims * 2));
+    reader_common_args[0] = src0_buffer->address();
+    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
+    uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
+    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
+    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
+    num_padded_tiles_per_dim[0] = num_padded_Xt;
+    num_padded_tiles_per_dim[1] = num_padded_Yt;
+    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
+        num_padded_tiles_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    uint32_t start_offset = ttnn::operations::data_movement::get_tiled_start_offset(input, args.slice_start);
+
+    // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
+    tt::tt_metal::KernelDescriptor::RuntimeArgs reader_runtime_args;
+    uint32_t num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            std::vector<uint32_t> reader_args(2 + num_dims, 0);
+            reader_runtime_args.emplace_back(core, std::move(reader_args));
+            continue;
+        }
+
+        std::vector<uint32_t> reader_args(2 + num_dims);
+        // Compute per-dim indices for this core's starting position
+        reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
+        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
+        uint32_t start_id = reader_args[2] + start_offset;
+        for (uint32_t j = 1; j < num_dims; ++j) {
+            reader_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
+            start_id += reader_args[2 + j] * accumulated_total_per_dim[j - 1];
+        }
+        reader_args[0] = start_id;
+        reader_args[1] = num_tiles_per_core;
+
+        reader_runtime_args.emplace_back(core, std::move(reader_args));
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    tt::tt_metal::KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+        "reader_unary_unpad_dims_interleaved_start_id.cpp";
+    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = all_cores;
+    reader_kernel_desc.compile_time_args = reader_compile_time_args;
+    reader_kernel_desc.named_compile_time_args = {{"cb_in", src0_cb_index}};
+    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
+    reader_kernel_desc.common_runtime_args = std::move(reader_common_args);
+    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
+    program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
+
+    // --- Writer Kernel Descriptor ---
+    // CB index via named compile-time arg (essential for fusion CB remapping).
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
+    tt::tt_metal::KernelDescriptor::RuntimeArgs writer_runtime_args;
+    num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
+            continue;
+        }
+
+        writer_runtime_args.emplace_back(
+            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    tt::tt_metal::KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+        "writer_unary_interleaved_start_id.cpp";
+    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = all_cores;
+    writer_kernel_desc.compile_time_args = writer_compile_time_args;
+    writer_kernel_desc.named_compile_time_args = {{"cb_out", src0_cb_index}};
+    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
+    writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
+    program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
+
+    return program_descriptor;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
+
+// Standalone ProgramDescriptor builders for slice.
+//
+// These hold the descriptor-construction logic that used to live as static
+// methods on the slice program factories. They are kept as free functions so
+// that descriptor consumers — the Python fusion compiler (via the pybind), and
+// mesh_partition's std::visit reuse — keep getting a ProgramDescriptor, even
+// after the slice program factories migrate to Metal 2.0 (where a factory may
+// not also expose create_descriptor; see operation_concepts.hpp
+// all_factories_valid "exactly one concept").
+//
+// The factory's Metal 2.0 create_program_spec and these builders are separate
+// entry points: descriptor IR for fusion, ProgramSpec for standalone dispatch.
+
+namespace ttnn::prim {
+
+tt::tt_metal::ProgramDescriptor build_slice_tile_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -4,178 +4,20 @@
 
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp"
 
-#include <optional>
-#include <tt-metalium/work_split.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-
-using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
+// The descriptor logic now lives in build_slice_tile_descriptor (a standalone
+// function shared with the pybind / fusion / mesh_partition consumers). This
+// thin delegate is the seam: when the factory migrates to Metal 2.0 it gains
+// create_program_spec and this create_descriptor is dropped, while the consumers
+// keep calling build_slice_tile_descriptor directly.
 tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto& input = tensor_args.input;
-    tt::tt_metal::IDevice* device = input.device();
-
-    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
-
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        args.sub_core_grids.has_value()
-            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
-            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
-
-    tt::tt_metal::Buffer* src0_buffer = input.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    uint32_t single_tile_size = tt::tile_size(cb_data_format);
-
-    const auto& input_shape = input.padded_shape();
-    const auto& output_shape = output.padded_shape();
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
-
-    // --- CB Descriptor ---
-    uint32_t src0_cb_index = 0;
-    uint32_t num_input_tiles = 2;
-
-    tt::tt_metal::ProgramDescriptor program_descriptor;
-
-    tt::tt_metal::CBDescriptor cb_desc;
-    cb_desc.total_size = num_input_tiles * single_tile_size;
-    cb_desc.core_ranges = all_cores;
-    cb_desc.format_descriptors.push_back(tt::tt_metal::CBFormatDescriptor{
-        .buffer_index = static_cast<uint8_t>(src0_cb_index),
-        .data_format = cb_data_format,
-        .page_size = single_tile_size});
-    program_descriptor.cbs.push_back(std::move(cb_desc));
-
-    // --- Reader Kernel Descriptor ---
-    // CB index via named compile-time arg (essential for fusion CB remapping).
-    std::vector<uint32_t> reader_compile_time_args = {num_dims};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-
-    // Reader common runtime args: [src_addr, num_unpadded_per_dim..., num_padded_per_dim...]
-    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
-    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
-    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
-    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
-    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
-    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
-
-    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
-    accumulated_total_per_dim[0] = num_total_Xt;
-    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
-
-    std::vector<uint32_t> reader_common_args(1 + (num_dims * 2));
-    reader_common_args[0] = src0_buffer->address();
-    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
-    uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
-    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
-    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
-    num_padded_tiles_per_dim[0] = num_padded_Xt;
-    num_padded_tiles_per_dim[1] = num_padded_Yt;
-    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
-        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
-        uint32_t num_total_dim = input_shape[-(i + 1)];
-        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
-        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
-        num_padded_tiles_per_dim[i] = num_padded_dim;
-        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
-    }
-
-    uint32_t start_offset = ttnn::operations::data_movement::get_tiled_start_offset(input, args.slice_start);
-
-    // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
-    tt::tt_metal::KernelDescriptor::RuntimeArgs reader_runtime_args;
-    uint32_t num_tiles_written = 0;
-    for (const auto& core : corerange_to_cores(all_cores)) {
-        uint32_t num_tiles_per_core;
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            // no-op core
-            std::vector<uint32_t> reader_args(2 + num_dims, 0);
-            reader_runtime_args.emplace_back(core, std::move(reader_args));
-            continue;
-        }
-
-        std::vector<uint32_t> reader_args(2 + num_dims);
-        // Compute per-dim indices for this core's starting position
-        reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
-        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
-        uint32_t start_id = reader_args[2] + start_offset;
-        for (uint32_t j = 1; j < num_dims; ++j) {
-            reader_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
-            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
-            start_id += reader_args[2 + j] * accumulated_total_per_dim[j - 1];
-        }
-        reader_args[0] = start_id;
-        reader_args[1] = num_tiles_per_core;
-
-        reader_runtime_args.emplace_back(core, std::move(reader_args));
-        num_tiles_written += num_tiles_per_core;
-    }
-
-    tt::tt_metal::KernelDescriptor reader_kernel_desc;
-    reader_kernel_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "reader_unary_unpad_dims_interleaved_start_id.cpp";
-    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
-    reader_kernel_desc.core_ranges = all_cores;
-    reader_kernel_desc.compile_time_args = reader_compile_time_args;
-    reader_kernel_desc.named_compile_time_args = {{"cb_in", src0_cb_index}};
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
-    reader_kernel_desc.common_runtime_args = std::move(reader_common_args);
-    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
-    program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
-
-    // --- Writer Kernel Descriptor ---
-    // CB index via named compile-time arg (essential for fusion CB remapping).
-    std::vector<uint32_t> writer_compile_time_args = {};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
-    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
-    tt::tt_metal::KernelDescriptor::RuntimeArgs writer_runtime_args;
-    num_tiles_written = 0;
-    for (const auto& core : corerange_to_cores(all_cores)) {
-        uint32_t num_tiles_per_core;
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            // no-op core
-            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
-            continue;
-        }
-
-        writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
-        num_tiles_written += num_tiles_per_core;
-    }
-
-    tt::tt_metal::KernelDescriptor writer_kernel_desc;
-    writer_kernel_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "writer_unary_interleaved_start_id.cpp";
-    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
-    writer_kernel_desc.core_ranges = all_cores;
-    writer_kernel_desc.compile_time_args = writer_compile_time_args;
-    writer_kernel_desc.named_compile_time_args = {{"cb_out", src0_cb_index}};
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
-    writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
-    program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
-
-    return program_descriptor;
+    return build_slice_tile_descriptor(args, tensor_args, output);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
@@ -18,6 +18,7 @@
 #include "slice.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp"
 
 namespace ttnn::operations::data_movement::detail {
 
@@ -158,14 +159,17 @@ void bind_slice_descriptor(nb::module_& mod) {
             nb::arg("operation_attributes"),
             nb::arg("tensor_args"));
 
+    // The Python-visible name stays SliceTileProgramFactory.create_descriptor (zero Python churn),
+    // but the implementation now calls the standalone build_slice_tile_descriptor — so the bind no
+    // longer depends on a create_descriptor method living on the factory. When the factory migrates
+    // to Metal 2.0 (and drops create_descriptor), this bind keeps working unchanged.
     nb::class_<ttnn::prim::SliceTileProgramFactory>(mod, "SliceTileProgramFactory")
         .def_static(
             "create_descriptor",
             [](const ttnn::prim::SliceParams& operation_attributes,
                const ttnn::prim::SliceInputs& tensor_args,
                Tensor& tensor_return_value) {
-                return ttnn::prim::SliceTileProgramFactory::create_descriptor(
-                    operation_attributes, tensor_args, tensor_return_value);
+                return ttnn::prim::build_slice_tile_descriptor(operation_attributes, tensor_args, tensor_return_value);
             },
             nb::arg("operation_attributes"),
             nb::arg("tensor_args"),

--- a/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
@@ -115,6 +115,7 @@ set(TTNN_OP_DATA_MOVEMENT_SRCS
     slice/device/slice_program_factory_rm_stride.cpp
     slice/device/slice_program_factory_tile.cpp
     slice/device/slice_program_factory_tile_tensor_args.cpp
+    slice/device/slice_descriptor_builders.cpp
     slice/slice.cpp
     split/device/split_device_operation.cpp
     split/device/split_program_factory.cpp


### PR DESCRIPTION
## What

Extracts `SliceTileProgramFactory::create_descriptor`'s body into a standalone free function `build_slice_tile_descriptor(...)`. The factory now delegates to it, and the pybind calls the free function directly (Python name `ttnn.SliceTileProgramFactory.create_descriptor` unchanged).

**No behavior change.** This is the *seam*, not the Metal 2.0 port itself.

## Why

Slice's `create_descriptor` is consumed outside its own dispatch — the pybind, the Python fusion compiler (`models/experimental/ops/descriptors/`), and `mesh_partition`'s `std::visit` reuse. When slice's factory eventually migrates to Metal 2.0, it gains `create_program_spec` and **must drop `create_descriptor`**: `operation_concepts.hpp` `all_factories_valid` requires each factory to satisfy *exactly one* concept, and a factory with both `create_descriptor` and `create_program_spec` satisfies two → `static_assert` fails.

By moving the descriptor builder off the factory now:
- the bind/fusion/`mesh_partition` consumers anchor to `build_slice_tile_descriptor`, independent of the factory's concept;
- the future Metal 2.0 port only has to **delete the thin delegate** — the descriptor consumers keep working untouched;
- Metal 2.0 is never exposed to Python (the fusion compiler keeps getting a structural `ProgramDescriptor`).

## Changes

- **new** `slice_descriptor_builders.{hpp,cpp}` — `build_slice_tile_descriptor` (body moved verbatim)
- `slice_program_factory_tile.cpp` — now a 1-line delegate
- `slice_nanobind.cpp` — bind points at the free function (Python API unchanged)
- `sources.cmake` — registers the new file

## Validation

- Builds clean (`_ttnncpp.so` + `_ttnn.so` link, install, 0 errors) — the re-pointed bind links with no undefined reference.
- On device (Wormhole): `ttnn.SliceTileProgramFactory.create_descriptor(...)` returns an identical `ProgramDescriptor` (2 kernels, 1 CB).

## Base

Targets `dgomez/metal2-ttnn-framework` (#46781) — the Metal 2.0 framework this depends on — under the assumption it merges first.

## Follow-up (not in this PR)

Add `create_program_spec` to the slice factories (re-express kernels to `dfb::`/`ta::name`/named-CTA/varargs), which by the all-or-nothing rule pulls all 5 slice factories to Metal 2.0; delete the delegate; re-point `mesh_partition`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metal2-slice-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metal2-slice-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-slice-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metal2-slice-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/metal2-slice-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/metal2-slice-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metal2-slice-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metal2-slice-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metal2-slice-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metal2-slice-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metal2-slice-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metal2-slice-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metal2-slice-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metal2-slice-wrapper)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metal2-slice-wrapper)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metal2-slice-wrapper)