### PR TITLE
MetalV2: borrowed-DFB prerequisites for op migration (L1_SMALL + same-core broadcast)

### DIFF
--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1261,10 +1261,15 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             dfb.unique_id,
             tp_name);
         const TensorSpec& tensor_spec = it->second->spec;
+        // A borrowed DFB may be backed by either L1 buffer type. L1_SMALL is physically L1 (a separate small
+        // allocator region), and a CB can be backed by an L1_SMALL buffer; rejecting it forces ops that keep
+        // small internal config/lookup tensors in L1_SMALL (e.g. sliding-window halo) to copy them into the
+        // main L1 pool just to borrow a DFB.
         TT_FATAL(
-            tensor_spec.memory_config().buffer_type() == tt::tt_metal::BufferType::L1,
-            "DFB '{}' borrows memory from TensorParameter '{}', but its TensorSpec is not L1-resident (L1 is "
-            "required).",
+            tensor_spec.memory_config().buffer_type() == tt::tt_metal::BufferType::L1 ||
+                tensor_spec.memory_config().buffer_type() == tt::tt_metal::BufferType::L1_SMALL,
+            "DFB '{}' borrows memory from TensorParameter '{}', but its TensorSpec is not L1-resident (L1 or "
+            "L1_SMALL is required).",
             dfb.unique_id,
             tp_name);
         // Coarse spec-time sizing check against the TensorSpec's full packed size. No Buffer is

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1134,14 +1134,19 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
 
         // (1) and (2): WU membership disjointness within each role + cross-role equality.
         // Compute per-role unions while also checking within-role pairwise disjointness.
