### PR TITLE
Fix sdpa_windowed writer_windowed Device 2.0 build break

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/dataflow/writer_windowed.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/dataflow/writer_windowed.cpp
@@ -49,6 +49,8 @@ void kernel_main() {
     constexpr uint32_t barrier_threshold = get_barrier_read_threshold<tile_bytes, num_cores>();
     uint32_t barrier_count = 0;
 
+    Noc noc;
+
     constexpr uint32_t cb_identity_scale_in = tt::CBIndex::c_5;
     constexpr uint32_t cb_col_identity = tt::CBIndex::c_7;
 
@@ -75,6 +77,7 @@ void kernel_main() {
                 const uint32_t out_row_tile_count = out_row_end_tile - out_row_start_tile;
                 uint32_t out_tile_id = out_tile_shape.id_of(nb, nq, out_row_start_tile, 0);
                 write_block(
+                    noc,
                     out_writer,
                     cb_out,
                     out_chunk_tiles,


### PR DESCRIPTION
## Summary

Fixes the kernel compilation break on `sdpa_windowed` introduced by #45015.

PR #45015 migrated `sdpa_windowed/reader_windowed.cpp` and the shared `write_block` helper in `sdpa/device/kernels/dataflow/dataflow_common.hpp` to the Device 2.0 API. It missed the companion `writer_windowed.cpp`. Every program that builds this kernel now fails with:

```
/work/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/dataflow/writer_windowed.cpp:77:28:
error: no matching function for call to 'write_block(...)'
  candidate 1: expects 6 arguments, 8 provided
  candidate 2: expects 9 arguments, 8 provided
```

## Root cause

Caught by tt-auto-triage: https://github.com/tenstorrent/tt-metal/actions/runs/27379818234 — `Qwen2.5-VL-32B unit tests` deterministic failure, (PR #45015).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/fix-sdpa-windowed-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/fix-sdpa-windowed-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/fix-sdpa-windowed-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/fix-sdpa-windowed-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/fix-sdpa-windowed-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/fix-sdpa-windowed-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/fix-sdpa-windowed-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/fix-sdpa-windowed-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/fix-sdpa-windowed-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/fix-sdpa-windowed-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/fix-sdpa-windowed-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/fix-sdpa-windowed-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/fix-sdpa-windowed-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/fix-sdpa-windowed-writer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/fix-sdpa-windowed-writer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/fix-sdpa-windowed-writer)