### PR TITLE
[CI Disable] t3000-demo-tests: skip qwen3_vl BERTScore CI test on wh_llmbox (accuracy below threshold)

### DIFF
--- a/models/demos/qwen3_vl/demo/demo.py
+++ b/models/demos/qwen3_vl/demo/demo.py
@@ -130,7 +130,8 @@ def create_tt_model(
             True,  # stop_at_eos
             False,  # ci_only
         ),
-        (  # Batch-1 run with full model for more stable BERTScore checks (CI only)
+        pytest.param(
+            # Batch-1 run with full model for more stable BERTScore checks (CI only)
             "models/demos/qwen3_vl/demo/sample_prompts/test_bert_score.json",
             True,  # instruct mode
             2,  # repeat_batches to simulate multiple users with the same prompt
@@ -142,6 +143,7 @@ def create_tt_model(
             {"temperature": 0, "top_p": 0.08},  # sampling_params (argmax)
             True,  # stop_at_eos
             True,  # ci_only
+            marks=pytest.mark.skip(reason="Disabled: see #46931"),
         ),
         (  # Batch-1 run with text only prompts hence skipping vision model (CI only)
             "models/demos/qwen3_vl/demo/sample_prompts/text_only.json",


### PR DESCRIPTION
Disable deterministically failing qwen3_vl BERTScore CI test on t3000-demo-tests wh_llmbox

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| models/demos/qwen3_vl/demo/demo.py::test_demo[wormhole_b0-mesh_device0-device_params0-performance-ci-only-bert-score] [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27387344895/job/80937973451 | [1491ae5d](https://github.com/tenstorrent/tt-metal/commit/1491ae5d30226804908e3e5f961a2e2e864aee7c) | 2026-06-12 20:05 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/t3000-demo-tests-qwen3vl-bertscore-2026-06-13)