### PR TITLE
emule: emit per-CB tile height/width for thin-tile reduce

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1035,27 +1035,48 @@ static std::map<std::string, std::string> build_kernel_defines(
     }
     defines["EMULE_SEM_ALIGN"] = std::to_string(EMULE_SEM_ALIGN);
 
-    // Collect CB tile sizes from program for constexpr get_tile_size().
+    // Collect CB tile sizes + per-CB tile shape from program for the constexpr
+    // get_tile_size() / get_tile_r_dim() / get_tile_c_dim() metadata. The shape
+    // (height/width) is the ground truth for thin tiles (e.g. Tile([1,16])) —
+    // the emulated reduce/unpack primitives bound their iteration by it instead
+    // of assuming a full 32x32 tile. Default 32x32 when a CB has no Tile spec.
     const auto& core_range_set = kernel.core_range_set();
     if (!core_range_set.ranges().empty()) {
         auto first_core = core_range_set.ranges().begin()->start_coord;
         auto cb_impls = impl.circular_buffers_on_core(first_core);
         uint32_t tile_sizes[EMULE_NUM_CBS] = {};
+        uint32_t tile_r_dim[EMULE_NUM_CBS];
+        uint32_t tile_c_dim[EMULE_NUM_CBS];
+        for (uint32_t i = 0; i < EMULE_NUM_CBS; i++) {
+            tile_r_dim[i] = tt::constants::TILE_HEIGHT;
+            tile_c_dim[i] = tt::constants::TILE_WIDTH;
+        }
         for (auto& cb_impl : cb_impls) {
+            const auto& tiles = cb_impl->config().tiles();
             for (uint8_t idx : cb_impl->local_buffer_indices()) {
                 if (idx < EMULE_NUM_CBS) {
                     tile_sizes[idx] = cb_impl->page_size(idx);
+                    if (tiles[idx].has_value()) {
+                        tile_r_dim[idx] = tiles[idx]->get_height();
+                        tile_c_dim[idx] = tiles[idx]->get_width();
+                    }
                 }
             }
         }
-        std::ostringstream ts;
+        std::ostringstream ts, tr, tc;
         for (uint32_t i = 0; i < EMULE_NUM_CBS; i++) {
             if (i) {
                 ts << ',';
+                tr << ',';
+                tc << ',';
             }
             ts << tile_sizes[i];
+            tr << tile_r_dim[i];
+            tc << tile_c_dim[i];
         }
         defines["EMULE_TILE_SIZES"] = ts.str();
+        defines["EMULE_TILE_R_DIM"] = tr.str();
+        defines["EMULE_TILE_C_DIM"] = tc.str();
     }
     return defines;
 }


### PR DESCRIPTION
## emule: emit per-CB tile height/width for thin-tile reduce

### Context
The emulated program runner emits per-CB metadata to the compute side as JIT defines (e.g. `EMULE_TILE_SIZES` = per-CB page bytes), but not the tile's height/width. Thin tiles (e.g. `Tile([1,16])`) need their active dimensions on the compute side so the emulated reduce primitive can bound its iteration to the active region instead of assuming a full 32×32 tile (which reads uninitialized lanes).

### Change
In the `EMULE_TILE_SIZES` emission loop, read each CB's `Tile` spec (`config().tiles()[idx]->get_height()/get_width()`, defaulting to 32×32 when the CB has no `Tile` spec) and emit two new defines — `EMULE_TILE_R_DIM` / `EMULE_TILE_C_DIM` — alongside `EMULE_TILE_SIZES`.

### Matched pair with tt-emule
This is the **emitter half**. The compute half (companion PR: https://github.com/tenstorrent/tt-emule/pull/156) populates `unpack_tile_r_dim[]` / `unpack_tile_c_dim[]` from these defines and bounds `reduce_tile`'s loops by them. The two should land together.

### Scope
One file; emulation path only — no effect on the real-silicon build.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/emule-thin-tile-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/emule-thin-tile-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/emule-thin-tile-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/emule-thin-tile-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=xchin/emule-thin-tile-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:xchin/emule-thin-tile-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/emule-thin-tile-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/emule-thin-tile-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/emule-thin-tile-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/emule-thin-tile-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/emule-thin-tile-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/emule-thin-tile-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/emule-thin-tile-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/emule-thin-tile-reduce)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/emule-thin-tile-reduce)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/emule-thin-tile-reduce)