### PR TITLE
ltx audio: faster decode — E2E 8.7→8.2s, audio 1.36→0.9s (bh 4x8) + gated 1x4 submesh

### DIFF
--- a/models/tt_dit/layers/audio_ops.py
+++ b/models/tt_dit/layers/audio_ops.py
@@ -548,15 +548,15 @@ class Conv2dViaConv3d(Module):
         if self.padding_mode == "causal_height" and self.pad_h > 0:
             B_, H_, W_, C_ = x_BHWC.shape
             pad_tensor_shape = (B_, self.pad_h, W_, C_)
-            zero_pad = ttnn.zeros(
-                pad_tensor_shape, dtype=x_BHWC.get_dtype(), layout=ttnn.ROW_MAJOR_LAYOUT, device=self.mesh_device
+            zero_pad = _persistent_zeros(
+                pad_tensor_shape, dtype=x_BHWC.get_dtype(), layout=ttnn.ROW_MAJOR_LAYOUT, mesh_device=self.mesh_device
             )
             x_BHWC = ttnn.concat([zero_pad, x_BHWC], dim=1)
         elif self.padding_mode == "causal_width" and self.pad_w > 0:
             B_, H_, W_, C_ = x_BHWC.shape
             pad_tensor_shape = (B_, H_, self.pad_w, C_)
-            zero_pad = ttnn.zeros(
-                pad_tensor_shape, dtype=x_BHWC.get_dtype(), layout=ttnn.ROW_MAJOR_LAYOUT, device=self.mesh_device
+            zero_pad = _persistent_zeros(
+                pad_tensor_shape, dtype=x_BHWC.get_dtype(), layout=ttnn.ROW_MAJOR_LAYOUT, mesh_device=self.mesh_device
             )
             x_BHWC = ttnn.concat([zero_pad, x_BHWC], dim=2)
 

--- a/models/tt_dit/layers/audio_resample.py
+++ b/models/tt_dit/layers/audio_resample.py
@@ -215,19 +215,22 @@ class UpSample1d(Module):
 
         if self._use_polyphase and self.ratio == 2:
             B_, T_pad, C_ = x_pad.shape
-            in0 = ttnn.slice(x_pad, [0, 2, 0], [B_, T_pad - 3, C_])
-            in1 = ttnn.slice(x_pad, [0, 3, 0], [B_, T_pad - 2, C_])
+            # Both phases share the one window x_pad[2:T_pad-2]: phase 0 reads taps at even
+            # positions, phase 1 at odd (= phase 0's window advanced by one sample). Padding
+            # each sub-tap vector with a zero — sub0 trailing, sub1 leading — folds that
+            # one-sample offset into the filter, so a single slice feeds both convs (was two,
+            # offset by one). Output length and result are bit-identical to the two-slice form.
+            base = ttnn.slice(x_pad, [0, 2, 0], [B_, T_pad - 2, C_])
             scaled_taps = [t * self.ratio for t in self._taps_cpu]
-            sub0 = [scaled_taps[2 * j + 0] for j in range(self._poly_K_sub)]
-            sub1 = [scaled_taps[2 * j + 1] for j in range(self._poly_K_sub)]
+            sub0 = [scaled_taps[2 * j + 0] for j in range(self._poly_K_sub)] + [0.0]
+            sub1 = [0.0] + [scaled_taps[2 * j + 1] for j in range(self._poly_K_sub)]
             ph0 = depthwise_tap_filter(
-                in0, sub0, 1, mesh_device=self.mesh_device, dtype=self.dtype, cache=self._conv1d_cache
+                base, sub0, 1, mesh_device=self.mesh_device, dtype=self.dtype, cache=self._conv1d_cache
             )
             ph1 = depthwise_tap_filter(
-                in1, sub1, 1, mesh_device=self.mesh_device, dtype=self.dtype, cache=self._conv1d_cache
+                base, sub1, 1, mesh_device=self.mesh_device, dtype=self.dtype, cache=self._conv1d_cache
             )
-            ttnn.deallocate(in0)
-            ttnn.deallocate(in1)
+            ttnn.deallocate(base)
             T_out = ph0.shape[1]
             ph0_b = ttnn.reshape(ph0, (B_, T_out, 1, C_))
             ph1_b = ttnn.reshape(ph1, (B_, T_out, 1, C_))

--- a/models/tt_dit/layers/audio_resample.py
+++ b/models/tt_dit/layers/audio_resample.py
@@ -201,26 +201,35 @@ class UpSample1d(Module):
         B, T, C = x_BTC.shape
         sharded = self.parallel_config is not None and self.parallel_config.factor > 1
 
-        if sharded and self.pad > 0:
+        poly2 = self._use_polyphase and self.ratio == 2
+        # The ratio-2 polyphase path only ever reads x_pad[2:T_pad-2], so pad two fewer rows
+        # per side and consume the result directly — no crop slice, and a 2-row-lighter halo
+        # exchange. Falls back to the full pad + slice when there aren't 2 rows to drop.
+        crop = 2 if (poly2 and self.pad >= 2) else 0
+        eff_pad = self.pad - crop
+
+        if sharded and eff_pad > 0:
             x_pad = _t_neighbor_pad(
                 x_BTC,
-                pad_left=self.pad,
-                pad_right=self.pad,
+                pad_left=eff_pad,
+                pad_right=eff_pad,
                 parallel_config=self.parallel_config,
                 ccl_manager=self.ccl_manager,
                 padding_mode="replicate",
             )
         else:
-            x_pad = _replicate_pad_t(x_BTC, self.pad, self.pad, self.mesh_device)
+            x_pad = _replicate_pad_t(x_BTC, eff_pad, eff_pad, self.mesh_device)
 
-        if self._use_polyphase and self.ratio == 2:
+        if poly2:
             B_, T_pad, C_ = x_pad.shape
-            # Both phases share the one window x_pad[2:T_pad-2]: phase 0 reads taps at even
-            # positions, phase 1 at odd (= phase 0's window advanced by one sample). Padding
-            # each sub-tap vector with a zero — sub0 trailing, sub1 leading — folds that
-            # one-sample offset into the filter, so a single slice feeds both convs (was two,
-            # offset by one). Output length and result are bit-identical to the two-slice form.
-            base = ttnn.slice(x_pad, [0, 2, 0], [B_, T_pad - 2, C_])
+            # Both phases share one window: phase 0 reads taps at even positions, phase 1 at odd
+            # (= phase 0's window advanced one sample). Zero-padding each sub-tap vector — sub0
+            # trailing, sub1 leading — folds that one-sample offset into the filter, so both convs
+            # read the same input. Bit-identical to the historical two-offset-slice form.
+            if crop:
+                base = x_pad
+            else:
+                base = ttnn.slice(x_pad, [0, 2, 0], [B_, T_pad - 2, C_])
             scaled_taps = [t * self.ratio for t in self._taps_cpu]
             sub0 = [scaled_taps[2 * j + 0] for j in range(self._poly_K_sub)] + [0.0]
             sub1 = [0.0] + [scaled_taps[2 * j + 1] for j in range(self._poly_K_sub)]
@@ -230,7 +239,8 @@ class UpSample1d(Module):
             ph1 = depthwise_tap_filter(
                 base, sub1, 1, mesh_device=self.mesh_device, dtype=self.dtype, cache=self._conv1d_cache
             )
-            ttnn.deallocate(base)
+            if base is not x_pad:
+                ttnn.deallocate(base)
             T_out = ph0.shape[1]
             ph0_b = ttnn.reshape(ph0, (B_, T_out, 1, C_))
             ph1_b = ttnn.reshape(ph1, (B_, T_out, 1, C_))

--- a/models/tt_dit/models/audio_vae/audio_decoder_ltx.py
+++ b/models/tt_dit/models/audio_vae/audio_decoder_ltx.py
@@ -11,6 +11,8 @@ causal on the height (time) axis. Single-chip.
 
 from __future__ import annotations
 
+from collections import OrderedDict
+
 import einops
 import torch
 
@@ -19,6 +21,7 @@ import ttnn
 from ...layers.audio_ops import Conv2dViaConv3d
 from ...layers.module import Module, ModuleList
 from ...utils.conv3d import conv_pad_in_channels
+from ...utils.tracing import Tracer
 
 LATENT_DOWNSAMPLE_FACTOR = 4
 
@@ -327,6 +330,15 @@ class AudioDecoder(Module):
         self._stats_std = torch.ones(ch)
         self._stats_mean = torch.zeros(ch)
 
+        # forward_traced state, mirroring Vocoder: capture the pure-device graph once per
+        # input shape and replay it (the conv ops are host-dispatch-bound, so this removes
+        # the dominant per-op dispatch cost). _target_shape is set per-input by
+        # _host_to_device and read by _device_to_host, so it is not baked into the graph.
+        self.use_trace = False
+        self._target_shape: tuple[int, int, int, int] | None = None
+        self._traces: "OrderedDict[tuple, Tracer]" = OrderedDict()
+        self._max_traces = None
+
         self.patchifier = AudioPatchifier(
             patch_size=1,
             sample_rate=sample_rate,
@@ -470,11 +482,12 @@ class AudioDecoder(Module):
 
         return decoded_output[:, :target_channels, :target_time, :target_freq]
 
-    def forward(self, latent: torch.Tensor) -> torch.Tensor:
-        """``latent``: ``(B, z_channels, frames, mel_bins)`` →
-        ``(B, out_ch, target_frames, target_mel_bins)``.
-        """
+    def _host_to_device(self, latent: torch.Tensor) -> ttnn.Tensor:
+        """Host preprocessing + upload. Split out so the pure-device graph can be captured
+        for trace replay; sets ``self._target_shape`` (input-dependent, read by
+        ``_device_to_host``) so it is not baked into the captured graph."""
         sample_bcfk, target_shape = self._denormalize_latents(latent)
+        self._target_shape = target_shape
 
         # To BHWC for the device (mel_bins is W).
         sample_bhwc = sample_bcfk.permute(0, 2, 3, 1).contiguous().to(torch.float32)
@@ -483,10 +496,12 @@ class AudioDecoder(Module):
         # Conv2dViaConv3d weight.
         sample_bhwc_padded = conv_pad_in_channels(sample_bhwc)
 
-        x = ttnn.from_torch(
+        return ttnn.from_torch(
             sample_bhwc_padded, device=self.mesh_device, layout=ttnn.ROW_MAJOR_LAYOUT, dtype=ttnn.bfloat16
         )
 
+    def _forward_device(self, x: ttnn.Tensor) -> ttnn.Tensor:
+        """The pure on-device decode graph (conv_in → conv_out). Captured for trace replay."""
         x = self.conv_in(x)
         x = self.mid(x)
 
@@ -497,12 +512,43 @@ class AudioDecoder(Module):
         x = self.norm_out(x)
         x = ttnn.silu(x)
         x = ttnn.to_layout(x, ttnn.ROW_MAJOR_LAYOUT) if x.layout != ttnn.ROW_MAJOR_LAYOUT else x
-        x = self.conv_out(x)
+        return self.conv_out(x)
 
+    def _device_to_host(self, x: ttnn.Tensor) -> torch.Tensor:
+        """Download + strip out_channels padding (Conv2dViaConv3d) + BHWC → BCHW + reshape."""
         out_bhwc = ttnn.to_torch(ttnn.get_device_tensors(x)[0])
-
-        # Strip out_channels padding from Conv2dViaConv3d, then BHWC → BCHW.
         out_bhwc = out_bhwc[..., : self.out_ch]
         out_bchw = out_bhwc.permute(0, 3, 1, 2).contiguous()
+        return self._adjust_output_shape(out_bchw, self._target_shape)
 
-        return self._adjust_output_shape(out_bchw, target_shape)
+    def forward(self, latent: torch.Tensor) -> torch.Tensor:
+        """``latent``: ``(B, z_channels, frames, mel_bins)`` →
+        ``(B, out_ch, target_frames, target_mel_bins)``.
+        """
+        x = self._host_to_device(latent)
+        y = self._forward_device(x)
+        return self._device_to_host(y)
+
+    def forward_traced(self, latent: torch.Tensor) -> torch.Tensor:
+        """Same result as ``forward`` but captures the device graph once per input shape and
+        replays it, removing per-op host dispatch. Requires the mesh opened with a
+        ``trace_region_size`` large enough for the resident trace."""
+        shape_key = tuple(latent.shape)
+        tracer = self._traces.get(shape_key)
+        if tracer is None:
+            tracer = Tracer(self._forward_device, device=self.mesh_device, prep_run=True, clone_prep_inputs=True)
+            self._traces[shape_key] = tracer
+            if self._max_traces is not None:
+                while len(self._traces) > self._max_traces:
+                    _, evicted = self._traces.popitem(last=False)  # LRU
+                    evicted.release_trace()
+        self._traces.move_to_end(shape_key)  # LRU touch
+        # _host_to_device sets self._target_shape for this shape (read by _device_to_host).
+        y = tracer(self._host_to_device(latent), tracer_blocking_execution=False, tracer_execute_on_capture=False)
+        return self._device_to_host(y)
+
+    def release_trace(self) -> None:
+        """Free all captured traces (call on shutdown, or before re-warming a new bucket set)."""
+        for tracer in self._traces.values():
+            tracer.release_trace()
+        self._traces.clear()

--- a/models/tt_dit/models/audio_vae/bwe_ltx.py
+++ b/models/tt_dit/models/audio_vae/bwe_ltx.py
@@ -237,13 +237,17 @@ class VocoderWithBWE(Module):
         ), "output_sampling_rate must be an integer multiple of input_sampling_rate"
         self.resampler = UpSample1d(ratio=ratio, window="hann", mesh_device=mesh_device, dtype=dtype)
 
-        # When set, the main vocoder runs via capture-once/replay (forward_traced); ~3x on
-        # its device graph. BWE stays eager (single-axis, known channel-TP divergence).
+        # When set, each generator runs via capture-once/replay (forward_traced), removing
+        # per-op host dispatch (~5x on its device graph). use_trace_bwe is separate so the
+        # BWE generator (historically eager over a suspected channel-TP divergence) can be
+        # gated independently of the main vocoder and validated against eager.
         self.use_trace = False
+        self.use_trace_bwe = False
 
     def release_trace(self) -> None:
-        """Free the main vocoder's captured trace; safe to call when none is active."""
+        """Free both generators' captured traces; safe to call when none is active."""
         self.vocoder.release_trace()
+        self.bwe_generator.release_trace()
 
     @property
     def conv_pre(self):
@@ -313,7 +317,9 @@ class VocoderWithBWE(Module):
 
         # bwe_generator expects (B, C, T_frames, n_mels).
         mel_for_bwe = mel.transpose(2, 3).contiguous()
-        residual = self.bwe_generator(mel_for_bwe)
+        residual = (
+            self.bwe_generator.forward_traced(mel_for_bwe) if self.use_trace_bwe else self.bwe_generator(mel_for_bwe)
+        )
 
         skip = self._resample_device(x)
         assert residual.shape == skip.shape, f"residual {tuple(residual.shape)} != skip {tuple(skip.shape)}"

--- a/models/tt_dit/models/audio_vae/vocoder_ltx.py
+++ b/models/tt_dit/models/audio_vae/vocoder_ltx.py
@@ -165,9 +165,12 @@ class AMPBlock1(Module):
             ]
         )
 
-    def forward(self, x_BTC: ttnn.Tensor, set_tail=None) -> ttnn.Tensor:
+    def forward(self, x_BTC: ttnn.Tensor, set_tail=None, x_rep=None) -> ttnn.Tensor:
         # set_tail(xd, mode) materializes the tile-align pad image to each op's boundary when
         # T-sharded (acts replicate the real boundary, convs zero it); identity when unsharded.
+        # x_rep, when given, is x_BTC already replicate-tailed: the three blocks of a stage share
+        # one input, so the caller computes that tail-set once and passes it here for acts1[0]
+        # (read-only — the block never deallocates it).
         st = set_tail if set_tail is not None else (lambda xd, mode: xd)
 
         def _apply(op, x, mode):
@@ -178,7 +181,10 @@ class AMPBlock1(Module):
             return y
 
         for i in range(self.num_branches):
-            xt = _apply(self.acts1[i], x_BTC, "replicate")
+            if i == 0 and x_rep is not None:
+                xt = self.acts1[0](x_rep)
+            else:
+                xt = _apply(self.acts1[i], x_BTC, "replicate")
             nxt = _apply(self.convs1[i], xt, "zeros")
             ttnn.deallocate(xt)
             xt = _apply(self.acts2[i], nxt, "replicate")
@@ -469,8 +475,13 @@ class Vocoder(Module):
             # Mean over the num_kernels parallel AMP branches. Each block sets its own op
             # boundaries (acts replicate, convs zeros) via stage_set_tail.
             block_outputs = []
+            # All three blocks read the same stage input; their acts1[0] each replicate-tail it
+            # identically, so do that tail-set once and share it (read-only) across the blocks.
+            x_rep = stage_set_tail(x_dev, "replicate")
             for idx in range(start, start + self.num_kernels):
-                block_outputs.append(self.resblocks[idx](x_dev, set_tail=stage_set_tail))
+                block_outputs.append(self.resblocks[idx](x_dev, set_tail=stage_set_tail, x_rep=x_rep))
+            if x_rep is not x_dev:
+                ttnn.deallocate(x_rep)
             ttnn.deallocate(x_dev)
             acc = block_outputs[0]
             for k in range(1, self.num_kernels):

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx.py
@@ -277,6 +277,26 @@ class LTXPipeline:
             self.vae_ccl_manager = CCLManager(
                 mesh_device, num_links=ccl_manager.num_links, topology=ttnn.Topology.Linear
             )
+
+        # Audio decode is torch-in/torch-out and self-contained on its own modules, so it can
+        # run on a SUBMESH of the full device while the video pipeline keeps the whole mesh.
+        # Fewer T-shards = fewer cross-chip causal-halo barriers (the audio vocoder's dominant
+        # device-side cost): T-shard=4 on a 1x4/2x4 slice beats T-shard=8 on the full 4x8.
+        # Defaults to the full mesh; LTX_AUDIO_SUBMESH=RxC slices an RxC submesh for audio.
+        self.audio_mesh_device = mesh_device
+        self.audio_ccl_manager = self.vae_ccl_manager
+        self._owned_audio_submesh = None
+        _audio_submesh = os.environ.get("LTX_AUDIO_SUBMESH")
+        if _audio_submesh:
+            r, c = (int(v) for v in _audio_submesh.lower().split("x"))
+            full = tuple(mesh_device.shape)
+            if r <= full[0] and c <= full[1] and (r, c) != full:
+                self.audio_mesh_device = mesh_device.create_submesh(ttnn.MeshShape(r, c))
+                self._owned_audio_submesh = self.audio_mesh_device
+                self.audio_ccl_manager = CCLManager(
+                    self.audio_mesh_device, num_links=ccl_manager.num_links, topology=ttnn.Topology.Linear
+                )
+                logger.info(f"Audio decode routed onto {r}x{c} submesh of {full[0]}x{full[1]}")
         if vae_parallel_config is None:
             vae_parallel_config = VaeHWParallelConfig(
                 height_parallel=parallel_config.tensor_parallel,
@@ -368,6 +388,23 @@ class LTXPipeline:
         self._trace_state.clear()
         self._prompt_v = StateTensor()
         self._prompt_a = StateTensor()
+
+    def release_audio_submesh(self) -> None:
+        """Drop the pipeline's references to the audio decode submesh (LTX_AUDIO_SUBMESH).
+
+        The submesh shares the parent mesh's command queue. ttnn forbids closing a
+        cq-sharing child while the parent is alive (close hangs) and forbids closing
+        the parent while the child is alive ("cq in use by child submesh"), so the
+        submesh's lifetime is bound to the parent: it is reclaimed when the parent mesh
+        closes at process teardown. This only frees the audio device tensors. No-op when
+        audio runs on the full mesh.
+        """
+        if self._owned_audio_submesh is not None:
+            ttnn.synchronize_device(self._owned_audio_submesh)
+            self.tt_audio_decoder = None
+            self.tt_vocoder_with_bwe = None
+            self.audio_ccl_manager = self.vae_ccl_manager
+            self.audio_mesh_device = self.mesh_device
 
     @staticmethod
     def _resolve_checkpoint_file(checkpoint: str, default_filename: str = "ltx-2.3-22b-dev.safetensors") -> str:
@@ -1479,7 +1516,7 @@ class LTXPipeline:
         voc_cfg = config["vocoder"]["vocoder"]
         bwe_cfg = config["vocoder"]["bwe"]
 
-        mesh_shape = tuple(self.mesh_device.shape)
+        mesh_shape = tuple(self.audio_mesh_device.shape)
         t_axis = 0 if mesh_shape[0] >= mesh_shape[1] else 1
         t_factor = mesh_shape[t_axis]
         c_axis = 1 - t_axis
@@ -1497,7 +1534,7 @@ class LTXPipeline:
             audio_parallel_config = ParallelFactor(factor=t_factor, mesh_axis=t_axis)
         else:
             audio_parallel_config = None
-        audio_ccl = self.vae_ccl_manager if audio_parallel_config is not None else None
+        audio_ccl = self.audio_ccl_manager if audio_parallel_config is not None else None
 
         self.tt_audio_decoder = AudioDecoder(
             ch=ddconfig.get("ch", 128),
@@ -1512,7 +1549,7 @@ class LTXPipeline:
             mel_hop_length=stft_cfg.get("hop_length", 160),
             is_causal=stft_cfg.get("causal", True),
             mel_bins=mel_bins,
-            mesh_device=self.mesh_device,
+            mesh_device=self.audio_mesh_device,
             dtype=ttnn.bfloat16,
         )
 
@@ -1534,7 +1571,7 @@ class LTXPipeline:
             return Vocoder(
                 **{k: cfg[k] for k in voc_keys if k in cfg},
                 apply_final_activation=apply_final_activation,
-                mesh_device=self.mesh_device,
+                mesh_device=self.audio_mesh_device,
                 dtype=ttnn.float32,
                 parallel_config=parallel_config,
                 ccl_manager=audio_ccl,
@@ -1558,7 +1595,7 @@ class LTXPipeline:
             hop_length=bwe_cfg["hop_length"],
             win_length=bwe_cfg["n_fft"],
             n_mel_channels=bwe_cfg["num_mels"],
-            mesh_device=self.mesh_device,
+            mesh_device=self.audio_mesh_device,
             dtype=ttnn.float32,
         )
         self.tt_vocoder_with_bwe = VocoderWithBWE(
@@ -1568,7 +1605,7 @@ class LTXPipeline:
             input_sampling_rate=bwe_cfg["input_sampling_rate"],
             output_sampling_rate=bwe_cfg["output_sampling_rate"],
             hop_length=bwe_cfg["hop_length"],
-            mesh_device=self.mesh_device,
+            mesh_device=self.audio_mesh_device,
             dtype=ttnn.float32,
         )
         # Capture-once/replay the main vocoder device graph when the pipeline runs traced.
@@ -1640,7 +1677,7 @@ class LTXPipeline:
                 model_name=model_name,
                 subfolder=dec_subfolder,
                 parallel_config=self.parallel_config,
-                mesh_shape=tuple(self.mesh_device.shape),
+                mesh_shape=tuple(self.audio_mesh_device.shape),
                 get_torch_state_dict=self._audio_decoder_state_provider,
             )
 
@@ -1653,7 +1690,7 @@ class LTXPipeline:
                 model_name=model_name,
                 subfolder=voc_subfolder,
                 parallel_config=self.parallel_config,
-                mesh_shape=tuple(self.mesh_device.shape),
+                mesh_shape=tuple(self.audio_mesh_device.shape),
                 get_torch_state_dict=self._vocoder_state_provider,
             )
 
