### PR TITLE
Fix SFPU math kernels for atanh, asinh, acosh utilizing stable log1p

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -12,6 +12,7 @@
 #include "ckernel_sfpu_sqrt_custom.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_log.h"
+#include "sfpu/ckernel_sfpu_log1p.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
@@ -789,40 +790,97 @@ inline void _calculate_cosine_(const int iterations) {
 }
 
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat log1p_or_log_dispatch(sfpi::vFloat arg, sfpi::vInt use_log1p) {
+    sfpi::vFloat res;
+    v_if(use_log1p) {
+        res = calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+    } v_else {
+        res = _calculate_log_body_no_init_(arg);
+    } v_endif;
+    return res;
+}
+
 // acosh(x) = log(x + sqrt(x^2 - 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_acosh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat res;
-        v_if(inp < sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(inp == sfpi::vConst1) { res = sfpi::vConst0; }
-        v_else {
-            sfpi::vFloat tmp = inp * inp;
-            tmp = tmp - sfpi::vConst1;
-            tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp = tmp + inp;
-            res = _calculate_log_body_no_init_(tmp);
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        
+        sfpi::vFloat arg = x;
+        sfpi::vInt use_log1p = 0;
+        
+        v_if(x < 1.5f) {
+            sfpi::vFloat xm1 = x - sfpi::vConst1;
+            sfpi::vFloat xp1 = x + sfpi::vConst1;
+            arg = xm1 + _calculate_sqrt_body_<APPROXIMATION_MODE>(xm1 * xp1);
+            use_log1p = 1;
+        } v_elseif(x < 268435456.0f) {
+            arg = x + _calculate_sqrt_body_<APPROXIMATION_MODE>(x * x - sfpi::vConst1);
+        } v_endif;
+        
+        sfpi::vFloat res = log1p_or_log_dispatch<is_fp32_dest_acc_en>(arg, use_log1p);
+        
+        v_if(x >= 268435456.0f) {
+            res += 0.693147182f; // LN2
+        } v_endif;
+
+        v_if(x < sfpi::vConst1) { 
+            res = std::numeric_limits<float>::quiet_NaN(); 
+        } v_elseif(x == sfpi::vConst1) { 
+            res = sfpi::vConst0; 
+        } v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
         }
-        v_endif;
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_asinh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp = tmp + sfpi::abs(inp);
-        auto res = _calculate_log_body_no_init_(tmp);
-        v_if(inp < sfpi::vConst0) { res = -res; }
-        v_endif;
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat a = sfpi::abs(x);
+        
+        sfpi::vFloat arg = a;
+        sfpi::vInt use_log1p = 1;
+
+        v_if (a < 0.5f) {
+            sfpi::vFloat a2 = a * a;
+            sfpi::vFloat den = sfpi::vConst1 + _calculate_sqrt_body_<APPROXIMATION_MODE>(sfpi::vConst1 + a2);
+            sfpi::vFloat recip = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
+            if constexpr (!is_fp32_dest_acc_en && !APPROXIMATION_MODE) {
+                recip = sfpi::convert<sfpi::vFloat16b>(recip, sfpi::RoundMode::NearestEven);
+            }
+            arg = a + a2 * recip;
+        } v_elseif (a < 268435456.0f) {
+            arg = a + (_calculate_sqrt_body_<APPROXIMATION_MODE>(sfpi::vConst1 + a * a) - sfpi::vConst1);
+        } v_else {
+            arg = a;
+            use_log1p = 0;
+        } v_endif;
+
+        sfpi::vFloat res = log1p_or_log_dispatch<is_fp32_dest_acc_en>(arg, use_log1p);
+
+        v_if (a >= 268435456.0f) {
+            res += 0.693147182f; // LN2
+        } v_endif;
+
+        res = sfpi::copysgn(res, x);
+        
+        v_if (a == std::numeric_limits<float>::infinity()) {
+            res = x;
+        } v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
+        }
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
@@ -833,42 +891,55 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_atanh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat abs_inp = sfpi::abs(inp);
-        sfpi::vFloat res;
-        v_if(abs_inp > sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(abs_inp == sfpi::vConst1) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat abs_x = sfpi::abs(x);
+        sfpi::vFloat num, den;
+
+        v_if (abs_x < 0.5f) {
+            num = x + x;
+            den = sfpi::vConst1 - x;
+        } v_else {
+            num = abs_x + abs_x;
+            den = sfpi::vConst1 - abs_x;
+        } v_endif;
+
+        sfpi::vFloat recip = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
+        if constexpr (!is_fp32_dest_acc_en && !APPROXIMATION_MODE) {
+            recip = sfpi::convert<sfpi::vFloat16b>(recip, sfpi::RoundMode::NearestEven);
+        }
+
+        sfpi::vFloat arg = num * recip;
+        sfpi::vFloat res = 0.5f * calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+
+        v_if (abs_x >= 0.5f) {
+            res = sfpi::copysgn(res, x);
+        } v_endif;
+
+        v_if(abs_x > sfpi::vConst1) {
+            res = std::numeric_limits<float>::quiet_NaN();
+        } v_elseif(abs_x == sfpi::vConst1) {
             sfpi::vFloat inf = std::numeric_limits<float>::infinity();
-            res = sfpi::copysgn(inf, inp);
+            res = sfpi::copysgn(inf, x);
+        } v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
         }
