### PR TITLE
Mask padded vocab logits in sampling

### DIFF
--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -23,6 +23,7 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.modules.lazy_buffer import LazyBuffer, resolve_lazy_buffer
 from models.common.modules.tt_ccl import default_topology, get_tt_ccl
+from models.common.sampling.vocab_padding import build_invalid_vocab_mask, get_vocab_shard_dims
 
 # ---------------------------------------------------------------------------
 # Power-of-2 helpers (local copies; keep this TTTv2 module self-contained)
@@ -52,7 +53,8 @@ class Sampling1DConfig:
     k/p/temp are NOT stored here — they are per-call forward args.
     """
 
-    vocab_size: int  # Required. Caller pre-pads to be divisible by num_devices.
+    vocab_size: int  # Required. Padded logits width; caller pre-pads to be divisible by num_devices.
+    valid_vocab_size: Optional[int] = None  # Real token vocabulary size. Defaults to vocab_size.
     mesh_device: Optional[ttnn.MeshDevice] = None  # None → GetDefaultDevice()
     tt_ccl: Any = None  # None → get_tt_ccl(mesh_device) if multi-device
     max_batch_size: int = 32
@@ -77,6 +79,7 @@ class Sampling1DConfig:
     local_indices: LazyBuffer | ttnn.Tensor | None = (
         None  # [1,1,32,W], uint16, TILE (W=vocab for 1x1, per_dev_vocab otherwise)
     )
+    invalid_vocab_mask: LazyBuffer | ttnn.Tensor | None = None  # [1,1,32,W], bf16, sharded like logits
     # Seed/ID buffers (seeds mutable via LazyBuffer.update(), user_ids static)
     seeds: LazyBuffer | ttnn.Tensor | None = None  # [32], uint32, ROW_MAJOR
     user_ids: LazyBuffer | ttnn.Tensor | None = None  # [32], uint32, ROW_MAJOR
@@ -94,9 +97,10 @@ class Sampling1DConfig:
             return False
         if self.mesh_device.get_num_devices() > 1 and self.tt_ccl is None:
             return False
-        return all(
-            self._buf_resolved(getattr(self, f)) for f in ("index_offsets", "local_indices", "seeds", "user_ids")
-        )
+        required_buffers = ["index_offsets", "local_indices", "seeds", "user_ids"]
+        if self.valid_vocab_size is not None and self.valid_vocab_size < self.vocab_size:
+            required_buffers.append("invalid_vocab_mask")
+        return all(self._buf_resolved(getattr(self, f)) for f in required_buffers)
 
 
 # ---------------------------------------------------------------------------
@@ -184,6 +188,7 @@ class Sampling1D(LightweightModule):
 
         self._index_offsets = _materialize(cfg.index_offsets)
         self._local_indices = _materialize(cfg.local_indices)
+        self._invalid_vocab_mask = _materialize(cfg.invalid_vocab_mask) if cfg.invalid_vocab_mask is not None else None
         self._seeds = _materialize(cfg.seeds)
         self._user_ids = _materialize(cfg.user_ids)
         from models.common.utils import LogProbsCalculator  # lazy: transitively imports torch
@@ -257,6 +262,7 @@ class Sampling1D(LightweightModule):
     # -- Argmax path (port from tt_sampling.py:310-341) -----------------------
 
     def _sample_argmax(self, logits, tt_out_tok):
+        logits = self._mask_invalid_vocab_logits(logits)
         logits = self._pre_argmax_gather(logits)
         x_untilized = ttnn.untilize(logits, use_multicore=True)
         tt_out_tok = ttnn.argmax(
@@ -352,6 +358,7 @@ class Sampling1D(LightweightModule):
         cfg = self.config
 
         x_bf16 = ttnn.typecast(logits, dtype=ttnn.bfloat16, sub_core_grids=cfg.sub_core_grids)
+        x_bf16 = self._mask_invalid_vocab_logits(x_bf16)
 
         # Strategy-dispatched top-k
         topk_values, topk_indices = self._topk(x_bf16)
@@ -407,6 +414,11 @@ class Sampling1D(LightweightModule):
         else:
             log_probs = None
         return tt_out_tok, log_probs
+
+    def _mask_invalid_vocab_logits(self, logits):
+        if self._invalid_vocab_mask is None:
+            return logits
+        return ttnn.add(logits, self._invalid_vocab_mask, memory_config=logits.memory_config())
 
     # -- Top-k strategies (bound at init, no if-else in forward) --------------
 
@@ -535,6 +547,7 @@ class Sampling1D(LightweightModule):
             )
         padded_vocab_size = getattr(args, "padded_vocab_size", None)
         vocab_size = padded_vocab_size if padded_vocab_size is not None else args.vocab_size
+        valid_vocab_size = getattr(args, "vocab_size", vocab_size)
 
         # Extract config from model_config dict
         mc = model_config or getattr(args, "model_config", {})
@@ -557,6 +570,7 @@ class Sampling1D(LightweightModule):
 
         config = Sampling1DConfig(
             vocab_size=vocab_size,
+            valid_vocab_size=valid_vocab_size,
             mesh_device=mesh_device,
             tt_ccl=tt_ccl,
             max_batch_size=getattr(args, "max_batch_size", 32),
@@ -597,6 +611,10 @@ def _resolve_sampling1d_config(config: Sampling1DConfig) -> Sampling1DConfig:
         to_set["tt_ccl"] = get_tt_ccl(mesh_device)
 
     # Phase 2: Scalar config defaults
+    valid_vocab_size = config.valid_vocab_size if config.valid_vocab_size is not None else config.vocab_size
+    if valid_vocab_size > config.vocab_size:
+        raise ValueError(f"valid_vocab_size ({valid_vocab_size}) must be <= vocab_size ({config.vocab_size})")
+    to_set["valid_vocab_size"] = valid_vocab_size
     if config.start_core is None:
         to_set["start_core"] = ttnn.CoreCoord(0, 0)
     if config.sampling_memory_config is None:
@@ -675,6 +693,22 @@ def _resolve_sampling1d_config(config: Sampling1DConfig) -> Sampling1DConfig:
         memory_config=ttnn.DRAM_MEMORY_CONFIG,
     )
     to_set["local_indices"] = _resolve_buf(config.local_indices, local_idx_defaults, _make_local_indices)
+
+    invalid_vocab_mask = build_invalid_vocab_mask(valid_vocab_size, V, B)
+    if invalid_vocab_mask is not None or config.invalid_vocab_mask is not None:
+        vocab_shard_dims = get_vocab_shard_dims(cluster_shape)
+        invalid_vocab_defaults = dict(
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=vocab_shard_dims, mesh_shape=cluster_shape),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+        to_set["invalid_vocab_mask"] = _resolve_buf(
+            config.invalid_vocab_mask,
+            invalid_vocab_defaults,
+            lambda: invalid_vocab_mask,
+        )
 
     # seeds and user_ids: [B], uint32, ROW_MAJOR
     seed_defaults = dict(

--- a/models/common/modules/sampling/sampling_1d.py
+++ b/models/common/modules/sampling/sampling_1d.py
@@ -23,7 +23,11 @@ import ttnn
 from models.common.lightweightmodule import LightweightModule
 from models.common.modules.lazy_buffer import LazyBuffer, resolve_lazy_buffer
 from models.common.modules.tt_ccl import default_topology, get_tt_ccl
-from models.common.sampling.vocab_padding import build_invalid_vocab_mask, get_vocab_shard_dims
+from models.common.sampling.vocab_padding import (
+    build_invalid_vocab_mask,
+    build_tail_invalid_vocab_mask,
+    get_vocab_shard_dims,
+)
 
 # ---------------------------------------------------------------------------
 # Power-of-2 helpers (local copies; keep this TTTv2 module self-contained)
@@ -79,7 +83,9 @@ class Sampling1DConfig:
     local_indices: LazyBuffer | ttnn.Tensor | None = (
         None  # [1,1,32,W], uint16, TILE (W=vocab for 1x1, per_dev_vocab otherwise)
     )
-    invalid_vocab_mask: LazyBuffer | ttnn.Tensor | None = None  # [1,1,32,W], bf16, sharded like logits
+    invalid_vocab_mask: LazyBuffer | ttnn.Tensor | None = None  # Full fallback mask, sharded like logits
+    invalid_vocab_tail_mask: LazyBuffer | ttnn.Tensor | None = None  # Compact [1,1,32,tail] local mask
+    invalid_vocab_tail_width: int = 0
     # Seed/ID buffers (seeds mutable via LazyBuffer.update(), user_ids static)
     seeds: LazyBuffer | ttnn.Tensor | None = None  # [32], uint32, ROW_MAJOR
     user_ids: LazyBuffer | ttnn.Tensor | None = None  # [32], uint32, ROW_MAJOR
@@ -98,9 +104,11 @@ class Sampling1DConfig:
         if self.mesh_device.get_num_devices() > 1 and self.tt_ccl is None:
             return False
         required_buffers = ["index_offsets", "local_indices", "seeds", "user_ids"]
+        if not all(self._buf_resolved(getattr(self, f)) for f in required_buffers):
+            return False
         if self.valid_vocab_size is not None and self.valid_vocab_size < self.vocab_size:
-            required_buffers.append("invalid_vocab_mask")
-        return all(self._buf_resolved(getattr(self, f)) for f in required_buffers)
+            return self._buf_resolved(self.invalid_vocab_mask) or self._buf_resolved(self.invalid_vocab_tail_mask)
+        return True
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +197,10 @@ class Sampling1D(LightweightModule):
         self._index_offsets = _materialize(cfg.index_offsets)
         self._local_indices = _materialize(cfg.local_indices)
         self._invalid_vocab_mask = _materialize(cfg.invalid_vocab_mask) if cfg.invalid_vocab_mask is not None else None
+        self._invalid_vocab_tail_mask = (
+            _materialize(cfg.invalid_vocab_tail_mask) if cfg.invalid_vocab_tail_mask is not None else None
+        )
+        self._invalid_vocab_tail_width = cfg.invalid_vocab_tail_width
         self._seeds = _materialize(cfg.seeds)
         self._user_ids = _materialize(cfg.user_ids)
         from models.common.utils import LogProbsCalculator  # lazy: transitively imports torch
@@ -262,8 +274,12 @@ class Sampling1D(LightweightModule):
     # -- Argmax path (port from tt_sampling.py:310-341) -----------------------
 
     def _sample_argmax(self, logits, tt_out_tok):
-        logits = self._mask_invalid_vocab_logits(logits)
+        slice_valid_vocab = self._can_slice_valid_vocab_for_argmax()
+        if not slice_valid_vocab:
+            logits = self._mask_invalid_vocab_logits(logits)
         logits = self._pre_argmax_gather(logits)
+        if slice_valid_vocab:
+            logits = self._slice_valid_vocab_for_argmax(logits)
         x_untilized = ttnn.untilize(logits, use_multicore=True)
         tt_out_tok = ttnn.argmax(
             x_untilized,
@@ -416,9 +432,67 @@ class Sampling1D(LightweightModule):
         return tt_out_tok, log_probs
 
     def _mask_invalid_vocab_logits(self, logits):
+        if self._invalid_vocab_tail_mask is not None:
+            return self._mask_invalid_vocab_tail_logits(logits)
         if self._invalid_vocab_mask is None:
             return logits
         return ttnn.add(logits, self._invalid_vocab_mask, memory_config=logits.memory_config())
+
+    def _mask_invalid_vocab_tail_logits(self, logits):
+        tail_width = self._invalid_vocab_tail_width
+        local_width = logits.shape[-1]
+        valid_width = local_width - tail_width
+        if tail_width <= 0 or valid_width < 0:
+            return self._mask_invalid_vocab_logits_fallback(logits)
+        if valid_width == 0:
+            return ttnn.add(logits, self._invalid_vocab_tail_mask, memory_config=logits.memory_config())
+
+        cfg = self.config
+        valid_logits = ttnn.slice(
+            logits,
+            [0, 0, 0, 0],
+            [logits.shape[0], logits.shape[1], logits.shape[2], valid_width],
+            memory_config=logits.memory_config(),
+            sub_core_grids=cfg.sub_core_grids,
+        )
+        tail_logits = ttnn.slice(
+            logits,
+            [0, 0, 0, valid_width],
+            [logits.shape[0], logits.shape[1], logits.shape[2], local_width],
+            memory_config=logits.memory_config(),
+            sub_core_grids=cfg.sub_core_grids,
+        )
+        masked_tail_logits = ttnn.add(tail_logits, self._invalid_vocab_tail_mask, memory_config=logits.memory_config())
+        masked_logits = ttnn.concat(
+            [valid_logits, masked_tail_logits],
+            dim=3,
+            memory_config=logits.memory_config(),
+        )
+        ttnn.deallocate(valid_logits)
+        ttnn.deallocate(tail_logits)
+        ttnn.deallocate(masked_tail_logits)
+        return masked_logits
+
+    def _mask_invalid_vocab_logits_fallback(self, logits):
+        if self._invalid_vocab_mask is None:
+            return logits
+        return ttnn.add(logits, self._invalid_vocab_mask, memory_config=logits.memory_config())
+
+    def _can_slice_valid_vocab_for_argmax(self):
+        cfg = self.config
+        return cfg.valid_vocab_size < cfg.vocab_size and cfg.valid_vocab_size % ttnn.TILE_SIZE == 0
+
+    def _slice_valid_vocab_for_argmax(self, logits):
+        cfg = self.config
+        if not self._can_slice_valid_vocab_for_argmax() or logits.shape[-1] != cfg.vocab_size:
+            return logits
+        return ttnn.slice(
+            logits,
+            [0, 0, 0, 0],
+            [logits.shape[0], logits.shape[1], logits.shape[2], cfg.valid_vocab_size],
+            memory_config=logits.memory_config(),
+            sub_core_grids=cfg.sub_core_grids,
+        )
 
     # -- Top-k strategies (bound at init, no if-else in forward) --------------
 
@@ -694,21 +768,42 @@ def _resolve_sampling1d_config(config: Sampling1DConfig) -> Sampling1DConfig:
     )
     to_set["local_indices"] = _resolve_buf(config.local_indices, local_idx_defaults, _make_local_indices)
 
-    invalid_vocab_mask = build_invalid_vocab_mask(valid_vocab_size, V, B)
-    if invalid_vocab_mask is not None or config.invalid_vocab_mask is not None:
-        vocab_shard_dims = get_vocab_shard_dims(cluster_shape)
-        invalid_vocab_defaults = dict(
-            dtype=ttnn.bfloat16,
-            layout=ttnn.TILE_LAYOUT,
-            device=mesh_device,
-            mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=vocab_shard_dims, mesh_shape=cluster_shape),
-            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    vocab_shard_dims = get_vocab_shard_dims(cluster_shape)
+    invalid_vocab_defaults = dict(
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(mesh_device, dims=vocab_shard_dims, mesh_shape=cluster_shape),
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+    )
+    invalid_vocab_tail_mask = build_tail_invalid_vocab_mask(
+        valid_vocab_size,
+        V,
+        B,
+        cluster_shape,
+        tile_size=ttnn.TILE_SIZE,
+    )
+    if config.invalid_vocab_mask is None and (
+        invalid_vocab_tail_mask is not None or config.invalid_vocab_tail_mask is not None
+    ):
+        to_set["invalid_vocab_tail_width"] = (
+            invalid_vocab_tail_mask.tail_width
+            if invalid_vocab_tail_mask is not None
+            else config.invalid_vocab_tail_width
         )
-        to_set["invalid_vocab_mask"] = _resolve_buf(
-            config.invalid_vocab_mask,
+        to_set["invalid_vocab_tail_mask"] = _resolve_buf(
+            config.invalid_vocab_tail_mask,
             invalid_vocab_defaults,
-            lambda: invalid_vocab_mask,
+            lambda: invalid_vocab_tail_mask.mask,
         )
+    else:
+        invalid_vocab_mask = build_invalid_vocab_mask(valid_vocab_size, V, B)
+        if invalid_vocab_mask is not None or config.invalid_vocab_mask is not None:
+            to_set["invalid_vocab_mask"] = _resolve_buf(
+                config.invalid_vocab_mask,
+                invalid_vocab_defaults,
+                lambda: invalid_vocab_mask,
+            )
 
     # seeds and user_ids: [B], uint32, ROW_MAJOR
     seed_defaults = dict(

--- a/models/common/sampling/README.md
+++ b/models/common/sampling/README.md
@@ -99,6 +99,8 @@ plus `apply_decode_state(...)`.
 
 **`padded_vocab_size` vs `vocab_size`**: TTSampling device offsets for global token IDs must use the padded vocab size to match how the LM head shards logits across devices. Using unpadded `vocab_size` for offsets shifts token IDs from devices 1+ and produces garbled output.
 
+**Padded vocab logits**: If the LM head pads output weights beyond the real tokenizer vocabulary, the sampler must mask those padded token IDs before force-argmax or local top-k. Zero-padded LM-head weights are useful for legal sharded matmul shapes, but they are not a sampling mask.
+
 **`sampling_dp`**: When >1, k/p/temp tensors must have length `max_batch_size * sampling_dp` and are row-sharded via `ShardTensor2dMesh(dims=(0, None))`. Use `chunk_sampling_params` + `apply_decode_state` to distribute params across mesh rows.
 
 **Batched prefill + on-device sampling**: This path is only valid when the

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -15,7 +15,11 @@ from models.common.sampling._utils import is_default_value, is_llama33_70b_model
 from models.common.sampling._utils import log_sampling_debug as _log_sampling_debug
 from models.common.sampling._utils import upper_power_of_2
 from models.common.sampling.tt_log_probs import LogProbsCalculator
-from models.common.sampling.vocab_padding import build_invalid_vocab_mask, get_vocab_shard_dims
+from models.common.sampling.vocab_padding import (
+    build_invalid_vocab_mask,
+    build_tail_invalid_vocab_mask,
+    get_vocab_shard_dims,
+)
 
 
 class TTSampling(LightweightModule):
@@ -316,16 +320,43 @@ class TTSampling(LightweightModule):
         )
 
     def _create_invalid_vocab_mask(self):
+        self.tt_invalid_vocab_mask = None
+        self.tt_invalid_vocab_tail_mask = None
+        self._invalid_vocab_tail_width = 0
+
+        vocab_shard_dims = get_vocab_shard_dims(self.cluster_shape, self.sampling_all_gather_axis)
+        tail_mask = build_tail_invalid_vocab_mask(
+            self.vocab_size,
+            self.padded_vocab_size,
+            self.max_batch_size,
+            self.cluster_shape,
+            self.sampling_all_gather_axis,
+            tile_size=ttnn.TILE_SIZE,
+        )
+        if tail_mask is not None:
+            self._invalid_vocab_tail_width = tail_mask.tail_width
+            self.tt_invalid_vocab_tail_mask = ttnn.from_torch(
+                tail_mask.mask,
+                dtype=ttnn.bfloat16,
+                layout=ttnn.TILE_LAYOUT,
+                device=self.mesh_device,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    self.mesh_device,
+                    dims=vocab_shard_dims,
+                    mesh_shape=self.cluster_shape,
+                ),
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            )
+            return
+
         invalid_vocab_mask = build_invalid_vocab_mask(
             self.vocab_size,
             self.padded_vocab_size,
             self.max_batch_size,
         )
         if invalid_vocab_mask is None:
-            self.tt_invalid_vocab_mask = None
             return
 
-        vocab_shard_dims = get_vocab_shard_dims(self.cluster_shape, self.sampling_all_gather_axis)
         self.tt_invalid_vocab_mask = ttnn.from_torch(
             invalid_vocab_mask,
             dtype=ttnn.bfloat16,
@@ -340,9 +371,66 @@ class TTSampling(LightweightModule):
         )
 
     def _mask_invalid_vocab_logits(self, logits):
+        if self.tt_invalid_vocab_tail_mask is not None:
+            return self._mask_invalid_vocab_tail_logits(logits)
         if self.tt_invalid_vocab_mask is None:
             return logits
         return ttnn.add(logits, self.tt_invalid_vocab_mask, memory_config=logits.memory_config())
+
+    def _mask_invalid_vocab_tail_logits(self, logits):
+        tail_width = self._invalid_vocab_tail_width
+        local_width = logits.shape[-1]
+        valid_width = local_width - tail_width
+        if tail_width <= 0 or valid_width < 0:
+            return self._mask_invalid_vocab_logits_fallback(logits)
+        if valid_width == 0:
+            return ttnn.add(logits, self.tt_invalid_vocab_tail_mask, memory_config=logits.memory_config())
+
+        valid_logits = ttnn.slice(
+            logits,
+            [0, 0, 0, 0],
+            [logits.shape[0], logits.shape[1], logits.shape[2], valid_width],
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
+        )
+        tail_logits = ttnn.slice(
+            logits,
+            [0, 0, 0, valid_width],
+            [logits.shape[0], logits.shape[1], logits.shape[2], local_width],
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
+        )
+        masked_tail_logits = ttnn.add(
+            tail_logits, self.tt_invalid_vocab_tail_mask, memory_config=logits.memory_config()
+        )
+        masked_logits = ttnn.concat(
+            [valid_logits, masked_tail_logits],
+            dim=3,
+            memory_config=logits.memory_config(),
+        )
+        ttnn.deallocate(valid_logits)
+        ttnn.deallocate(tail_logits)
+        ttnn.deallocate(masked_tail_logits)
+        return masked_logits
+
+    def _mask_invalid_vocab_logits_fallback(self, logits):
+        if self.tt_invalid_vocab_mask is None:
+            return logits
+        return ttnn.add(logits, self.tt_invalid_vocab_mask, memory_config=logits.memory_config())
+
+    def _can_slice_valid_vocab_for_argmax(self):
+        return self.vocab_size < self.padded_vocab_size and self.vocab_size % ttnn.TILE_SIZE == 0
+
+    def _slice_valid_vocab_for_argmax(self, logits):
+        if not self._can_slice_valid_vocab_for_argmax() or logits.shape[-1] != self.padded_vocab_size:
+            return logits
+        return ttnn.slice(
+            logits,
+            [0, 0, 0, 0],
+            [logits.shape[0], logits.shape[1], logits.shape[2], self.vocab_size],
+            memory_config=logits.memory_config(),
+            sub_core_grids=self.sub_core_grids,
+        )
 
     def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
         """
