### PR TITLE
[CI Disable] blackhole-post-commit: skip test_host_io_loopback DEVICE_PULL 512-byte tensor on bh_p300-viommu

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
@@ -54,6 +54,8 @@ def create_fabric_router_config(max_payload_size):
 def test_host_io_loopback(mesh_device, tensor_size_bytes, fifo_size, num_iterations, h2d_mode):
     if not is_slow_dispatch():
         pytest.skip("Skipping test in fast dispatch mode")
+    if h2d_mode == ttnn.H2DMode.DEVICE_PULL and tensor_size_bytes == 512 and fifo_size == 1024:
+        pytest.skip(reason="Disabled on blackhole P300-viommu (DEVICE_PULL mode, TT_THROW for 512-byte tensor): see #46929")
 
     ttnn.enable_asynchronous_slow_dispatch(mesh_device)
 


### PR DESCRIPTION
Disable deterministically failing test_host_io_loopback DEVICE_PULL 512-byte tensor test on blackhole-post-commit bh_p300-viommu

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py::test_host_io_loopback[blackhole-H2DMode.DEVICE_PULL-512-1024-512] [bh_p300-viommu] | https://github.com/tenstorrent/tt-metal/actions/runs/27441737760/job/81130000607 | [16e79a78](https://github.com/tenstorrent/tt-metal/commit/16e79a784996b0608f809a186f5816dd07e86d39) | 2026-06-12 22:13 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/blackhole-post-commit-host-io-device-pull-512-2026-06-13)