### PR TITLE
[skip ci] Fix sort order in environments with a different locale

### DIFF
--- a/.github/scripts/dockerfile-hash.sh
+++ b/.github/scripts/dockerfile-hash.sh
@@ -22,6 +22,7 @@
 #   dockerfile-hash.sh dockerfile/Dockerfile .github/workflows/build-docker-artifact.yaml
 
 set -euo pipefail
+export LC_ALL=C
 
 if [[ $# -lt 1 ]]; then
     echo "Usage: $0 <dockerfile> [extra-files...]" >&2


### PR DESCRIPTION
Cleanup: `sort -u` takes LC_ALL into account; without setting it we can get different results when run in different environments.

Make the sort stable so that the hash is stable.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=afuller/locale-agnostic-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:afuller/locale-agnostic-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=afuller/locale-agnostic-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:afuller/locale-agnostic-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=afuller/locale-agnostic-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:afuller/locale-agnostic-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=afuller/locale-agnostic-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:afuller/locale-agnostic-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=afuller/locale-agnostic-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:afuller/locale-agnostic-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=afuller/locale-agnostic-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:afuller/locale-agnostic-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=afuller/locale-agnostic-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:afuller/locale-agnostic-hashes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=afuller/locale-agnostic-hashes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:afuller/locale-agnostic-hashes)