### PR TITLE
ds_prefill - Combine refactor of ROW_MAJOR path and adding subdevice support for one line core grid

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_combine_subdevices.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_combine_subdevices.py
@@ -1,0 +1,330 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local-only test: combine op under edge-row / edge-column worker subdevices.
+
+The combine kernel lays its sender + untilizer cores along a single 1-D line of the
+worker grid.  When ``subdevice_id`` is None it uses the first row of the full grid
+(legacy behavior).  When an explicit subdevice is given, the kernel must lay the cores
+along whatever line that subdevice spans — a first/last ROW (varies in x) or a
+first/last COLUMN (varies in y).  This test confines combine to each of the four edge
+lines (plus the None default) and checks the output still matches the torch reference,
+exercising both the row-oriented and the new column-oriented core layouts.
+
+This file MUST NOT run in CI.  It is collected by every *DeepSeek_PREFILL_OP_TESTS job
+(some of which run the op_unit_tests/ folder unfiltered, e.g. bh_p150 / bh_p300), so a
+``-k`` filter cannot exclude it.  Instead it skips itself in CI via the is_ci_env /
+is_ci_v2_env fixtures (same mechanism as test_sub_device_load_clear_timing.py): all CI
+jobs collect it but report it as skipped, while it still runs locally with no env var.
+
+Run locally (needs an 8-chip box for the mesh-4x2 config):
+
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_combine_subdevices.py -vvv --tb=short
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.tt.moe.combine import TorchCombineModule
+from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import ALL_MESH_CONFIGS
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    ExpertMapping,
+    compute_constants,
+    extract_mesh_config,
+    get_ep_mesh_composer,
+    get_ep_mesh_mapper,
+    get_expert_token_counts_mesh_mapper,
+    get_gate_outputs,
+    initialize_test_inputs,
+)
+from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
+    assert_output_shape,
+    log_combine_mismatch_details,
+    log_per_chip_statistics,
+    validate_combine_output,
+)
+from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_validation_results
+
+# A single representative 2-D mesh config (8 chips). The subdevice placement under test is
+# a property of the per-chip worker grid, independent of the mesh topology, so one config
+# is enough to exercise all four edge lines.
+MESH_CONFIGS = [p for p in ALL_MESH_CONFIGS if p.id == "mesh-4x2"]
+
+# Small PCC-checked data case (same shape as test_prefill_combine.py's "pcc" case).
+SEQ_LEN_PER_CHIP = 128
+EMB_DIM = 7 * 1024
+NUM_ROUTED_EXPERTS = 16
+NUM_EXPERTS_PER_TOK = 4
+DISPATCH_BUFFER_CAPACITY_FACTOR = 4
+
+# The five placements the combine op must support.
+SUBDEVICE_EDGES = ["none", "first_row", "last_row", "first_col", "last_col"]
+
+
+def _edge_core_range_set(grid_x, grid_y, edge):
+    """Build a CoreRangeSet covering exactly one edge line of the worker grid.
+
+    CoreCoord is (x=column, y=row); CoreRange is an inclusive rectangle. A single row
+    collapses the y axis; a single column collapses the x axis.
+    """
+    if edge == "first_row":
+        return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, 0))})
+    if edge == "last_row":
+        return ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, grid_y - 1), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}
+        )
+    if edge == "first_col":
+        return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, grid_y - 1))})
+    if edge == "last_col":
+        return ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(grid_x - 1, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}
+        )
+    raise ValueError(f"unknown edge: {edge}")
+
+
+def _enumerate_cores(core_range_set):
+    """Expand a CoreRangeSet into the explicit sorted list of (x, y) cores it contains."""
+    cores = []
+    for r in core_range_set.ranges():
+        for y in range(r.start.y, r.end.y + 1):
+            for x in range(r.start.x, r.end.x + 1):
+                cores.append((x, y))
+    return sorted(cores)
+
+
+def _assert_edge_geometry(edge, core_range_set, grid_x, grid_y):
+    """Prove (and log) that ``core_range_set`` is exactly the named edge of the worker grid.
+
+    This is the geometric half of the proof: it confirms the subdevice we hand the op is
+    literally row 0 / the last row / column 0 / the last column. Combined with the op's
+    ``worker_cores(TENSIX, sub_device_id)`` contract (it lays its sender + untilizer kernels
+    on exactly this set), it pins down which cores combine actually runs on.
+    """
+    cores = _enumerate_cores(core_range_set)
+    xs = sorted({x for x, _ in cores})
+    ys = sorted({y for _, y in cores})
+    logger.info(f"[proof] subdevice='{edge}' worker_grid=({grid_x}x{grid_y}) n_cores={len(cores)} cores={cores}")
+
+    if edge == "first_row":
+        assert ys == [0], f"first_row must lie on y==0, got rows {ys}"
+        assert xs == list(range(grid_x)), f"first_row must span every column 0..{grid_x - 1}, got {xs}"
+        which = "row y=0 (first row)"
+    elif edge == "last_row":
+        assert ys == [grid_y - 1], f"last_row must lie on y=={grid_y - 1}, got rows {ys}"
+        assert xs == list(range(grid_x)), f"last_row must span every column 0..{grid_x - 1}, got {xs}"
+        which = f"row y={grid_y - 1} (last row)"
+    elif edge == "first_col":
+        assert xs == [0], f"first_col must lie on x==0, got cols {xs}"
+        assert ys == list(range(grid_y)), f"first_col must span every row 0..{grid_y - 1}, got {ys}"
+        which = "column x=0 (first column)"
+    elif edge == "last_col":
+        assert xs == [grid_x - 1], f"last_col must lie on x=={grid_x - 1}, got cols {xs}"
+        assert ys == list(range(grid_y)), f"last_col must span every row 0..{grid_y - 1}, got {ys}"
+        which = f"column x={grid_x - 1} (last column)"
+    else:
+        raise ValueError(f"unknown edge: {edge}")
+    logger.info(f"[proof] ✓ subdevice='{edge}' is exactly {which}")
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    MESH_CONFIGS,
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("subdevice_edge", SUBDEVICE_EDGES)
+def test_combine_subdevice_placement(
+    mesh_device, device_params, num_links, topology, subdevice_edge, is_ci_env, is_ci_v2_env
+):
+    """Run combine confined to an edge-row/column worker subdevice and validate vs torch.
+
+    The four edge subdevices overlap at the grid corners, so they cannot share one
+    sub-device manager; each placement gets its own manager, created and torn down here.
+    """
+    # Local-only: this file is collected by every DeepSeek_PREFILL_OP_TESTS job (some
+    # unfiltered, e.g. bh_p150/bh_p300), so a -k filter cannot exclude it. Skip in CI the
+    # same way test_sub_device_load_clear_timing.py does; runs locally with no env var.
+    if is_ci_env or is_ci_v2_env:
+        pytest.skip("Local-only combine subdevice test; skipped in CI")
+
+    torch.manual_seed(42)
+    num_devices = mesh_device.get_num_devices()
+
+    mesh_config = extract_mesh_config(mesh_device)
+    sp_axis = mesh_config.sp_axis
+    dispatch_group_size = mesh_config.dispatch_group_size
+    num_dispatch_groups = mesh_config.num_dispatch_groups
+
+    grid = mesh_device.compute_with_storage_grid_size()
+    logger.info(
+        f"subdevice_edge={subdevice_edge} mesh={tuple(mesh_device.shape)} worker_grid=({grid.x}x{grid.y}) "
+        f"dispatch_group_size={dispatch_group_size} num_dispatch_groups={num_dispatch_groups}"
+    )
+
+    (
+        experts_per_chip,
+        metadata_len,
+        max_dispatch_buffer_token_size,
+        max_dispatched_tokens_per_expert,
+    ) = compute_constants(
+        SEQ_LEN_PER_CHIP,
+        NUM_ROUTED_EXPERTS,
+        NUM_EXPERTS_PER_TOK,
+        num_devices,
+        dispatch_group_size,
+        DISPATCH_BUFFER_CAPACITY_FACTOR,
+    )
+
+    # --- Torch inputs (isolate combine via the torch dispatch reference) ---
+    x, weights, indices = initialize_test_inputs(
+        dispatch_group_size,
+        SEQ_LEN_PER_CHIP,
+        EMB_DIM,
+        NUM_ROUTED_EXPERTS,
+        NUM_EXPERTS_PER_TOK,
+        max_dispatched_tokens_per_expert,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+
+    expert_dispatch_table = ExpertMapping.create_dispatch_table(
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+        dispatch_group_size=dispatch_group_size,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+
+    expert_offsets, expert_token_counts, expert_region_offsets, _ = get_gate_outputs(
+        indices,
+        dispatch_group_size,
+        NUM_ROUTED_EXPERTS,
+        experts_per_chip,
+        SEQ_LEN_PER_CHIP,
+        NUM_EXPERTS_PER_TOK,
+        expert_dispatch_table=expert_dispatch_table,
+    )
+
+    torch_dispatch_module = TorchDispatchModule(
+        dispatch_group_size=dispatch_group_size,
+        experts_per_chip=experts_per_chip,
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
+        metadata_len=metadata_len,
+        max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
+        max_dispatch_buffer_token_size=max_dispatch_buffer_token_size,
+        seq_len_per_chip=SEQ_LEN_PER_CHIP,
+        emb_dim=EMB_DIM,
+        num_dispatch_groups=num_dispatch_groups,
+        expert_dispatch_table=expert_dispatch_table,
+    )
+    dispatched_buffer, dispatched_metadata = torch_dispatch_module(x, weights, indices, expert_offsets)
+
+    # --- Host -> device ---
+    mesh_mapper = get_ep_mesh_mapper(mesh_device)
+    tt_dispatched_buffer = ttnn.from_torch(
+        dispatched_buffer,
+        mesh_mapper=mesh_mapper,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.bfloat16,
+    )
+    tt_dispatched_metadata = ttnn.from_torch(
+        dispatched_metadata,
+        mesh_mapper=mesh_mapper,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.int32,
+    )
+    tt_expert_token_counts = ttnn.from_torch(
+        expert_token_counts,
+        mesh_mapper=get_expert_token_counts_mesh_mapper(mesh_device),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.int32,
+    )
+    tt_expert_region_offsets = ttnn.from_torch(
+        expert_region_offsets,
+        mesh_mapper=get_expert_token_counts_mesh_mapper(mesh_device),
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=mesh_device,
+        dtype=ttnn.int32,
+    )
+
+    # --- Torch golden ---
+    torch_combine = TorchCombineModule(
+        dispatch_group_size=dispatch_group_size,
+        experts_per_chip=experts_per_chip,
+        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
+        seq_len_per_chip=SEQ_LEN_PER_CHIP,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+    torch_output = torch_combine(dispatched_buffer, dispatched_metadata, expert_token_counts, expert_region_offsets)
+
+    # --- Build the edge subdevice (None == legacy first-row-of-full-grid path) ---
+    sd_manager = None
+    subdevice_id = None
+    if subdevice_edge == "none":
+        # Legacy path: no subdevice -> combine uses the first row of the full worker grid.
+        logger.info(f"[proof] subdevice='none' -> legacy path: first row (y=0) of the full {grid.x}x{grid.y} grid")
+    else:
+        edge_cores = _edge_core_range_set(grid.x, grid.y, subdevice_edge)
+        # Prove the subdevice we pass is exactly the named edge before handing it to the op.
+        _assert_edge_geometry(subdevice_edge, edge_cores, grid.x, grid.y)
+        # Each edge line shares one manager-of-one; the four edges overlap at corners so
+        # they cannot coexist in a single manager.
+        sd_manager = mesh_device.create_sub_device_manager([ttnn.SubDevice([edge_cores])], 0)
+        mesh_device.load_sub_device_manager(sd_manager)
+        subdevice_id = ttnn.SubDeviceId(0)
+
+    try:
+        tt_output = ttnn.experimental.deepseek_prefill.combine(
+            tt_dispatched_buffer,
+            tt_dispatched_metadata,
+            tt_expert_token_counts,
+            tt_expert_region_offsets,
+            dispatch_group_size=dispatch_group_size,
+            experts_per_chip=experts_per_chip,
+            num_experts_per_tok=NUM_EXPERTS_PER_TOK,
+            seq_len_per_chip=SEQ_LEN_PER_CHIP,
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            subdevice_id=subdevice_id,
+            cluster_axis=sp_axis,
+            num_links=num_links,
+            topology=topology,
+            init_zeros=False,
+        )
+
+        mesh_composer = get_ep_mesh_composer(mesh_device)
+        tt_output_torch = ttnn.to_torch(tt_output, mesh_composer=mesh_composer)
+    finally:
+        if sd_manager is not None:
+            mesh_device.clear_loaded_sub_device_manager()
+            mesh_device.remove_sub_device_manager(sd_manager)
+
+    # --- Validate (EP-rank-aware; bf16 -> allclose, same as test_prefill_combine.py) ---
+    assert_output_shape(tt_output_torch, num_dispatch_groups, dispatch_group_size, "combine output")
+    result = validate_combine_output(
+        torch_output,
+        tt_output_torch,
+        indices,
+        num_dispatch_groups,
+        NUM_ROUTED_EXPERTS,
+        use_pcc=False,
+        verbose=True,
+        expert_dispatch_table=expert_dispatch_table,
+        expert_token_counts=expert_token_counts,
+        experts_per_chip=experts_per_chip,
+    )
+    log_validation_results(
+        results=[result],
+        num_dispatch_groups=num_dispatch_groups,
+        dispatch_group_size=dispatch_group_size,
+        title=f"Combine Validation Results (subdevice={subdevice_edge})",
+    )
+    if not result.passed:
+        log_combine_mismatch_details(result.mismatches, torch_output, tt_output_torch)
+        log_per_chip_statistics(result.mismatches, dispatch_group_size, SEQ_LEN_PER_CHIP, NUM_EXPERTS_PER_TOK)
+    result.assert_passed(f"Combine data mismatch (subdevice={subdevice_edge})")
+
+    logger.info(f"✅ combine matches torch reference under subdevice={subdevice_edge}")

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_combine_subdevices.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_combine_subdevices.py
@@ -61,8 +61,10 @@ NUM_ROUTED_EXPERTS = 16
 NUM_EXPERTS_PER_TOK = 4
 DISPATCH_BUFFER_CAPACITY_FACTOR = 4
 
-# The five placements the combine op must support.
-SUBDEVICE_EDGES = ["none", "first_row", "last_row", "first_col", "last_col"]
+# The five placements the combine op must support, plus one it must reject: a 2-D subdevice
+# block (>1 row AND >1 column, smaller than the full grid) has no single-line core layout, so
+# combine must TT_FATAL on it.
+SUBDEVICE_EDGES = ["none", "first_row", "last_row", "first_col", "last_col", "grid_2d"]
 
 
 def _edge_core_range_set(grid_x, grid_y, edge):
@@ -83,6 +85,11 @@ def _edge_core_range_set(grid_x, grid_y, edge):
         return ttnn.CoreRangeSet(
             {ttnn.CoreRange(ttnn.CoreCoord(grid_x - 1, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}
         )
+    if edge == "grid_2d":
+        # Rejected case: a true 2-D block (rows 0..1 across every column, so >1 row AND >1
+        # column) that is strictly smaller than the full grid. The combine kernel has no
+        # single-line layout for this, so the op must TT_FATAL.
+        return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, 1))})
     raise ValueError(f"unknown edge: {edge}")
 
 
@@ -261,6 +268,45 @@ def test_combine_subdevice_placement(
     )
     torch_output = torch_combine(dispatched_buffer, dispatched_metadata, expert_token_counts, expert_region_offsets)
 
+    combine_kwargs = dict(
+        dispatch_group_size=dispatch_group_size,
+        experts_per_chip=experts_per_chip,
+        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
+        seq_len_per_chip=SEQ_LEN_PER_CHIP,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        cluster_axis=sp_axis,
+        num_links=num_links,
+        topology=topology,
+        init_zeros=False,
+    )
+
+    # --- Rejected case: a 2-D subdevice block must make combine TT_FATAL ---
+    if subdevice_edge == "grid_2d":
+        if grid.y < 3:
+            pytest.skip(f"grid_2d needs a worker grid taller than 2 rows; got {grid.x}x{grid.y}")
+        edge_cores = _edge_core_range_set(grid.x, grid.y, "grid_2d")
+        xs = sorted({x for x, _ in _enumerate_cores(edge_cores)})
+        ys = sorted({y for _, y in _enumerate_cores(edge_cores)})
+        assert len(xs) > 1 and len(ys) > 1, f"grid_2d must span >1 row AND >1 column, got cols={xs} rows={ys}"
+        logger.info(f"[proof] subdevice='grid_2d' is a {len(xs)}x{len(ys)} block (cols={xs}, rows={ys})")
+        sd_manager = mesh_device.create_sub_device_manager([ttnn.SubDevice([edge_cores])], 0)
+        mesh_device.load_sub_device_manager(sd_manager)
+        try:
+            with pytest.raises(RuntimeError, match="2-D subdevice core grid"):
+                ttnn.experimental.deepseek_prefill.combine(
+                    tt_dispatched_buffer,
+                    tt_dispatched_metadata,
+                    tt_expert_token_counts,
+                    tt_expert_region_offsets,
+                    subdevice_id=ttnn.SubDeviceId(0),
+                    **combine_kwargs,
+                )
+        finally:
+            mesh_device.clear_loaded_sub_device_manager()
+            mesh_device.remove_sub_device_manager(sd_manager)
+        logger.info("✅ combine correctly rejected a 2-D subdevice core grid")
+        return
+
     # --- Build the edge subdevice (None == legacy first-row-of-full-grid path) ---
     sd_manager = None
     subdevice_id = None
@@ -283,16 +329,8 @@ def test_combine_subdevice_placement(
             tt_dispatched_metadata,
             tt_expert_token_counts,
             tt_expert_region_offsets,
-            dispatch_group_size=dispatch_group_size,
-            experts_per_chip=experts_per_chip,
-            num_experts_per_tok=NUM_EXPERTS_PER_TOK,
-            seq_len_per_chip=SEQ_LEN_PER_CHIP,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
             subdevice_id=subdevice_id,
-            cluster_axis=sp_axis,
-            num_links=num_links,
-            topology=topology,
-            init_zeros=False,
+            **combine_kwargs,
         )
 
         mesh_composer = get_ep_mesh_composer(mesh_device)

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -9,6 +9,7 @@
 #include <map>
 #include <utility>
 #include <limits>
+#include <tt-metalium/constants.hpp>
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/program_descriptors.hpp>
@@ -195,8 +196,11 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     std::vector<CoreCoord> all_untilizer_cores;
     std::vector<uint32_t> untilizer_sender_map;
 
-    if (is_tile_layout) {
-        // TILE_LAYOUT: divide into groups, sender at the start of each group
+    // Both TILE_LAYOUT and ROW_MAJOR route dispatched_buffer through the untilizer pipeline, so
+    // both use the same layout: divide the line into per-sender groups with the sender at the
+    // start of each group (every untilizer sits to the sender's right).  In ROW_MAJOR the untilizer
+    // reader page-copies rows into c_2 instead of untilizing, but the core layout is identical.
+    {
         uint32_t base_group_size = total_row_cores / num_cores;
         uint32_t extra_groups = total_row_cores % num_cores;
 
@@ -216,18 +220,6 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
                 pos++;
             }
         }
-    } else {
-        // ROW_MAJOR: first num_cores cores are senders, all remaining are untilizer
-        for (uint32_t s = 0; s < num_cores; s++) {
-            sender_cores.push_back(all_row_cores[s]);
-        }
-        for (uint32_t i = num_cores; i < total_row_cores; i++) {
-            // Distribute untilizer cores round-robin across senders (for output-zeroing)
-            uint32_t s = (i - num_cores) % num_cores;
-            sender_untilizer_groups[s].push_back(all_row_cores[i]);
-            all_untilizer_cores.push_back(all_row_cores[i]);
-            untilizer_sender_map.push_back(s);
-        }
     }
 
     // Cap each sender's untilizer group at MAX_UNTILIZERS_PER_SENDER (TILE_LAYOUT only).  Required to
