### PR TITLE
emule: TT_EMULE_DEEP_SFPU env var to engage the deep SFPU path per op

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1076,6 +1076,37 @@ static std::map<std::string, std::string> build_kernel_defines(
         defines["EMULE_WAIT_TIMEOUT"] = "1";
     }
 
+    // Opt-in deep-SFPU override. TT_EMULE_DEEP_SFPU=sqrt,sigmoid promotes those
+    // shadowed SFPU ops from their layer-1 libm shadow to the deep path (the real
+    // silicon ckernel_sfpu_<op>.h run on emule's faithful sfpi backend — see
+    // tt-emule docs/sfpu-deep-path.md). Each comma-separated name becomes an
+    // EMULE_DEEP_SFPU_<UPPER> define. Routed through the defines map so it lands
+    // in the JIT cache key (toggling invalidates stale cached .so). Ops with no
+    // layer-1 shadow take the deep path automatically and need no opt-in.
+    if (const char* deep = std::getenv("TT_EMULE_DEEP_SFPU")) {
+        const std::string list(deep);
+        size_t start = 0;
+        while (start <= list.size()) {
+            const size_t comma = list.find(',', start);
+            const size_t end = (comma == std::string::npos) ? list.size() : comma;
+            std::string op;
+            for (size_t i = start; i < end; ++i) {
+                const char c = list[i];
+                if (c == ' ' || c == '\t') {
+                    continue;  // trim whitespace
+                }
+                op.push_back((c >= 'a' && c <= 'z') ? static_cast<char>(c - 'a' + 'A') : c);
+            }
+            if (!op.empty()) {
+                defines["EMULE_DEEP_SFPU_" + op] = "1";
+            }
+            if (comma == std::string::npos) {
+                break;
+            }
+            start = comma + 1;
+        }
+    }
+
     auto arch = MetalContext::instance().get_cluster().arch();
     if (arch == ARCH::QUASAR) {
         defines["ARCH_QUASAR"] = "1";


### PR DESCRIPTION
## Summary

Runtime toggle for the **deep-SFPU path** in emule. `TT_EMULE_DEEP_SFPU=sqrt,sigmoid` injects `EMULE_DEEP_SFPU_SQRT` / `_SIGMOID` into the JIT define set, promoting those shadowed SFPU ops from their layer-1 libm shadow to the **deep path** — running the real silicon `ckernel_sfpu_<op>.h` on emule's faithful `sfpi` backend.

Single-file change to `build_kernel_defines` in `emulated_program_runner.cpp`: parse the comma-separated env var (uppercased, whitespace-trimmed) and add one `EMULE_DEEP_SFPU_<OP>` define per name. Mirrors the existing `TT_EMULE_WAIT_TIMEOUT` pattern — routed through the defines map so it lands in the JIT cache key (toggling invalidates stale cached `.so`).

- **Off by default** → no behavior change unless the env var is set.
- Ops with **no** layer-1 shadow take the deep path automatically (via tt-emule's `sfpu_split_includes.h` deep arm) and need no opt-in; this var is for **promoting shadowed ops**.

## Sister PR

This is the tt-metal half of the tt-emule deep-SFPU work: **tenstorrent/tt-emule#155** (the `sfpi`-backend + per-op deep wiring + `docs/sfpu-deep-path.md`). The tt-emule headers define the `EMULE_DEEP_SFPU_<OP>` guards; this env var is what flips them at runtime.

## Verification

The deep path itself is verified in the tt-emule PR (real `ckernel_sfpu_{sqrt,log,silu,sigmoid,tanh}.h` compile + run on the `sfpi` backend; sqrt exact, others PCC ≥ 0.997 vs torch). This change only sources the existing `-D` from an env var. Base branch is the current emule pin (`arminale/emule-umd-fix-pin`); diff is the single runner change.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=xchin/sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:xchin/sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=xchin/sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:xchin/sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=xchin/sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:xchin/sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=xchin/sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:xchin/sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=xchin/sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:xchin/sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=xchin/sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:xchin/sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=xchin/sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:xchin/sfpu)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=xchin/sfpu)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:xchin/sfpu)