### PR TITLE
Fix alignment problem with 64bit values in DPRINT buffer

### DIFF
--- a/tt_metal/hw/inc/api/debug/device_print.h
+++ b/tt_metal/hw/inc/api/debug/device_print.h
@@ -675,6 +675,15 @@ struct device_print_type_info {
     uint32_t size_in_bytes;
 };
 
+// Store an 8-byte value into the print buffer as two 32-bit stores. This is a workaround for riscs
+// that have 8-byte registers. Problem is that our implementation keeps alignment to 4 bytes,
+// so 8-byte arguments are not guaranteed to be 8-byte aligned in the buffer.
+inline void store_64bit_value(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, uint64_t value) {
+    auto* dst = reinterpret_cast<device_print_buffer_ptr<uint32_t>>(device_print_buffer + offset);
+    dst[0] = static_cast<uint32_t>(value);
+    dst[1] = static_cast<uint32_t>(value >> 32);
+}
+
 // Type-to-info mapping for format strings and serialization
 template <typename T, typename = void>
 struct device_print_type {
@@ -731,14 +740,14 @@ template <>
 struct device_print_type<std::int64_t> {
     static constexpr device_print_type_info value = {'q', sizeof(std::int64_t)};
     static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, int64_t argument) {
-        *reinterpret_cast<device_print_buffer_ptr<int64_t>>(device_print_buffer + offset) = argument;
+        store_64bit_value(device_print_buffer, offset, static_cast<uint64_t>(argument));
     }
 };
 template <>
 struct device_print_type<std::uint64_t> {
     static constexpr device_print_type_info value = {'Q', sizeof(std::uint64_t)};
     static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, uint64_t argument) {
-        *reinterpret_cast<device_print_buffer_ptr<uint64_t>>(device_print_buffer + offset) = argument;
+        store_64bit_value(device_print_buffer, offset, argument);
     }
 };
 template <>
@@ -752,7 +761,7 @@ template <>
 struct device_print_type<double> {
     static constexpr device_print_type_info value = {'d', sizeof(double)};
     static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, double argument) {
-        *reinterpret_cast<device_print_buffer_ptr<double>>(device_print_buffer + offset) = argument;
+        store_64bit_value(device_print_buffer, offset, __builtin_bit_cast(uint64_t, argument));
     }
 };
 template <>
@@ -834,8 +843,7 @@ struct device_print_type<T*> {
             *reinterpret_cast<device_print_buffer_ptr<uint32_t>>(device_print_buffer + offset) =
                 reinterpret_cast<uint32_t>(argument);
         } else if constexpr (sizeof(T*) == 8) {
-            *reinterpret_cast<device_print_buffer_ptr<uint64_t>>(device_print_buffer + offset) =
-                reinterpret_cast<uint64_t>(argument);
+            store_64bit_value(device_print_buffer, offset, reinterpret_cast<uint64_t>(argument));
         } else {
             static_assert(sizeof(T*) == 4 || sizeof(T*) == 8, "Unsupported pointer size");
         }
@@ -845,16 +853,24 @@ template <>
 struct device_print_type<char*> {
     static constexpr device_print_type_info value = {'s', sizeof(char*)};
     static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, char* argument) {
-        *reinterpret_cast<device_print_buffer_ptr<std::uintptr_t>>(device_print_buffer + offset) =
-            reinterpret_cast<std::uintptr_t>(argument);
+        if constexpr (sizeof(std::uintptr_t) == 8) {
+            store_64bit_value(device_print_buffer, offset, reinterpret_cast<std::uintptr_t>(argument));
+        } else {
+            *reinterpret_cast<device_print_buffer_ptr<std::uintptr_t>>(device_print_buffer + offset) =
+                reinterpret_cast<std::uintptr_t>(argument);
+        }
     }
 };
 template <>
 struct device_print_type<const char*> {
     static constexpr device_print_type_info value = {'s', sizeof(const char*)};
     static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, const char* argument) {
-        *reinterpret_cast<device_print_buffer_ptr<std::uintptr_t>>(device_print_buffer + offset) =
-            reinterpret_cast<std::uintptr_t>(argument);
+        if constexpr (sizeof(std::uintptr_t) == 8) {
+            store_64bit_value(device_print_buffer, offset, reinterpret_cast<std::uintptr_t>(argument));
+        } else {
+            *reinterpret_cast<device_print_buffer_ptr<std::uintptr_t>>(device_print_buffer + offset) =
+                reinterpret_cast<std::uintptr_t>(argument);
+        }
     }
 };
 