@@ -237,7 +229,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     // initial split above are dropped: their row cores stay in the worker grid but get no
     // untilizer kernels.  k_s[i] = min(k_s[i], MAX_UNTILIZERS_PER_SENDER).
     constexpr uint32_t MAX_UNTILIZERS_PER_SENDER = 5;
-    if (is_tile_layout) {
+    {
         std::vector<CoreCoord> trimmed_all_untilizer_cores;
         std::vector<uint32_t> trimmed_untilizer_sender_map;
         for (uint32_t s = 0; s < num_cores; s++) {
@@ -319,7 +311,11 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     uint32_t output_init_complete_semaphore_id = add_sema(sender_core_grid);
     uint32_t output_init_barrier_semaphore_id = add_sema(sender_core_grid);
 
-    const uint32_t read_batch_size = is_tile_layout ? dispatched_buffer.tensor_spec().tile().get_height() : 8;
+    // Rows per untilize batch.  Both layouts route through the untilizer pipeline and share the
+    // same receive_buf ring / sender polling loop, so ROW_MAJOR uses the same batch size as TILE
+    // (tile height = 32) rather than diverging.
+    const uint32_t read_batch_size =
+        is_tile_layout ? dispatched_buffer.tensor_spec().tile().get_height() : tt::constants::TILE_HEIGHT;
 
     // c_1: dispatched_metadata scratch (reader-only, batched DRAM reads)
     detail::create_tensor_cb(
@@ -361,11 +357,12 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         /*cb_id=*/tt::CBIndex::c_8,
         "expert_region_offsets");
 
-    if (is_tile_layout) {
+    {
         // c_18: per-sender receive buffer.  Partitioned into k_s 16-row regions, one per untilizer
         // core in this sender's group.  Untilizer i writes to slot j in its region at offset
         //   c_18_base + i * SLOTS_PER_UNTILIZER * aligned_output_page_size + j * aligned_output_page_size
-        // Size depends on k_s, so allocate per sender on its single-core CRS.
+        // Size depends on k_s, so allocate per sender on its single-core CRS.  Both layouts use the
+        // untilizer pipeline, so c_18/c_19 are always allocated (no sender-side dispatched_buffer CB).
         for (uint32_t s = 0; s < num_cores; s++) {
             uint32_t k_s = static_cast<uint32_t>(sender_untilizer_groups[s].size());
             CoreRangeSet single_sender_crs({CoreRange(sender_cores[s])});
@@ -389,15 +386,6 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
                 /*cb_id=*/tt::CBIndex::c_19,
                 "metadata_ring_sender_" + std::to_string(s));
         }
-    } else {
-        // c_0 on sender cores: dispatched_buffer rows for ROW_MAJOR DMA reads
-        detail::create_tensor_cb(
-            desc,
-            sender_core_grid,
-            dispatched_buffer,
-            /*buffering_factor=*/read_batch_size,
-            /*cb_id=*/tt::CBIndex::c_0,
-            "dispatched_buffer_sender");
     }
 
     // c_3: merged route_info + output_data (reader -> writer).
@@ -579,7 +567,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         std::vector<std::pair<uint32_t, uint32_t>> untilizer_noc_coords;
     };
     std::vector<SenderMcastCfg> sender_mcast_cfgs(num_cores);
-    if (is_tile_layout) {
+    {
         // Compute per-sender NOC multicast bounding box (min/max x,y over untilizer cores)
         // and collect individual untilizer core NOC coordinates for semaphore signaling.
         for (uint32_t s = 0; s < num_cores; s++) {
@@ -615,7 +603,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     uint32_t counter_ready_semaphore_id = 0;
     std::vector<std::vector<uint32_t>> data_ready_semaphore_ids(num_cores);
     std::vector<std::vector<uint32_t>> credits_semaphore_ids(num_cores);
-    if (is_tile_layout) {
+    {
         // counter_ready semaphore: created only on sender + untilizer cores so get_semaphore() returns
         // the same L1 offset on both sides (sender writes to untilizer's copy, untilizer waits on its own)
         std::set<CoreRange> sender_and_untilizer_ranges;
@@ -664,9 +652,11 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         --block_ct_dim;
     }
 
-    if (is_tile_layout) {
+    {
         // c_1 on untilizer cores: receives the expert_token_counts multicast from the owning sender.
-        // MUST be allocated BEFORE c_0 so its L1 address matches the sender's c_1 address.
+        // MUST be allocated BEFORE c_0/c_2 so its L1 address matches the sender's c_1 address.
+        // Both layouts use the untilizer pipeline, so these CBs are always allocated; only c_0
+        // (tile-input for the compute kernel) is TILE-only.
         {
             uint32_t counter_pages = detail::get_num_pages(expert_token_counts);
             uint32_t counter_page_size = detail::get_aligned_page_size(expert_token_counts);
@@ -683,17 +673,22 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
                 }}},
             });
         }
-        // c_0 on untilizer cores: dispatched_buffer tiles, sized for double-buffered block_ct_dim chunks.
-        detail::create_tensor_cb(
-            desc,
-            untilizer_core_grid,
-            dispatched_buffer,
-            /*buffering_factor=*/2 * block_ct_dim,
-            /*cb_id=*/tt::CBIndex::c_0,
-            "dispatched_buffer_untilizer");
-        // c_2 on untilizer cores: untilized output rows, double-buffered (2 × read_batch_size).
-        // Lets compute pack batch N+1 into the second half while writer_untilize is still
-        // routing batch N out of the first half — overlapping pack with NOC sends.
+        // c_0 on untilizer cores: dispatched_buffer tiles, sized for double-buffered block_ct_dim
+        // chunks.  TILE_LAYOUT only — the compute kernel reads c_0 and untilizes into c_2.  In
+        // ROW_MAJOR there is no compute kernel and reader_untilize writes rows straight into c_2,
+        // so c_0 is not allocated.
+        if (is_tile_layout) {
+            detail::create_tensor_cb(
+                desc,
+                untilizer_core_grid,
+                dispatched_buffer,
+                /*buffering_factor=*/2 * block_ct_dim,
+                /*cb_id=*/tt::CBIndex::c_0,
+                "dispatched_buffer_untilizer");
+        }
+        // c_2 on untilizer cores: untilized (TILE) or row-copied (ROW_MAJOR) output rows,
+        // double-buffered (2 × read_batch_size).  Lets the producer fill batch N+1 into the
+        // second half while writer_untilize is still routing batch N out of the first half.
         detail::create_tensor_cb(
             desc,
             untilizer_core_grid,
@@ -730,9 +725,11 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     uint32_t counter_offset =
         mesh_col_coord * experts_per_dispatch_group + mesh_row_coord * operation_attributes.experts_per_chip;
 
-    // reader_untilize + compute kernels only needed for TILE_LAYOUT
+    // reader_untilize runs on untilizer cores for BOTH layouts: TILE reads tiles into c_0 (for the
+    // compute kernel), ROW_MAJOR reads rows straight into c_2 (no compute).  The compute kernel
+    // itself is created TILE-only further below.
     std::vector<tt::tt_metal::KernelHandle> reader_untilize_kernel_ids;
-    if (is_tile_layout) {
+    {
         // Compile-time args layout for reader_untilize (matching reader_untilize.cpp):
         //   0-11: shared base (below, includes max_dispatch_buffer_token_size at 11)
         //   12:   core_id   — local index within sender s's untilizer group (0..k_s-1)
@@ -745,8 +742,13 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         //                       compute kernel's per-block consumption)
         //   19+:  TensorAccessorArgs for dispatched_buffer, then TensorAccessorArgs for
         //         dispatched_metadata (no num_senders — single-sender kernel)
-        const uint32_t tile_height = dispatched_buffer.tensor_spec().tile().get_height();
-        const uint32_t tile_width = dispatched_buffer.tensor_spec().tile().get_width();
+        // ROW_MAJOR dispatched_buffer has no tile spec; use the hardware tile dims so the
+        // tile-aligned per-expert region math (start_token / tiles_per_batch) in reader_untilize
+        // matches the host's expert_region_offsets (cumsum of ceil(count, 32)*32) in both layouts.
+        const uint32_t tile_height =
+            is_tile_layout ? dispatched_buffer.tensor_spec().tile().get_height() : tt::constants::TILE_HEIGHT;
+        const uint32_t tile_width =
+            is_tile_layout ? dispatched_buffer.tensor_spec().tile().get_width() : tt::constants::TILE_WIDTH;
         const std::vector<uint32_t> reader_untilize_compile_time_args_base = {
             static_cast<uint32_t>(tt::CBIndex::c_1),           // 0:  cb_experts_tok_counter_id
             detail::get_num_pages(expert_token_counts),        // 1:  experts_tok_counter_pages
@@ -796,6 +798,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
                 reader_untilize_kd.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
                 reader_untilize_kd.core_ranges = single_untilizer_core;
                 reader_untilize_kd.compile_time_args = std::move(per_core_args);
+                reader_untilize_kd.defines = {{"IS_TILE_LAYOUT", is_tile_layout ? "1" : "0"}};
                 reader_untilize_kd.config = tt::tt_metal::DataMovementConfigDescriptor{
                     .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
                     .noc = tt::tt_metal::detail::preferred_noc_for_dram_read(mesh_device->arch()),
@@ -809,13 +812,11 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     std::map<std::string, std::string> writer_defines = fabric_defines;
     writer_defines["INIT_ZEROS"] = operation_attributes.init_zeros ? "1" : "0";
 
-    // writer_untilize kernel is launched whenever either:
-    //   (a) init_zeros=True — it does the per-bank output-zeroing of the output tensor
-    //   (b) is_tile_layout — it runs the post-output-zeroing untilized-data send loop
-    //                        (consumes cb_untilize_id, writes back to the sender's c_18).
-    // With init_zeros=False on TILE_LAYOUT only (b) applies, so the output-zeroing CBs/semaphore
-    // are skipped and the kernel is compiled with INIT_ZEROS=0.
-    const bool create_writer_untilize_kernel = init_zeros || is_tile_layout;
+    // writer_untilize runs on untilizer cores for BOTH layouts now: it consumes cb_untilize_id
+    // (c_2 — produced by the compute kernel in TILE, or directly by reader_untilize in ROW_MAJOR)
+    // and forwards each row to the owning sender's receive_buf (c_18) / metadata ring (c_19).  It
+    // also performs the optional per-bank output-zeroing when init_zeros=True (INIT_ZEROS define).
+    const bool create_writer_untilize_kernel = true;
 
     if (init_zeros) {
         uint32_t noc_max_burst_size;
@@ -868,9 +869,8 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         };
         tt::tt_metal::TensorAccessorArgs(output_tensor.buffer()).append_to(writer_untilize_compile_time_args);
 
-        // Tile-layout-only compile-time args used by the post-output-zeroing untilized-data send loop.
-        // In ROW_MAJOR the corresponding #if IS_TILE_LAYOUT block is compiled out, so these
-        // trailing args are ignored — still pushed unconditionally to keep the kernel object stable.
+        // Compile-time args for the untilized-data send loop, which now runs for BOTH layouts
+        // (writer_untilize forwards cb_untilize_id rows to the sender regardless of layout).
         writer_untilize_compile_time_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_2));  // cb_untilize_id
         writer_untilize_compile_time_args.push_back(
             static_cast<uint32_t>(tt::CBIndex::c_1));  // cb_experts_tok_counter_id
@@ -925,16 +925,16 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         reader_compile_time_args_base.push_back(
             num_untilizer_cores);  // num_total_untilizer_cores (both layouts need this)
     }
-    // num_untilizer_cores (per-sender k_s) and cb_untilize_id are appended per-sender below (TILE_LAYOUT only).
+    // num_untilizer_cores (per-sender k_s) and the c_18/c_19 ring CBs are appended per-sender below.
 
-    // One reader_combine kernel per sender.  For TILE_LAYOUT, k_s (per-sender untilizer count)
-    // is baked in as num_untilizer_cores so the sender only round-robins across its own dedicated
-    // untilizer cores.  For ROW_MAJOR, no untilizer-core args are needed.
+    // One reader_combine kernel per sender.  k_s (per-sender untilizer count) is baked in as
+    // num_untilizer_cores so the sender only round-robins across its own dedicated untilizer
+    // cores.  Both layouts use the untilizer-fed sender path, so these args are always appended.
     std::vector<tt::tt_metal::KernelHandle> reader_kernel_ids;
     reader_kernel_ids.reserve(num_cores);
     for (uint32_t s = 0; s < num_cores; s++) {
         auto per_sender_compile_args = reader_compile_time_args_base;
-        if (is_tile_layout) {
+        {
             uint32_t k_s = static_cast<uint32_t>(sender_untilizer_groups[s].size());
             per_sender_compile_args.push_back(k_s);  // num_untilizer_cores (per-sender)
             per_sender_compile_args.push_back(static_cast<uint32_t>(tt::CBIndex::c_18));  // cb_untilize_id
@@ -1051,9 +1051,9 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
                 }
             }
 
-            // TILE_LAYOUT: append owning-sender info so writer_untilize can run its send loop.
-            // In ROW_MAJOR the trailing args are ignored (kernel compiled with IS_TILE_LAYOUT=0).
-            if (is_tile_layout) {
+            // Append owning-sender info so writer_untilize can run its send loop.  Both layouts
+            // forward c_2 rows to the sender, so these args are always pushed.
+            {
                 uint32_t s = untilizer_sender_map[untilizer_idx];
                 uint32_t k_s = static_cast<uint32_t>(sender_untilizer_groups[s].size());
                 uint32_t expert_start = s * experts_per_core_range;
@@ -1106,7 +1106,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
             reader_runtime_args.push_back(sender_page_end);
             reader_runtime_args.push_back(output_init_done_semaphore_id);
         }
-        if (is_tile_layout) {
+        {
             // Multicast targets only this sender's dedicated untilizer group
             const auto& mcast_cfg = sender_mcast_cfgs[core_idx];
             reader_runtime_args.push_back(counter_ready_semaphore_id);
@@ -1214,12 +1214,13 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         core_idx++;
     }
 
-    // Set runtime args for untilizer cores (TILE_LAYOUT only — reader_untilize kernel).
+    // Set runtime args for untilizer cores (both layouts — reader_untilize kernel).
     // Layout: counter_ready_sem, dispatched_buffer_addr, expert_start, expert_end,
     //         dispatched_metadata_addr.
     // Sender NOC coords and per-sender data_ready/start semaphores are now consumed by
-    // writer_untilize on the same core (which owns the untilized-data send).
-    if (is_tile_layout) {
+    // writer_untilize on the same core (which owns the untilized-data send).  The compute
+    // kernel exists only in TILE_LAYOUT, so its runtime args are set under that guard below.
+    {
         for (uint32_t j = 0; j < num_untilizer_cores; j++) {
             uint32_t s = untilizer_sender_map[j];
             uint32_t k_s = static_cast<uint32_t>(sender_untilizer_groups[s].size());
@@ -1249,14 +1250,16 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
 
             // Compute kernel walks the same expert/batch iteration as reader_untilize and
             // writer_untilize (no per-batch signal CB).  Per-sender k_s + local_core_id drive
-            // round-robin batch assignment within the group.
-            tt::tt_metal::KernelDescriptor::RTArgList compute_rt_args;
-            compute_rt_args.push_back(expert_start);
-            compute_rt_args.push_back(expert_end);
-            compute_rt_args.push_back(local_core_id);
-            compute_rt_args.push_back(k_s);
-            desc.kernels[untilize_compute_kernel_id].emplace_runtime_args(
-                untilizer_row_cores[j], compute_rt_args);
+            // round-robin batch assignment within the group.  TILE_LAYOUT only — ROW_MAJOR has
+            // no compute kernel (reader_untilize writes rows straight into c_2).
+            if (is_tile_layout) {
+                tt::tt_metal::KernelDescriptor::RTArgList compute_rt_args;
+                compute_rt_args.push_back(expert_start);
+                compute_rt_args.push_back(expert_end);
+                compute_rt_args.push_back(local_core_id);
+                compute_rt_args.push_back(k_s);
+                desc.kernels[untilize_compute_kernel_id].emplace_runtime_args(untilizer_row_cores[j], compute_rt_args);
+            }
         }
     }
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -172,21 +172,47 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     //     [sender0, untilizer0_0..untilizer0_{k0-1}, sender1, untilizer1_0..untilizer1_{k1-1}, ...]
     //   ROW_MAJOR: first num_cores cores are senders, remaining are untilizer (for output-zeroing only).
     //     [sender0, sender1, untilizer0, untilizer1, untilizer2, ...]
-    // Collect all cores in the first row (y == subdevice_cores[0].y), sorted by x.
-    uint32_t sender_row_y = subdevice_cores.at(0).y;
-    std::vector<CoreCoord> all_row_cores;
+    // Lay the sender/untilizer groups along a 1-D line of worker cores taken from the (sub)device
+    // grid.  The subdevice is guaranteed to be a single line — first/last row OR first/last column —
+    // and the orientation is inferred here from the grid shape (no extra API flag is needed):
+    //   - single-column grid (all cores share x): use the whole column, ordered by y.
+    //   - single-row grid, or the default full 2-D worker grid (subdevice_id == None): use the first
+    //     row (smallest y), ordered by x — byte-identical to the previous behavior.
+    // Everything downstream is geometry-agnostic: it treats `all_row_cores` as an ordered line and
+    // addresses cores by absolute NOC coordinates, so a column needs no further changes.
+    uint32_t min_x = subdevice_cores.at(0).x, max_x = subdevice_cores.at(0).x;
+    uint32_t min_y = subdevice_cores.at(0).y, max_y = subdevice_cores.at(0).y;
     for (const auto& core : subdevice_cores) {
-        if (core.y == sender_row_y) {
-            all_row_cores.push_back(core);
-        }
+        min_x = std::min(min_x, (uint32_t)core.x);
+        max_x = std::max(max_x, (uint32_t)core.x);
+        min_y = std::min(min_y, (uint32_t)core.y);
+        max_y = std::max(max_y, (uint32_t)core.y);
     }
-    std::sort(
-        all_row_cores.begin(), all_row_cores.end(), [](const CoreCoord& a, const CoreCoord& b) { return a.x < b.x; });
+    const bool is_single_column = (min_x == max_x) && (max_y > min_y);
+
+    std::vector<CoreCoord> all_row_cores;
+    if (is_single_column) {
+        // First/last-column subdevice: every core shares x, so order the line by y.
+        all_row_cores = subdevice_cores;
+        std::sort(all_row_cores.begin(), all_row_cores.end(), [](const CoreCoord& a, const CoreCoord& b) {
+            return a.y < b.y;
+        });
+    } else {
+        // First/last-row subdevice or full 2-D grid: take the first row, ordered by x (legacy path).
+        for (const auto& core : subdevice_cores) {
+            if (core.y == min_y) {
+                all_row_cores.push_back(core);
+            }
+        }
+        std::sort(all_row_cores.begin(), all_row_cores.end(), [](const CoreCoord& a, const CoreCoord& b) {
+            return a.x < b.x;
+        });
+    }
 
     uint32_t total_row_cores = static_cast<uint32_t>(all_row_cores.size());
     TT_FATAL(
         total_row_cores > num_cores,
-        "Same-row has only {} cores for {} senders — need at least one untilizer core per sender",
+        "Worker line has only {} cores for {} senders — need at least one untilizer core per sender",
         total_row_cores,
         num_cores);
 
@@ -248,7 +274,7 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
     uint32_t num_untilizer_cores = static_cast<uint32_t>(all_untilizer_cores.size());
     TT_FATAL(
         num_untilizer_cores >= num_cores,
-        "Same-row has only {} untilizer cores for {} senders — need at least one untilizer core per sender",
+        "Worker line has only {} untilizer cores for {} senders — need at least one untilizer core per sender",
         num_untilizer_cores,
         num_cores);
     uint32_t untilizer_cores_per_sender = num_untilizer_cores / num_cores;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/combine_program_factory.cpp
@@ -188,6 +188,25 @@ tt::tt_metal::ProgramDescriptor build_program_for_coord(
         min_y = std::min(min_y, (uint32_t)core.y);
         max_y = std::max(max_y, (uint32_t)core.y);
     }
+    // The sender/untilizer pipeline is laid out along a single line of cores, so the worker
+    // subdevice must be a single row (first/last row) or single column (first/last column).
+    // A subdevice spanning both multiple rows and multiple columns has no defined line layout.
+    // The legacy no-subdevice path passes the full device worker grid (also 2-D) and is handled
+    // by taking its first row, so that case is exempted.
+    if ((max_x > min_x) && (max_y > min_y)) {
+        auto compute_grid = mesh_device->compute_with_storage_grid_size();
+        const bool is_full_worker_grid = min_x == 0 && min_y == 0 && max_x == compute_grid.x - 1 &&
+                                         max_y == compute_grid.y - 1 &&
+                                         subdevice_cores.size() == compute_grid.x * compute_grid.y;
+        TT_FATAL(
+            is_full_worker_grid,
+            "Combine requires the worker subdevice to be a single row (first/last row) or single column "
+            "(first/last column); a 2-D subdevice core grid spanning x=[{}, {}] y=[{}, {}] is not supported.",
+            min_x,
+            max_x,
+            min_y,
+            max_y);
+    }
     const bool is_single_column = (min_x == max_x) && (max_y > min_y);
 
     std::vector<CoreCoord> all_row_cores;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_combine.cpp
@@ -105,13 +105,15 @@ void kernel_main() {
     constexpr uint32_t tile_layout_args_base = expert_region_offsets_args.next_compile_time_args_offset();
 #endif
 
-#if IS_TILE_LAYOUT
+    // Sender always consumes untilized rows + routing metadata from its dedicated untilizer
+    // group's receive_buf (c_18) / metadata ring (c_19); these args are appended per-sender by
+    // the program factory for both TILE_LAYOUT and ROW_MAJOR (the ROW_MAJOR untilizer reader
+    // page-copies rows into c_2 instead of untilizing, but the sender path is identical).
     constexpr uint32_t num_untilizer_cores_group = get_compile_time_arg_val(tile_layout_args_base);
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(tile_layout_args_base + 1);
     constexpr uint32_t cb_metadata_buf_id = get_compile_time_arg_val(tile_layout_args_base + 2);
     // Per-untilizer ring depth on the sender's receive_buf (drives the slot ring below).
     constexpr uint32_t SLOTS_PER_UNTILIZER = get_compile_time_arg_val(tile_layout_args_base + 3);
-#endif
 
     // ===== Runtime Args =====
     uint32_t rt_args = 0;
@@ -156,7 +158,6 @@ void kernel_main() {
     }
 #endif
 
-#if IS_TILE_LAYOUT
     uint32_t counter_ready_semaphore_id = get_arg_val<uint32_t>(rt_args++);
     uint32_t mcast_start_x = get_arg_val<uint32_t>(rt_args++);
     uint32_t mcast_start_y = get_arg_val<uint32_t>(rt_args++);
@@ -193,7 +194,6 @@ void kernel_main() {
         self_data_ready_noc_addrs[c] = get_noc_addr(my_x[noc_index], my_y[noc_index], data_ready_l1);
         untilizer_credits_noc_addrs[c] = get_noc_addr(untilizer_noc_x[c], untilizer_noc_y[c], credits_l1);
     }
-#endif
 
 #if INIT_ZEROS
     // Signal writer that output-zeroing is complete
@@ -233,7 +233,6 @@ void kernel_main() {
     constexpr uint32_t experts_per_dispatch_group = experts_per_chip * num_chips;
     constexpr uint32_t offset = dispatch_group_idx * experts_per_dispatch_group + mesh_row * experts_per_chip;
     // Multicast expert token counts + receive_buf_addr to all untilizer cores
-#if IS_TILE_LAYOUT
     // Each sender multicasts token counts + its own receive_buf_addr to its dedicated untilizer
     // group. The mcast destination covers only this sender's k_s untilizer cores (per-sender
     // bounding box), so all senders can multicast in parallel.
@@ -261,17 +260,7 @@ void kernel_main() {
         noc_async_write_barrier();
         noc_semaphore_inc_multicast(mcast_counter_sem_noc_addr, 1, num_untilizer_cores_group);
     }
-#else
-    volatile tt_l1_ptr uint32_t* experts_tok_counter_l1 =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counter_base_addr) + offset;
-    // Set up scratch buffers for batched reads
-    cb_reserve_back(cb_dispatched_metadata_id, read_batch_size);
-    uint32_t metadata_base = get_write_ptr(cb_dispatched_metadata_id);
-    const auto dispatched_metadata_addr_gen =
-        TensorAccessor(dispatched_metadata_args, dispatched_metadata_addr, aligned_dispatched_metadata_page_size);
-#endif
 
-#if IS_TILE_LAYOUT
     uint32_t untilize_base = get_write_ptr(cb_untilize_id);
     uint32_t metadata_buf_base = get_write_ptr(cb_metadata_buf_id);
     // Both receive_buf (c_18) and metadata_ring (c_19) are partitioned k_s ways:
@@ -283,14 +272,7 @@ void kernel_main() {
     for (uint32_t c = 0; c < num_untilizer_cores_group; c++) {
         read_slots[c] = 0;
     }
-#else
-    cb_reserve_back(cb_dispatched_buffer_id, read_batch_size);
-    uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
-    const auto dispatched_buffer_addr_gen =
-        TensorAccessor(dispatched_buffer_args, dispatched_buffer_addr, aligned_dispatched_buffer_page_size);
-#endif
 
-#if IS_TILE_LAYOUT
     // Round-robin polling loop — sender polls all untilizer core CBs without blocking on any
     // single one.  Each untilizer core writes routing metadata + row data for every non-local row,
     // then sends ROUTE_INFO_SENTINEL when all its batches are complete.  Sender exits when
@@ -387,123 +369,6 @@ void kernel_main() {
             }
         }
     }
-#else
-    // ROW_MAJOR: read expert region offsets and process expert by expert, batch by batch.
-    const auto expert_region_offsets_addr_gen = TensorAccessor(expert_region_offsets_args, expert_region_offsets_addr);
-    cb_reserve_back(cb_expert_region_offsets_id, expert_region_offsets_pages);
-    uint32_t region_offsets_base_addr = get_write_ptr(cb_expert_region_offsets_id);
-    for (uint32_t i = 0; i < expert_region_offsets_pages; i++) {
-        noc_async_read_page(
-            i, expert_region_offsets_addr_gen, region_offsets_base_addr + i * aligned_expert_region_offsets_page_size);
-    }
-    noc_async_read_barrier();
-    volatile tt_l1_ptr uint32_t* expert_region_offsets_l1 =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(region_offsets_base_addr) + offset;
-
-    for (uint32_t local_expert = expert_start_idx; local_expert < expert_end_idx; local_expert++) {
-        uint32_t start_page = expert_region_offsets_l1[local_expert];
-        uint32_t expert_tokens = experts_tok_counter_l1[local_expert];
-        if (start_page >= max_dispatch_buffer_token_size) {
-            expert_tokens = 0;
-        } else if (start_page + expert_tokens > max_dispatch_buffer_token_size) {
-            expert_tokens = max_dispatch_buffer_token_size - start_page;
-        }
-        uint32_t end_page = start_page + expert_tokens;
-        uint32_t num_batches = (expert_tokens + read_batch_size - 1) / read_batch_size;
-
-        DPRINT_COMBINE("Expert={} tokens={}\n", local_expert, expert_tokens);
-
-        uint32_t first_batch_end = (start_page + read_batch_size < end_page) ? start_page + read_batch_size : end_page;
-        uint32_t first_batch_count = first_batch_end - start_page;
-        if (first_batch_count > 0) {
-            for (uint32_t t = 0; t < first_batch_count; t++) {
-                noc_async_read_page(
-                    start_page + t, dispatched_buffer_addr_gen, buffer_base + t * aligned_dispatched_buffer_page_size);
-                noc_async_read_page(
-                    start_page + t,
-                    dispatched_metadata_addr_gen,
-                    metadata_base + t * aligned_dispatched_metadata_page_size);
-            }
-            noc_async_read_barrier();
-        }
-
-        for (uint32_t B = 0; B < num_batches; B++) {
-            uint32_t batch_start = start_page + B * read_batch_size;
-            uint32_t batch_end = (batch_start + read_batch_size < end_page) ? batch_start + read_batch_size : end_page;
-            uint32_t batch_count = batch_end - batch_start;
-
-            bool batch_did_local_write = false;
-            for (uint32_t t = 0; t < batch_count; t++) {
-                uint32_t buffer_scratch_addr = buffer_base + t * aligned_dispatched_buffer_page_size;
-                volatile tt_l1_ptr uint32_t* metadata = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(
-                    metadata_base + t * aligned_dispatched_metadata_page_size);
-
-                auto dst_chip = metadata[0];
-                auto dst_token_idx = metadata[1];
-                auto dst_topk_indice = metadata[2];
-                uint32_t output_page_idx = dst_token_idx * num_experts_per_tok + dst_topk_indice;
-
-                if (dst_chip == linearized_mesh_coord) {
-                    noc_async_write_page(output_page_idx, output_addr_gen, buffer_scratch_addr);
-                    noc_async_writes_flushed();
-                    batch_did_local_write = true;
-                } else {
-                    if constexpr (is_1d_topology<topology>()) {
-                        uint32_t route = get_route<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
-                        uint32_t distance =
-                            manhattan_distance<topology, mesh_rows, mesh_cols>(linearized_mesh_coord, dst_chip);
-
-                        // Push route info to writer.
-                        // route_info layout: [0]=route, [1]=distance, [2]=output_page_idx, [3]=dst_chip.
-                        // route + distance are consumed by the 1D writer; under FABRIC_2D the writer
-                        // recomputes the EDM direction from route_info[3] and ignores slots [0..1].
-                        // All four slots are written unconditionally
-                        cb_reserve_back(cb_route_info_id, 1);
-                        uint32_t cb_base = get_write_ptr(cb_route_info_id);
-                        volatile tt_l1_ptr uint32_t* route_info =
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_base);
-                        route_info[0] = route;
-                        route_info[1] = distance;
-                        route_info[2] = output_page_idx;
-                        route_info[3] = dst_chip;
-
-                        uint32_t output_dst = cb_base + l1_alignment;
-                        noc_async_read(
-                            get_noc_addr(buffer_scratch_addr), output_dst, aligned_dispatched_buffer_page_size);
-                        noc_async_read_barrier();
-                        cb_push_back(cb_route_info_id, 1);
-                    }
-                }
-            }
-
-            uint32_t next_batch_start = batch_start + read_batch_size;
-            bool has_next_batch = (next_batch_start < end_page);
-            if (has_next_batch) {
-                uint32_t next_batch_end =
-                    (next_batch_start + read_batch_size < end_page) ? next_batch_start + read_batch_size : end_page;
-                uint32_t next_batch_count = next_batch_end - next_batch_start;
-                for (uint32_t t = 0; t < next_batch_count; t++) {
-                    noc_async_read_page(
-                        next_batch_start + t,
-                        dispatched_buffer_addr_gen,
-                        buffer_base + t * aligned_dispatched_buffer_page_size);
-                    noc_async_read_page(
-                        next_batch_start + t,
-                        dispatched_metadata_addr_gen,
-                        metadata_base + t * aligned_dispatched_metadata_page_size);
-                }
-            }
-
-            if (batch_did_local_write) {
-                noc_async_write_barrier();
-            }
-
-            if (has_next_batch) {
-                noc_async_read_barrier();
-            }
-        }
-    }
-#endif
 
     // Push sentinel to signal writer that all dispatches are done
     cb_reserve_back(cb_route_info_id, 1);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
@@ -17,9 +17,12 @@
 // For each assigned batch:
 //   1. Read this batch's metadata pages from DRAM into cb_metadata_batch_id (consumed by
 //      writer_untilize).
-//   2. Read dispatched_buffer tiles into cb_dispatched_buffer_id for compute to consume.
-// Compute (untilize_combine) and writer_untilize on this same core independently walk the
-// same expert/batch loop using the multicasted counter in c_1, so no per-batch signal CB
+//   2. TILE_LAYOUT: read dispatched_buffer tiles into cb_dispatched_buffer_id (c_0) for the
+//      compute kernel to untilize into cb_untilize_id (c_2).
+//      ROW_MAJOR: dispatched_buffer is already row-major, so read its rows page-per-page
+//      directly into cb_untilize_id (c_2); no compute kernel runs and c_0 is unused.
+// Compute (untilize_combine, TILE only) and writer_untilize on this same core independently walk
+// the same expert/batch loop using the multicasted counter in c_1, so no per-batch signal CB
 // is needed — producer-consumer ordering on c_0 / c_2 / c_9 keeps everyone in lock-step.
 //
 
@@ -208,11 +211,13 @@ void kernel_main() {
                 cb_push_back(cb_metadata_batch_id, read_batch_size);
             }
 
-            // 2. Read tiles for this batch in block_ct_dim-sized chunks so each push matches one
-            //    compute-side pack_untilize_block consumption of block_ct_dim tiles.  The CB
+#if IS_TILE_LAYOUT
+            // 2. TILE: read tiles for this batch in block_ct_dim-sized chunks so each push matches
+            //    one compute-side pack_untilize_block consumption of block_ct_dim tiles.  The CB
             //    write pointer advances with every push, so re-fetch it after each
             //    `cb_reserve_back` — capturing it once before the loop lands every chunk in
-            //    the same slot and leaves the other slot uninitialized.
+            //    the same slot and leaves the other slot uninitialized.  The paired compute
+            //    kernel untilizes cb_dispatched_buffer_id (c_0) -> cb_untilize_id (c_2).
             {
                 constexpr uint32_t num_blocks = tiles_per_batch / block_ct_dim;
                 for (uint32_t cnt = 0; cnt < num_blocks; cnt++) {
@@ -234,6 +239,33 @@ void kernel_main() {
                 // Steps 3-7 (wait for untilize, wait for sender's send signal, NOC-write to
                 // sender, signal sender, pop untilize CB) now run on writer_untilize.
             }
+#else
+            // 2. ROW_MAJOR: dispatched_buffer is already row-major, so there is no untilization to
+            //    do.  Read the batch's rows page-per-page straight into cb_untilize_id (c_2) — the
+            //    same CB the compute kernel fills in the TILE path — so writer_untilize consumes it
+            //    identically.  No compute kernel runs and cb_dispatched_buffer_id (c_0) is unused.
+            //    start_token is this expert's (tile-aligned) start row, == expert_region_offsets[e];
+            //    batch_token_start offsets to this batch within the expert.  Always reserve/push
+            //    read_batch_size pages so c_2 wraps cleanly (matching writer_untilize's
+            //    cb_wait_front(cb_untilize_id, read_batch_size)); only the first batch_count pages
+            //    hold valid rows.
+            {
+                uint32_t batch_row_start = start_token + batch_token_start;
+                cb_reserve_back(cb_untilize_id, read_batch_size);
+                uint32_t untilize_base = get_write_ptr(cb_untilize_id);
+                {
+                    // DeviceZoneScopedN("DISPATCHED-BUFFER-row-read");
+                    for (uint32_t t = 0; t < batch_count; t++) {
+                        noc_async_read_page(
+                            batch_row_start + t,
+                            dispatched_buffer_addr_gen,
+                            untilize_base + t * aligned_output_page_size);
+                    }
+                    noc_async_read_barrier();
+                }
+                cb_push_back(cb_untilize_id, read_batch_size);
+            }
+#endif
         }
         // Advance to the next expert's region.  Buffer and metadata both use the same
         // tile-aligned per-expert stride, so start_page_tiled (and start_token derived from

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
@@ -78,8 +78,9 @@ void kernel_main() {
     noc_async_atomic_barrier();
 #endif
 
-#if IS_TILE_LAYOUT
-    // ===== Untilized-data send path =====
+    // ===== Untilized-data send path (runs for both TILE_LAYOUT and ROW_MAJOR) =====
+    // cb_untilize_id (c_2) is filled by the compute kernel in TILE_LAYOUT or directly by
+    // reader_untilize in ROW_MAJOR; either way this kernel forwards each row to the sender.
     //
     // Compile-time args (appended after the output-zeroing TensorAccessorArgs block):
     //   +0: cb_untilize_id                        - CB into which compute pushes untilized batches
@@ -318,5 +319,4 @@ void kernel_main() {
     noc_semaphore_inc(sender_data_ready_noc_addr, 1);
     noc_async_atomic_barrier();
     cb_pop_front(cb_experts_tok_counter_id, cb_counter_total_pages);
-#endif
 }


### PR DESCRIPTION
### Ticket 
https://github.com/tenstorrent/tt-metal/issues/45817

### Problem description
Combine operator has different implementation for ROW_MAJOR and TILE_LAYOUT input. This should be changed so TILE_LAYOUT and ROW_MAJOR have mostly same implementation, where only difference is that **untilizer cores** do not untilize input when it is in ROW_MAJOR layout.
Current implementation doesn't have fully needed support for subdevices in order to overlap **combine** with **routed expert**. 

### What's changed
- Removed ROW_MAJOR path from `reader_combine.cpp`, added ROW_MAJOR input reading inside of `reader_untilize.cpp`
- Added support for first row, last row, first column and last column as subdevice support inside of `combine_program_factory.cpp` so it can be easily used when overlapping with routed expert
- Added test `models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_combine_subdevices.py` in order to test newly added subdevice features. Test `does not run in CI, local only`.

### DeepSeek CI

- [x] [![(T3K) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml/badge.svg?branch=pmilojevic/combine-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/t3000-e2e-tests.yaml?query=branch:pmilojevic/combine-refactor)
- [x] [![(BH) e2e
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=pmilojevic/combine-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:pmilojevic/combine-refactor)
- [x] [![Demo SP
Release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=pmilojevic/combine-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:pmilojevic/combine-refactor)
- [x] [![(Galaxy) DeepSeek Prefill
tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=pmilojevic/combine-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:pmilojevic/combine-refactor)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pmilojevic/combine-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pmilojevic/combine-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pmilojevic/combine-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pmilojevic/combine-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pmilojevic/combine-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pmilojevic/combine-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pmilojevic/combine-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pmilojevic/combine-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pmilojevic/combine-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pmilojevic/combine-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pmilojevic/combine-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pmilojevic/combine-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pmilojevic/combine-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pmilojevic/combine-refactor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pmilojevic/combine-refactor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pmilojevic/combine-refactor)