### PR TITLE
[LLK] remove debug bit 11 from custom reduce kernels

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/fpu/reduce_block_max_runtime.py
@@ -1,0 +1,53 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List
+
+from fuser.block_data import BlockData
+from fuser.compute_node import ComputeNode
+from fuser.fused_loop import FusedLoop, LoopBlockRow
+from fuser.fused_operation import FusedOperation
+from fuser.fuser_config import GlobalConfig
+
+from .reduce_block_max import ReduceBlockMaxFpu
+
+
+class ReduceBlockMaxRuntimeFpu(ReduceBlockMaxFpu):
+    loop: FusedLoop = LoopBlockRow()
+
+    def get_headers(self) -> List[str]:
+        return [
+            "experimental/llk_math_reduce_custom.h",
+            "experimental/llk_math_reduce_runtime_custom.h",
+        ]
+
+    def init(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        ct_dim = block.block_tiles_x
+        dest_acc = config.dest_acc.cpp_enum_value
+        return f"_llk_math_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim});\n"
+
+    def calculate(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        dest_acc = config.dest_acc.cpp_enum_value
+        return f"_llk_math_reduce_block_max_row_runtime_<{dest_acc}>({block.tile_id_block});\n"
+
+    def uninit(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        return "_llk_math_reduce_block_max_row_uninit_runtime_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/parser.py
@@ -38,12 +38,14 @@ from .fpu.eltwise import EltwiseFpu
 from .fpu.matmul import MatmulFpu
 from .fpu.reduce import ReduceFpu
 from .fpu.reduce_block_max import ReduceBlockMaxFpu
+from .fpu.reduce_block_max_runtime import ReduceBlockMaxRuntimeFpu
 from .packer.packer import Packer
 from .sfpu.binary import BinarySfpu
 from .sfpu.unary import UnarySfpu
 from .unpacker.matmul import MatmulUnpacker
 from .unpacker.reduce import ReduceUnpacker
 from .unpacker.reduce_block_max import ReduceBlockMaxUnpacker
+from .unpacker.reduce_block_max_runtime import ReduceBlockMaxRuntimeUnpacker
 from .unpacker.tilize_a import UnpackerTilizeA
 from .unpacker.unpack_a import UnpackerA
 from .unpacker.unpack_ab import UnpackerAB
@@ -104,6 +106,10 @@ UNPACKER_MAP = {
     ),
     "ReduceBlockMaxUnpacker": (
         lambda s: ReduceBlockMaxUnpacker(),
+        None,
+    ),
+    "ReduceBlockMaxRuntimeUnpacker": (
+        lambda s: ReduceBlockMaxRuntimeUnpacker(),
         None,
     ),
 }
@@ -195,6 +201,10 @@ FPU_MAP = {
         lambda s: ReduceBlockMaxFpu(),
         [_no_reuse_dest, _forced_unpacker("ReduceBlockMaxUnpacker")],
     ),
+    "ReduceBlockMaxRuntime": (
+        lambda s: ReduceBlockMaxRuntimeFpu(),
+        [_no_reuse_dest, _forced_unpacker("ReduceBlockMaxRuntimeUnpacker")],
+    ),
 }
 
 _l1_acc_format = (
@@ -219,6 +229,7 @@ OUTPUT_DIMS = {
     "Matmul": _matmul_dims,
     "Reduce": _src_a_dims,
     "ReduceBlockMax": _src_a_dims,
+    "ReduceBlockMaxRuntime": _src_a_dims,
 }
 
 UNARY_SFPU_OPS = {

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max_runtime.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/reduce_block_max_runtime.py
@@ -1,0 +1,87 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+#
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import List, Tuple
+
+import torch
+from fuser.block_data import BlockData
+from fuser.compute_node import ComputeNode
+from fuser.fused_loop import FusedLoop, LoopBlockRow
+from fuser.fused_operation import FusedOperation
+from fuser.fused_unpacker import Unpacker
+from fuser.fuser_config import GlobalConfig
+
+
+class ReduceBlockMaxRuntimeUnpacker(Unpacker):
+    loop: FusedLoop = LoopBlockRow()
+
+    def get_headers(self) -> List[str]:
+        return ["experimental/llk_unpack_AB_reduce_custom_runtime.h"]
+
+    def golden(
+        self,
+        tensor_a: torch.Tensor,
+        tensor_b: torch.Tensor,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode = None,
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
+        return tensor_a, tensor_b
+
+    def perf_set_valid(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        ct_dim = block.block_tiles_x
+        return (
+            f"_perf_unpack_loop_set_valid<false, true>(1);\n"
+            f"_perf_unpack_loop_set_valid<true, false>({ct_dim});\n"
+        )
+
+    def perf_clear_valid(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        ct_dim = block.block_tiles_x
+        return (
+            f"_perf_math_loop_clear_valid<true, false>({ct_dim});\n"
+            f"_perf_math_loop_clear_valid<false, true>(1);\n"
+        )
+
+    def init(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        ct_dim = block.block_tiles_x
+        dest_acc = config.dest_acc.cpp_enum_value
+        return f"_llk_unpack_AB_reduce_block_max_row_init_runtime_<{dest_acc}>({ct_dim});\n"
+
+    def unpack(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        buffer_a = compute_unit.src_a.cpp_name
+        buffer_b = compute_unit.src_b.cpp_name
+        return f"_llk_unpack_AB_reduce_block_max_row_runtime_(L1_ADDRESS({buffer_a}[{block.tile_id_global}]), L1_ADDRESS({buffer_b}[{block.tile_id_global}]));\n"
+
+    def uninit(
+        self,
+        operation: FusedOperation,
+        config: GlobalConfig,
+        compute_unit: ComputeNode,
+        block: BlockData,
+    ) -> str:
+        return f"_llk_unpack_AB_reduce_block_max_row_uninit_runtime_();\n"

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_block_max.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_block_max.yaml
@@ -1,14 +1,16 @@
+dest_acc: true
+
 operands:
   - name: "input_A"
     dims: [256, 256]
-    format: "Float16_b"
+    format: "Float32"
   - name: "input_B"
     dims: [256, 256]
-    format: "Float16_b"
+    format: "Float32"
     const_value: 1.0
   - name: "reduce_block_max_out"
     dims: [256, 256]
-    format: "Float16_b"
+    format: "Float32"
 
 operations:
   - output: "reduce_block_max_out"
@@ -20,4 +22,4 @@ operations:
         unpacker: "ReduceBlockMaxUnpacker"
         math_fidelity: "HiFi2"
     packer: "Packer"
-    block_size: [64, 128]
+    block_size: [64, 64]

--- a/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_block_max_runtime.yaml
+++ b/tt_metal/tt-llk/tests/python_tests/fuser_tests/fpu_reduce_block_max_runtime.yaml
@@ -1,16 +1,16 @@
-supported_archs: ["wormhole"]
+dest_acc: true
 
 operands:
   - name: "input_A"
     dims: [256, 256]
-    format: "Float16_b"
+    format: "Float32"
   - name: "input_B"
     dims: [256, 256]
-    format: "Float16_b"
+    format: "Float32"
     const_value: 1.0
   - name: "reduce_block_max_runtime_out"
     dims: [256, 256]
-    format: "Float16_b"
+    format: "Float32"
 
 operations:
   - output: "reduce_block_max_runtime_out"
@@ -22,4 +22,4 @@ operations:
         unpacker: "ReduceBlockMaxRuntimeUnpacker"
         math_fidelity: "HiFi2"
     packer: "Packer"
-    block_size: [64, 128]
+    block_size: [64, 64]

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
@@ -254,6 +254,20 @@ inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
 
     // Run the MOP, performing a column reduce across all 4 faces
     ckernel::ckernel_template::run();
+
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 1);
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(to_underlying(DataFormat::Tf32));
+    }
+
     // Replay the 13 instructions to transpose the reduced results
     lltt::replay(2, 13);
+
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 0);
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
+    }
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_custom.h
@@ -132,62 +132,30 @@ inline void _llk_math_reduce_block_max_row_mop_config_()
     TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
     TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
 
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        // FP32 destination mode, need to move high and low 16 bits to SrcB and transpose separately
+    // The following instructions are going to transpose the whole tile.
 
-        // The following instructions are repeated for F0&F1 reduced and F2&F3 reduced
-        // Move high 16 bits from DEST row 0 to SrcB rows 16 - 31 and transpose
-        TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
+    // Move row 0 from DEST to SrcB with offset of 16 rows and transpose
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
+    TTI_TRNSPSRCB;
+    // Move row 0 from SrcB to DEST in 4-row chunks
+    // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+    // ADDR_MOD_3 increments CR_D and Dest counter val by 20, to point to F2.
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
 
-        // Move high 16 bits back to Dest
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 4);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 8);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 12);
+    // Move row 32 (F2R0) from DEST to SrcB with offset of 16 rows and transpose
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
+    TTI_TRNSPSRCB;
+    // Move row 32 from SrcB to DEST in 4-row chunks
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 4);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 8);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 12);
 
