### PR TITLE
[Draft] slice: migrate all 5 factories to Metal 2.0 (ProgramSpec)

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -11,6 +11,7 @@
 #include <tt-metalium/sub_device.hpp>
 #include <tt-metalium/experimental/fabric/fabric.hpp>
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp"
 #include "ttnn/operations/ccl/common/host/moe_utils.hpp"
 
 namespace ttnn::operations::ccl {
@@ -28,6 +29,27 @@ uint32_t get_cluster_axis_index(
 namespace {
 
 using SliceOp = ttnn::prim::SliceDeviceOperation;
+
+// The slice program factories migrated to Metal 2.0 (create_program_spec) and no longer expose
+// create_descriptor. mesh_partition reuses slice's ProgramDescriptor, so it dispatches to the
+// standalone descriptor builders (slice_descriptor_builders.hpp) by selected factory type.
+template <typename Factory>
+tt::tt_metal::ProgramDescriptor slice_descriptor_for(
+    const ttnn::prim::SliceParams& attrs, const ttnn::prim::SliceInputs& inputs, Tensor& output) {
+    using namespace ttnn::prim;
+    if constexpr (std::is_same_v<Factory, SliceTileProgramFactory>) {
+        return build_slice_tile_descriptor(attrs, inputs, output);
+    } else if constexpr (std::is_same_v<Factory, SliceRmProgramFactory>) {
+        return build_slice_rm_descriptor(attrs, inputs, output);
+    } else if constexpr (std::is_same_v<Factory, SliceRmStrideProgramFactory>) {
+        return build_slice_rm_stride_descriptor(attrs, inputs, output);
+    } else if constexpr (std::is_same_v<Factory, SliceRmShardedProgramFactory>) {
+        return build_slice_rm_sharded_descriptor(attrs, inputs, output);
+    } else {
+        static_assert(std::is_same_v<Factory, SliceTileTensorArgsProgramFactory>, "unhandled slice factory");
+        return build_slice_tile_tensor_args_descriptor(attrs, inputs, output);
+    }
+}
 
 // Helper function to compute slice parameters for a given mesh coordinate
 auto compute_slice_parameters(
@@ -127,7 +149,7 @@ MeshPartitionDeviceOperation::MeshPartition::create_at(
     Program program = std::visit(
         [&](auto&& factory) -> Program {
             using Factory = std::decay_t<decltype(factory)>;
-            auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
+            auto descriptor = slice_descriptor_for<Factory>(slice_attrs, slice_tensor_args, tensor_return_value);
             return Program{descriptor};
         },
         program_factory);
@@ -157,7 +179,7 @@ void MeshPartitionDeviceOperation::MeshPartition::override_runtime_arguments(
         std::visit(
             [&](auto&& program_factory) {
                 using Factory = std::decay_t<decltype(program_factory)>;
-                auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
+                auto descriptor = slice_descriptor_for<Factory>(slice_attrs, slice_tensor_args, tensor_return_value);
                 tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
             },
             shared_variables.slice_program_factory);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd_m2.cpp
@@ -1,0 +1,129 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 slice rm-stride nd reader. Logic identical to reader_multicore_slice_nd.cpp
+// (that one stays for the legacy/descriptor path); bindings are Metal 2.0:
+//   - CB index      -> dfb::cb_out (this kernel is the DFB producer)
+//   - rank/element  -> named CTAs  (in the cache key)
+//   - input accessor -> ta::src    (address implicit; standard accessor)
+//   - num_rows/start_row -> named RTAs
+//   - per-dim arrays (input/output dims, slice start/end/step) -> RTA varargs,
+//     copied into local arrays (rank is compile-time, so arrays are fixed-size)
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_out = dfb::cb_out;
+    constexpr uint32_t tensor_rank = get_named_compile_time_arg_val("rank");
+    constexpr uint32_t element_size = get_named_compile_time_arg_val("element_size");
+
+    const uint32_t num_rows_for_this_core = get_arg(args::num_rows);
+    const uint32_t start_row_for_this_core = get_arg(args::start_row);
+
+    // Per-dim arrays as runtime varargs, in the order the factory appends them:
+    // [input_dims, output_dims, slice_starts, slice_ends, slice_steps], each `tensor_rank` long.
+    uint32_t input_dims[tensor_rank];
+    uint32_t output_dims[tensor_rank];
+    uint32_t slice_starts[tensor_rank];
+    uint32_t slice_ends[tensor_rank];
+    uint32_t slice_steps[tensor_rank];
+    for (uint32_t i = 0; i < tensor_rank; ++i) {
+        input_dims[i] = get_vararg(i);
+        output_dims[i] = get_vararg(tensor_rank + i);
+        slice_starts[i] = get_vararg(2 * tensor_rank + i);
+        slice_ends[i] = get_vararg(3 * tensor_rank + i);
+        slice_steps[i] = get_vararg(4 * tensor_rank + i);
+    }
+
+    const uint32_t input_bytes_per_row = input_dims[tensor_rank - 1] * element_size;
+
+    const auto s0 = TensorAccessor(ta::src);
+    Noc noc;
+    CircularBuffer cb_out(cb_id_out);
+
+    uint32_t coords[16];
+    for (uint32_t i = 0; i < tensor_rank; ++i) {
+        coords[i] = slice_starts[i];
+    }
+
+    uint32_t rows_processed = 0;
+    uint32_t current_logical_row = 0;
+    bool found_start = false;
+    bool more_iterations = true;
+
+    while (more_iterations && rows_processed < num_rows_for_this_core) {
+        bool should_process_row = false;
+        if (!found_start) {
+            if (current_logical_row == start_row_for_this_core) {
+                found_start = true;
+                should_process_row = true;
+            }
+        } else {
+            should_process_row = true;
+        }
+
+        if (should_process_row && rows_processed < num_rows_for_this_core) {
+            uint32_t input_row_idx = 0;
+            if (tensor_rank > 1) {
+                for (int32_t dim = 0; dim < (int32_t)(tensor_rank - 1); ++dim) {
+                    uint32_t stride = 1;
+                    for (int32_t d = dim + 1; d < (int32_t)(tensor_rank - 1); ++d) {
+                        stride *= input_dims[d];
+                    }
+                    input_row_idx += coords[dim] * stride;
+                }
+            }
+
+            cb_out.reserve_back(1);
+            uint32_t l1_write_addr = cb_out.get_write_ptr();
+
+            noc.async_read(
+                s0, cb_out, input_bytes_per_row, {.page_id = input_row_idx, .offset_bytes = 0}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+
+            uint32_t last_dim = tensor_rank - 1;
+            if (slice_starts[last_dim] != 0 || slice_steps[last_dim] != 1 ||
+                slice_ends[last_dim] != input_dims[last_dim]) {
+                volatile tt_l1_ptr uint8_t* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+                volatile tt_l1_ptr uint8_t* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+
+                uint32_t out_col = 0;
+                for (uint32_t input_col = slice_starts[last_dim];
+                     input_col < slice_ends[last_dim] && out_col < output_dims[last_dim];
+                     input_col += slice_steps[last_dim]) {
+                    for (uint32_t byte_idx = 0; byte_idx < element_size; ++byte_idx) {
+                        dst_ptr[out_col * element_size + byte_idx] = src_ptr[input_col * element_size + byte_idx];
+                    }
+                    out_col++;
+                }
+            }
+
+            cb_out.push_back(1);
+            rows_processed++;
+        }
+
+        current_logical_row++;
+
+        bool carry = true;
+        for (int32_t dim = (int32_t)(tensor_rank - 2); dim >= 0 && carry; --dim) {
+            coords[dim] += slice_steps[dim];
+            if (coords[dim] < slice_ends[dim]) {
+                carry = false;
+            } else {
+                coords[dim] = slice_starts[dim];
+            }
+        }
+        if (carry) {
+            more_iterations = false;
+        }
+
+        if (tensor_rank == 1) {
+            break;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd_m2.cpp
@@ -25,19 +25,19 @@ void kernel_main() {
     const uint32_t num_rows_for_this_core = get_arg(args::num_rows);
     const uint32_t start_row_for_this_core = get_arg(args::start_row);
 
-    // Per-dim arrays as runtime varargs, in the order the factory appends them:
-    // [input_dims, output_dims, slice_starts, slice_ends, slice_steps], each `tensor_rank` long.
+    // Per-dim arrays are op-level (identical across cores) -> common varargs, in the order the
+    // factory appends them: [input_dims, output_dims, slice_starts, slice_ends, slice_steps].
     uint32_t input_dims[tensor_rank];
     uint32_t output_dims[tensor_rank];
     uint32_t slice_starts[tensor_rank];
     uint32_t slice_ends[tensor_rank];
     uint32_t slice_steps[tensor_rank];
     for (uint32_t i = 0; i < tensor_rank; ++i) {
-        input_dims[i] = get_vararg(i);
-        output_dims[i] = get_vararg(tensor_rank + i);
-        slice_starts[i] = get_vararg(2 * tensor_rank + i);
-        slice_ends[i] = get_vararg(3 * tensor_rank + i);
-        slice_steps[i] = get_vararg(4 * tensor_rank + i);
+        input_dims[i] = get_common_vararg(i);
+        output_dims[i] = get_common_vararg(tensor_rank + i);
+        slice_starts[i] = get_common_vararg(2 * tensor_rank + i);
+        slice_ends[i] = get_common_vararg(3 * tensor_rank + i);
+        slice_steps[i] = get_common_vararg(4 * tensor_rank + i);
     }
 
     const uint32_t input_bytes_per_row = input_dims[tensor_rank - 1] * element_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_slice_tile_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_slice_tile_m2.cpp
@@ -1,0 +1,65 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 slice tile reader. Logic identical to
+// reader_unary_unpad_dims_interleaved_start_id.cpp (that one stays for the
+// legacy/descriptor consumers); only the bindings are Metal 2.0:
+//   - CB index            -> dfb::cb_in
+//   - num_dims            -> named CTA   (get_named_compile_time_arg_val)
+//   - input accessor      -> ta::src     (address implicit; no src_addr CRTA)
+//   - start_id/num_tiles  -> named RTAs  (get_arg(args::...))
+//   - per-dim shape arrays -> common varargs (read-only)
+//   - per-dim running index -> per-core varargs, copied into a local mutable array
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_in0 = dfb::cb_in;
+    constexpr uint32_t num_dims = get_named_compile_time_arg_val("num_dims");
+
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t num_tiles = get_arg(args::num_tiles);
+
+    // Read-only per-dim shape (common varargs): [num_unpadded[num_dims], num_padded[num_dims]].
+    // Mutable running index (per-core varargs): id_per_dim[num_dims] -> local copy.
+    uint32_t num_unpadded_tiles[num_dims];
+    uint32_t num_padded_tiles[num_dims];
+    uint32_t id_per_dim[num_dims];
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        num_unpadded_tiles[j] = get_common_vararg(j);
+        num_padded_tiles[j] = get_common_vararg(num_dims + j);
+        id_per_dim[j] = get_vararg(j);
+    }
+
+    const auto s0 = TensorAccessor(ta::src);
+
+    CircularBuffer cb_in0(cb_id_in0);
+    Noc noc;
+
+    const uint32_t tile_size = cb_in0.get_tile_size();
+
+    uint32_t src_tile_id = start_id;
+
+    for (uint32_t i = 0; i < num_tiles; ++i) {
+        // Copy Input
+        cb_in0.reserve_back(1);
+        noc.async_read(s0, cb_in0, tile_size, {.page_id = src_tile_id}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in0.push_back(1);
+        src_tile_id++;
+        for (uint32_t j = 0; j < num_dims; ++j) {
+            id_per_dim[j]++;
+            if (id_per_dim[j] == num_unpadded_tiles[j]) {
+                id_per_dim[j] = 0;
+                src_tile_id += num_padded_tiles[j];
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_slice_tile_tensor_args_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_slice_tile_tensor_args_m2.cpp
@@ -1,0 +1,132 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 slice tile reader (slice start/end come from device TENSORS). Logic
+// identical to reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp (that
+// one stays for the legacy/descriptor consumers); only the bindings are Metal 2.0:
+//   - src CB index        -> dfb::cb_in
+//   - staging CB index    -> dfb::cb_tensor (used to read the start/end tensor pages)
+//   - num_dims/tile_w/h   -> named CTAs (get_named_compile_time_arg_val)
+//   - input accessor      -> ta::src    (address implicit; no src_addr CRTA)
+//   - start accessor      -> ta::starts (address implicit; no start_addr CRTA)
+//   - end accessor        -> ta::ends   (address implicit; no end_addr CRTA)
+//   - start_id/num_tiles  -> named RTAs (get_arg(args::...))
+//   - per-dim shape arrays -> common varargs (read-only):
+//       [num_unpadded[num_dims], num_padded[num_dims], input_shape[num_dims]]
+//   - per-dim running index -> per-core varargs, copied into a local mutable array
+//
+// NOTE: the start/end tensors are read with a standard TensorAccessor (one page,
+// page_id = 0) into the staging CB, exactly as the legacy kernel does — so the
+// Metal 2.0 TensorAccessor binding fits cleanly. The `end` tensor is read but the
+// end indices are unused in the offset math (matching the legacy kernel, which only
+// uses the start indices); the binding is kept to preserve identical behavior.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_in0 = dfb::cb_in;
+    constexpr uint32_t cb_id_tensor = dfb::cb_tensor;
+    constexpr uint32_t num_dims = get_named_compile_time_arg_val("num_dims");
+    const uint32_t tile_width = get_named_compile_time_arg_val("tile_width");
+    const uint32_t tile_height = get_named_compile_time_arg_val("tile_height");
+
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t num_tiles = get_arg(args::num_tiles);
+
+    // Read-only per-dim shape (common varargs):
+    //   [num_unpadded[num_dims], num_padded[num_dims], input_shape[num_dims]].
+    // Mutable running index (per-core varargs): id_per_dim[num_dims] -> local copy.
+    uint32_t num_unpadded_tiles[num_dims];
+    uint32_t num_padded_tiles[num_dims];
+    uint32_t input_shape_args[num_dims];
+    uint32_t id_per_dim[num_dims];
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        num_unpadded_tiles[j] = get_common_vararg(j);
+        num_padded_tiles[j] = get_common_vararg(num_dims + j);
+        input_shape_args[j] = get_common_vararg(2 * num_dims + j);
+        id_per_dim[j] = get_vararg(j);
+    }
+
+    const auto s0 = TensorAccessor(ta::src);
+    const auto start_tensor_accessor = TensorAccessor(ta::starts);
+    const auto end_tensor_accessor = TensorAccessor(ta::ends);
+
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_tensor(cb_id_tensor);
+    Noc noc;
+
+    const uint32_t tile_size = cb_in0.get_tile_size();
+
+    // Read start and end indices from the start/end tensors using a staging CB.
+    uint32_t start_indices[num_dims];
+    uint32_t end_indices[num_dims];
+
+    cb_tensor.reserve_back(1);
+    uint32_t start_buffer_l1_addr = cb_tensor.get_write_ptr();
+    noc.async_read(start_tensor_accessor, cb_tensor, tile_size, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    volatile tt_l1_ptr uint32_t* start_data = (volatile tt_l1_ptr uint32_t*)start_buffer_l1_addr;
+    for (uint32_t i = 0; i < num_dims; i++) {
+        start_indices[i] = start_data[i];
+    }
+    cb_tensor.pop_front(1);
+
+    cb_tensor.reserve_back(1);
+    uint32_t end_buffer_l1_addr = cb_tensor.get_write_ptr();
+    noc.async_read(end_tensor_accessor, cb_tensor, tile_size, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+    volatile tt_l1_ptr uint32_t* end_data = (volatile tt_l1_ptr uint32_t*)end_buffer_l1_addr;
+    for (uint32_t i = 0; i < num_dims; i++) {
+        end_indices[i] = end_data[i];
+    }
+    cb_tensor.pop_front(1);
+
+    uint32_t start_offset = 0;
+
+    if (num_dims >= 2) {
+        uint32_t start_h_tiles = start_indices[num_dims - 2] / tile_height;
+        uint32_t start_w_tiles = start_indices[num_dims - 1] / tile_width;
+
+        uint32_t input_width = input_shape_args[num_dims - 1];
+        uint32_t input_height = input_shape_args[num_dims - 2];
+        uint32_t num_pages_width = input_width / tile_width;
+
+        start_offset += start_h_tiles * num_pages_width + start_w_tiles;
+
+        if (num_dims > 2) {
+            uint32_t upper_dims_offset = 0;
+            uint32_t multiplier = (input_height / tile_height) * num_pages_width;
+
+            for (int32_t i = num_dims - 3; i >= 0; i--) {
+                upper_dims_offset = upper_dims_offset * input_shape_args[i] + start_indices[i];
+            }
+            start_offset += upper_dims_offset * multiplier;
+        }
+    }
+
+    // Add the calculated offset to the base start_id
+    uint32_t src_tile_id = start_id + start_offset;
+
+    for (uint32_t i = 0; i < num_tiles; ++i) {
+        cb_in0.reserve_back(1);
+        noc.async_read(s0, cb_in0, tile_size, {.page_id = src_tile_id}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in0.push_back(1);
+
+        src_tile_id++;
+        for (uint32_t j = 0; j < num_dims; ++j) {
+            id_per_dim[j]++;
+            if (id_per_dim[j] == num_unpadded_tiles[j]) {
+                id_per_dim[j] = 0;
+                src_tile_id += num_padded_tiles[j];
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id_m2.cpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 row-major interleaved slice reader. Logic identical to
+// slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp (that one stays for the
+// legacy/descriptor consumers); only the bindings are Metal 2.0:
+//   - CB index                 -> dfb::cb_in   (Device 2.0 CircularBuffer preserved)
+//   - num_dims                 -> named CTA (get_named_compile_time_arg_val; sizes the loop)
+//   - input accessor           -> ta::src      (standard 2-arg TensorAccessor; page size is
+//                                  spec-derived (== padded_stick_size) and in the cache key.
+//                                  The within-row column offset is applied via the source
+//                                  page-spec offset_bytes, NOT a runtime base-address/page-size
+//                                  override — see column_offset_bytes below.)
+//   - op-level byte sizes      -> named CTAs (padded_stick_size / unpadded_stick_size /
+//                                  stick_size_offset / misalignment / column_offset_bytes;
+//                                  pure functions of shape + slice params, all in the cache key)
+//   - per-core scalars         -> named RTAs (start_id / num_sticks_per_core /
+//                                  num_sticks_per_core_read / num_read_per_barrier)
+//   - per-dim shape arrays      -> common varargs (read-only): [num_unpadded[], num_padded[]]
+//   - per-dim running index    -> per-core varargs (id_per_dim), copied into a local mutable array
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_in0 = dfb::cb_in;
+    constexpr uint32_t num_dims = get_named_compile_time_arg_val("num_dims");
+
+    // Op-level byte sizes (identical across cores; in the cache key).
+    constexpr uint32_t unpadded_stick_size = get_named_compile_time_arg_val("unpadded_stick_size");
+    constexpr uint32_t stick_size_offset = get_named_compile_time_arg_val("stick_size_offset");
+    constexpr uint32_t misalignment = get_named_compile_time_arg_val("misalignment");
+    // Byte offset of the slice's first column within each input row, rounded down to the source
+    // buffer alignment (== begins_bytes - misalignment in the legacy host). The legacy reader folded
+    // this into the accessor's base address; here it is the source page offset_bytes (which keeps the
+    // page base/page size spec-derived for the standard 2-arg accessor).
+    constexpr uint32_t column_offset_bytes = get_named_compile_time_arg_val("column_offset_bytes");
+
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t num_sticks_per_core = get_arg(args::num_sticks_per_core);
+    const uint32_t num_sticks_per_core_read = get_arg(args::num_sticks_per_core_read);
+    const uint32_t num_read_per_barrier = get_arg(args::num_read_per_barrier);
+
+    // Read-only per-dim shape (common varargs): [num_unpadded[num_dims], num_padded[num_dims]].
+    // Mutable running index (per-core varargs): id_per_dim[num_dims] -> local copy.
+    uint32_t num_unpadded_sticks[num_dims];
+    uint32_t num_padded_sticks[num_dims];
+    uint32_t id_per_dim[num_dims];
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        num_unpadded_sticks[j] = get_common_vararg(j);
+        num_padded_sticks[j] = get_common_vararg(num_dims + j);
+        id_per_dim[j] = get_vararg(j);
+    }
+
+    const uint32_t read_size = unpadded_stick_size + misalignment;
+
+    const auto s0 = TensorAccessor(ta::src);
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_in0(cb_id_in0);
+
+    uint32_t src_stick_id = start_id;
+    uint32_t sticks_read = 0;
+    for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
+        cb_in0.reserve_back(num_read_per_barrier);
+        uint32_t src_buffer_l1_addr = cb_in0.get_write_ptr();
+
+        for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
+            sticks_read++;
+            CoreLocalMem<uint32_t> dst(src_buffer_l1_addr);
+            noc.async_read(
+                s0, dst, read_size, {.page_id = src_stick_id, .offset_bytes = column_offset_bytes}, {.offset_bytes = 0});
+            if (misalignment != 0) {
+                noc.async_read_barrier();
+                tt::data_movement::common::tt_memmove<false, false, false, 0>(
+                    src_buffer_l1_addr, src_buffer_l1_addr + misalignment, unpadded_stick_size);
+            }
+            src_buffer_l1_addr += stick_size_offset;
+            src_stick_id++;
+            for (uint32_t j = 0; j < num_dims; j++) {
+                id_per_dim[j]++;
+                if (id_per_dim[j] == num_unpadded_sticks[j]) {
+                    id_per_dim[j] = 0;
+                    src_stick_id += num_padded_sticks[j];
+                } else {
+                    break;
+                }
+            }
+        }
+        noc.async_read_barrier();
+        cb_in0.push_back(num_read_per_barrier);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded_m2.cpp
@@ -1,0 +1,84 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 sharded row-major slice reader. Device-side dataflow — the Noc object, the
+// CoreLocalMem shard-to-shard reads, and the two CircularBuffers — is preserved verbatim from
+// the descriptor-era slice_reader_unary_unpad_dims_rm_sharded.cpp; only the binding mechanisms
+// change:
+//   - CB indices            -> dfb::cb_in / dfb::cb_out (both BORROWED from the sharded
+//                              input/output tensors; the borrowed-DFB machinery sets each CB's
+//                              backing L1 address from its tensor argument)
+//   - stick sizes / height  -> named CTAs (get_named_compile_time_arg_val), in the cache key
+//   - per-core arg blob      -> a single VARIABLE-LENGTH runtime vararg vector, decoded
+//                              positionally (get_vararg), exactly as the legacy kernel decoded
+//                              its positional RTA region. Layout (per core):
+//                                [0]                         num_cores_read (N)
+//                                [1 .. 1+2N)                 N (noc_x, noc_y) pairs
+//                                [1+2N .. 1+3N)              N per-core chunk counts
+//                                [1+3N .. )                  (chunk_start, chunk_len) pairs
+//
+// There is no TensorAccessor and no tensor_binding accessor: the shard-to-shard reads use
+// explicit (noc_x, noc_y, l1_addr) endpoints built from the borrowed CB write pointers.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t stick_size_padded = get_named_compile_time_arg_val("stick_size_padded");
+    constexpr uint32_t stick_size_unpadded = get_named_compile_time_arg_val("stick_size_unpadded");
+    constexpr uint32_t num_sticks_unpadded = get_named_compile_time_arg_val("num_sticks_unpadded");
+
+    const uint32_t num_cores_read = get_vararg(0);
+    // noc coords: pair k at varargs [1 + 2k, 2 + 2k]
+    const uint32_t noc_section_base = 1;
+    // chunk counts: one per core at varargs [1 + 2N + k]
+    const uint32_t chunk_count_base = 1 + num_cores_read * 2;
+    // (chunk_start, chunk_len) pairs at varargs [1 + 3N + 2c, 1 + 3N + 2c + 1]
+    const uint32_t chunk_data_base = 1 + num_cores_read * 3;
+
+    constexpr uint32_t cb_in0 = dfb::cb_in;
+    constexpr uint32_t cb_out0 = dfb::cb_out;
+
+    Noc noc;
+    CircularBuffer cb_in(cb_in0);
+    CircularBuffer cb_out(cb_out0);
+
+    cb_out.reserve_back(num_sticks_unpadded);
+    uint32_t l1_read_addr = cb_in.get_write_ptr();
+    uint32_t l1_write_addr = cb_out.get_write_ptr();
+
+    uint32_t chunk_data_offset = chunk_data_base;
+
+    for (uint32_t curr_core = 0; curr_core < num_cores_read; ++curr_core) {
+        const uint32_t src_noc_x = get_vararg(noc_section_base + curr_core * 2);
+        const uint32_t src_noc_y = get_vararg(noc_section_base + curr_core * 2 + 1);
+
+        const uint32_t curr_core_num_chunks = get_vararg(chunk_count_base + curr_core);
+
+        for (uint32_t curr_chunk = 0; curr_chunk < curr_core_num_chunks; ++curr_chunk) {
+            const uint32_t curr_start_id = get_vararg(chunk_data_offset);
+            const uint32_t curr_num_sticks = get_vararg(chunk_data_offset + 1);
+
+            const uint32_t l1_read_offset = curr_start_id * stick_size_unpadded;
+            const uint32_t read_data_size_bytes = curr_num_sticks * stick_size_unpadded;
+
+            CoreLocalMem<uint32_t> dst(l1_write_addr);
+            noc.async_read(
+                UnicastEndpoint{},
+                dst,
+                read_data_size_bytes,
+                {.noc_x = src_noc_x, .noc_y = src_noc_y, .addr = l1_read_addr + l1_read_offset},
+                {.offset_bytes = 0});
+            l1_write_addr += read_data_size_bytes;
+            chunk_data_offset += 2;
+        }
+    }
+
+    noc.async_read_barrier();
+    cb_out.push_back(num_sticks_unpadded);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id_m2.cpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 row-major interleaved slice writer. Logic identical to
+// slice_writer_unary_stick_layout_interleaved_start_id.cpp (that one stays for the
+// legacy/descriptor consumers); only the bindings are Metal 2.0:
+//   - CB index            -> dfb::cb_out  (Device 2.0 CircularBuffer preserved)
+//   - output accessor     -> ta::dst      (standard 2-arg TensorAccessor; no runtime page-size
+//                            override is needed — the destination page base/page size are
+//                            spec-derived and in the cache key)
+//   - stick_size          -> named CTA (bytes written per output row; the DFB entry_size is the
+//                            (possibly larger) aligned CB stride cb_page_size, so the write size
+//                            cannot be taken from cb.get_tile_size())
+//   - stick_size_offset   -> named CTA (op-level CB stride, in the cache key)
+//   - per-core scalars    -> named RTAs (num_sticks_per_core / num_sticks_per_core_read /
+//                            num_read_per_barrier / start_id)
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_out0 = dfb::cb_out;
+    // Bytes written per output row (the destination accessor's page size).
+    constexpr uint32_t stick_size = get_named_compile_time_arg_val("stick_size");
+    // CB read stride between consecutive sticks (op-level; in the cache key).
+    constexpr uint32_t stick_size_offset = get_named_compile_time_arg_val("stick_size_offset");
+
+    const uint32_t num_sticks_per_core = get_arg(args::num_sticks_per_core);
+    const uint32_t num_sticks_per_core_read = get_arg(args::num_sticks_per_core_read);
+    const uint32_t num_read_per_barrier = get_arg(args::num_read_per_barrier);
+    const uint32_t start_id = get_arg(args::start_id);
+
+    const auto s0 = TensorAccessor(ta::dst);
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_out0(cb_id_out0);
+
+    uint32_t i_stick = start_id;
+    uint32_t sticks_read = 0;
+    for (uint32_t iter = 0; iter < num_sticks_per_core_read and sticks_read < num_sticks_per_core; ++iter) {
+        cb_out0.wait_front(num_read_per_barrier);
+        uint32_t cb_read_offset = 0;
+
+        for (uint32_t i = 0; i < num_read_per_barrier and sticks_read < num_sticks_per_core; ++i) {
+            sticks_read++;
+            noc.async_write(
+                cb_out0, s0, stick_size, {.offset_bytes = cb_read_offset}, {.page_id = i_stick, .offset_bytes = 0});
+            cb_read_offset += stick_size_offset;
+            i_stick += 1;
+        }
+        noc.async_write_barrier();
+        cb_out0.pop_front(num_read_per_barrier);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd_m2.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 slice rm-stride nd writer. Slice-local copy of writer_multicore_slice_nd.cpp;
+// bindings are Metal 2.0 (dfb::cb_in consumer, ta::dst, named CTAs/RTAs, output_dims vararg).
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_in = dfb::cb_in;
+    constexpr uint32_t tensor_rank = get_named_compile_time_arg_val("rank");
+    constexpr uint32_t element_size = get_named_compile_time_arg_val("element_size");
+
+    const uint32_t num_rows_for_this_core = get_arg(args::num_rows);
+    const uint32_t start_row_for_this_core = get_arg(args::start_row);
+
+    // output_dims[tensor_rank] as runtime varargs.
+    uint32_t output_dims[tensor_rank];
+    for (uint32_t i = 0; i < tensor_rank; ++i) {
+        output_dims[i] = get_vararg(i);
+    }
+
+    const uint32_t output_bytes_per_row = output_dims[tensor_rank - 1] * element_size;
+
+    const auto s0 = TensorAccessor(ta::dst);
+    Noc noc;
+    CircularBuffer cb_in(cb_id_in);
+
+    for (uint32_t local_row = 0; local_row < num_rows_for_this_core; ++local_row) {
+        cb_in.wait_front(1);
+        uint32_t global_output_row = start_row_for_this_core + local_row;
+        noc.async_write(
+            cb_in, s0, output_bytes_per_row, {.offset_bytes = 0}, {.page_id = global_output_row, .offset_bytes = 0});
+        noc.async_writes_flushed();
+        cb_in.pop_front(1);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd_m2.cpp
@@ -19,10 +19,10 @@ void kernel_main() {
     const uint32_t num_rows_for_this_core = get_arg(args::num_rows);
     const uint32_t start_row_for_this_core = get_arg(args::start_row);
 
-    // output_dims[tensor_rank] as runtime varargs.
+    // output_dims[tensor_rank] is op-level (identical across cores) -> common varargs.
     uint32_t output_dims[tensor_rank];
     for (uint32_t i = 0; i < tensor_rank; ++i) {
-        output_dims[i] = get_vararg(i);
+        output_dims[i] = get_common_vararg(i);
     }
 
     const uint32_t output_bytes_per_row = output_dims[tensor_rank - 1] * element_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_slice_tile_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_slice_tile_m2.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 slice tile writer. A slice-local copy of the interleaved path of
+// writer_unary_interleaved_start_id.cpp (that kernel is shared by ~10 other ops
+// and must stay on the legacy arg model). Bindings are Metal 2.0:
+//   - CB index           -> dfb::cb_out
+//   - output accessor    -> ta::dst   (address implicit; no dst_addr RTA)
+//   - num_pages/start_id -> named RTAs
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t num_pages = get_arg(args::num_pages);
+    const uint32_t start_id = get_arg(args::start_id);
+
+    constexpr uint32_t cb_id_out = dfb::cb_out;
+
+    CircularBuffer cb_out(cb_id_out);
+    const uint32_t page_bytes = cb_out.get_tile_size();
+    Noc noc;
+
+    const auto s = TensorAccessor(ta::dst);
+
+    constexpr uint32_t onepage = 1;
+    const uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_out.wait_front(onepage);
+        noc.async_write(cb_out, s, page_bytes, {.offset_bytes = 0}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb_out.pop_front(onepage);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_slice_tile_tensor_args_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_slice_tile_tensor_args_m2.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 slice tile writer (tensor-args factory). A slice-local copy of the
+// interleaved path of writer_unary_interleaved_start_id.cpp (that kernel is shared
+// by ~10 other ops and must stay on the legacy arg model). Bindings are Metal 2.0:
+//   - CB index           -> dfb::cb_out
+//   - output accessor    -> ta::dst   (address implicit; no dst_addr RTA)
+//   - num_pages/start_id -> named RTAs
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+
+void kernel_main() {
+    const uint32_t num_pages = get_arg(args::num_pages);
+    const uint32_t start_id = get_arg(args::start_id);
+
+    constexpr uint32_t cb_id_out = dfb::cb_out;
+
+    CircularBuffer cb_out(cb_id_out);
+    const uint32_t page_bytes = cb_out.get_tile_size();
+    Noc noc;
+
+    const auto s = TensorAccessor(ta::dst);
+
+    constexpr uint32_t onepage = 1;
+    const uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_out.wait_front(onepage);
+        noc.async_write(cb_out, s, page_bytes, {.offset_bytes = 0}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb_out.pop_front(onepage);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_descriptor_builders.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_descriptor_builders.cpp
@@ -1,0 +1,184 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp"
+
+#include <optional>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/operations/data_movement/slice/slice.hpp"
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim {
+
+// Body moved verbatim from SliceTileProgramFactory::create_descriptor. The slice
+// factory now delegates here; the pybind and mesh_partition call this directly.
+tt::tt_metal::ProgramDescriptor build_slice_tile_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input;
+    tt::tt_metal::IDevice* device = input.device();
+
+    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+
+    tt::tt_metal::Buffer* src0_buffer = input.buffer();
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    const auto& input_shape = input.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+
+    // --- CB Descriptor ---
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = 2;
+
+    tt::tt_metal::ProgramDescriptor program_descriptor;
+
+    tt::tt_metal::CBDescriptor cb_desc;
+    cb_desc.total_size = num_input_tiles * single_tile_size;
+    cb_desc.core_ranges = all_cores;
+    cb_desc.format_descriptors.push_back(tt::tt_metal::CBFormatDescriptor{
+        .buffer_index = static_cast<uint8_t>(src0_cb_index),
+        .data_format = cb_data_format,
+        .page_size = single_tile_size});
+    program_descriptor.cbs.push_back(std::move(cb_desc));
+
+    // --- Reader Kernel Descriptor ---
+    // CB index via named compile-time arg (essential for fusion CB remapping).
+    std::vector<uint32_t> reader_compile_time_args = {num_dims};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+
+    // Reader common runtime args: [src_addr, num_unpadded_per_dim..., num_padded_per_dim...]
+    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
+    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
+    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
+    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    accumulated_total_per_dim[0] = num_total_Xt;
+    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+
+    std::vector<uint32_t> reader_common_args(1 + (num_dims * 2));
+    reader_common_args[0] = src0_buffer->address();
+    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
+    uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
+    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
+    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
+    num_padded_tiles_per_dim[0] = num_padded_Xt;
+    num_padded_tiles_per_dim[1] = num_padded_Yt;
+    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
+        num_padded_tiles_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    uint32_t start_offset = ttnn::operations::data_movement::get_tiled_start_offset(input, args.slice_start);
+
+    // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
+    tt::tt_metal::KernelDescriptor::RuntimeArgs reader_runtime_args;
+    uint32_t num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            std::vector<uint32_t> reader_args(2 + num_dims, 0);
+            reader_runtime_args.emplace_back(core, std::move(reader_args));
+            continue;
+        }
+
+        std::vector<uint32_t> reader_args(2 + num_dims);
+        // Compute per-dim indices for this core's starting position
+        reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
+        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
+        uint32_t start_id = reader_args[2] + start_offset;
+        for (uint32_t j = 1; j < num_dims; ++j) {
+            reader_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
+            start_id += reader_args[2 + j] * accumulated_total_per_dim[j - 1];
+        }
+        reader_args[0] = start_id;
+        reader_args[1] = num_tiles_per_core;
+
+        reader_runtime_args.emplace_back(core, std::move(reader_args));
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    tt::tt_metal::KernelDescriptor reader_kernel_desc;
+    reader_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+        "reader_unary_unpad_dims_interleaved_start_id.cpp";
+    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_kernel_desc.core_ranges = all_cores;
+    reader_kernel_desc.compile_time_args = reader_compile_time_args;
+    reader_kernel_desc.named_compile_time_args = {{"cb_in", src0_cb_index}};
+    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
+    reader_kernel_desc.common_runtime_args = std::move(reader_common_args);
+    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
+    program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
+
+    // --- Writer Kernel Descriptor ---
+    // CB index via named compile-time arg (essential for fusion CB remapping).
+    std::vector<uint32_t> writer_compile_time_args = {};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
+    tt::tt_metal::KernelDescriptor::RuntimeArgs writer_runtime_args;
+    num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
+            continue;
+        }
+
+        writer_runtime_args.emplace_back(
+            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    tt::tt_metal::KernelDescriptor writer_kernel_desc;
+    writer_kernel_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+        "writer_unary_interleaved_start_id.cpp";
+    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_kernel_desc.core_ranges = all_cores;
+    writer_kernel_desc.compile_time_args = writer_compile_time_args;
+    writer_kernel_desc.named_compile_time_args = {{"cb_out", src0_cb_index}};
+    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
+    writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
+    program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
+
+    return program_descriptor;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp
@@ -24,5 +24,13 @@ namespace ttnn::prim {
 
 tt::tt_metal::ProgramDescriptor build_slice_tile_descriptor(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+tt::tt_metal::ProgramDescriptor build_slice_rm_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+tt::tt_metal::ProgramDescriptor build_slice_rm_stride_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+tt::tt_metal::ProgramDescriptor build_slice_rm_sharded_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+tt::tt_metal::ProgramDescriptor build_slice_tile_tensor_args_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
+
+// Standalone ProgramDescriptor builders for slice.
+//
+// These hold the descriptor-construction logic that used to live as static
+// methods on the slice program factories. They are kept as free functions so
+// that descriptor consumers — the Python fusion compiler (via the pybind), and
+// mesh_partition's std::visit reuse — keep getting a ProgramDescriptor, even
+// after the slice program factories migrate to Metal 2.0 (where a factory may
+// not also expose create_descriptor; see operation_concepts.hpp
+// all_factories_valid "exactly one concept").
+//
+// The factory's Metal 2.0 create_program_spec and these builders are separate
+// entry points: descriptor IR for fusion, ProgramSpec for standalone dispatch.
+
+namespace ttnn::prim {
+
+tt::tt_metal::ProgramDescriptor build_slice_tile_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -2,155 +2,107 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 
+#include <algorithm>
+#include <filesystem>
 #include <optional>
+#include <vector>
+
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
-namespace ttnn::operations::data_movement {
+namespace ttnn::prim {
 
 namespace {
 
-inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm(
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
-    const ttnn::Shape& output_tensor_start,
-    uint32_t num_cores,
-    const std::vector<CoreCoord>& all_cores_vec,
-    const CoreRangeSet& core_group_1,
-    const CoreRangeSet& core_group_2,
-    uint32_t num_sticks_per_core_group_1,
-    uint32_t num_sticks_per_core_group_2,
-    uint32_t max_read_size) {
-    auto* output_buffer = output_tensor.buffer();
-    auto input_shape = input_tensor.padded_shape();
-    auto output_shape = output_tensor.padded_shape();
-
-    uint32_t padded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
-    uint32_t unpadded_row_size_bytes = output_shape[-1] * input_tensor.element_size();
-
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
-    std::vector<uint32_t> num_unpadded_sticks_per_dim(num_dims);
-    std::vector<uint32_t> num_padded_sticks_per_dim(num_dims);
-    std::vector<uint32_t> id_per_dim(num_dims);
-
-    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
-
-    // TODO: Remove first element of these arrays and update kernel accordingly
-    num_unpadded_sticks_per_dim[0] = 1;
-    num_padded_sticks_per_dim[0] = 0;
-    accumulated_total_per_dim[0] = 1;
-
-    for (int32_t i = 1; i < num_dims; i++) {
-        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
-        uint32_t num_total_dim = input_shape[-(i + 1)];
-        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
-        num_unpadded_sticks_per_dim[i] = num_unpadded_dim;
-        num_padded_sticks_per_dim[i] = num_padded_dim;
-        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
-    }
-
-    auto src_buffer_alignment = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
-                                    ? ::hal::get_dram_alignment()
-                                    : ::hal::get_l1_alignment();
-    auto dst_buffer_alignment = output_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
-                                    ? ::hal::get_dram_alignment()
-                                    : ::hal::get_l1_alignment();
-    auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
-    uint32_t begins_bytes = output_tensor_start[-1] * input_tensor.element_size();
-    uint32_t misalignment = begins_bytes % src_buffer_alignment;
-    uint32_t unpadded_row_size_bytes_offset = tt::round_up(unpadded_row_size_bytes, alignment);
-    uint32_t start_addr = input_tensor.buffer()->address();
-
-    std::vector<uint32_t> common_reader_kernel_args = {
-        start_addr + begins_bytes - misalignment,  // read from nearest aligned address,
-        padded_row_size_bytes,
-        unpadded_row_size_bytes,
-        unpadded_row_size_bytes_offset,
-        num_dims,
-        misalignment,
-        0,
-        0,
-        0,
-        0};
-    common_reader_kernel_args.insert(
-        common_reader_kernel_args.end(), num_unpadded_sticks_per_dim.begin(), num_unpadded_sticks_per_dim.end());
-    common_reader_kernel_args.insert(
-        common_reader_kernel_args.end(), num_padded_sticks_per_dim.begin(), num_padded_sticks_per_dim.end());
-
-    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val;
-    ret_val.reserve(num_cores);
-
-    uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(input_tensor, output_tensor_start);
-    uint32_t num_sticks_written = 0;
-    for (const auto& core : all_cores_vec) {
-        uint32_t num_sticks_per_core;
-        if (core_group_1.contains(core)) {
-            num_sticks_per_core = num_sticks_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_sticks_per_core = num_sticks_per_core_group_2;
-        } else {
-            num_sticks_per_core = 0;
-        }
-
-        uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
-        if (num_sticks_per_core != 0) {
-            auto num_sticks_per_core_pad32 = num_sticks_per_core + ((32 - num_sticks_per_core % 32) % 32);
-            num_sticks_per_core_read = tt::tt_metal::merge_num_sticks_to_read(
-                num_sticks_per_core_pad32, unpadded_row_size_bytes_offset, max_read_size);
-            num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
-        }
-
-        id_per_dim[0] = num_sticks_written % num_unpadded_sticks_per_dim[0];
-        uint32_t unpadded_written = num_sticks_written / num_unpadded_sticks_per_dim[0];
-        uint32_t start_id = id_per_dim[0] + start_offset;
-
-        for (uint32_t j = 1; j < num_dims; j++) {
-            id_per_dim[j] = unpadded_written % num_unpadded_sticks_per_dim[j];
-            unpadded_written = unpadded_written / num_unpadded_sticks_per_dim[j];
-            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
-        }
-        std::vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
-        uint32_t addr_offset = 6;
-        reader_kernel_args[addr_offset++] = start_id;
-        reader_kernel_args[addr_offset++] = num_sticks_per_core;
-        reader_kernel_args[addr_offset++] = num_sticks_per_core_read;
-        reader_kernel_args[addr_offset] = num_read_per_barrier;
-        reader_kernel_args.insert(reader_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
-
-        std::vector<uint32_t> writer_kernel_args = {
-            output_buffer->address(),
-            unpadded_row_size_bytes,
-            unpadded_row_size_bytes_offset,
-            num_sticks_per_core,
-            num_sticks_per_core_read,
-            num_read_per_barrier,
-            num_sticks_written,
-            0};
-        num_sticks_written += num_sticks_per_core;
-        ret_val.emplace_back(reader_kernel_args, writer_kernel_args);
-    }
-
-    return ret_val;
-}
+constexpr const char* READER_KERNEL =
+    "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+    "slice_reader_unary_unpad_dims_rm_interleaved_start_id_m2.cpp";
+constexpr const char* WRITER_KERNEL =
+    "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+    "slice_writer_unary_stick_layout_interleaved_start_id_m2.cpp";
 
 constexpr uint32_t MAX_READ_SIZE = 4096;
 
-std::tuple<uint32_t, uint32_t, uint32_t> compute_cb_size(
-    const Tensor& input,
-    const Tensor& output,
-    const Shape& output_tensor_start,
-    const uint32_t num_sticks_per_core_group_1,
-    const uint32_t num_sticks_per_core_group_2) {
+// Enqueue-invariant work geometry: a pure function of shape + slice params (all in the cache key).
+struct SliceRmGeometry {
+    CoreRangeSet all_cores;
+    std::vector<CoreCoord> cores;
+    uint32_t num_dims = 0;
+    tt::DataFormat data_format = tt::DataFormat::Invalid;
+
+    // Op-level byte sizes (identical across cores -> named CTAs).
+    uint32_t padded_stick_size = 0;          // input row size in bytes (== src accessor page size)
+    uint32_t unpadded_stick_size = 0;        // output row size in bytes (== dst accessor page size)
+    uint32_t stick_size_offset = 0;          // aligned CB stride between consecutive sticks
+    uint32_t misalignment = 0;               // slice column begin misalignment vs src alignment
+    uint32_t column_offset_bytes = 0;        // begins_bytes - misalignment (source page offset_bytes)
+
+    // CB sizing (program-scope, sized for the max-work core group).
+    uint32_t cb_entry_size = 0;              // == cb_page_size
+    uint32_t cb_num_entries = 0;             // == num_read_per_barrier_max * 2
+
+    // Common, broadcast to every core (read-only on device): [num_unpadded..., num_padded...].
+    std::vector<uint32_t> num_unpadded_per_dim;
+    std::vector<uint32_t> num_padded_per_dim;
+
+    // Per-core values (parallel to `cores`).
+    std::vector<uint32_t> start_id;
+    std::vector<uint32_t> num_sticks_per_core;
+    std::vector<uint32_t> num_sticks_per_core_read;
+    std::vector<uint32_t> num_read_per_barrier;
+    std::vector<std::vector<uint32_t>> id_per_dim;  // [core][num_dims], the running-index seed
+    std::vector<uint32_t> writer_start_id;          // == cumulative num_sticks_written
+};
+
+SliceRmGeometry compute_geometry(const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output) {
+    const auto& input = tensor_args.input;
+    IDevice* device = input.device();
+
+    SliceRmGeometry g;
+    g.data_format = datatype_to_dataformat_converter(input.dtype());
+
+    const auto& input_shape = input.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    g.num_dims = static_cast<uint32_t>(input_shape.rank());
+
+    uint32_t num_unpadded_sticks = output.physical_volume() / output_shape[-1];
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_sticks)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
+    g.all_cores = all_cores;
+
+    g.padded_stick_size = input_shape[-1] * input.element_size();
+    g.unpadded_stick_size = output_shape[-1] * input.element_size();
+
+    g.num_unpadded_per_dim.resize(g.num_dims);
+    g.num_padded_per_dim.resize(g.num_dims);
+    std::vector<uint32_t> accumulated_total_per_dim(g.num_dims);
+
+    // TODO: Remove first element of these arrays and update kernel accordingly
+    g.num_unpadded_per_dim[0] = 1;
+    g.num_padded_per_dim[0] = 0;
+    accumulated_total_per_dim[0] = 1;
+
+    for (uint32_t i = 1; i < g.num_dims; ++i) {
+        uint32_t num_unpadded_dim = output_shape[-(static_cast<int32_t>(i) + 1)];
+        uint32_t num_total_dim = input_shape[-(static_cast<int32_t>(i) + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        g.num_unpadded_per_dim[i] = num_unpadded_dim;
+        g.num_padded_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
     auto src_buffer_alignment = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
                                     ? ::hal::get_dram_alignment()
                                     : ::hal::get_l1_alignment();
@@ -158,125 +110,194 @@ std::tuple<uint32_t, uint32_t, uint32_t> compute_cb_size(
                                     ? ::hal::get_dram_alignment()
                                     : ::hal::get_l1_alignment();
     const auto single_alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
-    auto alignment = single_alignment;
 
-    uint32_t begins_bytes = output_tensor_start[-1] * input.element_size();
-    uint32_t misalignment = begins_bytes % src_buffer_alignment;
+    uint32_t begins_bytes = args.slice_start[-1] * input.element_size();
+    g.misalignment = begins_bytes % src_buffer_alignment;
+    // Source page offset_bytes (read from nearest aligned address): begins_bytes - misalignment.
+    g.column_offset_bytes = begins_bytes - g.misalignment;
 
-    if (misalignment != 0) {
-        alignment *= 2;
+    g.stick_size_offset = tt::round_up(g.unpadded_stick_size, single_alignment);
+
+    // CB page size: doubled alignment when misaligned (extra room for the memmove fixup).
+    auto cb_alignment = single_alignment;
+    if (g.misalignment != 0) {
+        cb_alignment *= 2;
     }
-    const ttnn::Shape& output_shape = output.padded_shape();
-    const uint32_t unpadded_row_size_bytes = output_shape[-1] * input.element_size();
-    const uint32_t cb_page_size = tt::round_up(unpadded_row_size_bytes, alignment);
-    const uint32_t stick_stride_for_merge = tt::round_up(unpadded_row_size_bytes, single_alignment);
-    const uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2
-                                         ? num_sticks_per_core_group_1
-                                         : num_sticks_per_core_group_2;
-    uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
+    const uint32_t cb_page_size = tt::round_up(g.unpadded_stick_size, cb_alignment);
+
+    // CB capacity is sized from the larger core group (max num_read_per_barrier).
+    const uint32_t num_input_pages =
+        std::max(num_sticks_per_core_group_1, num_sticks_per_core_group_2);
+    uint32_t num_read_per_barrier_max = 0;
     if (num_input_pages != 0) {
         auto num_sticks_per_core_pad32 = num_input_pages + ((32 - num_input_pages % 32) % 32);
-        num_sticks_per_core_read =
-            tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, stick_stride_for_merge, MAX_READ_SIZE);
-        num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
+        uint32_t num_sticks_per_core_read =
+            tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, g.stick_size_offset, MAX_READ_SIZE);
+        num_read_per_barrier_max = num_sticks_per_core_pad32 / num_sticks_per_core_read;
     }
+    g.cb_entry_size = cb_page_size;
+    g.cb_num_entries = num_read_per_barrier_max * 2;
 
-    return std::make_tuple(cb_page_size, num_read_per_barrier, misalignment);
+    uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(input, args.slice_start);
+
+    g.cores = corerange_to_cores(all_cores);
+    uint32_t num_sticks_written = 0;
+    for (const auto& core : g.cores) {
+        uint32_t num_sticks_per_core;
+        if (core_group_1.contains(core)) {
+            num_sticks_per_core = num_sticks_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_sticks_per_core = num_sticks_per_core_group_2;
+        } else {
+            // no-op core
+            g.start_id.push_back(0);
+            g.num_sticks_per_core.push_back(0);
+            g.num_sticks_per_core_read.push_back(0);
+            g.num_read_per_barrier.push_back(0);
+            g.id_per_dim.emplace_back(g.num_dims, 0);
+            g.writer_start_id.push_back(0);
+            continue;
+        }
+
+        uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
+        auto num_sticks_per_core_pad32 = num_sticks_per_core + ((32 - num_sticks_per_core % 32) % 32);
+        num_sticks_per_core_read =
+            tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, g.stick_size_offset, MAX_READ_SIZE);
+        num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
+
+        std::vector<uint32_t> ids(g.num_dims);
+        ids[0] = num_sticks_written % g.num_unpadded_per_dim[0];
+        uint32_t unpadded_written = num_sticks_written / g.num_unpadded_per_dim[0];
+        uint32_t start_id = ids[0] + start_offset;
+        for (uint32_t j = 1; j < g.num_dims; ++j) {
+            ids[j] = unpadded_written % g.num_unpadded_per_dim[j];
+            unpadded_written = unpadded_written / g.num_unpadded_per_dim[j];
+            start_id += ids[j] * accumulated_total_per_dim[j - 1];
+        }
+
+        g.start_id.push_back(start_id);
+        g.num_sticks_per_core.push_back(num_sticks_per_core);
+        g.num_sticks_per_core_read.push_back(num_sticks_per_core_read);
+        g.num_read_per_barrier.push_back(num_read_per_barrier);
+        g.id_per_dim.push_back(std::move(ids));
+        g.writer_start_id.push_back(num_sticks_written);
+        num_sticks_written += num_sticks_per_core;
+    }
+    return g;
+}
+
+m2::NodeCoord node_of(const CoreCoord& c) {
+    return m2::NodeCoord{static_cast<std::size_t>(c.x), static_cast<std::size_t>(c.y)};
 }
 
 }  // namespace
 
-}  // namespace ttnn::operations::data_movement
-
-namespace ttnn::prim {
-
-tt::tt_metal::ProgramDescriptor SliceRmProgramFactory::create_descriptor(
+m2::ProgramSpec SliceRmProgramFactory::create_program_spec(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto& input = tensor_args.input;
-    tt::tt_metal::IDevice* device = input.device();
-    ProgramDescriptor desc;
+    const auto g = compute_geometry(args, tensor_args, output);
 
-    uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];
+    m2::DataflowBufferSpec cb{
+        .unique_id = m2::DFBSpecName{"cb"},
+        .entry_size = g.cb_entry_size,
+        .num_entries = g.cb_num_entries,
+        .data_format_metadata = g.data_format,
+    };
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
-        args.sub_core_grids.has_value()
-            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_sticks)
-            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{READER_KERNEL},
+        .dfb_bindings = {m2::ProducerOf(m2::DFBSpecName{"cb"}, "cb_in")},
+        .tensor_bindings =
+            {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"}},
+        .compile_time_args =
+            {{"num_dims", g.num_dims},
+             {"unpadded_stick_size", g.unpadded_stick_size},
+             {"stick_size_offset", g.stick_size_offset},
+             {"misalignment", g.misalignment},
+             {"column_offset_bytes", g.column_offset_bytes}},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"start_id", "num_sticks_per_core", "num_sticks_per_core_read", "num_read_per_barrier"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementHardwareConfig::RoleHint::READER},
+        .advanced_options =
+            m2::KernelAdvancedOptions{
+                .num_runtime_varargs = g.num_dims, .num_common_runtime_varargs = 2 * g.num_dims},
+    };
 
-    tt::tt_metal::Buffer* src0_buffer = input.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{WRITER_KERNEL},
+        .dfb_bindings = {m2::ConsumerOf(m2::DFBSpecName{"cb"}, "cb_out")},
+        .tensor_bindings =
+            {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"}},
+        .compile_time_args = {{"stick_size", g.unpadded_stick_size}, {"stick_size_offset", g.stick_size_offset}},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"num_sticks_per_core", "num_sticks_per_core_read", "num_read_per_barrier", "start_id"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementHardwareConfig::RoleHint::WRITER},
+    };
 
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    m2::ProgramSpec spec;
+    spec.name = "slice_rm";
+    spec.kernels = {std::move(reader), std::move(writer)};
+    spec.dataflow_buffers = {std::move(cb)};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = tensor_args.input.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()}};
+    spec.work_units = {m2::WorkUnitSpec{
+        .name = "slice",
+        .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+        .target_nodes = g.all_cores}};
+    return spec;
+}
 
-    constexpr uint8_t src0_cb_index = 0;
+m2::ProgramRunArgs SliceRmProgramFactory::create_invariant_run_args(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto g = compute_geometry(args, tensor_args, output);
 
-    // CB sizing depends on slice_start (via misalignment / unpadded_row_size_bytes).
-    // padded_shape is folded into compute_program_hash() so each unique sizing
-    // gets its own cache entry; CB total_size/page_size are not patched on
-    // cache hit — the cached descriptor already carries the correct values.
-    const auto [cb_page_size, num_read_per_barrier, misalignment] = ttnn::operations::data_movement::compute_cb_size(
-        input, output, args.slice_start, num_sticks_per_core_group_1, num_sticks_per_core_group_2);
+    m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
+    m2::ProgramRunArgs::KernelRunArgs writer_args{.kernel = m2::KernelSpecName{"writer"}};
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_read_per_barrier * 2 * cb_page_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src0_cb_index,
-            .data_format = cb_data_format,
-            .page_size = cb_page_size,
-        }}},
-    });
+    // Common varargs (broadcast): [num_unpadded..., num_padded...].
+    auto& common = reader_args.advanced_options.common_runtime_varargs;
+    common.insert(common.end(), g.num_unpadded_per_dim.begin(), g.num_unpadded_per_dim.end());
+    common.insert(common.end(), g.num_padded_per_dim.begin(), g.num_padded_per_dim.end());
 
-    std::vector<uint32_t> writer_compile_time_args_vec = {static_cast<uint32_t>(src0_cb_index)};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args_vec);
-
-    std::vector<uint32_t> reader_compile_time_args_vec;
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args_vec);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args_vec);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "slice_writer_unary_stick_layout_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args_vec);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    auto all_cores_vec = corerange_to_cores(all_cores);
-    auto all_runtime_args = ttnn::operations::data_movement::get_slice_runtime_args_rm(
-        input,
-        output,
-        args.slice_start,
-        num_cores,
-        all_cores_vec,
-        core_group_1,
-        core_group_2,
-        num_sticks_per_core_group_1,
-        num_sticks_per_core_group_2,
-        ttnn::operations::data_movement::MAX_READ_SIZE);
-
-    reader_desc.runtime_args.reserve(all_cores_vec.size());
-    writer_desc.runtime_args.reserve(all_cores_vec.size());
-    for (size_t i = 0; i < all_cores_vec.size(); ++i) {
-        reader_desc.runtime_args.emplace_back(all_cores_vec[i], std::move(all_runtime_args[i].first));
-        writer_desc.runtime_args.emplace_back(all_cores_vec[i], std::move(all_runtime_args[i].second));
+    for (size_t i = 0; i < g.cores.size(); ++i) {
+        const auto node = node_of(g.cores[i]);
+        reader_args.runtime_arg_values.push_back(
+            {node,
+             {{"start_id", g.start_id[i]},
+              {"num_sticks_per_core", g.num_sticks_per_core[i]},
+              {"num_sticks_per_core_read", g.num_sticks_per_core_read[i]},
+              {"num_read_per_barrier", g.num_read_per_barrier[i]}}});
+        reader_args.advanced_options.runtime_varargs.emplace(
+            node, m2::AdvancedKernelRunArgs::Varargs(g.id_per_dim[i].begin(), g.id_per_dim[i].end()));
+        writer_args.runtime_arg_values.push_back(
+            {node,
+             {{"num_sticks_per_core", g.num_sticks_per_core[i]},
+              {"num_sticks_per_core_read", g.num_sticks_per_core_read[i]},
+              {"num_read_per_barrier", g.num_read_per_barrier[i]},
+              {"start_id", g.writer_start_id[i]}}});
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    m2::ProgramRunArgs run_args;
+    run_args.kernel_run_args.push_back(std::move(reader_args));
+    run_args.kernel_run_args.push_back(std::move(writer_args));
+    return run_args;
+}
 
-    return desc;
+m2::ProgramRunArgs SliceRmProgramFactory::create_per_enqueue_args(
+    const SliceParams& /*args*/,
+    const SliceInputs& tensor_args,
+    Tensor& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    m2::ProgramRunArgs run_args;
+    run_args.tensor_args.emplace(
+        m2::TensorParamName{"src"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.input.mesh_tensor())});
+    run_args.tensor_args.emplace(
+        m2::TensorParamName{"dst"}, m2::ProgramRunArgs::TensorArgument{std::cref(output.mesh_tensor())});
+    return run_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -252,7 +252,19 @@ m2::ProgramSpec SliceRmProgramFactory::create_program_spec(
 }
 
 m2::ProgramRunArgs SliceRmProgramFactory::create_invariant_run_args(
-    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const SliceParams& /*args*/, const SliceInputs& /*tensor_args*/, Tensor& /*output*/) {
+    // Nothing is enqueue-invariant here: the reader carries varargs (which cannot be designated
+    // invariant — gap #6), so on a cache hit every kernel with varargs must appear in the
+    // per-enqueue UpdateProgramRunArgs. We therefore re-apply all run args per dispatch (the
+    // framework's "++ by default") and keep this empty.
+    return m2::ProgramRunArgs{};
+}
+
+m2::ProgramRunArgs SliceRmProgramFactory::create_per_enqueue_args(
+    const SliceParams& args,
+    const SliceInputs& tensor_args,
+    Tensor& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
     const auto g = rm_compute_geometry(args, tensor_args, output);
 
     m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
@@ -284,15 +296,6 @@ m2::ProgramRunArgs SliceRmProgramFactory::create_invariant_run_args(
     m2::ProgramRunArgs run_args;
     run_args.kernel_run_args.push_back(std::move(reader_args));
     run_args.kernel_run_args.push_back(std::move(writer_args));
-    return run_args;
-}
-
-m2::ProgramRunArgs SliceRmProgramFactory::create_per_enqueue_args(
-    const SliceParams& /*args*/,
-    const SliceInputs& tensor_args,
-    Tensor& output,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    m2::ProgramRunArgs run_args;
     run_args.tensor_args.emplace(
         m2::TensorParamName{"src"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.input.mesh_tensor())});
     run_args.tensor_args.emplace(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.cpp
@@ -22,10 +22,10 @@ namespace ttnn::prim {
 
 namespace {
 
-constexpr const char* READER_KERNEL =
+constexpr const char* RM_READER_KERNEL =
     "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
     "slice_reader_unary_unpad_dims_rm_interleaved_start_id_m2.cpp";
-constexpr const char* WRITER_KERNEL =
+constexpr const char* RM_WRITER_KERNEL =
     "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
     "slice_writer_unary_stick_layout_interleaved_start_id_m2.cpp";
 
@@ -62,7 +62,7 @@ struct SliceRmGeometry {
     std::vector<uint32_t> writer_start_id;          // == cumulative num_sticks_written
 };
 
-SliceRmGeometry compute_geometry(const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output) {
+SliceRmGeometry rm_compute_geometry(const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output) {
     const auto& input = tensor_args.input;
     IDevice* device = input.device();
 
@@ -186,7 +186,7 @@ SliceRmGeometry compute_geometry(const SliceParams& args, const SliceInputs& ten
     return g;
 }
 
-m2::NodeCoord node_of(const CoreCoord& c) {
+m2::NodeCoord rm_node_of(const CoreCoord& c) {
     return m2::NodeCoord{static_cast<std::size_t>(c.x), static_cast<std::size_t>(c.y)};
 }
 
@@ -194,7 +194,7 @@ m2::NodeCoord node_of(const CoreCoord& c) {
 
 m2::ProgramSpec SliceRmProgramFactory::create_program_spec(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto g = compute_geometry(args, tensor_args, output);
+    const auto g = rm_compute_geometry(args, tensor_args, output);
 
     m2::DataflowBufferSpec cb{
         .unique_id = m2::DFBSpecName{"cb"},
@@ -205,7 +205,7 @@ m2::ProgramSpec SliceRmProgramFactory::create_program_spec(
 
     m2::KernelSpec reader{
         .unique_id = m2::KernelSpecName{"reader"},
-        .source = std::filesystem::path{READER_KERNEL},
+        .source = std::filesystem::path{RM_READER_KERNEL},
         .dfb_bindings = {m2::ProducerOf(m2::DFBSpecName{"cb"}, "cb_in")},
         .tensor_bindings =
             {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"}},
@@ -226,7 +226,7 @@ m2::ProgramSpec SliceRmProgramFactory::create_program_spec(
 
     m2::KernelSpec writer{
         .unique_id = m2::KernelSpecName{"writer"},
-        .source = std::filesystem::path{WRITER_KERNEL},
+        .source = std::filesystem::path{RM_WRITER_KERNEL},
         .dfb_bindings = {m2::ConsumerOf(m2::DFBSpecName{"cb"}, "cb_out")},
         .tensor_bindings =
             {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"}},
@@ -253,7 +253,7 @@ m2::ProgramSpec SliceRmProgramFactory::create_program_spec(
 
 m2::ProgramRunArgs SliceRmProgramFactory::create_invariant_run_args(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto g = compute_geometry(args, tensor_args, output);
+    const auto g = rm_compute_geometry(args, tensor_args, output);
 
     m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
     m2::ProgramRunArgs::KernelRunArgs writer_args{.kernel = m2::KernelSpecName{"writer"}};
@@ -264,7 +264,7 @@ m2::ProgramRunArgs SliceRmProgramFactory::create_invariant_run_args(
     common.insert(common.end(), g.num_padded_per_dim.begin(), g.num_padded_per_dim.end());
 
     for (size_t i = 0; i < g.cores.size(); ++i) {
-        const auto node = node_of(g.cores[i]);
+        const auto node = rm_node_of(g.cores[i]);
         reader_args.runtime_arg_values.push_back(
             {node,
              {{"start_id", g.start_id[i]},

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp
@@ -3,22 +3,31 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <optional>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
+// Metal 2.0 row-major interleaved slice factory. The immutable contract (create_program_spec)
+// plus the enqueue-invariant per-core work geometry (create_invariant_run_args, a pure function
+// of shape + slice params, all in the cache key) and the per-dispatch tensor bindings
+// (create_per_enqueue_args). The legacy descriptor for fusion/pybind/mesh_partition lives
+// separately in build_slice_rm_descriptor (slice_descriptor_builders.hpp).
 struct SliceRmProgramFactory {
-    // Contract (1): per-coord ProgramDescriptor.  The src0 CB's total_size /
-    // page_size depend on slice_start (via misalignment / unpadded_row_size_bytes),
-    // so padded_shape is folded into compute_program_hash() — each unique CB
-    // sizing keeps its own cache entry.  On cache hit the framework copies
-    // runtime args and patches dynamic CB addresses; CB total_size/page_size
-    // are not re-applied (the cached descriptor already carries them).
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static tt::tt_metal::experimental::ProgramSpec create_program_spec(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+    static tt::tt_metal::experimental::ProgramRunArgs create_invariant_run_args(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+    static tt::tt_metal::experimental::ProgramRunArgs create_per_enqueue_args(
+        const SliceParams& args,
+        const SliceInputs& tensor_args,
+        Tensor& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -324,7 +324,19 @@ m2::ProgramSpec SliceRmShardedProgramFactory::create_program_spec(
 }
 
 m2::ProgramRunArgs SliceRmShardedProgramFactory::create_invariant_run_args(
-    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const SliceParams& /*args*/, const SliceInputs& /*tensor_args*/, Tensor& /*output*/) {
+    // Nothing is enqueue-invariant here: the reader carries per-node varargs (which cannot be
+    // designated invariant — gap #6), so on a cache hit every kernel with varargs must appear in the
+    // per-enqueue UpdateProgramRunArgs. We therefore re-apply all run args per dispatch (the
+    // framework's "++ by default") and keep this empty.
+    return m2::ProgramRunArgs{};
+}
+
+m2::ProgramRunArgs SliceRmShardedProgramFactory::create_per_enqueue_args(
+    const SliceParams& args,
+    const SliceInputs& tensor_args,
+    Tensor& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
     const auto g = rmshd_compute_geometry(args, tensor_args, output);
 
     m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
@@ -336,15 +348,6 @@ m2::ProgramRunArgs SliceRmShardedProgramFactory::create_invariant_run_args(
 
     m2::ProgramRunArgs run_args;
     run_args.kernel_run_args.push_back(std::move(reader_args));
-    return run_args;
-}
-
-m2::ProgramRunArgs SliceRmShardedProgramFactory::create_per_enqueue_args(
-    const SliceParams& /*args*/,
-    const SliceInputs& tensor_args,
-    Tensor& output,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    m2::ProgramRunArgs run_args;
     // Borrowed-memory DFBs draw their backing L1 address from these tensor arguments.
     run_args.tensor_args.emplace(
         m2::TensorParamName{"input"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.input.mesh_tensor())});

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -2,32 +2,41 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 
+#include <filesystem>
 #include <map>
 #include <optional>
+#include <vector>
+
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/work_split.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
-namespace ttnn::operations::data_movement {
+namespace ttnn::prim {
 
 namespace {
 
-inline std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<uint32_t>& values) {
+constexpr const char* READER_KERNEL =
+    "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+    "slice_reader_unary_unpad_dims_rm_sharded_m2.cpp";
+
+m2::NodeCoord node_of(const CoreCoord& c) {
+    return m2::NodeCoord{static_cast<std::size_t>(c.x), static_cast<std::size_t>(c.y)};
+}
+
+std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<uint32_t>& values) {
     std::vector<std::vector<uint32_t>> chunks;
     if (values.empty()) {
         return chunks;
     }
 
-    // Initialize the first chunk
     std::vector<uint32_t> current_chunk;
     current_chunk.push_back(values[0]);
-
     for (size_t i = 1; i < values.size(); ++i) {
         if (values[i] == values[i - 1] + 1) {
             current_chunk.push_back(values[i]);
@@ -37,33 +46,82 @@ inline std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<ui
             current_chunk.push_back(values[i]);
         }
     }
-    // Add the last chunk
     chunks.push_back(current_chunk);
     return chunks;
 }
 
-inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm_sharded(
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
-    const ttnn::Shape& output_tensor_start,
-    uint32_t num_cores_unpadded,
-    bool row_major,
-    uint32_t num_cores_x_unpadded,
-    uint32_t num_cores_y_unpadded,
-    uint32_t shard_height_unpadded,
-    uint32_t shard_height_padded,
-    uint32_t num_cores_x_padded,
-    uint32_t num_cores_y_padded) {
-    tt::tt_metal::IDevice* device = input_tensor.device();
+// Enqueue-invariant work geometry: a pure function of shape + shard spec + slice params (all in the
+// cache key). The reader runtime args are a single variable-length blob per core, decoded positionally
+// on device — kept verbatim from the descriptor-era layout:
+//   [num_cores_read, (noc_x, noc_y)*num_cores_read, num_chunks_per_core*num_cores_read,
+//    (chunk_start, chunk_len)*total_chunks]
+struct SliceRmShardedGeometry {
+    CoreRangeSet all_cores_unpadded;
+    std::vector<CoreCoord> cores;  // in the legacy row-major / col-major index order
+    uint32_t stick_size_padded = 0;
+    uint32_t stick_size_unpadded = 0;
+    uint32_t shard_height_unpadded = 0;
 
-    auto input_shape = input_tensor.padded_shape();
-    auto output_shape = output_tensor.padded_shape();
+    tt::DataFormat src_cb_data_format = tt::DataFormat::Invalid;
+    tt::DataFormat dst_cb_data_format = tt::DataFormat::Invalid;
+    uint32_t cb_in_total_size = 0;
+    uint32_t cb_out_total_size = 0;
 
+    // Per-core reader arg blob, parallel to `cores`.
+    std::vector<std::vector<uint32_t>> reader_args;
+};
+
+SliceRmShardedGeometry compute_geometry(const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input;
+    IDevice* device = input.device();
+
+    SliceRmShardedGeometry g;
+
+    auto input_shape = input.padded_shape();
+    auto output_shape = output.padded_shape();
+
+    // Stick sizes.
+    uint32_t W_padded = input.logical_shape()[-1];
+    uint32_t W_unpadded = output.logical_shape()[-1];
+    g.stick_size_padded = W_padded * input.element_size();
+    g.stick_size_unpadded = W_unpadded * output.element_size();
+
+    g.src_cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    g.dst_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+
+    // Input shard spec (padded).
+    auto shard_spec_padded = input.shard_spec().value();
+    uint32_t shard_height_padded = shard_spec_padded.shape[0];
+    auto bbox_padded = shard_spec_padded.grid.bounding_box();
+    CoreCoord grid_size_padded = {bbox_padded.end_coord.x + 1, bbox_padded.end_coord.y + 1};
+    uint32_t num_cores_x_padded = grid_size_padded.x;
+    uint32_t num_cores_y_padded = grid_size_padded.y;
+
+    if (args.sub_core_grids.has_value()) {
+        log_warning(tt::LogOp, "sub_core_grids is not used when input tensor is sharded");
+    }
+
+    // Output shard spec (unpadded).
+    auto shard_spec_unpadded = output.shard_spec().value();
+    g.shard_height_unpadded = shard_spec_unpadded.shape[0];
+    bool row_major = shard_spec_unpadded.orientation == ShardOrientation::ROW_MAJOR;
+    g.all_cores_unpadded = shard_spec_unpadded.grid;
+    uint32_t num_cores_unpadded = shard_spec_unpadded.num_cores();
+    auto bbox_unpadded = g.all_cores_unpadded.bounding_box();
+    CoreCoord grid_size_unpadded = {bbox_unpadded.end_coord.x + 1, bbox_unpadded.end_coord.y + 1};
+    uint32_t num_cores_x_unpadded = grid_size_unpadded.x;
+    uint32_t num_cores_y_unpadded = grid_size_unpadded.y;
+
+    // Sharded CB total sizes. padded_shape is in the cache key (default reflection hash over
+    // op type + attrs + tensor spec), so each unique sizing gets its own cache entry.
+    g.cb_in_total_size = shard_height_padded * g.stick_size_padded;
+    g.cb_out_total_size = g.shard_height_unpadded * g.stick_size_unpadded;
+
+    // Per-dim stick counts (same recurrence as the descriptor era).
     std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
     std::vector<uint32_t> num_unpadded_sticks_per_dim(num_dims);
     std::vector<uint32_t> num_padded_sticks_per_dim(num_dims);
     std::vector<uint32_t> id_per_dim(num_dims);
-
     std::vector<uint32_t> accumulated_total_per_dim(num_dims);
 
     // TODO: Remove first element of these arrays and update kernel accordingly
@@ -81,9 +139,10 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
     }
 
-    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_unpadded);
+    g.cores.reserve(num_cores_unpadded);
+    g.reader_args.reserve(num_cores_unpadded);
 
-    uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(input_tensor, output_tensor_start);
+    uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(input, args.slice_start);
     for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_unpadded; i++) {
         CoreCoord core;
         if (row_major) {
@@ -91,7 +150,9 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         } else {
             core = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
         }
-        uint32_t num_sticks_per_core_unpadded = shard_height_unpadded;
+        g.cores.push_back(core);
+
+        uint32_t num_sticks_per_core_unpadded = g.shard_height_unpadded;
         uint32_t num_sticks_per_core_padded = shard_height_padded;
 
         // figure out the start read stick id for each core, and the start id for each dim
@@ -110,7 +171,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
         // stores all sticks id for a core
         std::vector<uint32_t> stick_ids_per_core;
         uint32_t src_stick_id = start_id;
-        for (uint32_t i = 0; i < num_sticks_per_core_unpadded; ++i) {
+        for (uint32_t s = 0; s < num_sticks_per_core_unpadded; ++s) {
             stick_ids_per_core.push_back(src_stick_id);
             src_stick_id++;
             for (uint32_t j = 0; j < num_dims; j++) {
@@ -126,8 +187,8 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 
         // figure out the stick id in a shard, and the core id for the stick.
         std::map<std::pair<uint32_t, uint32_t>, std::vector<uint32_t>> core_stick_map;
-        for (uint32_t i = 0; i < num_sticks_per_core_unpadded; ++i) {
-            uint32_t stick_id = stick_ids_per_core[i];
+        for (uint32_t s = 0; s < num_sticks_per_core_unpadded; ++s) {
+            uint32_t stick_id = stick_ids_per_core[s];
             uint32_t shard_id = stick_id / num_sticks_per_core_padded;
             uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core_padded);
 
@@ -148,7 +209,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             }
         }
 
-        // reader rt args
+        // Build the variable-length per-core reader arg blob (decoded positionally on device).
         std::vector<uint32_t> reader_kernel_args;
         reader_kernel_args.push_back(core_stick_map.size());  // num_cores
 
@@ -178,146 +239,118 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
             }
         }
 
-        std::vector<uint32_t> writer_kernel_args;
-        ret_val[i] = {reader_kernel_args, writer_kernel_args};
+        g.reader_args.push_back(std::move(reader_kernel_args));
     }
 
-    return ret_val;
+    return g;
 }
 
 }  // namespace
 
-}  // namespace ttnn::operations::data_movement
-
-namespace ttnn::prim {
-
-tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
+m2::ProgramSpec SliceRmShardedProgramFactory::create_program_spec(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto& input = tensor_args.input;
-    ProgramDescriptor desc;
+    const auto g = compute_geometry(args, tensor_args, output);
 
-    [[maybe_unused]] uint32_t num_padded_sticks = input.physical_volume() / input.padded_shape()[-1];
-    [[maybe_unused]] uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];
+    // Both CBs are sharded -> borrowed-memory DFBs. The descriptor era pinned
+    // CBDescriptor::buffer = input.buffer()/output.buffer(); here the backing L1 address is
+    // supplied per dispatch from the tensor argument (borrowed_from = TensorParamName). entry_size
+    // is the per-stick page size; num_entries the shard height (whole shard, single CB entry-set).
+    m2::DataflowBufferSpec cb_in{
+        .unique_id = m2::DFBSpecName{"cb_in"},
+        .entry_size = g.stick_size_padded,
+        .num_entries = g.cb_in_total_size / g.stick_size_padded,
+        .data_format_metadata = g.src_cb_data_format,
+        .borrowed_from = m2::TensorParamName{"input"},
+    };
+    m2::DataflowBufferSpec cb_out{
+        .unique_id = m2::DFBSpecName{"cb_out"},
+        .entry_size = g.stick_size_unpadded,
+        .num_entries = g.cb_out_total_size / g.stick_size_unpadded,
+        .data_format_metadata = g.dst_cb_data_format,
+        .borrowed_from = m2::TensorParamName{"output"},
+    };
 
-    // stick sizes
-    uint32_t W_padded = input.logical_shape()[-1];
-    uint32_t W_unpadded = output.logical_shape()[-1];
-    auto stick_size_padded = W_padded * input.element_size();
-    auto stick_size_unpadded = W_unpadded * output.element_size();
+    // The reader is a data-movement kernel, so binding the sharded tensors to it (for the borrowed
+    // CBs) is permitted. The kernel uses neither TensorAccessor — the shard-to-shard NOC reads use
+    // explicit (noc_x, noc_y, l1_addr) endpoints built from the borrowed CB write pointers and the
+    // per-core noc-coord varargs — so no tensor_bindings accessor name is needed on the kernel. The
+    // borrowed_from on each DFB is what wires the tensor L1 address into the CB.
+    //
+    // Self-loop bindings: with no separate writer kernel, the single reader plays BOTH the producer
+    // and consumer endpoint of each borrowed CB (matching the plusone sharded pattern).
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{READER_KERNEL},
+        .dfb_bindings =
+            {m2::ProducerOf(m2::DFBSpecName{"cb_in"}, "cb_in"),
+             m2::ConsumerOf(m2::DFBSpecName{"cb_in"}, "cb_in"),
+             m2::ProducerOf(m2::DFBSpecName{"cb_out"}, "cb_out"),
+             m2::ConsumerOf(m2::DFBSpecName{"cb_out"}, "cb_out")},
+        .compile_time_args =
+            {{"stick_size_padded", g.stick_size_padded},
+             {"stick_size_unpadded", g.stick_size_unpadded},
+             {"num_sticks_unpadded", g.shard_height_unpadded}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementHardwareConfig::RoleHint::READER},
+    };
 
-    // input shard spec
-    auto shard_spec_padded = input.shard_spec().value();
-    uint32_t shard_height_padded = shard_spec_padded.shape[0];
+    // Per-core reader arg blob is a single variable-length runtime vararg vector. Its length differs
+    // per core (the noc-coord list and chunk list depend on which remote shards a core reads from),
+    // so the count is declared per node via num_runtime_varargs_per_node (the scalar
+    // num_runtime_varargs only supports a uniform count).
+    // NOTE: num_runtime_varargs_per_node is [[deprecated]] in the Metal 2.0 API, but it is the ONLY
+    // mechanism for VARIABLE per-node vararg counts (the scalar num_runtime_varargs is uniform-only).
+    // The rm-sharded reader blob length genuinely differs per core. Suppress the deprecation warning
+    // locally; this should be revisited if/when typed std::array kernel args land (see advanced_options.hpp).
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+    for (size_t i = 0; i < g.cores.size(); ++i) {
+        reader.advanced_options.num_runtime_varargs_per_node.emplace(
+            m2::Nodes{node_of(g.cores[i])}, static_cast<uint32_t>(g.reader_args[i].size()));
+    }
+#pragma GCC diagnostic pop
 
-    [[maybe_unused]] auto& all_cores_padded = shard_spec_padded.grid;
-    [[maybe_unused]] uint32_t num_cores_padded = shard_spec_padded.num_cores();
-    auto bbox_padded = shard_spec_padded.grid.bounding_box();
-    CoreCoord grid_size_padded = {bbox_padded.end_coord.x + 1, bbox_padded.end_coord.y + 1};
-    uint32_t num_cores_x_padded = grid_size_padded.x;
-    uint32_t num_cores_y_padded = grid_size_padded.y;
+    m2::ProgramSpec spec;
+    spec.name = "slice_rm_sharded";
+    spec.kernels = {std::move(reader)};
+    spec.dataflow_buffers = {std::move(cb_in), std::move(cb_out)};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = tensor_args.input.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output.tensor_spec()}};
+    spec.work_units = {m2::WorkUnitSpec{
+        .name = "slice_rm_sharded",
+        .kernels = {m2::KernelSpecName{"reader"}},
+        .target_nodes = g.all_cores_unpadded}};
+    return spec;
+}
 
-    if (args.sub_core_grids.has_value()) {
-        log_warning(tt::LogOp, "sub_core_grids is not used when input tensor is sharded");
+m2::ProgramRunArgs SliceRmShardedProgramFactory::create_invariant_run_args(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto g = compute_geometry(args, tensor_args, output);
+
+    m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
+    for (size_t i = 0; i < g.cores.size(); ++i) {
+        const auto node = node_of(g.cores[i]);
+        reader_args.advanced_options.runtime_varargs.emplace(
+            node, m2::AdvancedKernelRunArgs::Varargs(g.reader_args[i].begin(), g.reader_args[i].end()));
     }
 
-    log_debug(tt::LogOp, "num_padded_sticks: {}", num_padded_sticks);
-    log_debug(tt::LogOp, "shard_height_padded: {}", shard_height_padded);
-    log_debug(tt::LogOp, "all_cores_padded: {}", all_cores_padded);
-    log_debug(tt::LogOp, "num_cores_padded: {}", num_cores_padded);
+    m2::ProgramRunArgs run_args;
+    run_args.kernel_run_args.push_back(std::move(reader_args));
+    return run_args;
+}
 
-    // output shard spec
-    auto shard_spec_unpadded = output.shard_spec().value();
-    uint32_t shard_height_unpadded = shard_spec_unpadded.shape[0];
-    bool row_major = shard_spec_unpadded.orientation == ShardOrientation::ROW_MAJOR;
-
-    auto& all_cores_unpadded = shard_spec_unpadded.grid;
-    uint32_t num_cores_unpadded = shard_spec_unpadded.num_cores();
-    auto bbox_unpadded = all_cores_unpadded.bounding_box();
-    CoreCoord grid_size_unpadded = {bbox_unpadded.end_coord.x + 1, bbox_unpadded.end_coord.y + 1};
-    uint32_t num_cores_x_unpadded = grid_size_unpadded.x;
-    uint32_t num_cores_y_unpadded = grid_size_unpadded.y;
-
-    log_debug(tt::LogOp, "num_unpadded_sticks: {}", num_unpadded_sticks);
-    log_debug(tt::LogOp, "shard_height_unpadded: {}", shard_height_unpadded);
-    log_debug(tt::LogOp, "all_cores_unpadded: {}", all_cores_unpadded);
-    log_debug(tt::LogOp, "num_cores_unpadded: {}", num_cores_unpadded);
-
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
-
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-
-    // Sharded CBs: total_size and page_size vary with shard shape / element size,
-    // so padded_shape is folded into compute_program_hash() to keep each unique
-    // sizing in its own cache entry.  On cache hit, the framework copies runtime
-    // args and patches dynamic CB addresses (.buffer is set below); CB sizing
-    // itself is not re-applied — it is carried by the cached descriptor.
-    constexpr uint8_t src0_cb_index = 0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = shard_height_padded * stick_size_padded,
-        .core_ranges = all_cores_unpadded,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src0_cb_index,
-            .data_format = cb_data_format,
-            .page_size = stick_size_padded,
-        }}},
-        .buffer = input.buffer(),
-    });
-
-    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = shard_height_unpadded * stick_size_unpadded,
-        .core_ranges = all_cores_unpadded,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = dst_cb_data_format,
-            .page_size = stick_size_unpadded,
-        }}},
-        .buffer = output.buffer(),
-    });
-
-    std::vector<uint32_t> reader_ct_args = {
-        static_cast<uint32_t>(stick_size_padded),
-        static_cast<uint32_t>(stick_size_unpadded),
-        static_cast<uint32_t>(shard_height_unpadded)};
-
-    auto all_runtime_args = ttnn::operations::data_movement::get_slice_runtime_args_rm_sharded(
-        input,
-        output,
-        args.slice_start,
-        num_cores_unpadded,
-        row_major,
-        num_cores_x_unpadded,
-        num_cores_y_unpadded,
-        shard_height_unpadded,
-        shard_height_padded,
-        num_cores_x_padded,
-        num_cores_y_padded);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "slice_reader_unary_unpad_dims_rm_sharded.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores_unpadded;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    reader_desc.runtime_args.reserve(num_cores_unpadded);
-    for (uint32_t i = 0; i < num_cores_unpadded; ++i) {
-        CoreCoord core;
-        if (row_major) {
-            core = {i % num_cores_x_unpadded, i / num_cores_x_unpadded};
-        } else {
-            core = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
-        }
-        reader_desc.runtime_args.emplace_back(core, std::move(all_runtime_args[i].first));
-    }
-
-    desc.kernels.push_back(std::move(reader_desc));
-
-    return desc;
+m2::ProgramRunArgs SliceRmShardedProgramFactory::create_per_enqueue_args(
+    const SliceParams& /*args*/,
+    const SliceInputs& tensor_args,
+    Tensor& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    m2::ProgramRunArgs run_args;
+    // Borrowed-memory DFBs draw their backing L1 address from these tensor arguments.
+    run_args.tensor_args.emplace(
+        m2::TensorParamName{"input"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.input.mesh_tensor())});
+    run_args.tensor_args.emplace(
+        m2::TensorParamName{"output"}, m2::ProgramRunArgs::TensorArgument{std::cref(output.mesh_tensor())});
+    return run_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -21,11 +21,11 @@ namespace ttnn::prim {
 
 namespace {
 
-constexpr const char* READER_KERNEL =
+constexpr const char* RMSHD_READER_KERNEL =
     "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
     "slice_reader_unary_unpad_dims_rm_sharded_m2.cpp";
 
-m2::NodeCoord node_of(const CoreCoord& c) {
+m2::NodeCoord rmshd_node_of(const CoreCoord& c) {
     return m2::NodeCoord{static_cast<std::size_t>(c.x), static_cast<std::size_t>(c.y)};
 }
 
@@ -71,7 +71,7 @@ struct SliceRmShardedGeometry {
     std::vector<std::vector<uint32_t>> reader_args;
 };
 
-SliceRmShardedGeometry compute_geometry(const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+SliceRmShardedGeometry rmshd_compute_geometry(const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
     const auto& input = tensor_args.input;
     IDevice* device = input.device();
 
@@ -249,7 +249,7 @@ SliceRmShardedGeometry compute_geometry(const SliceParams& args, const SliceInpu
 
 m2::ProgramSpec SliceRmShardedProgramFactory::create_program_spec(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto g = compute_geometry(args, tensor_args, output);
+    const auto g = rmshd_compute_geometry(args, tensor_args, output);
 
     // Both CBs are sharded -> borrowed-memory DFBs. The descriptor era pinned
     // CBDescriptor::buffer = input.buffer()/output.buffer(); here the backing L1 address is
@@ -280,7 +280,7 @@ m2::ProgramSpec SliceRmShardedProgramFactory::create_program_spec(
     // and consumer endpoint of each borrowed CB (matching the plusone sharded pattern).
     m2::KernelSpec reader{
         .unique_id = m2::KernelSpecName{"reader"},
-        .source = std::filesystem::path{READER_KERNEL},
+        .source = std::filesystem::path{RMSHD_READER_KERNEL},
         .dfb_bindings =
             {m2::ProducerOf(m2::DFBSpecName{"cb_in"}, "cb_in"),
              m2::ConsumerOf(m2::DFBSpecName{"cb_in"}, "cb_in"),
@@ -305,7 +305,7 @@ m2::ProgramSpec SliceRmShardedProgramFactory::create_program_spec(
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     for (size_t i = 0; i < g.cores.size(); ++i) {
         reader.advanced_options.num_runtime_varargs_per_node.emplace(
-            m2::Nodes{node_of(g.cores[i])}, static_cast<uint32_t>(g.reader_args[i].size()));
+            m2::Nodes{rmshd_node_of(g.cores[i])}, static_cast<uint32_t>(g.reader_args[i].size()));
     }
 #pragma GCC diagnostic pop
 
@@ -325,11 +325,11 @@ m2::ProgramSpec SliceRmShardedProgramFactory::create_program_spec(
 
 m2::ProgramRunArgs SliceRmShardedProgramFactory::create_invariant_run_args(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto g = compute_geometry(args, tensor_args, output);
+    const auto g = rmshd_compute_geometry(args, tensor_args, output);
 
     m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
     for (size_t i = 0; i < g.cores.size(); ++i) {
-        const auto node = node_of(g.cores[i]);
+        const auto node = rmshd_node_of(g.cores[i]);
         reader_args.advanced_options.runtime_varargs.emplace(
             node, m2::AdvancedKernelRunArgs::Varargs(g.reader_args[i].begin(), g.reader_args[i].end()));
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp
@@ -3,22 +3,37 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <optional>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
+// Metal 2.0 sharded row-major slice factory. The immutable contract (create_program_spec)
+// plus the enqueue-invariant per-core work geometry (create_invariant_run_args — a pure
+// function of shape + shard spec + slice params, all in the cache key) and the per-dispatch
+// tensor bindings (create_per_enqueue_args).
+//
+// Both circular buffers are SHARDED — in the descriptor era CBDescriptor::buffer was pinned to
+// input.buffer()/output.buffer(). In Metal 2.0 those become BORROWED-MEMORY DataflowBuffers:
+// DataflowBufferSpec::borrowed_from = TensorParamName, with the backing L1 address supplied per
+// dispatch via the tensor argument. The single data-movement reader does shard-to-shard NOC
+// reads (it is a DM kernel, so binding the sharded tensors to it is allowed) and writes directly
+// into the borrowed output CB; there is no separate writer kernel (same as the legacy factory).
 struct SliceRmShardedProgramFactory {
-    // Contract (1): per-coord ProgramDescriptor.  Both CBs are sharded
-    // (CBDescriptor::buffer bound to input/output buffers); the framework
-    // patches the dynamic CB addresses on cache hit via
-    // apply_descriptor_runtime_args.  CB total_size/page_size are NOT patched
-    // — padded_shape is folded into compute_program_hash() so each unique
-    // sizing gets its own cache entry.
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static tt::tt_metal::experimental::ProgramSpec create_program_spec(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+    static tt::tt_metal::experimental::ProgramRunArgs create_invariant_run_args(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+    static tt::tt_metal::experimental::ProgramRunArgs create_per_enqueue_args(
+        const SliceParams& args,
+        const SliceInputs& tensor_args,
+        Tensor& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
@@ -169,7 +169,19 @@ m2::ProgramSpec SliceRmStrideProgramFactory::create_program_spec(
 }
 
 m2::ProgramRunArgs SliceRmStrideProgramFactory::create_invariant_run_args(
-    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const SliceParams& /*args*/, const SliceInputs& /*tensor_args*/, Tensor& /*output*/) {
+    // Nothing is enqueue-invariant here: the kernels carry varargs (which cannot be designated
+    // invariant — gap #6), so on a cache hit every kernel with varargs must appear in the
+    // per-enqueue UpdateProgramRunArgs. We therefore re-apply all run args per dispatch (the
+    // framework's "++ by default") and keep this empty.
+    return m2::ProgramRunArgs{};
+}
+
+m2::ProgramRunArgs SliceRmStrideProgramFactory::create_per_enqueue_args(
+    const SliceParams& args,
+    const SliceInputs& tensor_args,
+    Tensor& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
     const auto g = rmstr_compute_geometry(args, tensor_args, output);
 
     m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
@@ -198,15 +210,6 @@ m2::ProgramRunArgs SliceRmStrideProgramFactory::create_invariant_run_args(
     m2::ProgramRunArgs run_args;
     run_args.kernel_run_args.push_back(std::move(reader_args));
     run_args.kernel_run_args.push_back(std::move(writer_args));
-    return run_args;
-}
-
-m2::ProgramRunArgs SliceRmStrideProgramFactory::create_per_enqueue_args(
-    const SliceParams& /*args*/,
-    const SliceInputs& tensor_args,
-    Tensor& output,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    m2::ProgramRunArgs run_args;
     run_args.tensor_args.emplace(
         m2::TensorParamName{"src"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.input.mesh_tensor())});
     run_args.tensor_args.emplace(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
@@ -2,32 +2,68 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 
+#include <algorithm>
+#include <filesystem>
 #include <optional>
+#include <vector>
+
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/math.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor SliceRmStrideProgramFactory::create_descriptor(
-    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto& input_tensor = tensor_args.input;
-    tt::tt_metal::IDevice* device = input_tensor.device();
-    ProgramDescriptor desc;
+namespace {
 
-    const auto& input_shape = input_tensor.padded_shape();
+// Always the nd kernels (they handle all ranks).
+constexpr const char* READER_KERNEL =
+    "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd_m2.cpp";
+constexpr const char* WRITER_KERNEL =
+    "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd_m2.cpp";
+
+// Enqueue-invariant work geometry: a pure function of shape + slice params (all in the cache key).
+struct SliceRmStrideGeometry {
+    CoreRangeSet all_cores;
+    std::vector<CoreCoord> cores;
+    uint32_t rank = 0;
+    uint32_t element_size = 0;
+    uint32_t cb_page_size_aligned = 0;
+    tt::DataFormat data_format = tt::DataFormat::Invalid;
+
+    // Op-level arrays, broadcast to every core (read-only on device).
+    // Reader common varargs order: [input_dims, output_dims, slice_starts, slice_ends, slice_steps].
+    std::vector<uint32_t> input_shape;
+    std::vector<uint32_t> output_shape;
+    std::vector<uint32_t> slice_start;
+    std::vector<uint32_t> slice_end;
+    std::vector<uint32_t> slice_step;
+
+    // Per-core values (parallel to `cores`).
+    std::vector<uint32_t> num_rows;   // rows_for_this_core
+    std::vector<uint32_t> start_row;  // row_start_id
+};
+
+SliceRmStrideGeometry compute_geometry(
+    const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output) {
+    const auto& input = tensor_args.input;
+    IDevice* device = input.device();
+
+    SliceRmStrideGeometry g;
+    g.data_format = datatype_to_dataformat_converter(input.dtype());
+    g.element_size = input.element_size();
+
+    const auto& input_shape = input.padded_shape();
     const auto& output_shape = output.padded_shape();
-    uint32_t element_size = input_tensor.element_size();
+    g.rank = static_cast<uint32_t>(input_shape.rank());
 
-    // Calculate total output rows based on tensor rank
+    // Total output rows based on tensor rank.
     uint32_t total_output_rows = output_shape.volume() / output_shape[-1];
 
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
@@ -35,142 +71,147 @@ tt::tt_metal::ProgramDescriptor SliceRmStrideProgramFactory::create_descriptor(
         args.sub_core_grids.has_value()
             ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), total_output_rows)
             : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, total_output_rows);
+    g.all_cores = all_cores;
 
-    // Select kernels based on tensor rank
-    std::string reader_kernel_path;
-    std::string writer_kernel_path;
-    if (input_shape.rank() <= 4) {
-        reader_kernel_path =
-            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp";
-        writer_kernel_path =
-            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp";
-    } else {
-        reader_kernel_path =
-            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp";
-        writer_kernel_path =
-            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp";
-    }
-
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    // CB sizing: one page = one full input row, aligned to max(src, dst) buffer alignment.
     uint32_t actual_input_w = input_shape[-1];
-    uint32_t input_bytes_per_row = actual_input_w * element_size;
+    uint32_t input_bytes_per_row = actual_input_w * g.element_size;
     uint32_t cb_page_size = input_bytes_per_row;
 
-    auto src_buffer_alignment = input_tensor.buffer()->alignment();
+    auto src_buffer_alignment = input.buffer()->alignment();
     auto dst_buffer_alignment = output.buffer()->alignment();
     auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+    g.cb_page_size_aligned = tt::round_up(cb_page_size, alignment);
 
-    uint32_t cb_page_size_aligned = tt::round_up(cb_page_size, alignment);
-    uint32_t cb_total_size = 2 * cb_page_size_aligned;
+    // Op-level arrays (identical across cores).
+    g.input_shape.assign(input_shape.cbegin(), input_shape.cend());
+    g.output_shape.assign(output_shape.cbegin(), output_shape.cend());
+    g.slice_start.assign(args.slice_start.cbegin(), args.slice_start.cend());
+    g.slice_end.assign(args.slice_end.cbegin(), args.slice_end.cend());
+    g.slice_step.assign(args.step.cbegin(), args.step.cend());
 
-    constexpr uint8_t in_cb = 0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_total_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = in_cb,
-            .data_format = cb_data_format,
-            .page_size = cb_page_size_aligned,
-        }}},
-    });
-
-    std::vector<uint32_t> reader_compile_time_args = {in_cb, element_size};
-    TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
-
-    std::vector<uint32_t> writer_compile_time_args = {in_cb, element_size};
-    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source = reader_kernel_path;
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source = writer_kernel_path;
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    // Calculate runtime arguments
-    uint32_t tensor_rank = input_shape.rank();
+    // Per-core row split (matches the legacy base/extra distribution over all cores).
+    g.cores = corerange_to_cores(all_cores);
     uint32_t base_rows_per_core = total_output_rows / num_cores;
     uint32_t extra_rows = total_output_rows % num_cores;
 
-    const bool using_4d_kernels = input_shape.rank() <= 4;
-    const auto& slice_start = args.slice_start;
-    const auto& slice_end = args.slice_end;
-    const auto& slice_step = args.step;
-
-    auto all_cores_vec = corerange_to_cores(all_cores);
-    reader_desc.runtime_args.reserve(all_cores_vec.size());
-    writer_desc.runtime_args.reserve(all_cores_vec.size());
+    g.num_rows.reserve(g.cores.size());
+    g.start_row.reserve(g.cores.size());
 
     uint32_t row_start_id = 0;
     uint32_t extra_rows_remaining = extra_rows;
-
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output.buffer();
-
-    for (const auto& core : all_cores_vec) {
+    for (size_t i = 0; i < g.cores.size(); ++i) {
         uint32_t rows_for_this_core = base_rows_per_core;
         if (extra_rows_remaining > 0) {
             rows_for_this_core += 1;
             extra_rows_remaining -= 1;
         }
-
-        if (using_4d_kernels) {
-            reader_desc.emplace_runtime_args(
-                core, {input_buffer,    tensor_rank,      input_shape[-1],  input_shape[-2],    input_shape[-3],
-                       input_shape[-4], output_shape[-1], output_shape[-2], output_shape[-3],   output_shape[-4],
-                       slice_start[-1], slice_end[-1],    slice_step[-1],   slice_start[-2],    slice_end[-2],
-                       slice_step[-2],  slice_start[-3],  slice_end[-3],    slice_step[-3],     slice_start[-4],
-                       slice_end[-4],   slice_step[-4],   element_size,     rows_for_this_core, row_start_id});
-
-            writer_desc.emplace_runtime_args(
-                core,
-                {output_buffer,
-                 tensor_rank,
-                 output_shape[-1],
-                 output_shape[-2],
-                 output_shape[-3],
-                 output_shape[-4],
-                 element_size,
-                 rows_for_this_core,
-                 row_start_id});
-        } else {
-            KernelDescriptor::RTArgList reader_args;
-            reader_args.push_back(input_buffer);
-            reader_args.push_back(tensor_rank);
-            reader_args.push_back(element_size);
-            reader_args.push_back(rows_for_this_core);
-            reader_args.push_back(row_start_id);
-            reader_args.append(std::vector<uint32_t>(input_shape.cbegin(), input_shape.cend()));
-            reader_args.append(std::vector<uint32_t>(output_shape.cbegin(), output_shape.cend()));
-            reader_args.append(std::vector<uint32_t>(slice_start.cbegin(), slice_start.cend()));
-            reader_args.append(std::vector<uint32_t>(slice_end.cbegin(), slice_end.cend()));
-            reader_args.append(std::vector<uint32_t>(slice_step.cbegin(), slice_step.cend()));
-            reader_desc.emplace_runtime_args(core, reader_args);
-
-            KernelDescriptor::RTArgList writer_args;
-            writer_args.push_back(output_buffer);
-            writer_args.push_back(tensor_rank);
-            writer_args.push_back(element_size);
-            writer_args.push_back(rows_for_this_core);
-            writer_args.push_back(row_start_id);
-            writer_args.append(std::vector<uint32_t>(output_shape.cbegin(), output_shape.cend()));
-            writer_desc.emplace_runtime_args(core, writer_args);
-        }
-
+        g.num_rows.push_back(rows_for_this_core);
+        g.start_row.push_back(row_start_id);
         row_start_id += rows_for_this_core;
     }
+    return g;
+}
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+m2::NodeCoord node_of(const CoreCoord& c) {
+    return m2::NodeCoord{static_cast<std::size_t>(c.x), static_cast<std::size_t>(c.y)};
+}
 
-    return desc;
+}  // namespace
+
+m2::ProgramSpec SliceRmStrideProgramFactory::create_program_spec(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto g = compute_geometry(args, tensor_args, output);
+
+    m2::DataflowBufferSpec cb{
+        .unique_id = m2::DFBSpecName{"cb"},
+        .entry_size = g.cb_page_size_aligned,
+        .num_entries = 2,
+        .data_format_metadata = g.data_format,
+    };
+
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{READER_KERNEL},
+        .dfb_bindings = {m2::ProducerOf(m2::DFBSpecName{"cb"}, "cb_out")},
+        .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"}},
+        .compile_time_args = {{"rank", g.rank}, {"element_size", g.element_size}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "start_row"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementHardwareConfig::RoleHint::READER},
+        .advanced_options =
+            m2::KernelAdvancedOptions{.num_runtime_varargs = 0, .num_common_runtime_varargs = 5 * g.rank},
+    };
+
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{WRITER_KERNEL},
+        .dfb_bindings = {m2::ConsumerOf(m2::DFBSpecName{"cb"}, "cb_in")},
+        .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"}},
+        .compile_time_args = {{"rank", g.rank}, {"element_size", g.element_size}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_rows", "start_row"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementHardwareConfig::RoleHint::WRITER},
+        .advanced_options =
+            m2::KernelAdvancedOptions{.num_runtime_varargs = 0, .num_common_runtime_varargs = g.rank},
+    };
+
+    m2::ProgramSpec spec;
+    spec.name = "slice_rm_stride";
+    spec.kernels = {std::move(reader), std::move(writer)};
+    spec.dataflow_buffers = {std::move(cb)};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = tensor_args.input.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()}};
+    spec.work_units = {m2::WorkUnitSpec{
+        .name = "slice",
+        .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+        .target_nodes = g.all_cores}};
+    return spec;
+}
+
+m2::ProgramRunArgs SliceRmStrideProgramFactory::create_invariant_run_args(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto g = compute_geometry(args, tensor_args, output);
+
+    m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
+    m2::ProgramRunArgs::KernelRunArgs writer_args{.kernel = m2::KernelSpecName{"writer"}};
+
+    // Reader common varargs: [input_dims, output_dims, slice_starts, slice_ends, slice_steps].
+    auto& reader_common = reader_args.advanced_options.common_runtime_varargs;
+    reader_common.insert(reader_common.end(), g.input_shape.begin(), g.input_shape.end());
+    reader_common.insert(reader_common.end(), g.output_shape.begin(), g.output_shape.end());
+    reader_common.insert(reader_common.end(), g.slice_start.begin(), g.slice_start.end());
+    reader_common.insert(reader_common.end(), g.slice_end.begin(), g.slice_end.end());
+    reader_common.insert(reader_common.end(), g.slice_step.begin(), g.slice_step.end());
+
+    // Writer common varargs: [output_dims].
+    auto& writer_common = writer_args.advanced_options.common_runtime_varargs;
+    writer_common.insert(writer_common.end(), g.output_shape.begin(), g.output_shape.end());
+
+    for (size_t i = 0; i < g.cores.size(); ++i) {
+        const auto node = node_of(g.cores[i]);
+        reader_args.runtime_arg_values.push_back(
+            {node, {{"num_rows", g.num_rows[i]}, {"start_row", g.start_row[i]}}});
+        writer_args.runtime_arg_values.push_back(
+            {node, {{"num_rows", g.num_rows[i]}, {"start_row", g.start_row[i]}}});
+    }
+
+    m2::ProgramRunArgs run_args;
+    run_args.kernel_run_args.push_back(std::move(reader_args));
+    run_args.kernel_run_args.push_back(std::move(writer_args));
+    return run_args;
+}
+
+m2::ProgramRunArgs SliceRmStrideProgramFactory::create_per_enqueue_args(
+    const SliceParams& /*args*/,
+    const SliceInputs& tensor_args,
+    Tensor& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    m2::ProgramRunArgs run_args;
+    run_args.tensor_args.emplace(
+        m2::TensorParamName{"src"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.input.mesh_tensor())});
+    run_args.tensor_args.emplace(
+        m2::TensorParamName{"dst"}, m2::ProgramRunArgs::TensorArgument{std::cref(output.mesh_tensor())});
+    return run_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
@@ -23,9 +23,9 @@ namespace ttnn::prim {
 namespace {
 
 // Always the nd kernels (they handle all ranks).
-constexpr const char* READER_KERNEL =
+constexpr const char* RMSTR_READER_KERNEL =
     "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd_m2.cpp";
-constexpr const char* WRITER_KERNEL =
+constexpr const char* RMSTR_WRITER_KERNEL =
     "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd_m2.cpp";
 
 // Enqueue-invariant work geometry: a pure function of shape + slice params (all in the cache key).
@@ -50,7 +50,7 @@ struct SliceRmStrideGeometry {
     std::vector<uint32_t> start_row;  // row_start_id
 };
 
-SliceRmStrideGeometry compute_geometry(
+SliceRmStrideGeometry rmstr_compute_geometry(
     const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output) {
     const auto& input = tensor_args.input;
     IDevice* device = input.device();
@@ -113,7 +113,7 @@ SliceRmStrideGeometry compute_geometry(
     return g;
 }
 
-m2::NodeCoord node_of(const CoreCoord& c) {
+m2::NodeCoord rmstr_node_of(const CoreCoord& c) {
     return m2::NodeCoord{static_cast<std::size_t>(c.x), static_cast<std::size_t>(c.y)};
 }
 
@@ -121,7 +121,7 @@ m2::NodeCoord node_of(const CoreCoord& c) {
 
 m2::ProgramSpec SliceRmStrideProgramFactory::create_program_spec(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto g = compute_geometry(args, tensor_args, output);
+    const auto g = rmstr_compute_geometry(args, tensor_args, output);
 
     m2::DataflowBufferSpec cb{
         .unique_id = m2::DFBSpecName{"cb"},
@@ -132,7 +132,7 @@ m2::ProgramSpec SliceRmStrideProgramFactory::create_program_spec(
 
     m2::KernelSpec reader{
         .unique_id = m2::KernelSpecName{"reader"},
-        .source = std::filesystem::path{READER_KERNEL},
+        .source = std::filesystem::path{RMSTR_READER_KERNEL},
         .dfb_bindings = {m2::ProducerOf(m2::DFBSpecName{"cb"}, "cb_out")},
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"}},
         .compile_time_args = {{"rank", g.rank}, {"element_size", g.element_size}},
@@ -144,7 +144,7 @@ m2::ProgramSpec SliceRmStrideProgramFactory::create_program_spec(
 
     m2::KernelSpec writer{
         .unique_id = m2::KernelSpecName{"writer"},
-        .source = std::filesystem::path{WRITER_KERNEL},
+        .source = std::filesystem::path{RMSTR_WRITER_KERNEL},
         .dfb_bindings = {m2::ConsumerOf(m2::DFBSpecName{"cb"}, "cb_in")},
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"}},
         .compile_time_args = {{"rank", g.rank}, {"element_size", g.element_size}},
@@ -170,7 +170,7 @@ m2::ProgramSpec SliceRmStrideProgramFactory::create_program_spec(
 
 m2::ProgramRunArgs SliceRmStrideProgramFactory::create_invariant_run_args(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto g = compute_geometry(args, tensor_args, output);
+    const auto g = rmstr_compute_geometry(args, tensor_args, output);
 
     m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
     m2::ProgramRunArgs::KernelRunArgs writer_args{.kernel = m2::KernelSpecName{"writer"}};
@@ -188,7 +188,7 @@ m2::ProgramRunArgs SliceRmStrideProgramFactory::create_invariant_run_args(
     writer_common.insert(writer_common.end(), g.output_shape.begin(), g.output_shape.end());
 
     for (size_t i = 0; i < g.cores.size(); ++i) {
-        const auto node = node_of(g.cores[i]);
+        const auto node = rmstr_node_of(g.cores[i]);
         reader_args.runtime_arg_values.push_back(
             {node, {{"num_rows", g.num_rows[i]}, {"start_row", g.start_row[i]}}});
         writer_args.runtime_arg_values.push_back(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp
@@ -3,16 +3,30 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <optional>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
+// Metal 2.0 slice row-major strided factory. The immutable contract (create_program_spec) plus the
+// enqueue-invariant per-core work geometry (create_invariant_run_args, a pure function of
+// shape + slice params, all in the cache key) and the per-dispatch tensor bindings
+// (create_per_enqueue_args). Always uses the nd kernels (they handle all ranks).
 struct SliceRmStrideProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static tt::tt_metal::experimental::ProgramSpec create_program_spec(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+    static tt::tt_metal::experimental::ProgramRunArgs create_invariant_run_args(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+    static tt::tt_metal::experimental::ProgramRunArgs create_per_enqueue_args(
+        const SliceParams& args,
+        const SliceInputs& tensor_args,
+        Tensor& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -4,178 +4,20 @@
 
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp"
 
-#include <optional>
-#include <tt-metalium/work_split.hpp>
-#include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-
-using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
+// The descriptor logic now lives in build_slice_tile_descriptor (a standalone
+// function shared with the pybind / fusion / mesh_partition consumers). This
+// thin delegate is the seam: when the factory migrates to Metal 2.0 it gains
+// create_program_spec and this create_descriptor is dropped, while the consumers
+// keep calling build_slice_tile_descriptor directly.
 tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto& input = tensor_args.input;
-    tt::tt_metal::IDevice* device = input.device();
-
-    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
-
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        args.sub_core_grids.has_value()
-            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
-            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
-
-    tt::tt_metal::Buffer* src0_buffer = input.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
-    uint32_t single_tile_size = tt::tile_size(cb_data_format);
-
-    const auto& input_shape = input.padded_shape();
-    const auto& output_shape = output.padded_shape();
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
-
-    // --- CB Descriptor ---
-    uint32_t src0_cb_index = 0;
-    uint32_t num_input_tiles = 2;
-
-    tt::tt_metal::ProgramDescriptor program_descriptor;
-
-    tt::tt_metal::CBDescriptor cb_desc;
-    cb_desc.total_size = num_input_tiles * single_tile_size;
-    cb_desc.core_ranges = all_cores;
-    cb_desc.format_descriptors.push_back(tt::tt_metal::CBFormatDescriptor{
-        .buffer_index = static_cast<uint8_t>(src0_cb_index),
-        .data_format = cb_data_format,
-        .page_size = single_tile_size});
-    program_descriptor.cbs.push_back(std::move(cb_desc));
-
-    // --- Reader Kernel Descriptor ---
-    // CB index via named compile-time arg (essential for fusion CB remapping).
-    std::vector<uint32_t> reader_compile_time_args = {num_dims};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-
-    // Reader common runtime args: [src_addr, num_unpadded_per_dim..., num_padded_per_dim...]
-    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
-    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
-    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
-    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
-    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
-    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
-
-    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
-    accumulated_total_per_dim[0] = num_total_Xt;
-    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
-
-    std::vector<uint32_t> reader_common_args(1 + (num_dims * 2));
-    reader_common_args[0] = src0_buffer->address();
-    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 1;
-    uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
-    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
-    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
-    num_padded_tiles_per_dim[0] = num_padded_Xt;
-    num_padded_tiles_per_dim[1] = num_padded_Yt;
-    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
-        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
-        uint32_t num_total_dim = input_shape[-(i + 1)];
-        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
-        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
-        num_padded_tiles_per_dim[i] = num_padded_dim;
-        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
-    }
-
-    uint32_t start_offset = ttnn::operations::data_movement::get_tiled_start_offset(input, args.slice_start);
-
-    // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
-    tt::tt_metal::KernelDescriptor::RuntimeArgs reader_runtime_args;
-    uint32_t num_tiles_written = 0;
-    for (const auto& core : corerange_to_cores(all_cores)) {
-        uint32_t num_tiles_per_core;
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            // no-op core
-            std::vector<uint32_t> reader_args(2 + num_dims, 0);
-            reader_runtime_args.emplace_back(core, std::move(reader_args));
-            continue;
-        }
-
-        std::vector<uint32_t> reader_args(2 + num_dims);
-        // Compute per-dim indices for this core's starting position
-        reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
-        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
-        uint32_t start_id = reader_args[2] + start_offset;
-        for (uint32_t j = 1; j < num_dims; ++j) {
-            reader_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
-            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
-            start_id += reader_args[2 + j] * accumulated_total_per_dim[j - 1];
-        }
-        reader_args[0] = start_id;
-        reader_args[1] = num_tiles_per_core;
-
-        reader_runtime_args.emplace_back(core, std::move(reader_args));
-        num_tiles_written += num_tiles_per_core;
-    }
-
-    tt::tt_metal::KernelDescriptor reader_kernel_desc;
-    reader_kernel_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "reader_unary_unpad_dims_interleaved_start_id.cpp";
-    reader_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
-    reader_kernel_desc.core_ranges = all_cores;
-    reader_kernel_desc.compile_time_args = reader_compile_time_args;
-    reader_kernel_desc.named_compile_time_args = {{"cb_in", src0_cb_index}};
-    reader_kernel_desc.runtime_args = std::move(reader_runtime_args);
-    reader_kernel_desc.common_runtime_args = std::move(reader_common_args);
-    reader_kernel_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
-    program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
-
-    // --- Writer Kernel Descriptor ---
-    // CB index via named compile-time arg (essential for fusion CB remapping).
-    std::vector<uint32_t> writer_compile_time_args = {};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
-    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
-    tt::tt_metal::KernelDescriptor::RuntimeArgs writer_runtime_args;
-    num_tiles_written = 0;
-    for (const auto& core : corerange_to_cores(all_cores)) {
-        uint32_t num_tiles_per_core;
-        if (core_group_1.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_tiles_per_core = num_tiles_per_core_group_2;
-        } else {
-            // no-op core
-            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
-            continue;
-        }
-
-        writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
-        num_tiles_written += num_tiles_per_core;
-    }
-
-    tt::tt_metal::KernelDescriptor writer_kernel_desc;
-    writer_kernel_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "writer_unary_interleaved_start_id.cpp";
-    writer_kernel_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
-    writer_kernel_desc.core_ranges = all_cores;
-    writer_kernel_desc.compile_time_args = writer_compile_time_args;
-    writer_kernel_desc.named_compile_time_args = {{"cb_out", src0_cb_index}};
-    writer_kernel_desc.runtime_args = std::move(writer_runtime_args);
-    writer_kernel_desc.config = tt::tt_metal::WriterConfigDescriptor{};
-    program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
-
-    return program_descriptor;
+    return build_slice_tile_descriptor(args, tensor_args, output);
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -20,9 +20,9 @@ namespace ttnn::prim {
 
 namespace {
 
-constexpr const char* READER_KERNEL =
+constexpr const char* TILE_READER_KERNEL =
     "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_slice_tile_m2.cpp";
-constexpr const char* WRITER_KERNEL =
+constexpr const char* TILE_WRITER_KERNEL =
     "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_slice_tile_m2.cpp";
 
 // Enqueue-invariant work geometry: a pure function of shape + slice params (all in the cache key).
@@ -44,7 +44,7 @@ struct SliceTileGeometry {
     std::vector<uint32_t> writer_start_id;          // == cumulative num_tiles_written
 };
 
-SliceTileGeometry compute_geometry(const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output) {
+SliceTileGeometry tile_compute_geometry(const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output) {
     const auto& input = tensor_args.input;
     IDevice* device = input.device();
 
@@ -127,7 +127,7 @@ SliceTileGeometry compute_geometry(const SliceParams& args, const SliceInputs& t
     return g;
 }
 
-m2::NodeCoord node_of(const CoreCoord& c) {
+m2::NodeCoord tile_node_of(const CoreCoord& c) {
     return m2::NodeCoord{static_cast<std::size_t>(c.x), static_cast<std::size_t>(c.y)};
 }
 
@@ -135,7 +135,7 @@ m2::NodeCoord node_of(const CoreCoord& c) {
 
 m2::ProgramSpec SliceTileProgramFactory::create_program_spec(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto g = compute_geometry(args, tensor_args, output);
+    const auto g = tile_compute_geometry(args, tensor_args, output);
 
     m2::DataflowBufferSpec cb{
         .unique_id = m2::DFBSpecName{"cb"},
@@ -146,7 +146,7 @@ m2::ProgramSpec SliceTileProgramFactory::create_program_spec(
 
     m2::KernelSpec reader{
         .unique_id = m2::KernelSpecName{"reader"},
-        .source = std::filesystem::path{READER_KERNEL},
+        .source = std::filesystem::path{TILE_READER_KERNEL},
         .dfb_bindings = {m2::ProducerOf(m2::DFBSpecName{"cb"}, "cb_in")},
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"}},
         .compile_time_args = {{"num_dims", g.num_dims}},
@@ -159,7 +159,7 @@ m2::ProgramSpec SliceTileProgramFactory::create_program_spec(
 
     m2::KernelSpec writer{
         .unique_id = m2::KernelSpecName{"writer"},
-        .source = std::filesystem::path{WRITER_KERNEL},
+        .source = std::filesystem::path{TILE_WRITER_KERNEL},
         .dfb_bindings = {m2::ConsumerOf(m2::DFBSpecName{"cb"}, "cb_out")},
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
@@ -182,7 +182,7 @@ m2::ProgramSpec SliceTileProgramFactory::create_program_spec(
 
 m2::ProgramRunArgs SliceTileProgramFactory::create_invariant_run_args(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto g = compute_geometry(args, tensor_args, output);
+    const auto g = tile_compute_geometry(args, tensor_args, output);
 
     m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
     m2::ProgramRunArgs::KernelRunArgs writer_args{.kernel = m2::KernelSpecName{"writer"}};
@@ -193,7 +193,7 @@ m2::ProgramRunArgs SliceTileProgramFactory::create_invariant_run_args(
     common.insert(common.end(), g.num_padded_per_dim.begin(), g.num_padded_per_dim.end());
 
     for (size_t i = 0; i < g.cores.size(); ++i) {
-        const auto node = node_of(g.cores[i]);
+        const auto node = tile_node_of(g.cores[i]);
         reader_args.runtime_arg_values.push_back(
             {node, {{"start_id", g.reader_start_id[i]}, {"num_tiles", g.reader_num_tiles[i]}}});
         reader_args.advanced_options.runtime_varargs.emplace(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -181,7 +181,19 @@ m2::ProgramSpec SliceTileProgramFactory::create_program_spec(
 }
 
 m2::ProgramRunArgs SliceTileProgramFactory::create_invariant_run_args(
-    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const SliceParams& /*args*/, const SliceInputs& /*tensor_args*/, Tensor& /*output*/) {
+    // Nothing is enqueue-invariant here: the reader carries varargs (which cannot be designated
+    // invariant — gap #6), so on a cache hit every kernel with varargs must appear in the
+    // per-enqueue UpdateProgramRunArgs. We therefore re-apply all run args per dispatch (the
+    // framework's "++ by default") and keep this empty.
+    return m2::ProgramRunArgs{};
+}
+
+m2::ProgramRunArgs SliceTileProgramFactory::create_per_enqueue_args(
+    const SliceParams& args,
+    const SliceInputs& tensor_args,
+    Tensor& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
     const auto g = tile_compute_geometry(args, tensor_args, output);
 
     m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
@@ -205,15 +217,6 @@ m2::ProgramRunArgs SliceTileProgramFactory::create_invariant_run_args(
     m2::ProgramRunArgs run_args;
     run_args.kernel_run_args.push_back(std::move(reader_args));
     run_args.kernel_run_args.push_back(std::move(writer_args));
-    return run_args;
-}
-
-m2::ProgramRunArgs SliceTileProgramFactory::create_per_enqueue_args(
-    const SliceParams& /*args*/,
-    const SliceInputs& tensor_args,
-    Tensor& output,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    m2::ProgramRunArgs run_args;
     run_args.tensor_args.emplace(
         m2::TensorParamName{"src"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.input.mesh_tensor())});
     run_args.tensor_args.emplace(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -2,22 +2,223 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
-#include "ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 
+#include <filesystem>
+#include <optional>
+#include <vector>
+
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+
+using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-// The descriptor logic now lives in build_slice_tile_descriptor (a standalone
-// function shared with the pybind / fusion / mesh_partition consumers). This
-// thin delegate is the seam: when the factory migrates to Metal 2.0 it gains
-// create_program_spec and this create_descriptor is dropped, while the consumers
-// keep calling build_slice_tile_descriptor directly.
-tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
+namespace {
+
+constexpr const char* READER_KERNEL =
+    "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_slice_tile_m2.cpp";
+constexpr const char* WRITER_KERNEL =
+    "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_slice_tile_m2.cpp";
+
+// Enqueue-invariant work geometry: a pure function of shape + slice params (all in the cache key).
+struct SliceTileGeometry {
+    CoreRangeSet all_cores;
+    std::vector<CoreCoord> cores;
+    uint32_t num_dims = 0;
+    uint32_t single_tile_size = 0;
+    tt::DataFormat data_format = tt::DataFormat::Invalid;
+
+    // Common, broadcast to every core (read-only on device): [num_unpadded..., num_padded...].
+    std::vector<uint32_t> num_unpadded_per_dim;
+    std::vector<uint32_t> num_padded_per_dim;
+
+    // Per-core values (parallel to `cores`).
+    std::vector<uint32_t> reader_start_id;
+    std::vector<uint32_t> reader_num_tiles;
+    std::vector<std::vector<uint32_t>> id_per_dim;  // [core][num_dims], the running-index seed
+    std::vector<uint32_t> writer_start_id;          // == cumulative num_tiles_written
+};
+
+SliceTileGeometry compute_geometry(const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output) {
+    const auto& input = tensor_args.input;
+    IDevice* device = input.device();
+
+    SliceTileGeometry g;
+    g.data_format = datatype_to_dataformat_converter(input.dtype());
+    g.single_tile_size = tt::tile_size(g.data_format);
+
+    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+    g.all_cores = all_cores;
+
+    const auto& input_shape = input.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    g.num_dims = static_cast<uint32_t>(input_shape.rank());
+
+    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
+    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
+    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
+    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
+
+    std::vector<uint32_t> accumulated_total_per_dim(g.num_dims);
+    accumulated_total_per_dim[0] = num_total_Xt;
+    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+
+    g.num_unpadded_per_dim.resize(g.num_dims);
+    g.num_padded_per_dim.resize(g.num_dims);
+    g.num_unpadded_per_dim[0] = num_unpadded_Xt;
+    g.num_unpadded_per_dim[1] = num_unpadded_Yt;
+    g.num_padded_per_dim[0] = num_padded_Xt;
+    g.num_padded_per_dim[1] = num_padded_Yt;
+    for (int32_t i = 2; i < static_cast<int32_t>(g.num_dims); ++i) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        g.num_unpadded_per_dim[i] = num_unpadded_dim;
+        g.num_padded_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    uint32_t start_offset = ttnn::operations::data_movement::get_tiled_start_offset(input, args.slice_start);
+
+    g.cores = corerange_to_cores(all_cores);
+    uint32_t num_tiles_written = 0;
+    for (const auto& core : g.cores) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            g.reader_start_id.push_back(0);
+            g.reader_num_tiles.push_back(0);
+            g.id_per_dim.emplace_back(g.num_dims, 0);
+            g.writer_start_id.push_back(0);
+            continue;
+        }
+
+        std::vector<uint32_t> ids(g.num_dims);
+        ids[0] = num_tiles_written % g.num_unpadded_per_dim[0];
+        uint32_t unpadded_written = num_tiles_written / g.num_unpadded_per_dim[0];
+        uint32_t start_id = ids[0] + start_offset;
+        for (uint32_t j = 1; j < g.num_dims; ++j) {
+            ids[j] = unpadded_written % g.num_unpadded_per_dim[j];
+            unpadded_written = unpadded_written / g.num_unpadded_per_dim[j];
+            start_id += ids[j] * accumulated_total_per_dim[j - 1];
+        }
+        g.reader_start_id.push_back(start_id);
+        g.reader_num_tiles.push_back(num_tiles_per_core);
+        g.id_per_dim.push_back(std::move(ids));
+        g.writer_start_id.push_back(num_tiles_written);
+        num_tiles_written += num_tiles_per_core;
+    }
+    return g;
+}
+
+m2::NodeCoord node_of(const CoreCoord& c) {
+    return m2::NodeCoord{static_cast<std::size_t>(c.x), static_cast<std::size_t>(c.y)};
+}
+
+}  // namespace
+
+m2::ProgramSpec SliceTileProgramFactory::create_program_spec(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    return build_slice_tile_descriptor(args, tensor_args, output);
+    const auto g = compute_geometry(args, tensor_args, output);
+
+    m2::DataflowBufferSpec cb{
+        .unique_id = m2::DFBSpecName{"cb"},
+        .entry_size = g.single_tile_size,
+        .num_entries = 2,
+        .data_format_metadata = g.data_format,
+    };
+
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{READER_KERNEL},
+        .dfb_bindings = {m2::ProducerOf(m2::DFBSpecName{"cb"}, "cb_in")},
+        .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"}},
+        .compile_time_args = {{"num_dims", g.num_dims}},
+        .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_tiles"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementHardwareConfig::RoleHint::READER},
+        .advanced_options =
+            m2::KernelAdvancedOptions{
+                .num_runtime_varargs = g.num_dims, .num_common_runtime_varargs = 2 * g.num_dims},
+    };
+
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{WRITER_KERNEL},
+        .dfb_bindings = {m2::ConsumerOf(m2::DFBSpecName{"cb"}, "cb_out")},
+        .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementHardwareConfig::RoleHint::WRITER},
+    };
+
+    m2::ProgramSpec spec;
+    spec.name = "slice_tile";
+    spec.kernels = {std::move(reader), std::move(writer)};
+    spec.dataflow_buffers = {std::move(cb)};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = tensor_args.input.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()}};
+    spec.work_units = {m2::WorkUnitSpec{
+        .name = "slice",
+        .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+        .target_nodes = g.all_cores}};
+    return spec;
+}
+
+m2::ProgramRunArgs SliceTileProgramFactory::create_invariant_run_args(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto g = compute_geometry(args, tensor_args, output);
+
+    m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
+    m2::ProgramRunArgs::KernelRunArgs writer_args{.kernel = m2::KernelSpecName{"writer"}};
+
+    // Common varargs (broadcast): [num_unpadded..., num_padded...].
+    auto& common = reader_args.advanced_options.common_runtime_varargs;
+    common.insert(common.end(), g.num_unpadded_per_dim.begin(), g.num_unpadded_per_dim.end());
+    common.insert(common.end(), g.num_padded_per_dim.begin(), g.num_padded_per_dim.end());
+
+    for (size_t i = 0; i < g.cores.size(); ++i) {
+        const auto node = node_of(g.cores[i]);
+        reader_args.runtime_arg_values.push_back(
+            {node, {{"start_id", g.reader_start_id[i]}, {"num_tiles", g.reader_num_tiles[i]}}});
+        reader_args.advanced_options.runtime_varargs.emplace(
+            node, m2::AdvancedKernelRunArgs::Varargs(g.id_per_dim[i].begin(), g.id_per_dim[i].end()));
+        writer_args.runtime_arg_values.push_back(
+            {node, {{"num_pages", g.reader_num_tiles[i]}, {"start_id", g.writer_start_id[i]}}});
+    }
+
+    m2::ProgramRunArgs run_args;
+    run_args.kernel_run_args.push_back(std::move(reader_args));
+    run_args.kernel_run_args.push_back(std::move(writer_args));
+    return run_args;
+}
+
+m2::ProgramRunArgs SliceTileProgramFactory::create_per_enqueue_args(
+    const SliceParams& /*args*/,
+    const SliceInputs& tensor_args,
+    Tensor& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    m2::ProgramRunArgs run_args;
+    run_args.tensor_args.emplace(
+        m2::TensorParamName{"src"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.input.mesh_tensor())});
+    run_args.tensor_args.emplace(
+        m2::TensorParamName{"dst"}, m2::ProgramRunArgs::TensorArgument{std::cref(output.mesh_tensor())});
+    return run_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp
@@ -3,16 +3,31 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <optional>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
+// Metal 2.0 slice tile factory. The immutable contract (create_program_spec) plus the
+// enqueue-invariant per-core work geometry (create_invariant_run_args, a pure function of
+// shape + slice params, all in the cache key) and the per-dispatch tensor bindings
+// (create_per_enqueue_args). The legacy descriptor for fusion/pybind/mesh_partition lives
+// separately in build_slice_tile_descriptor (slice_descriptor_builders.hpp).
 struct SliceTileProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static tt::tt_metal::experimental::ProgramSpec create_program_spec(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+    static tt::tt_metal::experimental::ProgramRunArgs create_invariant_run_args(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+    static tt::tt_metal::experimental::ProgramRunArgs create_per_enqueue_args(
+        const SliceParams& args,
+        const SliceInputs& tensor_args,
+        Tensor& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -2,92 +2,79 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 
+#include <filesystem>
 #include <optional>
+#include <vector>
+
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descriptor(
-    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& start_tensor = tensor_args.start_tensor.value();
-    const auto& end_tensor = tensor_args.end_tensor.value();
-    tt::tt_metal::IDevice* device = input_tensor.device();
-    ProgramDescriptor desc;
+namespace {
+
+constexpr const char* READER_KERNEL =
+    "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_slice_tile_tensor_args_m2.cpp";
+constexpr const char* WRITER_KERNEL =
+    "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_slice_tile_tensor_args_m2.cpp";
+
+// Enqueue-invariant work geometry: a pure function of shape + slice params (all in the cache key).
+// Note: unlike the static-args tile factory, the per-core reader start_id here is the *base* tile
+// id (start_offset == 0); the slice start_offset is computed on-device from the start tensor.
+struct SliceTileTensorArgsGeometry {
+    CoreRangeSet all_cores;
+    std::vector<CoreCoord> cores;
+    uint32_t num_dims = 0;
+    uint32_t single_tile_size = 0;
+    uint32_t tile_width = 0;
+    uint32_t tile_height = 0;
+    tt::DataFormat data_format = tt::DataFormat::Invalid;
+
+    // Common, broadcast to every core (read-only on device):
+    // [num_unpadded..., num_padded..., input_shape...].
+    std::vector<uint32_t> num_unpadded_per_dim;
+    std::vector<uint32_t> num_padded_per_dim;
+    std::vector<uint32_t> input_shape_per_dim;
+
+    // Per-core values (parallel to `cores`).
+    std::vector<uint32_t> reader_start_id;
+    std::vector<uint32_t> reader_num_tiles;
+    std::vector<std::vector<uint32_t>> id_per_dim;  // [core][num_dims], the running-index seed
+    std::vector<uint32_t> writer_start_id;          // == cumulative num_tiles_written
+};
+
+SliceTileTensorArgsGeometry compute_geometry(
+    const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output) {
+    const auto& input = tensor_args.input;
+    IDevice* device = input.device();
+
+    SliceTileTensorArgsGeometry g;
+    g.data_format = datatype_to_dataformat_converter(input.dtype());
+    g.single_tile_size = tt::tile_size(g.data_format);
+
+    auto tile_shape = input.tensor_spec().tile().get_tile_shape();
+    g.tile_width = tile_shape[1];
+    g.tile_height = tile_shape[0];
 
     uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
-
     auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
     auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
         args.sub_core_grids.has_value()
             ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
             : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+    g.all_cores = all_cores;
 
-    tt::tt_metal::Buffer* src_buffer = input_tensor.buffer();
-    tt::tt_metal::Buffer* start_buffer = start_tensor.buffer();
-    tt::tt_metal::Buffer* end_buffer = end_tensor.buffer();
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-
-    TT_FATAL(src_buffer != nullptr, "Input buffer should be allocated on device!");
-    TT_FATAL(start_buffer != nullptr, "Start buffer should be allocated on device!");
-    TT_FATAL(end_buffer != nullptr, "End buffer should be allocated on device!");
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-
-    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    uint32_t single_tile_size = tt::tile_size(cb_data_format);
-
-    constexpr uint8_t src0_cb_index = 0;
-    constexpr uint8_t tensor_cb_index = 1;
-    constexpr uint32_t num_input_tiles = 2;
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src0_cb_index,
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = tensor_cb_index,
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
-
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_tensor.padded_shape().rank());
-    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
-    uint32_t tile_width = tile_shape[1];
-    uint32_t tile_height = tile_shape[0];
-
-    std::vector<uint32_t> reader_compile_time_args = {
-        src0_cb_index, tensor_cb_index, num_dims, tile_width, tile_height};
-    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*start_buffer).append_to(reader_compile_time_args);
-    TensorAccessorArgs(*end_buffer).append_to(reader_compile_time_args);
-
-    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
-    // Reader common runtime args layout (matches kernel):
-    //   [src_addr, start_buf_addr, end_buf_addr,
-    //    num_unpadded_per_dim..., num_padded_per_dim..., input_shape...]
-    const auto& input_shape = input_tensor.padded_shape();
+    const auto& input_shape = input.padded_shape();
     const auto& output_shape = output.padded_shape();
+    g.num_dims = static_cast<uint32_t>(input_shape.rank());
+
     uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
     uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
     uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
@@ -95,40 +82,35 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
     uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
     uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
 
-    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    std::vector<uint32_t> accumulated_total_per_dim(g.num_dims);
     accumulated_total_per_dim[0] = num_total_Xt;
     accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
 
-    std::vector<uint32_t> reader_common_args(3 + (num_dims * 3));
-    reader_common_args[0] = src_buffer->address();
-    reader_common_args[1] = start_buffer->address();
-    reader_common_args[2] = end_buffer->address();
-    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 3;
-    uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
-    uint32_t* input_shape_args = num_padded_tiles_per_dim + num_dims;
-    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
-    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
-    num_padded_tiles_per_dim[0] = num_padded_Xt;
-    num_padded_tiles_per_dim[1] = num_padded_Yt;
-    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
+    g.num_unpadded_per_dim.resize(g.num_dims);
+    g.num_padded_per_dim.resize(g.num_dims);
+    g.input_shape_per_dim.resize(g.num_dims);
+    g.num_unpadded_per_dim[0] = num_unpadded_Xt;
+    g.num_unpadded_per_dim[1] = num_unpadded_Yt;
+    g.num_padded_per_dim[0] = num_padded_Xt;
+    g.num_padded_per_dim[1] = num_padded_Yt;
+    for (int32_t i = 2; i < static_cast<int32_t>(g.num_dims); ++i) {
         uint32_t num_unpadded_dim = output_shape[-(i + 1)];
         uint32_t num_total_dim = input_shape[-(i + 1)];
         uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
-        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
-        num_padded_tiles_per_dim[i] = num_padded_dim;
+        g.num_unpadded_per_dim[i] = num_unpadded_dim;
+        g.num_padded_per_dim[i] = num_padded_dim;
         accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
     }
-    for (int32_t i = 0; i < static_cast<int32_t>(num_dims); ++i) {
-        input_shape_args[i] = input_shape[i];
+    for (int32_t i = 0; i < static_cast<int32_t>(g.num_dims); ++i) {
+        g.input_shape_per_dim[i] = input_shape[i];
     }
 
-    // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
-    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
+    // start_offset is computed on-device from the start tensor, so the host seeds with 0.
     constexpr uint32_t start_offset = 0;
-    KernelDescriptor::RuntimeArgs reader_runtime_args;
-    KernelDescriptor::RuntimeArgs writer_runtime_args;
+
+    g.cores = corerange_to_cores(all_cores);
     uint32_t num_tiles_written = 0;
-    for (const auto& core : corerange_to_cores(all_cores)) {
+    for (const auto& core : g.cores) {
         uint32_t num_tiles_per_core;
         if (core_group_1.contains(core)) {
             num_tiles_per_core = num_tiles_per_core_group_1;
@@ -136,53 +118,148 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
             num_tiles_per_core = num_tiles_per_core_group_2;
         } else {
             // no-op core
-            std::vector<uint32_t> reader_args(2 + num_dims, 0);
-            reader_runtime_args.emplace_back(core, std::move(reader_args));
-            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
+            g.reader_start_id.push_back(0);
+            g.reader_num_tiles.push_back(0);
+            g.id_per_dim.emplace_back(g.num_dims, 0);
+            g.writer_start_id.push_back(0);
             continue;
         }
 
-        std::vector<uint32_t> reader_args(2 + num_dims);
-        reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
-        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
-        uint32_t start_id = reader_args[2] + start_offset;
-        for (uint32_t j = 1; j < num_dims; ++j) {
-            reader_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
-            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
-            start_id += reader_args[2 + j] * accumulated_total_per_dim[j - 1];
+        std::vector<uint32_t> ids(g.num_dims);
+        ids[0] = num_tiles_written % g.num_unpadded_per_dim[0];
+        uint32_t unpadded_written = num_tiles_written / g.num_unpadded_per_dim[0];
+        uint32_t start_id = ids[0] + start_offset;
+        for (uint32_t j = 1; j < g.num_dims; ++j) {
+            ids[j] = unpadded_written % g.num_unpadded_per_dim[j];
+            unpadded_written = unpadded_written / g.num_unpadded_per_dim[j];
+            start_id += ids[j] * accumulated_total_per_dim[j - 1];
         }
-        reader_args[0] = start_id;
-        reader_args[1] = num_tiles_per_core;
-
-        reader_runtime_args.emplace_back(core, std::move(reader_args));
-        writer_runtime_args.emplace_back(
-            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        g.reader_start_id.push_back(start_id);
+        g.reader_num_tiles.push_back(num_tiles_per_core);
+        g.id_per_dim.push_back(std::move(ids));
+        g.writer_start_id.push_back(num_tiles_written);
         num_tiles_written += num_tiles_per_core;
     }
+    return g;
+}
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
-        "reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.runtime_args = std::move(reader_runtime_args);
-    reader_desc.common_runtime_args = std::move(reader_common_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-    desc.kernels.push_back(std::move(reader_desc));
+m2::NodeCoord node_of(const CoreCoord& c) {
+    return m2::NodeCoord{static_cast<std::size_t>(c.x), static_cast<std::size_t>(c.y)};
+}
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.runtime_args = std::move(writer_runtime_args);
-    writer_desc.config = WriterConfigDescriptor{};
-    desc.kernels.push_back(std::move(writer_desc));
+}  // namespace
 
-    return desc;
+m2::ProgramSpec SliceTileTensorArgsProgramFactory::create_program_spec(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto g = compute_geometry(args, tensor_args, output);
+
+    // Source-tile staging CB (double-buffered).
+    m2::DataflowBufferSpec cb{
+        .unique_id = m2::DFBSpecName{"cb"},
+        .entry_size = g.single_tile_size,
+        .num_entries = 2,
+        .data_format_metadata = g.data_format,
+    };
+    // Single-entry staging CB used to read the start/end index tensors.
+    m2::DataflowBufferSpec cb_tensor{
+        .unique_id = m2::DFBSpecName{"cb_tensor"},
+        .entry_size = g.single_tile_size,
+        .num_entries = 1,
+        .data_format_metadata = g.data_format,
+    };
+
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{READER_KERNEL},
+        .dfb_bindings =
+            {m2::ProducerOf(m2::DFBSpecName{"cb"}, "cb_in"),
+             m2::ProducerOf(m2::DFBSpecName{"cb_tensor"}, "cb_tensor")},
+        .tensor_bindings =
+            {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"},
+             m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"starts"}, .accessor_name = "starts"},
+             m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"ends"}, .accessor_name = "ends"}},
+        .compile_time_args =
+            {{"num_dims", g.num_dims}, {"tile_width", g.tile_width}, {"tile_height", g.tile_height}},
+        .runtime_arg_schema = {.runtime_arg_names = {"start_id", "num_tiles"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementHardwareConfig::RoleHint::READER},
+        .advanced_options =
+            m2::KernelAdvancedOptions{
+                .num_runtime_varargs = g.num_dims, .num_common_runtime_varargs = 3 * g.num_dims},
+    };
+
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{WRITER_KERNEL},
+        .dfb_bindings = {m2::ConsumerOf(m2::DFBSpecName{"cb"}, "cb_out")},
+        .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementHardwareConfig::RoleHint::WRITER},
+    };
+
+    m2::ProgramSpec spec;
+    spec.name = "slice_tile_tensor_args";
+    spec.kernels = {std::move(reader), std::move(writer)};
+    spec.dataflow_buffers = {std::move(cb), std::move(cb_tensor)};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = tensor_args.input.tensor_spec()},
+        m2::TensorParameter{
+            .unique_id = m2::TensorParamName{"starts"}, .spec = tensor_args.start_tensor.value().tensor_spec()},
+        m2::TensorParameter{
+            .unique_id = m2::TensorParamName{"ends"}, .spec = tensor_args.end_tensor.value().tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()}};
+    spec.work_units = {m2::WorkUnitSpec{
+        .name = "slice",
+        .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+        .target_nodes = g.all_cores}};
+    return spec;
+}
+
+m2::ProgramRunArgs SliceTileTensorArgsProgramFactory::create_invariant_run_args(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto g = compute_geometry(args, tensor_args, output);
+
+    m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
+    m2::ProgramRunArgs::KernelRunArgs writer_args{.kernel = m2::KernelSpecName{"writer"}};
+
+    // Common varargs (broadcast): [num_unpadded..., num_padded..., input_shape...].
+    auto& common = reader_args.advanced_options.common_runtime_varargs;
+    common.insert(common.end(), g.num_unpadded_per_dim.begin(), g.num_unpadded_per_dim.end());
+    common.insert(common.end(), g.num_padded_per_dim.begin(), g.num_padded_per_dim.end());
+    common.insert(common.end(), g.input_shape_per_dim.begin(), g.input_shape_per_dim.end());
+
+    for (size_t i = 0; i < g.cores.size(); ++i) {
+        const auto node = node_of(g.cores[i]);
+        reader_args.runtime_arg_values.push_back(
+            {node, {{"start_id", g.reader_start_id[i]}, {"num_tiles", g.reader_num_tiles[i]}}});
+        reader_args.advanced_options.runtime_varargs.emplace(
+            node, m2::AdvancedKernelRunArgs::Varargs(g.id_per_dim[i].begin(), g.id_per_dim[i].end()));
+        writer_args.runtime_arg_values.push_back(
+            {node, {{"num_pages", g.reader_num_tiles[i]}, {"start_id", g.writer_start_id[i]}}});
+    }
+
+    m2::ProgramRunArgs run_args;
+    run_args.kernel_run_args.push_back(std::move(reader_args));
+    run_args.kernel_run_args.push_back(std::move(writer_args));
+    return run_args;
+}
+
+m2::ProgramRunArgs SliceTileTensorArgsProgramFactory::create_per_enqueue_args(
+    const SliceParams& /*args*/,
+    const SliceInputs& tensor_args,
+    Tensor& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    m2::ProgramRunArgs run_args;
+    run_args.tensor_args.emplace(
+        m2::TensorParamName{"src"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.input.mesh_tensor())});
+    run_args.tensor_args.emplace(
+        m2::TensorParamName{"starts"},
+        m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.start_tensor.value().mesh_tensor())});
+    run_args.tensor_args.emplace(
+        m2::TensorParamName{"ends"},
+        m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.end_tensor.value().mesh_tensor())});
+    run_args.tensor_args.emplace(
+        m2::TensorParamName{"dst"}, m2::ProgramRunArgs::TensorArgument{std::cref(output.mesh_tensor())});
+    return run_args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -215,7 +215,19 @@ m2::ProgramSpec SliceTileTensorArgsProgramFactory::create_program_spec(
 }
 
 m2::ProgramRunArgs SliceTileTensorArgsProgramFactory::create_invariant_run_args(
-    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const SliceParams& /*args*/, const SliceInputs& /*tensor_args*/, Tensor& /*output*/) {
+    // Nothing is enqueue-invariant here: the reader carries varargs (which cannot be designated
+    // invariant — gap #6), so on a cache hit every kernel with varargs must appear in the
+    // per-enqueue UpdateProgramRunArgs. We therefore re-apply all run args per dispatch (the
+    // framework's "++ by default") and keep this empty.
+    return m2::ProgramRunArgs{};
+}
+
+m2::ProgramRunArgs SliceTileTensorArgsProgramFactory::create_per_enqueue_args(
+    const SliceParams& args,
+    const SliceInputs& tensor_args,
+    Tensor& output,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
     const auto g = tta_compute_geometry(args, tensor_args, output);
 
     m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
@@ -240,15 +252,6 @@ m2::ProgramRunArgs SliceTileTensorArgsProgramFactory::create_invariant_run_args(
     m2::ProgramRunArgs run_args;
     run_args.kernel_run_args.push_back(std::move(reader_args));
     run_args.kernel_run_args.push_back(std::move(writer_args));
-    return run_args;
-}
-
-m2::ProgramRunArgs SliceTileTensorArgsProgramFactory::create_per_enqueue_args(
-    const SliceParams& /*args*/,
-    const SliceInputs& tensor_args,
-    Tensor& output,
-    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
-    m2::ProgramRunArgs run_args;
     run_args.tensor_args.emplace(
         m2::TensorParamName{"src"}, m2::ProgramRunArgs::TensorArgument{std::cref(tensor_args.input.mesh_tensor())});
     run_args.tensor_args.emplace(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -173,7 +173,10 @@ m2::ProgramSpec SliceTileTensorArgsProgramFactory::create_program_spec(
         .source = std::filesystem::path{TTA_READER_KERNEL},
         .dfb_bindings =
             {m2::ProducerOf(m2::DFBSpecName{"cb"}, "cb_in"),
-             m2::ProducerOf(m2::DFBSpecName{"cb_tensor"}, "cb_tensor")},
+             // The reader stages the start/end index tensors into cb_tensor and reads them back
+             // itself to compute the start offset — a self-loop, so it is both producer and consumer.
+             m2::ProducerOf(m2::DFBSpecName{"cb_tensor"}, "cb_tensor"),
+             m2::ConsumerOf(m2::DFBSpecName{"cb_tensor"}, "cb_tensor")},
         .tensor_bindings =
             {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"},
              m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"starts"}, .accessor_name = "starts"},

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -20,9 +20,9 @@ namespace ttnn::prim {
 
 namespace {
 
-constexpr const char* READER_KERNEL =
+constexpr const char* TTA_READER_KERNEL =
     "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_slice_tile_tensor_args_m2.cpp";
-constexpr const char* WRITER_KERNEL =
+constexpr const char* TTA_WRITER_KERNEL =
     "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_slice_tile_tensor_args_m2.cpp";
 
 // Enqueue-invariant work geometry: a pure function of shape + slice params (all in the cache key).
@@ -50,7 +50,7 @@ struct SliceTileTensorArgsGeometry {
     std::vector<uint32_t> writer_start_id;          // == cumulative num_tiles_written
 };
 
-SliceTileTensorArgsGeometry compute_geometry(
+SliceTileTensorArgsGeometry tta_compute_geometry(
     const SliceParams& args, const SliceInputs& tensor_args, const Tensor& output) {
     const auto& input = tensor_args.input;
     IDevice* device = input.device();
@@ -143,7 +143,7 @@ SliceTileTensorArgsGeometry compute_geometry(
     return g;
 }
 
-m2::NodeCoord node_of(const CoreCoord& c) {
+m2::NodeCoord tta_node_of(const CoreCoord& c) {
     return m2::NodeCoord{static_cast<std::size_t>(c.x), static_cast<std::size_t>(c.y)};
 }
 
@@ -151,7 +151,7 @@ m2::NodeCoord node_of(const CoreCoord& c) {
 
 m2::ProgramSpec SliceTileTensorArgsProgramFactory::create_program_spec(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto g = compute_geometry(args, tensor_args, output);
+    const auto g = tta_compute_geometry(args, tensor_args, output);
 
     // Source-tile staging CB (double-buffered).
     m2::DataflowBufferSpec cb{
@@ -170,7 +170,7 @@ m2::ProgramSpec SliceTileTensorArgsProgramFactory::create_program_spec(
 
     m2::KernelSpec reader{
         .unique_id = m2::KernelSpecName{"reader"},
-        .source = std::filesystem::path{READER_KERNEL},
+        .source = std::filesystem::path{TTA_READER_KERNEL},
         .dfb_bindings =
             {m2::ProducerOf(m2::DFBSpecName{"cb"}, "cb_in"),
              m2::ProducerOf(m2::DFBSpecName{"cb_tensor"}, "cb_tensor")},
@@ -189,7 +189,7 @@ m2::ProgramSpec SliceTileTensorArgsProgramFactory::create_program_spec(
 
     m2::KernelSpec writer{
         .unique_id = m2::KernelSpecName{"writer"},
-        .source = std::filesystem::path{WRITER_KERNEL},
+        .source = std::filesystem::path{TTA_WRITER_KERNEL},
         .dfb_bindings = {m2::ConsumerOf(m2::DFBSpecName{"cb"}, "cb_out")},
         .tensor_bindings = {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"}},
         .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
@@ -216,7 +216,7 @@ m2::ProgramSpec SliceTileTensorArgsProgramFactory::create_program_spec(
 
 m2::ProgramRunArgs SliceTileTensorArgsProgramFactory::create_invariant_run_args(
     const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
-    const auto g = compute_geometry(args, tensor_args, output);
+    const auto g = tta_compute_geometry(args, tensor_args, output);
 
     m2::ProgramRunArgs::KernelRunArgs reader_args{.kernel = m2::KernelSpecName{"reader"}};
     m2::ProgramRunArgs::KernelRunArgs writer_args{.kernel = m2::KernelSpecName{"writer"}};
@@ -228,7 +228,7 @@ m2::ProgramRunArgs SliceTileTensorArgsProgramFactory::create_invariant_run_args(
     common.insert(common.end(), g.input_shape_per_dim.begin(), g.input_shape_per_dim.end());
 
     for (size_t i = 0; i < g.cores.size(); ++i) {
-        const auto node = node_of(g.cores[i]);
+        const auto node = tta_node_of(g.cores[i]);
         reader_args.runtime_arg_values.push_back(
             {node, {{"start_id", g.reader_start_id[i]}, {"num_tiles", g.reader_num_tiles[i]}}});
         reader_args.advanced_options.runtime_varargs.emplace(

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp
@@ -3,16 +3,32 @@
 // SPDX-License-Identifier: Apache-2.0
 #pragma once
 
-#include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
+#include <optional>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/distributed/types.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
+// Metal 2.0 slice tile factory where the slice start/end come from device TENSORS.
+// The immutable contract (create_program_spec) plus the enqueue-invariant per-core
+// work geometry (create_invariant_run_args, a pure function of shape + slice params,
+// all in the cache key) and the per-dispatch tensor bindings (create_per_enqueue_args:
+// src, starts, ends, dst). The legacy descriptor for fusion/pybind/mesh_partition
+// lives separately.
 struct SliceTileTensorArgsProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static tt::tt_metal::experimental::ProgramSpec create_program_spec(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+    static tt::tt_metal::experimental::ProgramRunArgs create_invariant_run_args(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+    static tt::tt_metal::experimental::ProgramRunArgs create_per_enqueue_args(
+        const SliceParams& args,
+        const SliceInputs& tensor_args,
+        Tensor& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_rm_descriptor_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_rm_descriptor_builder.cpp
@@ -1,0 +1,282 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm.hpp"
+
+#include <optional>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::data_movement {
+
+namespace {
+
+inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const ttnn::Shape& output_tensor_start,
+    uint32_t num_cores,
+    const std::vector<CoreCoord>& all_cores_vec,
+    const CoreRangeSet& core_group_1,
+    const CoreRangeSet& core_group_2,
+    uint32_t num_sticks_per_core_group_1,
+    uint32_t num_sticks_per_core_group_2,
+    uint32_t max_read_size) {
+    auto* output_buffer = output_tensor.buffer();
+    auto input_shape = input_tensor.padded_shape();
+    auto output_shape = output_tensor.padded_shape();
+
+    uint32_t padded_row_size_bytes = input_shape[-1] * input_tensor.element_size();
+    uint32_t unpadded_row_size_bytes = output_shape[-1] * input_tensor.element_size();
+
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    std::vector<uint32_t> num_unpadded_sticks_per_dim(num_dims);
+    std::vector<uint32_t> num_padded_sticks_per_dim(num_dims);
+    std::vector<uint32_t> id_per_dim(num_dims);
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+
+    // TODO: Remove first element of these arrays and update kernel accordingly
+    num_unpadded_sticks_per_dim[0] = 1;
+    num_padded_sticks_per_dim[0] = 0;
+    accumulated_total_per_dim[0] = 1;
+
+    for (int32_t i = 1; i < num_dims; i++) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_unpadded_sticks_per_dim[i] = num_unpadded_dim;
+        num_padded_sticks_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    auto src_buffer_alignment = input_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? ::hal::get_dram_alignment()
+                                    : ::hal::get_l1_alignment();
+    auto dst_buffer_alignment = output_tensor.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? ::hal::get_dram_alignment()
+                                    : ::hal::get_l1_alignment();
+    auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+    uint32_t begins_bytes = output_tensor_start[-1] * input_tensor.element_size();
+    uint32_t misalignment = begins_bytes % src_buffer_alignment;
+    uint32_t unpadded_row_size_bytes_offset = tt::round_up(unpadded_row_size_bytes, alignment);
+    uint32_t start_addr = input_tensor.buffer()->address();
+
+    std::vector<uint32_t> common_reader_kernel_args = {
+        start_addr + begins_bytes - misalignment,  // read from nearest aligned address,
+        padded_row_size_bytes,
+        unpadded_row_size_bytes,
+        unpadded_row_size_bytes_offset,
+        num_dims,
+        misalignment,
+        0,
+        0,
+        0,
+        0};
+    common_reader_kernel_args.insert(
+        common_reader_kernel_args.end(), num_unpadded_sticks_per_dim.begin(), num_unpadded_sticks_per_dim.end());
+    common_reader_kernel_args.insert(
+        common_reader_kernel_args.end(), num_padded_sticks_per_dim.begin(), num_padded_sticks_per_dim.end());
+
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val;
+    ret_val.reserve(num_cores);
+
+    uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(input_tensor, output_tensor_start);
+    uint32_t num_sticks_written = 0;
+    for (const auto& core : all_cores_vec) {
+        uint32_t num_sticks_per_core;
+        if (core_group_1.contains(core)) {
+            num_sticks_per_core = num_sticks_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_sticks_per_core = num_sticks_per_core_group_2;
+        } else {
+            num_sticks_per_core = 0;
+        }
+
+        uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
+        if (num_sticks_per_core != 0) {
+            auto num_sticks_per_core_pad32 = num_sticks_per_core + ((32 - num_sticks_per_core % 32) % 32);
+            num_sticks_per_core_read = tt::tt_metal::merge_num_sticks_to_read(
+                num_sticks_per_core_pad32, unpadded_row_size_bytes_offset, max_read_size);
+            num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
+        }
+
+        id_per_dim[0] = num_sticks_written % num_unpadded_sticks_per_dim[0];
+        uint32_t unpadded_written = num_sticks_written / num_unpadded_sticks_per_dim[0];
+        uint32_t start_id = id_per_dim[0] + start_offset;
+
+        for (uint32_t j = 1; j < num_dims; j++) {
+            id_per_dim[j] = unpadded_written % num_unpadded_sticks_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_sticks_per_dim[j];
+            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+        }
+        std::vector<uint32_t> reader_kernel_args = common_reader_kernel_args;
+        uint32_t addr_offset = 6;
+        reader_kernel_args[addr_offset++] = start_id;
+        reader_kernel_args[addr_offset++] = num_sticks_per_core;
+        reader_kernel_args[addr_offset++] = num_sticks_per_core_read;
+        reader_kernel_args[addr_offset] = num_read_per_barrier;
+        reader_kernel_args.insert(reader_kernel_args.end(), id_per_dim.begin(), id_per_dim.end());
+
+        std::vector<uint32_t> writer_kernel_args = {
+            output_buffer->address(),
+            unpadded_row_size_bytes,
+            unpadded_row_size_bytes_offset,
+            num_sticks_per_core,
+            num_sticks_per_core_read,
+            num_read_per_barrier,
+            num_sticks_written,
+            0};
+        num_sticks_written += num_sticks_per_core;
+        ret_val.emplace_back(reader_kernel_args, writer_kernel_args);
+    }
+
+    return ret_val;
+}
+
+constexpr uint32_t MAX_READ_SIZE = 4096;
+
+std::tuple<uint32_t, uint32_t, uint32_t> compute_cb_size(
+    const Tensor& input,
+    const Tensor& output,
+    const Shape& output_tensor_start,
+    const uint32_t num_sticks_per_core_group_1,
+    const uint32_t num_sticks_per_core_group_2) {
+    auto src_buffer_alignment = input.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? ::hal::get_dram_alignment()
+                                    : ::hal::get_l1_alignment();
+    auto dst_buffer_alignment = output.buffer()->buffer_type() == tt::tt_metal::BufferType::DRAM
+                                    ? ::hal::get_dram_alignment()
+                                    : ::hal::get_l1_alignment();
+    const auto single_alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+    auto alignment = single_alignment;
+
+    uint32_t begins_bytes = output_tensor_start[-1] * input.element_size();
+    uint32_t misalignment = begins_bytes % src_buffer_alignment;
+
+    if (misalignment != 0) {
+        alignment *= 2;
+    }
+    const ttnn::Shape& output_shape = output.padded_shape();
+    const uint32_t unpadded_row_size_bytes = output_shape[-1] * input.element_size();
+    const uint32_t cb_page_size = tt::round_up(unpadded_row_size_bytes, alignment);
+    const uint32_t stick_stride_for_merge = tt::round_up(unpadded_row_size_bytes, single_alignment);
+    const uint32_t num_input_pages = num_sticks_per_core_group_1 > num_sticks_per_core_group_2
+                                         ? num_sticks_per_core_group_1
+                                         : num_sticks_per_core_group_2;
+    uint32_t num_sticks_per_core_read = 0, num_read_per_barrier = 0;
+    if (num_input_pages != 0) {
+        auto num_sticks_per_core_pad32 = num_input_pages + ((32 - num_input_pages % 32) % 32);
+        num_sticks_per_core_read =
+            tt::tt_metal::merge_num_sticks_to_read(num_sticks_per_core_pad32, stick_stride_for_merge, MAX_READ_SIZE);
+        num_read_per_barrier = num_sticks_per_core_pad32 / num_sticks_per_core_read;
+    }
+
+    return std::make_tuple(cb_page_size, num_read_per_barrier, misalignment);
+}
+
+}  // namespace
+
+}  // namespace ttnn::operations::data_movement
+
+namespace ttnn::prim {
+
+tt::tt_metal::ProgramDescriptor build_slice_rm_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input;
+    tt::tt_metal::IDevice* device = input.device();
+    ProgramDescriptor desc;
+
+    uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_sticks_per_core_group_1, num_sticks_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_sticks)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_sticks);
+
+    tt::tt_metal::Buffer* src0_buffer = input.buffer();
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+
+    constexpr uint8_t src0_cb_index = 0;
+
+    // CB sizing depends on slice_start (via misalignment / unpadded_row_size_bytes).
+    // padded_shape is folded into compute_program_hash() so each unique sizing
+    // gets its own cache entry; CB total_size/page_size are not patched on
+    // cache hit — the cached descriptor already carries the correct values.
+    const auto [cb_page_size, num_read_per_barrier, misalignment] = ttnn::operations::data_movement::compute_cb_size(
+        input, output, args.slice_start, num_sticks_per_core_group_1, num_sticks_per_core_group_2);
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_read_per_barrier * 2 * cb_page_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = cb_page_size,
+        }}},
+    });
+
+    std::vector<uint32_t> writer_compile_time_args_vec = {static_cast<uint32_t>(src0_cb_index)};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args_vec);
+
+    std::vector<uint32_t> reader_compile_time_args_vec;
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args_vec);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+        "slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args_vec);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+        "slice_writer_unary_stick_layout_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args_vec);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    auto all_cores_vec = corerange_to_cores(all_cores);
+    auto all_runtime_args = ttnn::operations::data_movement::get_slice_runtime_args_rm(
+        input,
+        output,
+        args.slice_start,
+        num_cores,
+        all_cores_vec,
+        core_group_1,
+        core_group_2,
+        num_sticks_per_core_group_1,
+        num_sticks_per_core_group_2,
+        ttnn::operations::data_movement::MAX_READ_SIZE);
+
+    reader_desc.runtime_args.reserve(all_cores_vec.size());
+    writer_desc.runtime_args.reserve(all_cores_vec.size());
+    for (size_t i = 0; i < all_cores_vec.size(); ++i) {
+        reader_desc.runtime_args.emplace_back(all_cores_vec[i], std::move(all_runtime_args[i].first));
+        writer_desc.runtime_args.emplace_back(all_cores_vec[i], std::move(all_runtime_args[i].second));
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_rm_sharded_descriptor_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_rm_sharded_descriptor_builder.cpp
@@ -1,0 +1,323 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp"
+
+#include <map>
+#include <optional>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::operations::data_movement {
+
+namespace {
+
+inline std::vector<std::vector<uint32_t>> group_contiguous_values(std::vector<uint32_t>& values) {
+    std::vector<std::vector<uint32_t>> chunks;
+    if (values.empty()) {
+        return chunks;
+    }
+
+    // Initialize the first chunk
+    std::vector<uint32_t> current_chunk;
+    current_chunk.push_back(values[0]);
+
+    for (size_t i = 1; i < values.size(); ++i) {
+        if (values[i] == values[i - 1] + 1) {
+            current_chunk.push_back(values[i]);
+        } else {
+            chunks.push_back(current_chunk);
+            current_chunk.clear();
+            current_chunk.push_back(values[i]);
+        }
+    }
+    // Add the last chunk
+    chunks.push_back(current_chunk);
+    return chunks;
+}
+
+inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_slice_runtime_args_rm_sharded(
+    const Tensor& input_tensor,
+    Tensor& output_tensor,
+    const ttnn::Shape& output_tensor_start,
+    uint32_t num_cores_unpadded,
+    bool row_major,
+    uint32_t num_cores_x_unpadded,
+    uint32_t num_cores_y_unpadded,
+    uint32_t shard_height_unpadded,
+    uint32_t shard_height_padded,
+    uint32_t num_cores_x_padded,
+    uint32_t num_cores_y_padded) {
+    tt::tt_metal::IDevice* device = input_tensor.device();
+
+    auto input_shape = input_tensor.padded_shape();
+    auto output_shape = output_tensor.padded_shape();
+
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+    std::vector<uint32_t> num_unpadded_sticks_per_dim(num_dims);
+    std::vector<uint32_t> num_padded_sticks_per_dim(num_dims);
+    std::vector<uint32_t> id_per_dim(num_dims);
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+
+    // TODO: Remove first element of these arrays and update kernel accordingly
+    // This currently just matches tile version where we iterate over the row as well
+    num_unpadded_sticks_per_dim[0] = 1;
+    num_padded_sticks_per_dim[0] = 0;
+    accumulated_total_per_dim[0] = 1;
+
+    for (int32_t i = 1; i < num_dims; i++) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_unpadded_sticks_per_dim[i] = num_unpadded_dim;
+        num_padded_sticks_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> ret_val(num_cores_unpadded);
+
+    uint32_t start_offset = ttnn::operations::data_movement::get_rm_start_offset(input_tensor, output_tensor_start);
+    for (uint32_t i = 0, num_sticks_written = 0; i < num_cores_unpadded; i++) {
+        CoreCoord core;
+        if (row_major) {
+            core = {i % num_cores_x_unpadded, i / num_cores_x_unpadded};
+        } else {
+            core = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
+        }
+        uint32_t num_sticks_per_core_unpadded = shard_height_unpadded;
+        uint32_t num_sticks_per_core_padded = shard_height_padded;
+
+        // figure out the start read stick id for each core, and the start id for each dim
+        id_per_dim[0] = num_sticks_written % num_unpadded_sticks_per_dim[0];
+        uint32_t unpadded_written = num_sticks_written / num_unpadded_sticks_per_dim[0];
+        uint32_t start_id = id_per_dim[0] + start_offset;
+
+        for (uint32_t j = 1; j < num_dims; j++) {
+            id_per_dim[j] = unpadded_written % num_unpadded_sticks_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_sticks_per_dim[j];
+            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+        }
+
+        num_sticks_written += num_sticks_per_core_unpadded;
+
+        // stores all sticks id for a core
+        std::vector<uint32_t> stick_ids_per_core;
+        uint32_t src_stick_id = start_id;
+        for (uint32_t i = 0; i < num_sticks_per_core_unpadded; ++i) {
+            stick_ids_per_core.push_back(src_stick_id);
+            src_stick_id++;
+            for (uint32_t j = 0; j < num_dims; j++) {
+                id_per_dim[j]++;
+                if (id_per_dim[j] == num_unpadded_sticks_per_dim[j]) {
+                    id_per_dim[j] = 0;
+                    src_stick_id += num_padded_sticks_per_dim[j];
+                } else {
+                    break;
+                }
+            }
+        }
+
+        // figure out the stick id in a shard, and the core id for the stick.
+        std::map<std::pair<uint32_t, uint32_t>, std::vector<uint32_t>> core_stick_map;
+        for (uint32_t i = 0; i < num_sticks_per_core_unpadded; ++i) {
+            uint32_t stick_id = stick_ids_per_core[i];
+            uint32_t shard_id = stick_id / num_sticks_per_core_padded;
+            uint32_t stick_id_in_shard = stick_id - (shard_id * num_sticks_per_core_padded);
+
+            uint32_t shard_grid_inner_dim = row_major ? num_cores_x_padded : num_cores_y_padded;
+            uint32_t shard_grid_outer_dim_id = shard_id / shard_grid_inner_dim;
+            uint32_t shard_grid_inner_dim_id = shard_id - (shard_grid_outer_dim_id * shard_grid_inner_dim);
+
+            uint32_t worker_y_logical = row_major ? shard_grid_outer_dim_id : shard_grid_inner_dim_id;
+            uint32_t worker_x_logical = row_major ? shard_grid_inner_dim_id : shard_grid_outer_dim_id;
+
+            if (worker_x_logical < num_cores_x_padded and worker_y_logical < num_cores_y_padded) {
+                auto core_physical =
+                    device->worker_core_from_logical_core(CoreCoord{worker_x_logical, worker_y_logical});
+                // save stick id in a shard, and core coord into a map
+                std::pair<uint32_t, uint32_t> xy_pair = row_major ? std::make_pair(core_physical.y, core_physical.x)
+                                                                  : std::make_pair(core_physical.x, core_physical.y);
+                core_stick_map[xy_pair].push_back(stick_id_in_shard);
+            }
+        }
+
+        // reader rt args
+        std::vector<uint32_t> reader_kernel_args;
+        reader_kernel_args.push_back(core_stick_map.size());  // num_cores
+
+        for (const auto& core_stick_pair : core_stick_map) {
+            auto xy_pair = core_stick_pair.first;
+            if (row_major) {
+                reader_kernel_args.push_back(xy_pair.second);  // noc x
+                reader_kernel_args.push_back(xy_pair.first);   // noc y
+            } else {
+                reader_kernel_args.push_back(xy_pair.first);   // noc x
+                reader_kernel_args.push_back(xy_pair.second);  // noc y
+            }
+        }
+
+        // coalesce the sticks into chunks
+        std::vector<std::vector<std::vector<uint32_t>>> stick_chunks_per_core;
+        for (auto core_stick_pair : core_stick_map) {
+            auto stick_chunks = group_contiguous_values(core_stick_pair.second);
+            stick_chunks_per_core.push_back(stick_chunks);
+
+            reader_kernel_args.push_back(stick_chunks.size());  // num_chunks for current core
+        }
+        for (const auto& stick_chunks : stick_chunks_per_core) {
+            for (auto chunk : stick_chunks) {
+                reader_kernel_args.push_back(chunk[0]);      // start id of a chunk
+                reader_kernel_args.push_back(chunk.size());  // length of a chunk
+            }
+        }
+
+        std::vector<uint32_t> writer_kernel_args;
+        ret_val[i] = {reader_kernel_args, writer_kernel_args};
+    }
+
+    return ret_val;
+}
+
+}  // namespace
+
+}  // namespace ttnn::operations::data_movement
+
+namespace ttnn::prim {
+
+tt::tt_metal::ProgramDescriptor build_slice_rm_sharded_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input;
+    ProgramDescriptor desc;
+
+    [[maybe_unused]] uint32_t num_padded_sticks = input.physical_volume() / input.padded_shape()[-1];
+    [[maybe_unused]] uint32_t num_unpadded_sticks = output.physical_volume() / output.padded_shape()[-1];
+
+    // stick sizes
+    uint32_t W_padded = input.logical_shape()[-1];
+    uint32_t W_unpadded = output.logical_shape()[-1];
+    auto stick_size_padded = W_padded * input.element_size();
+    auto stick_size_unpadded = W_unpadded * output.element_size();
+
+    // input shard spec
+    auto shard_spec_padded = input.shard_spec().value();
+    uint32_t shard_height_padded = shard_spec_padded.shape[0];
+
+    [[maybe_unused]] auto& all_cores_padded = shard_spec_padded.grid;
+    [[maybe_unused]] uint32_t num_cores_padded = shard_spec_padded.num_cores();
+    auto bbox_padded = shard_spec_padded.grid.bounding_box();
+    CoreCoord grid_size_padded = {bbox_padded.end_coord.x + 1, bbox_padded.end_coord.y + 1};
+    uint32_t num_cores_x_padded = grid_size_padded.x;
+    uint32_t num_cores_y_padded = grid_size_padded.y;
+
+    if (args.sub_core_grids.has_value()) {
+        log_warning(tt::LogOp, "sub_core_grids is not used when input tensor is sharded");
+    }
+
+    log_debug(tt::LogOp, "num_padded_sticks: {}", num_padded_sticks);
+    log_debug(tt::LogOp, "shard_height_padded: {}", shard_height_padded);
+    log_debug(tt::LogOp, "all_cores_padded: {}", all_cores_padded);
+    log_debug(tt::LogOp, "num_cores_padded: {}", num_cores_padded);
+
+    // output shard spec
+    auto shard_spec_unpadded = output.shard_spec().value();
+    uint32_t shard_height_unpadded = shard_spec_unpadded.shape[0];
+    bool row_major = shard_spec_unpadded.orientation == ShardOrientation::ROW_MAJOR;
+
+    auto& all_cores_unpadded = shard_spec_unpadded.grid;
+    uint32_t num_cores_unpadded = shard_spec_unpadded.num_cores();
+    auto bbox_unpadded = all_cores_unpadded.bounding_box();
+    CoreCoord grid_size_unpadded = {bbox_unpadded.end_coord.x + 1, bbox_unpadded.end_coord.y + 1};
+    uint32_t num_cores_x_unpadded = grid_size_unpadded.x;
+    uint32_t num_cores_y_unpadded = grid_size_unpadded.y;
+
+    log_debug(tt::LogOp, "num_unpadded_sticks: {}", num_unpadded_sticks);
+    log_debug(tt::LogOp, "shard_height_unpadded: {}", shard_height_unpadded);
+    log_debug(tt::LogOp, "all_cores_unpadded: {}", all_cores_unpadded);
+    log_debug(tt::LogOp, "num_cores_unpadded: {}", num_cores_unpadded);
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    // Sharded CBs: total_size and page_size vary with shard shape / element size,
+    // so padded_shape is folded into compute_program_hash() to keep each unique
+    // sizing in its own cache entry.  On cache hit, the framework copies runtime
+    // args and patches dynamic CB addresses (.buffer is set below); CB sizing
+    // itself is not re-applied — it is carried by the cached descriptor.
+    constexpr uint8_t src0_cb_index = 0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = shard_height_padded * stick_size_padded,
+        .core_ranges = all_cores_unpadded,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = stick_size_padded,
+        }}},
+        .buffer = input.buffer(),
+    });
+
+    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = shard_height_unpadded * stick_size_unpadded,
+        .core_ranges = all_cores_unpadded,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = output_cb_index,
+            .data_format = dst_cb_data_format,
+            .page_size = stick_size_unpadded,
+        }}},
+        .buffer = output.buffer(),
+    });
+
+    std::vector<uint32_t> reader_ct_args = {
+        static_cast<uint32_t>(stick_size_padded),
+        static_cast<uint32_t>(stick_size_unpadded),
+        static_cast<uint32_t>(shard_height_unpadded)};
+
+    auto all_runtime_args = ttnn::operations::data_movement::get_slice_runtime_args_rm_sharded(
+        input,
+        output,
+        args.slice_start,
+        num_cores_unpadded,
+        row_major,
+        num_cores_x_unpadded,
+        num_cores_y_unpadded,
+        shard_height_unpadded,
+        shard_height_padded,
+        num_cores_x_padded,
+        num_cores_y_padded);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+        "slice_reader_unary_unpad_dims_rm_sharded.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores_unpadded;
+    reader_desc.compile_time_args = std::move(reader_ct_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    reader_desc.runtime_args.reserve(num_cores_unpadded);
+    for (uint32_t i = 0; i < num_cores_unpadded; ++i) {
+        CoreCoord core;
+        if (row_major) {
+            core = {i % num_cores_x_unpadded, i / num_cores_x_unpadded};
+        } else {
+            core = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
+        }
+        reader_desc.runtime_args.emplace_back(core, std::move(all_runtime_args[i].first));
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_rm_stride_descriptor_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_rm_stride_descriptor_builder.cpp
@@ -1,0 +1,176 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp"
+
+#include <optional>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim {
+
+tt::tt_metal::ProgramDescriptor build_slice_rm_stride_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input_tensor = tensor_args.input;
+    tt::tt_metal::IDevice* device = input_tensor.device();
+    ProgramDescriptor desc;
+
+    const auto& input_shape = input_tensor.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    uint32_t element_size = input_tensor.element_size();
+
+    // Calculate total output rows based on tensor rank
+    uint32_t total_output_rows = output_shape.volume() / output_shape[-1];
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), total_output_rows)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, total_output_rows);
+
+    // Select kernels based on tensor rank
+    std::string reader_kernel_path;
+    std::string writer_kernel_path;
+    if (input_shape.rank() <= 4) {
+        reader_kernel_path =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp";
+        writer_kernel_path =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp";
+    } else {
+        reader_kernel_path =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp";
+        writer_kernel_path =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp";
+    }
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t actual_input_w = input_shape[-1];
+    uint32_t input_bytes_per_row = actual_input_w * element_size;
+    uint32_t cb_page_size = input_bytes_per_row;
+
+    auto src_buffer_alignment = input_tensor.buffer()->alignment();
+    auto dst_buffer_alignment = output.buffer()->alignment();
+    auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+
+    uint32_t cb_page_size_aligned = tt::round_up(cb_page_size, alignment);
+    uint32_t cb_total_size = 2 * cb_page_size_aligned;
+
+    constexpr uint8_t in_cb = 0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = cb_total_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = in_cb,
+            .data_format = cb_data_format,
+            .page_size = cb_page_size_aligned,
+        }}},
+    });
+
+    std::vector<uint32_t> reader_compile_time_args = {in_cb, element_size};
+    TensorAccessorArgs(*input_tensor.buffer()).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {in_cb, element_size};
+    TensorAccessorArgs(*output.buffer()).append_to(writer_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = reader_kernel_path;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = writer_kernel_path;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Calculate runtime arguments
+    uint32_t tensor_rank = input_shape.rank();
+    uint32_t base_rows_per_core = total_output_rows / num_cores;
+    uint32_t extra_rows = total_output_rows % num_cores;
+
+    const bool using_4d_kernels = input_shape.rank() <= 4;
+    const auto& slice_start = args.slice_start;
+    const auto& slice_end = args.slice_end;
+    const auto& slice_step = args.step;
+
+    auto all_cores_vec = corerange_to_cores(all_cores);
+    reader_desc.runtime_args.reserve(all_cores_vec.size());
+    writer_desc.runtime_args.reserve(all_cores_vec.size());
+
+    uint32_t row_start_id = 0;
+    uint32_t extra_rows_remaining = extra_rows;
+
+    auto* input_buffer = input_tensor.buffer();
+    auto* output_buffer = output.buffer();
+
+    for (const auto& core : all_cores_vec) {
+        uint32_t rows_for_this_core = base_rows_per_core;
+        if (extra_rows_remaining > 0) {
+            rows_for_this_core += 1;
+            extra_rows_remaining -= 1;
+        }
+
+        if (using_4d_kernels) {
+            reader_desc.emplace_runtime_args(
+                core, {input_buffer,    tensor_rank,      input_shape[-1],  input_shape[-2],    input_shape[-3],
+                       input_shape[-4], output_shape[-1], output_shape[-2], output_shape[-3],   output_shape[-4],
+                       slice_start[-1], slice_end[-1],    slice_step[-1],   slice_start[-2],    slice_end[-2],
+                       slice_step[-2],  slice_start[-3],  slice_end[-3],    slice_step[-3],     slice_start[-4],
+                       slice_end[-4],   slice_step[-4],   element_size,     rows_for_this_core, row_start_id});
+
+            writer_desc.emplace_runtime_args(
+                core,
+                {output_buffer,
+                 tensor_rank,
+                 output_shape[-1],
+                 output_shape[-2],
+                 output_shape[-3],
+                 output_shape[-4],
+                 element_size,
+                 rows_for_this_core,
+                 row_start_id});
+        } else {
+            KernelDescriptor::RTArgList reader_args;
+            reader_args.push_back(input_buffer);
+            reader_args.push_back(tensor_rank);
+            reader_args.push_back(element_size);
+            reader_args.push_back(rows_for_this_core);
+            reader_args.push_back(row_start_id);
+            reader_args.append(std::vector<uint32_t>(input_shape.cbegin(), input_shape.cend()));
+            reader_args.append(std::vector<uint32_t>(output_shape.cbegin(), output_shape.cend()));
+            reader_args.append(std::vector<uint32_t>(slice_start.cbegin(), slice_start.cend()));
+            reader_args.append(std::vector<uint32_t>(slice_end.cbegin(), slice_end.cend()));
+            reader_args.append(std::vector<uint32_t>(slice_step.cbegin(), slice_step.cend()));
+            reader_desc.emplace_runtime_args(core, reader_args);
+
+            KernelDescriptor::RTArgList writer_args;
+            writer_args.push_back(output_buffer);
+            writer_args.push_back(tensor_rank);
+            writer_args.push_back(element_size);
+            writer_args.push_back(rows_for_this_core);
+            writer_args.push_back(row_start_id);
+            writer_args.append(std::vector<uint32_t>(output_shape.cbegin(), output_shape.cend()));
+            writer_desc.emplace_runtime_args(core, writer_args);
+        }
+
+        row_start_id += rows_for_this_core;
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_tile_tensor_args_descriptor_builder.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_tile_tensor_args_descriptor_builder.cpp
@@ -1,0 +1,188 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp"
+
+#include <optional>
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+
+using namespace tt::constants;
+using namespace tt::tt_metal;
+
+namespace ttnn::prim {
+
+tt::tt_metal::ProgramDescriptor build_slice_tile_tensor_args_descriptor(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& start_tensor = tensor_args.start_tensor.value();
+    const auto& end_tensor = tensor_args.end_tensor.value();
+    tt::tt_metal::IDevice* device = input_tensor.device();
+    ProgramDescriptor desc;
+
+    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+
+    tt::tt_metal::Buffer* src_buffer = input_tensor.buffer();
+    tt::tt_metal::Buffer* start_buffer = start_tensor.buffer();
+    tt::tt_metal::Buffer* end_buffer = end_tensor.buffer();
+    tt::tt_metal::Buffer* dst_buffer = output.buffer();
+
+    TT_FATAL(src_buffer != nullptr, "Input buffer should be allocated on device!");
+    TT_FATAL(start_buffer != nullptr, "Start buffer should be allocated on device!");
+    TT_FATAL(end_buffer != nullptr, "End buffer should be allocated on device!");
+    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    constexpr uint8_t src0_cb_index = 0;
+    constexpr uint8_t tensor_cb_index = 1;
+    constexpr uint32_t num_input_tiles = 2;
+
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_input_tiles * single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = src0_cb_index,
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = single_tile_size,
+        .core_ranges = all_cores,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = tensor_cb_index,
+            .data_format = cb_data_format,
+            .page_size = single_tile_size,
+        }}},
+    });
+
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_tensor.padded_shape().rank());
+    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    uint32_t tile_width = tile_shape[1];
+    uint32_t tile_height = tile_shape[0];
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        src0_cb_index, tensor_cb_index, num_dims, tile_width, tile_height};
+    TensorAccessorArgs(*src_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*start_buffer).append_to(reader_compile_time_args);
+    TensorAccessorArgs(*end_buffer).append_to(reader_compile_time_args);
+
+    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    // Reader common runtime args layout (matches kernel):
+    //   [src_addr, start_buf_addr, end_buf_addr,
+    //    num_unpadded_per_dim..., num_padded_per_dim..., input_shape...]
+    const auto& input_shape = input_tensor.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
+    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
+    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
+    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    accumulated_total_per_dim[0] = num_total_Xt;
+    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+
+    std::vector<uint32_t> reader_common_args(3 + (num_dims * 3));
+    reader_common_args[0] = src_buffer->address();
+    reader_common_args[1] = start_buffer->address();
+    reader_common_args[2] = end_buffer->address();
+    uint32_t* num_unpadded_tiles_per_dim = reader_common_args.data() + 3;
+    uint32_t* num_padded_tiles_per_dim = num_unpadded_tiles_per_dim + num_dims;
+    uint32_t* input_shape_args = num_padded_tiles_per_dim + num_dims;
+    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
+    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
+    num_padded_tiles_per_dim[0] = num_padded_Xt;
+    num_padded_tiles_per_dim[1] = num_padded_Yt;
+    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
+        num_padded_tiles_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+    for (int32_t i = 0; i < static_cast<int32_t>(num_dims); ++i) {
+        input_shape_args[i] = input_shape[i];
+    }
+
+    // Reader per-core runtime args: [start_id, num_tiles, id_per_dim...]
+    // Writer per-core runtime args: [dst_addr, num_tiles, start_id]
+    constexpr uint32_t start_offset = 0;
+    KernelDescriptor::RuntimeArgs reader_runtime_args;
+    KernelDescriptor::RuntimeArgs writer_runtime_args;
+    uint32_t num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core
+            std::vector<uint32_t> reader_args(2 + num_dims, 0);
+            reader_runtime_args.emplace_back(core, std::move(reader_args));
+            writer_runtime_args.emplace_back(core, std::vector<uint32_t>{0, 0, 0});
+            continue;
+        }
+
+        std::vector<uint32_t> reader_args(2 + num_dims);
+        reader_args[2] = num_tiles_written % num_unpadded_tiles_per_dim[0];
+        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
+        uint32_t start_id = reader_args[2] + start_offset;
+        for (uint32_t j = 1; j < num_dims; ++j) {
+            reader_args[2 + j] = unpadded_written % num_unpadded_tiles_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
+            start_id += reader_args[2 + j] * accumulated_total_per_dim[j - 1];
+        }
+        reader_args[0] = start_id;
+        reader_args[1] = num_tiles_per_core;
+
+        reader_runtime_args.emplace_back(core, std::move(reader_args));
+        writer_runtime_args.emplace_back(
+            core, std::vector<uint32_t>{dst_buffer->address(), num_tiles_per_core, num_tiles_written});
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+        "reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.runtime_args = std::move(reader_runtime_args);
+    reader_desc.common_runtime_args = std::move(reader_common_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+    desc.kernels.push_back(std::move(reader_desc));
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.runtime_args = std::move(writer_runtime_args);
+    writer_desc.config = WriterConfigDescriptor{};
+    desc.kernels.push_back(std::move(writer_desc));
+
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice_nanobind.cpp
@@ -18,6 +18,7 @@
 #include "slice.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
+#include "ttnn/operations/data_movement/slice/device/slice_descriptor_builders.hpp"
 
 namespace ttnn::operations::data_movement::detail {
 
@@ -158,14 +159,17 @@ void bind_slice_descriptor(nb::module_& mod) {
             nb::arg("operation_attributes"),
             nb::arg("tensor_args"));
 
+    // The Python-visible name stays SliceTileProgramFactory.create_descriptor (zero Python churn),
+    // but the implementation now calls the standalone build_slice_tile_descriptor — so the bind no
+    // longer depends on a create_descriptor method living on the factory. When the factory migrates
+    // to Metal 2.0 (and drops create_descriptor), this bind keeps working unchanged.
     nb::class_<ttnn::prim::SliceTileProgramFactory>(mod, "SliceTileProgramFactory")
         .def_static(
             "create_descriptor",
             [](const ttnn::prim::SliceParams& operation_attributes,
                const ttnn::prim::SliceInputs& tensor_args,
                Tensor& tensor_return_value) {
-                return ttnn::prim::SliceTileProgramFactory::create_descriptor(
-                    operation_attributes, tensor_args, tensor_return_value);
+                return ttnn::prim::build_slice_tile_descriptor(operation_attributes, tensor_args, tensor_return_value);
             },
             nb::arg("operation_attributes"),
             nb::arg("tensor_args"),

--- a/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
@@ -115,6 +115,7 @@ set(TTNN_OP_DATA_MOVEMENT_SRCS
     slice/device/slice_program_factory_rm_stride.cpp
     slice/device/slice_program_factory_tile.cpp
     slice/device/slice_program_factory_tile_tensor_args.cpp
+    slice/device/slice_descriptor_builders.cpp
     slice/slice.cpp
     split/device/split_device_operation.cpp
     split/device/split_program_factory.cpp

--- a/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/data_movement/sources.cmake
@@ -116,6 +116,10 @@ set(TTNN_OP_DATA_MOVEMENT_SRCS
     slice/device/slice_program_factory_tile.cpp
     slice/device/slice_program_factory_tile_tensor_args.cpp
     slice/device/slice_descriptor_builders.cpp
+    slice/device/slice_rm_descriptor_builder.cpp
+    slice/device/slice_rm_stride_descriptor_builder.cpp
+    slice/device/slice_rm_sharded_descriptor_builder.cpp
+    slice/device/slice_tile_tensor_args_descriptor_builder.cpp
     slice/slice.cpp
     split/device/split_device_operation.cpp
     split/device/split_program_factory.cpp


### PR DESCRIPTION
Migrates **`data_movement/slice`** fully to the Metal 2.0 (`ProgramSpec`) API — all 5 program factories — while keeping its `ProgramDescriptor` consumers (pybind, the Python fusion compiler, and `mesh_partition`) working unchanged.

Stacks on the extraction seam (#46902); base is the MetalV2 framework branch (#46781).

## What changed

**All 5 factories → MetalV2 `ProgramSpec`** (`create_program_spec` / `create_invariant_run_args` / `create_per_enqueue_args`), each with slice-local re-expressed kernels (`dfb::` / `ta::name` / named CTAs / named + vararg RTAs; sharded uses borrowed-memory DFBs):
- `SliceTileProgramFactory`
- `SliceRmProgramFactory` (runtime page-size override → spec-derived page size + `offset_bytes`)
- `SliceRmStrideProgramFactory` (nd path; per-dim/slice arrays as common varargs)
- `SliceRmShardedProgramFactory` (CBs pinned to sharded tensors → `borrowed_from` DFBs)
- `SliceTileTensorArgsProgramFactory` (start/end-as-tensors → 4 `TensorParameter`s)

**Descriptor consumers preserved.** Because the framework forbids a factory exposing both `create_descriptor` and `create_program_spec` (`all_factories_valid`), the descriptor logic moved into standalone `build_slice_*_descriptor` free functions. The pybind (`SliceTileProgramFactory.create_descriptor`, Python name unchanged) and `mesh_partition`'s `std::visit` now call those builders, so they keep getting a `ProgramDescriptor` while slice dispatches on Metal 2.0.

**`mesh_partition`** re-pointed at the standalone builders via a factory-type→builder dispatch.

## Notable fixes during bring-up
- **Unity-build collisions** — per-variant prefixes on factory-local symbols (`READER_KERNEL`/`node_of`/`compute_geometry`).
- **Cache-hit `UpdateProgramRunArgs` FATAL** — kernels with varargs can't be enqueue-invariant (gap #6), so all run args are re-applied per dispatch (`create_invariant_run_args` empty).
- **`tile_tensor_args` "DFB has no consumer"** — the index-staging CB is read back by the same kernel; bound as a producer+consumer self-loop.

## Validation
- Builds clean end-to-end (op + `mesh_partition` + recovered builders), 0 errors.
- **Full `tests/.../data_movement/test_slice.py` suite passes** (exit 0, 0 failures), covering tile / rm / rm_stride / rm_sharded / tile_tensor_args / subcores / whisper / program-cache paths.

## Open items
- **rm_sharded** rides the `[[deprecated]] num_runtime_varargs_per_node` table — the only Metal 2.0 mechanism for non-uniform per-node vararg counts. Works behind a deprecation pragma; flagging for the metal owners (Audrey) on the sanctioned path.
- **Perf:** run args are re-applied every dispatch for correctness; the shape-derived named RTAs could later be declared `enqueue_invariant` so only varargs/tensors re-apply.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metal2-slice-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metal2-slice-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-slice-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metal2-slice-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/metal2-slice-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/metal2-slice-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metal2-slice-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metal2-slice-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metal2-slice-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metal2-slice-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metal2-slice-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metal2-slice-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metal2-slice-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metal2-slice-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metal2-slice-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metal2-slice-migration)