### PR TITLE
Add op-level unit test for windowed SDPA

### DIFF
--- a/tests/ttnn/unit_tests/operations/sdpa/test_windowed_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_windowed_sdpa.py
@@ -42,7 +42,18 @@ def windowed_mask(seq_len, cu_window_seqlens):
     ids=["s128_w2", "s128_w3", "s256_w3"],
 )
 @pytest.mark.parametrize("num_heads", [1, 8])
-def test_windowed_sdpa_smoke(device, num_heads, seq_len, cu_window_seqlens):
+@pytest.mark.parametrize(
+    "dtype, pcc_threshold",
+    [
+        (ttnn.bfloat16, 0.99),
+        # bfloat8_b mirrors the dtype Qwen2.5-VL actually feeds the op
+        # (vision_attention.py typecasts q/k/v to bf8 before the call); looser
+        # PCC accounts for the reduced input precision.
+        (ttnn.bfloat8_b, 0.98),
+    ],
+    ids=["bf16", "bf8"],
+)
+def test_windowed_sdpa_smoke(device, dtype, pcc_threshold, num_heads, seq_len, cu_window_seqlens):
     torch.manual_seed(42)
     b, dh, chunk = 1, 128, 32
     scale = dh**-0.5
@@ -64,9 +75,9 @@ def test_windowed_sdpa_smoke(device, num_heads, seq_len, cu_window_seqlens):
         packer_l1_acc=True,
     )
 