-        v_else {
-            sfpi::vFloat num = sfpi::vConst1 + inp;
-            sfpi::vFloat den = sfpi::vConst1 - inp;
-            sfpi::vFloat tmp = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
-            tmp = sfpi::copysgn(tmp, den);
-            if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
-                den = tmp;
-            } else {
-                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
-            }
-            num = num * den;
-            den = _calculate_log_body_no_init_(num);
-            res = 0.5f * den;
-        }
-        v_endif;
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 void init_inverse_hyperbolic() {
     sqrt_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 void init_atanh() {
     _init_sfpu_reciprocal_<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -12,6 +12,7 @@
 #include "ckernel_sfpu_sqrt_custom.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_log.h"
+#include "sfpu/ckernel_sfpu_log1p.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
@@ -817,39 +818,98 @@ inline void _calculate_cosine_(const int iterations) {
     }
 }
 
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat log1p_or_log_dispatch(sfpi::vFloat arg, sfpi::vInt use_log1p) {
+    sfpi::vFloat res;
+    v_if(use_log1p) {
+        res = calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+    } v_else {
+        res = _calculate_log_body_no_init_(arg);
+    } v_endif;
+    return res;
+}
+
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_acosh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        v_if(inp < sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(inp == sfpi::vConst1) { sfpi::dst_reg[0] = sfpi::vConst0; }
-        v_else {
-            sfpi::vFloat tmp = inp * inp;
-            tmp = tmp - sfpi::vConst1;
-            tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp = tmp + inp;
-            sfpi::dst_reg[0] = _calculate_log_body_no_init_(tmp);
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        
+        sfpi::vFloat arg = x;
+        sfpi::vInt use_log1p = 0;
+        
+        v_if(x < 1.5f) {
+            sfpi::vFloat xm1 = x - sfpi::vConst1;
+            sfpi::vFloat xp1 = x + sfpi::vConst1;
+            arg = xm1 + _calculate_sqrt_body_<APPROXIMATION_MODE>(xm1 * xp1);
+            use_log1p = 1;
+        } v_elseif(x < 268435456.0f) {
+            arg = x + _calculate_sqrt_body_<APPROXIMATION_MODE>(x * x - sfpi::vConst1);
+        } v_endif;
+        
+        sfpi::vFloat res = log1p_or_log_dispatch<is_fp32_dest_acc_en>(arg, use_log1p);
+        
+        v_if(x >= 268435456.0f) {
+            res += 0.693147182f; // LN2
+        } v_endif;
+
+        v_if(x < sfpi::vConst1) { 
+            res = std::numeric_limits<float>::quiet_NaN(); 
+        } v_elseif(x == sfpi::vConst1) { 
+            res = sfpi::vConst0; 
+        } v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
         }
-        v_endif;
+        sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_asinh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp = tmp + sfpi::abs(inp);
-        auto res = _calculate_log_body_no_init_(tmp);
-        v_if(inp < sfpi::vConst0) { res = -res; }
-        v_endif;
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat a = sfpi::abs(x);
+        
+        sfpi::vFloat arg = a;
+        sfpi::vInt use_log1p = 1;
+
+        v_if (a < 0.5f) {
+            sfpi::vFloat a2 = a * a;
+            sfpi::vFloat den = sfpi::vConst1 + _calculate_sqrt_body_<APPROXIMATION_MODE>(sfpi::vConst1 + a2);
+            sfpi::vFloat recip = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
+            if constexpr (!is_fp32_dest_acc_en && !APPROXIMATION_MODE) {
+                recip = sfpi::convert<sfpi::vFloat16b>(recip, sfpi::RoundMode::NearestEven);
+            }
+            arg = a + a2 * recip;
+        } v_elseif (a < 268435456.0f) {
+            arg = a + (_calculate_sqrt_body_<APPROXIMATION_MODE>(sfpi::vConst1 + a * a) - sfpi::vConst1);
+        } v_else {
+            arg = a;
+            use_log1p = 0;
+        } v_endif;
+
+        sfpi::vFloat res = log1p_or_log_dispatch<is_fp32_dest_acc_en>(arg, use_log1p);
+
+        v_if (a >= 268435456.0f) {
+            res += 0.693147182f; // LN2
+        } v_endif;
+
+        res = sfpi::copysgn(res, x);
+        
+        v_if (a == std::numeric_limits<float>::infinity()) {
+            res = x;
+        } v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
+        }
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
@@ -860,42 +920,55 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_atanh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat abs_inp = sfpi::abs(inp);
-        sfpi::vFloat res;
-        v_if(abs_inp > sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(abs_inp == sfpi::vConst1) {
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat abs_x = sfpi::abs(x);
+        sfpi::vFloat num, den;
+
+        v_if (abs_x < 0.5f) {
+            num = x + x;
+            den = sfpi::vConst1 - x;
+        } v_else {
+            num = abs_x + abs_x;
+            den = sfpi::vConst1 - abs_x;
+        } v_endif;
+
+        sfpi::vFloat recip = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
+        if constexpr (!is_fp32_dest_acc_en && !APPROXIMATION_MODE) {
+            recip = sfpi::convert<sfpi::vFloat16b>(recip, sfpi::RoundMode::NearestEven);
+        }
+
+        sfpi::vFloat arg = num * recip;
+        sfpi::vFloat res = 0.5f * calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+
+        v_if (abs_x >= 0.5f) {
+            res = sfpi::copysgn(res, x);
+        } v_endif;
+
+        v_if(abs_x > sfpi::vConst1) {
+            res = std::numeric_limits<float>::quiet_NaN();
+        } v_elseif(abs_x == sfpi::vConst1) {
             sfpi::vFloat inf = std::numeric_limits<float>::infinity();
-            res = sfpi::copysgn(inf, inp);
+            res = sfpi::copysgn(inf, x);
+        } v_endif;
+
+        if constexpr (!is_fp32_dest_acc_en) {
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
         }
-        v_else {
-            sfpi::vFloat num = sfpi::vConst1 + inp;
-            sfpi::vFloat den = sfpi::vConst1 - inp;
-            sfpi::vFloat tmp = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
-            tmp = sfpi::copysgn(tmp, den);
-            if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
-                den = tmp;
-            } else {
-                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
-            }
-            num = num * den;
-            den = _calculate_log_body_no_init_(num);
-            res = 0.5f * den;
-        }
-        v_endif;
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 void init_inverse_hyperbolic() {
     sqrt_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX, bool is_fp32_dest_acc_en>
 void init_atanh() {
     _init_sfpu_reciprocal_<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
@@ -62,7 +62,8 @@ ALWI void cos_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void acosh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(acosh, ckernel::sfpu::init_inverse_hyperbolic, APPROX)); }
+template <bool fast_and_approx = false>
+ALWI void acosh_tile_init() { MATH(SFPU_THREE_TEMPLATE_PARAM_INIT(acosh, ckernel::sfpu::init_inverse_hyperbolic, APPROX, fast_and_approx, DST_ACCUM_MODE)); }
 
 // clang-format off
 /**
@@ -79,7 +80,7 @@ ALWI void acosh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(acosh, ckernel::sfpu::i
  */
 // clang-format on
 ALWI void acosh_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(calculate_acosh, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_acosh, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
@@ -109,7 +110,8 @@ ALWI void tan_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void asinh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(asinh, ckernel::sfpu::init_inverse_hyperbolic, APPROX)); }
+template <bool fast_and_approx = false>
+ALWI void asinh_tile_init() { MATH(SFPU_THREE_TEMPLATE_PARAM_INIT(asinh, ckernel::sfpu::init_inverse_hyperbolic, APPROX, fast_and_approx, DST_ACCUM_MODE)); }
 
 // clang-format off
 /**
@@ -126,13 +128,14 @@ ALWI void asinh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(asinh, ckernel::sfpu::i
  */
 // clang-format on
 ALWI void asinh_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(calculate_asinh, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_asinh, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void atanh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(atanh, ckernel::sfpu::init_atanh, APPROX)); }