@@ -1715,13 +1752,13 @@ class LTXPipeline:
         if _time_stages:
             import time as _t
 
-            ttnn.synchronize_device(self.mesh_device)
+            ttnn.synchronize_device(self.audio_mesh_device)
             _t0 = _t.perf_counter()
             mel = self._decode_mel(audio_spatial)
-            ttnn.synchronize_device(self.mesh_device)
+            ttnn.synchronize_device(self.audio_mesh_device)
             _t_vae = _t.perf_counter()
             waveform = self.tt_vocoder_with_bwe(mel).squeeze(0).float()
-            ttnn.synchronize_device(self.mesh_device)
+            ttnn.synchronize_device(self.audio_mesh_device)
             _t_voc = _t.perf_counter()
             logger.info(
                 f"STAGE_SPLIT mel_vae={(_t_vae - _t0) * 1000:.1f}ms " f"vocoder+bwe={(_t_voc - _t_vae) * 1000:.1f}ms"

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx.py
@@ -1560,11 +1560,11 @@ class LTXPipeline:
         # prep_run=False so capture and every replay share the post-mel-VAE free-list. Gated by the
         # test_audio_decode_girl conv1d-vs-torch oracle, which now runs under trace.)
         self.tt_vocoder_with_bwe.use_trace = self._traced
-        # BWE/VAE trace are env-toggleable for A/B: at real frame counts the audio path is
-        # device-compute-bound, where trace-replay can be net-negative (mel-VAE measured 0.86x).
-        # VAE trace defaults OFF (slower); BWE trace defaults ON — the BWE generator is a second
-        # full Vocoder whose forward is ~90% host-bound, validated 5.36x bit-identical on bh 4x8.
-        self.tt_vocoder_with_bwe.use_trace_bwe = self._traced and os.environ.get("LTX_BWE_TRACE", "1") != "0"
+        # BWE/VAE trace are env-toggleable for A/B. Both default OFF: at real frame counts the
+        # BWE and mel-VAE forwards are device-compute-bound, where trace-replay is net-negative
+        # (mel-VAE 0.86x; BWE 1.74s traced vs 1.17s eager on the 6s girl clip, bh 4x8). Trace only
+        # wins on short, host-dispatch-bound inputs. Set LTX_BWE_TRACE=1 / LTX_VAE_TRACE=1 to force.
+        self.tt_vocoder_with_bwe.use_trace_bwe = self._traced and os.environ.get("LTX_BWE_TRACE", "0") == "1"
         self.tt_audio_decoder.use_trace = self._traced and os.environ.get("LTX_VAE_TRACE", "0") == "1"
         if isinstance(audio_parallel_config, AudioTCParallelConfig):
             cfg_desc = f"T-shard={t_factor} axis{t_axis} + channel-TP={c_factor} axis{c_axis}"

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx.py
@@ -1559,11 +1559,14 @@ class LTXPipeline:
         # Vocoder.forward_traced — warm caches on a prior eager decode, then capture with
         # prep_run=False so capture and every replay share the post-mel-VAE free-list. Gated by the
         # test_audio_decode_girl conv1d-vs-torch oracle, which now runs under trace.)
-        self.tt_vocoder_with_bwe.use_trace = self._traced
-        # BWE/VAE trace are env-toggleable for A/B. Both default OFF: at real frame counts the
-        # BWE and mel-VAE forwards are device-compute-bound, where trace-replay is net-negative
-        # (mel-VAE 0.86x; BWE 1.74s traced vs 1.17s eager on the 6s girl clip, bh 4x8). Trace only
-        # wins on short, host-dispatch-bound inputs. Set LTX_BWE_TRACE=1 / LTX_VAE_TRACE=1 to force.
+        # Main-vocoder trace defaults ON (wins on small/host-bound meshes — loudbox 2x4: 0.80s
+        # traced). On large/CCL-bound meshes it is net-negative (galaxy 4x8: 1.37s traced vs 1.07s
+        # eager — T-shard=8 AllGather/halo dominates, audio decode does not scale with chips), so
+        # set LTX_VOC_TRACE=0 there.
+        self.tt_vocoder_with_bwe.use_trace = self._traced and os.environ.get("LTX_VOC_TRACE", "1") != "0"
+        # BWE/VAE trace default OFF: device-compute-bound at real frame counts, trace-replay
+        # net-negative (mel-VAE 0.86x; BWE 1.74s traced vs 1.17s eager, bh 4x8). LTX_BWE_TRACE=1 /
+        # LTX_VAE_TRACE=1 to force on for short, host-dispatch-bound inputs.
         self.tt_vocoder_with_bwe.use_trace_bwe = self._traced and os.environ.get("LTX_BWE_TRACE", "0") == "1"
         self.tt_audio_decoder.use_trace = self._traced and os.environ.get("LTX_VAE_TRACE", "0") == "1"
         if isinstance(audio_parallel_config, AudioTCParallelConfig):

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx.py
@@ -247,6 +247,7 @@ class LTXPipeline:
         width: int = 0,
         run_warmup: bool = False,
         traced: bool = False,
+        audio_only: bool = False,
         extra_transformer_variants: list[tuple[str, list[LoraSpec]]] | None = None,
     ):
         self.mesh_device = mesh_device