-        // Move low 16 bits to SrcB rows 16 - 31 and transpose
-        TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
-
-        // Move low 16 bits from SrcB rows 16 - 31 to DEST rows 0, 4, 8, 12
-        // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        // ADDR_MOD_3 increments CR_D and Dest counter val by 20, to point to F2.
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
-        // Clear B valid bits at the end and all address counters
-        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
-    }
-    else
-    {
-        // The following instructions are going to transpose the whole tile, unlike the FP32 mode.
-
-        // Move row 0 from DEST to SrcB with offset of 16 rows and transpose
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
-        // Move row 0 from SrcB to DEST in 4-row chunks
-        // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        // ADDR_MOD_3 increments CR_D and Dest counter val by 20, to point to F2.
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
-
-        // Move row 32 (F2R0) from DEST to SrcB with offset of 16 rows and transpose
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
-        // Move row 32 from SrcB to DEST in 4-row chunks
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 4);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 8);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 12);
-
-        // Clear B valid bits at the end and all address counters
-        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
-    }
+    // Clear B valid bits at the end and all address counters
+    TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
 
     static constexpr std::uint32_t outer_loop = block_ct_dim;
     static constexpr std::uint32_t inner_loop = 4;
@@ -250,11 +218,6 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_()
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_init_()
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_math_dbg_feature_disable_();
-    }
-
     reduce_max_row_configure_addrmod();
 
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
@@ -267,10 +230,6 @@ inline void _llk_math_reduce_block_max_row_init_()
 template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_uninit_()
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_math_dbg_feature_enable_();
-    }
 }
 
 /**
@@ -293,24 +252,8 @@ inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
 {
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        // Run the MOP, performing a column reduce across all 4 faces
-        ckernel::ckernel_template::run();
-        // needs to be disabled for MOVD2B/B2D on BH (Issue ##449)
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(0);
-        // Replay the 12 instructions to transpose the reduced F0&F1 results
-        lltt::replay(2, 12);
-        // Replay the 13 instructions to transpose the reduced F2&F3 results
-        // 13th instruction clears B valid bit to release SrcB bank and clears all address counters
-        lltt::replay(2, 13);
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(1);
-    }
-    else
-    {
-        // Run the MOP, performing a column reduce across all 4 faces
-        ckernel::ckernel_template::run();
-        // Replay the 13 instructions to transpose the reduced results
-        lltt::replay(2, 13);
-    }
+    // Run the MOP, performing a column reduce across all 4 faces
+    ckernel::ckernel_template::run();
+    // Replay the 13 instructions to transpose the reduced results
+    lltt::replay(2, 13);
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -279,8 +279,22 @@ inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_inde
 
     // Run the MOP, performing a column reduce across all 4 faces
     ckernel::ckernel_template::run();
+
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 1);
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG0_SrcA_RMW>(to_underlying(DataFormat::Tf32));
+    }
+
     // Replay the 13 instructions to transpose the reduced results
     lltt::replay(2, 13);
+
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        TTI_SETC16(DISABLE_IMPLIED_SRCA_FMT_Base_ADDR32, 0);
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
+    }
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -163,62 +163,30 @@ inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t blo
     TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
     TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
 
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        // FP32 destination mode, need to move high and low 16 bits to SrcB and transpose separately
+    // The following instructions are going to transpose the whole tile.
 
-        // The following instructions are repeated for F0&F1 reduced and F2&F3 reduced
-        // Move high 16 bits from DEST row 0 to SrcB rows 16 - 31 and transpose
-        TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
+    // Move row 0 from DEST to SrcB with offset of 16 rows and transpose
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
+    TTI_TRNSPSRCB;
+    // Move row 0 from SrcB to DEST in 4-row chunks
+    // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+    // ADDR_MOD_3 increments CR_D and Dest counter val by 20, to point to F2.
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
 
-        // Move high 16 bits back to Dest
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 4);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 8);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 12);
+    // Move row 32 (F2R0) from DEST to SrcB with offset of 16 rows and transpose
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
+    TTI_TRNSPSRCB;
+    // Move row 32 from SrcB to DEST in 4-row chunks
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 4);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 8);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 12);
 
-        // Move low 16 bits to SrcB rows 16 - 31 and transpose
-        TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
-
-        // Move low 16 bits from SrcB rows 16 - 31 to DEST rows 0, 4, 8, 12
-        // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        // ADDR_MOD_3 increments CR_D and Dest counter val by 20, to point to F2.
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
-        // Clear B valid bits at the end and all address counters
-        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
-    }
-    else
-    {
-        // The following instructions are going to transpose the whole tile, unlike the FP32 mode.
-
-        // Move row 0 from DEST to SrcB with offset of 16 rows and transpose
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
-        // Move row 0 from SrcB to DEST in 4-row chunks
-        // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        // ADDR_MOD_3 increments CR_D and Dest counter val by 20, to point to F2.
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
-
-        // Move row 32 (F2R0) from DEST to SrcB with offset of 16 rows and transpose
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
-        // Move row 32 from SrcB to DEST in 4-row chunks
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 4);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 8);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_6, p_movb2d::MOV_4_ROWS, 12);
-
-        // Clear B valid bits at the end and all address counters
-        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
-    }
+    // Clear B valid bits at the end and all address counters
+    TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
 
     const std::uint32_t outer_loop = block_ct_dim;
     const std::uint32_t inner_loop = 4;
@@ -275,11 +243,6 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint
 template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim)
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_math_dbg_feature_disable_();
-    }
-
     reduce_max_row_configure_addrmod_runtime();
 
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
@@ -292,10 +255,6 @@ inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_
 template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_uninit_runtime_()
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_math_dbg_feature_enable_();
-    }
 }
 
 /**
@@ -318,26 +277,10 @@ inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_inde
 {
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        // Run the MOP, performing a column reduce across all 4 faces
-        ckernel::ckernel_template::run();
-        // needs to be disabled for MOVD2B/B2D on BH (Issue ##449)
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(0);
-        // Replay the 12 instructions to transpose the reduced F0&F1 results
-        lltt::replay(2, 12);
-        // Replay the 13 instructions to transpose the reduced F2&F3 results
-        // 13th instruction clears B valid bit to release SrcB bank and clears all address counters
-        lltt::replay(2, 13);
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(1);
-    }
-    else
-    {
-        // Run the MOP, performing a column reduce across all 4 faces
-        ckernel::ckernel_template::run();
-        // Replay the 13 instructions to transpose the reduced results
-        lltt::replay(2, 13);
-    }
+    // Run the MOP, performing a column reduce across all 4 faces
+    ckernel::ckernel_template::run();
+    // Replay the 13 instructions to transpose the reduced results
+    lltt::replay(2, 13);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
@@ -104,62 +104,30 @@ inline void _llk_math_reduce_block_max_row_mop_config_()
     TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
     TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
 
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        // FP32 destination mode, need to move high and low 16 bits to SrcB and transpose separately
+    // The following instructions are going to transpose the whole tile.
 
-        // The following instructions are repeated for F0&F1 reduced and F2&F3 reduced
-        // Move high 16 bits from DEST row 0 to SrcB rows 16 - 31 and transpose
-        TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
+    // Move row 0 from DEST to SrcB with offset of 16 rows and transpose
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+    TTI_TRNSPSRCB;
+    // Move row 0 from SrcB to DEST in 4-row chunks
+    // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+    // ADDR_MOD_3 increments CR_D and Dest counter val by 20, to point to F2.
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
 
-        // Move high 16 bits back to Dest
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+    // Move row 32 (F2R0) from DEST to SrcB with offset of 16 rows and transpose
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+    TTI_TRNSPSRCB;
+    // Move row 32 from SrcB to DEST in 4-row chunks
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
 
-        // Move low 16 bits to SrcB rows 16 - 31 and transpose
-        TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
-
-        // Move low 16 bits from SrcB rows 16 - 31 to DEST rows 0, 4, 8, 12
-        // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        // ADDR_MOD_3 increments CR_D and Dest counter val by 20, to point to F2.
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
-        // Clear B valid bits at the end and all address counters
-        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
-    }
-    else
-    {
-        // The following instructions are going to transpose the whole tile, unlike the FP32 mode.
-
-        // Move row 0 from DEST to SrcB with offset of 16 rows and transpose
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
-        // Move row 0 from SrcB to DEST in 4-row chunks
-        // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        // ADDR_MOD_3 increments CR_D and Dest counter val by 20, to point to F2.
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
-
-        // Move row 32 (F2R0) from DEST to SrcB with offset of 16 rows and transpose
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
-        // Move row 32 from SrcB to DEST in 4-row chunks
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
-
-        // Clear B valid bits at the end and all address counters
-        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
-    }
+    // Clear B valid bits at the end and all address counters
+    TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
 
     static constexpr std::uint32_t outer_loop = block_ct_dim;
     static constexpr std::uint32_t inner_loop = 4;
@@ -197,11 +165,6 @@ inline void _llk_math_reduce_block_max_row_mop_config_()
 template <std::uint32_t block_ct_dim, bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_init_()
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_math_dbg_feature_disable_();
-    }
-
     reduce_max_row_configure_addrmod();
 
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
@@ -214,10 +177,6 @@ inline void _llk_math_reduce_block_max_row_init_()
 template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_uninit_()
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_math_dbg_feature_enable_();
-    }
 }
 
 /**
@@ -240,24 +199,8 @@ inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
 {
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        // Run the MOP, performing a column reduce across all 4 faces
-        ckernel::ckernel_template::run();
-        // needs to be disabled for MOVD2B/B2D on BH (Issue ##449)
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(0);
-        // Replay the 12 instructions to transpose the reduced F0&F1 results
-        lltt::replay(2, 12);
-        // Replay the 13 instructions to transpose the reduced F2&F3 results
-        // 13th instruction clears B valid bit to release SrcB bank and clears all address counters
-        lltt::replay(2, 13);
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(1);
-    }
-    else
-    {
-        // Run the MOP, performing a column reduce across all 4 faces
-        ckernel::ckernel_template::run();
-        // Replay the 13 instructions to transpose the reduced results
-        lltt::replay(2, 13);
-    }
+    // Run the MOP, performing a column reduce across all 4 faces
+    ckernel::ckernel_template::run();
+    // Replay the 13 instructions to transpose the reduced results
+    lltt::replay(2, 13);
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_custom.h
@@ -201,6 +201,20 @@ inline void _llk_math_reduce_block_max_row_(const std::uint32_t dst_index)
 
     // Run the MOP, performing a column reduce across all 4 faces
     ckernel::ckernel_template::run();
+
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(to_underlying(DataFormat::Tf32));
+    }
+
     // Replay the 13 instructions to transpose the reduced results
     lltt::replay(2, 13);
+
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
+    }
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -72,62 +72,30 @@ inline void _llk_math_reduce_block_max_row_mop_config_runtime_(std::uint32_t blo
     TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
     TTI_GMPOOL(p_setrwc::CLR_NONE, p_gpool::DIM_16X16, ADDR_MOD_1, p_gpool::INDEX_DIS, 0);
 
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        // FP32 destination mode, need to move high and low 16 bits to SrcB and transpose separately
+    // The following instructions are going to transpose the whole tile.
 
-        // The following instructions are repeated for F0&F1 reduced and F2&F3 reduced
-        // Move high 16 bits from DEST row 0 to SrcB rows 16 - 31 and transpose
-        TTI_MOVD2B(p_mov::DEST_NORM, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
+    // Move row 0 from DEST to SrcB with offset of 16 rows and transpose
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+    TTI_TRNSPSRCB;
+    // Move row 0 from SrcB to DEST in 4-row chunks
+    // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
+    // ADDR_MOD_3 increments CR_D and Dest counter val by 20, to point to F2.
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
 
-        // Move high 16 bits back to Dest
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
-        TTI_MOVB2D(p_mov::DEST_NORM, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
+    // Move row 32 (F2R0) from DEST to SrcB with offset of 16 rows and transpose
+    TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
+    TTI_TRNSPSRCB;
+    // Move row 32 from SrcB to DEST in 4-row chunks
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
+    TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
 
-        // Move low 16 bits to SrcB rows 16 - 31 and transpose
-        TTI_MOVD2B(p_mov::DEST_32B_LOW, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
-
-        // Move low 16 bits from SrcB rows 16 - 31 to DEST rows 0, 4, 8, 12
-        // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        // ADDR_MOD_3 increments CR_D and Dest counter val by 20, to point to F2.
-        TTI_MOVB2D(p_mov::DEST_32B_LOW, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
-        // Clear B valid bits at the end and all address counters
-        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
-    }
-    else
-    {
-        // The following instructions are going to transpose the whole tile, unlike the FP32 mode.
-
-        // Move row 0 from DEST to SrcB with offset of 16 rows and transpose
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
-        // Move row 0 from SrcB to DEST in 4-row chunks
-        // ADDR_MOD_2 increments CR_D and Dest counter val by 4, so that's why DEST location is '0', not '0, 4, 8, 12'.
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_2, p_movb2d::MOV_4_ROWS, 0);
-        // ADDR_MOD_3 increments CR_D and Dest counter val by 20, to point to F2.
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_3, p_movb2d::MOV_4_ROWS, 0);
-
-        // Move row 32 (F2R0) from DEST to SrcB with offset of 16 rows and transpose
-        TTI_MOVD2B(0, p_movd2b::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movd2b::MOV_1_ROW, 0);
-        TTI_TRNSPSRCB;
-        // Move row 32 from SrcB to DEST in 4-row chunks
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 0);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 4, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 4);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 8, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 8);
-        TTI_MOVB2D(0, p_movb2d::SRC_ROW16_OFFSET + 12, ADDR_MOD_0, p_movb2d::MOV_4_ROWS, 12);
-
-        // Clear B valid bits at the end and all address counters
-        TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
-    }
+    // Clear B valid bits at the end and all address counters
+    TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_ABD);
 
     const std::uint32_t outer_loop = block_ct_dim;
     const std::uint32_t inner_loop = 4;
@@ -184,11 +152,6 @@ inline void _llk_math_reduce_block_max_row_mop_reprogram_only_runtime_(std::uint
 template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_dim)
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_math_dbg_feature_disable_();
-    }
-
     reduce_max_row_configure_addrmod_reinit_runtime();
 
     TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0);
@@ -201,10 +164,6 @@ inline void _llk_math_reduce_block_max_row_init_runtime_(std::uint32_t block_ct_
 template <bool is_fp32_dest_acc_en = false>
 inline void _llk_math_reduce_block_max_row_uninit_runtime_()
 {
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        _llk_math_dbg_feature_enable_();
-    }
 }
 
 /**
@@ -227,26 +186,10 @@ inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_inde
 {
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
 
-    if constexpr (is_fp32_dest_acc_en)
-    {
-        // Run the MOP, performing a column reduce across all 4 faces
-        ckernel::ckernel_template::run();
-        // needs to be disabled for MOVD2B/B2D on BH (Issue ##449)
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(0);
-        // Replay the 12 instructions to transpose the reduced F0&F1 results
-        lltt::replay(2, 12);
-        // Replay the 13 instructions to transpose the reduced F2&F3 results
-        // 13th instruction clears B valid bit to release SrcB bank and clears all address counters
-        lltt::replay(2, 13);
-        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Fp32_enabled_RMW>(1);
-    }
-    else
-    {
-        // Run the MOP, performing a column reduce across all 4 faces
-        ckernel::ckernel_template::run();
-        // Replay the 13 instructions to transpose the reduced results
-        lltt::replay(2, 13);
-    }
+    // Run the MOP, performing a column reduce across all 4 faces
+    ckernel::ckernel_template::run();
+    // Replay the 13 instructions to transpose the reduced results
+    lltt::replay(2, 13);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_reduce_runtime_custom.h
@@ -188,8 +188,22 @@ inline void _llk_math_reduce_block_max_row_runtime_(const std::uint32_t dst_inde
 
     // Run the MOP, performing a column reduce across all 4 faces
     ckernel::ckernel_template::run();
+
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(1);
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(1);
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_val_RMW>(to_underlying(DataFormat::Tf32));
+    }
+
     // Replay the 13 instructions to transpose the reduced results
     lltt::replay(2, 13);
+
+    if constexpr (is_fp32_dest_acc_en)
+    {
+        cfg_reg_rmw_tensix<ALU_FORMAT_SPEC_REG_SrcA_override_RMW>(0);
+        cfg_reg_rmw_tensix<ALU_ACC_CTRL_Zero_Flag_disabled_src_RMW>(0);
+    }
 }
 
 /**


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

#45515

Custom reduce max operations don't need a dedicated 32-bit transpose algorithm. `GMPOOL` simply copies data from the source register, so results are at most 19 bits wide and can be transposed in a single pass.

Why the old code was broken
The previous two-pass 32-bit transpose didn't actually work when `is_fp32_dest_acc_en` was enabled. The first pass transposes the high bits and writes them to dest like this:

```
  uint16_t LowMantissa = ((SrcBVal >> 8) & 7) << 13;
  Dst32b[DstRow][Column] = (uint32_t(Val16b) << 16) | LowMantissa;
```

This write zeros out the low bits in dest. The second pass then tries to transpose those low bits using `p_mov::DEST_32B_LOW`, but due to a hardware bug the values end up written to the high addresses instead. The root cause is that shifting to the low bit destination also requires changing the data format to Float16_b, which was never done.

Since `GMPOOL` results always fit in 19 bits, we don't need the two pass path at all and can just remove it.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=marko/reduce_custom_bit11)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:marko/reduce_custom_bit11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=marko/reduce_custom_bit11)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:marko/reduce_custom_bit11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=marko/reduce_custom_bit11)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:marko/reduce_custom_bit11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=marko/reduce_custom_bit11)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:marko/reduce_custom_bit11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=marko/reduce_custom_bit11)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:marko/reduce_custom_bit11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=marko/reduce_custom_bit11)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:marko/reduce_custom_bit11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=marko/reduce_custom_bit11)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:marko/reduce_custom_bit11)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=marko/reduce_custom_bit11)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:marko/reduce_custom_bit11)