### PR TITLE
[CI Disable] blackhole-demo-tests: skip mochi encoder performance test on bh_quietbox_2 (below threshold)

### DIFF
--- a/models/tt_dit/tests/models/mochi/test_performance_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_performance_mochi.py
@@ -25,7 +25,7 @@ from ....pipelines.mochi.pipeline_mochi import MochiPipeline as TTMochiPipeline
     "mesh_device, sp_axis, tp_axis, vae_mesh_shape, vae_sp_axis, vae_tp_axis, topology, num_links",
     [
         pytest.param(
-            [(2, 2), 0, 1, (1, 4), 0, 1, ttnn.Topology.Linear, 2],
+            (2, 2), 0, 1, (1, 4), 0, 1, ttnn.Topology.Linear, 2,
             id="dit_2x2sp0tp1_vae_1x4sp0tp1_BH_QB",
             marks=pytest.mark.skip(reason="Disabled: see #46933"),
         ),

--- a/models/tt_dit/tests/models/mochi/test_performance_mochi.py
+++ b/models/tt_dit/tests/models/mochi/test_performance_mochi.py
@@ -24,7 +24,11 @@ from ....pipelines.mochi.pipeline_mochi import MochiPipeline as TTMochiPipeline
 @pytest.mark.parametrize(
     "mesh_device, sp_axis, tp_axis, vae_mesh_shape, vae_sp_axis, vae_tp_axis, topology, num_links",
     [
-        [(2, 2), 0, 1, (1, 4), 0, 1, ttnn.Topology.Linear, 2],
+        pytest.param(
+            [(2, 2), 0, 1, (1, 4), 0, 1, ttnn.Topology.Linear, 2],
+            id="dit_2x2sp0tp1_vae_1x4sp0tp1_BH_QB",
+            marks=pytest.mark.skip(reason="Disabled: see #46933"),
+        ),
         [(2, 4), 0, 1, (1, 8), 0, 1, ttnn.Topology.Linear, 2],  # VAE mesh shape = (1, 8) is more memory efficient.
         [(2, 4), 0, 1, (1, 8), 0, 1, ttnn.Topology.Linear, 1],
         [(4, 8), 1, 0, (4, 8), 0, 1, ttnn.Topology.Linear, 4],  # note sp <-> tp switch for VAE for memory efficiency.


### PR DESCRIPTION
Disable deterministically failing mochi encoder performance test on blackhole-demo-tests bh_quietbox_2

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| models/tt_dit/tests/models/mochi/test_performance_mochi.py::test_mochi_pipeline_performance[blackhole-device_params0-dit_2x2sp0tp1_vae_1x4sp0tp1_BH_QB-genmo/mochi-1-preview-848-480-3.5-50-168] [bh_quietbox_2] | https://github.com/tenstorrent/tt-metal/actions/runs/27457802737/job/81165940451 | [f1e8f9b6](https://github.com/tenstorrent/tt-metal/commit/f1e8f9b60d09e0858bc2164fb2f855fa2586e4d8) | 2026-06-13 05:59 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/blackhole-demo-tests-mochi-encoder-perf-2026-06-13)