### PR TITLE
Changing expected perf for moe perf test

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
+++ b/models/demos/deepseek_v3_d_p/tests/perf/test_moe_perf.py
@@ -59,7 +59,7 @@ def test_deepseek_v3_moe_perf_galaxy():
         pytest.skip("This test requires 8x4 mesh - galaxy. (set MESH_DEVICE=TG)")
     run_model_device_perf_test_with_merge(
         command=_CMD_8X4,
-        expected_device_perf_ns_per_iteration=105_670_132,
+        expected_device_perf_ns_per_iteration=41_294_210,
         subdir="deepseek_v3_moe",
         model_name="deepseek_v3_moe_glx_8x4",
         num_iterations=1,


### PR DESCRIPTION
### Summary
Adjusting the expected perf for moe after the unified expert.

AVG DEVICE KERNEL DURATION [ns] 41294210.28125 is outside of expected range (102500028.03999999, 108840235.96000001)
-- | -- | -- | --


[(Galaxy) DeepSeek Prefill PERF [bh_galaxy]](https://github.com/tenstorrent/tt-metal/actions/runs/27414503173/job/81025650060#step:11:1)	model:accuracy	1	AVG DEVICE KERNEL DURATION [ns] 41294210.28125 is outside of expected range (102500028.03999999, 108840235.96000001)

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml/badge.svg?branch=ddjekic/moe_perf_threshold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/demo-sp-release.yaml?query=branch:ddjekic/moe_perf_threshold_fix)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ddjekic/moe_perf_threshold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ddjekic/moe_perf_threshold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ddjekic/moe_perf_threshold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ddjekic/moe_perf_threshold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ddjekic/moe_perf_threshold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ddjekic/moe_perf_threshold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ddjekic/moe_perf_threshold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ddjekic/moe_perf_threshold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ddjekic/moe_perf_threshold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ddjekic/moe_perf_threshold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ddjekic/moe_perf_threshold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ddjekic/moe_perf_threshold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ddjekic/moe_perf_threshold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ddjekic/moe_perf_threshold_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ddjekic/moe_perf_threshold_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ddjekic/moe_perf_threshold_fix)