### PR TITLE
[Bug fix] deepseek prefill migration: block-cyclic KV chunk address table

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/runners/integration_setup.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/integration_setup.py
@@ -86,7 +86,8 @@ def build_and_serialize_kv_chunk_table(
     cfg.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
     cfg.chunk_size_bytes = _CHUNK_SIZE_BYTES
     if layout == "deepseek":
-        assert chunk_size_global is not None, "layout='deepseek' requires chunk_size_global"
+        if chunk_size_global is None:
+            raise ValueError("layout='deepseek' requires chunk_size_global")
         table = create_kv_chunk_address_table_deepseek(
             config=cfg,
             mesh_device=mesh_device,

--- a/models/demos/deepseek_v3_d_p/tt/runners/integration_setup.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/integration_setup.py
@@ -28,7 +28,7 @@ from loguru import logger
 import ttnn
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
-    create_kv_chunk_address_table_kimi,
+    create_kv_chunk_address_table_deepseek,
 )
 
 # bfp8 [1, 1, 32, 576] KV chunk: 18 tiles * 1088 B = 19584 B.
@@ -51,21 +51,24 @@ def _serialize_table_to_path(table, path: str) -> None:
 
 
 def build_and_serialize_kv_chunk_table(
-    *, mesh_device, kvpe_cache, seq_len, num_layers, mesh_shape, sp_axis, num_users, path
+    *, mesh_device, kvpe_cache, seq_len, num_layers, mesh_shape, sp_axis, num_users, chunk_size_global, path
 ) -> str:
-    """Build the KV chunk address table from the device KV layout (via the shared
-    kv_cache_utils.create_kv_chunk_address_table_kimi) and serialize it to ``path`` for
-    the inference server to forward via SET_TABLE. Returns the path on success.
+    """Build the KV chunk address table from the device KV layout and serialize it to ``path``
+    for the inference server to forward via SET_TABLE. Returns the path on success.
 
-    Uses the kimi (non-balanced, sequential-layout) builder, which lays out one slot per
-    user — matching the user-major KV cache batch (slot = user*num_layers + layer)."""
+    Uses the DeepSeek BLOCK-CYCLIC builder (create_kv_chunk_address_table_deepseek): the DeepSeek
+    non-balanced prefill cache stores positions block-cyclic across the SP shards (NOT the Kimi
+    contiguous-block layout), so each natural position must map to its true block-cyclic storage
+    chip + offset — otherwise a partial migration copies the wrong (un-prefilled) storage chunks
+    and the migrated KV fails its PCC check. ``chunk_size_global`` is the prefill chunk size (the
+    block-cyclic period; same value passed to blockcyclic_positions)."""
     cfg = _disaggregation().KvChunkAddressTableConfig()
     cfg.num_layers = num_layers
     cfg.max_sequence_length = seq_len
     cfg.num_slots = num_users
     cfg.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
     cfg.chunk_size_bytes = _CHUNK_SIZE_BYTES
-    table = create_kv_chunk_address_table_kimi(
+    table = create_kv_chunk_address_table_deepseek(
         config=cfg,
         mesh_device=mesh_device,
         mesh_shape=mesh_shape,
@@ -74,6 +77,7 @@ def build_and_serialize_kv_chunk_table(
         tt_kvpe_cache=kvpe_cache,
         chunk_size_bytes=_CHUNK_SIZE_BYTES,
         num_users=num_users,
+        chunk_size_global=chunk_size_global,
     )
     _serialize_table_to_path(table, path)
     logger.info(f"[migration] KV chunk address table serialized to {path} (entries={table.total_entries()})")

--- a/models/demos/deepseek_v3_d_p/tt/runners/integration_setup.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/integration_setup.py
@@ -29,6 +29,7 @@ import ttnn
 from models.demos.deepseek_v3_d_p.utils.kv_cache_utils import (
     NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK,
     create_kv_chunk_address_table_deepseek,
+    create_kv_chunk_address_table_kimi,
 )
 
 # bfp8 [1, 1, 32, 576] KV chunk: 18 tiles * 1088 B = 19584 B.
@@ -51,34 +52,65 @@ def _serialize_table_to_path(table, path: str) -> None:
 
 
 def build_and_serialize_kv_chunk_table(
-    *, mesh_device, kvpe_cache, seq_len, num_layers, mesh_shape, sp_axis, num_users, chunk_size_global, path
+    *,
+    mesh_device,
+    kvpe_cache,
+    seq_len,
+    num_layers,
+    mesh_shape,
+    sp_axis,
+    num_users,
+    path,
+    layout="deepseek",
+    chunk_size_global=None,
 ) -> str:
     """Build the KV chunk address table from the device KV layout and serialize it to ``path``
     for the inference server to forward via SET_TABLE. Returns the path on success.
 
-    Uses the DeepSeek BLOCK-CYCLIC builder (create_kv_chunk_address_table_deepseek): the DeepSeek
-    non-balanced prefill cache stores positions block-cyclic across the SP shards (NOT the Kimi
-    contiguous-block layout), so each natural position must map to its true block-cyclic storage
-    chip + offset — otherwise a partial migration copies the wrong (un-prefilled) storage chunks
-    and the migrated KV fails its PCC check. ``chunk_size_global`` is the prefill chunk size (the
-    block-cyclic period; same value passed to blockcyclic_positions)."""
+    ``layout`` selects the storage-layout builder (both lay out one slot per user, matching the
+    user-major KV cache batch slot = user*num_layers + layer):
+
+    - ``"deepseek"`` (default): the DeepSeek non-balanced prefill cache stores positions
+      BLOCK-CYCLIC across the SP shards, so each natural position must map to its true
+      block-cyclic storage chip + offset — otherwise a partial migration copies the wrong
+      (un-prefilled) storage chunks and the migrated KV fails its PCC check. Requires
+      ``chunk_size_global`` = the prefill chunk size (the block-cyclic period; same value
+      passed to blockcyclic_positions).
+    - ``"kimi"``: the Kimi-K2.6 contiguous/sequential-layout builder (position P on chip
+      P // seq_len_local). ``chunk_size_global`` is ignored.
+    """
     cfg = _disaggregation().KvChunkAddressTableConfig()
     cfg.num_layers = num_layers
     cfg.max_sequence_length = seq_len
     cfg.num_slots = num_users
     cfg.chunk_n_tokens = NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
     cfg.chunk_size_bytes = _CHUNK_SIZE_BYTES
-    table = create_kv_chunk_address_table_deepseek(
-        config=cfg,
-        mesh_device=mesh_device,
-        mesh_shape=mesh_shape,
-        seq_len=seq_len,
-        sp_axis=sp_axis,
-        tt_kvpe_cache=kvpe_cache,
-        chunk_size_bytes=_CHUNK_SIZE_BYTES,
-        num_users=num_users,
-        chunk_size_global=chunk_size_global,
-    )
+    if layout == "deepseek":
+        assert chunk_size_global is not None, "layout='deepseek' requires chunk_size_global"
+        table = create_kv_chunk_address_table_deepseek(
+            config=cfg,
+            mesh_device=mesh_device,
+            mesh_shape=mesh_shape,
+            seq_len=seq_len,
+            sp_axis=sp_axis,
+            tt_kvpe_cache=kvpe_cache,
+            chunk_size_bytes=_CHUNK_SIZE_BYTES,
+            num_users=num_users,
+            chunk_size_global=chunk_size_global,
+        )
+    elif layout == "kimi":
+        table = create_kv_chunk_address_table_kimi(
+            config=cfg,
+            mesh_device=mesh_device,
+            mesh_shape=mesh_shape,
+            seq_len=seq_len,
+            sp_axis=sp_axis,
+            tt_kvpe_cache=kvpe_cache,
+            chunk_size_bytes=_CHUNK_SIZE_BYTES,
+            num_users=num_users,
+        )
+    else:
+        raise ValueError(f"unknown KV chunk table layout {layout!r} (expected 'deepseek' or 'kimi')")
     _serialize_table_to_path(table, path)
     logger.info(f"[migration] KV chunk address table serialized to {path} (entries={table.total_entries()})")
     return path

--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
@@ -611,6 +611,7 @@ def main() -> None:
             mesh_shape=GLOBAL_MESH_SHAPE,
             sp_axis=0,  # GLOBAL_MESH_SHAPE = (sp, tp) — SP is axis 0
             num_users=NUM_USERS,
+            chunk_size_global=CHUNK_SIZE,  # block-cyclic period of the non-balanced prefill cache
             path=table_path,
         )
         send_kv_chunk_table(table_path)

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -223,6 +223,91 @@ def create_kv_chunk_address_table_kimi(
     return lookup_table
 
 
+def create_kv_chunk_address_table_deepseek(
+    config, mesh_device, mesh_shape, seq_len, sp_axis, tt_kvpe_cache, chunk_size_bytes, num_users, chunk_size_global
+):
+    """Block-cyclic-aware KV chunk address table for the DeepSeek non-balanced prefill cache.
+
+    The DeepSeek prefill KV cache stores positions in BLOCK-CYCLIC order across the SP shards
+    (see tt.mla.utils.blockcyclic_positions / update_padded_kv_cache): natural position P lives on
+    SP-row chip ``c = (P % chunk_size_global) // chunk_local`` at local row
+    ``lr = (P // chunk_size_global) * chunk_local + (P % chunk_size_global) % chunk_local``,
+    where ``chunk_local = chunk_size_global // sp``.
+
+    The Kimi builder instead assumes a CONTIGUOUS-block layout (position P on chip
+    P // seq_len_local), which mismaps every position: a partial migration of natural range [0, N)
+    then copies contiguous storage chunk 0..N/32 — mostly UN-prefilled storage — instead of the
+    block-cyclic-scattered chunks that actually hold the first N tokens (observed: AFTER-migration
+    KV PCC ~0.35 because only ~1/sp of the data lands correctly). This builder maps each natural
+    position to its true block-cyclic storage chip + local DRAM-bank offset, reusing the same
+    ROUND_ROBIN_1D bank/offset math as init_kvpe_cache's NdShardSpec
+    (linear = batch * chunks_per_layer_local + local_chunk; bank = linear % banks;
+    offset = (linear // banks) * chunk_size_bytes), so a [0, N) migration moves exactly the
+    prefilled KV. ``slot`` is the user index; cache batch index = slot * num_layers + layer.
+    """
+    sp = mesh_shape[sp_axis]
+    assert (
+        seq_len % (sp * NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK) == 0
+    ), f"seq_len {seq_len} must be divisible by sp({sp}) * {NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK}"
+    assert chunk_size_global % sp == 0, f"chunk_size_global {chunk_size_global} must be divisible by sp {sp}"
+    chunk_local = chunk_size_global // sp
+    assert (
+        chunk_local % NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK == 0
+    ), f"chunk_local {chunk_local} must be divisible by {NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK}"
+    seq_len_local = seq_len // sp
+    chunks_per_layer_local = seq_len_local // NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+
+    lookup_table = ttnn.experimental.disaggregation.KvChunkAddressTable(config)
+    host_name = socket.gethostname()
+    num_layers = config.num_layers
+
+    # One device group per SP row (the row's TP columns hold replicated KV). Single-process
+    # runner => rank 0 of size 1 => covers all rows; multi-rank slices rows per rank.
+    rank = ttnn.distributed_context_get_rank()
+    size = ttnn.distributed_context_get_size()
+    total_rows = mesh_shape[0]
+    rank_row_start = int(rank) * total_rows // int(size)
+    rank_row_end = rank_row_start + total_rows // int(size)
+    device_group_for_row = {}
+    all_fabric_node_ids = []
+    for row in range(rank_row_start, rank_row_end):
+        fabric_node_ids = [
+            mesh_device.get_fabric_node_id(ttnn.MeshCoordinate(row, col)) for col in range(mesh_shape[1])
+        ]
+        all_fabric_node_ids.extend(fabric_node_ids)
+        device_group_for_row[row] = lookup_table.add_device_group(fabric_node_ids)
+    for fid in all_fabric_node_ids:
+        lookup_table.set_fabric_node_host(fid, host_name=host_name)
+
+    dram_bank_base_addr = tt_kvpe_cache.buffer_address()
+    for slot in range(num_users):
+        for layer in range(num_layers):
+            batch = slot * num_layers + layer
+            for position in range(0, seq_len, NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK):
+                slab = position // chunk_size_global
+                rem = position % chunk_size_global
+                c = rem // chunk_local
+                if c < rank_row_start or c >= rank_row_end:
+                    continue  # this SP-row chip is owned by another rank
+                off = rem % chunk_local
+                local_row = slab * chunk_local + off
+                local_chunk = local_row // NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK
+                linear = batch * chunks_per_layer_local + local_chunk
+                bank_id = linear % BH_NUM_DRAM_BANKS
+                bank_offset = (linear // BH_NUM_DRAM_BANKS) * chunk_size_bytes
+                location = ttnn.experimental.disaggregation.KvCacheLocation()
+                location.noc_addr = (bank_id << 32) | (dram_bank_base_addr + bank_offset)
+                location.size_bytes = chunk_size_bytes
+                location.device_group_index = device_group_for_row[c]
+                lookup_table.set(layer, position, slot, location)
+
+    logger.info(
+        f"[migration] DeepSeek block-cyclic KV chunk table: sp={sp} chunk_local={chunk_local} "
+        f"seq_len_local={seq_len_local} entries={lookup_table.total_entries()}"
+    )
+    return lookup_table
+
+
 def init_kvpe_cache(kvpe_cache_head_dim, mesh_device, seq_len, mesh_shape, sp_axis, num_kvpe_cache_layers, num_users=1):
     """
     Initialize KVPE cache for MLA.

--- a/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
+++ b/models/demos/deepseek_v3_d_p/utils/kv_cache_utils.py
@@ -229,7 +229,8 @@ def create_kv_chunk_address_table_deepseek(
     """Block-cyclic-aware KV chunk address table for the DeepSeek non-balanced prefill cache.
 
     The DeepSeek prefill KV cache stores positions in BLOCK-CYCLIC order across the SP shards
-    (see tt.mla.utils.blockcyclic_positions / update_padded_kv_cache): natural position P lives on
+    (see models.demos.deepseek_v3_d_p.tt.mla.utils.blockcyclic_positions /
+    ttnn.experimental.deepseek_prefill.update_padded_kv_cache): natural position P lives on
     SP-row chip ``c = (P % chunk_size_global) // chunk_local`` at local row
     ``lr = (P // chunk_size_global) * chunk_local + (P % chunk_size_global) % chunk_local``,
     where ``chunk_local = chunk_size_global // sp``.
@@ -245,7 +246,9 @@ def create_kv_chunk_address_table_deepseek(
     offset = (linear // banks) * chunk_size_bytes), so a [0, N) migration moves exactly the
     prefilled KV. ``slot`` is the user index; cache batch index = slot * num_layers + layer.
     """
-    sp = mesh_shape[sp_axis]
+    if sp_axis != 0:
+        raise ValueError(f"DeepSeek block-cyclic KV cache assumes sp_axis=0 (mesh rows); got sp_axis={sp_axis}")
+    sp = mesh_shape[0]
     assert (
         seq_len % (sp * NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK) == 0
     ), f"seq_len {seq_len} must be divisible by sp({sp}) * {NUM_CONTIGUOUS_TOKENS_IN_DRAM_BANK}"


### PR DESCRIPTION


### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

With balancing off (PREFILL_IS_BALANCED=0, the default), the DeepSeek prefill KV cache stores positions BLOCK-CYCLIC across the SP shards, but the migration KV chunk address table was built with create_kv_chunk_address_table_kimi, which assumes a CONTIGUOUS-block layout. That mismaps every position: a partial [0, N) migration copies contiguous storage chunks 0..N/32 — mostly un-prefilled storage — instead of the block-cyclic-scattered chunks that hold the first N tokens, so the migrated KV PCCs at ~0.35 (only ~1/sp of the data lands).

Add create_kv_chunk_address_table_deepseek, which maps each natural position to its true block-cyclic storage chip + DRAM-bank offset, reusing init_kvpe_cache's ROUND_ROBIN_1D bank/offset math, and wire it through build_and_serialize_kv_chunk_table (new chunk_size_global arg = the prefill chunk size / block-cyclic period).

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bzhang/deepseek-blockcyclic-kv-chunk-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bzhang/deepseek-blockcyclic-kv-chunk-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bzhang/deepseek-blockcyclic-kv-chunk-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bzhang/deepseek-blockcyclic-kv-chunk-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bzhang/deepseek-blockcyclic-kv-chunk-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bzhang/deepseek-blockcyclic-kv-chunk-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bzhang/deepseek-blockcyclic-kv-chunk-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bzhang/deepseek-blockcyclic-kv-chunk-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bzhang/deepseek-blockcyclic-kv-chunk-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bzhang/deepseek-blockcyclic-kv-chunk-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bzhang/deepseek-blockcyclic-kv-chunk-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bzhang/deepseek-blockcyclic-kv-chunk-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bzhang/deepseek-blockcyclic-kv-chunk-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bzhang/deepseek-blockcyclic-kv-chunk-table)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bzhang/deepseek-blockcyclic-kv-chunk-table)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bzhang/deepseek-blockcyclic-kv-chunk-table)