@@ -864,8 +880,12 @@ template <>
 struct device_print_type<ct_string> {
     static constexpr device_print_type_info value = {'s', sizeof(const char*)};
     static void serialize(device_print_buffer_ptr<uint8_t> device_print_buffer, uint32_t offset, ct_string argument) {
-        *reinterpret_cast<device_print_buffer_ptr<std::uintptr_t>>(device_print_buffer + offset) =
-            reinterpret_cast<std::uintptr_t>(argument.ptr);
+        if constexpr (sizeof(std::uintptr_t) == 8) {
+            store_64bit_value(device_print_buffer, offset, reinterpret_cast<std::uintptr_t>(argument.ptr));
+        } else {
+            *reinterpret_cast<device_print_buffer_ptr<std::uintptr_t>>(device_print_buffer + offset) =
+                reinterpret_cast<std::uintptr_t>(argument.ptr);
+        }
     }
 };
 

--- a/tt_metal/hw/toolchain/erisc-b0-kernel.ld
+++ b/tt_metal/hw/toolchain/erisc-b0-kernel.ld
@@ -32,7 +32,7 @@ SECTIONS
   PROVIDE (__erisc_jump_table = ORIGIN(ERISC_JUMPTABLE));
 
   /* DEVICE_PRINT string table – file-only section, VMA = 0x6400000 */
-  .device_print_strings 0x6400000 :
+  .device_print_strings 0x6400000 (INFO) :
   {
     __device_print_strings_start = .;
     KEEP(*(.device_print_strings))
@@ -41,7 +41,7 @@ SECTIONS
   }
 
   /* DEVICE_PRINT strings info table – file-only section, VMA = 0x6500000 */
-  .device_print_strings_info 0x6500000 :
+  .device_print_strings_info 0x6500000 (INFO) :
   {
       __device_print_strings_info_start = .;
       KEEP(*(.device_print_strings_info))

--- a/tt_metal/hw/toolchain/main.ld
+++ b/tt_metal/hw/toolchain/main.ld
@@ -135,7 +135,7 @@ PHDRS {
 SECTIONS
 {
   /* DEVICE_PRINT string table – file-only section, VMA = 0x6400000 */
-  .device_print_strings 0x6400000 :
+  .device_print_strings 0x6400000 (INFO) :
   {
     __device_print_strings_start = .;
     KEEP(*(.device_print_strings))
@@ -144,7 +144,7 @@ SECTIONS
   }
 
   /* DEVICE_PRINT strings info table – file-only section, VMA = 0x6500000 */
-  .device_print_strings_info 0x6500000 :
+  .device_print_strings_info 0x6500000 (INFO) :
   {
       __device_print_strings_info_start = .;
       KEEP(*(.device_print_strings_info))

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -96,7 +96,14 @@ public:
     HalJitBuildQueryBlackHole(const Hal& hal, bool enable_2_erisc_mode) :
         HalJitBuildQueryBase(hal), enable_2_erisc_mode_(enable_2_erisc_mode) {}
 
-    std::string linker_flags([[maybe_unused]] const Params& params) const override { return ""; }
+    std::string linker_flags([[maybe_unused]] const Params& params) const override {
+        // Suppress LTO false positive on the device-print lock's atomic exchange.
+        // GCC's -Wstringop-overflow object-size analysis treats the fixed L1
+        // mailbox address backing the atomic as a size-0 object. Source-level
+        // #pragma diagnostic doesn't apply to LTO-emitted warnings, so the
+        // suppression has to live on the link command.
+        return "-Wno-stringop-overflow ";
+    }
 
     std::vector<std::string> link_objs(const Params& params) const override {
         std::vector<std::string> objs;


### PR DESCRIPTION
### PR Category
Bug fix


### Summary

Fixes alignment issues when storing 64-bit values in the device print buffer, ensuring proper serialization for various data types. Adds INFO attributes to DEVICE_PRINT string tables in linker scripts to silence one warning and suppresses LTO false positives related to atomic exchanges.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=vjovanovic/fix_dprint_64bit_write_on_rocket)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:vjovanovic/fix_dprint_64bit_write_on_rocket)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=vjovanovic/fix_dprint_64bit_write_on_rocket)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:vjovanovic/fix_dprint_64bit_write_on_rocket)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=vjovanovic/fix_dprint_64bit_write_on_rocket)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:vjovanovic/fix_dprint_64bit_write_on_rocket)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=vjovanovic/fix_dprint_64bit_write_on_rocket)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:vjovanovic/fix_dprint_64bit_write_on_rocket)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=vjovanovic/fix_dprint_64bit_write_on_rocket)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:vjovanovic/fix_dprint_64bit_write_on_rocket)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=vjovanovic/fix_dprint_64bit_write_on_rocket)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:vjovanovic/fix_dprint_64bit_write_on_rocket)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=vjovanovic/fix_dprint_64bit_write_on_rocket)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:vjovanovic/fix_dprint_64bit_write_on_rocket)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=vjovanovic/fix_dprint_64bit_write_on_rocket)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:vjovanovic/fix_dprint_64bit_write_on_rocket)