### PR TITLE
Bug fix: recompute ND shard metadata for shrinking slice outputs

### DIFF
--- a/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_slice.py
@@ -3,13 +3,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import pytest
-
 import torch
 
 import ttnn
-from tests.ttnn.utils_for_testing import assert_with_pcc, assert_equal
-from tests.ttnn.unit_tests.operations.test_utils import round_up
-import math
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc
 
 
 def random_torch_tensor(dtype, shape):
@@ -1309,6 +1306,62 @@ def test_slice_sharded_auto_shard_spec_recomputation(
     tt_output_torch = ttnn.to_torch(tt_output_cpu)
     torch_expected = torch_input[begins[0] : ends[0], begins[1] : ends[1], begins[2] : ends[2], begins[3] : ends[3]]
 
+    assert_equal(torch_expected, tt_output_torch)
+
+
+@pytest.mark.parametrize(
+    "input_shape, input_nd_shard_shape, begins, ends",
+    [
+        ([1, 1, 128, 64], [1, 1, 64, 64], [0, 0, 0, 0], [1, 1, 64, 64]),
+        ([1, 1, 128, 64], [1, 1, 96, 64], [0, 0, 32, 0], [1, 1, 96, 64]),
+    ],
+)
+@pytest.mark.parametrize(
+    "shard_orientation",
+    [
+        ttnn.ShardOrientation.ROW_MAJOR,
+        ttnn.ShardOrientation.COL_MAJOR,
+    ],
+)
+def test_slice_nd_sharded_auto_shard_spec_recomputation(
+    input_shape, input_nd_shard_shape, begins, ends, shard_orientation, device
+):
+    torch.manual_seed(2005)
+
+    torch_input = torch.rand(input_shape, dtype=torch.bfloat16)
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(1, 0))})
+    input_nd_shard_spec = ttnn.NdShardSpec(input_nd_shard_shape, shard_grid, orientation=shard_orientation)
+    input_mem_config = ttnn.MemoryConfig(ttnn.BufferType.L1, input_nd_shard_spec)
+
+    tt_input = ttnn.from_torch(
+        torch_input,
+        device=device,
+        layout=ttnn.TILE_LAYOUT,
+        dtype=ttnn.bfloat16,
+        memory_config=input_mem_config,
+    )
+
+    tt_output = ttnn.slice(tt_input, begins, ends)
+
+    expected_shape = [ends[i] - begins[i] for i in range(len(begins))]
+    assert list(tt_output.shape) == expected_shape
+
+    output_mem_config = tt_output.memory_config()
+    assert output_mem_config.is_sharded()
+    assert output_mem_config.nd_shard_spec is not None
+
+    output_nd_shard_spec = output_mem_config.nd_shard_spec
+    assert output_nd_shard_spec.orientation == input_nd_shard_spec.orientation
+
+    output_nd_shard_shape = list(output_nd_shard_spec.shard_shape)
+    expected_nd_shard_shape = list(input_nd_shard_shape)
+    expected_nd_shard_shape[-2] = min(expected_nd_shard_shape[-2], expected_shape[-2])
+    expected_nd_shard_shape[-1] = min(expected_nd_shard_shape[-1], expected_shape[-1])
+    assert output_nd_shard_shape == expected_nd_shard_shape
+
+    tt_output_cpu = ttnn.to_memory_config(tt_output, ttnn.DRAM_MEMORY_CONFIG)
+    tt_output_torch = ttnn.to_torch(tt_output_cpu)
+    torch_expected = torch_input[begins[0] : ends[0], begins[1] : ends[1], begins[2] : ends[2], begins[3] : ends[3]]
     assert_equal(torch_expected, tt_output_torch)
 
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp
@@ -248,28 +248,52 @@ ttnn::Tensor slice(
     // (ends are padded downstream, so only begin alignment matters).
     rm_only = (input_tensor.layout() != Layout::TILE) || (!no_step || one_dimensional || !handled_tile_alignment);
 
-    // Implicit inheritance from a sharded input: rescale the shard spec to the sliced shape so the
-    // output doesn't reuse the input's (oversized) spec. Covers HEIGHT/WIDTH/BLOCK. (Issue #38016)
+    // Implicit inheritance from a sharded input: rescale the shard metadata to the sliced shape so the
+    // output doesn't reuse the input's oversized spec. Covers legacy shard_spec and ND shard provenance.
     if (!memory_config_arg.has_value() && !optional_output_tensor.has_value() && input_tensor.is_sharded() &&
         input_rank >= 2) {
         const auto& mem_layout = output_memory_config.memory_layout();
+
+        // Compute output dimensions once for all implicit sharded-output adjustments.
+        ttnn::SmallVector<uint32_t> output_dims(input_rank);
+        for (size_t i = 0; i < input_rank; i++) {
+            output_dims[i] = output_dim_i(i, modified_ends);
+        }
+        if (!rm_only) {
+            output_dims[input_rank - 2] =
+                std::max(tt::round_up(output_dims[input_rank - 2], tile_shape[0]), tile_shape[0]);
+            output_dims[input_rank - 1] =
+                std::max(tt::round_up(output_dims[input_rank - 1], tile_shape[1]), tile_shape[1]);
+        }
+
+        if (output_memory_config.created_with_nd_shard_spec()) {
+            const auto& input_nd_shard_spec = output_memory_config.nd_shard_spec().value();
+            auto output_nd_shard_shape = input_nd_shard_spec.shard_shape;
+            const auto input_nd_rank = output_nd_shard_shape.rank();
+            TT_FATAL(
+                input_nd_rank <= input_rank,
+                "NdShardSpec rank {} cannot exceed slice input rank {}",
+                input_nd_rank,
+                input_rank);
+
+            for (size_t i = 0; i < input_nd_rank; ++i) {
+                const auto output_dim_index = input_rank - input_nd_rank + i;
+                output_nd_shard_shape[i] = std::min(output_nd_shard_shape[i], output_dims[output_dim_index]);
+            }
+
+            if (output_nd_shard_shape != input_nd_shard_spec.shard_shape) {
+                output_memory_config = MemoryConfig::create_with_prepopulated_shard_specs(
+                    output_memory_config.memory_layout(),
+                    output_memory_config.buffer_type(),
+                    output_memory_config.shard_spec(),
+                    input_nd_shard_spec.with_shard_shape(output_nd_shard_shape),
+                    output_memory_config.created_with_nd_shard_spec());
+            }
+        }
         if (mem_layout == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED ||
             mem_layout == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED ||
             mem_layout == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED) {
             const auto& shard_spec_val = output_memory_config.shard_spec().value();
-
-            // Compute output dimensions, tile-aligned if using TILE path
-            ttsl::SmallVector<uint32_t> output_dims(input_rank);
-            for (size_t i = 0; i < input_rank; i++) {
-                output_dims[i] = output_dim_i(i, modified_ends);
-            }
-            if (!rm_only) {
-                output_dims[input_rank - 2] =
-                    std::max(tt::round_up(output_dims[input_rank - 2], tile_shape[0]), tile_shape[0]);
-                output_dims[input_rank - 1] =
-                    std::max(tt::round_up(output_dims[input_rank - 1], tile_shape[1]), tile_shape[1]);
-            }
-
             // Flatten to 2D: height = product of all dims except last, width = last dim
             uint32_t output_height = 1;
             for (size_t i = 0; i + 1 < input_rank; i++) {
@@ -315,8 +339,17 @@ ttnn::Tensor slice(
             if (new_shard_shape != shard_spec_val.shape) {
                 auto new_shard_spec =
                     tt::tt_metal::ShardSpec(shard_spec_val.grid, new_shard_shape, shard_spec_val.orientation);
-                output_memory_config = MemoryConfig(
-                    output_memory_config.memory_layout(), output_memory_config.buffer_type(), new_shard_spec);
+                if (output_memory_config.created_with_nd_shard_spec()) {
+                    output_memory_config = MemoryConfig::create_with_prepopulated_shard_specs(
+                        output_memory_config.memory_layout(),
+                        output_memory_config.buffer_type(),
+                        new_shard_spec,
+                        output_memory_config.nd_shard_spec(),
+                        output_memory_config.created_with_nd_shard_spec());
+                } else {
+                    output_memory_config = MemoryConfig(
+                        output_memory_config.memory_layout(), output_memory_config.buffer_type(), new_shard_spec);
+                }
             }
         }
     }


### PR DESCRIPTION
PR Category
Bug fix

Summary
Fixes #46954.

ttnn.slice(...) recomputes inherited sharded output configs when the caller omits output memory_config, but that path only refreshed the legacy shard_spec.

For tensors created from NdShardSpec, slice could shrink the output shape while keeping stale nd_shard_spec metadata from the input.

This patch clamps the inherited nd_shard_spec shard_shape to the sliced output dimensions first, then refreshes any prepopulated legacy shard_spec without losing ND creation provenance.

Notes for reviewers
The semantic change lives in ttnn/cpp/ttnn/operations/data_movement/slice/slice.cpp.

The regression in tests/ttnn/unit_tests/operations/data_movement/test_slice.py covers an ND-created sharded TILE input, no explicit output memory_config, and a shrinking slice. It asserts:
- the output remains sharded and exposes nd_shard_spec
- the output ND shard orientation equals the input contract
- the inherited nd_shard_spec shard_shape shrinks with the output
- the sliced values still match torch

Source evidence:
https://github.com/peter941221/tt-metal/blob/da7ff8bdfa6647a5ff033e8c45dc75c5c06c55bd/ttnn/cpp/ttnn-nanobind/tensor.cpp#L517-L535
https://github.com/peter941221/tt-metal/blob/da7ff8bdfa6647a5ff033e8c45dc75c5c06c55bd/tests/ttnn/unit_tests/operations/data_movement/test_slice.py#L1349-L1360

Validation on the current rebased head da7ff8bdfa:
- git diff --check origin/main...HEAD
- python3 -m py_compile tests/ttnn/unit_tests/operations/data_movement/test_slice.py

The maintainer L2 rerun on the previous head reached the regression and exposed a test-only binding mismatch: the test accessed MemoryConfig.created_with_nd_shard_spec, while the Python binding exposes nd_shard_spec instead. This is fixed in da7ff8bdfa; a CI rerun has been requested.

The same L2 run also reported unrelated existing failures in test_index_fill_cross_layout_to_col_sharded and test_full_nd_sharded_manual_sharding.