+template <bool fast_and_approx = false>
+ALWI void atanh_tile_init() { MATH(SFPU_THREE_TEMPLATE_PARAM_INIT(atanh, ckernel::sfpu::init_atanh, APPROX, fast_and_approx, DST_ACCUM_MODE)); }
 
 // clang-format off
 /**

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -74,11 +74,11 @@ void call_unary_sfpu_operation_init()
 {
     if constexpr (OPERATION == SfpuType::acosh || OPERATION == SfpuType::asinh)
     {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_inverse_hyperbolic<APPROX_MODE>);
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_inverse_hyperbolic<APPROX_MODE, FAST_MODE, is_fp32_dest_acc_en>);
     }
     else if constexpr (OPERATION == SfpuType::atanh)
     {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_atanh<APPROX_MODE>);
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_atanh<APPROX_MODE, FAST_MODE, is_fp32_dest_acc_en>);
     }
     else if constexpr (OPERATION == SfpuType::exp2)
     {
@@ -168,11 +168,11 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::acosh)
     {
-        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::asinh)
     {
-        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::atanh)
     {


### PR DESCRIPTION
Resolves #46862.

Implemented numerically stable log1p-based formulations for tanh, sinh, and cosh on Wormhole B0 and Blackhole architectures. This resolves catastrophic cancellation near boundaries (e.g. x = 0 for sinh, |x| = 1 for tanh and cosh).

- Uses a piecewise dispatch mapped to log1p_or_log_dispatch to limit branch evaluation times.
- Folds 