### PR TITLE
Bug fix: preserve transpose fallback shard orientation

### DIFF
--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -1423,8 +1423,9 @@ def test_transpose_preserves_col_major_orientation_on_fallback_generated_shard_s
     tt_output_tensor = ttnn.transpose(tt_input_tensor, 2, 3, memory_config=output_memory_config)
 
     output_shard_spec = tt_output_tensor.memory_config().shard_spec()
+    expected_orientation = input_memory_config.shard_spec().orientation
     assert output_shard_spec is not None
-    assert output_shard_spec.orientation == ttnn.ShardOrientation.COL_MAJOR
+    assert output_shard_spec.orientation == expected_orientation
 
 
 @pytest.mark.parametrize(["dim0", "dim1"], [(2, 3), (2, 1), (0, 1)], ids=["wh", "hc", "cn"])

--- a/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
+++ b/tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py
@@ -7,7 +7,6 @@ import torch
 import numpy as np
 
 import ttnn
-
 from loguru import logger
 from models.common.utility_functions import is_blackhole, torch_random
 from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc, comp_equal
@@ -1398,6 +1397,34 @@ def test_transpose_hc_mem_config(device, n, c, h, w):
     tt_output_tensor = ttnn.to_torch(tt_output_tensor)
 
     assert_with_pcc(torch_output_tensor, tt_output_tensor, 0.9999)
+
+
+def test_transpose_preserves_col_major_orientation_on_fallback_generated_shard_spec(device):
+    torch.manual_seed(2005)
+    torch_input_tensor = torch.rand((1, 1, 224, 32), dtype=torch.bfloat16)
+    tt_input_tensor = ttnn.from_torch(
+        torch_input_tensor,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=ttnn.L1_MEMORY_CONFIG,
+    )
+
+    input_memory_config = ttnn.create_sharded_memory_config(
+        (32, 32),
+        core_grid=ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, 6))}),
+        strategy=ttnn.ShardStrategy.HEIGHT,
+        orientation=ttnn.ShardOrientation.COL_MAJOR,
+        use_height_and_width_as_shard_shape=True,
+    )
+    output_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+
+    tt_input_tensor = ttnn.to_memory_config(tt_input_tensor, input_memory_config)
+    tt_output_tensor = ttnn.transpose(tt_input_tensor, 2, 3, memory_config=output_memory_config)
+
+    output_shard_spec = tt_output_tensor.memory_config().shard_spec()
+    assert output_shard_spec is not None
+    assert output_shard_spec.orientation == ttnn.ShardOrientation.COL_MAJOR
 
 
 @pytest.mark.parametrize(["dim0", "dim1"], [(2, 3), (2, 1), (0, 1)], ids=["wh", "hc", "cn"])

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp
@@ -129,8 +129,9 @@ std::optional<ShardSpec> adjust_shard_spec_to_shape(
     return ret;
 }
 
-// Build a sharded spec over the full compute grid (used when no input shard_spec is available
-// to scale from, e.g. interleaved input + sharded output request).
+// Build a sharded spec over the full compute grid. When a sharded input already carries an
+// orientation contract but its shard geometry can't be scaled to the output shape, preserve that
+// orientation on the fresh spec. Interleaved inputs still fall back to ROW_MAJOR.
 ShardSpec generate_transpose_shard_spec(
     const Tensor& input_tensor, const ttnn::Shape& padded_out_shape, TensorMemoryLayout memory_layout) {
     auto* device = input_tensor.device();
@@ -166,8 +167,10 @@ ShardSpec generate_transpose_shard_spec(
             tt::round_up(tt::div_up(tensor_width, static_cast<uint64_t>(grid_size.x)), tt::constants::TILE_WIDTH);
         shard_shape = {static_cast<uint32_t>(shard_height), static_cast<uint32_t>(shard_width)};
     }
+    const auto orientation =
+        input_tensor.shard_spec().has_value() ? input_tensor.shard_spec()->orientation : ShardOrientation::ROW_MAJOR;
     log_debug(tt::LogOp, "Transpose: generated shard spec over full compute grid ({} cores)", num_cores);
-    return ShardSpec(all_cores, shard_shape, ShardOrientation::ROW_MAJOR);
+    return ShardSpec(all_cores, shard_shape, orientation);
 }
 
 }  // namespace ttnn::operations::data_movement::transpose


### PR DESCRIPTION
PR Category
Bug fix

Summary
Fixes #46956.

`ttnn.transpose(...)` fallback shard-spec synthesis now preserves the input shard orientation when it rebuilds a sharded output spec.

Before this change, `generate_transpose_shard_spec(...)` always returned a fresh `ROW_MAJOR` shard spec. That was correct for interleaved inputs, but it rewrote the orientation contract for sharded inputs whose shard geometry could not be scaled exactly.

This change keeps the fix local. If the input already has a shard spec, the synthesized output spec inherits that orientation. Interleaved inputs still fall back to `ROW_MAJOR`.

Notes for reviewers
Source proof:
`ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_utils.cpp`

Regression:
`tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py::test_transpose_preserves_col_major_orientation_on_fallback_generated_shard_spec`

Validation:
`python3 -m py_compile tests/tt_eager/python_api_testing/unit_testing/misc/test_transpose.py`
`ninja -C .build-46956 ttnn/cpp/ttnn/operations/data_movement/ttnn_op_data_movement`
Focused pytest did not run here because both available Python interpreters on this machine lack `pytest`.