@@ -336,9 +337,11 @@ class LTXPipeline:
             self._register_coresident_exclusions()
             self._prime_caches()
             # Tracing (prep_run=False) requires precompiled kernels + pre-allocated trace I/O,
-            # so warmup is mandatory when traced.
+            # so warmup is mandatory when traced. audio_only skips the (video) warmup entirely:
+            # decode_audio compiles + captures its own trace lazily on the first call, so the
+            # ~10-min video stage1/upsample/stage2/gemma warmup is pure waste for audio decode.
             valid_shape = num_frames > 0 and height > 0 and width > 0
-            if (run_warmup or traced) and valid_shape:
+            if (run_warmup or traced) and valid_shape and not audio_only:
                 if traced and not run_warmup:
                     logger.info("traced=True: forcing warmup (trace capture requires precompiled kernels)")
                 self.warmup_buffers(num_frames=num_frames, height=height, width=width)
@@ -355,6 +358,8 @@ class LTXPipeline:
                 tracer.release_trace()
         if self.tt_vocoder_with_bwe is not None:
             self.tt_vocoder_with_bwe.release_trace()
+        if self.tt_audio_decoder is not None:
+            self.tt_audio_decoder.release_trace()
         self._trace_state.clear()
         self._prompt_v = StateTensor()
         self._prompt_a = StateTensor()
@@ -1555,10 +1560,12 @@ class LTXPipeline:
         # prep_run=False so capture and every replay share the post-mel-VAE free-list. Gated by the
         # test_audio_decode_girl conv1d-vs-torch oracle, which now runs under trace.)
         self.tt_vocoder_with_bwe.use_trace = self._traced
-        # The BWE generator is a second full Vocoder run eager today — its forward is ~90% host-bound
-        # like the main vocoder, so tracing it removes the bulk of the remaining decode dispatch. Same
-        # self-warming forward_traced path, so the warmup decode covers both generators identically.
-        self.tt_vocoder_with_bwe.use_trace_bwe = self._traced
+        # BWE/VAE trace are env-toggleable for A/B: at real frame counts the audio path is
+        # device-compute-bound, where trace-replay can be net-negative (mel-VAE measured 0.86x).
+        # VAE trace defaults OFF (slower); BWE trace defaults ON — the BWE generator is a second
+        # full Vocoder whose forward is ~90% host-bound, validated 5.36x bit-identical on bh 4x8.
+        self.tt_vocoder_with_bwe.use_trace_bwe = self._traced and os.environ.get("LTX_BWE_TRACE", "1") != "0"
+        self.tt_audio_decoder.use_trace = self._traced and os.environ.get("LTX_VAE_TRACE", "0") == "1"
         if isinstance(audio_parallel_config, AudioTCParallelConfig):
             cfg_desc = f"T-shard={t_factor} axis{t_axis} + channel-TP={c_factor} axis{c_axis}"
         elif audio_parallel_config is not None:
@@ -1638,6 +1645,12 @@ class LTXPipeline:
 
         logger.info("Loaded TTNN audio decoder + vocoder")
 
+    def _decode_mel(self, audio_spatial: torch.Tensor) -> torch.Tensor:
+        """Run the mel-VAE decoder, traced (capture-once/replay) when the pipeline is traced."""
+        if self.tt_audio_decoder.use_trace:
+            return self.tt_audio_decoder.forward_traced(audio_spatial)
+        return self.tt_audio_decoder(audio_spatial)
+
     def decode_audio(self, audio_latent: torch.Tensor, num_frames: int, fps: float = 24.0) -> Audio:
         """Decode an audio latent ``(1, audio_N, 128)`` to a waveform, fully on device.
 
@@ -1674,8 +1687,27 @@ class LTXPipeline:
         z = self.tt_audio_decoder.z_channels
         audio_spatial = audio_latent.reshape(1, audio_N, z, audio_latent.shape[2] // z).permute(0, 2, 1, 3).float()
 
-        mel = self.tt_audio_decoder(audio_spatial)
-        waveform = self.tt_vocoder_with_bwe(mel).squeeze(0).float()
+        # Optional stage-wall split (LTX_TIME_STAGES=1): mel-VAE vs vocoder+BWE, to find
+        # the dominant decode stage. Syncs are host-wall, so this is a coarse stage timer,
+        # not a per-op device profile.
+        _time_stages = os.environ.get("LTX_TIME_STAGES") in ("1", "true", "True")
+        if _time_stages:
+            import time as _t
+
+            ttnn.synchronize_device(self.mesh_device)
+            _t0 = _t.perf_counter()
+            mel = self._decode_mel(audio_spatial)
+            ttnn.synchronize_device(self.mesh_device)
+            _t_vae = _t.perf_counter()
+            waveform = self.tt_vocoder_with_bwe(mel).squeeze(0).float()
+            ttnn.synchronize_device(self.mesh_device)
+            _t_voc = _t.perf_counter()
+            logger.info(
+                f"STAGE_SPLIT mel_vae={(_t_vae - _t0) * 1000:.1f}ms " f"vocoder+bwe={(_t_voc - _t_vae) * 1000:.1f}ms"
+            )
+        else:
+            mel = self._decode_mel(audio_spatial)
+            waveform = self.tt_vocoder_with_bwe(mel).squeeze(0).float()
         sampling_rate = self.tt_vocoder_with_bwe.output_sampling_rate
 
         # Trim to video duration.

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx.py
@@ -1555,6 +1555,10 @@ class LTXPipeline:
         # prep_run=False so capture and every replay share the post-mel-VAE free-list. Gated by the
         # test_audio_decode_girl conv1d-vs-torch oracle, which now runs under trace.)
         self.tt_vocoder_with_bwe.use_trace = self._traced
+        # The BWE generator is a second full Vocoder run eager today — its forward is ~90% host-bound
+        # like the main vocoder, so tracing it removes the bulk of the remaining decode dispatch. Same
+        # self-warming forward_traced path, so the warmup decode covers both generators identically.
+        self.tt_vocoder_with_bwe.use_trace_bwe = self._traced
         if isinstance(audio_parallel_config, AudioTCParallelConfig):
             cfg_desc = f"T-shard={t_factor} axis{t_axis} + channel-TP={c_factor} axis{c_axis}"
         elif audio_parallel_config is not None:

--- a/models/tt_dit/pipelines/ltx/pipeline_ltx.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx.py
@@ -331,11 +331,16 @@ class LTXPipeline:
         self.tt_audio_decoder = None
         self.tt_vocoder_with_bwe = None
 
+        # decode_audio only touches the audio decoder + vocoder, so audio_only skips building
+        # AND priming the 22B transformer / video VAE / upsampler — that prime is the bulk of a
+        # cold run (~100s of 22B weight push) and is pure waste for the audio test.
+        self.audio_only = audio_only
+
         if self.checkpoint_name is not None:
             self._load_config_from_checkpoint()
-            self._instantiate_modules(extra_transformer_variants or [])
+            self._instantiate_modules(extra_transformer_variants or [], audio_only=audio_only)
             self._register_coresident_exclusions()
-            self._prime_caches()
+            self._prime_caches(audio_only=audio_only)
             # Tracing (prep_run=False) requires precompiled kernels + pre-allocated trace I/O,
             # so warmup is mandatory when traced. audio_only skips the (video) warmup entirely:
             # decode_audio compiles + captures its own trace lazily on the first call, so the
@@ -580,9 +585,17 @@ class LTXPipeline:
             num_frames=latent_frames,
         )
 
-    def _instantiate_modules(self, extra_variants: list[tuple[str, list[LoraSpec]]]) -> None:
+    def _instantiate_modules(
+        self, extra_variants: list[tuple[str, list[LoraSpec]]], *, audio_only: bool = False
+    ) -> None:
         """Build every TT Module the pipeline will use. No DRAM weights yet —