@@ -489,7 +577,9 @@ class TTSampling(LightweightModule):
         )
         if self._force_argmax_sampling:
             logger.info("Forcing argmax sampling")
-            x = self._mask_invalid_vocab_logits(x)
+            slice_valid_vocab = self._can_slice_valid_vocab_for_argmax()
+            if not slice_valid_vocab:
+                x = self._mask_invalid_vocab_logits(x)
             # Gather the output across all devices and untilize the tensor (for argmax)
             num_devices = self.mesh_device.get_num_devices()
             if num_devices > 1:
@@ -513,6 +603,8 @@ class TTSampling(LightweightModule):
                     num_workers_per_link=self.argmax_num_workers_per_link,
                     num_buffers_per_channel=2,
                 )
+            if slice_valid_vocab:
+                x = self._slice_valid_vocab_for_argmax(x)
             x_untilized = ttnn.untilize(x, use_multicore=True)
             tt_out_tok = ttnn.argmax(
                 x_untilized,

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -15,6 +15,7 @@ from models.common.sampling._utils import is_default_value, is_llama33_70b_model
 from models.common.sampling._utils import log_sampling_debug as _log_sampling_debug
 from models.common.sampling._utils import upper_power_of_2
 from models.common.sampling.tt_log_probs import LogProbsCalculator
+from models.common.sampling.vocab_padding import build_invalid_vocab_mask, get_vocab_shard_dims
 
 
 class TTSampling(LightweightModule):
@@ -223,6 +224,7 @@ class TTSampling(LightweightModule):
 
         # Create device offset indices for global indexing
         self._create_indices_tensors()
+        self._create_invalid_vocab_mask()
         # Log-probs tensor to store the log-probs for the batch
         self.tt_log_probs = None
         self.log_probs_calculator = LogProbsCalculator(
@@ -254,23 +256,21 @@ class TTSampling(LightweightModule):
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
 
+    def _get_num_sampling_shards(self):
+        if self.multi_step_reduction:
+            return 2
+        if 1 in self.cluster_shape:
+            return max(self.cluster_shape[0], self.cluster_shape[1])
+
+        assert self.sampling_all_gather_axis in (
+            0,
+            1,
+        ), f"sampling_all_gather_axis must be 0 or 1 for 2D meshes, got {self.sampling_all_gather_axis}"
+        return self.cluster_shape[self.sampling_all_gather_axis]
+
     def _create_indices_tensors(self):
         """Create the indices tensors needed for distributed top-k operations."""
-        # Create indices tensor for device offsets
-        # For multi-step reduction, we use reduce over 2 steps in a single device
-        if self.multi_step_reduction:
-            num_devices_in_mesh = 2
-        else:
-            # If the mesh is effectively 1D, use the non-singleton dimension.
-            # If the mesh is 2D, use the configured gather axis.
-            if 1 in self.cluster_shape:
-                num_devices_in_mesh = max(self.cluster_shape[0], self.cluster_shape[1])
-            else:
-                assert self.sampling_all_gather_axis in (
-                    0,
-                    1,
-                ), f"sampling_all_gather_axis must be 0 or 1 for 2D meshes, got {self.sampling_all_gather_axis}"
-                num_devices_in_mesh = self.cluster_shape[self.sampling_all_gather_axis]
+        num_devices_in_mesh = self._get_num_sampling_shards()
         indices_device_offsets = torch.ones(
             1, 1, self.max_batch_size, self.max_top_k * num_devices_in_mesh, dtype=torch.int64
         )
@@ -314,6 +314,35 @@ class TTSampling(LightweightModule):
             mesh_mapper=ttnn.ShardTensor2dMesh(self.mesh_device, dims=(None, None), mesh_shape=self.cluster_shape),
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
         )
+
+    def _create_invalid_vocab_mask(self):
+        invalid_vocab_mask = build_invalid_vocab_mask(
+            self.vocab_size,
+            self.padded_vocab_size,
+            self.max_batch_size,
+        )
+        if invalid_vocab_mask is None:
+            self.tt_invalid_vocab_mask = None
+            return
+
+        vocab_shard_dims = get_vocab_shard_dims(self.cluster_shape, self.sampling_all_gather_axis)
+        self.tt_invalid_vocab_mask = ttnn.from_torch(
+            invalid_vocab_mask,
+            dtype=ttnn.bfloat16,
+            layout=ttnn.TILE_LAYOUT,
+            device=self.mesh_device,
+            mesh_mapper=ttnn.ShardTensor2dMesh(
+                self.mesh_device,
+                dims=vocab_shard_dims,
+                mesh_shape=self.cluster_shape,
+            ),
+            memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        )
+
+    def _mask_invalid_vocab_logits(self, logits):
+        if self.tt_invalid_vocab_mask is None:
+            return logits
+        return ttnn.add(logits, self.tt_invalid_vocab_mask, memory_config=logits.memory_config())
 
     def _perform_all_gather(self, tensor, dim, cluster_axis, memory_config, num_links, buffer_key=None, dtype=None):
         """
@@ -460,6 +489,7 @@ class TTSampling(LightweightModule):
         )
         if self._force_argmax_sampling:
             logger.info("Forcing argmax sampling")
+            x = self._mask_invalid_vocab_logits(x)
             # Gather the output across all devices and untilize the tensor (for argmax)
             num_devices = self.mesh_device.get_num_devices()
             if num_devices > 1:
@@ -497,6 +527,7 @@ class TTSampling(LightweightModule):
 
         # Convert to bfloat16 for top-k operations (typecast is no-op if already bfloat16)
         x_bf16 = ttnn.typecast(x, dtype=ttnn.bfloat16, sub_core_grids=self.sub_core_grids)
+        x_bf16 = self._mask_invalid_vocab_logits(x_bf16)
 
         if self.multi_step_reduction:
             x_bf16_list = ttnn.split(x_bf16, x_bf16.shape[-1] // 2, dim=3)

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -262,10 +262,10 @@ class TTSampling(LightweightModule):
         if 1 in self.cluster_shape:
             return max(self.cluster_shape[0], self.cluster_shape[1])
 
-        assert self.sampling_all_gather_axis in (
-            0,
-            1,
-        ), f"sampling_all_gather_axis must be 0 or 1 for 2D meshes, got {self.sampling_all_gather_axis}"
+        if self.sampling_all_gather_axis not in (0, 1):
+            raise ValueError(
+                f"sampling_all_gather_axis must be 0 or 1 for 2D meshes, got {self.sampling_all_gather_axis}"
+            )
         return self.cluster_shape[self.sampling_all_gather_axis]
 
     def _create_indices_tensors(self):

--- a/models/common/sampling/vocab_padding.py
+++ b/models/common/sampling/vocab_padding.py
@@ -1,7 +1,19 @@
 # SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import dataclass
+
 import torch
+
+
+@dataclass(frozen=True)
+class InvalidVocabTailMask:
+    """A compact additive mask for the tile-aligned invalid tail of the final vocab shard."""
+
+    mask: torch.Tensor
+    tail_width: int
+    shard_width: int
+    num_vocab_shards: int
 
 
 def build_invalid_vocab_mask(
@@ -34,17 +46,99 @@ def build_invalid_vocab_mask(
     return mask
 
 
-def get_vocab_shard_dims(
-    cluster_shape: tuple[int, int] | list[int],
-    sampling_all_gather_axis: int = 0,
-) -> tuple[int | None, int | None]:
-    """Return the 2D mesh mapper dims for sharding vocab over the sampling TP axis."""
+def _validate_cluster_shape(cluster_shape: tuple[int, int] | list[int]) -> tuple[int, int]:
+    cluster_shape = tuple(cluster_shape)
     if len(cluster_shape) != 2:
         raise ValueError(f"cluster_shape must have two dimensions, got {cluster_shape}")
 
     rows, cols = int(cluster_shape[0]), int(cluster_shape[1])
     if rows <= 0 or cols <= 0:
         raise ValueError(f"cluster_shape dimensions must be positive, got {cluster_shape}")
+    return rows, cols
+
+
+def get_vocab_num_shards(
+    cluster_shape: tuple[int, int] | list[int],
+    sampling_all_gather_axis: int = 0,
+) -> int:
+    """Return how many mesh partitions own contiguous slices of the vocab dimension."""
+    rows, cols = _validate_cluster_shape(cluster_shape)
+
+    if rows == 1 and cols == 1:
+        return 1
+    if rows == 1:
+        return cols
+    if cols == 1:
+        return rows
+    if sampling_all_gather_axis == 0:
+        return rows
+    if sampling_all_gather_axis == 1:
+        return cols
+    raise ValueError(f"sampling_all_gather_axis must be 0 or 1, got {sampling_all_gather_axis}")
+
+
+def build_tail_invalid_vocab_mask(
+    vocab_size: int,
+    padded_vocab_size: int,
+    max_batch_size: int,
+    cluster_shape: tuple[int, int] | list[int],
+    sampling_all_gather_axis: int = 0,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+    tile_size: int = 32,
+) -> InvalidVocabTailMask | None:
+    """Build a compact mask for padding that lives only at the final shard tail.
+
+    The sampling logits are sharded into equal local vocab widths. For model
+    shapes like Qwen3-32B on T3K, all invalid IDs are a small tile-aligned suffix
+    of the last local shard. In that case callers can mask only the local tail
+    slice instead of adding a full-vocab all-zero mask on every device.
+
+    Returns ``None`` when the invalid range is not a tile-aligned final-shard
+    suffix; callers should use ``build_invalid_vocab_mask`` as the correctness
+    fallback.
+    """
+    if vocab_size < 0:
+        raise ValueError(f"vocab_size must be non-negative, got {vocab_size}")
+    if padded_vocab_size < vocab_size:
+        raise ValueError(f"padded_vocab_size ({padded_vocab_size}) must be >= vocab_size ({vocab_size})")
+    if max_batch_size <= 0:
+        raise ValueError(f"max_batch_size must be positive, got {max_batch_size}")
+    if tile_size <= 0:
+        raise ValueError(f"tile_size must be positive, got {tile_size}")
+    if vocab_size == padded_vocab_size:
+        return None
+    if not torch.empty((), dtype=dtype).is_floating_point():
+        raise TypeError(f"dtype must be a floating point torch dtype, got {dtype}")
+
+    num_vocab_shards = get_vocab_num_shards(cluster_shape, sampling_all_gather_axis)
+    if padded_vocab_size % num_vocab_shards != 0:
+        return None
+
+    shard_width = padded_vocab_size // num_vocab_shards
+    tail_width = padded_vocab_size - vocab_size
+    if tail_width > shard_width:
+        return None
+    if tail_width % tile_size != 0 or (shard_width - tail_width) % tile_size != 0:
+        return None
+
+    mask = torch.zeros(1, 1, max_batch_size, tail_width * num_vocab_shards, dtype=dtype)
+    final_tail_start = tail_width * (num_vocab_shards - 1)
+    mask[..., final_tail_start:] = torch.finfo(dtype).min
+    return InvalidVocabTailMask(
+        mask=mask,
+        tail_width=tail_width,
+        shard_width=shard_width,
+        num_vocab_shards=num_vocab_shards,
+    )
+
+
+def get_vocab_shard_dims(
+    cluster_shape: tuple[int, int] | list[int],
+    sampling_all_gather_axis: int = 0,
+) -> tuple[int | None, int | None]:
+    """Return the 2D mesh mapper dims for sharding vocab over the sampling TP axis."""
+    rows, cols = _validate_cluster_shape(cluster_shape)
 
     if rows == 1 and cols == 1:
         return (None, None)

--- a/models/common/sampling/vocab_padding.py
+++ b/models/common/sampling/vocab_padding.py
@@ -26,6 +26,9 @@ def build_invalid_vocab_mask(
     if vocab_size == padded_vocab_size:
         return None
 
+    if not torch.empty((), dtype=dtype).is_floating_point():
+        raise TypeError(f"dtype must be a floating point torch dtype, got {dtype}")
+
     mask = torch.zeros(1, 1, max_batch_size, padded_vocab_size, dtype=dtype)
     mask[..., vocab_size:] = torch.finfo(dtype).min
     return mask

--- a/models/common/sampling/vocab_padding.py
+++ b/models/common/sampling/vocab_padding.py
@@ -1,0 +1,56 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import torch
+
+
+def build_invalid_vocab_mask(
+    vocab_size: int,
+    padded_vocab_size: int,
+    max_batch_size: int,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor | None:
+    """Build an additive logits mask for LM-head vocabulary padding.
+
+    LM heads may pad output weights so the sharded matmul has legal tile/device
+    dimensions. Those padded columns produce logits, but they are not real token
+    IDs and must be masked before argmax or top-k sampling.
+    """
+    if vocab_size < 0:
+        raise ValueError(f"vocab_size must be non-negative, got {vocab_size}")
+    if padded_vocab_size < vocab_size:
+        raise ValueError(f"padded_vocab_size ({padded_vocab_size}) must be >= vocab_size ({vocab_size})")
+    if max_batch_size <= 0:
+        raise ValueError(f"max_batch_size must be positive, got {max_batch_size}")
+    if vocab_size == padded_vocab_size:
+        return None
+
+    mask = torch.zeros(1, 1, max_batch_size, padded_vocab_size, dtype=dtype)
+    mask[..., vocab_size:] = torch.finfo(dtype).min
+    return mask
+
+
+def get_vocab_shard_dims(
+    cluster_shape: tuple[int, int] | list[int],
+    sampling_all_gather_axis: int = 0,
+) -> tuple[int | None, int | None]:
+    """Return the 2D mesh mapper dims for sharding vocab over the sampling TP axis."""
+    if len(cluster_shape) != 2:
+        raise ValueError(f"cluster_shape must have two dimensions, got {cluster_shape}")
+
+    rows, cols = int(cluster_shape[0]), int(cluster_shape[1])
+    if rows <= 0 or cols <= 0:
+        raise ValueError(f"cluster_shape dimensions must be positive, got {cluster_shape}")
+
+    if rows == 1 and cols == 1:
+        return (None, None)
+    if rows == 1:
+        return (None, 3)
+    if cols == 1:
+        return (3, None)
+    if sampling_all_gather_axis == 0:
+        return (3, None)
+    if sampling_all_gather_axis == 1:
+        return (None, 3)
+    raise ValueError(f"sampling_all_gather_axis must be 0 or 1, got {sampling_all_gather_axis}")

--- a/models/common/tests/modules/sampling/test_sampling_1d.py
+++ b/models/common/tests/modules/sampling/test_sampling_1d.py
@@ -677,6 +677,59 @@ def test_sampling1d_argmax_vs_reference(ttnn_mesh_device):
     ), f"argmax path mismatch:\n  got:      {tokens_host[:8]}\n  expected: {expected[:8]}"
 
 
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 8)], ids=["1x8"], indirect=True)
+def test_sampling1d_qwen3_32b_uses_compact_tail_mask(ttnn_mesh_device):
+    sampler = Sampling1D(vocab_size=152064, valid_vocab_size=151936, mesh_device=ttnn_mesh_device)
+    sampler.load_device_buffers()
+
+    assert sampler._invalid_vocab_mask is None
+    assert isinstance(sampler._invalid_vocab_tail_mask, ttnn.Tensor)
+    assert sampler._invalid_vocab_tail_width == 128
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 8)], ids=["1x8"], indirect=True)
+def test_sampling1d_topk_masks_qwen3_32b_padded_tail(ttnn_mesh_device):
+    B = 32
+    valid_vocab_size = 151936
+    padded_vocab_size = 152064
+    sampler = Sampling1D(vocab_size=padded_vocab_size, valid_vocab_size=valid_vocab_size, mesh_device=ttnn_mesh_device)
+
+    logits_host = torch.full((1, 1, B, padded_vocab_size), -1.0, dtype=torch.bfloat16)
+    logits_host[..., valid_vocab_size:] = 0.0
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+
+    cluster_shape = tuple(ttnn_mesh_device.shape)
+    k, p, temp = _make_sampling_params(
+        ttnn_mesh_device, B, k_val=1, p_val=0.0, temp_val=1.0, cluster_shape=cluster_shape
+    )
+    tokens_tt, _ = sampler.decode_forward(logits_tt, k=k, p=p, temp=temp)
+    tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B].long()
+
+    assert torch.all(tokens_host < valid_vocab_size)
+
+
+@pytest.mark.parametrize("ttnn_mesh_device", [(1, 8)], ids=["1x8"], indirect=True)
+def test_sampling1d_argmax_slices_qwen3_32b_padded_tail(ttnn_mesh_device):
+    B = 32
+    valid_vocab_size = 151936
+    padded_vocab_size = 152064
+    sampler = Sampling1D(
+        vocab_size=padded_vocab_size,
+        valid_vocab_size=valid_vocab_size,
+        mesh_device=ttnn_mesh_device,
+        allow_force_argmax=True,
+    )
+
+    logits_host = torch.full((1, 1, B, padded_vocab_size), -1.0, dtype=torch.bfloat16)
+    logits_host[..., valid_vocab_size:] = 0.0
+    logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device, shard_vocab=True)
+
+    tokens_tt, _ = sampler.decode_forward(logits_tt)
+    tokens_host = to_torch_auto_compose(tokens_tt).flatten()[:B].long()
+
+    assert torch.all(tokens_host < valid_vocab_size)
+
+
 @pytest.mark.parametrize("ttnn_mesh_device", [(1, 1), (1, 2), (1, 8)], ids=["1x1", "1x2", "1x8"], indirect=True)
 def test_sampling1d_topk32_in_range(ttnn_mesh_device):
     """

--- a/models/common/tests/modules/sampling/test_sampling_1d.py
+++ b/models/common/tests/modules/sampling/test_sampling_1d.py
@@ -169,14 +169,14 @@ class TestSampling1DDevice:
         ), f"Argmax mismatch: got {tokens_flat[:5]} vs expected {expected_flat[:5]}"
 
     @pytest.mark.parametrize("vocab_size", [1024])