-    q_tt = ttnn.from_torch(q, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
-    k_tt = ttnn.from_torch(k, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
-    v_tt = ttnn.from_torch(v, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    q_tt = ttnn.from_torch(q, device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype)
+    k_tt = ttnn.from_torch(k, device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype)
+    v_tt = ttnn.from_torch(v, device=device, layout=ttnn.TILE_LAYOUT, dtype=dtype)
     cu_tt = ttnn.from_torch(
         torch.tensor(cu_window_seqlens, dtype=torch.int32),
         device=device,
@@ -90,7 +101,7 @@ def test_windowed_sdpa_smoke(device, num_heads, seq_len, cu_window_seqlens):
         q.to(torch.float32), k.to(torch.float32), v.to(torch.float32), attn_mask=mask, scale=scale
     )
 
-    passing, pcc = comp_pcc(gt, out, 0.99)
-    logger.info(f"windowed SDPA s={seq_len} heads={num_heads} windows={cu_window_seqlens} pcc={pcc}")
+    passing, pcc = comp_pcc(gt, out, pcc_threshold)
+    logger.info(f"windowed SDPA dtype={dtype} s={seq_len} heads={num_heads} windows={cu_window_seqlens} pcc={pcc}")
     assert passing, f"PCC below threshold: {pcc}"
     assert out.shape == gt.shape, f"shape mismatch: {out.shape} vs {gt.shape}"

--- a/tests/ttnn/unit_tests/operations/sdpa/test_windowed_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_windowed_sdpa.py
@@ -1,0 +1,96 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Op-level smoke test for ttnn.transformer.windowed_scaled_dot_product_attention.
+
+This intentionally lives next to the other SDPA op tests (instead of only under
+models/demos/qwen25_vl/) so that any change to the shared SDPA kernel helpers
+(e.g. dataflow_common.hpp / write_block) exercises the windowed writer kernel in
+a pre-merge / per-commit gate. Device kernels are JIT-built at op invocation, so
+running the op on hardware is the only way to catch a kernel-signature break -
+which is exactly what slipped through in #45015 and broke Qwen2.5-VL nightly.
+
+Correctness is checked against torch SDPA with the equivalent block-diagonal
+window mask.
+"""
+
+import torch
+import pytest
+from loguru import logger
+
+import ttnn
+from tests.tt_eager.python_api_testing.sweep_tests.comparison_funcs import comp_pcc
+
+
+def windowed_mask(seq_len, cu_window_seqlens):
+    """Block-diagonal mask: token i attends only to tokens in the same window."""
+    mask = torch.full((seq_len, seq_len), float("-inf"), dtype=torch.float32)
+    for i in range(1, len(cu_window_seqlens)):
+        start, end = cu_window_seqlens[i - 1], cu_window_seqlens[i]
+        mask[start:end, start:end] = 0.0
+    return mask
+
+
+@pytest.mark.parametrize(
+    "seq_len, cu_window_seqlens",
+    [
+        (128, [0, 64, 128]),  # two equal tile-aligned windows
+        (128, [0, 32, 96, 128]),  # three uneven windows
+        (256, [0, 64, 128, 256]),  # larger sequence
+    ],
+    ids=["s128_w2", "s128_w3", "s256_w3"],
+)
+@pytest.mark.parametrize("num_heads", [1, 8])
+def test_windowed_sdpa_smoke(device, num_heads, seq_len, cu_window_seqlens):
+    torch.manual_seed(42)
+    b, dh, chunk = 1, 128, 32
+    scale = dh**-0.5
+
+    q = torch.randn(b, num_heads, seq_len, dh, dtype=torch.bfloat16)
+    k = torch.randn(b, num_heads, seq_len, dh, dtype=torch.bfloat16)
+    v = torch.randn(b, num_heads, seq_len, dh, dtype=torch.bfloat16)
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+        exp_approx_mode=False,
+        q_chunk_size=chunk,
+        k_chunk_size=chunk,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi4,
+        math_approx_mode=False,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    q_tt = ttnn.from_torch(q, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    k_tt = ttnn.from_torch(k, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    v_tt = ttnn.from_torch(v, device=device, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16)
+    cu_tt = ttnn.from_torch(
+        torch.tensor(cu_window_seqlens, dtype=torch.int32),
+        device=device,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        dtype=ttnn.uint32,
+    )
+
+    out_tt = ttnn.transformer.windowed_scaled_dot_product_attention(
+        q_tt,
+        k_tt,
+        v_tt,
+        cu_tt,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+    )
+    out = ttnn.to_torch(out_tt).to(torch.float32)
+
+    mask = windowed_mask(seq_len, cu_window_seqlens).unsqueeze(0).unsqueeze(0)
+    gt = torch.nn.functional.scaled_dot_product_attention(
+        q.to(torch.float32), k.to(torch.float32), v.to(torch.float32), attn_mask=mask, scale=scale
+    )
+
+    passing, pcc = comp_pcc(gt, out, 0.99)
+    logger.info(f"windowed SDPA s={seq_len} heads={num_heads} windows={cu_window_seqlens} pcc={pcc}")
+    assert passing, f"PCC below threshold: {pcc}"
+    assert out.shape == gt.shape, f"shape mismatch: {out.shape} vs {gt.shape}"


### PR DESCRIPTION
## Problem

`sdpa_windowed/device/kernels/dataflow/writer_windowed.cpp` fails to build (brisc JIT) on `main` with:

```
writer_windowed.cpp:77:28: error: no matching function for call to
'write_block(const TensorAccessor<...>&, const uint32_t&, ...)'
```

### Root cause

PR #45015 ("Move transformer operations to device 2.0 API", merged 2026-06-10) changed `write_block()` in `sdpa/device/kernels/dataflow/dataflow_common.hpp` to take a `Noc noc` as its **first parameter**, and updated all the regular SDPA writer kernels (`writer_interleaved`, `joint_writer`, `ring_joint_writer`, ...). The **`sdpa_windowed`** writer lives in a separate directory and was missed by that migration, so it still calls the old 8-arg signature.

`reader_windowed.cpp` was *not* affected — it was already migrated (declares `Noc noc;` and uses `noc.async_read(...)`), which is why the build error pointed only at the writer.

### Blast radius

Every test exercising windowed SDPA has been red since ~Jun 10:
- **Qwen2.5-VL-72B** — Tier 2 e2e + Tier 2 unit (`wh_llmbox_perf`)
- **Qwen2.5-VL-32B** — Tier 3 unit (`wh_llmbox_perf`)

## Fix

Mirror the known-good `writer_interleaved.cpp` sibling:
1. `#include "api/dataflow/noc.h"`
2. declare `Noc noc;` at the top of `kernel_main()`
3. pass `noc` as the first arg to `write_block(...)`

No other windowed kernel needs changes.

## Testing

Device kernels are JIT-built on hardware, so this can't be host-compiled locally; the change is byte-for-byte the same pattern as the already-migrated `writer_interleaved.cpp`. CI (Qwen2.5-VL e2e/unit) will confirm the brisc build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/fix-windowed-sdpa-write-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/fix-windowed-sdpa-write-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/fix-windowed-sdpa-write-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/fix-windowed-sdpa-write-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/fix-windowed-sdpa-write-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/fix-windowed-sdpa-write-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/fix-windowed-sdpa-write-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/fix-windowed-sdpa-write-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/fix-windowed-sdpa-write-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/fix-windowed-sdpa-write-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/fix-windowed-sdpa-write-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/fix-windowed-sdpa-write-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/fix-windowed-sdpa-write-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/fix-windowed-sdpa-write-block)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/fix-windowed-sdpa-write-block)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/fix-windowed-sdpa-write-block)
## Op-level smoke test + CI validation

Added `tests/ttnn/unit_tests/operations/sdpa/test_windowed_sdpa.py` — an op-level test for `ttnn.transformer.windowed_scaled_dot_product_attention`, checked against torch SDPA with the equivalent block-diagonal window mask. It is auto-collected by the existing **"ttnn sdpa group"** in `tests/pipeline_reorg/ttnn-tests.yaml` (runs `tests/ttnn/unit_tests/operations/sdpa` on wh_n300 + bh_p100/p150 in post-commit), so any future change to the shared SDPA kernel helpers exercises the windowed writer kernel — closing the gap that let #45015 break this op undetected until the nightly model run.

**CI run (TTNN unit tests on this branch, incl. the new test):** https://github.com/tenstorrent/tt-metal/actions/runs/27547926283