### PR TITLE
[Runtime] Make BuildEnvManager per-ContextId (closes #38661)

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
+++ b/tests/tt_metal/tt_metal/api/test_compiler_include_paths.cpp
@@ -227,8 +227,9 @@ void kernel_main() {
             MetalContext::instance().hal().get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
         const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
         const int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(DataMovementProcessor::RISCV_0);
-        const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
-            device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
+        const JitBuildState& build_state =
+            BuildEnvManager::get_instance(extract_context_id(device))
+                .get_kernel_build_state(device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
         const auto& kernels = program.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
         const std::string full_kernel_name = kernels.at(kernel_handle)->get_full_kernel_name();
         return build_state.get_target_out_path(full_kernel_name);

--- a/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
+++ b/tests/tt_metal/tt_metal/api/test_kernel_compile_cache.cpp
@@ -48,10 +48,12 @@ TEST_F(MeshDeviceFixture, TensixTestEquivalentDataMovementKernelsWithDifferentPr
         const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
         const int riscv_0_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(config_riscv_0.processor);
         const int riscv_1_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(config_riscv_1.processor);
-        const JitBuildState& build_state_riscv_0 = BuildEnvManager::get_instance().get_kernel_build_state(
-            device->build_id(), tensix_core_type, dm_class_idx, riscv_0_id);
-        const JitBuildState& build_state_riscv_1 = BuildEnvManager::get_instance().get_kernel_build_state(
-            device->build_id(), tensix_core_type, dm_class_idx, riscv_1_id);
+        const JitBuildState& build_state_riscv_0 =
+            BuildEnvManager::get_instance(extract_context_id(device))
+                .get_kernel_build_state(device->build_id(), tensix_core_type, dm_class_idx, riscv_0_id);
+        const JitBuildState& build_state_riscv_1 =
+            BuildEnvManager::get_instance(extract_context_id(device))
+                .get_kernel_build_state(device->build_id(), tensix_core_type, dm_class_idx, riscv_1_id);
 
         const auto& kernels = program.impl().get_kernels(static_cast<uint32_t>(HalProgrammableCoreType::TENSIX));
         const std::string full_kernel_name_riscv_0 = kernels.at(kernel_handle_riscv_0)->get_full_kernel_name();

--- a/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
+++ b/tests/tt_metal/tt_metal/api/test_offline_kernel_compile.cpp
@@ -81,8 +81,9 @@ ScopedCopiedPrecompiledRoot precompiled_root_from_live_compile(IDevice* device) 
     JitSrcsBaseline jit_srcs;
     detail::CompileProgram(device, jit_program);
     TT_FATAL(jit_srcs.delta() > 0, "Expected seed JIT compile to invoke jit_build");
-    const fs::path jit_kernel_root =
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path();
+    const fs::path jit_kernel_root = BuildEnvManager::get_instance(extract_context_id(device))
+                                         .get_device_build_env(device->build_id())
+                                         .build_env.get_out_kernel_root_path();
     const fs::path jit_kernel_subdir = jit_kernel_root / kReaderKernelName;
     TT_FATAL(fs::exists(jit_kernel_subdir), "Expected JIT kernel artifacts at {}", jit_kernel_subdir.string());
 

--- a/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
+++ b/tests/tt_metal/tt_metal/debug_tools/debug_tools_fixture.hpp
@@ -308,8 +308,9 @@ public:
 
         int riscv_id = static_cast<std::underlying_type_t<tt::tt_metal::DataMovementProcessor>>(config.processor);
 
-        const auto& build_state = tt::tt_metal::BuildEnvManager::get_instance().get_kernel_build_state(
-            device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
+        const auto& build_state =
+            tt::tt_metal::BuildEnvManager::get_instance(extract_context_id(device))
+                .get_kernel_build_state(device->build_id(), tensix_core_type, dm_class_idx, riscv_id);
 
         const auto& kernel = program_.impl().get_kernel(kernel_handle);
         const std::string full_kernel_name = kernel->get_full_kernel_name();

--- a/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
+++ b/tests/tt_metal/tt_metal/eth/test_erisc_app_direct_send.cpp
@@ -266,10 +266,10 @@ bool send_over_eth(
     // TODO: this should be updated to use kernel api
     uint32_t active_eth_index = tt_metal::MetalContext::instance().hal().get_programmable_core_type_index(
         tt_metal::HalProgrammableCoreType::ACTIVE_ETH);
-    auto sender_firmware_path = tt_metal::BuildEnvManager::get_instance().get_firmware_binary_path(
-        sender_device->build_id(), active_eth_index, 0, 0);
-    auto receiver_firmware_path = tt_metal::BuildEnvManager::get_instance().get_firmware_binary_path(
-        receiver_device->build_id(), active_eth_index, 0, 0);
+    auto sender_firmware_path = tt_metal::BuildEnvManager::get_instance(extract_context_id(sender_device))
+                                    .get_firmware_binary_path(sender_device->build_id(), active_eth_index, 0, 0);
+    auto receiver_firmware_path = tt_metal::BuildEnvManager::get_instance(extract_context_id(receiver_device))
+                                      .get_firmware_binary_path(receiver_device->build_id(), active_eth_index, 0, 0);
     const ll_api::memory& binary_mem_send = llrt::get_risc_binary(sender_firmware_path);
     const ll_api::memory& binary_mem_receive = llrt::get_risc_binary(receiver_firmware_path);
 

--- a/tests/tt_metal/tt_metal/test_compile_args.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_args.cpp
@@ -67,12 +67,12 @@ int main(int argc, char** argv) {
         tt_metal::IDevice* device = tt_metal::CreateDevice(device_id);
         // Remove old compiled kernels
         static const std::string kernel_name = "test_compile_args";
-        auto binary_path_str =
-            kernel
-                ->binaries(
-                    tt::tt_metal::BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env)
-                .get_out_kernel_root_path() +
-            kernel_name;
+        auto binary_path_str = kernel
+                                   ->binaries(tt::tt_metal::BuildEnvManager::get_instance(extract_context_id(device))
+                                                  .get_device_build_env(device->build_id())
+                                                  .build_env)
+                                   .get_out_kernel_root_path() +
+                               kernel_name;
         std::filesystem::remove_all(binary_path_str);
 
         pass &= test_compile_args({0, 68, 0, 124}, device);

--- a/tests/tt_metal/tt_metal/test_compile_program.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_program.cpp
@@ -68,13 +68,17 @@ std::unordered_map<std::string, std::string> get_last_program_binary_path(
 KernelCacheStatus CompileProgramTestWrapper(IDevice* device, Program& program, bool /*profile_kernel*/ = false) {
     std::unordered_map<std::string, std::string> pre_compile_kernel_to_hash_str = get_last_program_binary_path(
         program,
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path());
+        BuildEnvManager::get_instance(extract_context_id(device))
+            .get_device_build_env(device->build_id())
+            .build_env.get_out_kernel_root_path());
 
     detail::CompileProgram(device, program);
 
     std::unordered_map<std::string, std::string> post_compile_kernel_to_hash_str = get_last_program_binary_path(
         program,
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path());
+        BuildEnvManager::get_instance(extract_context_id(device))
+            .get_device_build_env(device->build_id())
+            .build_env.get_out_kernel_root_path());
 
     KernelCacheStatus kernel_cache_status;
     for (const auto& [kernel_name, hash_str] : post_compile_kernel_to_hash_str) {
@@ -230,7 +234,9 @@ std::unordered_map<std::string, std::string> compile_program_with_modified_kerne
     auto kernel_cache_status = CompileProgramTestWrapper(device, program);
     assert_kernel_binary_path_exists(
         program,
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env.get_out_kernel_root_path(),
+        BuildEnvManager::get_instance(extract_context_id(device))
+            .get_device_build_env(device->build_id())
+            .build_env.get_out_kernel_root_path(),
         kernel_cache_status);
     assert_cache_hit_status_for_kernel_type(program, kernel_type_to_cache_hit_status, kernel_cache_status);
     assert_hash_comparison_for_kernel_type(
@@ -244,8 +250,9 @@ std::unordered_map<std::string, std::string> compile_program_with_modified_kerne
 TEST_F(MeshDispatchFixture, CompileProgramInLoop) {
     IDevice* dev = devices_[0]->get_devices()[0];
 
-    ClearKernelCache(
-        BuildEnvManager::get_instance().get_device_build_env(dev->build_id()).build_env.get_out_kernel_root_path());
+    ClearKernelCache(BuildEnvManager::get_instance(extract_context_id(dev))
+                         .get_device_build_env(dev->build_id())
+                         .build_env.get_out_kernel_root_path());
     ProgramAttributes default_attributes;
     auto program = create_program(dev, default_attributes);
 
@@ -256,7 +263,7 @@ TEST_F(MeshDispatchFixture, CompileProgramInLoop) {
         if (compile_idx == 0) {
             assert_kernel_binary_path_exists(
                 program,
-                BuildEnvManager::get_instance()
+                BuildEnvManager::get_instance(extract_context_id(dev))
                     .get_device_build_env(dev->build_id())
                     .build_env.get_out_kernel_root_path(),
                 kernel_cache_status);
@@ -272,8 +279,9 @@ TEST_F(MeshDispatchFixture, CompileProgramInLoop) {
 TEST_F(MeshDispatchFixture, CompileProgramAfterCleanKernelBinaryDirectory) {
     IDevice* dev = devices_[0]->get_devices()[0];
 
-    ClearKernelCache(
-        BuildEnvManager::get_instance().get_device_build_env(dev->build_id()).build_env.get_out_kernel_root_path());
+    ClearKernelCache(BuildEnvManager::get_instance(extract_context_id(dev))
+                         .get_device_build_env(dev->build_id())
+                         .build_env.get_out_kernel_root_path());
 
     ProgramAttributes default_attributes;
     auto program = create_program(dev, default_attributes);
@@ -282,13 +290,16 @@ TEST_F(MeshDispatchFixture, CompileProgramAfterCleanKernelBinaryDirectory) {
 
     assert_kernel_binary_path_exists(
         program,
-        BuildEnvManager::get_instance().get_device_build_env(dev->build_id()).build_env.get_out_kernel_root_path(),
+        BuildEnvManager::get_instance(extract_context_id(dev))
+            .get_device_build_env(dev->build_id())
+            .build_env.get_out_kernel_root_path(),
         kernel_cache_status);
     assert_program_cache_hit_status(program, /*hit_expected=*/false, kernel_cache_status);
     std::unordered_map<std::string, std::string> kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;
 
-    ClearKernelCache(
-        BuildEnvManager::get_instance().get_device_build_env(dev->build_id()).build_env.get_out_kernel_root_path());
+    ClearKernelCache(BuildEnvManager::get_instance(extract_context_id(dev))
+                         .get_device_build_env(dev->build_id())
+                         .build_env.get_out_kernel_root_path());
     auto second_program = create_program(dev, default_attributes);
     auto second_kernel_cache_status = CompileProgramTestWrapper(dev, second_program);
     assert_program_cache_hit_status(second_program, /*hit_expected=*/false, second_kernel_cache_status);
@@ -310,15 +321,18 @@ TEST_F(MeshDispatchFixture, CompileProgramWithModifiedProgram) {
     const static std::unordered_map<HalProcessorClassType, bool> compute_miss_data_movement_miss = {
         {HalProcessorClassType::COMPUTE, false}, {HalProcessorClassType::DM, false}};
 
-    ClearKernelCache(
-        BuildEnvManager::get_instance().get_device_build_env(dev->build_id()).build_env.get_out_kernel_root_path());
+    ClearKernelCache(BuildEnvManager::get_instance(extract_context_id(dev))
+                         .get_device_build_env(dev->build_id())
+                         .build_env.get_out_kernel_root_path());
 
     ProgramAttributes attributes;
     auto program = create_program(dev, attributes);
     auto kernel_cache_status = CompileProgramTestWrapper(dev, program);
     assert_kernel_binary_path_exists(
         program,
-        BuildEnvManager::get_instance().get_device_build_env(dev->build_id()).build_env.get_out_kernel_root_path(),
+        BuildEnvManager::get_instance(extract_context_id(dev))
+            .get_device_build_env(dev->build_id())
+            .build_env.get_out_kernel_root_path(),
         kernel_cache_status);
     assert_program_cache_hit_status(program, /*hit_expected=*/false, kernel_cache_status);
     std::unordered_map<std::string, std::string> kernel_name_to_hash = kernel_cache_status.kernel_name_to_hash_str;

--- a/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
+++ b/tests/tt_metal/tt_metal/test_compile_sets_kernel_binaries.cpp
@@ -159,7 +159,9 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
         }
         TT_FATAL(compute_kernel != nullptr && riscv0_kernel != nullptr && riscv1_kernel != nullptr, "Error");
 
-        auto mask = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key();
+        auto mask = BuildEnvManager::get_instance(extract_context_id(device))
+                        .get_device_build_env(device->build_id())
+                        .build_key();
         detail::CompileProgram(device, program);
         compute_binaries.insert({mask, compute_kernel->binaries(mask)});
         TT_FATAL(compute_binaries.at(mask).size() == 3, "Expected 3 Compute binaries!");
@@ -175,7 +177,7 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
         for (int i = 0; i < num_devices_; i++) {
             for (const auto& kernel_name : kernel_names) {
                 std::filesystem::remove_all(
-                    BuildEnvManager::get_instance()
+                    BuildEnvManager::get_instance(extract_context_id(devices_[i]))
                         .get_device_build_env(devices_[i]->id())
                         .build_env.get_out_kernel_root_path() +
                     kernel_name);
@@ -199,7 +201,9 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
             auto& program = new_programs[i];
             ths.emplace_back([&] {
                 for (int j = 0; j < num_compiles; j++) {
-                    auto mask = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key();
+                    auto mask = BuildEnvManager::get_instance(extract_context_id(device))
+                                    .get_device_build_env(device->build_id())
+                                    .build_key();
                     detail::CompileProgram(device, program);
                     uint32_t programmable_core_index = MetalContext::instance().hal().get_programmable_core_type_index(
                         HalProgrammableCoreType::TENSIX);
@@ -228,12 +232,12 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
                     TT_FATAL(riscv1_kernel->binaries(mask) == ncrisc_binaries.at(mask), "Error");
 
                     std::string kernel_name = get_latest_kernel_binary_path(
-                        BuildEnvManager::get_instance()
+                        BuildEnvManager::get_instance(extract_context_id(device))
                             .get_device_build_env(device->build_id())
                             .build_env.get_out_kernel_root_path(),
                         riscv0_kernel);
                     std::string brisc_hex_path =
-                        BuildEnvManager::get_instance()
+                        BuildEnvManager::get_instance(extract_context_id(device))
                             .get_kernel_build_state(device->build_id(), programmable_core_index, dm_class_idx, 0)
                             .get_target_out_path(kernel_name);
                     const ll_api::memory& brisc_binary =
@@ -242,12 +246,12 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
                         brisc_binary == *brisc_binaries.at(mask).at(0),
                         "Expected saved BRISC binary to be the same as binary in persistent cache");
                     kernel_name = get_latest_kernel_binary_path(
-                        BuildEnvManager::get_instance()
+                        BuildEnvManager::get_instance(extract_context_id(device))
                             .get_device_build_env(device->build_id())
                             .build_env.get_out_kernel_root_path(),
                         riscv1_kernel);
                     std::string ncrisc_hex_path =
-                        BuildEnvManager::get_instance()
+                        BuildEnvManager::get_instance(extract_context_id(device))
                             .get_kernel_build_state(device->build_id(), programmable_core_index, dm_class_idx, 1)
                             .get_target_out_path(kernel_name);
                     auto load_type = (device->arch() == tt::ARCH::WORMHOLE_B0)
@@ -259,13 +263,13 @@ TEST_F(CompileSetsKernelBinariesFixture, CompileSetsKernelBinaries) {
                         "Expected saved NCRISC binary to be the same as binary in persistent cache");
                     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
                         kernel_name = get_latest_kernel_binary_path(
-                            BuildEnvManager::get_instance()
+                            BuildEnvManager::get_instance(extract_context_id(device))
                                 .get_device_build_env(device->build_id())
                                 .build_env.get_out_kernel_root_path(),
                             compute_kernel);
                         std::string trisc_id_str = std::to_string(trisc_id);
                         std::string trisc_hex_path =
-                            BuildEnvManager::get_instance()
+                            BuildEnvManager::get_instance(extract_context_id(device))
                                 .get_kernel_build_state(
                                     device->build_id(), programmable_core_index, compute_class_idx, trisc_id)
                                 .get_target_out_path(kernel_name);

--- a/tt_metal/impl/context/metal_context.cpp
+++ b/tt_metal/impl/context/metal_context.cpp
@@ -220,7 +220,7 @@ void MetalContext::initialize(
                 rank = *world_context->rank();
             }
         }
-        inspector_data_ = Inspector::initialize(rank);
+        inspector_data_ = Inspector::initialize(rank, get_context_id());
         // Set fw_compile_hash for Inspector RPC build environment info
         Inspector::set_build_env_fw_compile_hash(fw_compile_hash);
     }
@@ -430,10 +430,10 @@ ContextId MetalContext::create_default_instance_implicit_locked() {
     instance->env_owned_ = true;
 
     g_instances[DEFAULT_CONTEXT_ID.get()].store(instance, std::memory_order_release);
-    // Seed the process-wide BuildEnvManager singleton with this context's HAL on first call,
+    // Seed the per-context BuildEnvManager slot with this context's HAL on first call,
     // no-op thereafter. Using the by-HAL form (rather than get_instance(ContextId)) avoids
     // re-entering MetalContext::instance() while we hold g_instance_mutex.
-    BuildEnvManager::seed_if_unseeded_with_hal(instance->hal());
+    BuildEnvManager::seed_if_unseeded_with_hal(DEFAULT_CONTEXT_ID, instance->hal());
     return DEFAULT_CONTEXT_ID;
 }
 
@@ -448,16 +448,16 @@ ContextId MetalContext::create_instance(MetalEnv& env_to_use) {
         }
         MetalContext* instance = new MetalContext(DEFAULT_CONTEXT_ID, env_to_use);
         g_instances[DEFAULT_CONTEXT_ID.get()].store(instance, std::memory_order_release);
-        // Seed the process-wide BuildEnvManager with this context's HAL on first call.
+        // Seed the per-context BuildEnvManager slot with this context's HAL on first call.
         // By-HAL form avoids re-entering MetalContext::instance() while holding g_instance_mutex.
-        BuildEnvManager::seed_if_unseeded_with_hal(instance->hal());
+        BuildEnvManager::seed_if_unseeded_with_hal(DEFAULT_CONTEXT_ID, instance->hal());
         return DEFAULT_CONTEXT_ID;
     }
 
     ContextId context_id = find_free_context_id_locked();
     MetalContext* instance = new MetalContext(context_id, env_to_use);
     g_instances[context_id.get()].store(instance, std::memory_order_release);
-    BuildEnvManager::seed_if_unseeded_with_hal(instance->hal());
+    BuildEnvManager::seed_if_unseeded_with_hal(context_id, instance->hal());
     return context_id;
 }
 
@@ -478,6 +478,8 @@ void MetalContext::destroy_instance(bool check_device_count, ContextId context_i
     // Only store to g_instance after the instance is deleted to allow MetalContext::instance() calls during teardown to
     // return the old instance.
     g_instances[index].store(nullptr, std::memory_order_release);
+    // Free the slot so a recycled context_id reseeds fresh.
+    BuildEnvManager::destroy_for_context(context_id);
 }
 
 void MetalContext::destroy_all_instances(bool check_device_count) {

--- a/tt_metal/impl/debug/dprint_server.cpp
+++ b/tt_metal/impl/debug/dprint_server.cpp
@@ -429,11 +429,12 @@ void DPrintServer::Impl::print_buffer_data(
                     // Find firmware elf path from BuildEnvManager.
                     auto [processor_class, processor_type_idx] =
                         hal.get_processor_class_and_type_from_index(programmable_core_type, header->risc_id);
-                    auto firmware_elf_path = BuildEnvManager::get_instance().get_firmware_binary_path(
-                        device_id,
-                        programmable_core_type_idx,
-                        static_cast<uint32_t>(processor_class),
-                        processor_type_idx);
+                    auto firmware_elf_path = BuildEnvManager::get_instance(context_->get_context_id())
+                                                 .get_firmware_binary_path(
+                                                     device_id,
+                                                     programmable_core_type_idx,
+                                                     static_cast<uint32_t>(processor_class),
+                                                     processor_type_idx);
 
                     risc_data.firmware_elf_path = firmware_elf_path;
                     risc_data.firmware_elf_parser = DevicePrintParser::get_parser_for_elf(firmware_elf_path);

--- a/tt_metal/impl/debug/inspector/data.cpp
+++ b/tt_metal/impl/debug/inspector/data.cpp
@@ -41,7 +41,8 @@ std::string stringify_tensor_specs(const std::vector<TensorSpec>& tensor_specs) 
     return std::string(buf.data(), buf.size());
 }
 
-Data::Data(std::optional<int> rank) : logger(MetalContext::instance().rtoptions().get_inspector_log_path(), rank) {
+Data::Data(std::optional<int> rank, ContextId context_id) :
+    context_id(context_id), logger(MetalContext::instance().rtoptions().get_inspector_log_path(), rank) {
     // Initialize RPC server if enabled
     const auto& rtoptions = MetalContext::instance().rtoptions();
     if (rtoptions.get_inspector_rpc_server_enabled()) {
@@ -280,9 +281,9 @@ void Data::rpc_get_kernel(rpc::Inspector::GetKernelParams::Reader params, rpc::I
 // Declared here in Data to centralize Inspector RPC callback registration and
 // tie it to Inspector Data's lifetime
 void Data::rpc_get_all_build_envs(rpc::Inspector::GetAllBuildEnvsResults::Builder results) {
-    // Get build environment info for all devices
-    // Calls to BuildEnvManager::get_all_build_envs_info are thread-safe as it's protected by an internal mutex
-    const auto& build_envs_info = BuildEnvManager::get_instance().get_all_build_envs_info();
+    // Get build environment info for all devices in this Inspector's owning MetalContext.
+    // Calls to BuildEnvManager::get_all_build_envs_info are thread-safe as it's protected by an internal mutex.
+    const auto& build_envs_info = BuildEnvManager::get_instance(context_id).get_all_build_envs_info();
     // Populate RPC response with build environment info for all devices
     auto result_build_envs = results.initBuildEnvs(build_envs_info.size());
     const auto fw_compile_hash = this->fw_compile_hash.load(std::memory_order_acquire);

--- a/tt_metal/impl/debug/inspector/data.hpp
+++ b/tt_metal/impl/debug/inspector/data.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "impl/context/context_types.hpp"
 #include "impl/debug/inspector/logger.hpp"
 #include "impl/debug/inspector/rpc_server_controller.hpp"
 #include <tt-metalium/mesh_trace_id.hpp>
@@ -19,7 +20,9 @@ public:
     ~Data();
 
 private:
-    Data(std::optional<int> rank);  // NOLINT - False alarm, tt::tt_metal::Inspector is calling this constructor.
+    Data(
+        std::optional<int> rank,
+        ContextId context_id);  // NOLINT - False alarm, tt::tt_metal::Inspector is calling this constructor.
 
     void serialize_rpc();
     RpcServer& get_rpc_server();
@@ -48,6 +51,8 @@ private:
         rpc::CoreCategory category_type,
         const std::unordered_map<tt_cxy_pair, CoreInfo>& core_info,
         const std::unordered_map<ChipId, std::vector<uint32_t>>& cq_to_event_by_device);
+
+    ContextId context_id;  // Owning MetalContext's id
 
     inspector::Logger logger;
     RpcServerController rpc_server_controller;

--- a/tt_metal/impl/debug/inspector/inspector.cpp
+++ b/tt_metal/impl/debug/inspector/inspector.cpp
@@ -42,13 +42,13 @@ bool Inspector::is_enabled() {
     return false;
 }
 
-std::unique_ptr<inspector::Data> Inspector::initialize(std::optional<int> rank) {
+std::unique_ptr<inspector::Data> Inspector::initialize(std::optional<int> rank, ContextId context_id) {
     if (!is_enabled()) {
         // Inspector is not enabled, skipping initialization.
         return nullptr;
     }
     try {
-        auto* data = new inspector::Data(rank);
+        auto* data = new inspector::Data(rank, context_id);
 
         return std::unique_ptr<inspector::Data>(data);
     } catch (const std::exception& e) {

--- a/tt_metal/impl/debug/inspector/inspector.hpp
+++ b/tt_metal/impl/debug/inspector/inspector.hpp
@@ -7,6 +7,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include "impl/context/context_types.hpp"
 #include "impl/program/program_impl.hpp"
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/mesh_trace_id.hpp>
@@ -29,7 +30,7 @@ class Inspector {
 public:
     static bool is_enabled();
 
-    static std::unique_ptr<inspector::Data> initialize(std::optional<int> rank);
+    static std::unique_ptr<inspector::Data> initialize(std::optional<int> rank, ContextId context_id);
     static void serialize_rpc();
 
     static void program_created(const detail::ProgramImpl* program) noexcept;

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -166,8 +166,8 @@ void RiscFirmwareInitializer::run_async_build_phase(const std::set<tt::ChipId>& 
 
             // Register the build env unconditionally so JIT compilation (CompileProgram) works on mock
             // and emulated devices too. The build env is HAL/arch-derived and does not probe hardware.
-            BuildEnvManager::get_instance().add_build_env(
-                device_id, num_hw_cqs_, descriptor_->metal_context().get_context_id());
+            const ContextId ctx_id = descriptor_->metal_context().get_context_id();
+            BuildEnvManager::get_instance(ctx_id).add_build_env(device_id, num_hw_cqs_, ctx_id);
             // build_firmware() is a pure compile/link step that doesn't touch hardware, and the
             // resulting ELFs export symbols (e.g. __fw_export_text_end) that kernel linker scripts
             // depend on -- without them, JIT-compiling kernels on a mock device fails with
@@ -182,7 +182,7 @@ void RiscFirmwareInitializer::run_async_build_phase(const std::set<tt::ChipId>& 
                                        (cluster_.get_target_device_type() == tt::TargetDevice::Mock &&
                                         !mock_firmware_sources_available_for(cluster_.arch()));
             if (!skip_fw_build) {
-                BuildEnvManager::get_instance().build_firmware(device_id);
+                BuildEnvManager::get_instance(ctx_id).build_firmware(device_id);
             }
             if (!cluster_.is_mock_or_emulated()) {
                 // Clear the entire launch message ring buffer on ethernet cores before application firmware is
@@ -1015,6 +1015,8 @@ void RiscFirmwareInitializer::initialize_firmware(
     std::optional<CoreCoord> end_core) {
     ZoneScoped;
 
+    const ContextId ctx_id = descriptor_->metal_context().get_context_id();
+
     TT_FATAL(
         core_type != HalProgrammableCoreType::TENSIX or end_core.has_value(),
         "Tensix cores require end_core to be specified for bank to noc table initialization.");
@@ -1096,10 +1098,10 @@ void RiscFirmwareInitializer::initialize_firmware(
     switch (core_type) {
         case HalProgrammableCoreType::TENSIX: {
             for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
-                auto [_, num_build_states] = BuildEnvManager::get_instance().get_build_index_and_state_count(
+                auto [_, num_build_states] = BuildEnvManager::get_instance(ctx_id).get_build_index_and_state_count(
                     core_type_idx, processor_class, true);
                 for (uint32_t riscv_id = 0; riscv_id < num_build_states; riscv_id++) {
-                    auto fw_path = BuildEnvManager::get_instance().get_firmware_binary_path(
+                    auto fw_path = BuildEnvManager::get_instance(ctx_id).get_firmware_binary_path(
                         device_id, core_type_idx, processor_class, riscv_id);
                     const ll_api::memory& binary_mem = llrt::get_risc_binary(fw_path);
                     uint32_t fw_size = binary_mem.get_text_size();
@@ -1169,7 +1171,7 @@ void RiscFirmwareInitializer::initialize_firmware(
                 for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
                     auto num_build_states = hal_.get_processor_types_count(core_type_idx, processor_class);
                     for (uint32_t eriscv_id = 0; eriscv_id < num_build_states; eriscv_id++) {
-                        auto fw_path = BuildEnvManager::get_instance().get_firmware_binary_path(
+                        auto fw_path = BuildEnvManager::get_instance(ctx_id).get_firmware_binary_path(
                             device_id, core_type_idx, processor_class, eriscv_id);
                         const ll_api::memory& binary_mem = llrt::get_risc_binary(fw_path);
                         llrt::test_load_write_read_risc_binary(
@@ -1221,7 +1223,7 @@ void RiscFirmwareInitializer::initialize_firmware(
                 for (uint32_t processor_class = 0; processor_class < processor_class_count; processor_class++) {
                     auto num_build_states = hal_.get_processor_types_count(core_type_idx, processor_class);
                     for (uint32_t drisc_id = 0; drisc_id < num_build_states; drisc_id++) {
-                        auto fw_path = BuildEnvManager::get_instance().get_firmware_binary_path(
+                        auto fw_path = BuildEnvManager::get_instance(ctx_id).get_firmware_binary_path(
                             device_id, core_type_idx, processor_class, drisc_id);
                         const ll_api::memory& binary_mem = llrt::get_risc_binary(fw_path);
                         llrt::test_load_write_read_risc_binary(

--- a/tt_metal/impl/jit_server/remote_compile_coordinator.cpp
+++ b/tt_metal/impl/jit_server/remote_compile_coordinator.cpp
@@ -26,8 +26,9 @@ std::unordered_map<std::string, std::shared_future<void>> RemoteCompileCoordinat
 std::unordered_map<uint64_t, jit_server::UploadFirmwareRequest> RemoteCompileCoordinator::s_fw_cache_;
 
 RemoteCompileCoordinator::RemoteCompileCoordinator(
-    std::vector<std::string> endpoints, ChipId device_build_id, uint64_t build_key) :
+    std::vector<std::string> endpoints, ContextId context_id, ChipId device_build_id, uint64_t build_key) :
     endpoints_(std::move(endpoints)),
+    context_id_(context_id),
     device_build_id_(device_build_id),
     build_key_(build_key),
     sessions_(endpoints_.size()),
@@ -160,7 +161,7 @@ const jit_server::UploadFirmwareRequest& RemoteCompileCoordinator::get_firmware_
     std::lock_guard lock(s_fw_gate_mutex_);
     auto it = s_fw_cache_.find(build_key_);
     if (it == s_fw_cache_.end()) {
-        const auto& dev_env = BuildEnvManager::get_instance().get_device_build_env(device_build_id_);
+        const auto& dev_env = BuildEnvManager::get_instance(context_id_).get_device_build_env(device_build_id_);
 
         jit_server::UploadFirmwareRequest req;
         req.build_key = build_key_;

--- a/tt_metal/impl/jit_server/remote_compile_coordinator.hpp
+++ b/tt_metal/impl/jit_server/remote_compile_coordinator.hpp
@@ -14,6 +14,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "impl/context/context_types.hpp"
 #include "impl/jit_server/jit_compile_rpc_client.hpp"
 #include "impl/jit_server/types.hpp"
 #include <umd/device/types/cluster_descriptor_types.hpp>
@@ -41,7 +42,8 @@ struct KernelCompileDescriptor {
 // program.cpp prepares descriptors; this class owns all mechanics.
 class RemoteCompileCoordinator {
 public:
-    RemoteCompileCoordinator(std::vector<std::string> endpoints, ChipId device_build_id, uint64_t build_key);
+    RemoteCompileCoordinator(
+        std::vector<std::string> endpoints, ContextId context_id, ChipId device_build_id, uint64_t build_key);
     ~RemoteCompileCoordinator();
 
     RemoteCompileCoordinator(const RemoteCompileCoordinator&) = delete;
@@ -65,6 +67,7 @@ private:
 
     // -- Configuration (immutable after construction) --
     std::vector<std::string> endpoints_;
+    ContextId context_id_;
     ChipId device_build_id_;
     uint64_t build_key_;
 

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -355,13 +355,14 @@ bool Kernel::binaries_exist_on_disk(const IDevice* device, const std::string& bi
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t processor_class = enchantum::to_underlying(this->get_kernel_processor_class());
     for (int i = 0; i < this->expected_num_binaries(); ++i) {
-        auto elf_path = BuildEnvManager::get_instance().get_kernel_binary_path(
-            device->build_id(),
-            core_type,
-            processor_class,
-            this->get_kernel_processor_type(i),
-            binary_root,
-            this->kernel_full_name_);
+        auto elf_path = BuildEnvManager::get_instance(extract_context_id(device))
+                            .get_kernel_binary_path(
+                                device->build_id(),
+                                core_type,
+                                processor_class,
+                                this->get_kernel_processor_type(i),
+                                binary_root,
+                                this->kernel_full_name_);
 
         if (!std::filesystem::exists(elf_path)) {
             return false;
@@ -377,13 +378,14 @@ std::vector<std::string> Kernel::file_paths(const IDevice& device, const std::st
     uint32_t core_type = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t processor_class = enchantum::to_underlying(this->get_kernel_processor_class());
     for (int i = 0; i < this->expected_num_binaries(); i++) {
-        file_paths.push_back(BuildEnvManager::get_instance().get_kernel_binary_path(
-            device.build_id(),
-            core_type,
-            processor_class,
-            this->get_kernel_processor_type(i),
-            binary_root,
-            this->kernel_full_name_));
+        file_paths.push_back(BuildEnvManager::get_instance(extract_context_id(&device))
+                                 .get_kernel_binary_path(
+                                     device.build_id(),
+                                     core_type,
+                                     processor_class,
+                                     this->get_kernel_processor_type(i),
+                                     binary_root,
+                                     this->kernel_full_name_));
     }
     return file_paths;
 }
@@ -767,13 +769,15 @@ detail::KernelMeta Kernel::meta(IDevice* device) const {
 
 uint32_t Kernel::get_binary_packed_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary
-    auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
+    auto iter = binaries_.find(
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key());
     return iter != this->binaries_.end() ? iter->second[index]->get_packed_size() : 0;
 }
 
 uint32_t Kernel::get_binary_text_size(IDevice* device, int index) const {
     // In testing situations we can query the size w/o a binary
-    auto iter = binaries_.find(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
+    auto iter = binaries_.find(
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key());
     return iter != this->binaries_.end() ? iter->second[index]->get_text_size() : 0;
 }
 
@@ -788,49 +792,58 @@ void ComputeKernel::set_build_options(JitBuildOptions& build_options) const {
 
 void DataMovementKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
     jit_build_genfiles_kernel_include(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
+        *this,
+        this->kernel_src_);
     uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(this->config_.processor);
     jit_build(
-        BuildEnvManager::get_instance().get_kernel_build_state(
-            device->build_id(), tensix_core_type, dm_class_idx, riscv_id),
+        BuildEnvManager::get_instance(extract_context_id(device))
+            .get_kernel_build_state(device->build_id(), tensix_core_type, dm_class_idx, riscv_id),
         this);
 }
 
 void EthernetKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
     jit_build_genfiles_kernel_include(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
+        *this,
+        this->kernel_src_);
     uint32_t erisc_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     int erisc_id = enchantum::to_underlying(this->config_.processor);
     jit_build(
-        BuildEnvManager::get_instance().get_kernel_build_state(
-            device->build_id(), erisc_core_type, dm_class_idx, erisc_id),
+        BuildEnvManager::get_instance(extract_context_id(device))
+            .get_kernel_build_state(device->build_id(), erisc_core_type, dm_class_idx, erisc_id),
         this);
 }
 
 void DramKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
     jit_build_genfiles_kernel_include(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
+        *this,
+        this->kernel_src_);
     uint32_t dram_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
     jit_build(
-        BuildEnvManager::get_instance().get_kernel_build_state(device->build_id(), dram_core_type, dm_class_idx, 0),
+        BuildEnvManager::get_instance(extract_context_id(device))
+            .get_kernel_build_state(device->build_id(), dram_core_type, dm_class_idx, 0),
         this);
 }
 
 void ComputeKernel::generate_binaries(IDevice* device, JitBuildOptions& /*build_options*/) const {
     jit_build_genfiles_triscs_src(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
+        *this,
+        this->kernel_src_);
     uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
-    auto build_states = BuildEnvManager::get_instance().get_kernel_build_states(
-        device->build_id(), tensix_core_type, compute_class_idx);
+    auto build_states = BuildEnvManager::get_instance(extract_context_id(device))
+                            .get_kernel_build_states(device->build_id(), tensix_core_type, compute_class_idx);
     jit_build_subset(build_states, this);
 }
 
@@ -857,14 +870,17 @@ void DataMovementKernel::read_binaries(IDevice* device, const std::string& binar
     int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(this->config_.processor);
     auto load_type =
         MetalContext::instance().hal().get_jit_build_config(tensix_core_type, dm_class_idx, riscv_id).memory_load;
-    const auto binary_path = BuildEnvManager::get_instance().get_kernel_binary_path(
-        device->build_id(), tensix_core_type, dm_class_idx, riscv_id, binary_root, this->kernel_full_name_);
+    const auto binary_path =
+        BuildEnvManager::get_instance(extract_context_id(device))
+            .get_kernel_binary_path(
+                device->build_id(), tensix_core_type, dm_class_idx, riscv_id, binary_root, this->kernel_full_name_);
     const ll_api::memory& binary_mem = llrt::get_risc_binary(binary_path, load_type);
     binaries.push_back(&binary_mem);
     [[maybe_unused]] uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "RISC={}, name={}, size={} (bytes)", riscv_id, this->name(), binary_size);
     this->set_binaries(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key(), std::move(binaries));
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key(),
+        std::move(binaries));
 }
 
 void DramKernel::read_binaries(IDevice* device, const std::string& binary_root) {
@@ -874,13 +890,16 @@ void DramKernel::read_binaries(IDevice* device, const std::string& binary_root) 
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     constexpr auto k_DmClassIndex = enchantum::to_underlying(HalProcessorClassType::DM);
     auto load_type = MetalContext::instance().hal().get_jit_build_config(dram_core_type, k_DmClassIndex, 0).memory_load;
-    const auto binary_path = BuildEnvManager::get_instance().get_kernel_binary_path(
-        device->build_id(), dram_core_type, k_DmClassIndex, 0, binary_root, this->kernel_full_name_);
+    const auto binary_path =
+        BuildEnvManager::get_instance(extract_context_id(device))
+            .get_kernel_binary_path(
+                device->build_id(), dram_core_type, k_DmClassIndex, 0, binary_root, this->kernel_full_name_);
     const ll_api::memory& binary_mem = llrt::get_risc_binary(binary_path, load_type);
     binaries.push_back(&binary_mem);
     log_debug(LogLoader, "DRISC=0, name={}, size={} (bytes)", this->name(), binary_mem.get_packed_size());
     this->set_binaries(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key(), std::move(binaries));
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key(),
+        std::move(binaries));
 }
 
 void EthernetKernel::read_binaries(IDevice* device, const std::string& binary_root) {
@@ -894,8 +913,10 @@ void EthernetKernel::read_binaries(IDevice* device, const std::string& binary_ro
     // TODO: fix when active eth supports relo
     auto load_type =
         MetalContext::instance().hal().get_jit_build_config(erisc_core_type, k_EthDmClassIndex, erisc_id).memory_load;
-    const auto binary_path = BuildEnvManager::get_instance().get_kernel_binary_path(
-        device->build_id(), erisc_core_type, k_EthDmClassIndex, erisc_id, binary_root, this->kernel_full_name_);
+    const auto binary_path =
+        BuildEnvManager::get_instance(extract_context_id(device))
+            .get_kernel_binary_path(
+                device->build_id(), erisc_core_type, k_EthDmClassIndex, erisc_id, binary_root, this->kernel_full_name_);
     const ll_api::memory& binary_mem =
         llrt::get_risc_binary(binary_path, load_type, [this](ll_api::memory& binary_mem) {
             if (tt::tt_metal::MetalContext::instance().rtoptions().get_erisc_iram_enabled() &&
@@ -915,7 +936,8 @@ void EthernetKernel::read_binaries(IDevice* device, const std::string& binary_ro
     [[maybe_unused]] uint32_t binary_size = binary_mem.get_packed_size();
     log_debug(LogLoader, "ERISC={}, name={}, size={} (bytes)", erisc_id, this->name(), binary_size);
     this->set_binaries(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key(), std::move(binaries));
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key(),
+        std::move(binaries));
 }
 
 void ComputeKernel::read_binaries(IDevice* device, const std::string& binary_root) {
@@ -929,13 +951,20 @@ void ComputeKernel::read_binaries(IDevice* device, const std::string& binary_roo
                              .hal()
                              .get_jit_build_config(tensix_core_type, compute_class_idx, trisc_id)
                              .memory_load;
-        const auto binary_path = BuildEnvManager::get_instance().get_kernel_binary_path(
-            device->build_id(), tensix_core_type, compute_class_idx, trisc_id, binary_root, this->kernel_full_name_);
+        const auto binary_path = BuildEnvManager::get_instance(extract_context_id(device))
+                                     .get_kernel_binary_path(
+                                         device->build_id(),
+                                         tensix_core_type,
+                                         compute_class_idx,
+                                         trisc_id,
+                                         binary_root,
+                                         this->kernel_full_name_);
         const ll_api::memory& binary_mem = llrt::get_risc_binary(binary_path, load_type);
         binaries.push_back(&binary_mem);
     }
     this->set_binaries(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key(), std::move(binaries));
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key(),
+        std::move(binaries));
 }
 
 bool DataMovementKernel::configure(
@@ -945,8 +974,9 @@ bool DataMovementKernel::configure(
     }
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
-    const ll_api::memory& binary_mem =
-        *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key())[0];
+    const ll_api::memory& binary_mem = *this->binaries(BuildEnvManager::get_instance(extract_context_id(device))
+                                                           .get_device_build_env(device->build_id())
+                                                           .build_key())[0];
     int riscv_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(this->config_.processor);
     llrt::write_binary_to_address(binary_mem, device_id, worker_core, base_address + offsets[riscv_id]);
 
@@ -958,8 +988,9 @@ bool EthernetKernel::configure(
     const auto& hal = MetalContext::instance().hal();
     auto device_id = device->id();
     auto ethernet_core = device->ethernet_core_from_logical_core(logical_core);
-    const ll_api::memory& binary_mem =
-        *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key())[0];
+    const ll_api::memory& binary_mem = *this->binaries(BuildEnvManager::get_instance(extract_context_id(device))
+                                                           .get_device_build_env(device->build_id())
+                                                           .build_key())[0];
 
     if (hal.get_core_kernel_stored_in_config_buffer(this->get_kernel_programmable_core_type())) {
         uint32_t offset_idx = hal.get_processor_index(
@@ -986,8 +1017,9 @@ bool DramKernel::configure(
     const auto& hal = MetalContext::instance().hal();
     auto device_id = device->id();
     auto dram_core = device->virtual_core_from_logical_core(logical_core, CoreType::DRAM);
-    const ll_api::memory& binary_mem =
-        *this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key())[0];
+    const ll_api::memory& binary_mem = *this->binaries(BuildEnvManager::get_instance(extract_context_id(device))
+                                                           .get_device_build_env(device->build_id())
+                                                           .build_key())[0];
 
     const auto dram_core_index = hal.get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
@@ -1004,8 +1036,8 @@ bool ComputeKernel::configure(
     }
     auto device_id = device->id();
     auto worker_core = device->worker_core_from_logical_core(logical_core);
-    const std::vector<const ll_api::memory*>& binaries =
-        this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
+    const std::vector<const ll_api::memory*>& binaries = this->binaries(
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key());
     int32_t dm_count = MetalContext::instance().hal().get_processor_types_count(HalProgrammableCoreType::TENSIX, 0);
     for (int trisc_id = 0; trisc_id <= 2; trisc_id++) {
         llrt::write_binary_to_address(
@@ -1071,7 +1103,9 @@ std::vector<uint32_t> QuasarDataMovementKernel::get_processor_indices_for_binary
 
 void QuasarDataMovementKernel::generate_binaries(IDevice* device, JitBuildOptions&) const {
     jit_build_genfiles_kernel_include(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
+        *this,
+        this->kernel_src_);
     const uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t dm_class_idx = enchantum::to_underlying(HalProcessorClassType::DM);
@@ -1081,13 +1115,13 @@ void QuasarDataMovementKernel::generate_binaries(IDevice* device, JitBuildOption
         targets.reserve(this->dm_processors_.size());
         for (const auto& proc : this->dm_processors_) {
             int id = static_cast<std::underlying_type_t<DataMovementProcessor>>(proc);
-            targets.push_back(&BuildEnvManager::get_instance().get_kernel_build_state(
-                device->build_id(), tensix_core_type, dm_class_idx, id));
+            targets.push_back(&BuildEnvManager::get_instance(extract_context_id(device))
+                                   .get_kernel_build_state(device->build_id(), tensix_core_type, dm_class_idx, id));
         }
         jit_build_for_processors(targets, this);
     } else {
         const int canonical_id = static_cast<std::underlying_type_t<DataMovementProcessor>>(this->dm_processors_[0]);
-        const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
+        const JitBuildState& build_state = BuildEnvManager::get_instance(extract_context_id(device)).get_kernel_build_state(
             device->build_id(), tensix_core_type, dm_class_idx, canonical_id);
         jit_build(build_state, this);
     }
@@ -1106,7 +1140,7 @@ void QuasarDataMovementKernel::read_binaries(IDevice* device, const std::string&
                                  .hal()
                                  .get_jit_build_config(tensix_core_type, dm_class_idx, riscv_id)
                                  .memory_load;
-            const auto binary_path = BuildEnvManager::get_instance().get_kernel_binary_path(
+            const auto binary_path = BuildEnvManager::get_instance(extract_context_id(device)).get_kernel_binary_path(
                 device->build_id(), tensix_core_type, dm_class_idx, riscv_id, binary_root, this->kernel_full_name_);
             const ll_api::memory& binary_mem = llrt::get_risc_binary(binary_path, load_type);
             binaries.push_back(&binary_mem);
@@ -1117,13 +1151,14 @@ void QuasarDataMovementKernel::read_binaries(IDevice* device, const std::string&
                              .hal()
                              .get_jit_build_config(tensix_core_type, dm_class_idx, canonical_id)
                              .memory_load;
-        const auto binary_path = BuildEnvManager::get_instance().get_kernel_binary_path(
+        const auto binary_path = BuildEnvManager::get_instance(extract_context_id(device)).get_kernel_binary_path(
             device->build_id(), tensix_core_type, dm_class_idx, canonical_id, binary_root, this->kernel_full_name_);
         const ll_api::memory& binary_mem = llrt::get_risc_binary(binary_path, load_type);
         binaries.push_back(&binary_mem);
     }
     this->set_binaries(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key(), std::move(binaries));
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key(),
+        std::move(binaries));
 }
 
 void QuasarDataMovementKernel::process_defines(
@@ -1142,8 +1177,8 @@ bool QuasarDataMovementKernel::configure(
         is_on_logical_core(logical_core), "Cannot configure kernel because it is not on core {}", logical_core.str());
     const ChipId device_id = device->id();
     const CoreCoord worker_core = device->worker_core_from_logical_core(logical_core);
-    const std::vector<const ll_api::memory*>& binaries =
-        this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
+    const std::vector<const ll_api::memory*>& binaries = this->binaries(
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key());
     if (config_.is_legacy_kernel) {
         for (int i = 0; i < this->expected_num_binaries(); i++) {
             llrt::write_binary_to_address(
@@ -1202,7 +1237,9 @@ std::vector<uint32_t> QuasarComputeKernel::get_processor_indices_for_binary(int 
 
 void QuasarComputeKernel::generate_binaries(IDevice* device, JitBuildOptions&) const {
     jit_build_genfiles_triscs_src(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env, *this, this->kernel_src_);
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env,
+        *this,
+        this->kernel_src_);
     const uint32_t tensix_core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(this->get_kernel_programmable_core_type());
     const uint32_t compute_class_idx = enchantum::to_underlying(HalProcessorClassType::COMPUTE);
@@ -1210,7 +1247,7 @@ void QuasarComputeKernel::generate_binaries(IDevice* device, JitBuildOptions&) c
     // One compile/link per TRISC slot (UNPACK/MATH/PACK/ISOLATE_SFPU), shared across all NEOs using that slot.
     for (const auto& group : this->trisc_binary_groups_) {
         const int processor_id = static_cast<int>(enchantum::to_underlying(group[0]));
-        const JitBuildState& build_state = BuildEnvManager::get_instance().get_kernel_build_state(
+        const JitBuildState& build_state = BuildEnvManager::get_instance(extract_context_id(device)).get_kernel_build_state(
             device->build_id(), tensix_core_type, compute_class_idx, processor_id);
         jit_build(build_state, this);
     }
@@ -1229,7 +1266,7 @@ void QuasarComputeKernel::read_binaries(IDevice* device, const std::string& bina
                              .hal()
                              .get_jit_build_config(tensix_core_type, compute_class_idx, processor_id)
                              .memory_load;
-        const auto binary_path = BuildEnvManager::get_instance().get_kernel_binary_path(
+        const auto binary_path = BuildEnvManager::get_instance(extract_context_id(device)).get_kernel_binary_path(
             device->build_id(),
             tensix_core_type,
             compute_class_idx,
@@ -1240,7 +1277,8 @@ void QuasarComputeKernel::read_binaries(IDevice* device, const std::string& bina
         binaries.push_back(&binary_mem);
     }
     this->set_binaries(
-        BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key(), std::move(binaries));
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key(),
+        std::move(binaries));
 }
 
 void QuasarComputeKernel::process_defines(
@@ -1258,8 +1296,8 @@ bool QuasarComputeKernel::configure(
         is_on_logical_core(logical_core), "Cannot configure kernel because it is not on core {}", logical_core.str());
     const ChipId device_id = device->id();
     const CoreCoord worker_core = device->worker_core_from_logical_core(logical_core);
-    const std::vector<const ll_api::memory*>& binaries =
-        this->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
+    const std::vector<const ll_api::memory*>& binaries = this->binaries(
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key());
     const uint32_t dm_count = MetalContext::instance().hal().get_processor_types_count(
         HalProgrammableCoreType::TENSIX, enchantum::to_underlying(HalProcessorClassType::DM));
     for (size_t i = 0; i < this->trisc_binary_groups_.size(); ++i) {

--- a/tt_metal/impl/program/dispatch.cpp
+++ b/tt_metal/impl/program/dispatch.cpp
@@ -380,8 +380,9 @@ uint32_t finalize_kernel_bins(
         std::ranges::fill(kg->kernel_text_offsets, 0);
         for (auto kernel_id : kg->kernel_ids) {
             const auto& kernel = kernels.at(kernel_id);
-            const auto& binaries =
-                kernel->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
+            const auto& binaries = kernel->binaries(BuildEnvManager::get_instance(extract_context_id(device))
+                                                        .get_device_build_env(device->build_id())
+                                                        .build_key());
             uint32_t num_binaries = kernel->expected_num_binaries();
             TT_ASSERT(kernel->get_kernel_programmable_core_type() == programmable_core_type);
             for (uint32_t i = 0; i < num_binaries; i++) {

--- a/tt_metal/impl/program/program.cpp
+++ b/tt_metal/impl/program/program.cpp
@@ -161,7 +161,8 @@ namespace {
 // Similar to Kernel::generate_binaries(), but does not run the compiler.  Used by remote compilation.
 void generate_kernel_source_files(
     IDevice* device, const JitBuildOptions& build_options, const std::shared_ptr<Kernel>& kernel) {
-    const auto& env = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_env;
+    const auto& env =
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_env;
     jit_build_genfiles_descriptors(env, build_options);
     if (kernel->get_kernel_processor_class() == HalProcessorClassType::COMPUTE) {
         jit_build_genfiles_triscs_src(env, *kernel, kernel->kernel_source());
@@ -176,7 +177,8 @@ KernelCompileDescriptor build_kernel_descriptor(
     const std::shared_ptr<Kernel>& kernel,
     const JitBuildOptions& build_options,
     std::size_t kernel_hash) {
-    const auto& build_env = BuildEnvManager::get_instance().get_device_build_env(device->build_id());
+    const auto& build_env =
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id());
 
     uint32_t core_type =
         MetalContext::instance().hal().get_programmable_core_type_index(kernel->get_kernel_programmable_core_type());
@@ -192,8 +194,10 @@ KernelCompileDescriptor build_kernel_descriptor(
 
     int num_binaries = kernel->expected_num_binaries();
     for (int i = 0; i < num_binaries; ++i) {
-        const JitBuildState& bs = BuildEnvManager::get_instance().get_kernel_build_state(
-            device->build_id(), core_type, proc_class, kernel->get_kernel_processor_type(i));
+        const JitBuildState& bs =
+            BuildEnvManager::get_instance(extract_context_id(device))
+                .get_kernel_build_state(
+                    device->build_id(), core_type, proc_class, kernel->get_kernel_processor_type(i));
         desc.request.targets.push_back(bs.export_target_recipe(kernel.get()));
         desc.expected_elf_paths.push_back(bs.get_target_out_path(kernel->get_full_kernel_name()));
     }
@@ -1792,8 +1796,9 @@ void detail::ProgramImpl::populate_dispatch_data(IDevice* device) {
     // This is generic for workers and eth cores
     for (const auto& kernels : this->kernels_) {
         for (const auto& [kernel_id, kernel] : kernels) {
-            const auto& binaries =
-                kernel->binaries(BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key());
+            const auto& binaries = kernel->binaries(BuildEnvManager::get_instance(extract_context_id(device))
+                                                        .get_device_build_env(device->build_id())
+                                                        .build_key());
             std::vector<uint32_t> dst_base_addrs;
             std::vector<uint32_t> page_offsets;
             std::vector<uint32_t> lengths;
@@ -2011,7 +2016,8 @@ void detail::ProgramImpl::allocate_kernel_bin_buf_on_device(IDevice* device) {
 void ProgramImpl::generate_dispatch_commands(IDevice* device, bool use_prefetcher_cache) {
     uint64_t command_hash = *device->get_active_sub_device_manager_id();
 
-    uint64_t device_hash = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key();
+    uint64_t device_hash =
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key();
     if (not MetalContext::instance().hal().is_coordinate_virtualization_enabled()) {
         // When coordinate virtualization is not enabled, explicitly encode the device
         // id into the device hash, to always assert on programs being reused across devices.
@@ -2053,7 +2059,8 @@ void ProgramImpl::generate_dispatch_commands(IDevice* device, bool use_prefetche
 void ProgramImpl::generate_trace_dispatch_commands(IDevice* device, bool use_prefetcher_cache) {
     uint64_t command_hash = *device->get_active_sub_device_manager_id();
 
-    uint64_t device_hash = BuildEnvManager::get_instance().get_device_build_env(device->build_id()).build_key();
+    uint64_t device_hash =
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id()).build_key();
     if (not MetalContext::instance().hal().is_coordinate_virtualization_enabled()) {
         // When coordinate virtualization is not enabled, explicitly encode the device
         // id into the device hash, to always assert on programs being reused across devices.
@@ -2092,7 +2099,8 @@ void ProgramImpl::generate_trace_dispatch_commands(IDevice* device, bool use_pre
 
 void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
     // ZoneScoped;
-    const auto& build_env = BuildEnvManager::get_instance().get_device_build_env(device->build_id());
+    const auto& build_env =
+        BuildEnvManager::get_instance(extract_context_id(device)).get_device_build_env(device->build_id());
 
     if (compiled_.contains(build_env.build_key())) {
         Inspector::program_compile_already_exists(this, device, build_env.build_key());
@@ -2161,7 +2169,8 @@ void detail::ProgramImpl::compile(IDevice* device, bool force_slow_dispatch) {
             !endpoints.empty(),
             "TT_METAL_JIT_SERVER_ENABLE is set but no compile-server endpoints are configured. "
             "Set TT_METAL_JIT_SERVER_ENDPOINTS or TT_METAL_JIT_SERVER_ENDPOINT.");
-        RemoteCompileCoordinator coordinator(std::move(endpoints), device->build_id(), build_env.build_key());
+        RemoteCompileCoordinator coordinator(
+            std::move(endpoints), extract_context_id(device), device->build_id(), build_env.build_key());
 
         std::vector<std::pair<std::shared_ptr<Kernel>, JitBuildOptions>> submitted_kernels;
 

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -5,10 +5,12 @@
 #include "build_env_manager.hpp"
 
 #include <tracy/Tracy.hpp>
+#include <array>
 #include <cmath>
 #include <cstddef>
 #include <filesystem>
 #include <map>
+#include <memory>
 #include <string>
 
 #include <tt_stl/assert.hpp>
@@ -25,57 +27,82 @@ namespace tt::tt_metal {
 
 namespace {
 
-// Process-wide singleton state. Seeded once via seed_if_unseeded_with_hal(), then read-only
-// for the lifetime of the process. Driven by MetalContext::create_* so that the seeding HAL
-// is always the HAL of the first MetalContext that comes into existence -- no implicit
-// silicon initialisation, and no walking of g_instances slots from outside MetalContext.
-std::atomic<BuildEnvManager*> s_instance{nullptr};
+// Per-ContextId BuildEnvManager instances. Each MetalContext (silicon, mock, future) gets its
+// own slot so that contexts with different dispatch configurations do not share
+// device_id_to_build_env_ entries. Seeded lazily by seed_if_unseeded_with_hal(ContextId, Hal).
+// Slots are read-only for the lifetime of the process once seeded.
+//
+// PRE-EXISTING LIMITATION (carried forward from the original singleton design, now scoped
+// per-context): HAL layout within a single context can be modulated by rtoptions --
+// simulator mode, Blackhole DRAM programmable cores, 2-erisc mode -- so the HAL that first
+// seeds a context's slot wins and shapes the kernel/firmware build_state_indices_ tables
+// for the lifetime of that context. Cross-context, the slots are independent and unaffected.
+std::array<std::atomic<BuildEnvManager*>, MAX_CONTEXT_COUNT> s_instances{};
 std::mutex s_seed_mutex;
 
 }  // namespace
 
-void BuildEnvManager::seed_if_unseeded_with_hal(const Hal& hal) {
-    // Fast path: already seeded. No lock, no allocation.
-    if (s_instance.load(std::memory_order_acquire) != nullptr) {
+void BuildEnvManager::seed_if_unseeded_with_hal(ContextId context_id, const Hal& hal) {
+    const int slot = context_id.get();
+    TT_FATAL(
+        slot >= 0 && static_cast<size_t>(slot) < MAX_CONTEXT_COUNT,
+        "BuildEnvManager: context_id {} out of range [0, {})",
+        slot,
+        MAX_CONTEXT_COUNT);
+    // Fast path: this context's slot is already seeded. No lock, no allocation.
+    if (s_instances[slot].load(std::memory_order_acquire) != nullptr) {
         return;
     }
     std::lock_guard<std::mutex> lock(s_seed_mutex);
-    if (s_instance.load(std::memory_order_acquire) != nullptr) {
+    if (s_instances[slot].load(std::memory_order_acquire) != nullptr) {
         return;
     }
-    // Seed the singleton with the supplied HAL. The constructor sizes
+    // Seed this context's slot with the supplied HAL. The constructor sizes
     // kernel_build_state_indices_ / firmware_build_state_indices_ from that HAL's
     // programmable-core-type, processor-class, and fw-binary counts.
-    //
-    // PRE-EXISTING LIMITATION (not introduced by the explicit-seeding refactor, but surfaced
-    // once contexts can genuinely coexist in-process): HAL layout can be modulated by
-    // rtoptions -- simulator mode, Blackhole DRAM programmable cores, 2-erisc mode -- so two
-    // contexts on the same arch with disagreeing rtoptions, or two contexts on different
-    // arches, can produce different layout counts. Whichever HAL seeds this singleton first
-    // wins; the other context will index build states through a table sized for the wrong
-    // layout. This is a property of the singleton design.
-    // TODO(#TBD): key BuildEnvManager by a stable HAL signature (arch + relevant rtoptions),
-    // or move the index computation into per-device DeviceBuildEnv so each device carries
-    // its own mapping. That refactor closes the cross-arch / cross-rtoptions hazard above.
-    s_instance.store(new BuildEnvManager(hal), std::memory_order_release);
+    s_instances[slot].store(new BuildEnvManager(hal), std::memory_order_release);
+}
+
+void BuildEnvManager::destroy_for_context(ContextId context_id) {
+    const int slot = context_id.get();
+    TT_FATAL(
+        slot >= 0 && static_cast<size_t>(slot) < MAX_CONTEXT_COUNT,
+        "BuildEnvManager: context_id {} out of range [0, {})",
+        slot,
+        MAX_CONTEXT_COUNT);
+    // Lock pairs with seed_if_unseeded_with_hal()'s double-check to avoid a concurrent reseed.
+    std::lock_guard<std::mutex> lock(s_seed_mutex);
+    auto* existing = s_instances[slot].exchange(nullptr, std::memory_order_acq_rel);
+    delete existing;
 }
 
 BuildEnvManager& BuildEnvManager::get_instance(ContextId context_id) {
-    // Resolve the ContextId to a HAL via MetalContext::instance(context_id), then seed.
+    const int slot = context_id.get();
+    TT_FATAL(
+        slot >= 0 && static_cast<size_t>(slot) < MAX_CONTEXT_COUNT,
+        "BuildEnvManager: context_id {} out of range [0, {})",
+        slot,
+        MAX_CONTEXT_COUNT);
+    auto* existing = s_instances[slot].load(std::memory_order_acquire);
+    if (existing != nullptr) {
+        return *existing;
+    }
+    // Lazy seeding path: resolve the ContextId to a HAL via MetalContext::instance(context_id).
     // Callers that already hold g_instance_mutex (i.e. MetalContext::create_*) must use
     // seed_if_unseeded_with_hal() directly with the in-scope HAL to avoid re-entering
     // MetalContext::instance().
-    seed_if_unseeded_with_hal(MetalContext::instance(context_id).hal());
-    return *s_instance.load(std::memory_order_acquire);
+    seed_if_unseeded_with_hal(context_id, MetalContext::instance(context_id).hal());
+    return *s_instances[slot].load(std::memory_order_acquire);
 }
 
 BuildEnvManager& BuildEnvManager::get_instance() {
-    auto* existing = s_instance.load(std::memory_order_acquire);
+    auto* existing = s_instances[DEFAULT_CONTEXT_ID.get()].load(std::memory_order_acquire);
     TT_FATAL(
         existing != nullptr,
-        "BuildEnvManager::get_instance() called before any MetalContext was created. The "
-        "singleton is seeded by MetalContext::create_instance(); ensure at least one "
-        "MetalEnv has been constructed first, or call get_instance(ContextId) explicitly.");
+        "BuildEnvManager::get_instance() called before the default-context MetalContext was "
+        "created. The default-context slot is seeded by MetalContext::create_instance(); "
+        "ensure at least one default-context MetalEnv has been constructed first, or call "
+        "get_instance(ContextId) explicitly for a non-default context.");
     return *existing;
 }
 

--- a/tt_metal/jit_build/build_env_manager.hpp
+++ b/tt_metal/jit_build/build_env_manager.hpp
@@ -47,24 +47,30 @@ public:
     BuildEnvManager(BuildEnvManager&&) = delete;
     BuildEnvManager& operator=(BuildEnvManager&&) = delete;
 
-    // Returns the process-wide singleton, seeding its HAL on first call from the supplied
-    // ContextId's MetalContext. Subsequent calls return the same singleton regardless of
-    // which ContextId is passed -- the parameter is therefore advisory after first seeding.
-    // It exists to make the BuildEnvManager-to-MetalContext dependency explicit at the API
-    // surface so a future per-ContextId BuildEnvManager refactor (#38445 follow-up) has the
-    // right shape already.
+    // Returns the per-context BuildEnvManager for the supplied ContextId, seeding its HAL on
+    // first call from that ContextId's MetalContext. Each ContextId gets its own
+    // BuildEnvManager instance so that contexts with different dispatch configurations
+    // (e.g. silicon vs mock) do not share device_id_to_build_env_ slots and overwrite each
+    // other's build_keys. Required to fix the mock/silicon coexistence regression
+    // (#38445 follow-up).
     static BuildEnvManager& get_instance(ContextId context_id);
 
-    // Legacy no-arg accessor for callers that only have a build_id / device pointer in scope.
-    // Asserts that the singleton has already been seeded (driven by MetalContext::create_*),
-    // which is true for every reader that runs after a MetalEnv has been constructed.
+    // Legacy no-arg accessor that returns the DEFAULT_CONTEXT_ID instance. Asserts that the
+    // default context's BuildEnvManager has been seeded (driven by MetalContext::create_*),
+    // which is true for every reader that runs after the default-context MetalEnv has been
+    // constructed. Callers that may run under a non-default ContextId must use the
+    // get_instance(ContextId) overload instead.
     static BuildEnvManager& get_instance();
 
-    // Internal seeding entry: seeds the singleton with the supplied HAL on first call,
-    // no-op thereafter. Takes a HAL by reference so callers that already hold
-    // g_instance_mutex (e.g. MetalContext::create_*) can seed without re-entering
+    // Internal seeding entry: seeds the BuildEnvManager slot for the given ContextId with the
+    // supplied HAL on first call, no-op thereafter. Takes a HAL by reference so callers that
+    // already hold g_instance_mutex (e.g. MetalContext::create_*) can seed without re-entering
     // MetalContext::instance(ContextId). Idempotent and thread-safe.
-    static void seed_if_unseeded_with_hal(const Hal& hal);
+    static void seed_if_unseeded_with_hal(ContextId context_id, const Hal& hal);
+
+    // Frees the per-context slot so a recycled context_id seeds fresh on next create.
+    // No-op on an unseeded slot.
+    static void destroy_for_context(ContextId context_id);
 
     // Add a new build environment for the corresponding device id and num_hw_cqs. Also generates the build key and
     // build states.  This requires a live device to be available at device_id.


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
BuildEnvManager was a process-wide singleton, so when tt-mlir opens a mock device for op-model cost queries (at optimization_level=1), mock's add_build_env overwrote the silicon's slot — both contexts have a "device 0". The next silicon enqueue then hit a TT_FATAL on the program-cache device_hash check because the cached build_key no longer matched what was stored in the (polluted) slot.

This PR completes the follow-up that PR #43754 ("Fix mock+silicon coexistence via MetalEnv") left open: BuildEnvManager is now per-ContextId, so mock and silicon get isolated slots and can no longer overwrite each other. The get_instance(ContextId) API was already pre-shaped for this; only the storage and callers needed updating.

Partial fix for #38661 (per-ContextId routing — full move to MetalContext ownership left as follow-up)
Surfaced by tenstorrent/tt-xla#5176

### Notes for reviewers
Most of the diff is mechanical plumbing — every BuildEnvManager::get_instance() callsite now passes the context via extract_context_id(device) (existing helper from context_types.hpp, no IDevice interface change). The interesting bits are small:

- **Core change**: build_env_manager.cpp — s_instance replaced with s_instances[MAX_CONTEXT_COUNT]; seed_if_unseeded_with_hal now takes a ContextId; get_instance(ContextId) actually routes per-context now.
- **Seeding**: 3 sites in metal_context.cpp pass their own ContextId.
- **Debug components owned by MetalContext** (dprint_server, inspector): each now uses its owning MetalContext's ContextId rather than a hardcoded default. DPrintServer's Impl already held a MetalContext* — switched to context_->get_context_id(). Inspector::Data now stores a ContextId member, plumbed through Inspector::initialize(rank, ContextId) from MetalContext::initialize().
- **remote_compile_coordinator** now stores a ContextId member — added one extra arg to its constructor (single call site in program.cpp).
- Legacy get_instance() no-arg overload still works (routes to DEFAULT_CONTEXT_ID) so existing callers don't break.

Verified with the original failing case from tt-xla#5176 (Playground v2.5 e2e benchmark — opt_level=0 for text encoders + UNet, opt_level=1 for VAE in the same Python process): previously crashed in VAE warmup, now passes end-to-end.

Note: sanity test failures on my branch also occur in main ([run 27610483397](https://github.com/tenstorrent/tt-metal/actions/runs/27610483397)), confirming this change introduces no regression.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kkannan/per-context-build-env-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kkannan/per-context-build-env-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kkannan/per-context-build-env-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kkannan/per-context-build-env-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kkannan/per-context-build-env-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kkannan/per-context-build-env-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kkannan/per-context-build-env-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kkannan/per-context-build-env-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kkannan/per-context-build-env-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kkannan/per-context-build-env-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kkannan/per-context-build-env-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kkannan/per-context-build-env-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kkannan/per-context-build-env-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kkannan/per-context-build-env-manager)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kkannan/per-context-build-env-manager)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kkannan/per-context-build-env-manager)