### PR TITLE
perf(mla): tune chunked-prefill 640 matmul/SDPA configs for Kimi K2.6

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py
@@ -15,6 +15,13 @@ _TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_mla.py::test_ds_mla"
 _CMD_2X4 = f"pytest {_TEST_PATH} -k 'balanced-skip_check-seq100k-scaled_sl-random-line-2x4'"
 _CMD_8X4 = f"pytest {_TEST_PATH} -k 'balanced-skip_check-seq100k-scaled_sl-random-line-8x4'"
 
+# Kimi K2.6 chunked prefill: 50k KV-cache prefix + one fresh 5k chunk (chunk_size_global=5120). On
+# the 8x4 Galaxy (sp=8) this lands chunk_local=640 per chip, exercising the num_heads=64 chunked-only
+# 640 matmul/SDPA configs. Functional reference (no PCC) keeps the measured region to the single
+# forward (the 50k prefix is preloaded host->device before the MLA_START signpost, so it is not timed).
+_CHUNKED_TEST_PATH = "models/demos/deepseek_v3_d_p/tests/test_mla.py::test_mla_chunked_prefill"
+_CMD_CHUNKED_8X4 = f"pytest {_CHUNKED_TEST_PATH} -k 'deep-50k+5k and kimi and func and 8x4 and ring'"
+
 
 @pytest.mark.timeout(0)
 def test_deepseek_v3_mla_perf_loudbox():
@@ -45,4 +52,23 @@ def test_deepseek_v3_mla_perf_galaxy():
         batch_size=1,
         margin=0.03,
         comments="seq100k_scaled_glx_8x4_ground_truth",
+    )
+
+
+@pytest.mark.timeout(0)
+def test_kimi_mla_chunked_perf_galaxy():
+    """Kimi K2.6 chunked-prefill MLA perf on the 8x4 Galaxy: 50k KV-cache prefix + one fresh 5k chunk
+    (640 tokens/chip). Functional (no reference), so the single timed forward exercises the chunked
+    640 matmul/SDPA configs end to end. Ground-truth 8x4 measurement (no 2x4 approximation)."""
+    if not _is_galaxy_env():
+        pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
+    run_model_device_perf_test_with_merge(
+        command=_CMD_CHUNKED_8X4,
+        expected_device_perf_ns_per_iteration=6_740_968,
+        subdir="deepseek_v3_mla",
+        model_name="kimi_mla_chunked_glx_8x4",
+        num_iterations=1,
+        batch_size=1,
+        margin=0.03,
+        comments="kimi_chunked_50k+5k_glx_8x4_ground_truth",
     )