-        ``_prime_caches`` (next) attaches them."""
+        ``_prime_caches`` (next) attaches them. ``audio_only`` builds just the
+        audio decoder shell; the transformer/VAE/upsampler are never used by
+        ``decode_audio``."""
+        if audio_only:
+            if self.checkpoint_name is not None:
+                self._new_audio_decoder()
+            return
         self.transformer = self._new_transformer()
         self.transformer_states.append(
             TransformerState(
@@ -659,9 +672,14 @@ class LTXPipeline:
         # even with the fp32 vocoder's conv3d activations live. Excluding them only
         # forces a redundant audio reload at decode (~6s warm) for no memory gain.
 
-    def _prime_caches(self) -> None:
+    def _prime_caches(self, *, audio_only: bool = False) -> None:
         """Load every module in reverse use order so variant 0 is resident in
-        DRAM after ``__init__`` (matches Wan's reverse-use-order priming)."""
+        DRAM after ``__init__`` (matches Wan's reverse-use-order priming).
+        ``audio_only`` primes just the audio decoder — the 22B transformer push
+        dominates a cold run and decode_audio never touches it."""
+        if audio_only:
+            self._prepare_audio_decoder()
+            return
         for idx in range(len(self.transformer_states) - 1, 0, -1):
             self._prepare_transformer(idx)
         # Each _prepare_* no-ops when its module isn't present (None), so no call-site guards.

--- a/models/tt_dit/tests/models/ltx/audio_warm_harness.py
+++ b/models/tt_dit/tests/models/ltx/audio_warm_harness.py
@@ -1,0 +1,160 @@
+"""Persistent warm dev harness for LTX audio decode (Step 0).
+
+ONE process: build the audio_only pipeline once (pays the ~317s one-time device-side
+program/mesh-workload assembly ONCE), then loop many warm decodes — eager AND traced —
+reporting per-stage (mel-VAE / vocoder+BWE) warm walls. This is the fast-iteration tool
+the plan's Step 0 calls for: after the single cold prime, each extra decode is ~1s, so
+eager-vs-traced (Phase 1b) is answered in one ~6-min process instead of two ~14-min runs.
+
+Env knobs:
+  EAGER_REPS   (default 5)  warm eager decodes to average
+  TRACED_REPS  (default 5)  warm traced decodes to average (0 to skip the traced leg)
+  LTX_VOC_TRACE / LTX_BWE_TRACE / LTX_VAE_TRACE  passed through to the traced leg
+  WARMUP_DECODES (default 1) untimed decodes after a mode switch to settle steady state
+  NUM_FRAMES / HEIGHT / WIDTH  clip shape (defaults match test_audio_decode_girl)
+
+Quality is NOT checked here (no torch oracle) — that stays test_audio_decode_girl's job
+(LTX_TRACED=0, conv1d-vs-torch PCC>0.95). This harness is timing/iteration only.
+
+Run via the broker against the worktree env, e.g.:
+  python -m pytest models/tt_dit/tests/models/ltx/audio_warm_harness.py -k bh_4x8sp1tp0 -s
+"""
+import os
+import time
+
+import numpy as np
+import pytest
+import torch
+
+import ttnn
+from models.tt_dit.pipelines.ltx.pipeline_ltx_distilled import LTXDistilledPipeline
+from models.tt_dit.utils.ltx import default_ltx_checkpoint, default_ltx_gemma
+from models.tt_dit.utils.patchifiers import AudioLatentShape, VideoPixelShape
+from models.tt_dit.utils.test import line_params
+
+line_trace_params = {**line_params, "trace_region_size": 300_000_000}
+
+
+def _stage_decode(pipeline, latent, num_frames):
+    """One decode, returning (mel_ms, voc_ms, total_ms). Mirrors decode_audio's stage split
+    but measured here so it works regardless of LTX_TIME_STAGES."""
+    z = pipeline.tt_audio_decoder.z_channels
+    audio_spatial = latent.reshape(1, latent.shape[1], z, latent.shape[2] // z).permute(0, 2, 1, 3).float()
+    ttnn.synchronize_device(pipeline.mesh_device)
+    t0 = time.perf_counter()
+    mel = pipeline._decode_mel(audio_spatial)
+    ttnn.synchronize_device(pipeline.mesh_device)
+    t1 = time.perf_counter()
+    wav = pipeline.tt_vocoder_with_bwe(mel).squeeze(0).float()
+    ttnn.synchronize_device(pipeline.mesh_device)
+    t2 = time.perf_counter()
+    return (t1 - t0) * 1000, (t2 - t1) * 1000, (t2 - t0) * 1000, wav
+
+
+def _avg_leg(pipeline, latent, num_frames, reps, warmups, label):
+    for _ in range(warmups):
+        _stage_decode(pipeline, latent, num_frames)
+    mels, vocs, tots = [], [], []
+    wav = None
+    for _ in range(reps):
+        m, v, t, wav = _stage_decode(pipeline, latent, num_frames)
+        mels.append(m)
+        vocs.append(v)
+        tots.append(t)
+
+    def _med(xs):
+        return sorted(xs)[len(xs) // 2]
+
+    print(
+        f"\nWARM_HARNESS {label} reps={reps} "
+        f"mel_vae={_med(mels):.1f}ms vocoder+bwe={_med(vocs):.1f}ms total={_med(tots):.1f}ms "
+        f"(min_total={min(tots):.1f} max_total={max(tots):.1f})",
+        flush=True,
+    )
+    return _med(tots), wav
+
+
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
+    [
+        [(2, 4), (2, 4), 1, 0, 2, True, line_trace_params, ttnn.Topology.Linear, False],
+        [(4, 8), (4, 8), 1, 0, 2, False, line_trace_params, ttnn.Topology.Linear, False],
+    ],
+    ids=["bh_2x4sp1tp0", "bh_4x8sp1tp0"],
+    indirect=["mesh_device", "device_params"],
+)
+def test_warm_harness(
+    mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp
+):
+    parent_mesh = mesh_device
+    mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
+
+    num_frames = int(os.environ.get("NUM_FRAMES", "145"))
+    height = int(os.environ.get("HEIGHT", "1088"))
+    width = int(os.environ.get("WIDTH", "1920"))
+    eager_reps = int(os.environ.get("EAGER_REPS", "5"))
+    traced_reps = int(os.environ.get("TRACED_REPS", "5"))
+    warmups = int(os.environ.get("WARMUP_DECODES", "1"))
+
+    import models.tt_dit.layers.audio_ops as _ao
+
+    _ao._USE_CONV1D_DEPTHWISE = True  # conv1d path (the PCC-validated one)
+
+    # Build pipeline EAGER first (traced=False). The single cold decode below pays the
+    # one-time device-side assembly; both legs reuse the same warm pipeline + kernel cache.
+    pipeline = LTXDistilledPipeline.create_pipeline(
+        mesh_device=mesh_device,
+        checkpoint_name=default_ltx_checkpoint("ltx-2.3-22b-distilled-1.1.safetensors"),
+        gemma_path=default_ltx_gemma(),
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+        dynamic_load=dynamic_load,
+        topology=topology,
+        is_fsdp=is_fsdp,
+        run_warmup=False,
+        traced=False,
+        audio_only=True,
+        num_frames=num_frames,
+        height=height,
+        width=width,
+    )
+
+    vps = VideoPixelShape(batch=1, frames=num_frames, height=height, width=width, fps=24)
+    als = AudioLatentShape.from_video_pixel_shape(vps)
+    _lat = os.environ.get("AUDIO_LATENT") or os.path.join(
+        os.path.dirname(__file__), "fixtures", "girl_audio_latent.npy"
+    )
+    if os.path.exists(_lat):
+        latent = (torch.from_numpy(np.load(_lat)) if _lat.endswith(".npy") else torch.load(_lat)).float()
+    else:
+        torch.manual_seed(0)
+        latent = torch.randn(1, als.frames, pipeline.in_channels, dtype=torch.float32) * 0.5
+
+    # COLD: one-time device-side program/mesh-workload assembly (~317s on 4x8, NOT JIT).
+    t0 = time.perf_counter()
+    pipeline.decode_audio(latent, num_frames, fps=24.0)
+    cold_ms = (time.perf_counter() - t0) * 1000
+    print(f"\nWARM_HARNESS cold={cold_ms:.1f}ms", flush=True)
+
+    # ---- EAGER leg ----
+    pipeline._traced = False
+    eager_total, _ = _avg_leg(pipeline, latent, num_frames, eager_reps, warmups, "EAGER")
+
+    # ---- TRACED leg ---- (in-process switch: release any traces, flip flag, re-prime flags)
+    if traced_reps > 0:
+        pipeline.release_traces()
+        pipeline._traced = True
+        # _prepare_audio_decoder re-reads self._traced + env each call, so the next decode
+        # lazily captures the vocoder/VAE trace per LTX_VOC_TRACE/LTX_BWE_TRACE/LTX_VAE_TRACE.
+        # Use extra warmups so the lazy capture cost isn't counted in the timed reps.
+        traced_total, _ = _avg_leg(pipeline, latent, num_frames, traced_reps, max(warmups, 2), "TRACED")
+        delta = traced_total - eager_total
+        print(
+            f"\nWARM_HARNESS EAGER_vs_TRACED eager_total={eager_total:.1f}ms "
+            f"traced_total={traced_total:.1f}ms delta={delta:+.1f}ms "
+            f"({'traced FASTER' if delta < 0 else 'traced SLOWER'})",
+            flush=True,
+        )
+
+    pipeline.release_traces()

--- a/models/tt_dit/tests/models/ltx/audio_warm_harness.py
+++ b/models/tt_dit/tests/models/ltx/audio_warm_harness.py
@@ -40,13 +40,13 @@ def _stage_decode(pipeline, latent, num_frames):
     but measured here so it works regardless of LTX_TIME_STAGES."""
     z = pipeline.tt_audio_decoder.z_channels
     audio_spatial = latent.reshape(1, latent.shape[1], z, latent.shape[2] // z).permute(0, 2, 1, 3).float()
-    ttnn.synchronize_device(pipeline.mesh_device)
+    ttnn.synchronize_device(pipeline.audio_mesh_device)
     t0 = time.perf_counter()
     mel = pipeline._decode_mel(audio_spatial)
-    ttnn.synchronize_device(pipeline.mesh_device)
+    ttnn.synchronize_device(pipeline.audio_mesh_device)
     t1 = time.perf_counter()
     wav = pipeline.tt_vocoder_with_bwe(mel).squeeze(0).float()
-    ttnn.synchronize_device(pipeline.mesh_device)
+    ttnn.synchronize_device(pipeline.audio_mesh_device)
     t2 = time.perf_counter()
     return (t1 - t0) * 1000, (t2 - t1) * 1000, (t2 - t0) * 1000, wav
 
@@ -63,15 +63,15 @@ def _probe_split(pipeline, latent, num_frames, reps, label):
     voc_ms, bwe_ms = [], []
     for _ in range(reps):
         md = mel.float()
-        ttnn.synchronize_device(pipeline.mesh_device)
+        ttnn.synchronize_device(pipeline.audio_mesh_device)
         t0 = time.perf_counter()
         x = vwb.vocoder.forward_traced(md) if vwb.use_trace else vwb.vocoder(md)
-        ttnn.synchronize_device(pipeline.mesh_device)
+        ttnn.synchronize_device(pipeline.audio_mesh_device)
         t1 = time.perf_counter()
         B, C, low = x.shape
         out_len = low * vwb.output_sampling_rate // vwb.input_sampling_rate
         _ = vwb._bwe_from_waveform(x, input_dtype=md.dtype, output_length=out_len)
-        ttnn.synchronize_device(pipeline.mesh_device)
+        ttnn.synchronize_device(pipeline.audio_mesh_device)
         t2 = time.perf_counter()
         voc_ms.append((t1 - t0) * 1000)
         bwe_ms.append((t2 - t1) * 1000)
@@ -113,11 +113,16 @@ def _avg_leg(pipeline, latent, num_frames, reps, warmups, label):
 
 @pytest.mark.parametrize(
     "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
+    # mesh_device (fixture param) always opens the FULL (4,8) galaxy — opening a 2x4/1x4
+    # SUBSET of mmio devices standalone fails fabric router sync on this machine. The
+    # SUBMESH to actually run the audio decode on is `mesh_shape` (sliced from the full
+    # parent via create_submesh), so this directly measures submesh-routed audio decode.
     [
-        [(2, 4), (2, 4), 1, 0, 2, True, line_trace_params, ttnn.Topology.Linear, False],
+        [(4, 8), (1, 4), 1, 0, 2, True, line_trace_params, ttnn.Topology.Linear, False],
+        [(4, 8), (2, 4), 1, 0, 2, True, line_trace_params, ttnn.Topology.Linear, False],
         [(4, 8), (4, 8), 1, 0, 2, False, line_trace_params, ttnn.Topology.Linear, False],
     ],
-    ids=["bh_2x4sp1tp0", "bh_4x8sp1tp0"],
+    ids=["bh_1x4sp1tp0", "bh_2x4sp1tp0", "bh_4x8sp1tp0"],
     indirect=["mesh_device", "device_params"],
 )
 def test_warm_harness(
@@ -201,3 +206,4 @@ def test_warm_harness(
         )
 
     pipeline.release_traces()
+    pipeline.release_audio_submesh()

--- a/models/tt_dit/tests/models/ltx/audio_warm_harness.py
+++ b/models/tt_dit/tests/models/ltx/audio_warm_harness.py
@@ -51,6 +51,43 @@ def _stage_decode(pipeline, latent, num_frames):
     return (t1 - t0) * 1000, (t2 - t1) * 1000, (t2 - t0) * 1000, wav
 
 
+def _probe_split(pipeline, latent, num_frames, reps, label):
+    """Split the vocoder+bwe wall into (main-vocoder) vs (bwe-half) with device syncs around
+    each, to settle the dispatch paradox: the main vocoder is the part that runs traced in the
+    TRACED leg. If its wall does NOT shrink when traced (host dispatch removed), the stage is
+    device-bound and op-count reduction — not trace — is the durable lever."""
+    vwb = pipeline.tt_vocoder_with_bwe
+    z = pipeline.tt_audio_decoder.z_channels
+    audio_spatial = latent.reshape(1, latent.shape[1], z, latent.shape[2] // z).permute(0, 2, 1, 3).float()
+    mel = pipeline._decode_mel(audio_spatial)
+    voc_ms, bwe_ms = [], []
+    for _ in range(reps):
+        md = mel.float()
+        ttnn.synchronize_device(pipeline.mesh_device)
+        t0 = time.perf_counter()
+        x = vwb.vocoder.forward_traced(md) if vwb.use_trace else vwb.vocoder(md)
+        ttnn.synchronize_device(pipeline.mesh_device)
+        t1 = time.perf_counter()
+        B, C, low = x.shape
+        out_len = low * vwb.output_sampling_rate // vwb.input_sampling_rate
+        _ = vwb._bwe_from_waveform(x, input_dtype=md.dtype, output_length=out_len)
+        ttnn.synchronize_device(pipeline.mesh_device)
+        t2 = time.perf_counter()
+        voc_ms.append((t1 - t0) * 1000)
+        bwe_ms.append((t2 - t1) * 1000)
+
+    def _med(xs):
+        return sorted(xs)[len(xs) // 2]
+
+    print(
+        f"\nWARM_HARNESS PROBE {label} reps={reps} "
+        f"main_vocoder={_med(voc_ms):.1f}ms bwe_half={_med(bwe_ms):.1f}ms "
+        f"(voc_min={min(voc_ms):.1f} voc_max={max(voc_ms):.1f})",
+        flush=True,
+    )
+    return _med(voc_ms), _med(bwe_ms)
+
+
 def _avg_leg(pipeline, latent, num_frames, reps, warmups, label):
     for _ in range(warmups):
         _stage_decode(pipeline, latent, num_frames)
@@ -137,9 +174,13 @@ def test_warm_harness(
     cold_ms = (time.perf_counter() - t0) * 1000
     print(f"\nWARM_HARNESS cold={cold_ms:.1f}ms", flush=True)
 
+    probe = os.environ.get("PROBE_SPLIT") == "1"
+
     # ---- EAGER leg ----
     pipeline._traced = False
     eager_total, _ = _avg_leg(pipeline, latent, num_frames, eager_reps, warmups, "EAGER")
+    if probe:
+        _probe_split(pipeline, latent, num_frames, max(eager_reps, 3), "EAGER")
 
     # ---- TRACED leg ---- (in-process switch: release any traces, flip flag, re-prime flags)
     if traced_reps > 0:
@@ -149,6 +190,8 @@ def test_warm_harness(
         # lazily captures the vocoder/VAE trace per LTX_VOC_TRACE/LTX_BWE_TRACE/LTX_VAE_TRACE.
         # Use extra warmups so the lazy capture cost isn't counted in the timed reps.
         traced_total, _ = _avg_leg(pipeline, latent, num_frames, traced_reps, max(warmups, 2), "TRACED")
+        if probe:
+            _probe_split(pipeline, latent, num_frames, max(traced_reps, 3), "TRACED")
         delta = traced_total - eager_total
         print(
             f"\nWARM_HARNESS EAGER_vs_TRACED eager_total={eager_total:.1f}ms "

--- a/models/tt_dit/tests/models/ltx/prof_girl_decode.py
+++ b/models/tt_dit/tests/models/ltx/prof_girl_decode.py
@@ -40,8 +40,8 @@ def _flush_after(cls, mesh):
 
 @pytest.mark.parametrize(
     "mesh_device, mesh_shape, device_params",
-    [[(2, 4), (2, 4), line_params]],
-    ids=["bh_2x4sp1tp0"],
+    [[(2, 4), (2, 4), line_params], [(4, 8), (4, 8), line_params]],
+    ids=["bh_2x4sp1tp0", "bh_4x8sp1tp0"],
     indirect=["mesh_device", "device_params"],
 )
 def test_prof_girl_decode(mesh_device, mesh_shape, device_params):
@@ -62,7 +62,7 @@ def test_prof_girl_decode(mesh_device, mesh_shape, device_params):
         sp_axis=1,
         tp_axis=0,
         num_links=2,
-        dynamic_load=True,
+        dynamic_load=(mesh_shape != (4, 8)),
         topology=ttnn.Topology.Linear,
         is_fsdp=False,
         run_warmup=False,

--- a/models/tt_dit/tests/models/ltx/prof_girl_decode.py
+++ b/models/tt_dit/tests/models/ltx/prof_girl_decode.py
@@ -57,6 +57,11 @@ def test_prof_girl_decode(mesh_device, mesh_shape, device_params):
         _flush_after(ConvTranspose1dViaConv3d, mesh)  # upsample inner-convs
 
     num_frames = int(os.environ.get("NUM_FRAMES", "145"))
+    # PROF_TRACED=1 captures the TRACED vocoder graph instead of eager. Used to settle the
+    # dispatch paradox: compare the per-op device-active sum eager-vs-traced at constant op
+    # count. If traced RAISES device-active, the wall-vs-device gap is device-side (per-op
+    # sync / scheduling) and the durable fix is op-count reduction, not host-dispatch removal.
+    prof_traced = os.environ.get("PROF_TRACED") == "1"
     pipeline = LTXDistilledPipeline.create_pipeline(
         mesh_device=mesh,
         checkpoint_name=default_ltx_checkpoint("ltx-2.3-22b-distilled-1.1.safetensors"),
@@ -68,7 +73,7 @@ def test_prof_girl_decode(mesh_device, mesh_shape, device_params):
         topology=ttnn.Topology.Linear,
         is_fsdp=False,
         run_warmup=False,
-        traced=False,
+        traced=prof_traced,
         audio_only=True,  # skip the 22B transformer/VAE build+prime decode_audio never uses
         num_frames=num_frames,
         height=1088,

--- a/models/tt_dit/tests/models/ltx/prof_girl_decode.py
+++ b/models/tt_dit/tests/models/ltx/prof_girl_decode.py
@@ -40,19 +40,21 @@ def _flush_after(cls, mesh):
 
 @pytest.mark.parametrize(
     "mesh_device, mesh_shape, device_params",
-    [[(2, 4), (2, 4), line_params], [(4, 8), (4, 8), line_params]],
-    ids=["bh_2x4sp1tp0", "bh_4x8sp1tp0"],
+    [[(1, 4), (1, 4), line_params], [(2, 4), (2, 4), line_params], [(4, 8), (4, 8), line_params]],
+    ids=["bh_1x4sp1tp0", "bh_2x4sp1tp0", "bh_4x8sp1tp0"],
     indirect=["mesh_device", "device_params"],
 )
 def test_prof_girl_decode(mesh_device, mesh_shape, device_params):
     parent = mesh_device
     mesh = parent.create_submesh(ttnn.MeshShape(*mesh_shape))
 
-    # Flush per conv wrapper (every conv in mel-VAE / vocoder / BWE goes through one of these).
-    # Per-block was borderline — a window occasionally exceeded the 1000-zone buffer and dropped an op.
-    _flush_after(Conv1dViaConv3d, mesh)  # _AlignedOutConv1d inherits this forward
-    _flush_after(Conv2dViaConv3d, mesh)  # mel-VAE
-    _flush_after(ConvTranspose1dViaConv3d, mesh)  # upsample inner-convs
+    # Per-conv ReadDeviceProfiler flushes bound the device zone buffer, but on a 32-chip mesh each
+    # is a full mesh sync (poisons OP-TO-OP LATENCY and writes a huge device log). Set
+    # LTX_PROF_NOFLUSH=1 and rely on a large --op-support-count for a clean streaming capture.
+    if os.environ.get("LTX_PROF_NOFLUSH") != "1":
+        _flush_after(Conv1dViaConv3d, mesh)  # _AlignedOutConv1d inherits this forward
+        _flush_after(Conv2dViaConv3d, mesh)  # mel-VAE
+        _flush_after(ConvTranspose1dViaConv3d, mesh)  # upsample inner-convs
 
     num_frames = int(os.environ.get("NUM_FRAMES", "145"))
     pipeline = LTXDistilledPipeline.create_pipeline(

--- a/models/tt_dit/tests/models/ltx/prof_girl_decode.py
+++ b/models/tt_dit/tests/models/ltx/prof_girl_decode.py
@@ -69,6 +69,7 @@ def test_prof_girl_decode(mesh_device, mesh_shape, device_params):
         is_fsdp=False,
         run_warmup=False,
         traced=False,
+        audio_only=True,  # skip the 22B transformer/VAE build+prime decode_audio never uses
         num_frames=num_frames,
         height=1088,
         width=1920,
@@ -77,8 +78,13 @@ def test_prof_girl_decode(mesh_device, mesh_shape, device_params):
     lat = os.environ.get("AUDIO_LATENT") or os.path.join(os.path.dirname(__file__), "fixtures", "girl_audio_latent.npy")
     latent = torch.from_numpy(np.load(lat)).float()
 
-    # Single decode (cold: weight load + compile is host-side, so per-op DEVICE times are
-    # valid). One decode halves the captured zone count vs cold+warm → faster post-processing.
+    # PROF_WARM=1 (default): an untimed cold decode does the one-time device-side mesh-workload
+    # assembly first, then ReadDeviceProfiler drains those zones, so the profiled decode below
+    # captures WARM steady-state op times + clean OP-TO-OP gaps (not assembly overhead).
+    # PROF_WARM=0 profiles the cold decode (per-op DEVICE times still valid; fewer zones to drain).
+    if os.environ.get("PROF_WARM", "1") != "0":
+        pipeline.decode_audio(latent, num_frames, fps=24.0)
+        ttnn.ReadDeviceProfiler(mesh)  # discard cold-assembly zones
     pipeline.decode_audio(latent, num_frames, fps=24.0)
     ttnn.ReadDeviceProfiler(mesh)
     pipeline.release_traces()

--- a/models/tt_dit/tests/models/ltx/prof_vocoder_forward.py
+++ b/models/tt_dit/tests/models/ltx/prof_vocoder_forward.py
@@ -457,16 +457,25 @@ def test_full_forward_wall(mesh_device, mesh_shape, t_factor, t_axis, c_factor, 
     [{"l1_small_size": 32768, "fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 300000000}],
     indirect=True,
 )
-@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
-def test_vocoder_with_bwe_traced(mesh_device, device_params):
-    # Validate the VocoderWithBWE.use_trace wiring: traced main vocoder + eager BWE == fully eager.
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, t_factor, t_axis, c_factor, c_axis",
+    [
+        [(2, 4), (2, 4), 4, 1, 2, 0],
+        [(4, 8), (4, 8), 8, 1, 4, 0],
+    ],
+    ids=["bh_2x4", "bh_4x8"],
+    indirect=["mesh_device"],
+)
+def test_vocoder_with_bwe_traced(mesh_device, mesh_shape, t_factor, t_axis, c_factor, c_axis, device_params):
+    # Validate both generators traced (main + BWE) == fully eager, on the replayed graph (the
+    # production path): warm -> capture -> replay, compare replay to eager.
     from models.tt_dit.tests.models.ltx.test_audio_components_ltx import _build_torch_stage_c, _build_tt_stage_c
 
     parent = mesh_device
-    mesh = parent.create_submesh(ttnn.MeshShape(2, 4))
+    mesh = parent.create_submesh(ttnn.MeshShape(*mesh_shape))
     pc = AudioTCParallelConfig(
-        time_parallel=ParallelFactor(factor=4, mesh_axis=1),
-        channel_parallel=ParallelFactor(factor=2, mesh_axis=0),
+        time_parallel=ParallelFactor(factor=t_factor, mesh_axis=t_axis),
+        channel_parallel=ParallelFactor(factor=c_factor, mesh_axis=c_axis),
     )
     ccl = CCLManager(mesh, num_links=1, topology=ttnn.Topology.Linear)
     torch_full = _build_torch_stage_c(seed=42)
@@ -477,13 +486,25 @@ def test_vocoder_with_bwe_traced(mesh_device, device_params):
 
     mel = _vocoder_mel()
     tt_full.use_trace = False
+    tt_full.use_trace_bwe = False
     out_eager = tt_full(mel)
+    t0 = time.perf_counter()
+    for _ in range(5):
+        out_eager = tt_full(mel)
+    eager_ms = (time.perf_counter() - t0) * 1000 / 5
     tt_full.use_trace = True
-    _ = tt_full(mel)  # capture
-    out_traced = tt_full(mel)  # replay
+    tt_full.use_trace_bwe = True
+    _ = tt_full(mel)  # warm lazy device-graph state
+    _ = tt_full(mel)  # capture (prep_run=False)
+    out_traced = tt_full(mel)  # replay — the production path
+    t0 = time.perf_counter()
+    for _ in range(5):
+        out_traced = tt_full(mel)
+    traced_ms = (time.perf_counter() - t0) * 1000 / 5
     tt_full.release_trace()
     max_abs = (out_eager - out_traced).abs().max().item()
-    print(f"\nVOC_BWE_TRACED max|Δ|(traced vs eager)={max_abs:.3e}", flush=True)
+    print(f"\nVOC_BWE_TRACED max|Δ|(replay vs eager)={max_abs:.3e}", flush=True)
+    print(f"VOC_BWE_WALL eager={eager_ms:.2f}ms traced={traced_ms:.2f}ms speedup={eager_ms/traced_ms:.2f}x", flush=True)
     assert max_abs < 5e-3, f"VocoderWithBWE traced diverged: {max_abs:.3e}"
 
 

--- a/models/tt_dit/tests/models/ltx/prof_vocoder_forward.py
+++ b/models/tt_dit/tests/models/ltx/prof_vocoder_forward.py
@@ -241,25 +241,31 @@ def test_prof_vocoder_devicetime(mesh_device, mesh_shape, t_factor, t_axis, c_fa
     )
     tt_voc.load_torch_state_dict(_diffusers_vocoder_state_to_tt(torch_voc.state_dict()))
 
-    # Periodic profiler flush after each AMPBlock1 to bound the device zone buffer.
+    # Periodic profiler flush after each AMPBlock1 to bound the device zone buffer. On a
+    # 32-chip mesh each flush is a full mesh sync + readback (~seconds), so per-block flushing
+    # is the run-phase pathology. Set LTX_PROF_NOFLUSH=1 (with a buffer big enough via
+    # TT_METAL_PROFILER_PROGRAM_SUPPORT_COUNT) to capture everything in ONE end-of-run readback.
+    _noflush = os.environ.get("LTX_PROF_NOFLUSH") == "1"
+
     def _walk(m):
         yield m
         for _, c in m.named_children():
             yield from _walk(c)
 
-    for mod in _walk(tt_voc):
-        if isinstance(mod, AMPBlock1):
-            orig = mod.forward
+    if not _noflush:
+        for mod in _walk(tt_voc):
+            if isinstance(mod, AMPBlock1):
+                orig = mod.forward
 
-            def timed(*a, _orig=orig, **k):
-                r = _orig(*a, **k)
-                # Flush only at a quiesced point — reading mid-flight truncates an open
-                # CCL/halo zone -> "End marker without start marker" abort on dump.
-                ttnn.synchronize_device(mesh)
-                ttnn.ReadDeviceProfiler(mesh)
-                return r
+                def timed(*a, _orig=orig, **k):
+                    r = _orig(*a, **k)
+                    # Flush only at a quiesced point — reading mid-flight truncates an open
+                    # CCL/halo zone -> "End marker without start marker" abort on dump.
+                    ttnn.synchronize_device(mesh)
+                    ttnn.ReadDeviceProfiler(mesh)
+                    return r
 
-            mod.forward = timed
+                mod.forward = timed
 
     mel = _vocoder_mel()
     _ = tt_voc(mel)
@@ -703,3 +709,76 @@ def test_prof_bwe_per_conv(mesh_device, device_params):
 
 def _round32(c):
     return ((c + 31) // 32) * 32
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": 32768, "fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 300000000}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape",
+    [[(2, 4), (2, 4)], [(4, 8), (4, 8)]],
+    ids=["bh_2x4", "bh_4x8"],
+    indirect=["mesh_device"],
+)
+def test_audio_decoder_traced_wall(mesh_device, mesh_shape, device_params):
+    """Gate + size the mel-VAE (AudioDecoder) trace: eager vs forward_traced, bit-identical.
+    Validates the Conv2dViaConv3d _persistent_zeros fix makes the device graph capturable."""
+    from models.tt_dit.models.audio_vae.audio_decoder_ltx import AudioDecoder
+    from models.tt_dit.tests.models.ltx.test_audio_components_ltx import (
+        _AUDIO_DECODER_CFG,
+        _audio_decoder_state_from_diffusers,
+        _require_diffusers,
+    )
+
+    AutoencoderKLLTX2Audio, _, _ = _require_diffusers()
+    parent = mesh_device
+    mesh = parent.create_submesh(ttnn.MeshShape(*mesh_shape))
+
+    torch.manual_seed(42)
+    ref_vae = AutoencoderKLLTX2Audio(
+        base_channels=_AUDIO_DECODER_CFG["ch"],
+        output_channels=_AUDIO_DECODER_CFG["out_ch"],
+        ch_mult=_AUDIO_DECODER_CFG["ch_mult"],
+        num_res_blocks=_AUDIO_DECODER_CFG["num_res_blocks"],
+        attn_resolutions=_AUDIO_DECODER_CFG["attn_resolutions"],
+        resolution=_AUDIO_DECODER_CFG["resolution"],
+        latent_channels=_AUDIO_DECODER_CFG["z_channels"],
+        norm_type="pixel",
+        causality_axis="height",
+        mid_block_add_attention=_AUDIO_DECODER_CFG["mid_block_add_attention"],
+        sample_rate=_AUDIO_DECODER_CFG["sample_rate"],
+        mel_hop_length=_AUDIO_DECODER_CFG["mel_hop_length"],
+        is_causal=_AUDIO_DECODER_CFG["is_causal"],
+        mel_bins=_AUDIO_DECODER_CFG["mel_bins"],
+    ).eval()
+
+    z_times_f = _AUDIO_DECODER_CFG["z_channels"] * _AUDIO_DECODER_CFG["mel_bins"]
+    tt_decoder = AudioDecoder(mesh_device=mesh, **_AUDIO_DECODER_CFG)
+    tt_decoder.load_torch_state_dict(
+        _audio_decoder_state_from_diffusers(ref_vae, stats_std=torch.ones(z_times_f), stats_mean=torch.zeros(z_times_f))
+    )
+
+    latent = torch.randn(1, _AUDIO_DECODER_CFG["z_channels"], 64, _AUDIO_DECODER_CFG["mel_bins"], dtype=torch.float32)
+
+    def wall(fn, n=5):
+        ttnn.synchronize_device(mesh)
+        t = time.perf_counter()
+        for _ in range(n):
+            out = fn(latent)
+        ttnn.synchronize_device(mesh)
+        return out, (time.perf_counter() - t) * 1000 / n
+
+    out_eager, ms_eager = wall(tt_decoder.forward)
+    _ = tt_decoder.forward_traced(latent)  # capture
+    out_traced, ms_traced = wall(tt_decoder.forward_traced)
+    tt_decoder.release_trace()
+
+    max_abs = (out_eager - out_traced).abs().max().item()
+    print(
+        f"\nAUDIO_DECODER_TRACE_WALL eager={ms_eager:.1f}ms traced={ms_traced:.1f}ms "
+        f"speedup={ms_eager / ms_traced:.2f}x | max|Δ|={max_abs:.3e}",
+        flush=True,
+    )
+    assert max_abs < 5e-3, f"AudioDecoder traced diverged: {max_abs:.3e}"

--- a/models/tt_dit/tests/models/ltx/prof_vocoder_forward.py
+++ b/models/tt_dit/tests/models/ltx/prof_vocoder_forward.py
@@ -47,12 +47,21 @@ def _wrap_conv(mod):
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": 32768, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
 )
-@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
-def test_prof_vocoder_per_conv(mesh_device, device_params):
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, t_factor, t_axis, c_factor, c_axis",
+    [
+        [(2, 4), (2, 4), 4, 1, 2, 0],
+        [(4, 8), (4, 8), 8, 1, 4, 0],
+    ],
+    ids=["bh_2x4", "bh_4x8"],
+    indirect=["mesh_device"],
+)
+def test_prof_vocoder_per_conv(mesh_device, mesh_shape, t_factor, t_axis, c_factor, c_axis, device_params):
     parent = mesh_device
-    mesh = parent.create_submesh(ttnn.MeshShape(2, 4))
+    mesh = parent.create_submesh(ttnn.MeshShape(*mesh_shape))
     pc = AudioTCParallelConfig(
-        time_parallel=ParallelFactor(factor=4, mesh_axis=1), channel_parallel=ParallelFactor(factor=2, mesh_axis=0)
+        time_parallel=ParallelFactor(factor=t_factor, mesh_axis=t_axis),
+        channel_parallel=ParallelFactor(factor=c_factor, mesh_axis=c_axis),
     )
     ccl = CCLManager(mesh, num_links=1, topology=ttnn.Topology.Linear)
     torch_voc = _build_torch_stage_b(seed=42)
@@ -125,12 +134,21 @@ def _wrap_cat(mod, label):
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": 32768, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
 )
-@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
-def test_prof_vocoder_categories(mesh_device, device_params):
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, t_factor, t_axis, c_factor, c_axis",
+    [
+        [(2, 4), (2, 4), 4, 1, 2, 0],
+        [(4, 8), (4, 8), 8, 1, 4, 0],
+    ],
+    ids=["bh_2x4", "bh_4x8"],
+    indirect=["mesh_device"],
+)
+def test_prof_vocoder_categories(mesh_device, mesh_shape, t_factor, t_axis, c_factor, c_axis, device_params):
     parent = mesh_device
-    mesh = parent.create_submesh(ttnn.MeshShape(2, 4))
+    mesh = parent.create_submesh(ttnn.MeshShape(*mesh_shape))
     pc = AudioTCParallelConfig(
-        time_parallel=ParallelFactor(factor=4, mesh_axis=1), channel_parallel=ParallelFactor(factor=2, mesh_axis=0)
+        time_parallel=ParallelFactor(factor=t_factor, mesh_axis=t_axis),
+        channel_parallel=ParallelFactor(factor=c_factor, mesh_axis=c_axis),
     )
     ccl = CCLManager(mesh, num_links=1, topology=ttnn.Topology.Linear)
     torch_voc = _build_torch_stage_b(seed=42)
@@ -189,18 +207,26 @@ def test_prof_vocoder_categories(mesh_device, device_params):
 @pytest.mark.parametrize(
     "device_params", [{"l1_small_size": 32768, "fabric_config": ttnn.FabricConfig.FABRIC_1D}], indirect=True
 )
-@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
-def test_prof_vocoder_devicetime(mesh_device, device_params):
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, t_factor, t_axis, c_factor, c_axis",
+    [
+        [(2, 4), (2, 4), 4, 1, 2, 0],
+        [(4, 8), (4, 8), 8, 1, 4, 0],
+    ],
+    ids=["bh_2x4", "bh_4x8"],
+    indirect=["mesh_device"],
+)
+def test_prof_vocoder_devicetime(mesh_device, mesh_shape, t_factor, t_axis, c_factor, c_axis, device_params):
     # Run under: python -m tracy -p -r -m pytest <this>::test_prof_vocoder_devicetime
     # Flushes the on-device profiler buffer after each AMPBlock1 (~300 ops/window) to stay
     # under the 1000-zone tracy buffer limit; the CSV then has every op's DEVICE FW DURATION.
     # Sum of DEVICE FW DURATION over one forward = true device-active time; compare to the
     # host wall (printed) to get the host-dispatch-bound fraction (the trace-mode ceiling).
     parent = mesh_device
-    mesh = parent.create_submesh(ttnn.MeshShape(2, 4))
+    mesh = parent.create_submesh(ttnn.MeshShape(*mesh_shape))
     pc = AudioTCParallelConfig(
-        time_parallel=ParallelFactor(factor=4, mesh_axis=1),
-        channel_parallel=ParallelFactor(factor=2, mesh_axis=0),
+        time_parallel=ParallelFactor(factor=t_factor, mesh_axis=t_axis),
+        channel_parallel=ParallelFactor(factor=c_factor, mesh_axis=c_axis),
     )
     ccl = CCLManager(mesh, num_links=1, topology=ttnn.Topology.Linear)
     torch_voc = _build_torch_stage_b(seed=42)
@@ -227,6 +253,9 @@ def test_prof_vocoder_devicetime(mesh_device, device_params):
 
             def timed(*a, _orig=orig, **k):
                 r = _orig(*a, **k)
+                # Flush only at a quiesced point — reading mid-flight truncates an open
+                # CCL/halo zone -> "End marker without start marker" abort on dump.
+                ttnn.synchronize_device(mesh)
                 ttnn.ReadDeviceProfiler(mesh)
                 return r
 
@@ -368,14 +397,22 @@ def test_forward_traced_correctness(mesh_device, device_params):
     [{"l1_small_size": 32768, "fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 300000000}],
     indirect=True,
 )
-@pytest.mark.parametrize("mesh_device", [(2, 4)], indirect=True)
-def test_full_forward_wall(mesh_device, device_params):
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, t_factor, t_axis, c_factor, c_axis",
+    [
+        [(2, 4), (2, 4), 4, 1, 2, 0],
+        [(4, 8), (4, 8), 8, 1, 4, 0],
+    ],
+    ids=["bh_2x4", "bh_4x8"],
+    indirect=["mesh_device"],
+)
+def test_full_forward_wall(mesh_device, mesh_shape, t_factor, t_axis, c_factor, c_axis, device_params):
     # Full vocoder forward (host prep + device + readback) wall: eager vs forward_traced.
     parent = mesh_device
-    mesh = parent.create_submesh(ttnn.MeshShape(2, 4))
+    mesh = parent.create_submesh(ttnn.MeshShape(*mesh_shape))
     pc = AudioTCParallelConfig(
-        time_parallel=ParallelFactor(factor=4, mesh_axis=1),
-        channel_parallel=ParallelFactor(factor=2, mesh_axis=0),
+        time_parallel=ParallelFactor(factor=t_factor, mesh_axis=t_axis),
+        channel_parallel=ParallelFactor(factor=c_factor, mesh_axis=c_axis),
     )
     ccl = CCLManager(mesh, num_links=1, topology=ttnn.Topology.Linear)
     torch_voc = _build_torch_stage_b(seed=42)
@@ -442,6 +479,73 @@ def test_vocoder_with_bwe_traced(mesh_device, device_params):
     max_abs = (out_eager - out_traced).abs().max().item()
     print(f"\nVOC_BWE_TRACED max|Δ|(traced vs eager)={max_abs:.3e}", flush=True)
     assert max_abs < 5e-3, f"VocoderWithBWE traced diverged: {max_abs:.3e}"
+
+
+@pytest.mark.parametrize(
+    "device_params",
+    [{"l1_small_size": 32768, "fabric_config": ttnn.FabricConfig.FABRIC_1D, "trace_region_size": 300000000}],
+    indirect=True,
+)
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, t_factor, t_axis, c_factor, c_axis",
+    [
+        [(2, 4), (2, 4), 4, 1, 2, 0],
+        [(4, 8), (4, 8), 8, 1, 4, 0],
+    ],
+    ids=["bh_2x4", "bh_4x8"],
+    indirect=["mesh_device"],
+)
+def test_bwe_traced_wall(mesh_device, mesh_shape, t_factor, t_axis, c_factor, c_axis, device_params):
+    """Size the BWE-trace prize: full VocoderWithBWE (main+BWE) eager vs main-traced-only
+    (current prod) vs both-traced. Gate: both-traced must match eager (max|Δ|<5e-3)."""
+    from models.tt_dit.tests.models.ltx.test_audio_components_ltx import (
+        _build_torch_stage_c,
+        _build_tt_stage_c,
+        _diffusers_vocoder_with_bwe_state_to_tt,
+    )
+
+    parent = mesh_device
+    mesh = parent.create_submesh(ttnn.MeshShape(*mesh_shape))
+    pc = AudioTCParallelConfig(
+        time_parallel=ParallelFactor(factor=t_factor, mesh_axis=t_axis),
+        channel_parallel=ParallelFactor(factor=c_factor, mesh_axis=c_axis),
+    )
+    ccl = CCLManager(mesh, num_links=1, topology=ttnn.Topology.Linear)
+    torch_full = _build_torch_stage_c(seed=42)
+    tt_full = _build_tt_stage_c(mesh, parallel_config=pc, ccl_manager=ccl)
+    tt_full.load_torch_state_dict(_diffusers_vocoder_with_bwe_state_to_tt(torch_full.state_dict()))
+
+    mel = _vocoder_mel()
+
+    def wall(n=5):
+        ttnn.synchronize_device(mesh)
+        t = time.perf_counter()
+        for _ in range(n):
+            out = tt_full(mel)
+        ttnn.synchronize_device(mesh)
+        return out, (time.perf_counter() - t) * 1000 / n
+
+    tt_full.use_trace = False
+    tt_full.use_trace_bwe = False
+    out_eager, ms_eager = wall()
+
+    tt_full.use_trace = True  # current production path: main vocoder traced, BWE eager
+    _ = tt_full(mel)  # capture main
+    _, ms_main = wall()
+
+    tt_full.use_trace_bwe = True  # proposed: BWE traced too
+    _ = tt_full(mel)  # capture BWE
+    out_both, ms_both = wall()
+    tt_full.release_trace()
+
+    max_abs = (out_eager - out_both).abs().max().item()
+    print(
+        f"\nBWE_TRACE_WALL eager={ms_eager:.1f}ms main_traced={ms_main:.1f}ms both_traced={ms_both:.1f}ms "
+        f"| main_speedup={ms_eager / ms_main:.2f}x both_speedup={ms_eager / ms_both:.2f}x "
+        f"| max|Δ|(both vs eager)={max_abs:.3e}",
+        flush=True,
+    )
+    assert max_abs < 5e-3, f"BWE traced diverged: {max_abs:.3e}"
 
 
 @pytest.mark.parametrize(

--- a/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
+++ b/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
@@ -242,7 +242,9 @@ def test_audio_decode_girl(mesh_device, mesh_shape, sp_axis, tp_axis, num_links,
     # One untimed decode to absorb a late first-replay cost (the BWE trace captures on the
     # first post-cold call, not during the cold decode), so warm_ms is true steady state.
     pipeline.decode_audio(latent, num_frames, fps=24.0)
-    N = 5
+    # WARM_REPS shrinks the steady-state loop for fast dev iteration (the PCC oracle below is
+    # unaffected); default 5 keeps warm_ms a stable average for reported timings.
+    N = int(os.environ.get("WARM_REPS", "5"))
     t0 = time.perf_counter()
     for _ in range(N):
         audio = pipeline.decode_audio(latent, num_frames, fps=24.0)

--- a/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
+++ b/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
@@ -178,7 +178,7 @@ def test_pipeline_distilled(
 @pytest.mark.parametrize(
     "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
     [
-        [(2, 4), (2, 4), 1, 0, 2, True, ring_trace_params, ttnn.Topology.Linear, False],
+        [(2, 4), (2, 4), 1, 0, 2, True, line_trace_params, ttnn.Topology.Linear, False],
         [(4, 8), (4, 8), 1, 0, 2, False, line_trace_params, ttnn.Topology.Linear, False],
     ],
     ids=["bh_2x4sp1tp0", "bh_4x8sp1tp0"],
@@ -215,6 +215,7 @@ def test_audio_decode_girl(mesh_device, mesh_shape, sp_axis, tp_axis, num_links,
         is_fsdp=is_fsdp,
         run_warmup=False,
         traced=traced,
+        audio_only=True,  # skip the ~10-min video warmup; decode_audio captures its own trace
         num_frames=num_frames,
         height=height,
         width=width,
@@ -238,6 +239,9 @@ def test_audio_decode_girl(mesh_device, mesh_shape, sp_axis, tp_axis, num_links,
     audio = pipeline.decode_audio(latent, num_frames, fps=24.0)  # cold: weight load + compile (+ capture)
     cold_ms = (time.perf_counter() - t0) * 1000
 
+    # One untimed decode to absorb a late first-replay cost (the BWE trace captures on the
+    # first post-cold call, not during the cold decode), so warm_ms is true steady state.
+    pipeline.decode_audio(latent, num_frames, fps=24.0)
     N = 5
     t0 = time.perf_counter()
     for _ in range(N):

--- a/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
+++ b/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
@@ -323,6 +323,7 @@ def test_audio_decode_girl(mesh_device, mesh_shape, sp_axis, tp_axis, num_links,
     assert c_pcc > 0.95, f"conv1d-vs-torch PCC {c_pcc:.4f} below floor (traced={traced}) — vocoder output is wrong"
 
     pipeline.release_traces()
+    pipeline.release_audio_submesh()
     dur = wav.shape[-1] / sr
     print(
         f"\nAUDIO_GIRL depthwise={'conv1d' if _ao._USE_CONV1D_DEPTHWISE else 'mac'} traced={traced} "

--- a/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
+++ b/models/tt_dit/tests/models/ltx/test_pipeline_ltx_distilled.py
@@ -25,8 +25,6 @@ from models.tt_dit.utils.test import line_params, ring_params
 
 # Trace region for LTX_TRACED=1. Holds both stage traces' command streams (s1 + larger-seq
 # s2); measured need is ~236 MB at 1080p (get_trace_buffers_size), so 300 MB gives headroom.
-# One per fabric topology so the trace region pairs with the row's own fabric config. Harmless
-# for eager runs (the region is just reserved DRAM, never written).
 ring_trace_params = {**ring_params, "trace_region_size": 300_000_000}
 line_trace_params = {**line_params, "trace_region_size": 300_000_000}
 
@@ -47,8 +45,8 @@ line_trace_params = {**line_params, "trace_region_size": 300_000_000}
     [
         [(2, 2), (2, 2), 0, 1, 2, False, line_params, ttnn.Topology.Linear, True],
         [(2, 4), (2, 4), 0, 1, 1, True, line_params, ttnn.Topology.Linear, True],
-        # BH on 2x4 (line_trace_params so LTX_TRACED=1 is runnable here; line fabric matches Linear)
-        [(2, 4), (2, 4), 1, 0, 2, True, line_trace_params, ttnn.Topology.Linear, False],
+        # BH on 2x4
+        [(2, 4), (2, 4), 1, 0, 2, True, line_params, ttnn.Topology.Linear, False],
         # WH (ring) on 4x8. Requires increased worker_l1_size to avoid code-size error in RingAttention.
         [(4, 8), (4, 8), 1, 0, 4, True, {"worker_l1_size": 1344544, **ring_params}, ttnn.Topology.Ring, True],
         # BH (linear) on 4x8
@@ -180,9 +178,10 @@ def test_pipeline_distilled(
 @pytest.mark.parametrize(
     "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
     [
-        [(2, 4), (2, 4), 1, 0, 2, True, line_trace_params, ttnn.Topology.Linear, False],
+        [(2, 4), (2, 4), 1, 0, 2, True, ring_trace_params, ttnn.Topology.Linear, False],
+        [(4, 8), (4, 8), 1, 0, 2, False, line_trace_params, ttnn.Topology.Linear, False],
     ],
-    ids=["bh_2x4sp1tp0"],
+    ids=["bh_2x4sp1tp0", "bh_4x8sp1tp0"],
     indirect=["mesh_device", "device_params"],
 )
 def test_audio_decode_girl(mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, topology, is_fsdp):

--- a/models/tt_dit/utils/conv3d.py
+++ b/models/tt_dit/utils/conv3d.py
@@ -475,6 +475,17 @@ _DEFAULT_BLOCKINGS = {
     (128, 48, (3, 3, 3)): (128, 32, 1, 8, 8),  # s4_out
     (1024, 4096, (1, 3, 3)): (256, 32, 1, 1, 1),  # upsampler (kT=1)
     (1024, 128, (3, 3, 3)): (256, 32, 1, 1, 1),  # upsampler final_conv
+    # LTX-2.3 audio mel-VAE decoder (Conv2dViaConv3d, kT=1, W=mel_bins=16). These
+    # combos otherwise fell to the hardcoded (Cin, 32, 1, 1, 1) default, whose
+    # H_out=W_out=1 forces one output pixel per work-unit (4-16ms/conv). Block the
+    # full mel width (W_out=16) and a height chunk so each unit produces more output.
+    (512, 512, (1, 3, 3)): (512, 32, 1, 8, 16),
+    (256, 256, (1, 3, 3)): (256, 32, 1, 8, 16),
+    (128, 128, (1, 3, 3)): (128, 32, 1, 8, 16),
+    (512, 256, (1, 3, 3)): (512, 32, 1, 8, 16),
+    (256, 128, (1, 3, 3)): (256, 32, 1, 8, 16),
+    (32, 512, (1, 3, 3)): (32, 32, 1, 8, 16),  # conv_in (z_channels 8 -> aligned 32)
+    (128, 32, (1, 3, 3)): (128, 32, 1, 8, 16),  # conv_out (out_ch 2 -> aligned 32)
 }
 
 

--- a/tools/tracy/process_ops_logs.py
+++ b/tools/tracy/process_ops_logs.py
@@ -209,6 +209,22 @@ def build_sub_device_id_lookup_from_device_csv(
     if not device_log_path.is_file():
         return lookup
 
+    # profile_log_device.csv is tens of GB of per-core timeseries; the sub_device_id
+    # meta is sparse and absent in the common (no sub-device) case, where a full
+    # pd.read_csv + row scan costs minutes to build an empty lookup. Cheaply byte-scan
+    # for the marker first and skip the parse entirely when it never appears.
+    with open(device_log_path, "rb") as fh:
+        marker = b"sub_device_id"
+        tail = b""
+        present = False
+        while chunk := fh.read(1 << 24):  # 16 MiB
+            if marker in tail + chunk:
+                present = True
+                break
+            tail = chunk[-(len(marker) - 1) :]
+        if not present:
+            return lookup
+
     df = pd.read_csv(device_log_path, skiprows=1, header=0, na_filter=False)
     for row in df.itertuples():
         meta_data = parse_device_csv_meta_data(row[15])
@@ -444,10 +460,30 @@ def import_tracy_op_logs(
     for opData in opsData:
         ops[opData["global_call_count"]] = opData
 
+    # tracy_ops_times.csv is dominated by per-call zone rows this import discards: only rows
+    # whose `name` is a TT_DNN/TT_METAL op (host_time) or whose `special_parent_text` carries
+    # an "id:" parent tag (child_calls) are used — ~1% on a big-mesh capture; the other ~99%
+    # (e.g. SetRuntimeArgs zones) are parsed then thrown away (a 25GB / ~200M-row capture takes
+    # minutes). Pre-filter with a streaming grep so pandas parses only the rows that matter; the
+    # exact column filtering below still runs, so the grep is a safe (superset) pre-pass.
+    import subprocess
+    import tempfile
+
+    with open(tracyOpTimesLog) as _f:
+        _header = _f.readline()
+    _tmp = tempfile.NamedTemporaryFile("w", suffix=".csv", dir=os.path.dirname(tracyOpTimesLog), delete=False)
     try:
-        df = pd.read_csv(tracyOpTimesLog, engine="pyarrow")
-    except (ImportError, ValueError):
-        df = pd.read_csv(tracyOpTimesLog)
+        _tmp.write(_header)
+        _tmp.flush()
+        # grep exits 1 when there are no matches — not an error here.
+        subprocess.run(["grep", "-E", "TT_DNN|TT_METAL|id:", tracyOpTimesLog], stdout=_tmp, check=False)
+        _tmp.close()
+        try:
+            df = pd.read_csv(_tmp.name, engine="pyarrow")
+        except (ImportError, ValueError):
+            df = pd.read_csv(_tmp.name)
+    finally:
+        os.remove(_tmp.name)
 
     # Filter and update host_time for TT_DNN/TT_METAL ops
     # Ensure name is string type before using .str accessor
@@ -609,9 +645,14 @@ def _enrich_ops_from_perf_csv(
             )
 
             # Create one enriched op per ProgramExecutionUID row in the C++ report.
+            # Only top-level keys are added below, and host_op is consumed here (its list
+            # is replaced by enriched_ops), so the single-row case — the vast majority —
+            # reuses host_op in place: no per-op deepcopy (the merge's dominant cost at
+            # ~100k+ ops). Multiple rows (trace replays) still need independent copies.
+            single = len(candidates) == 1
             for perf_row in candidates:
                 perf_row = perf_row.copy()
-                enriched_op = copy.deepcopy(host_op)
+                enriched_op = host_op if single else copy.deepcopy(host_op)
 
                 core_count = perf_row.get("CORE COUNT")
                 if core_count is not None:


### PR DESCRIPTION
## Audio-decode speedups (bh 4x8, PCC conv1d-vs-torch 0.99379 throughout)

**E2E (test_pipeline_distilled bh_4x8sp1tp0_ring, gen#1 steady-state replay):**
| stage | before | after |
|---|---|---|
| Audio decode | 1.36 s | **0.90 s** |
| Total compute | ~8.7 s | **8.2 s** |

Default path (no env) is byte-identical correctness to baseline; the speedups are math-invariant.

### Wins
- **mel-VAE Conv3d blocking** (74fc7765): the audio `Conv2dViaConv3d` combos had no `_DEFAULT_BLOCKINGS` entry → degenerate 1-pixel output tiles. Added `(Cin,32,1,8,16)`. **mel-VAE stage 182→56ms (3.3×).**
- **Polyphase UpSample1d slice elimination** (98543b2, 3454004c): both phase convs read one shared slice; drop the crop slice. **vocoder+BWE −72ms (~8%).**
- **`LTX_AUDIO_SUBMESH=RxC`** (6182a3b, **gated off by default**): routes only `decode_audio` onto an R×C submesh (audio doesn't scale with chips — cross-chip T-halo barriers dominate). `=1x4`: warm decode **674ms** and cold device graph-assembly **496s→5.6s**. Off-by-default pending a ttnn submesh-cq-close fix (only bites the pytest fixture, not a one-shot gen).
- Trace correctly **gated OFF** (BWE + main-vocoder): both were net-negative regressions at real scale on 4x8.
- **process_ops_logs 5×** post-processing; conv2d trace-safe; `audio_only` fast decode; warm dev harness; profiling harness improvements.

Supersedes #46789 (its commits are included here). Not yet validated: 1x2/1x1 submesh (sweep in progress).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=smarton/optimizer/ltx-audio-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:smarton/optimizer/ltx-audio-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=smarton/optimizer/ltx-audio-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:smarton/optimizer/ltx-audio-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=smarton/optimizer/ltx-audio-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:smarton/optimizer/ltx-audio-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=smarton/optimizer/ltx-audio-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:smarton/optimizer/ltx-audio-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=smarton/optimizer/ltx-audio-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:smarton/optimizer/ltx-audio-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=smarton/optimizer/ltx-audio-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:smarton/optimizer/ltx-audio-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=smarton/optimizer/ltx-audio-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:smarton/optimizer/ltx-audio-kernel)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=smarton/optimizer/ltx-audio-kernel)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:smarton/optimizer/ltx-audio-kernel)