### PR TITLE
Fix Gemma4 decode demo: normalize ttnn_decode_forward return arity

### DIFF
--- a/models/demos/gemma4/demo/text_demo.py
+++ b/models/demos/gemma4/demo/text_demo.py
@@ -720,7 +720,7 @@ def run_generation(
             return inputs
 
         def _fwd(device_inputs):
-            return model.ttnn_decode_forward(
+            out = model.ttnn_decode_forward(
                 x=device_inputs["tokens"],
                 current_pos=device_inputs["position"],
                 rot_mat_idxs=device_inputs["position_int32"],  # pos_int32 passed as rot_mat_idxs
@@ -729,6 +729,10 @@ def run_generation(
                 on_device_logits=on_device_sampling,
                 pli_combined=device_inputs.get("pli"),
             )
+            # ttnn_decode_forward returns a bare logits tensor on the on-device-sampling
+            # path (on_device_logits=True) and a (logits, None) tuple otherwise. Normalize
+            # to a 2-tuple so the trace-capture call sites below can always unpack two values.
+            return out if isinstance(out, tuple) else (out, None)
 
         def _inputs_to_device(inputs):
             return {k: ttnn.to_device(v, device=mesh_device) for k, v in inputs.items() if v is not None}


### PR DESCRIPTION
## Problem

`Gemma-4-26B-A4B` and `Gemma-4-31B` e2e tests fail on Tier 2 with:

```
models/demos/gemma4/demo/text_demo.py:482: ValueError
ValueError: not enough values to unpack (expected 2, got 1)
```

at `test_demo[...-prefill_128-*]`, during decode trace capture.

### Root cause

`model.ttnn_decode_forward()` returns **inconsistent arity** depending on `on_device_logits`:

```python
# models/demos/gemma4/tt/model.py
if on_device_logits:
    ...
    return logits          # bare tensor   (on-device sampling path)
return logits, None        # 2-tuple       (host sampling path)
```

The demo's decode trace-capture path always unpacks two values at three sites (lines 482, 500, 514):

```python
decode_logits, _ = _fwd(inputs_d)
```

`_fwd` passes `on_device_logits=on_device_sampling`. With on-device sampling enabled (26B-A4B / 31B configs), `ttnn_decode_forward` returns a single tensor → the unpack raises.

The bare-tensor return on the sampling path was introduced by #45166 ("Clean up sampling separation in generators", 2026-06-11); the demo's 2-tuple unpack predates it (#43199, May), so this is a regression from that cleanup. Timeline matches the CI onset.

## Fix

Normalize in the demo's `_fwd` wrapper so all three trace call sites can unpack two values regardless of `on_device_logits` (the second element is always discarded `_`):

```python
out = model.ttnn_decode_forward(...)
return out if isinstance(out, tuple) else (out, None)
```

This is purely demo-side — it does **not** touch `ttnn_decode_forward`, keeping the model's Generator / vLLM sampling interface intact.

## Notes

- This is one of two separate Gemma4 CI failures. The Gemma3n-style **E2B/E4B** variants fail earlier with a different bug (`KeyError: 'k_proj.weight'` in `attention/weights.py` for KV-shared layers) — that one is an architectural weight-loading issue tracked separately.

## Testing

Demo runs on hardware; CI (Gemma-4-26B-A4B / 31B e2e) will confirm. Change is a localized return-normalization with no behavioral change on the host-sampling path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/fix-gemma4-decode-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/fix-gemma4-decode-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/fix-gemma4-decode-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/fix-gemma4-decode-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/fix-gemma4-decode-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/fix-gemma4-decode-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/fix-gemma4-decode-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/fix-gemma4-decode-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/fix-gemma4-decode-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/fix-gemma4-decode-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/fix-gemma4-decode-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/fix-gemma4-decode-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/fix-gemma4-decode-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/fix-gemma4-decode-unpack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/fix-gemma4-decode-unpack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/fix-gemma4-decode-unpack)