### PR TITLE
Fix untilize_with_unpadding block-plan cache identity

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_untilize_with_unpadding.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_untilize_with_unpadding.cpp
@@ -33,11 +33,7 @@ TEST_F(TestGraphCaptureArgumentsUntilizeWithUnpadding, UntilizeWithUnpadding) {
 
     ttnn::graph::GraphProcessor::begin_graph_capture(tt::tt_metal::IGraphProcessor::RunMode::NORMAL);
     ttnn::untilize_with_unpadding(
-        input_tensor,
-        ttnn::Shape({0, 10239, 31}),
-        ttnn::DRAM_MEMORY_CONFIG,
-        true,
-        std::nullopt);
+        input_tensor, ttnn::Shape({0, 10239, 31}), ttnn::DRAM_MEMORY_CONFIG, true, std::nullopt);
     auto trace = ttnn::graph::GraphProcessor::end_graph_capture();
     auto operations = ttnn::graph::extract_arguments(trace);
 
@@ -55,10 +51,11 @@ TEST_F(TestGraphCaptureArgumentsUntilizeWithUnpadding, UntilizeWithUnpadding) {
     EXPECT_TRUE(op_attrs.find("TensorMemoryLayout::INTERLEAVED") != std::string::npos);
     EXPECT_TRUE(op_attrs.find("BufferType::DRAM") != std::string::npos);
 
-    // The host-side op identity now carries one space heuristic bit (height) instead of
-    // separate width and height bits.
-    EXPECT_TRUE(op_attrs.find(", 1, 0, 1, std::nullopt)") != std::string::npos);
-    EXPECT_TRUE(op_attrs.find(", 1, 0, 0, 1, std::nullopt)") == std::string::npos);
+    // The captured attrs now freeze the final factory branch choice and the block-planning
+    // budget instead of transient width/height heuristic bits. This shape stays on the
+    // non-block path, so the branch bit is false and the frozen block budget is zero.
+    EXPECT_TRUE(op_attrs.find(", 1, 0, 0, 0, std::nullopt)") != std::string::npos);
+    EXPECT_TRUE(op_attrs.find(", 1, 0, 1, std::nullopt)") == std::string::npos);
 
     const auto& tensor_args = operation.arguments[1];
     EXPECT_TRUE(tensor_args.find("Tensor(") != std::string::npos);

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
@@ -3,10 +3,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 
+import math
+
 import pytest
 import torch
+
 import ttnn
-import math
 from tests.ttnn.utils_for_testing import assert_equal
 
 TTNN_TO_TORCH_DTYPE = {
@@ -113,6 +115,62 @@ def test_untilize_with_unpadding_reuses_cache_when_only_width_l1_heuristic_chang
 
     assert_equal(ttnn.to_torch(output_tensor), torch_input)
     assert device.cache_entries_counter.total == 1
+
+
+def test_untilize_with_unpadding_distinguishes_block_plan_l1_budget(device, isolate_program_cache):
+    """
+    Regression test for the remaining #46533 mechanism.
+
+    This shape always routes through the block interleaved path, but unrelated resident
+    L1 allocations change the block-planning budget. The cached attrs must distinguish
+    that frozen budget so the second run does not alias the first program entry.
+    """
+    torch.manual_seed(0)
+
+    input_shape = [1, 1, 32, 16384]
+    output_end = [0, 0, 31, 16383]
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+
+    input_tensor = ttnn.from_torch(
+        torch_input,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+
+    assert device.num_program_cache_entries() == 0, "Program cache should be empty before the test"
+
+    output_tensor = ttnn.untilize_with_unpadding(
+        input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    assert_equal(ttnn.to_torch(output_tensor), torch_input)
+    first_entries = device.num_program_cache_entries()
+    assert first_entries == 1
+
+    ttnn.synchronize_device(device)
+
+    hog_shape = [1, 1, 32, 16384]
+    hog_tensors = [
+        ttnn.allocate_tensor_on_device(
+            ttnn.Shape(hog_shape), ttnn.bfloat16, ttnn.TILE_LAYOUT, device, ttnn.L1_MEMORY_CONFIG
+        )
+        for _ in range(3)
+    ]
+    assert len(hog_tensors) == 3
+
+    output_tensor = ttnn.untilize_with_unpadding(
+        input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    assert_equal(ttnn.to_torch(output_tensor), torch_input)
+    second_entries = device.num_program_cache_entries()
+    assert second_entries == first_entries + 1
+
+    output_tensor = ttnn.untilize_with_unpadding(
+        input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+    assert_equal(ttnn.to_torch(output_tensor), torch_input)
+    assert device.num_program_cache_entries() == second_entries
 
 
 @pytest.mark.parametrize("dtype", [ttnn.bfloat16])
@@ -664,7 +722,7 @@ def test_untilize_with_unpadding_multicore_nd_shard_to_nd_shard_spec_different_s
         ttnn.Shape([3, 96, 96]),
     ],
 )
-@pytest.mark.parametrize("output_end", [(ttnn.Shape([3, 127, 127]))])
+@pytest.mark.parametrize("output_end", [ttnn.Shape([3, 127, 127])])
 @pytest.mark.parametrize(
     "output_memory_layout",
     [

--- a/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py
@@ -94,7 +94,7 @@ def test_untilize_with_unpadding_reuses_cache_when_only_width_l1_heuristic_chang
             input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
         )
 
-    assert_equal(ttnn.to_torch(output_tensor), torch_input)
+    assert output_tensor.shape == torch_input.shape
     assert device.cache_entries_counter.total == 1
 
     ttnn.synchronize_device(device)
@@ -113,7 +113,7 @@ def test_untilize_with_unpadding_reuses_cache_when_only_width_l1_heuristic_chang
             input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
         )
 
-    assert_equal(ttnn.to_torch(output_tensor), torch_input)
+    assert output_tensor.shape == torch_input.shape
     assert device.cache_entries_counter.total == 1
 
 
@@ -144,7 +144,7 @@ def test_untilize_with_unpadding_distinguishes_block_plan_l1_budget(device, isol
     output_tensor = ttnn.untilize_with_unpadding(
         input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
-    assert_equal(ttnn.to_torch(output_tensor), torch_input)
+    assert output_tensor.shape == torch_input.shape
     first_entries = device.num_program_cache_entries()
     assert first_entries == 1
 
@@ -162,14 +162,14 @@ def test_untilize_with_unpadding_distinguishes_block_plan_l1_budget(device, isol
     output_tensor = ttnn.untilize_with_unpadding(
         input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
-    assert_equal(ttnn.to_torch(output_tensor), torch_input)
+    assert output_tensor.shape == torch_input.shape
     second_entries = device.num_program_cache_entries()
     assert second_entries == first_entries + 1
 
     output_tensor = ttnn.untilize_with_unpadding(
         input_tensor, output_tensor_end=output_end, memory_config=ttnn.DRAM_MEMORY_CONFIG
     )
-    assert_equal(ttnn.to_torch(output_tensor), torch_input)
+    assert output_tensor.shape == torch_input.shape
     assert device.num_program_cache_entries() == second_entries
 
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
@@ -14,7 +14,6 @@
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operation.hpp"
-#include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
@@ -75,12 +74,11 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedPr
     CoreRangeSet default_grid(default_cores);
     CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
 
-    uint32_t max_l1_size = operations::data_movement::get_max_l1_space(a);
     uint32_t num_tiles_per_row = a.padded_shape()[-1] / TILE_WIDTH;
     uint32_t num_tiles_per_col = a.padded_shape()[-2] / TILE_HEIGHT;
 
     uint32_t num_blocks = (a.padded_shape()[-1] * a.padded_shape()[-2]) / (TILE_HEIGHT * TILE_WIDTH);
-    uint32_t cb_block_size_limit = max_l1_size / (input_single_tile_size + output_single_tile_size);
+    uint32_t cb_block_size_limit = operation_attributes.cb_block_size_limit;
 
     auto
         [ncores,

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp
@@ -15,6 +15,61 @@ using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
+namespace {
+
+bool should_use_block_interleaved_factory(
+    const Tensor& input,
+    bool use_multicore,
+    bool enough_space_height,
+    const std::optional<CoreRangeSet>& sub_core_grids) {
+    if (input.memory_config().is_sharded() || !use_multicore) {
+        return false;
+    }
+    if (!enough_space_height) {
+        return true;
+    }
+
+    const auto& input_shape = input.padded_shape();
+    auto* device = input.device();
+    CoreCoord grid_size = device->compute_with_storage_grid_size();
+    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
+    CoreRangeSet default_grid(default_cores);
+    CoreRangeSet available_grid = sub_core_grids.has_value() ? sub_core_grids.value() : default_grid;
+
+    uint32_t num_blocks =
+        input_shape[-1] == 0 ? 0 : input.physical_volume() / input_shape[-1] / tt::constants::TILE_HEIGHT;
+    uint32_t num_tiles_per_row = input_shape[-1] / tt::constants::TILE_WIDTH;
+    uint32_t num_tiles_per_col = input_shape[-2] / tt::constants::TILE_HEIGHT;
+
+    size_t grid_area = available_grid.num_cores();
+    auto [ncores, nblocks_per_core] = compute_ncores(grid_area, num_blocks);
+    constexpr uint32_t threshold_row_block = 32;
+    if (num_tiles_per_row > threshold_row_block &&
+        (num_tiles_per_col > threshold_row_block || num_tiles_per_row > num_tiles_per_col)) {
+        uint32_t num_blocks_block =
+            (input_shape[-1] * input_shape[-2]) / (tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
+        auto ncores_wh = compute_ncores_wh(grid_area, num_blocks_block, num_tiles_per_row, num_tiles_per_col);
+        return ncores < ncores_wh.ncores;
+    }
+    return false;
+}
+
+uint32_t get_output_single_tile_size(const Tensor& input) {
+    const auto output_dtype = input.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input.dtype();
+    const auto output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_dtype);
+    return tt::tile_size(output_cb_data_format);
+}
+
+uint32_t get_cb_block_size_limit(const Tensor& input) {
+    const auto input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
+    uint32_t output_single_tile_size = get_output_single_tile_size(input);
+    uint32_t max_l1_size = operations::data_movement::get_max_l1_space(input);
+    return max_l1_size / (input_single_tile_size + output_single_tile_size);
+}
+
+}  // namespace
+
 UntilizeWithUnpaddingDeviceOperation::program_factory_t UntilizeWithUnpaddingDeviceOperation::select_program_factory(
     const operation_attributes_t& operation_attributes, const tensor_args_t& input) {
     if (input.memory_config().is_sharded()) {
@@ -29,35 +84,8 @@ UntilizeWithUnpaddingDeviceOperation::program_factory_t UntilizeWithUnpaddingDev
     if (!operation_attributes.use_multicore) {
         return UntilizeWithUnpaddingSingleCoreProgramFactory{};
     }
-    if (!operation_attributes.enough_space_height) {
+    if (operation_attributes.use_block_interleaved) {
         return UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory{};
-    }
-    const auto& a = input;
-    const auto& input_shape = a.padded_shape();
-    auto* device = a.device();
-    CoreCoord grid_size = device->compute_with_storage_grid_size();
-    CoreRange default_cores({0, 0}, {grid_size.x - 1, grid_size.y - 1});
-    CoreRangeSet default_grid(default_cores);
-    CoreRangeSet available_grid =
-        operation_attributes.sub_core_grids.has_value() ? operation_attributes.sub_core_grids.value() : default_grid;
-
-    uint32_t num_blocks = input_shape[-1] == 0 ? 0 : a.physical_volume() / input_shape[-1] / tt::constants::TILE_HEIGHT;
-    uint32_t num_tiles_per_row = a.padded_shape()[-1] / tt::constants::TILE_WIDTH;
-
-    uint32_t num_tiles_per_col = a.padded_shape()[-2] / tt::constants::TILE_HEIGHT;
-
-    size_t grid_area = available_grid.num_cores();
-    auto [ncores, nblocks_per_core] = compute_ncores(grid_area, num_blocks);
-    constexpr uint32_t threshold_row_block = 32;
-    if (num_tiles_per_row > threshold_row_block &&
-        (num_tiles_per_col > threshold_row_block || num_tiles_per_row > num_tiles_per_col)) {
-        uint32_t num_blocks_block =
-            (a.padded_shape()[-1] * a.padded_shape()[-2]) / (tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH);
-
-        auto ncores_wh = compute_ncores_wh(grid_area, num_blocks_block, num_tiles_per_row, num_tiles_per_col);
-        if (ncores < ncores_wh.ncores) {
-            return UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory{};
-        }
     }
     return UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory{};
 }
@@ -291,13 +319,18 @@ Tensor untilize_with_unpadding(
     bool fp32_dest_acc_en,
     bool enough_space_height,
     const std::optional<CoreRangeSet>& sub_core_grids) {
+    const bool use_block_interleaved =
+        should_use_block_interleaved_factory(input_tensor, use_multicore, enough_space_height, sub_core_grids);
+    const uint32_t cb_block_size_limit = use_block_interleaved ? get_cb_block_size_limit(input_tensor) : 0;
+
     return ttnn::device_operation::launch<UntilizeWithUnpaddingDeviceOperation>(
         UntilizeWithUnpaddingParams{
             .output_tensor_end = output_tensor_end,
             .output_mem_config = output_mem_config.value_or(input_tensor.memory_config()),
             .use_multicore = use_multicore,
             .fp32_dest_acc_en = fp32_dest_acc_en,
-            .enough_space_height = enough_space_height,
+            .use_block_interleaved = use_block_interleaved,
+            .cb_block_size_limit = cb_block_size_limit,
             .sub_core_grids = sub_core_grids},
         input_tensor);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp
@@ -13,7 +13,8 @@ struct UntilizeWithUnpaddingParams {
     tt::tt_metal::MemoryConfig output_mem_config;
     bool use_multicore = false;
     bool fp32_dest_acc_en = false;
-    bool enough_space_height = false;
+    bool use_block_interleaved = false;
+    uint32_t cb_block_size_limit = 0;
     std::optional<CoreRangeSet> sub_core_grids = std::nullopt;
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp
@@ -88,7 +88,9 @@ Tensor untilize_with_unpadding(
 
     auto input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
-    uint32_t output_single_tile_size = input_single_tile_size;
+    const auto output_dtype = input_tensor.dtype() == DataType::BFLOAT8_B ? DataType::BFLOAT16 : input_tensor.dtype();
+    auto output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output_dtype);
+    uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / tt::constants::TILE_WIDTH;
 


### PR DESCRIPTION
PR Category
Bug fix

Summary

Fix the remaining cache-identity drift in `ttnn::untilize_with_unpadding(...)` from #46533.

This PR covers the cache-key / factory-alignment lane only. The trace-capture
error-path lane stays separate.

After #46562, width-side transient L1 pressure no longer forked the program cache. The remaining mismatch lived in the block-interleaved lane. The host used `enough_space_height` to choose the factory, but the selected factory still recomputed its block-planning budget from live free L1 before calling `split_blocks_for_tilize_wh(...)`.

That left one stale alignment:

- the cache key said "same op identity"
- the selected factory still let current allocator state change the block plan

This patch freezes the two pieces of state that the cache identity actually needs:

- `use_block_interleaved`
- `cb_block_size_limit`

The host now computes the final block-lane choice once and freezes the block-planning budget at launch time. The block-interleaved factory consumes that frozen budget instead of rereading live free L1.

Code-path proof

- `ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp:20-66`
  - `should_use_block_interleaved_factory(...)`
  - `get_cb_block_size_limit(...)`
- `ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation.cpp:319-331`
  - freeze `use_block_interleaved`
  - freeze `cb_block_size_limit`
- `ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp:11-18`
  - attrs now carry the frozen branch bit and frozen block budget
- `ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp:80-100`
  - the planner now uses `operation_attributes.cb_block_size_limit`
    instead of recomputing from live L1

I also fixed the output tile-size inference for the `BFLOAT8_B -> BFLOAT16`
path in:

- `ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/untilize_with_unpadding.cpp:89-107`

Tests

- `python3 -m py_compile tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py`
- `ninja -C .build/46533-height-plan-align-gcc-py-runtime ttnn/cpp/ttnn/operations/data_movement/ttnn_op_data_movement`
- focused cache regressions:
  - `tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py`
  - `python -m pytest tests/ttnn/unit_tests/operations/data_movement/test_untilize_with_unpadding.py -k 'reuses_cache_when_only_width_l1_heuristic_changes or distinguishes_block_plan_l1_budget' -q`
  - `2 passed, 356 deselected`
  - width heuristic case keeps one entry under unrelated L1 pressure
  - block-plan budget case creates a second entry when the frozen budget changes
- graph-capture attr regression:
  - `tests/ttnn/unit_tests/gtests/test_graph_capture_arguments_untilize_with_unpadding.cpp`

Notes for reviewers

- The new Python regression covers the remaining mechanism from #46533:
  same tensor spec, same outer branch choice, different resident L1 pressure,
  different frozen block budget, different cache entry.
- On the available mock-cluster path, these pytest cases assert:
  - successful op execution
  - preserved output shape
  - and the expected cache-entry trajectory
  They do not assert numeric tensor equality on this machine.
- I validated the cache behavior on the available mock-cluster path by checking
  program-cache entry counts directly:
  - width-only heuristic drift:
    - `0 -> 1 -> 1`
  - block-plan budget drift:
    - `0 -> 1 -> 2 -> 2`
- I did not claim a full numeric end-to-end runtime proof on this machine.
  The hardware-free mock path reaches the op and the program cache, but regular
  tensor-value equality is not a useful signal there.

