### PR TITLE
[skip ci] [Models CI] Raise stale perf targets for Qwen3-32B, Qwen2.5-Coder-32B, Qwen2.5-VL-32B

### DIFF
--- a/models/model_targets.yaml
+++ b/models/model_targets.yaml
@@ -1027,10 +1027,12 @@ targets:
           - batch_size: 32
             seq_len: 707
             status: active
-            # decode_t/s/u is run-to-run unstable (observed 14.4–18.3 across runs);
-            # target the midpoint with a wide tolerance. See issue #46214.
+            # decode_t/s/u is run-to-run unstable (see issue #46214). Recent
+            # scheduled runs have shifted up (measured 20.6-21.9 across the last
+            # week), so center raised 16.0 -> 20.0 while keeping the wide 0.2
+            # tolerance ([16, 24]) to absorb the run-to-run swing.
             perf:
-              decode_t/s/u: 16.0
+              decode_t/s/u: 20.0
               decode_t_s_u_tolerance: 0.2
               prefill_time_to_first_token: 105
             accuracy: {}
@@ -1050,8 +1052,10 @@ targets:
               # gross regressions without flaking on the swing.
               prefill_time_to_first_token: 351
               prefill_time_to_first_token_tolerance: 0.4
-              decode_t/s/u: 19.9
-              decode_t/s: 19.9
+              # decode raised 19.9 -> 23.8: 4/4 recent scheduled runs measured
+              # 23.1-24.4 t/s/u on wh_llmbox_perf (consistently above old target).
+              decode_t/s/u: 23.8
+              decode_t/s: 23.8
             accuracy: {}
             owner_id: U07RY6B5FLJ # Gongyu Wang
             team: models
@@ -1110,11 +1114,15 @@ targets:
           - batch_size: 32
             seq_len: 686
             status: active
+            # Targets raised to match sustained perf on bh_quietbox_2 (p300x2):
+            # 6/6 recent scheduled runs measured decode_t/s ~680-703, t/s/u ~21.8,
+            # TTFT ~86-88ms (old targets 278 / 18.7 / 207 were stale). decode_t/s
+            # = batch_size * decode_t/s/u (32 * 21.6 ~= 691).
             perf:
-              prefill_time_to_first_token: 207
+              prefill_time_to_first_token: 87
               prefill_time_to_first_token_tolerance: 0.2
-              decode_t/s/u: 18.7
-              decode_t/s: 278
+              decode_t/s/u: 21.6
+              decode_t/s: 691
             accuracy: {}
             owner_id: U03PUAKE719 # Miguel Tairum Cruz
             team: models


### PR DESCRIPTION
## What

Three perf entries in `models/model_targets.yaml` have been failing scheduled Models CI on `main` with the validator message *"much better than expected, update target"* — measured perf sits **consistently above** the enforced upper bound across many consecutive runs. This bumps the targets to match sustained measured perf.

## Evidence (scheduled runs on `main`)

| Model / SKU | Metric | Old target | Measured (recent runs) | New target |
|---|---|---|---|---|
| qwen3-32b / `p300x2` (bh_quietbox_2, b32/s686) | decode_t/s | 278 | 680–703 (6/6 runs) | **691** |
| | decode_t/s/u | 18.7 | 21.78–21.97 | **21.6** |
| | prefill_ttft | 207 ms | 86–88 ms | **87 ms** |
| qwen2.5-vl-32b / `wh_llmbox_perf` (b1/s128) | decode_t/s & t/s/u | 19.9 | 23.1–24.4 (4/4 runs) | **23.8** |
| qwen2.5-coder-32b / `wh_llmbox_perf` (b32/s707) | decode_t/s/u | 16.0 | 20.6–21.9 (4/4 reported) | **20.0** |

New targets were centered on the observed mean; all measured values fall within the resulting tolerance band (default ±15%, or the per-metric tolerance where set).

## Notes

- **qwen3-32b**: `decode_t/s == batch_size * decode_t/s/u` (32 × 21.6 ≈ 691); the old `decode_t/s` of 278 was internally inconsistent with the t/s/u target.
- **qwen2.5-coder-32b**: this metric is documented as run-to-run unstable (#46214) — 2 of the last 8 scheduled runs passed under the old band. I raised the center 16 → 20 but **kept the wide 0.2 tolerance** so the band `[16, 24]` still absorbs the downward swing rather than introducing lower-bound flakes. If low-side flakes reappear, widen tolerance rather than lowering the center.
- The other two entries are rock-solid (tight measured ranges), so confident bumps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/bump-perf-targets-qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/bump-perf-targets-qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/bump-perf-targets-qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/bump-perf-targets-qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/bump-perf-targets-qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/bump-perf-targets-qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/bump-perf-targets-qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/bump-perf-targets-qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/bump-perf-targets-qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/bump-perf-targets-qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/bump-perf-targets-qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/bump-perf-targets-qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/bump-perf-targets-qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/bump-perf-targets-qwen)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/bump-perf-targets-qwen)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/bump-perf-targets-qwen)