-        auto compute_role_union = [&](const auto& records, std::string_view role) {
+        // allow_shared_wu permits multiple same-role KernelSpecs in one WorkUnitSpec. This is legal for
+        // CONSUMERS only: several same-kind data-movement kernels on the same node may each read one local
+        // DFB (a same-core broadcast — e.g. the sliding-window halo split reader, where two RISC data-movement
+        // kernels on a core both consume the borrowed src CB). PRODUCERS must still be pairwise-disjoint: two
+        // producers on one node would have ambiguous write-pointer ownership of the single CB instance.
+        auto compute_role_union = [&](const auto& records, std::string_view role, bool allow_shared_wu) {
             std::set<const WorkUnitSpec*> role_union;
             for (const auto& rec : records) {
                 const auto wu_set = kernel_work_unit_set(rec.kernel->unique_id);
                 for (const WorkUnitSpec* wu : wu_set) {
                     auto [it, inserted] = role_union.insert(wu);
                     TT_FATAL(
-                        inserted,
+                        inserted || allow_shared_wu,
                         "DFB '{}' has multiple {} KernelSpecs sharing WorkUnitSpec '{}' (kernel '{}' collides with a "
                         "prior {} binding). Same-role bindings must have pairwise-disjoint WorkUnitSpec membership.",
                         dfb.unique_id,
@@ -1153,8 +1158,8 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             }
             return role_union;
         };
-        const auto producer_wu_union = compute_role_union(endpoints.producers, "PRODUCER");
-        const auto consumer_wu_union = compute_role_union(endpoints.consumers, "CONSUMER");
+        const auto producer_wu_union = compute_role_union(endpoints.producers, "PRODUCER", /*allow_shared_wu=*/false);
+        const auto consumer_wu_union = compute_role_union(endpoints.consumers, "CONSUMER", /*allow_shared_wu=*/true);
         TT_FATAL(
             producer_wu_union == consumer_wu_union,
             "Local DFB '{}' producer and consumer KernelSpecs do not cover the same WorkUnitSpec(s). "
@@ -1188,12 +1193,25 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             for (const auto& c : endpoints.consumers) {
                 consumer_kernels.insert(c.kernel);
             }
+            // Every PRODUCER of a self-looped DFB must also be a consumer (i.e. genuinely self-loop), but the
+            // consumer set MAY include extra pure-consumer kernels: a same-core broadcast where one kernel
+            // produces+consumes the local CB and additional same-kind kernels on the node also read it (the
+            // halo split reader: reader0 self-loops src, reader1 also consumes it). A producer that is not
+            // also a consumer is still rejected — that would make per-instance tensix-scope semantics
+            // ambiguous.
+            bool producers_are_self_loopers = true;
+            for (const KernelSpec* pk : producer_kernels) {
+                if (consumer_kernels.find(pk) == consumer_kernels.end()) {
+                    producers_are_self_loopers = false;
+                    break;
+                }
+            }
             TT_FATAL(
-                producer_kernels == consumer_kernels,
-                "DFB '{}' is self-looped (some kernel appears as both producer and consumer), but "
-                "the set of producer KernelSpecs differs from the set of consumer KernelSpecs. "
-                "When a DFB is self-looped, every same-side binding must come from a self-loop "
-                "participant (i.e. a kernel that appears on both sides).",
+                producers_are_self_loopers,
+                "DFB '{}' is self-looped (some kernel appears as both producer and consumer), but a producer "
+                "KernelSpec is not also a consumer. When a DFB is self-looped, every producer must come from a "
+                "self-loop participant (a kernel that appears on both sides); extra pure-consumer kernels are "
+                "permitted (same-core broadcast).",
                 dfb.unique_id);
 
             // All self-loop participants must agree on the tensix-scope for this DFB —
@@ -2223,12 +2241,25 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
     // and user-validated on Gen1 (see Step 2b in MakeProgramFromSpec). So any
     // representative producer/consumer gives the correct DFB config — we take the first.
     const KernelSpec* producer = dfb_endpoint_info.producers.front().kernel;
-    const KernelSpec* consumer = dfb_endpoint_info.consumers.front().kernel;
     const DFBBinding* producer_binding = dfb_endpoint_info.producers.front().binding;
     const DFBBinding* consumer_binding = dfb_endpoint_info.consumers.front().binding;
 
     uint16_t producer_risc_mask = kernel_to_risc_mask.at(producer);
-    uint16_t consumer_risc_mask = kernel_to_risc_mask.at(consumer);
+    // Consumers may form a same-core broadcast (multiple kernels on different RISCs reading one local CB),
+    // so the consumer-side processor mask is the UNION of every consumer kernel's mask, and the consumer
+    // count sums their threads. Producers are single-mask (validated). For the common single-consumer case
+    // this reduces to the first consumer's mask / num_threads.
+    uint16_t consumer_risc_mask = 0;
+    uint8_t consumer_thread_count = 0;
+    {
+        std::unordered_set<const KernelSpec*> seen_consumers;
+        for (const auto& c : dfb_endpoint_info.consumers) {
+            consumer_risc_mask |= kernel_to_risc_mask.at(c.kernel);
+            if (seen_consumers.insert(c.kernel).second) {
+                consumer_thread_count += static_cast<uint8_t>(c.kernel->num_threads);
+            }
+        }
+    }
 
     // Convert user-facing access pattern enum to hardware interface access pattern enum
     // (TODO: We should merge these enums; it's silly to have separate ones.)
@@ -2303,7 +2334,7 @@ experimental::dfb::DataflowBufferConfig MakeDataflowBufferConfig(
         .num_producers = static_cast<uint8_t>(producer->num_threads),
         .pap = producer_access_pattern,
         .consumer_risc_mask = consumer_risc_mask,
-        .num_consumers = static_cast<uint8_t>(consumer->num_threads),
+        .num_consumers = consumer_thread_count,
         .cap = consumer_access_pattern,
         .enable_producer_implicit_sync = side_implicit_sync_enabled(dfb_endpoint_info.producers),
         .enable_consumer_implicit_sync = side_implicit_sync_enabled(dfb_endpoint_info.consumers),
@@ -2562,8 +2593,12 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
     //   property is guaranteed by construction; the check is retained as a defensive assertion.
     for (const auto& dfb : spec.dataflow_buffers) {
         const auto& endpoints = collected.dfb_endpoints.at(dfb.unique_id);
-        auto check_uniform_mask = [&](const auto& records, std::string_view role) {
-            if (records.size() < 2) {
+        // allow_union: CONSUMERS may sit on different processors (a same-core broadcast — e.g. two RISC
+        // data-movement kernels on one core both reading a local CB). Their per-role processor mask is the
+        // UNION of the individual masks (computed in MakeDataflowBufferConfig). PRODUCERS must still share a
+        // single mask: two producers on different processors would have ambiguous write-pointer ownership.
+        auto check_uniform_mask = [&](const auto& records, std::string_view role, bool allow_union) {
+            if (records.size() < 2 || allow_union) {
                 return;
             }
             const uint16_t first_mask = kernel_to_risc_mask.at(records[0].kernel);
@@ -2601,8 +2636,8 @@ Program MakeProgramFromSpec(const distributed::MeshDevice& mesh_device, const Pr
                 }
             }
         };
-        check_uniform_mask(endpoints.producers, "PRODUCER");
-        check_uniform_mask(endpoints.consumers, "CONSUMER");
+        check_uniform_mask(endpoints.producers, "PRODUCER", /*allow_union=*/false);
+        check_uniform_mask(endpoints.consumers, "CONSUMER", /*allow_union=*/true);
     }
 
     // Step 2c: Resolve TensorParameters against the MeshDevice into static CTA payloads.


### PR DESCRIPTION
Two MetalV2 `DataflowBufferSpec` limitations block the sliding-window **halo** op migration (ttnn #46781). Both are addressed here. Opening as **draft** for metalium review of the validator/dep-graph relaxations.

### 1. Borrowed DFB rejects `L1_SMALL`
`ValidateProgramSpec` required a borrowed DFB's `TensorParameter` to be `BufferType::L1`. `L1_SMALL` is physically L1 (a separate small-allocator region) and a CB can be backed by an `L1_SMALL` buffer. halo keeps its four sliding-window config tensors in `L1_SMALL` by design, so the check forced copying them into the main L1 pool just to borrow a DFB. Now accepts `L1 || L1_SMALL`.

### 2. Same-core broadcast of a local/borrowed DFB
halo's split reader runs two data-movement kernels on the **same core** (RISCV0/1); in the row-major (skip-untilize) path both consume one borrowed `src` CB. The local-DFB model assumed at most one same-role binding per node. `RemoteDataflowBufferSpec` doesn't fit — it's cross-*node* (producer-node→consumer-node map) and multicast is TBD. This PR lets a local DFB have multiple same-kind same-core consumers:

- **`ValidateProgramSpec`**: consumers may share a `WorkUnitSpec` (producers must still be pairwise-disjoint — two producers per node = ambiguous write ownership); a self-looped DFB may carry extra pure-consumer kernels (producers ⊆ consumers, not strict equality); the per-role uniform-risc-mask check is relaxed for consumers.
- **`MakeDataflowBufferConfig`**: `consumer_risc_mask` is the **union** of all consumer kernels' masks and `num_consumers` sums their threads (reduces to prior behavior for a single consumer).

Producer-side invariants are unchanged.

### Validation
With both fixes, the halo MetalV2 migration passes end-to-end on N150:
- BLOCK_SHARDED conv2d (halo tiled **and** row-major): 49 passed, 0 failed (PCC ≥ 0.9997)
- HEIGHT/WIDTH-sharded conv2d: 98 passed
- rand + plusone regression: 81 passed (no DFB-validator regressions)

### Dependency
**ttnn #46781 (halo MetalV2 migration) needs this PR to land first.**

@akerteszTT — flagging the validator/config relaxations in (2) for your review; the runtime CB-sync correctly handles the multi-RISC consumer (all row-major cases pass), but you'll know best whether the relaxed invariants have implications beyond this case.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metalv2-borrowed-dfb-prereqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metalv2-borrowed-dfb-prereqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metalv2-borrowed-dfb-prereqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metalv2-borrowed-dfb-prereqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/metalv2-borrowed-dfb-prereqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/metalv2-borrowed-dfb-prereqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metalv2-borrowed-dfb-prereqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metalv2-borrowed-dfb-prereqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metalv2-borrowed-dfb-prereqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metalv2-borrowed-dfb-prereqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metalv2-borrowed-dfb-prereqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metalv2-borrowed-dfb-prereqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metalv2-borrowed-dfb-prereqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metalv2-borrowed-dfb-prereqs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metalv2-borrowed-dfb-prereqs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metalv2-borrowed-dfb-prereqs)