--- a/models/demos/deepseek_v3_d_p/tests/test_mla.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_mla.py
@@ -505,6 +505,7 @@ def _run_chunked_prefill(
     prefill_len=0,
     num_users=1,
     use_pretrained=False,
+    topology=ttnn.Topology.Linear,
 ):
     """Unified chunked-prefill scenario, decoupled from the reference.
 
@@ -605,7 +606,7 @@ def _run_chunked_prefill(
         sp_axis=sp_axis,
         tp_axis=tp_axis,
         is_balanced=False,
-        topology=ttnn.Topology.Linear,
+        topology=topology,
         is_chunked=True,
         slot_num=num_users,
         layer_num=1,
@@ -783,8 +784,16 @@ _CHUNKED_SCENARIOS = (
 # TODO(FABRIC_2D): the BH Galaxy 8x4 prefill target moved to FABRIC_2D (#45595, which fixed the MLA
 # ring all-gather writer this path uses). Add a fabric2d device_params variant (router config +
 # RELAXED_INIT + per-mesh num_links, via conftest's FABRIC_2D_PREFILL_BLOCK_MESH_PARAMS) in a
-# follow-up, validated on BH Galaxy. This test currently covers FABRIC_1D only.
-@pytest.mark.parametrize("device_params", [{"fabric_config": ttnn.FabricConfig.FABRIC_1D}], ids=["line"], indirect=True)
+# follow-up, validated on BH Galaxy. This test currently covers FABRIC_1D (line + ring) only.
+@pytest.mark.parametrize(
+    "device_params",
+    [
+        {"fabric_config": ttnn.FabricConfig.FABRIC_1D},
+        {"fabric_config": ttnn.FabricConfig.FABRIC_1D_RING},
+    ],
+    ids=["line", "ring"],
+    indirect=True,
+)
 @pytest.mark.parametrize("mesh_device", [(2, 2), (2, 4), (8, 4)], ids=["2x2", "2x4", "8x4"], indirect=True)
 @pytest.mark.parametrize("reference", ["cpu", "trace", None], ids=["cpu", "trace", "func"])
 @pytest.mark.parametrize("kwargs", [kw for _, kw in _CHUNKED_SCENARIOS], ids=[sid for sid, _ in _CHUNKED_SCENARIOS])
@@ -813,4 +822,9 @@ def test_mla_chunked_prefill(request, mesh_device, kwargs, reference, device_par
     # fixture skips the test if the env var is set but the checkpoint is incomplete.
     if reference == "cpu" and os.environ.get(variant.env_var) and not kwargs.get("use_pretrained"):
         kwargs = {**kwargs, "use_pretrained": True}
-    _run_chunked_prefill(request, mesh_device, reference=reference, **kwargs)
+    topology = (
+        ttnn.Topology.Ring
+        if device_params.get("fabric_config") == ttnn.FabricConfig.FABRIC_1D_RING
+        else ttnn.Topology.Linear
+    )
+    _run_chunked_prefill(request, mesh_device, reference=reference, topology=topology, **kwargs)

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -403,9 +403,33 @@ class ttMLA:
         "wkv_b2": ("kv_lora_rank", "v_head_dim"),
     }
 
+    def _resolve_mm_cfg(self, weight_name: str, seq_len_local: int) -> dict | None:
+        """Resolve the tuned matmul config for this weight/seq_len, applying head-count and
+        chunked-mode gating. Returns None when no tuned config applies (caller falls back to defaults).
+        """
+        cfg = self.mm_configs[weight_name].get(seq_len_local) if is_blackhole() else None
+        # Some tuned configs are head-count specific (the chunked-prefill 640 set was tuned for Kimi's
+        # 64 heads; several program_configs overflow the grid at DeepSeek's 128). A config may declare
+        # the num_heads it was tuned for; when it doesn't match this model, fall back so a different
+        # variant at the same seq_len_local doesn't pick up a dimensionally-invalid program_config.
+        if cfg is not None and cfg.get("num_heads") not in (None, self.num_heads):
+            cfg = None
+        # The chunked-prefill 640 set is only dimensionally valid in chunked mode (e.g. wkv_b1/wkv_b2
+        # are true batched per-head matmuls over the per-head SDPA output; the single-shot path applies
+        # them to a batch=1 latent). Fall back to defaults when this ttMLA was not built for chunked.
+        if cfg is not None and cfg.get("chunked_only") and not self.is_chunked:
+            cfg = None
+        return cfg
+
+    def _get_act_mem_config(self, weight_name: str, seq_len_local: int) -> ttnn.MemoryConfig:
+        """Memory config for the activation (in0) feeding this weight's matmul, as tuned in the mm
+        config (act_mem_config). Defaults to DRAM when no tuned config applies."""
+        cfg = self._resolve_mm_cfg(weight_name, seq_len_local)
+        return cfg["act_mem_config"] if cfg is not None else ttnn.DRAM_MEMORY_CONFIG
+
     def _get_mm_kwargs(self, weight_name: str, seq_len_local: int) -> dict:
         """Get matmul kwargs from config, falling back to defaults."""
-        cfg = self.mm_configs[weight_name].get(seq_len_local) if is_blackhole() else None
+        cfg = self._resolve_mm_cfg(weight_name, seq_len_local)
         if cfg is None:
             if weight_name in self._BATCHED_MM_DIMS:
                 return self._make_batched_mm_kwargs(weight_name, seq_len_local)
@@ -464,6 +488,13 @@ class ttMLA:
     def _get_sdpa_program_config(self, seq_len_local: int) -> ttnn.SDPAProgramConfig:
         """Get SDPA program config, falling back to default chunk sizes."""
         cfg = self.sdpa_configs.get(seq_len_local)
+        # Like the matmul configs, an SDPA config may be head-count specific (the chunked 640 entry
+        # was tuned for Kimi's 64 heads). Fall back to defaults when it doesn't match this model.
+        if cfg is not None and cfg.get("num_heads") not in (None, self.num_heads):
+            cfg = None
+        # The 640 chunk tiling drives ring joint attention and is only valid in chunked mode.
+        if cfg is not None and cfg.get("chunked_only") and not self.is_chunked:
+            cfg = None
         q_chunk_size = cfg["q_chunk_size"] if cfg else 32
         k_chunk_size = cfg["k_chunk_size"] if cfg else 32
         return ttnn.SDPAProgramConfig(
@@ -591,12 +622,16 @@ class ttMLA:
             kv_actual_isl=kv_actual_isl,
         )
 
-        # ring_mla output is in kv_lora_rank (latent V) space; expand to v_head_dim per head.
+        # ring_mla output is in kv_lora_rank (latent V) space; expand to v_head_dim per head. Unlike the
+        # single-shot path this in0 is the per-head SDPA output (batch=local_heads), so the tuned 640
+        # config is a true batched MatmulMultiCoreReuse. When no tuned config matches (non-Kimi variant
+        # or non-blackhole) _get_mm_kwargs falls back to the 1D batched default.
+        # NOTE: Input is ideally L1 but DRAM comes from SDPA
         attn_out = ttnn.linear(
             attn_out,
             self.wkv_b2_weight,
             compute_kernel_config=self.default_compute_kernel_config,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            **self._get_mm_kwargs("wkv_b2", seq_len_local),
         )
         return attn_out
 
@@ -637,6 +672,7 @@ class ttMLA:
         cache_batch_idx = cache_user_id * self.layer_num + cache_layer_idx
 
         # q_projection
+        # NOTE: input is ideally L1 for chunked, but hidden states memory config is set outside the module
         tt_q = ttnn.linear(
             hidden_states,
             self.q_a_proj_weight,
@@ -673,7 +709,7 @@ class ttMLA:
             tt_q,
             weight=self.q_a_layernorm_weight,
             epsilon=self.config.rms_norm_eps,
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            memory_config=self._get_act_mem_config("q_b_proj", seq_len_local),
             compute_kernel_config=self.default_compute_kernel_config,
         )
         tt_q = ttnn.linear(
@@ -715,6 +751,7 @@ class ttMLA:
         ttnn.deallocate(tt_q_rope)
 
         # kv
+        # NOTE: input is ideally L1 for chunked, but hidden states memory config is set outside the module
         tt_kv = ttnn.linear(
             hidden_states,
             self.kv_a_proj_with_mqa_weight,

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla_config.py
@@ -21,6 +21,24 @@ COMPUTE_GRID = (11, 10)
 MLA_MATMUL_CONFIG = {
     # hidden_states @ q_a_proj_weight
     "q_a_proj": {
+        640: {
+            "num_heads": 64,
+            "chunked_only": True,
+            "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=COMPUTE_GRID,
+                in0_block_w=8,
+                out_subblock_h=1,
+                out_subblock_w=5,
+                per_core_M=2,
+                per_core_N=5,
+                transpose_mcast=False,
+                fuse_batch=False,
+                fused_activation=None,
+            ),
+            "act_mem_config": ttnn.DRAM_MEMORY_CONFIG,
+            "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+            "out_dtype": ttnn.bfloat16,
+        },
         4096: {
             "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=COMPUTE_GRID,
@@ -56,6 +74,24 @@ MLA_MATMUL_CONFIG = {
     },
     # tt_q @ q_b_proj_weight (after layernorm)
     "q_b_proj": {
+        640: {
+            "num_heads": 64,
+            "chunked_only": True,
+            "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=COMPUTE_GRID,
+                in0_block_w=8,
+                out_subblock_h=1,
+                out_subblock_w=3,
+                per_core_M=2,
+                per_core_N=9,
+                transpose_mcast=False,
+                fuse_batch=False,
+                fused_activation=None,
+            ),
+            "act_mem_config": ttnn.L1_MEMORY_CONFIG,
+            "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+            "out_dtype": ttnn.bfloat16,
+        },
         4096: {
             "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=COMPUTE_GRID,
@@ -91,6 +127,21 @@ MLA_MATMUL_CONFIG = {
     },
     # tt_q_nope @ wkv_b1_weight
     "wkv_b1": {
+        640: {
+            "num_heads": 64,
+            "chunked_only": True,
+            "program_config": ttnn.MatmulMultiCoreReuseProgramConfig(
+                compute_with_storage_grid_size=COMPUTE_GRID,
+                in0_block_w=2,
+                out_subblock_h=2,
+                out_subblock_w=4,
+                per_core_M=4,
+                per_core_N=16,
+            ),
+            "act_mem_config": ttnn.DRAM_MEMORY_CONFIG,
+            "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+            "out_dtype": ttnn.bfloat16,
+        },
         4096: {
             "program_config": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=COMPUTE_GRID,
@@ -124,6 +175,24 @@ MLA_MATMUL_CONFIG = {
     },
     # hidden_states @ kv_a_proj_with_mqa_weight
     "kv_a_proj_with_mqa": {
+        640: {
+            "num_heads": 64,
+            "chunked_only": True,
+            "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=COMPUTE_GRID,
+                in0_block_w=14,
+                out_subblock_h=2,
+                out_subblock_w=1,
+                per_core_M=2,
+                per_core_N=2,
+                transpose_mcast=False,
+                fuse_batch=False,
+                fused_activation=None,
+            ),
+            "act_mem_config": ttnn.L1_MEMORY_CONFIG,
+            "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+            "out_dtype": ttnn.bfloat16,
+        },
         4096: {
             "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=COMPUTE_GRID,
@@ -159,6 +228,21 @@ MLA_MATMUL_CONFIG = {
     },
     # tt_v_latent_post_repeat @ wkv_b2_weight
     "wkv_b2": {
+        640: {
+            "num_heads": 64,
+            "chunked_only": True,
+            "program_config": ttnn.MatmulMultiCoreReuseProgramConfig(
+                compute_with_storage_grid_size=COMPUTE_GRID,
+                in0_block_w=2,
+                out_subblock_h=4,
+                out_subblock_w=1,
+                per_core_M=4,
+                per_core_N=4,
+            ),
+            "act_mem_config": ttnn.L1_MEMORY_CONFIG,
+            "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+            "out_dtype": ttnn.bfloat8_b,
+        },
         4096: {
             "program_config": ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                 compute_with_storage_grid_size=COMPUTE_GRID,
@@ -194,6 +278,24 @@ MLA_MATMUL_CONFIG = {
     },
     # v_out @ o_proj_weight
     "o_proj": {
+        640: {
+            "num_heads": 64,
+            "chunked_only": True,
+            "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
+                compute_with_storage_grid_size=COMPUTE_GRID,
+                in0_block_w=8,
+                out_subblock_h=1,
+                out_subblock_w=7,
+                per_core_M=2,
+                per_core_N=21,
+                transpose_mcast=False,
+                fuse_batch=False,
+                fused_activation=None,
+            ),
+            "act_mem_config": ttnn.DRAM_MEMORY_CONFIG,
+            "out_mem_config": ttnn.L1_MEMORY_CONFIG,
+            "out_dtype": ttnn.bfloat16,
+        },
         4096: {
             "program_config": ttnn.MatmulMultiCoreReuseMultiCastProgramConfig(
                 compute_with_storage_grid_size=COMPUTE_GRID,
@@ -251,6 +353,13 @@ MLA_SDPA_CONFIG = {
     3200: {
         "q_chunk_size": 160,
         "k_chunk_size": 320,
+    },
+    # 5k total seq_len → 640 per device on 8x4
+    640: {
+        "q_chunk_size": 32,
+        "k_chunk_size": 640,
+        "num_heads": 64,
+        "chunked_only": True,
     },
 }
 

--- a/tests/pipeline_reorg/demo_sp_release_tests.yaml
+++ b/tests/pipeline_reorg/demo_sp_release_tests.yaml
@@ -39,6 +39,7 @@
     pytest models/demos/deepseek_v3_d_p/tests/perf/test_prefill_block_perf.py -k "block_8x4" -vvv --tb=short
     pytest models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py::test_deepseek_v3_moe_perf_galaxy -vvv --tb=short
     pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_deepseek_v3_mla_perf_galaxy -vvv --tb=short
+    pytest models/demos/deepseek_v3_d_p/tests/perf/test_mla_perf.py::test_kimi_mla_chunked_perf_galaxy -vvv --tb=short
   model: deepseek_prefill
   skus:
     bh_galaxy:


### PR DESCRIPTION
## What

Resolves #45838. Adds tuned matmul and SDPA program_configs at `seq_len_local=640` for the DeepSeek/Kimi MLA chunked-prefill path. 640 is what a 5k chunk (on top of a 50k KV-cache prefix) lands at per chip on the 8x4 Galaxy (sp=8). The configs are tuned for Kimi K2.6's 64 heads.

## How

The new 640 entries are gated so they only apply where dimensionally valid; everything else falls back to existing defaults:

- **`_resolve_mm_cfg()`** — centralizes config lookup + gating. A config declaring `num_heads` or `chunked_only` is dropped when it doesn't match this `ttMLA` (e.g. DeepSeek's 128 heads, or the single-shot path), so a variant at the same `seq_len_local` can't pick up a program_config that overflows the grid or is shaped for the wrong path.
- **`_get_act_mem_config()`** — threads each weight's tuned activation `memory_config` (L1 vs DRAM) into the op that feeds it; defaults to DRAM.
- **SDPA** gets the same `num_heads`/`chunked_only` gating.
- **`wkv_b2`** expansion now uses its tuned batched `MatmulMultiCoreReuse` config (the in0 here is the per-head SDPA output, a true batched matmul).

## Testing

- `test_mla_chunked_prefill`: add `FABRIC_1D_RING` (ring topology) coverage alongside line.
- New `test_kimi_mla_chunked_perf_galaxy` device-perf test (50k+5k, functional, ground-truth 8x4), wired into `demo_sp_release_tests.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

- [x] [![galaxy-deepseek-prefill-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ipotkonjak/chunked_mla_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ipotkonjak/chunked_mla_perf) 
- [x] [![blackhole-e2e-tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ipotkonjak/chunked_mla_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ipotkonjak/chunked_mla_perf)
- [x] [![demo-sp-release](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=ipotkonjak/chunked_mla_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:ipotkonjak/chunked_mla_perf) 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ipotkonjak/chunked_mla_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ipotkonjak/chunked_mla_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ipotkonjak/chunked_mla_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ipotkonjak/chunked_mla_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ipotkonjak/chunked_mla_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ipotkonjak/chunked_mla_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ipotkonjak/chunked_mla_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ipotkonjak/chunked_mla_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ipotkonjak/chunked_mla_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ipotkonjak/chunked_mla_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ipotkonjak/chunked_mla_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ipotkonjak/chunked_mla_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ipotkonjak/chunked_mla_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ipotkonjak/chunked_mla_perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ipotkonjak/chunked_mla_perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ipotkonjak/chunked_mla_perf)