-    def test_error_on_partial_params(self, ttnn_mesh_device, vocab_size):
+    def test_error_on_partial_params(self, ttnn_mesh_device, vocab_size, expect_error):
         """k provided but not p/temp → ValueError."""
         sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
         logits_host = torch.randn(1, 1, 32, vocab_size, dtype=torch.bfloat16)
         logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
         k_tt = ttnn.from_torch(torch.ones(32), device=ttnn_mesh_device, dtype=ttnn.uint32, layout=ttnn.ROW_MAJOR_LAYOUT)
 
-        with pytest.raises(ValueError, match="k, p, temp must all be provided"):
+        with expect_error(ValueError, "k, p, temp must all be provided"):
             sampler.decode_forward(logits_tt, k=k_tt)
 
     @pytest.mark.parametrize("vocab_size", [1024])
@@ -256,13 +256,13 @@ class TestSampling1DDevice:
     # ------------------------------------------------------------------
 
     @pytest.mark.parametrize("vocab_size", [1024])
-    def test_error_all_none_no_force_argmax(self, ttnn_mesh_device, vocab_size):
+    def test_error_all_none_no_force_argmax(self, ttnn_mesh_device, vocab_size, expect_error):
         """decode_forward with all-None k/p/temp when allow_force_argmax=False → ValueError (line 178)."""
         sampler = Sampling1D(vocab_size=vocab_size, mesh_device=ttnn_mesh_device)
         logits_host = torch.randn(1, 1, 32, vocab_size, dtype=torch.bfloat16)
         logits_tt = _make_logits_tt(logits_host, ttnn_mesh_device)
 
