### PR TITLE
[CI Disable] t3000-unit-tests: skip IntermeshSplit2x2FabricFixture.RandomizedInterMeshUnicast and MultiHostSocketTestSplitT3K.SocketTests on wh_llmbox

### DIFF
--- a/tests/tt_metal/multihost/fabric_tests/intermesh_routing.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/intermesh_routing.cpp
@@ -21,6 +21,7 @@ namespace tt::tt_fabric::fabric_router_tests::multihost {
 // ========= Data-Movement Tests for 2 Host, 1 T3K bringup machine  =========
 
 TEST_F(IntermeshSplit2x2FabricFixture, RandomizedInterMeshUnicast) {
+    GTEST_SKIP() << "Disabled: see #46952";
     for (uint32_t i = 0; i < 100; i++) {
         multihost_utils::RandomizedInterMeshUnicast(this);
     }

--- a/tests/tt_metal/multihost/fabric_tests/socket_send_recv.cpp
+++ b/tests/tt_metal/multihost/fabric_tests/socket_send_recv.cpp
@@ -114,7 +114,10 @@ using MeshDeviceNanoExabox1x8Fixture = MultiHostSocketTest<MeshDeviceNanoExabox1
 using MultiHostSocketTestExabox = MultiHostSocketTest<MeshDeviceExaboxFixture>;
 using MultiHostSocketTestSplitGalaxy = MultiHostSocketTest<SplitGalaxyMeshDeviceFixture>;
 
-TEST_P(MultiHostSocketTestSplitT3K, SocketTests) { RunTest(); }
+TEST_P(MultiHostSocketTestSplitT3K, SocketTests) {
+    GTEST_SKIP() << "Disabled: see #46952";
+    RunTest();
+}
 
 TEST_P(MultiHostSocketTestDualT3K, SocketTests) { RunTest(); }
 


### PR DESCRIPTION
Disable deterministically failing t3000-unit-tests multiprocess socket and intermesh routing tests on wh_llmbox

| Disabled test | Most recent failing main run (job link) | Commit | Run completed at |
|---|---|---|---|
| IntermeshSplit2x2FabricFixture.RandomizedInterMeshUnicast [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshSingleConnectionBwd_SplitT3K_1024_64_2048 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshSingleConnectionFwd_SplitT3K_1024_64_2048 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshMultiConnectionFwd_SplitT3K_1024_64_2048 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiConnectionBidirectional_SplitT3K_1024_64_2048 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshSingleConnectionBwd_SplitT3K_1024_128_4096 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshSingleConnectionFwd_SplitT3K_1024_128_4096 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshMultiConnectionFwd_SplitT3K_1024_128_4096 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiConnectionBidirectional_SplitT3K_1024_128_4096 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshSingleConnectionBwd_SplitT3K_2048_256_4096 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshSingleConnectionFwd_SplitT3K_2048_256_4096 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshMultiConnectionFwd_SplitT3K_2048_256_4096 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiConnectionBidirectional_SplitT3K_2048_256_4096 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshSingleConnectionBwd_SplitT3K_4096_1088_78336 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshSingleConnectionFwd_SplitT3K_4096_1088_78336 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshMultiConnectionFwd_SplitT3K_4096_1088_78336 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiConnectionBidirectional_SplitT3K_4096_1088_78336 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshSingleConnectionBwd_SplitT3K_512_128_16384 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshSingleConnectionFwd_SplitT3K_512_128_16384 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiMeshMultiConnectionFwd_SplitT3K_512_128_16384 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |
| MultiHostSocketTestsSplitT3K/MultiHostSocketTestSplitT3K.SocketTests/MultiConnectionBidirectional_SplitT3K_512_128_16384 [wh_llmbox] | https://github.com/tenstorrent/tt-metal/actions/runs/27480951725/job/81228951510 | [10358b93](https://github.com/tenstorrent/tt-metal/commit/10358b932eda035c3704d5c06183a429da4c5302) | 2026-06-13 23:02 UTC |

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ci-disable/t3000-unit-tests-multiprocess-socket-2026-06-14)