-        with pytest.raises(ValueError, match="allow_force_argmax is False"):
+        with expect_error(ValueError, "allow_force_argmax is False"):
             sampler.decode_forward(logits_tt)
 
     @pytest.mark.parametrize("vocab_size", [1024])
@@ -419,7 +419,7 @@ class TestSampling1DDevice:
         assert isinstance(resolved.index_offsets, LazyBuffer)
         assert resolved.index_offsets.device is ttnn_mesh_device  # filled in by resolve_lazy_buffer
 
-    def test_rejects_galaxy(self, ttnn_mesh_device):
+    def test_rejects_galaxy(self, ttnn_mesh_device, expect_error):
         """from_model_args should reject 2D (Galaxy) topologies."""
 
         class FakeMesh:
@@ -435,7 +435,7 @@ class TestSampling1DDevice:
             start_core = ttnn.CoreCoord(0, 0)
             max_top_k = 32
 
-        with pytest.raises(ValueError, match="1D mesh topologies"):
+        with expect_error(ValueError, "1D mesh topologies"):
             Sampling1D.from_model_args(FakeMesh(), None, MockArgs())
 
 

--- a/models/common/tests/test_sampling_vocab_padding.py
+++ b/models/common/tests/test_sampling_vocab_padding.py
@@ -4,7 +4,12 @@
 import pytest
 import torch
 
-from models.common.sampling.vocab_padding import build_invalid_vocab_mask, get_vocab_shard_dims
+from models.common.sampling.vocab_padding import (
+    build_invalid_vocab_mask,
+    build_tail_invalid_vocab_mask,
+    get_vocab_num_shards,
+    get_vocab_shard_dims,
+)
 
 
 def test_invalid_vocab_mask_not_needed_without_padding():
@@ -20,6 +25,79 @@ def test_invalid_vocab_mask_marks_only_padded_tokens():
     assert torch.all(mask[..., 10:] == torch.finfo(torch.bfloat16).min)
 
 
+def test_invalid_vocab_mask_prevents_padded_token_argmax():
+    logits = torch.full((1, 1, 1, 16), -1.0, dtype=torch.bfloat16)
+    logits[..., 10:] = 0.0
+
+    assert logits.argmax(dim=-1).item() == 10
+
+    mask = build_invalid_vocab_mask(vocab_size=10, padded_vocab_size=16, max_batch_size=1)
+    masked_logits = logits + mask
+
+    assert masked_logits.argmax(dim=-1).item() == 0
+
+
+def test_tail_invalid_vocab_mask_not_needed_without_padding():
+    assert (
+        build_tail_invalid_vocab_mask(
+            vocab_size=128256,
+            padded_vocab_size=128256,
+            max_batch_size=32,
+            cluster_shape=(1, 8),
+        )
+        is None
+    )
+
+
+def test_tail_invalid_vocab_mask_matches_qwen3_32b_t3k_layout():
+    tail_mask = build_tail_invalid_vocab_mask(
+        vocab_size=151936,
+        padded_vocab_size=152064,
+        max_batch_size=32,
+        cluster_shape=(1, 8),
+    )
+
+    assert tail_mask is not None
+    assert tail_mask.tail_width == 128
+    assert tail_mask.shard_width == 19008
+    assert tail_mask.num_vocab_shards == 8
+    assert tail_mask.mask.shape == (1, 1, 32, 1024)
+
+    min_value = torch.finfo(torch.bfloat16).min
+    for shard_id in range(7):
+        shard_slice = tail_mask.mask[..., shard_id * 128 : (shard_id + 1) * 128]
+        assert torch.all(shard_slice == 0)
+    assert torch.all(tail_mask.mask[..., 7 * 128 :] == min_value)
+
+
+def test_tail_invalid_vocab_mask_accepts_ttnn_mesh_shape_like_iterable():
+    class MeshShapeLike:
+        def __iter__(self):
+            return iter((1, 8))
+
+    tail_mask = build_tail_invalid_vocab_mask(
+        vocab_size=151936,
+        padded_vocab_size=152064,
+        max_batch_size=32,
+        cluster_shape=MeshShapeLike(),
+    )
+
+    assert tail_mask is not None
+    assert tail_mask.num_vocab_shards == 8
+
+
+def test_tail_invalid_vocab_mask_falls_back_for_non_tile_aligned_tail():
+    assert (
+        build_tail_invalid_vocab_mask(
+            vocab_size=10,
+            padded_vocab_size=16,
+            max_batch_size=2,
+            cluster_shape=(1, 1),
+        )
+        is None
+    )
+
+
 @pytest.mark.parametrize(
     "cluster_shape,sampling_all_gather_axis,expected",
     [
@@ -32,3 +110,17 @@ def test_invalid_vocab_mask_marks_only_padded_tokens():
 )
 def test_vocab_shard_dims_follow_sampling_tp_axis(cluster_shape, sampling_all_gather_axis, expected):
     assert get_vocab_shard_dims(cluster_shape, sampling_all_gather_axis) == expected
+
+
+@pytest.mark.parametrize(
+    "cluster_shape,sampling_all_gather_axis,expected",
+    [
+        ((1, 1), 0, 1),
+        ((1, 8), 0, 8),
+        ((8, 1), 0, 8),
+        ((8, 4), 0, 8),
+        ((8, 4), 1, 4),
+    ],
+)
+def test_vocab_num_shards_follow_sampling_tp_axis(cluster_shape, sampling_all_gather_axis, expected):
+    assert get_vocab_num_shards(cluster_shape, sampling_all_gather_axis) == expected

--- a/models/common/tests/test_sampling_vocab_padding.py
+++ b/models/common/tests/test_sampling_vocab_padding.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+import torch
+
+from models.common.sampling.vocab_padding import build_invalid_vocab_mask, get_vocab_shard_dims
+
+
+def test_invalid_vocab_mask_not_needed_without_padding():
+    assert build_invalid_vocab_mask(vocab_size=128256, padded_vocab_size=128256, max_batch_size=32) is None
+
+
+def test_invalid_vocab_mask_marks_only_padded_tokens():
+    mask = build_invalid_vocab_mask(vocab_size=10, padded_vocab_size=16, max_batch_size=2)
+
+    assert mask.shape == (1, 1, 2, 16)
+    assert mask.dtype == torch.bfloat16
+    assert torch.all(mask[..., :10] == 0)
+    assert torch.all(mask[..., 10:] == torch.finfo(torch.bfloat16).min)
+
+
+@pytest.mark.parametrize(
+    "cluster_shape,sampling_all_gather_axis,expected",
+    [
+        ((1, 1), 0, (None, None)),
+        ((1, 8), 0, (None, 3)),
+        ((8, 1), 0, (3, None)),
+        ((8, 4), 0, (3, None)),
+        ((8, 4), 1, (None, 3)),
+    ],
+)
+def test_vocab_shard_dims_follow_sampling_tp_axis(cluster_shape, sampling_all_gather_axis, expected):
+    assert get_vocab_shard_dims(cluster_shape, sampling_all_gather_axis) == expected


### PR DESCRIPTION
## Summary
- Add a shared helper for building additive masks for LM-head padded vocab logits.
- Apply the mask before force-argmax and local top-k in `TTSampling` and `Sampling1D`.
- Keep `Sampling1D`'s padded logits width separate from the real tokenizer vocabulary via `valid_vocab_size`.
- Document that zero-padded LM-head weights are not a sampling mask.

## Problem
LM heads sometimes pad their output weights with zero columns so sharded/tiled matmuls have legal shapes. Those padded columns produce logits for token IDs `>= vocab_size`, but those IDs are not real tokenizer tokens.

The sampler already needs `padded_vocab_size` for device offsets, because that is how the LM-head output is sharded. The missing piece was masking the padded token IDs before token selection. If a model has negative real logits, a zero logit from padded weights can enter local top-k or force-argmax and produce an invalid token.

## Solution
Build a `[1, 1, batch, padded_vocab_size]` additive mask with:
- `0` for real token IDs `< vocab_size`
- bf16 minimum for padded token IDs `>= vocab_size`

Shard that mask the same way the logits are sharded, and add it before force-argmax or local top-k. When `vocab_size == padded_vocab_size`, no mask tensor is created and the sampling path is unchanged.

## Testing
- `pre-commit` hooks run by `git commit`
- `git diff --check`
- `python3 -m py_compile models/common/sampling/vocab_padding.py models/common/sampling/tt_sampling.py models/common/modules/sampling/sampling_1d.py models/common/tests/test_sampling_vocab_padding.py`
- Not run locally: `pytest` because this local worktree has no populated tt-metal Python environment with Torch/pytest. I am triggering a focused CI pytest through `Custom test dispatch`.

## CI Badge
[![Static checks (yieldthought/mask-padded-vocab-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-static-checks.yaml/badge.svg?branch=yieldthought%2Fmask-padded-vocab-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-static-checks.yaml?query=branch%3Ayieldthought%2Fmask-padded-vocab-sampling)
[![Focused sampling pytest (yieldthought/mask-padded-vocab-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/test-dispatch.yaml/badge.svg?branch=yieldthought%2Fmask-padded-vocab-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/test-dispatch.yaml?query=branch%3Ayieldthought%2Fmask-padded-vocab-sampling)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=yieldthought/mask-padded-vocab-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:yieldthought/mask-padded-vocab-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=yieldthought/mask-padded-vocab-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:yieldthought/mask-padded-vocab-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=yieldthought/mask-padded-vocab-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:yieldthought/mask-padded-vocab-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=yieldthought/mask-padded-vocab-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:yieldthought/mask-padded-vocab-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=yieldthought/mask-padded-vocab-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:yieldthought/mask-padded-vocab-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=yieldthought/mask-padded-vocab-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:yieldthought/mask-padded-vocab-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=yieldthought/mask-padded-vocab-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:yieldthought/mask-padded-vocab-sampling)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=yieldthought/mask-padded-vocab-sampling)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:yieldthought/mask-padded-vocab-sampling)