### PR TITLE
[Cleanup] more data movement kernels migrated to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h.cpp
@@ -7,10 +7,18 @@
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;
+    constexpr uint32_t cb_a_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b_id = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out_id = tt::CBIndex::c_16;
+
+    CircularBuffer cb_a(cb_a_id);
+    CircularBuffer cb_b(cb_b_id);
+    CircularBuffer cb_out(cb_out_id);
+
     uint32_t B = get_arg_val<uint32_t>(0);
     uint32_t Ht = get_arg_val<uint32_t>(1);
     uint32_t Wt = get_arg_val<uint32_t>(2);
-    init_bcast<BCAST_LLKOP, BCAST_DIM>(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+    init_bcast<BCAST_LLKOP, BCAST_DIM>(cb_a_id, cb_b_id, cb_out_id);
 
     for (uint32_t b = 0; b < B; b++) {
         for (uint32_t h = 0; h < Ht; h++) {
@@ -18,23 +26,23 @@ void kernel_main() {
                 // For this bcast-h op the reader will wrap the RHS source tile around at Wt
                 // so here we just linearly read 2 parallel arrays and apply bcast op per tile
                 // (bcast_h propagates the op down the H dimension, so it can be though of as bcast to H)
-                cb_wait_front(tt::CBIndex::c_1, onetile);
-                cb_wait_front(tt::CBIndex::c_0, onetile);
+                cb_b.wait_front(onetile);
+                cb_a.wait_front(onetile);
 
                 tile_regs_acquire();
-                BCAST_OP<BroadcastType::ROW>(tt::CBIndex::c_0, tt::CBIndex::c_1, 0, 0, 0);
+                BCAST_OP<BroadcastType::ROW>(cb_a_id, cb_b_id, 0, 0, 0);
                 tile_regs_commit();
 
-                cb_pop_front(tt::CBIndex::c_0, onetile);
-                cb_pop_front(tt::CBIndex::c_1, onetile);
+                cb_a.pop_front(onetile);
+                cb_b.pop_front(onetile);
 
-                cb_reserve_back(tt::CBIndex::c_16, onetile);
+                cb_out.reserve_back(onetile);
 
                 tile_regs_wait();
-                pack_tile(0, tt::CBIndex::c_16);
+                pack_tile(0, cb_out_id);
                 tile_regs_release();
 
-                cb_push_back(tt::CBIndex::c_16, onetile);
+                cb_out.push_back(onetile);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/compute/bcast.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h_sharded_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h_sharded_optimised.cpp
@@ -7,6 +7,14 @@
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;
+    constexpr uint32_t cb_a_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b_id = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out_id = tt::CBIndex::c_16;
+
+    CircularBuffer cb_a(cb_a_id);
+    CircularBuffer cb_b(cb_b_id);
+    CircularBuffer cb_out(cb_out_id);
+
     uint32_t NC = get_arg_val<uint32_t>(0);
     uint32_t Ht = get_arg_val<uint32_t>(1);
     uint32_t Wt = get_arg_val<uint32_t>(2);
@@ -14,33 +22,33 @@ void kernel_main() {
     uint32_t batch_b = get_arg_val<uint32_t>(4);
     uint32_t Ht_per_batch_b = get_arg_val<uint32_t>(5);
 
-    init_bcast<BCAST_LLKOP, BCAST_DIM>(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+    init_bcast<BCAST_LLKOP, BCAST_DIM>(cb_a_id, cb_b_id, cb_out_id);
 
-    cb_wait_front(tt::CBIndex::c_0, Wt * Ht);
-    cb_reserve_back(tt::CBIndex::c_16, Wt * Ht);
+    cb_a.wait_front(Wt * Ht);
+    cb_out.reserve_back(Wt * Ht);
     uint32_t b_offset = 0;
     for (uint32_t bn = 0; bn < batch_b; bn++) {
         for (uint32_t wt = 0; wt < Wt; wt++) {
-            cb_wait_front(tt::CBIndex::c_1, onetile);
+            cb_b.wait_front(onetile);
             for (uint32_t ht = 0; ht < Ht_per_batch_b; ht += h_blk) {
                 tile_regs_acquire();
                 for (uint32_t htr = 0; htr < h_blk; htr++) {
                     uint32_t current_index = b_offset + (ht + htr) * Wt + wt;
-                    BCAST_OP<BroadcastType::ROW>(tt::CBIndex::c_0, tt::CBIndex::c_1, current_index, 0, htr);
+                    BCAST_OP<BroadcastType::ROW>(cb_a_id, cb_b_id, current_index, 0, htr);
                 }
                 tile_regs_commit();
 
                 tile_regs_wait();
                 for (uint32_t htr = 0; htr < h_blk; htr++) {
                     uint32_t current_index = b_offset + (ht + htr) * Wt + wt;
-                    pack_tile<true>(htr, tt::CBIndex::c_16, current_index);
+                    pack_tile<true>(htr, cb_out_id, current_index);
                 }
                 tile_regs_release();
             }
-            cb_pop_front(tt::CBIndex::c_1, onetile);
+            cb_b.pop_front(onetile);
         }
         b_offset += Ht_per_batch_b * Wt;
     }
-    cb_pop_front(tt::CBIndex::c_0, Wt * Ht);
-    cb_push_back(tt::CBIndex::c_16, Wt * Ht);
+    cb_a.pop_front(Wt * Ht);
+    cb_out.push_back(Wt * Ht);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h_sharded_optimised.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_h_sharded_optimised.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdint>
 #include "api/compute/bcast.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_hw.cpp
@@ -8,39 +8,47 @@
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;
+    constexpr uint32_t cb_a_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b_id = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out_id = tt::CBIndex::c_16;
+
+    CircularBuffer cb_a(cb_a_id);
+    CircularBuffer cb_b(cb_b_id);
+    CircularBuffer cb_out(cb_out_id);
+
     uint32_t B = get_arg_val<uint32_t>(0);
     uint32_t Ht = get_arg_val<uint32_t>(1);
     uint32_t Wt = get_arg_val<uint32_t>(2);
-    init_bcast<BCAST_LLKOP, BCAST_DIM>(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+    init_bcast<BCAST_LLKOP, BCAST_DIM>(cb_a_id, cb_b_id, cb_out_id);
 
 #ifdef BCAST_SCALAR
-    cb_wait_front(tt::CBIndex::c_1, onetile);
+    cb_b.wait_front(onetile);
 #endif
 
     for (uint32_t b = 0; b < B; b++) {
         for (uint32_t h = 0; h < Ht; h++) {
             for (uint32_t w = 0; w < Wt; w++) {
 #ifndef BCAST_SCALAR
-                cb_wait_front(tt::CBIndex::c_1, onetile);
+                cb_b.wait_front(onetile);
 #endif
-                cb_wait_front(tt::CBIndex::c_0, onetile);
+                cb_a.wait_front(onetile);
 
                 tile_regs_acquire();
-                BCAST_OP<BroadcastType::SCALAR>(tt::CBIndex::c_0, tt::CBIndex::c_1, 0, 0, 0);
+                BCAST_OP<BroadcastType::SCALAR>(cb_a_id, cb_b_id, 0, 0, 0);
                 tile_regs_commit();
 
-                cb_pop_front(tt::CBIndex::c_0, onetile);
+                cb_a.pop_front(onetile);
 #ifndef BCAST_SCALAR
-                cb_pop_front(tt::CBIndex::c_1, onetile);
+                cb_b.pop_front(onetile);
 #endif
 
-                cb_reserve_back(tt::CBIndex::c_16, onetile);
+                cb_out.reserve_back(onetile);
 
                 tile_regs_wait();
-                pack_tile(0, tt::CBIndex::c_16);
+                pack_tile(0, cb_out_id);
                 tile_regs_release();
 
-                cb_push_back(tt::CBIndex::c_16, onetile);
+                cb_out.push_back(onetile);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_hw.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "api/compute/bcast.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_w.cpp
@@ -9,33 +9,41 @@
 void kernel_main() {
     uint32_t w = 0;
     constexpr uint32_t onetile = 1;
+    constexpr uint32_t cb_a_id = tt::CBIndex::c_0;
+    constexpr uint32_t cb_b_id = tt::CBIndex::c_1;
+    constexpr uint32_t cb_out_id = tt::CBIndex::c_16;
+
+    CircularBuffer cb_a(cb_a_id);
+    CircularBuffer cb_b(cb_b_id);
+    CircularBuffer cb_out(cb_out_id);
+
     uint32_t B = get_arg_val<uint32_t>(0);
     uint32_t Ht = get_arg_val<uint32_t>(1);
     uint32_t Wt = get_arg_val<uint32_t>(2);
 
-    init_bcast<BCAST_LLKOP, BCAST_DIM>(tt::CBIndex::c_0, tt::CBIndex::c_1, tt::CBIndex::c_16);
+    init_bcast<BCAST_LLKOP, BCAST_DIM>(cb_a_id, cb_b_id, cb_out_id);
 
     for (uint32_t b = 0; b < B; b++) {
         for (uint32_t h = 0; h < Ht; h++) {
-            cb_wait_front(tt::CBIndex::c_1, onetile);
+            cb_b.wait_front(onetile);
             for (uint32_t w = 0; w < Wt; w++) {
-                cb_wait_front(tt::CBIndex::c_0, onetile);
+                cb_a.wait_front(onetile);
 
                 tile_regs_acquire();
-                BCAST_OP<BroadcastType::COL>(tt::CBIndex::c_0, tt::CBIndex::c_1, 0, 0, 0);
+                BCAST_OP<BroadcastType::COL>(cb_a_id, cb_b_id, 0, 0, 0);
                 tile_regs_commit();
 
-                cb_pop_front(tt::CBIndex::c_0, onetile);
+                cb_a.pop_front(onetile);
 
-                cb_reserve_back(tt::CBIndex::c_16, onetile);
+                cb_out.reserve_back(onetile);
 
                 tile_regs_wait();
-                pack_tile(0, tt::CBIndex::c_16);
+                pack_tile(0, cb_out_id);
                 tile_regs_release();
 
-                cb_push_back(tt::CBIndex::c_16, onetile);
+                cb_out.push_back(onetile);
             }
-            cb_pop_front(tt::CBIndex::c_1, onetile);
+            cb_b.pop_front(onetile);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_w.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/compute/bcast_w.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "api/compute/bcast.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     uint32_t w = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -11,6 +11,10 @@
 #include <stdio.h>
 #include <cstring>
 #include <type_traits>
+
+#include "api/dataflow/noc.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 
 constexpr uint64_t ALIGN_REQ_64 = 64;
 constexpr uint64_t MASK_64 = 0xFFFFFFFFFFFFFFC0;
@@ -34,6 +38,22 @@ FORCE_INLINE void enhanced_noc_async_read(
     }
 }
 
+template <uint32_t max_transfer_size, bool only_reads>
+FORCE_INLINE void enhanced_noc_async_read(
+    Noc noc, const uint64_t src_noc_addr, const uint32_t dst_l1_addr, const uint32_t bytes) {
+    constexpr uint32_t page_size = (only_reads && max_transfer_size <= NOC_MAX_BURST_SIZE)
+                                       ? NOC_MAX_BURST_SIZE
+                                       : (max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size);
+    noc.async_read<NocOptions::DEFAULT, page_size>(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(dst_l1_addr),
+        bytes,
+        {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(src_noc_addr),
+         .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(src_noc_addr),
+         .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(src_noc_addr)},
+        {.offset_bytes = 0});
+}
+
 template <uint32_t max_transfer_size, bool only_writes>
 FORCE_INLINE void enhanced_noc_async_write(
     const uint32_t src_l1_addr, const uint64_t dst_noc_addr, const uint32_t bytes) {
@@ -45,6 +65,22 @@ FORCE_INLINE void enhanced_noc_async_write(
         noc_async_write<max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size>(
             src_l1_addr, dst_noc_addr, bytes);
     }
+}
+
+template <uint32_t max_transfer_size, bool only_writes>
+FORCE_INLINE void enhanced_noc_async_write(
+    Noc noc, const uint32_t src_l1_addr, const uint64_t dst_noc_addr, const uint32_t bytes) {
+    constexpr uint32_t page_size = (only_writes && max_transfer_size <= NOC_MAX_BURST_SIZE)
+                                       ? NOC_MAX_BURST_SIZE
+                                       : (max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size);
+    noc.async_write<NocOptions::DEFAULT, page_size>(
+        CoreLocalMem<uint32_t>(src_l1_addr),
+        UnicastEndpoint{},
+        bytes,
+        {.offset_bytes = 0},
+        {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(dst_noc_addr),
+         .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(dst_noc_addr),
+         .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(dst_noc_addr)});
 }
 
 template <bool guaranteed_16B_aligned, bool copy_async, bool use_read_datamover, uint32_t max_transfer_size>
@@ -82,6 +118,49 @@ FORCE_INLINE void tt_memmove(const uint32_t dst_l1_addr, const uint32_t src_l1_a
                 enhanced_noc_async_write<max_transfer_size, false>(src_l1_addr, get_noc_addr(dst_l1_addr), bytes);
                 if constexpr (!copy_async) {
                     noc_async_write_barrier();
+                }
+            } else {
+                invalidate_l1_cache();
+                memmove((void*)(dst_l1_addr), (void*)(src_l1_addr), (size_t)(bytes));
+            }
+        }
+    }
+}
+
+template <bool guaranteed_16B_aligned, bool copy_async, bool use_read_datamover, uint32_t max_transfer_size>
+FORCE_INLINE void tt_memmove(Noc noc, const uint32_t dst_l1_addr, const uint32_t src_l1_addr, const uint32_t bytes) {
+    if constexpr (use_read_datamover) {
+        if constexpr (guaranteed_16B_aligned) {
+            enhanced_noc_async_read<max_transfer_size, false>(
+                noc, get_noc_addr(src_l1_addr, noc.get_noc_id()), dst_l1_addr, bytes);
+            if constexpr (!copy_async) {
+                noc.async_read_barrier();
+            }
+        } else {
+            if ((dst_l1_addr & OFFSET_16) == (src_l1_addr & OFFSET_16)) {
+                enhanced_noc_async_read<max_transfer_size, false>(
+                    noc, get_noc_addr(src_l1_addr, noc.get_noc_id()), dst_l1_addr, bytes);
+                if constexpr (!copy_async) {
+                    noc.async_read_barrier();
+                }
+            } else {
+                invalidate_l1_cache();
+                memmove((void*)(dst_l1_addr), (void*)(src_l1_addr), (size_t)(bytes));
+            }
+        }
+    } else {
+        if constexpr (guaranteed_16B_aligned) {
+            enhanced_noc_async_write<max_transfer_size, false>(
+                noc, src_l1_addr, get_noc_addr(dst_l1_addr, noc.get_noc_id()), bytes);
+            if constexpr (!copy_async) {
+                noc.async_write_barrier();
+            }
+        } else {
+            if ((dst_l1_addr & OFFSET_16) == (src_l1_addr & OFFSET_16)) {
+                enhanced_noc_async_write<max_transfer_size, false>(
+                    noc, src_l1_addr, get_noc_addr(dst_l1_addr, noc.get_noc_id()), bytes);
+                if constexpr (!copy_async) {
+                    noc.async_write_barrier();
                 }
             } else {
                 invalidate_l1_cache();
@@ -227,6 +306,40 @@ FORCE_INLINE void noc_async_write_sharded(
 }
 
 template <typename AddrGenType>
+FORCE_INLINE void noc_async_write_sharded(
+    Noc noc, uint32_t l1_addr, AddrGenType tensor, uint32_t dest_id, uint32_t offset, uint32_t size) {
+    if constexpr (AddrGenType::DSpec::is_interleaved) {
+        noc.async_write(
+            CoreLocalMem<uint32_t>(l1_addr), tensor, size, {}, {.page_id = dest_id, .offset_bytes = offset});
+    } else {
+        const auto& dspec = tensor.dspec();
+        const uint32_t r = dspec.rank();
+        const uint32_t pages_per_row = (r > 1) ? dspec.tensor_shape()[r - 1] : 1u;
+        if (pages_per_row <= 1) {
+            noc.async_write(
+                CoreLocalMem<uint32_t>(l1_addr), tensor, size, {}, {.page_id = dest_id, .offset_bytes = offset});
+            return;
+        }
+        const uint32_t page_size = tensor.get_aligned_page_size();
+        uint32_t sharded_dest_id = dest_id * pages_per_row + offset / page_size;
+        uint32_t sharded_offset = offset % page_size;
+        uint32_t num_pages = div_up(size + sharded_offset, page_size);
+        for (uint32_t i = 0; i < num_pages; i++) {
+            uint32_t write_size = std::min(size - i * page_size, page_size - sharded_offset);
+            noc.async_write(
+                CoreLocalMem<uint32_t>(l1_addr),
+                tensor,
+                write_size,
+                {},
+                {.page_id = sharded_dest_id, .offset_bytes = sharded_offset});
+            sharded_dest_id++;
+            sharded_offset = 0;
+            l1_addr += write_size;
+        }
+    }
+}
+
+template <typename AddrGenType>
 FORCE_INLINE void noc_async_read_sharded(
     uint32_t l1_addr, AddrGenType tensor, uint32_t src_id, uint32_t offset, uint32_t size) {
     if constexpr (AddrGenType::DSpec::is_interleaved) {
@@ -247,6 +360,39 @@ FORCE_INLINE void noc_async_read_sharded(
             uint64_t src_noc_addr = tensor.get_noc_addr(sharded_src_id, sharded_offset);
             uint32_t read_size = std::min(size - i * page_size, page_size - sharded_offset);
             noc_async_read(src_noc_addr, l1_addr, read_size);
+            sharded_src_id++;
+            sharded_offset = 0;
+            l1_addr += read_size;
+        }
+    }
+}
+
+template <typename AddrGenType>
+FORCE_INLINE void noc_async_read_sharded(
+    Noc noc, uint32_t l1_addr, AddrGenType tensor, uint32_t src_id, uint32_t offset, uint32_t size) {
+    if constexpr (AddrGenType::DSpec::is_interleaved) {
+        noc.async_read(tensor, CoreLocalMem<uint32_t>(l1_addr), size, {.page_id = src_id, .offset_bytes = offset}, {});
+    } else {
+        const auto& dspec = tensor.dspec();
+        const uint32_t r = dspec.rank();
+        const uint32_t pages_per_row = (r > 1) ? dspec.tensor_shape()[r - 1] : 1u;
+        if (pages_per_row <= 1) {
+            noc.async_read(
+                tensor, CoreLocalMem<uint32_t>(l1_addr), size, {.page_id = src_id, .offset_bytes = offset}, {});
+            return;
+        }
+        const uint32_t page_size = tensor.get_aligned_page_size();
+        uint32_t sharded_src_id = src_id * pages_per_row + offset / page_size;
+        uint32_t sharded_offset = offset % page_size;
+        uint32_t num_pages = div_up(size + sharded_offset, page_size);
+        for (uint32_t i = 0; i < num_pages; i++) {
+            uint32_t read_size = std::min(size - i * page_size, page_size - sharded_offset);
+            noc.async_read(
+                tensor,
+                CoreLocalMem<uint32_t>(l1_addr),
+                read_size,
+                {.page_id = sharded_src_id, .offset_bytes = sharded_offset},
+                {});
             sharded_src_id++;
             sharded_offset = 0;
             l1_addr += read_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/redistribute_pages_row_major_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/copy/device/kernels/redistribute_pages_row_major_reader.cpp
@@ -106,6 +106,7 @@ void kernel_main() {
                 uint32_t l1_output_subblock_write_addr =
                     cb_in1.get_write_ptr();  // write the output subblock to the output cb
                 tt::data_movement::common::tt_memmove<false, false, true, 0>(
+                    noc,
                     l1_output_subblock_write_addr + l1_output_subblock_write_addr_offset,
                     input_l1_write_addr + l1_input_subblock_read_addr_offset,
                     bytes_to_write_to_output_subblock);
@@ -159,6 +160,7 @@ void kernel_main() {
                 uint32_t l1_output_subblock_write_addr =
                     cb_in1.get_write_ptr();  // Write the output subblock to the output cb
                 tt::data_movement::common::tt_memmove<false, false, true, 0>(
+                    noc,
                     l1_output_subblock_write_addr + l1_output_subblock_write_addr_offset,
                     input_l1_write_addr + l1_input_subblock_read_addr_offset,
                     bytes_to_write_to_output_subblock);

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/compute/fill_pad_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/device/kernels/compute/fill_pad_compute.cpp
@@ -7,22 +7,24 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/fill.h"
 #include "api/compute/eltwise_unary/where.h"
+#include "api/dataflow/circular_buffer.h"
 
-ALWI void process_masked_tile(uint32_t cb_data_in, uint32_t cb_mask, uint32_t cb_data_out, uint32_t fill_bits) {
+ALWI void process_masked_tile(
+    CircularBuffer& cb_data_in, CircularBuffer& cb_mask, CircularBuffer& cb_data_out, uint32_t fill_bits) {
     constexpr uint32_t CB_DATA_IN = 0;
     constexpr uint32_t CB_DATA_PADDING = 1;
     constexpr uint32_t CB_MASK = 2;
     constexpr uint32_t CB_OUT = 2;  // reuse CB_MASK tile
 
-    cb_wait_front(cb_data_in, 1);
-    cb_reserve_back(cb_data_out, 1);
+    cb_data_in.wait_front(1);
+    cb_data_out.reserve_back(1);
     tile_regs_acquire();
 
-    copy_tile_to_dst_init_short(cb_data_in);
-    copy_tile(cb_data_in, 0, CB_DATA_IN);  // data → DST[0]
+    copy_tile_to_dst_init_short(cb_data_in.get_cb_id());
+    copy_tile(cb_data_in.get_cb_id(), 0, CB_DATA_IN);  // data → DST[0]
 
-    copy_tile_to_dst_init_short(cb_mask);
-    copy_tile(cb_mask, 0, CB_MASK);  // mask → DST[2]
+    copy_tile_to_dst_init_short(cb_mask.get_cb_id());
+    copy_tile(cb_mask.get_cb_id(), 0, CB_MASK);  // mask → DST[2]
 
     fill_tile_init();
     FILL_PAD_FILL_FN(CB_DATA_PADDING, FILL_PAD_FILL_ARG);  // fill → DST
@@ -32,34 +34,38 @@ ALWI void process_masked_tile(uint32_t cb_data_in, uint32_t cb_mask, uint32_t cb
 
     tile_regs_commit();
     tile_regs_wait();
-    pack_tile(CB_OUT, cb_data_out);  // result is at DST[2]
+    pack_tile(CB_OUT, cb_data_out.get_cb_id());  // result is at DST[2]
     tile_regs_release();
 
-    cb_pop_front(cb_data_in, 1);
-    cb_push_back(cb_data_out, 1);
+    cb_data_in.pop_front(1);
+    cb_data_out.push_back(1);
 }
 
 // Corner tile: two sequential where_tile calls give (right_mask OR bot_mask) → fill.
 ALWI void process_corner_tile(
-    uint32_t cb_data_in, uint32_t cb_right_mask, uint32_t cb_bot_mask, uint32_t cb_data_out, uint32_t fill_bits) {
+    CircularBuffer& cb_data_in,
+    CircularBuffer& cb_right_mask,
+    CircularBuffer& cb_bot_mask,
+    CircularBuffer& cb_data_out,
+    uint32_t fill_bits) {
     constexpr uint32_t CB_DATA_IN = 0;
     constexpr uint32_t CB_DATA_PADDING = 1;
     constexpr uint32_t CB_RIGHT_MASK = 2;
     constexpr uint32_t CB_BOTTOM_MASK = 3;
     constexpr uint32_t CB_OUT = 3;  // reuse CB_MASK tile
 
-    cb_wait_front(cb_data_in, 1);
-    cb_reserve_back(cb_data_out, 1);
+    cb_data_in.wait_front(1);
+    cb_data_out.reserve_back(1);
     tile_regs_acquire();
 
-    copy_tile_to_dst_init_short(cb_data_in);
-    copy_tile(cb_data_in, 0, CB_DATA_IN);  // data       → DST[0]
+    copy_tile_to_dst_init_short(cb_data_in.get_cb_id());
+    copy_tile(cb_data_in.get_cb_id(), 0, CB_DATA_IN);  // data       → DST[0]
 
-    copy_tile_to_dst_init_short(cb_right_mask);
-    copy_tile(cb_right_mask, 0, CB_RIGHT_MASK);  // right_mask → DST[2]
+    copy_tile_to_dst_init_short(cb_right_mask.get_cb_id());
+    copy_tile(cb_right_mask.get_cb_id(), 0, CB_RIGHT_MASK);  // right_mask → DST[2]
 
-    copy_tile_to_dst_init_short(cb_bot_mask);
-    copy_tile(cb_bot_mask, 0, CB_BOTTOM_MASK);  // bot_mask   → DST[3]
+    copy_tile_to_dst_init_short(cb_bot_mask.get_cb_id());
+    copy_tile(cb_bot_mask.get_cb_id(), 0, CB_BOTTOM_MASK);  // bot_mask   → DST[3]
 
     fill_tile_init();
     FILL_PAD_FILL_FN(CB_DATA_PADDING, FILL_PAD_FILL_ARG);  // fill → DST[1]
@@ -73,11 +79,11 @@ ALWI void process_corner_tile(
 
     tile_regs_commit();
     tile_regs_wait();
-    pack_tile(CB_OUT, cb_data_out);  // final result is at DST[3]
+    pack_tile(CB_OUT, cb_data_out.get_cb_id());  // final result is at DST[3]
     tile_regs_release();
 
-    cb_pop_front(cb_data_in, 1);
-    cb_push_back(cb_data_out, 1);
+    cb_data_in.pop_front(1);
+    cb_data_out.push_back(1);
 }
 
 void kernel_main() {
@@ -87,10 +93,10 @@ void kernel_main() {
     constexpr uint32_t has_bottom_pad = get_compile_time_arg_val(3);
     constexpr uint32_t elem_size = get_compile_time_arg_val(4);
     constexpr uint32_t fill_bits_ct = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_data_in = get_compile_time_arg_val(6);
-    constexpr uint32_t cb_right_mask = get_compile_time_arg_val(7);
-    constexpr uint32_t cb_bot_mask = get_compile_time_arg_val(8);
-    constexpr uint32_t cb_data_out = get_compile_time_arg_val(9);
+    constexpr uint32_t cb_data_in_id = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_right_mask_id = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_bot_mask_id = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_data_out_id = get_compile_time_arg_val(9);
 
     // Per-phase tile counts. Phases with num == 0 are skipped. When the
     // corresponding global has_*_pad CT is 0 the host always sets num to 0,
@@ -103,16 +109,21 @@ void kernel_main() {
         return;
     }
 
+    CircularBuffer cb_data_in(cb_data_in_id);
+    CircularBuffer cb_right_mask(cb_right_mask_id);
+    CircularBuffer cb_bot_mask(cb_bot_mask_id);
+    CircularBuffer cb_data_out(cb_data_out_id);
+
     // Standard init for unary-style SFPU compute with one primary input CB.
-    unary_op_init_common(cb_data_in, cb_data_out);
+    unary_op_init_common(cb_data_in_id, cb_data_out_id);
 
     // Wait for persistent mask tiles pushed once by the writer. They are popped
     // once at cleanup; during the main loop they are reused persistently.
     if constexpr (has_right_pad) {
-        cb_wait_front(cb_right_mask, 1);
+        cb_right_mask.wait_front(1);
     }
     if constexpr (has_bottom_pad) {
-        cb_wait_front(cb_bot_mask, 1);
+        cb_bot_mask.wait_front(1);
     }
 
     // ---- Main loop: same tile ordering as reader and writer (right/bottom/corner) ----
@@ -135,9 +146,9 @@ void kernel_main() {
 
     // Clean-up
     if constexpr (has_right_pad) {
-        cb_pop_front(cb_right_mask, 1);
+        cb_right_mask.pop_front(1);
     }
     if constexpr (has_bottom_pad) {
-        cb_pop_front(cb_bot_mask, 1);
+        cb_bot_mask.pop_front(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/indexed_fill/device/kernels/dataflow/indexed_fill_writer.cpp
@@ -10,16 +10,19 @@
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     uint32_t batch_size_in_pages = get_arg_val<uint32_t>(0);
 
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
+    constexpr uint32_t cb_in0_id = get_compile_time_arg_val(0);
 
     if (batch_size_in_pages == 0) {
         return;
     }
 
-    cb_wait_front(cb_id_in0, batch_size_in_pages);
-    cb_pop_front(cb_id_in0, batch_size_in_pages);
+    CircularBuffer cb_in0(cb_in0_id);
+
+    cb_in0.wait_front(batch_size_in_pages);
+    cb_in0.pop_front(batch_size_in_pages);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_expert_token_remap/device/kernels/dataflow/writer_moe_expert_token_remap.cpp
@@ -81,7 +81,7 @@ void kernel_main() {
                 const uint32_t topk_l1_addr = data_cb.get_read_ptr() + expert_idx * datum_size_bytes;
                 const uint32_t output_l1_element_addr = output_l1_addr + e * datum_size_bytes;
                 tt::data_movement::common::tt_memmove<false, false, false, datum_size_bytes>(
-                    output_l1_element_addr, topk_l1_addr, datum_size_bytes);
+                    noc, output_l1_element_addr, topk_l1_addr, datum_size_bytes);
 
                 reduced_l1_ptr[e] = 1;
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/kernels/dataflow/writer_moe_routing_remap.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/moe_routing_remap/device/kernels/dataflow/writer_moe_routing_remap.cpp
@@ -49,7 +49,7 @@ void kernel_main() {
     for (uint32_t i = 0; i < num_non_zero_per_device; ++i) {
         const uint32_t offset = local_weights_idxs_ptr[i] * weight_datum_size_bytes;
         tt_memmove<false, false, false, weight_datum_size_bytes>(
-            local_weights_l1_addr + offset, routing_weights_addr + offset, weight_datum_size_bytes);
+            noc, local_weights_l1_addr + offset, routing_weights_addr + offset, weight_datum_size_bytes);
     }
     noc.async_write_barrier();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_blocked_generic.cpp
@@ -115,7 +115,7 @@ void kernel_main() {
         for (uint32_t x = x_start; x < x_end; ++x) {
             uint64_t addr_offset = base_addr_offset + x * X_stride;
             tt::data_movement::common::noc_async_read_sharded(
-                src_buffer_l1_addr + page_offset, s0, addr_offset, w_offset, w_read_size_bytes);
+                noc, src_buffer_l1_addr + page_offset, s0, addr_offset, w_offset, w_read_size_bytes);
 
             // Advance output pointer by one page size for next row
             page_offset += input_cb_page_size;

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_rm_row_invariant.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
     for (uint32_t row = start_row; row < end_row; ++row) {
         cb.reserve_back(1);
         uint32_t l1_write_addr = cb.get_write_ptr();
-        tt::data_movement::common::noc_async_read_sharded(l1_write_addr, s0, row, 0, page_size);
+        tt::data_movement::common::noc_async_read_sharded(noc, l1_write_addr, s0, row, 0, page_size);
         noc.async_read_barrier();
         cb.push_back(1);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/reader_permute_interleaved_tiled_generic.cpp
@@ -216,7 +216,7 @@ void kernel_main() {
                                 {.offset_bytes = 0});
                             noc.async_read_barrier();
                             tt::data_movement::common::tt_memmove<true, false, false, SUBTILE_LINE_BYTES>(
-                                l1_base, misaligned_addr, SUBTILE_LINE_BYTES);
+                                noc, l1_base, misaligned_addr, SUBTILE_LINE_BYTES);
                         } else {
                             CoreLocalMem<uint32_t> dst(l1_col_base + cb_w_offset);
                             noc.async_read(

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_blocked_generic.cpp
@@ -156,7 +156,7 @@ void kernel_main() {
 
             uint32_t l1_addr = transposed_buffer_read_addr + (w - w_start) * output_cb_page_size;
             tt::data_movement::common::noc_async_write_sharded(
-                l1_addr, s0, dest_linear_idx, x_offset, x_read_size_bytes);
+                noc, l1_addr, s0, dest_linear_idx, x_offset, x_read_size_bytes);
         }
 
         // Wait until all writes are completed before proceeding to the next block

--- a/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/permute/device/kernels/dataflow/writer_permute_interleaved_rm_row_invariant.cpp
@@ -56,7 +56,7 @@ void kernel_main() {
         }
         cb.wait_front(1);
         uint32_t l1_read_addr = cb.get_read_ptr();
-        tt::data_movement::common::noc_async_write_sharded(l1_read_addr, s0, dest_linear_idx, 0, page_size);
+        tt::data_movement::common::noc_async_write_sharded(noc, l1_read_addr, s0, dest_linear_idx, 0, page_size);
         noc.async_write_barrier();
         cb.pop_front(1);
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm.cpp
@@ -106,6 +106,7 @@ void kernel_main() {
                             alignment_buffer +
                             (dst_noc_addr & w_offset_to_use);  // Guaranteed aligned to target page addr
                         tt_memmove<false, false, false, original_page_size_bytes>(
+                            noc,
                             target_align_buffer,
                             data_location,
                             original_page_size_bytes);  // Data is copied to align buffer

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm.cpp
@@ -102,7 +102,7 @@ void kernel_main() {
             for (uint32_t j = 0; j < num_doublings; j++) {
                 // This ensures the cur_page_size will be aligned to 16B so future walk retains alignment
                 tt_memmove<false, false, false, 16 * original_page_size_bytes>(
-                    data_location + target_offset, data_location, cur_page_size);
+                    noc, data_location + target_offset, data_location, cur_page_size);
                 target_offset += cur_page_size;
                 cur_page_size *= 2;
             }
@@ -112,7 +112,7 @@ void kernel_main() {
         if ((data_location & w_offset_to_use) != (dst_noc_addr & w_offset_to_use)) {
             // Can't directly copy due to alignment
             tt_memmove<false, false, false, 16 * original_page_size_bytes>(
-                alignment_buffer + (dst_noc_addr & w_offset_to_use), data_location, cur_page_size);
+                noc, alignment_buffer + (dst_noc_addr & w_offset_to_use), data_location, cur_page_size);
             data_location = alignment_buffer + (dst_noc_addr & w_offset_to_use);
         }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/reader_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/reader_reshape_tiled.cpp
@@ -5,6 +5,7 @@
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/operations/data_movement/reshape_view/device/hostdevcommon/common.hpp"
@@ -34,12 +35,13 @@ void kernel_main() {
     const auto input_addr_gen = TensorAccessor(input_args, input_addr);
     const auto map_addr_gen = TensorAccessor(map_args, map_addr);
 
+    Noc noc;
     bool first = true;
     for (uint32_t out_page_idx = start_output_page_idx; out_page_idx < end_output_page_idx; ++out_page_idx) {
         cb_reserve_back(mapping_cb_id, One_Tile_Reserve);
         const uint64_t map_noc_addr = map_addr_gen.get_noc_addr(out_page_idx);
         const uint32_t map_addr = get_write_ptr(mapping_cb_id);
-        enhanced_noc_async_read<Max_Map_Size_Bytes, true>(map_noc_addr, map_addr, Max_Map_Size_Bytes);
+        enhanced_noc_async_read<Max_Map_Size_Bytes, true>(noc, map_noc_addr, map_addr, Max_Map_Size_Bytes);
         noc_async_read_barrier();
         cb_push_back(mapping_cb_id, 1);
 
@@ -63,7 +65,7 @@ void kernel_main() {
             cb_reserve_back(input_cb_id, One_Tile_Reserve);
             const uint32_t input_write_addr = get_write_ptr(input_cb_id);
             const uint64_t input_page_noc_addr = input_addr_gen.get_noc_addr(input_page_idx);
-            enhanced_noc_async_read<Tile_Size_Bytes, true>(input_page_noc_addr, input_write_addr, Tile_Size_Bytes);
+            enhanced_noc_async_read<Tile_Size_Bytes, true>(noc, input_page_noc_addr, input_write_addr, Tile_Size_Bytes);
             previous_input_page_idx = input_page_idx;
             noc_async_read_barrier();
             cb_push_back(input_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/dataflow/writer_reshape_tiled.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "ttnn/operations/data_movement/reshape_view/device/hostdevcommon/common.hpp"
@@ -27,6 +28,7 @@ void kernel_main() {
 
     const auto output_addrgen = TensorAccessor(output_args, output_base_addr);
 
+    Noc noc;
     // loop over output (reshaped) pages this core is responsible for
     bool first = true;
     cb_reserve_back(cb_id_working, 1);
@@ -62,12 +64,12 @@ void kernel_main() {
             const uint32_t output_addr = working_write_addr + map_ptr[seg_idx].output_page_offset * element_sz_bytes;
             const uint32_t input_addr = input_base_addr + map_ptr[seg_idx].input_page_offset * element_sz_bytes;
             const uint32_t szbytes = map_ptr[seg_idx].num_elements * element_sz_bytes;
-            tt_memmove<false, true, false, Tile_size_bytes>(output_addr, input_addr, szbytes);
+            tt_memmove<false, true, false, Tile_size_bytes>(noc, output_addr, input_addr, szbytes);
         }
         noc_async_write_barrier();
 
         const uint64_t output_noc_addr = output_addrgen.get_noc_addr(output_page_idx);
-        enhanced_noc_async_write<Tile_size_bytes, true>(working_write_addr, output_noc_addr, Tile_size_bytes);
+        enhanced_noc_async_write<Tile_size_bytes, true>(noc, working_write_addr, output_noc_addr, Tile_size_bytes);
         noc_async_write_barrier();
 
         cb_pop_front(cb_id_mapping, 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_view/device/device/rm_reshape_interleaved.cpp
@@ -28,6 +28,7 @@ Runtime arguments
 */
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
 #include "api/debug/dprint.h"  // required in all kernels using DPRINT
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 
@@ -62,6 +63,7 @@ void kernel_main() {
     const auto s = TensorAccessor(src_args, src_addr);
     const auto d = TensorAccessor(dst_args, dst_addr);
 
+    Noc noc;
     uint32_t read_offset = 0;
     uint32_t write_page = write_start_page;
     uint32_t readable = 0;
@@ -89,15 +91,15 @@ void kernel_main() {
         if constexpr (src_aligned_to_64 || ((!src_args.is_dram) && src_aligned_to_16)) {  // Aligned to 64 bytes or 16
                                                                                           // bytes but L1
             tt::data_movement::common::enhanced_noc_async_read<source_page_size_bytes, false>(
-                src_noc_addr, source_buffer, source_page_size_bytes);
+                noc, src_noc_addr, source_buffer, source_page_size_bytes);
             read_offset = 0;
         } else if constexpr (src_args.is_dram) {  // DDR but not aligned to 64 (potentially also not aligned to 16)
             tt::data_movement::common::enhanced_noc_async_read<(source_page_size_bytes + 128), false>(
-                src_noc_addr & MASK_64, source_buffer, source_read_size_bytes);
+                noc, src_noc_addr & MASK_64, source_buffer, source_read_size_bytes);
             read_offset = src_noc_addr & OFFSET_64;
         } else {  // L1 but not aligned to 16
             tt::data_movement::common::enhanced_noc_async_read<(source_page_size_bytes + 128), false>(
-                src_noc_addr & MASK_16, source_buffer, source_read_size_bytes);
+                noc, src_noc_addr & MASK_16, source_buffer, source_read_size_bytes);
             read_offset = src_noc_addr & OFFSET_16;
         }
 
@@ -112,14 +114,14 @@ void kernel_main() {
             {
                 if constexpr (can_be_clean) {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                        source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, readable);
+                        noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, readable);
                     dst_noc_addr_offset = dst_noc_addr_offset + readable;
                 } else {
                     tt::data_movement::common::tt_memmove<false, true, false, dest_page_size_bytes>(
-                        dest_buffer + write_offset, source_buffer + read_offset, readable);
+                        noc, dest_buffer + write_offset, source_buffer + read_offset, readable);
                     if (i == read_end_page - 1) {
                         tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                            dest_buffer + begin_write_offset, dst_noc_addr, end_to_write);
+                            noc, dest_buffer + begin_write_offset, dst_noc_addr, end_to_write);
                         noc_async_write_barrier();
                         return;
                     }
@@ -134,12 +136,12 @@ void kernel_main() {
             {
                 if constexpr (can_be_clean) {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                        source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, readable);
+                        noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, readable);
                 } else {
                     tt::data_movement::common::tt_memmove<false, false, false, dest_page_size_bytes>(
-                        dest_buffer + write_offset, source_buffer + read_offset, readable);
+                        noc, dest_buffer + write_offset, source_buffer + read_offset, readable);
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                        dest_buffer + begin_write_offset, dst_noc_addr, dest_page_size_bytes);
+                        noc, dest_buffer + begin_write_offset, dst_noc_addr, dest_page_size_bytes);
                 }
                 dst_noc_addr_offset = 0;
 
@@ -161,12 +163,12 @@ void kernel_main() {
             {
                 if constexpr (can_be_clean) {
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                        source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, writable);
+                        noc, source_buffer + read_offset, dst_noc_addr + dst_noc_addr_offset, writable);
                 } else {
                     tt::data_movement::common::tt_memmove<false, false, false, dest_page_size_bytes>(
-                        dest_buffer + write_offset, source_buffer + read_offset, writable);
+                        noc, dest_buffer + write_offset, source_buffer + read_offset, writable);
                     tt::data_movement::common::enhanced_noc_async_write<dest_page_size_bytes, false>(
-                        dest_buffer + begin_write_offset, dst_noc_addr, dest_page_size_bytes);
+                        noc, dest_buffer + begin_write_offset, dst_noc_addr, dest_page_size_bytes);
                 }
                 // writable < readable
                 readable = readable - writable;

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/common.hpp
@@ -7,6 +7,8 @@
 
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 
 constexpr uint32_t ONE_PAGE = 1;
 
@@ -119,6 +121,7 @@ std::array<uint32_t, N> make_shape_array_from_runtime_args(const uint32_t& C) {
 // this function is supposed to load either a whole stick or part of it
 template <typename AddrGen>
 FORCE_INLINE void load_to_cb(
+    Noc noc,
     const uint32_t& cb,
     const AddrGen& addr_gtor,
     const uint32_t& offset_bytes,
@@ -126,12 +129,18 @@ FORCE_INLINE void load_to_cb(
     const uint32_t& stick_id) {
     CircularBuffer cb_exp(cb);
     cb_exp.reserve_back(ONE_PAGE);
-    const uint64_t source_noc_address = addr_gtor.get_noc_addr(stick_id);
+    const uint64_t source_noc_address = addr_gtor.get_noc_addr(stick_id) + offset_bytes;
     const uint32_t l1_write_address = cb_exp.get_write_ptr();
 
-    // Use legacy NOC API for raw address reads
-    noc_async_read(source_noc_address + offset_bytes, l1_write_address, chunk_size_bytes);
-    noc_async_read_barrier();
+    noc.async_read(
+        UnicastEndpoint{},
+        CoreLocalMem<uint32_t>(l1_write_address),
+        chunk_size_bytes,
+        {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(source_noc_address),
+         .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(source_noc_address),
+         .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(source_noc_address)},
+        {.offset_bytes = 0});
+    noc.async_read_barrier();
 
     cb_exp.push_back(ONE_PAGE);
 }
@@ -139,6 +148,7 @@ FORCE_INLINE void load_to_cb(
 // this function is supposed to write either a whole stick or part of it (76800 elements)
 template <typename AddrGen>
 FORCE_INLINE void write_to_output(
+    Noc noc,
     const uint32_t& cb,
     const AddrGen& addr_gtor,
     const uint32_t& offset_bytes,
@@ -146,12 +156,18 @@ FORCE_INLINE void write_to_output(
     const uint32_t& stick_id) {
     CircularBuffer cb_exp(cb);
     cb_exp.wait_front(ONE_PAGE);
-    const uint64_t destination_noc_address = addr_gtor.get_noc_addr(stick_id);
+    const uint64_t destination_noc_address = addr_gtor.get_noc_addr(stick_id) + offset_bytes;
     const uint32_t l1_read_address = cb_exp.get_read_ptr();
 
-    // Use legacy NOC API for raw address writes
-    noc_async_write(l1_read_address, destination_noc_address + offset_bytes, chunk_size_bytes);
-    noc_async_write_barrier();
+    noc.async_write(
+        CoreLocalMem<uint32_t>(l1_read_address),
+        UnicastEndpoint{},
+        chunk_size_bytes,
+        {.offset_bytes = 0},
+        {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(destination_noc_address),
+         .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(destination_noc_address),
+         .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(destination_noc_address)});
+    noc.async_write_barrier();
 
     cb_exp.pop_front(ONE_PAGE);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_bf16_reduction_scatter.cpp
@@ -110,6 +110,7 @@ FORCE_INLINE void copy_fp32_temp_to_output(uint32_t fp32_temp_cb, uint32_t outpu
 }  // namespace
 
 void kernel_main() {
+    Noc noc;
     constexpr auto ctas{get_ctas()};
 
     const uint32_t input_buffer_address = get_arg_val<uint32_t>(0);
@@ -157,6 +158,7 @@ void kernel_main() {
 
             // first phase: copy input data to output
             load_to_cb(
+                noc,
                 ctas.input_cb,
                 input_addr_gtor,
                 input_offset * sizeof(input_std_type),
@@ -179,6 +181,7 @@ void kernel_main() {
                         std::min(ctas.source_stick_size - source_offset, source_chunk_size);
 
                     load_to_cb(
+                        noc,
                         ctas.index_cb,
                         index_addr_gtor,
                         index_offset * sizeof(index_std_type),
@@ -187,6 +190,7 @@ void kernel_main() {
                     // source tensor is sliced beforehand to match index tensor's dimensions, therefore their stick ids
                     // map 1:1
                     load_to_cb(
+                        noc,
                         ctas.source_cb,
                         source_addr_gtor,
                         source_offset * sizeof(input_std_type),

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/reader_scatter.cpp
@@ -97,6 +97,7 @@ FORCE_INLINE void scatter_along_chunk(
 }  // namespace
 
 void kernel_main() {
+    Noc noc;
     constexpr auto ctas{get_ctas()};
 
     const uint32_t input_buffer_address = get_arg_val<uint32_t>(0);
@@ -143,6 +144,7 @@ void kernel_main() {
 
             // first phase: copy input data to output
             load_to_cb(
+                noc,
                 ctas.input_cb,
                 input_addr_gtor,
                 input_offset * sizeof(input_std_type),
@@ -165,6 +167,7 @@ void kernel_main() {
                         std::min(ctas.source_stick_size - source_offset, source_chunk_size);
 
                     load_to_cb(
+                        noc,
                         ctas.index_cb,
                         index_addr_gtor,
                         index_offset * sizeof(index_std_type),
@@ -173,6 +176,7 @@ void kernel_main() {
                     // source tensor is sliced beforehand to match index tensor's dimensions, therefore their stick ids
                     // map 1:1
                     load_to_cb(
+                        noc,
                         ctas.source_cb,
                         source_addr_gtor,
                         source_offset * sizeof(input_std_type),

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/writer_bf16_reduction_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/writer_bf16_reduction_scatter.cpp
@@ -7,6 +7,7 @@
 #include "../scatter_bf16_reduction_common.hpp"
 
 void kernel_main() {
+    Noc noc;
     constexpr auto ctas{get_ctas()};
 
     const uint32_t output_buffer_address = get_arg_val<uint32_t>(0);
@@ -25,7 +26,7 @@ void kernel_main() {
              offset_bytes += input_and_output_chunk_size * sizeof(output_std_type)) {
             const uint32_t chunk_write_bytes = std::min(
                 ctas.output_stick_size_bytes - offset_bytes, input_and_output_chunk_size * sizeof(output_std_type));
-            write_to_output(ctas.output_cb, output_addr_gtor, offset_bytes, chunk_write_bytes, stick_id);
+            write_to_output(noc, ctas.output_cb, output_addr_gtor, offset_bytes, chunk_write_bytes, stick_id);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/writer_scatter.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/scatter/device/kernels/dataflow/writer_scatter.cpp
@@ -7,6 +7,7 @@
 #include "../scatter_common.hpp"
 
 void kernel_main() {
+    Noc noc;
     constexpr auto ctas{get_ctas()};
 
     const uint32_t output_buffer_address = get_arg_val<uint32_t>(0);
@@ -25,7 +26,7 @@ void kernel_main() {
              offset_bytes += input_and_output_chunk_size * sizeof(output_std_type)) {
             const uint32_t chunk_write_bytes = std::min(
                 ctas.output_stick_size_bytes - offset_bytes, input_and_output_chunk_size * sizeof(output_std_type));
-            write_to_output(ctas.output_cb, output_addr_gtor, offset_bytes, chunk_write_bytes, stick_id);
+            write_to_output(noc, ctas.output_cb, output_addr_gtor, offset_bytes, chunk_write_bytes, stick_id);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d.cpp
@@ -155,7 +155,7 @@ void kernel_main() {
                 // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
                 // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.
                 tt::data_movement::common::noc_async_read_sharded(
-                    l1_write_addr, s0, input_row_idx, /*offset=*/0, /*size=*/input_bytes_per_row);
+                    noc, l1_write_addr, s0, input_row_idx, /*offset=*/0, /*size=*/input_bytes_per_row);
                 noc.async_read_barrier();
 
                 // Now slice the row according to width slice parameters

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd.cpp
@@ -140,7 +140,7 @@ void kernel_main() {
             // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
             // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.
             tt::data_movement::common::noc_async_read_sharded(
-                l1_write_addr, s0, input_row_idx, /*offset=*/0, /*size=*/input_bytes_per_row);
+                noc, l1_write_addr, s0, input_row_idx, /*offset=*/0, /*size=*/input_bytes_per_row);
             noc.async_read_barrier();
 
             // Now slice the row according to width slice parameters (last dimension)

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp
@@ -50,11 +50,11 @@ void kernel_main() {
             // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
             // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.
             tt::data_movement::common::noc_async_read_sharded(
-                src_buffer_l1_addr, s0, src_stick_id, /*offset=*/0, /*size=*/read_size);
+                noc, src_buffer_l1_addr, s0, src_stick_id, /*offset=*/0, /*size=*/read_size);
             if (misalignment != 0) {
                 noc.async_read_barrier();
                 tt::data_movement::common::tt_memmove<false, false, false, 0>(
-                    src_buffer_l1_addr, src_buffer_l1_addr + misalignment, unpadded_stick_size);
+                    noc, src_buffer_l1_addr, src_buffer_l1_addr + misalignment, unpadded_stick_size);
             }
             src_buffer_l1_addr += stick_size_offset;
             src_stick_id++;

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_writer_unary_stick_layout_interleaved_start_id.cpp
@@ -41,7 +41,7 @@ void kernel_main() {
             // noc_async_write_sharded splits the write across shards for B/W-sharded outputs;
             // falls through to a single noc_async_write for interleaved / HEIGHT-sharded.
             tt::data_movement::common::noc_async_write_sharded(
-                l1_read_addr, s0, i_stick, /*offset=*/0, /*size=*/stick_size);
+                noc, l1_read_addr, s0, i_stick, /*offset=*/0, /*size=*/stick_size);
             l1_read_addr += stick_size_offset;
             i_stick += 1;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d.cpp
@@ -87,7 +87,7 @@ void kernel_main() {
         // noc_async_write_sharded splits the write across shards for B/W-sharded outputs;
         // falls through to a single noc_async_write for interleaved / HEIGHT-sharded.
         tt::data_movement::common::noc_async_write_sharded(
-            l1_read_addr, s0, global_output_row, /*offset=*/0, /*size=*/output_bytes_per_row);
+            noc, l1_read_addr, s0, global_output_row, /*offset=*/0, /*size=*/output_bytes_per_row);
         noc.async_writes_flushed();
 
         cb_in.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd.cpp
@@ -94,7 +94,7 @@ void kernel_main() {
         // noc_async_write_sharded splits the write across shards for B/W-sharded outputs;
         // falls through to a single noc_async_write for interleaved / HEIGHT-sharded.
         tt::data_movement::common::noc_async_write_sharded(
-            l1_read_addr, s0, global_output_row, /*offset=*/0, /*size=*/output_bytes_per_row);
+            noc, l1_read_addr, s0, global_output_row, /*offset=*/0, /*size=*/output_bytes_per_row);
         noc.async_writes_flushed();
 
         cb_in.pop_front(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_common.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include "api/dataflow/circular_buffer.h"
+
 /**
  * @brief Sorts Wt tiles from row-major order into a bitonic sequence using local sorting and transposition.
  *
@@ -12,10 +14,10 @@
  * and transposed tiles into output buffers. The sorting direction can be switched
  * between pairs to facilitate bitonic merge sort.
  *
- * @param input_cb_index Index of the input circular buffer containing value tiles.
- * @param index_cb_index Index of the input circular buffer containing index tiles.
- * @param input_transposed_cb_index Index of the output circular buffer for transposed value tiles.
- * @param index_transposed_cb_index Index of the output circular buffer for transposed index tiles.
+ * @param input_cb Input circular buffer containing value tiles.
+ * @param index_cb Input circular buffer containing index tiles.
+ * @param input_transposed_cb Output circular buffer for transposed value tiles.
+ * @param index_transposed_cb Output circular buffer for transposed index tiles.
  * @param Wt Number of tiles to process (should be even).
  * @param switch_dir If true, alternates the sorting direction for each tile pair to build a bitonic sequence.
  * @param ascending Initial sorting direction: true for ascending, false for descending.
@@ -26,34 +28,34 @@
  * tiles in pairs, and pushes the results to the output buffers upon completion.
  */
 void sort_Wt_tiles_row_to_bitonic_sequence(
-    const uint32_t input_cb_index,
-    const uint32_t index_cb_index,
-    const uint32_t input_transposed_cb_index,
-    const uint32_t index_transposed_cb_index,
+    CircularBuffer& input_cb,
+    CircularBuffer& index_cb,
+    CircularBuffer& input_transposed_cb,
+    CircularBuffer& index_transposed_cb,
     const uint32_t Wt,
     const bool switch_dir,
     const bool ascending,
     const int end_phase) {
-    cb_reserve_back(input_transposed_cb_index, Wt);
-    cb_reserve_back(index_transposed_cb_index, Wt);
+    input_transposed_cb.reserve_back(Wt);
+    index_transposed_cb.reserve_back(Wt);
 
     bool ascending_local = ascending;
     for (uint32_t wt = 0; wt < Wt; wt += 2) {
         tile_regs_acquire();
 
-        cb_wait_front(input_cb_index, 2);
-        cb_wait_front(index_cb_index, 2);
+        input_cb.wait_front(2);
+        index_cb.wait_front(2);
 
         // topk_local_sort sorts by columns - transpose input tiles for sorting
-        reconfig_data_format_srca(input_cb_index);
-        transpose_wh_init_short(input_cb_index);
-        transpose_wh_tile(input_cb_index, 0, 0);
-        transpose_wh_tile(input_cb_index, 1, 1);
+        reconfig_data_format_srca(input_cb.get_cb_id());
+        transpose_wh_init_short(input_cb.get_cb_id());
+        transpose_wh_tile(input_cb.get_cb_id(), 0, 0);
+        transpose_wh_tile(input_cb.get_cb_id(), 1, 1);
 
-        reconfig_data_format_srca(index_cb_index);
-        transpose_wh_init_short(index_cb_index);
-        transpose_wh_tile(index_cb_index, 0, 2);
-        transpose_wh_tile(index_cb_index, 1, 3);
+        reconfig_data_format_srca(index_cb.get_cb_id());
+        transpose_wh_init_short(index_cb.get_cb_id());
+        transpose_wh_tile(index_cb.get_cb_id(), 0, 2);
+        transpose_wh_tile(index_cb.get_cb_id(), 1, 3);
 
         // llk_topk_sort -> inplace
         ckernel::topk_local_sort(0, (int)ascending_local, end_phase);
@@ -62,16 +64,16 @@ void sort_Wt_tiles_row_to_bitonic_sequence(
         tile_regs_wait();
 
         // pack value tiles into transposed buffer
-        pack_reconfig_data_format(input_transposed_cb_index);
-        pack_tile(0, input_transposed_cb_index);
-        pack_tile(1, input_transposed_cb_index);
+        pack_reconfig_data_format(input_transposed_cb.get_cb_id());
+        pack_tile(0, input_transposed_cb.get_cb_id());
+        pack_tile(1, input_transposed_cb.get_cb_id());
 
         // pack index tiles into index transposed buffer
-        pack_reconfig_data_format(index_transposed_cb_index);
-        pack_tile(2, index_transposed_cb_index);
-        pack_tile(3, index_transposed_cb_index);
-        cb_pop_front(input_cb_index, 2);
-        cb_pop_front(index_cb_index, 2);
+        pack_reconfig_data_format(index_transposed_cb.get_cb_id());
+        pack_tile(2, index_transposed_cb.get_cb_id());
+        pack_tile(3, index_transposed_cb.get_cb_id());
+        input_cb.pop_front(2);
+        index_cb.pop_front(2);
 
         tile_regs_release();
 
@@ -79,8 +81,8 @@ void sort_Wt_tiles_row_to_bitonic_sequence(
         ascending_local = switch_dir ? !ascending_local : ascending_local;
     }
 
-    cb_push_back(input_transposed_cb_index, Wt);
-    cb_push_back(index_transposed_cb_index, Wt);
+    input_transposed_cb.push_back(Wt);
+    index_transposed_cb.push_back(Wt);
 }
 
 /**
@@ -99,37 +101,37 @@ void sort_Wt_tiles_row_to_bitonic_sequence(
  *    - Pushing the packed tile to the destination buffer.
  * 5. After processing all tiles, waits for the source buffer and pops the processed tiles.
  *
- * @param transposed_cb_index Index of the source circular buffer containing tiles to be transposed.
- * @param dest_cb_index Index of the destination circular buffer where packed tiles will be stored.
+ * @param transposed_cb Source circular buffer containing tiles to be transposed.
+ * @param dest_cb Destination circular buffer where packed tiles will be stored.
  * @param Wt Number of tiles to process (width in tiles).
  */
-void transpose_and_pack(uint32_t transposed_cb_index, uint32_t dest_cb_index, uint32_t Wt) {
+void transpose_and_pack(CircularBuffer& transposed_cb, CircularBuffer& dest_cb, uint32_t Wt) {
     constexpr uint32_t one_tile = 1;
 
     // Transpose from sorting by column to right structure
-    reconfig_data_format_srca(transposed_cb_index);
-    transpose_wh_init_short(transposed_cb_index);
-    pack_reconfig_data_format(dest_cb_index);
+    reconfig_data_format_srca(transposed_cb.get_cb_id());
+    transpose_wh_init_short(transposed_cb.get_cb_id());
+    pack_reconfig_data_format(dest_cb.get_cb_id());
 
-    cb_wait_front(transposed_cb_index, Wt);
+    transposed_cb.wait_front(Wt);
 
     for (uint32_t i = 0; i < Wt; ++i) {
         tile_regs_acquire();
 
-        cb_reserve_back(dest_cb_index, one_tile);
-        transpose_wh_tile(transposed_cb_index, i, 0);
+        dest_cb.reserve_back(one_tile);
+        transpose_wh_tile(transposed_cb.get_cb_id(), i, 0);
 
         tile_regs_commit();
         tile_regs_wait();
 
-        pack_tile(0, dest_cb_index);
-        cb_push_back(dest_cb_index, one_tile);
+        pack_tile(0, dest_cb.get_cb_id());
+        dest_cb.push_back(one_tile);
 
         tile_regs_release();
     }
 
-    cb_wait_front(transposed_cb_index, Wt);
-    cb_pop_front(transposed_cb_index, Wt);
+    transposed_cb.wait_front(Wt);
+    transposed_cb.pop_front(Wt);
 }
 
 /**
@@ -171,20 +173,20 @@ constexpr uint32_t ilog2(uint32_t n) { return 31 - __builtin_clz(n); }
  * operation has not yet finished but the packer from the next operation has already started.
  * Using this synchronization prevents data hazards and ensures correct ordering of operations.
  *
- * @param packer_unpacker_sync_cb_index The index of the circular buffer used for synchronization.
+ * @param packer_unpacker_sync_cb The circular buffer used for synchronization.
  */
 FORCE_INLINE
-void sync_packer_unpacker(uint32_t packer_unpacker_sync_cb_index) {
+void sync_packer_unpacker(CircularBuffer& packer_unpacker_sync_cb) {
     constexpr uint32_t ONE_TILE = 1;
 
     // This double sequence forces both the packer and the unpacker to wait for the other.
     // If we had a single sequence:
     //
-    // If packer_unpacker_sync_cb_index is empty
+    // If packer_unpacker_sync_cb is empty
     // - if packer is first, then it will push a tile and continue (it does not wait for the unpacker)
     // - if unpacker is first, then it will wait for packer
     //
-    // If packer_unpacker_sync_cb_index is full
+    // If packer_unpacker_sync_cb is full
     // - if packer is first, then it will wait for unpacker
     // - if unpacker is first, then it will pop a tile and continue (it does not wait for the packer)
     //
@@ -195,17 +197,17 @@ void sync_packer_unpacker(uint32_t packer_unpacker_sync_cb_index) {
     // - if unpacker is first and CB is full, then it will pop a tile and continue until second sequence where it
     // will wait because CB will be empty (it will wait for packer to push tile).
 
-    cb_reserve_back(packer_unpacker_sync_cb_index, ONE_TILE);
-    cb_push_back(packer_unpacker_sync_cb_index, ONE_TILE);
+    packer_unpacker_sync_cb.reserve_back(ONE_TILE);
+    packer_unpacker_sync_cb.push_back(ONE_TILE);
 
-    cb_wait_front(packer_unpacker_sync_cb_index, ONE_TILE);
-    cb_pop_front(packer_unpacker_sync_cb_index, ONE_TILE);
+    packer_unpacker_sync_cb.wait_front(ONE_TILE);
+    packer_unpacker_sync_cb.pop_front(ONE_TILE);
 
-    cb_reserve_back(packer_unpacker_sync_cb_index, ONE_TILE);
-    cb_push_back(packer_unpacker_sync_cb_index, ONE_TILE);
+    packer_unpacker_sync_cb.reserve_back(ONE_TILE);
+    packer_unpacker_sync_cb.push_back(ONE_TILE);
 
-    cb_wait_front(packer_unpacker_sync_cb_index, ONE_TILE);
-    cb_pop_front(packer_unpacker_sync_cb_index, ONE_TILE);
+    packer_unpacker_sync_cb.wait_front(ONE_TILE);
+    packer_unpacker_sync_cb.pop_front(ONE_TILE);
 }
 
 /**
@@ -217,16 +219,16 @@ void sync_packer_unpacker(uint32_t packer_unpacker_sync_cb_index) {
  * for the destination CB and releases the tile registers after the operation.
  *
  * @param last_used_cb_index Last used global circular buffer index.
- * @param src_cb_index Index of the source circular buffer from which tile will be copied.
+ * @param src_cb Source circular buffer from which tile will be copied.
  * @param src_tile_id Index of the tile in the circular buffer.
- * @param dst_cb_index Index of the destination circular buffer to which tile will be copied.
+ * @param dst_cb Destination circular buffer to which tile will be copied.
  * @param dst_tile_id Index of the tile in the destination circular buffer.
  */
 void copy_tile_between_cbs(
     uint32_t& last_used_cb_index,
-    uint32_t src_cb_index,
+    CircularBuffer& src_cb,
     uint32_t src_tile_id,
-    uint32_t dst_cb_index,
+    CircularBuffer& dst_cb,
     uint32_t dst_tile_id = 0) {
     // Constants
     constexpr uint32_t dest_idx = 0;
@@ -236,18 +238,18 @@ void copy_tile_between_cbs(
     tile_regs_acquire();
 
     // Copy tile to DST register
-    copy_tile_to_dst_init_with_cb_update(src_cb_index, last_used_cb_index);
-    copy_tile(src_cb_index, src_tile_id, dest_idx);
+    copy_tile_to_dst_init_with_cb_update(src_cb.get_cb_id(), last_used_cb_index);
+    copy_tile(src_cb.get_cb_id(), src_tile_id, dest_idx);
 
     tile_regs_commit();
     tile_regs_wait();
 
     // Pack the tile into the destination circular buffer
-    pack_reconfig_data_format(dst_cb_index);
+    pack_reconfig_data_format(dst_cb.get_cb_id());
     if (dst_tile_id != 0) {
-        pack_tile<true>(dest_idx, dst_cb_index, dst_tile_id);
+        pack_tile<true>(dest_idx, dst_cb.get_cb_id(), dst_tile_id);
     } else {
-        pack_tile(dest_idx, dst_cb_index, 0);  // Append to the end of the CB
+        pack_tile(dest_idx, dst_cb.get_cb_id(), 0);  // Append to the end of the CB
     }
 
     // Release tile registers

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_cross_core_data_exchange.cpp
@@ -12,6 +12,7 @@
 #include "api/compute/binary_max_min.h"
 #include "api/compute/tilize.h"
 #include "api/compute/pack_untilize.h"
+#include "api/dataflow/circular_buffer.h"
 
 #include "sort_common.hpp"
 
@@ -26,22 +27,38 @@ void kernel_main() {
     constexpr uint32_t number_of_tiles_per_core = get_compile_time_arg_val(4);
     constexpr uint32_t number_of_cores_used = get_compile_time_arg_val(5);
     constexpr bool ascending = get_compile_time_arg_val(6) == 1;
-    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(7);
-    constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(8);
-    constexpr uint32_t input_tensor_transposed_cb_index = get_compile_time_arg_val(9);
-    constexpr uint32_t index_tensor_transposed_cb_index = get_compile_time_arg_val(10);
-    constexpr uint32_t value_tensor_cb_index = get_compile_time_arg_val(11);
-    constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(12);
-    constexpr uint32_t value_tensor_intermediate_cb_index = get_compile_time_arg_val(13);
-    constexpr uint32_t index_tensor_intermediate_cb_index = get_compile_time_arg_val(14);
-    constexpr uint32_t value_tensor_peer_cb_index = get_compile_time_arg_val(15);
-    constexpr uint32_t index_tensor_peer_cb_index = get_compile_time_arg_val(16);
-    constexpr uint32_t packer_unpacker_sync_cb_index = get_compile_time_arg_val(17);
+    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(7);
+    constexpr uint32_t index_tensor_cb_id = get_compile_time_arg_val(8);
+    constexpr uint32_t input_tensor_transposed_cb_id = get_compile_time_arg_val(9);
+    constexpr uint32_t index_tensor_transposed_cb_id = get_compile_time_arg_val(10);
+    constexpr uint32_t value_tensor_cb_id = get_compile_time_arg_val(11);
+    constexpr uint32_t index_tensor_output_cb_id = get_compile_time_arg_val(12);
+    constexpr uint32_t value_tensor_intermediate_cb_id = get_compile_time_arg_val(13);
+    constexpr uint32_t index_tensor_intermediate_cb_id = get_compile_time_arg_val(14);
+    constexpr uint32_t value_tensor_peer_cb_id = get_compile_time_arg_val(15);
+    constexpr uint32_t index_tensor_peer_cb_id = get_compile_time_arg_val(16);
+    constexpr uint32_t packer_unpacker_sync_cb_id = get_compile_time_arg_val(17);
     constexpr bool is_row_major = get_compile_time_arg_val(18) == 1;
-    constexpr uint32_t rm_input_cb_index = get_compile_time_arg_val(19);
-    constexpr uint32_t rm_value_output_cb_index = get_compile_time_arg_val(20);
-    constexpr uint32_t rm_index_output_cb_index = get_compile_time_arg_val(21);
-    constexpr uint32_t rm_post_sort_index_cb_index = get_compile_time_arg_val(22);
+    constexpr uint32_t rm_input_cb_id = get_compile_time_arg_val(19);
+    constexpr uint32_t rm_value_output_cb_id = get_compile_time_arg_val(20);
+    constexpr uint32_t rm_index_output_cb_id = get_compile_time_arg_val(21);
+    constexpr uint32_t rm_post_sort_index_cb_id = get_compile_time_arg_val(22);
+
+    CircularBuffer input_tensor_cb(input_tensor_cb_id);
+    CircularBuffer index_tensor_cb(index_tensor_cb_id);
+    CircularBuffer input_tensor_transposed_cb(input_tensor_transposed_cb_id);
+    CircularBuffer index_tensor_transposed_cb(index_tensor_transposed_cb_id);
+    CircularBuffer value_tensor_cb(value_tensor_cb_id);
+    CircularBuffer index_tensor_output_cb(index_tensor_output_cb_id);
+    CircularBuffer value_tensor_intermediate_cb(value_tensor_intermediate_cb_id);
+    CircularBuffer index_tensor_intermediate_cb(index_tensor_intermediate_cb_id);
+    CircularBuffer value_tensor_peer_cb(value_tensor_peer_cb_id);
+    CircularBuffer index_tensor_peer_cb(index_tensor_peer_cb_id);
+    CircularBuffer packer_unpacker_sync_cb(packer_unpacker_sync_cb_id);
+    CircularBuffer rm_input_cb(rm_input_cb_id);
+    CircularBuffer rm_value_output_cb(rm_value_output_cb_id);
+    CircularBuffer rm_index_output_cb(rm_index_output_cb_id);
+    CircularBuffer rm_post_sort_index_cb(rm_post_sort_index_cb_id);
 
     // Constants
     constexpr uint32_t one_tile = 1;
@@ -62,43 +79,43 @@ void kernel_main() {
 
     // LLK setup — one compute_kernel_hw_startup at the start, then full inits.
     compute_kernel_hw_startup(
-        is_row_major ? rm_input_cb_index : input_tensor_cb_index, index_tensor_cb_index, input_tensor_cb_index);
+        is_row_major ? rm_input_cb_id : input_tensor_cb_id, index_tensor_cb_id, input_tensor_cb_id);
     if constexpr (is_row_major) {
-        binary_op_init_common(input_tensor_cb_index, index_tensor_cb_index, input_tensor_transposed_cb_index);
+        binary_op_init_common(input_tensor_cb_id, index_tensor_cb_id, input_tensor_transposed_cb_id);
     }
     ckernel::topk_tile_init();
-    transpose_wh_init(input_tensor_cb_index, input_tensor_transposed_cb_index);
+    transpose_wh_init(input_tensor_cb_id, input_tensor_transposed_cb_id);
 
     for (uint32_t h = 0; h < Ht; h++) {
         if constexpr (is_row_major) {
             constexpr uint32_t TILE_H = 32;
-            tilize_init(rm_input_cb_index, number_of_tiles_per_core, input_tensor_cb_index);
-            cb_wait_front(rm_input_cb_index, TILE_H);
-            cb_reserve_back(input_tensor_cb_index, number_of_tiles_per_core);
-            tilize_block(rm_input_cb_index, number_of_tiles_per_core, input_tensor_cb_index);
-            cb_push_back(input_tensor_cb_index, number_of_tiles_per_core);
-            cb_pop_front(rm_input_cb_index, TILE_H);
-            tilize_uninit(rm_input_cb_index, input_tensor_cb_index);
+            tilize_init(rm_input_cb_id, number_of_tiles_per_core, input_tensor_cb_id);
+            rm_input_cb.wait_front(TILE_H);
+            input_tensor_cb.reserve_back(number_of_tiles_per_core);
+            tilize_block(rm_input_cb_id, number_of_tiles_per_core, input_tensor_cb_id);
+            input_tensor_cb.push_back(number_of_tiles_per_core);
+            rm_input_cb.pop_front(TILE_H);
+            tilize_uninit(rm_input_cb_id, input_tensor_cb_id);
         }
 
         bool dir = ascending ^ ((core_id & 1) == 1);
 
         // Read input value data
         sort_Wt_tiles_row_to_bitonic_sequence(
-            input_tensor_cb_index,
-            index_tensor_cb_index,
-            input_tensor_transposed_cb_index,
-            index_tensor_transposed_cb_index,
+            input_tensor_cb,
+            index_tensor_cb,
+            input_tensor_transposed_cb,
+            index_tensor_transposed_cb,
             number_of_tiles_per_core,
             /*switch_dir=*/true,
             dir,
             /*end_phase(log2(K))=*/5);
 
-        global_old_cb = index_tensor_cb_index;
+        global_old_cb = index_tensor_cb_id;
 
         // Wait for bitonic sequence of Wt tiles
-        cb_wait_front(input_tensor_transposed_cb_index, number_of_tiles_per_core);
-        cb_wait_front(index_tensor_transposed_cb_index, number_of_tiles_per_core);
+        input_tensor_transposed_cb.wait_front(number_of_tiles_per_core);
+        index_tensor_transposed_cb.wait_front(number_of_tiles_per_core);
 
         // Sort and merge step of bitonic merge sort
         const uint32_t stages = ilog2(Wt);
@@ -115,7 +132,7 @@ void kernel_main() {
                         continue;
                     }
 
-                    sync_packer_unpacker(packer_unpacker_sync_cb_index);
+                    sync_packer_unpacker(packer_unpacker_sync_cb);
 
                     // Determine direction for this comparison block
                     const bool ascending_block = ((i >> stage) & 1) == 0;
@@ -132,14 +149,14 @@ void kernel_main() {
                             tile_regs_acquire();
 
                             // Copy value tiles to DST register
-                            copy_tile_to_dst_init_with_cb_update(input_tensor_transposed_cb_index, global_old_cb);
-                            copy_tile(input_tensor_transposed_cb_index, left_tile_id, input_dest_start);
-                            copy_tile(input_tensor_transposed_cb_index, right_tile_id, input_dest_end);
+                            copy_tile_to_dst_init_with_cb_update(input_tensor_transposed_cb_id, global_old_cb);
+                            copy_tile(input_tensor_transposed_cb_id, left_tile_id, input_dest_start);
+                            copy_tile(input_tensor_transposed_cb_id, right_tile_id, input_dest_end);
 
                             // Copy index tiles to DST register
-                            copy_tile_to_dst_init_with_cb_update(index_tensor_transposed_cb_index, global_old_cb);
-                            copy_tile(index_tensor_transposed_cb_index, left_tile_id, index_dest_start);
-                            copy_tile(index_tensor_transposed_cb_index, right_tile_id, index_dest_end);
+                            copy_tile_to_dst_init_with_cb_update(index_tensor_transposed_cb_id, global_old_cb);
+                            copy_tile(index_tensor_transposed_cb_id, left_tile_id, index_dest_start);
+                            copy_tile(index_tensor_transposed_cb_id, right_tile_id, index_dest_end);
 
                             uint32_t tile_input_low = input_dest_start;
                             uint32_t tile_input_high = input_dest_end;
@@ -165,14 +182,14 @@ void kernel_main() {
                             tile_regs_wait();
 
                             // Pack value tiles to CB
-                            pack_reconfig_data_format(input_tensor_transposed_cb_index);
-                            pack_tile<true>(tile_input_low, input_tensor_transposed_cb_index, left_tile_id);
-                            pack_tile<true>(tile_input_high, input_tensor_transposed_cb_index, right_tile_id);
+                            pack_reconfig_data_format(input_tensor_transposed_cb_id);
+                            pack_tile<true>(tile_input_low, input_tensor_transposed_cb_id, left_tile_id);
+                            pack_tile<true>(tile_input_high, input_tensor_transposed_cb_id, right_tile_id);
 
                             // Pack index tiles to CB
-                            pack_reconfig_data_format(index_tensor_transposed_cb_index);
-                            pack_tile<true>(tile_index_low, index_tensor_transposed_cb_index, left_tile_id);
-                            pack_tile<true>(tile_index_high, index_tensor_transposed_cb_index, right_tile_id);
+                            pack_reconfig_data_format(index_tensor_transposed_cb_id);
+                            pack_tile<true>(tile_index_low, index_tensor_transposed_cb_id, left_tile_id);
+                            pack_tile<true>(tile_index_high, index_tensor_transposed_cb_id, right_tile_id);
 
                             tile_regs_release();
                         }
@@ -181,69 +198,57 @@ void kernel_main() {
                         constexpr uint32_t FIRST_TILE = 0;
 
                         if ((i & 1) == 0) {  // i % 2
-                            cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
-                            cb_reserve_back(index_tensor_intermediate_cb_index, one_tile);
+                            value_tensor_intermediate_cb.reserve_back(one_tile);
+                            index_tensor_intermediate_cb.reserve_back(one_tile);
 
                             copy_tile_between_cbs(
-                                global_old_cb,
-                                index_tensor_transposed_cb_index,
-                                tile_id,
-                                index_tensor_intermediate_cb_index);
-                            cb_push_back(index_tensor_intermediate_cb_index, one_tile);
+                                global_old_cb, index_tensor_transposed_cb, tile_id, index_tensor_intermediate_cb);
+                            index_tensor_intermediate_cb.push_back(one_tile);
 
                             copy_tile_between_cbs(
-                                global_old_cb,
-                                input_tensor_transposed_cb_index,
-                                tile_id,
-                                value_tensor_intermediate_cb_index);
-                            cb_push_back(value_tensor_intermediate_cb_index, one_tile);
+                                global_old_cb, input_tensor_transposed_cb, tile_id, value_tensor_intermediate_cb);
+                            value_tensor_intermediate_cb.push_back(one_tile);
 
-                            cb_reserve_back(value_tensor_intermediate_cb_index, one_tile);
-                            cb_reserve_back(index_tensor_intermediate_cb_index, one_tile);
+                            value_tensor_intermediate_cb.reserve_back(one_tile);
+                            index_tensor_intermediate_cb.reserve_back(one_tile);
 
                             copy_tile_between_cbs(
-                                global_old_cb,
-                                index_tensor_transposed_cb_index,
-                                tile_id + 1,
-                                index_tensor_intermediate_cb_index);
-                            cb_push_back(index_tensor_intermediate_cb_index, one_tile);
+                                global_old_cb, index_tensor_transposed_cb, tile_id + 1, index_tensor_intermediate_cb);
+                            index_tensor_intermediate_cb.push_back(one_tile);
 
                             copy_tile_between_cbs(
-                                global_old_cb,
-                                input_tensor_transposed_cb_index,
-                                tile_id + 1,
-                                value_tensor_intermediate_cb_index);
-                            cb_push_back(value_tensor_intermediate_cb_index, one_tile);
-                            sync_packer_unpacker(packer_unpacker_sync_cb_index);
+                                global_old_cb, input_tensor_transposed_cb, tile_id + 1, value_tensor_intermediate_cb);
+                            value_tensor_intermediate_cb.push_back(one_tile);
+                            sync_packer_unpacker(packer_unpacker_sync_cb);
                         }
 
                         // Process received tiles from other core
                         tile_regs_acquire();
 
                         // Prepare local index tiles for sorting with new tiles
-                        copy_tile_to_dst_init_with_cb_update(index_tensor_transposed_cb_index, global_old_cb);
-                        copy_tile(index_tensor_transposed_cb_index, tile_id, index_dest_start);
+                        copy_tile_to_dst_init_with_cb_update(index_tensor_transposed_cb_id, global_old_cb);
+                        copy_tile(index_tensor_transposed_cb_id, tile_id, index_dest_start);
 
                         // Prepare local value tiles for sorting with new tiles
-                        copy_tile_to_dst_init_with_cb_update(input_tensor_transposed_cb_index, global_old_cb);
-                        copy_tile(input_tensor_transposed_cb_index, tile_id, input_dest_start);
+                        copy_tile_to_dst_init_with_cb_update(input_tensor_transposed_cb_id, global_old_cb);
+                        copy_tile(input_tensor_transposed_cb_id, tile_id, input_dest_start);
 
-                        cb_wait_front(index_tensor_peer_cb_index, one_tile);
+                        index_tensor_peer_cb.wait_front(one_tile);
 
                         // Load new index tile for sorting
-                        copy_tile_to_dst_init_with_cb_update(index_tensor_peer_cb_index, global_old_cb);
-                        copy_tile(index_tensor_peer_cb_index, FIRST_TILE, index_dest_end);
+                        copy_tile_to_dst_init_with_cb_update(index_tensor_peer_cb_id, global_old_cb);
+                        copy_tile(index_tensor_peer_cb_id, FIRST_TILE, index_dest_end);
 
-                        cb_pop_front(index_tensor_peer_cb_index, one_tile);
+                        index_tensor_peer_cb.pop_front(one_tile);
 
                         // Read other tile from writer
-                        cb_wait_front(value_tensor_peer_cb_index, one_tile);
+                        value_tensor_peer_cb.wait_front(one_tile);
 
                         // Load new value tile for sorting
-                        copy_tile_to_dst_init_with_cb_update(value_tensor_peer_cb_index, global_old_cb);
-                        copy_tile(value_tensor_peer_cb_index, FIRST_TILE, input_dest_end);
+                        copy_tile_to_dst_init_with_cb_update(value_tensor_peer_cb_id, global_old_cb);
+                        copy_tile(value_tensor_peer_cb_id, FIRST_TILE, input_dest_end);
 
-                        cb_pop_front(value_tensor_peer_cb_index, one_tile);
+                        value_tensor_peer_cb.pop_front(one_tile);
 
                         ckernel::topk_merge(0, m_iter, 32);
 
@@ -262,12 +267,12 @@ void kernel_main() {
                         tile_regs_wait();
 
                         // Pack sorted index tiles to CB
-                        pack_reconfig_data_format(index_tensor_transposed_cb_index);
-                        pack_tile<true>(index_output_tile, index_tensor_transposed_cb_index, tile_id);
+                        pack_reconfig_data_format(index_tensor_transposed_cb_id);
+                        pack_tile<true>(index_output_tile, index_tensor_transposed_cb_id, tile_id);
 
                         // Pack sorted value tiles to CB
-                        pack_reconfig_data_format(input_tensor_transposed_cb_index);
-                        pack_tile<true>(value_output_tile, input_tensor_transposed_cb_index, tile_id);
+                        pack_reconfig_data_format(input_tensor_transposed_cb_id);
+                        pack_tile<true>(value_output_tile, input_tensor_transposed_cb_id, tile_id);
 
                         tile_regs_release();
                     }
@@ -275,19 +280,18 @@ void kernel_main() {
             }  // sub loop
         }  // stages loop
 
-        cb_reserve_back(input_tensor_transposed_cb_index, number_of_tiles_per_core);
-        cb_reserve_back(index_tensor_transposed_cb_index, number_of_tiles_per_core);
+        input_tensor_transposed_cb.reserve_back(number_of_tiles_per_core);
+        index_tensor_transposed_cb.reserve_back(number_of_tiles_per_core);
 
-        cb_pop_front(input_tensor_transposed_cb_index, number_of_tiles_per_core);
-        cb_pop_front(index_tensor_transposed_cb_index, number_of_tiles_per_core);
+        input_tensor_transposed_cb.pop_front(number_of_tiles_per_core);
+        index_tensor_transposed_cb.pop_front(number_of_tiles_per_core);
 
-        cb_push_back(input_tensor_transposed_cb_index, number_of_tiles_per_core);
-        cb_push_back(index_tensor_transposed_cb_index, number_of_tiles_per_core);
+        input_tensor_transposed_cb.push_back(number_of_tiles_per_core);
+        index_tensor_transposed_cb.push_back(number_of_tiles_per_core);
 
         if constexpr (!is_row_major) {
-            transpose_and_pack(input_tensor_transposed_cb_index, value_tensor_cb_index, number_of_tiles_per_core);
-            transpose_and_pack(
-                index_tensor_transposed_cb_index, index_tensor_output_cb_index, number_of_tiles_per_core);
+            transpose_and_pack(input_tensor_transposed_cb, value_tensor_cb, number_of_tiles_per_core);
+            transpose_and_pack(index_tensor_transposed_cb, index_tensor_output_cb, number_of_tiles_per_core);
         } else {
             // ROW_MAJOR output: un-transpose the sorted tiles back into the
             // PACK-only RM-input/index CBs (which are now empty after the
@@ -311,37 +315,36 @@ void kernel_main() {
                 number_of_tiles_per_core % SUB_BLOCK_DIM == 0,
                 "number_of_tiles_per_core must be divisible by SUB_BLOCK_DIM");
 
-            transpose_and_pack(input_tensor_transposed_cb_index, input_tensor_cb_index, number_of_tiles_per_core);
+            transpose_and_pack(input_tensor_transposed_cb, input_tensor_cb, number_of_tiles_per_core);
 
-            transpose_and_pack(index_tensor_transposed_cb_index, rm_post_sort_index_cb_index, number_of_tiles_per_core);
+            transpose_and_pack(index_tensor_transposed_cb, rm_post_sort_index_cb, number_of_tiles_per_core);
 
             // Untilize values: number_of_tiles_per_core tiles → TILE_H RM pages.
-            binary_op_init_common(input_tensor_cb_index, index_tensor_cb_index, rm_value_output_cb_index);
-            pack_untilize_init<SUB_BLOCK_DIM, number_of_tiles_per_core>(
-                input_tensor_cb_index, rm_value_output_cb_index);
-            cb_wait_front(input_tensor_cb_index, number_of_tiles_per_core);
-            cb_reserve_back(rm_value_output_cb_index, TILE_H);
+            binary_op_init_common(input_tensor_cb_id, index_tensor_cb_id, rm_value_output_cb_id);
+            pack_untilize_init<SUB_BLOCK_DIM, number_of_tiles_per_core>(input_tensor_cb_id, rm_value_output_cb_id);
+            input_tensor_cb.wait_front(number_of_tiles_per_core);
+            rm_value_output_cb.reserve_back(TILE_H);
             for (uint32_t b = 0; b < NUM_SUB_BLOCKS; ++b) {
                 pack_untilize_block<SUB_BLOCK_DIM, number_of_tiles_per_core>(
-                    input_tensor_cb_index, 1, rm_value_output_cb_index, b);
-                cb_pop_front(input_tensor_cb_index, SUB_BLOCK_DIM);
+                    input_tensor_cb_id, 1, rm_value_output_cb_id, b);
+                input_tensor_cb.pop_front(SUB_BLOCK_DIM);
             }
-            cb_push_back(rm_value_output_cb_index, TILE_H);
-            pack_untilize_uninit(rm_value_output_cb_index);
+            rm_value_output_cb.push_back(TILE_H);
+            pack_untilize_uninit(rm_value_output_cb_id);
 
             // Untilize indices: number_of_tiles_per_core tiles → TILE_H RM pages.
-            binary_op_init_common(rm_post_sort_index_cb_index, input_tensor_cb_index, rm_index_output_cb_index);
+            binary_op_init_common(rm_post_sort_index_cb_id, input_tensor_cb_id, rm_index_output_cb_id);
             pack_untilize_init<SUB_BLOCK_DIM, number_of_tiles_per_core>(
-                rm_post_sort_index_cb_index, rm_index_output_cb_index);
-            cb_wait_front(rm_post_sort_index_cb_index, number_of_tiles_per_core);
-            cb_reserve_back(rm_index_output_cb_index, TILE_H);
+                rm_post_sort_index_cb_id, rm_index_output_cb_id);
+            rm_post_sort_index_cb.wait_front(number_of_tiles_per_core);
+            rm_index_output_cb.reserve_back(TILE_H);
             for (uint32_t b = 0; b < NUM_SUB_BLOCKS; ++b) {
                 pack_untilize_block<SUB_BLOCK_DIM, number_of_tiles_per_core>(
-                    rm_post_sort_index_cb_index, 1, rm_index_output_cb_index, b);
-                cb_pop_front(rm_post_sort_index_cb_index, SUB_BLOCK_DIM);
+                    rm_post_sort_index_cb_id, 1, rm_index_output_cb_id, b);
+                rm_post_sort_index_cb.pop_front(SUB_BLOCK_DIM);
             }
-            cb_push_back(rm_index_output_cb_index, TILE_H);
-            pack_untilize_uninit(rm_index_output_cb_index);
+            rm_index_output_cb.push_back(TILE_H);
+            pack_untilize_uninit(rm_index_output_cb_id);
         }
     }  // h loop
 }  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_multi_core.cpp
@@ -11,15 +11,16 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tilize.h"
 #include "api/compute/pack_untilize.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     // Compile time args
-    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(1);
-    constexpr uint32_t input_tensor_transposed_cb_index = get_compile_time_arg_val(2);
-    constexpr uint32_t index_tensor_transposed_cb_index = get_compile_time_arg_val(3);
-    constexpr uint32_t input_tensor_output_cb_index = get_compile_time_arg_val(4);
-    constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(5);
+    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t index_tensor_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t input_tensor_transposed_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t index_tensor_transposed_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t input_tensor_output_cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t index_tensor_output_cb_id = get_compile_time_arg_val(5);
     constexpr uint32_t Wt = get_compile_time_arg_val(6);
     constexpr uint32_t Ht = get_compile_time_arg_val(7);
     constexpr uint32_t number_of_available_cores = get_compile_time_arg_val(8);
@@ -32,10 +33,21 @@ void kernel_main() {
                                        // Issue: https://github.com/tenstorrent/tt-metal/issues/20625
     constexpr uint32_t log2Wt = get_compile_time_arg_val(13);
     constexpr bool is_row_major = get_compile_time_arg_val(14) == 1;
-    constexpr uint32_t rm_input_value_cb_index = get_compile_time_arg_val(15);
-    constexpr uint32_t rm_input_index_cb_index = get_compile_time_arg_val(16);
-    constexpr uint32_t rm_output_value_cb_index = get_compile_time_arg_val(17);
-    constexpr uint32_t rm_output_index_cb_index = get_compile_time_arg_val(18);
+    constexpr uint32_t rm_input_value_cb_id = get_compile_time_arg_val(15);
+    constexpr uint32_t rm_input_index_cb_id = get_compile_time_arg_val(16);
+    constexpr uint32_t rm_output_value_cb_id = get_compile_time_arg_val(17);
+    constexpr uint32_t rm_output_index_cb_id = get_compile_time_arg_val(18);
+
+    CircularBuffer input_tensor_cb(input_tensor_cb_id);
+    CircularBuffer index_tensor_cb(index_tensor_cb_id);
+    CircularBuffer input_tensor_transposed_cb(input_tensor_transposed_cb_id);
+    CircularBuffer index_tensor_transposed_cb(index_tensor_transposed_cb_id);
+    CircularBuffer input_tensor_output_cb(input_tensor_output_cb_id);
+    CircularBuffer index_tensor_output_cb(index_tensor_output_cb_id);
+    CircularBuffer rm_input_value_cb(rm_input_value_cb_id);
+    CircularBuffer rm_input_index_cb(rm_input_index_cb_id);
+    CircularBuffer rm_output_value_cb(rm_output_value_cb_id);
+    CircularBuffer rm_output_index_cb(rm_output_index_cb_id);
 
     // Constants
     constexpr uint32_t one_tile = 1;
@@ -49,10 +61,10 @@ void kernel_main() {
     // semaphore required by tilize_block before the first pair is processed.
     // For TILE layout the existing topk_tile_init + transpose_wh_init path is used.
     if constexpr (is_row_major) {
-        compute_kernel_hw_startup(rm_input_value_cb_index, rm_input_index_cb_index, input_tensor_cb_index);
+        compute_kernel_hw_startup(rm_input_value_cb_id, rm_input_index_cb_id, input_tensor_cb_id);
     } else {
         ckernel::topk_tile_init();
-        transpose_wh_init(input_tensor_cb_index, input_tensor_transposed_cb_index);
+        transpose_wh_init(input_tensor_cb_id, input_tensor_transposed_cb_id);
     }
 
     for (uint32_t h = 0; h < Ht; h++) {
@@ -75,32 +87,31 @@ void kernel_main() {
 
                         if (pair_id == processing_pair_id) {
                             if constexpr (is_row_major) {
-                                tilize_init(rm_input_value_cb_index, 2, input_tensor_cb_index);
-                                cb_wait_front(rm_input_value_cb_index, 2 * TILE_H);
-                                cb_reserve_back(input_tensor_cb_index, 2);
-                                tilize_block(rm_input_value_cb_index, 2, input_tensor_cb_index);
-                                cb_push_back(input_tensor_cb_index, 2);
-                                cb_pop_front(rm_input_value_cb_index, 2 * TILE_H);
-                                tilize_uninit(rm_input_value_cb_index, input_tensor_cb_index);
-                                binary_op_init_common(
-                                    rm_input_index_cb_index, rm_input_index_cb_index, index_tensor_cb_index);
+                                tilize_init(rm_input_value_cb_id, 2, input_tensor_cb_id);
+                                rm_input_value_cb.wait_front(2 * TILE_H);
+                                input_tensor_cb.reserve_back(2);
+                                tilize_block(rm_input_value_cb_id, 2, input_tensor_cb_id);
+                                input_tensor_cb.push_back(2);
+                                rm_input_value_cb.pop_front(2 * TILE_H);
+                                tilize_uninit(rm_input_value_cb_id, input_tensor_cb_id);
+                                binary_op_init_common(rm_input_index_cb_id, rm_input_index_cb_id, index_tensor_cb_id);
 
-                                tilize_init(rm_input_index_cb_index, 2, index_tensor_cb_index);
-                                cb_wait_front(rm_input_index_cb_index, 2 * TILE_H);
-                                cb_reserve_back(index_tensor_cb_index, 2);
-                                tilize_block(rm_input_index_cb_index, 2, index_tensor_cb_index);
-                                cb_push_back(index_tensor_cb_index, 2);
-                                cb_pop_front(rm_input_index_cb_index, 2 * TILE_H);
-                                tilize_uninit(rm_input_index_cb_index, index_tensor_cb_index);
+                                tilize_init(rm_input_index_cb_id, 2, index_tensor_cb_id);
+                                rm_input_index_cb.wait_front(2 * TILE_H);
+                                index_tensor_cb.reserve_back(2);
+                                tilize_block(rm_input_index_cb_id, 2, index_tensor_cb_id);
+                                index_tensor_cb.push_back(2);
+                                rm_input_index_cb.pop_front(2 * TILE_H);
+                                tilize_uninit(rm_input_index_cb_id, index_tensor_cb_id);
                                 binary_op_init_common(
-                                    input_tensor_cb_index, index_tensor_cb_index, input_tensor_transposed_cb_index);
+                                    input_tensor_cb_id, index_tensor_cb_id, input_tensor_transposed_cb_id);
 
                                 ckernel::topk_tile_init();
-                                transpose_wh_init(input_tensor_cb_index, input_tensor_transposed_cb_index);
+                                transpose_wh_init(input_tensor_cb_id, input_tensor_transposed_cb_id);
                             }
 
-                            cb_wait_front(input_tensor_cb_index, 2 * one_tile);
-                            cb_wait_front(index_tensor_cb_index, 2 * one_tile);
+                            input_tensor_cb.wait_front(2 * one_tile);
+                            index_tensor_cb.wait_front(2 * one_tile);
 
                             tile_regs_acquire();
                             // For RM, tiles from tilize are always regular (non-transposed),
@@ -108,29 +119,29 @@ void kernel_main() {
                             // branch in the TILE path).  For TILE, tiles are pre-transposed
                             // in all stages except the very first.
                             if ((stage == 1 && sub == 1) || is_row_major) {
-                                reconfig_data_format_srca(input_tensor_cb_index);
-                                transpose_wh_init_short(input_tensor_cb_index);
-                                transpose_wh_tile(input_tensor_cb_index, 0, input_dest_start);
-                                transpose_wh_tile(input_tensor_cb_index, 1, input_dest_end);
+                                reconfig_data_format_srca(input_tensor_cb_id);
+                                transpose_wh_init_short(input_tensor_cb_id);
+                                transpose_wh_tile(input_tensor_cb_id, 0, input_dest_start);
+                                transpose_wh_tile(input_tensor_cb_id, 1, input_dest_end);
 
                                 // Process index tiles
-                                reconfig_data_format_srca(index_tensor_cb_index);
-                                transpose_wh_init_short(index_tensor_cb_index);
-                                transpose_wh_tile(index_tensor_cb_index, 0, index_dest_start);
-                                transpose_wh_tile(index_tensor_cb_index, 1, index_dest_end);
+                                reconfig_data_format_srca(index_tensor_cb_id);
+                                transpose_wh_init_short(index_tensor_cb_id);
+                                transpose_wh_tile(index_tensor_cb_id, 0, index_dest_start);
+                                transpose_wh_tile(index_tensor_cb_id, 1, index_dest_end);
                             } else {
                                 // Intermediate step - tiles are already transposed
                                 // Process value tiles
-                                reconfig_data_format_srca(input_tensor_cb_index);
-                                copy_tile_to_dst_init_short(input_tensor_cb_index);
-                                copy_tile(input_tensor_cb_index, 0, input_dest_start);
-                                copy_tile(input_tensor_cb_index, 1, input_dest_end);
+                                reconfig_data_format_srca(input_tensor_cb_id);
+                                copy_tile_to_dst_init_short(input_tensor_cb_id);
+                                copy_tile(input_tensor_cb_id, 0, input_dest_start);
+                                copy_tile(input_tensor_cb_id, 1, input_dest_end);
 
                                 // Process index tiles
-                                reconfig_data_format_srca(index_tensor_cb_index);
-                                copy_tile_to_dst_init_short(index_tensor_cb_index);
-                                copy_tile(index_tensor_cb_index, 0, index_dest_start);
-                                copy_tile(index_tensor_cb_index, 1, index_dest_end);
+                                reconfig_data_format_srca(index_tensor_cb_id);
+                                copy_tile_to_dst_init_short(index_tensor_cb_id);
+                                copy_tile(index_tensor_cb_id, 0, index_dest_start);
+                                copy_tile(index_tensor_cb_id, 1, index_dest_end);
                             }
 
                             uint32_t tile_input_low = input_dest_start;
@@ -158,8 +169,8 @@ void kernel_main() {
 
                             tile_regs_commit();
 
-                            cb_pop_front(input_tensor_cb_index, 2 * one_tile);
-                            cb_pop_front(index_tensor_cb_index, 2 * one_tile);
+                            input_tensor_cb.pop_front(2 * one_tile);
+                            index_tensor_cb.pop_front(2 * one_tile);
 
                             // For RM: always transpose back so the packed tile is in
                             // regular (non-transposed) format, which pack_untilize_block
@@ -167,109 +178,108 @@ void kernel_main() {
                             // stage/sub (intermediate stages keep the transposed format in
                             // DRAM to avoid an extra transpose next stage).
                             if ((stage == log2Wt && sub == 1) || is_row_major) {
-                                cb_reserve_back(input_tensor_transposed_cb_index, 2 * one_tile);
-                                cb_reserve_back(index_tensor_transposed_cb_index, 2 * one_tile);
+                                input_tensor_transposed_cb.reserve_back(2 * one_tile);
+                                index_tensor_transposed_cb.reserve_back(2 * one_tile);
 
                                 tile_regs_wait();
-                                pack_reconfig_data_format(input_tensor_transposed_cb_index);
-                                pack_tile(tile_input_low, input_tensor_transposed_cb_index);
-                                pack_tile(tile_input_high, input_tensor_transposed_cb_index);
+                                pack_reconfig_data_format(input_tensor_transposed_cb_id);
+                                pack_tile(tile_input_low, input_tensor_transposed_cb_id);
+                                pack_tile(tile_input_high, input_tensor_transposed_cb_id);
 
-                                pack_reconfig_data_format(index_tensor_transposed_cb_index);
-                                pack_tile(tile_index_low, index_tensor_transposed_cb_index);
-                                pack_tile(tile_index_high, index_tensor_transposed_cb_index);
+                                pack_reconfig_data_format(index_tensor_transposed_cb_id);
+                                pack_tile(tile_index_low, index_tensor_transposed_cb_id);
+                                pack_tile(tile_index_high, index_tensor_transposed_cb_id);
                                 tile_regs_release();
 
-                                cb_push_back(input_tensor_transposed_cb_index, 2 * one_tile);
-                                cb_push_back(index_tensor_transposed_cb_index, 2 * one_tile);
+                                input_tensor_transposed_cb.push_back(2 * one_tile);
+                                index_tensor_transposed_cb.push_back(2 * one_tile);
 
                                 // Pack and push sorted values tensor tiles
-                                cb_wait_front(input_tensor_transposed_cb_index, 2 * one_tile);
+                                input_tensor_transposed_cb.wait_front(2 * one_tile);
 
                                 tile_regs_acquire();
-                                reconfig_data_format_srca(input_tensor_transposed_cb_index);
-                                transpose_wh_init_short(input_tensor_transposed_cb_index);
-                                transpose_wh_tile(input_tensor_transposed_cb_index, 0, input_dest_start);
-                                transpose_wh_tile(input_tensor_transposed_cb_index, 1, input_dest_end);
+                                reconfig_data_format_srca(input_tensor_transposed_cb_id);
+                                transpose_wh_init_short(input_tensor_transposed_cb_id);
+                                transpose_wh_tile(input_tensor_transposed_cb_id, 0, input_dest_start);
+                                transpose_wh_tile(input_tensor_transposed_cb_id, 1, input_dest_end);
                                 tile_regs_commit();
 
-                                cb_pop_front(input_tensor_transposed_cb_index, 2 * one_tile);
+                                input_tensor_transposed_cb.pop_front(2 * one_tile);
 
-                                cb_reserve_back(input_tensor_output_cb_index, 2 * one_tile);
+                                input_tensor_output_cb.reserve_back(2 * one_tile);
 
                                 tile_regs_wait();
-                                pack_reconfig_data_format(input_tensor_output_cb_index);
-                                pack_tile(input_dest_start, input_tensor_output_cb_index);
-                                pack_tile(input_dest_end, input_tensor_output_cb_index);
+                                pack_reconfig_data_format(input_tensor_output_cb_id);
+                                pack_tile(input_dest_start, input_tensor_output_cb_id);
+                                pack_tile(input_dest_end, input_tensor_output_cb_id);
                                 tile_regs_release();
 
                                 // Push tiles to writer
-                                cb_push_back(input_tensor_output_cb_index, 2 * one_tile);
+                                input_tensor_output_cb.push_back(2 * one_tile);
 
                                 // Pack and push adjusted index tensor tiles
-                                cb_wait_front(index_tensor_transposed_cb_index, 2 * one_tile);
+                                index_tensor_transposed_cb.wait_front(2 * one_tile);
 
                                 tile_regs_acquire();
-                                reconfig_data_format_srca(index_tensor_transposed_cb_index);
-                                transpose_wh_init_short(index_tensor_transposed_cb_index);
-                                transpose_wh_tile(index_tensor_transposed_cb_index, 0, input_dest_start);
-                                transpose_wh_tile(index_tensor_transposed_cb_index, 1, input_dest_end);
+                                reconfig_data_format_srca(index_tensor_transposed_cb_id);
+                                transpose_wh_init_short(index_tensor_transposed_cb_id);
+                                transpose_wh_tile(index_tensor_transposed_cb_id, 0, input_dest_start);
+                                transpose_wh_tile(index_tensor_transposed_cb_id, 1, input_dest_end);
                                 tile_regs_commit();
 
-                                cb_pop_front(index_tensor_transposed_cb_index, 2 * one_tile);
+                                index_tensor_transposed_cb.pop_front(2 * one_tile);
 
-                                cb_reserve_back(index_tensor_output_cb_index, 2 * one_tile);
+                                index_tensor_output_cb.reserve_back(2 * one_tile);
 
                                 tile_regs_wait();
-                                pack_reconfig_data_format(index_tensor_output_cb_index);
-                                pack_tile(input_dest_start, index_tensor_output_cb_index);
-                                pack_tile(input_dest_end, index_tensor_output_cb_index);
+                                pack_reconfig_data_format(index_tensor_output_cb_id);
+                                pack_tile(input_dest_start, index_tensor_output_cb_id);
+                                pack_tile(input_dest_end, index_tensor_output_cb_id);
                                 tile_regs_release();
 
-                                cb_push_back(index_tensor_output_cb_index, 2 * one_tile);
+                                index_tensor_output_cb.push_back(2 * one_tile);
                             } else {
                                 // Intermediate step - pack and push transposed tiles to be saved for the next stage
-                                cb_reserve_back(index_tensor_output_cb_index, 2 * one_tile);
-                                cb_reserve_back(input_tensor_output_cb_index, 2 * one_tile);
+                                index_tensor_output_cb.reserve_back(2 * one_tile);
+                                input_tensor_output_cb.reserve_back(2 * one_tile);
 
                                 tile_regs_wait();
                                 // Process value tiles
-                                pack_reconfig_data_format(input_tensor_output_cb_index);
-                                pack_tile(tile_input_low, input_tensor_output_cb_index);
-                                pack_tile(tile_input_high, input_tensor_output_cb_index);
+                                pack_reconfig_data_format(input_tensor_output_cb_id);
+                                pack_tile(tile_input_low, input_tensor_output_cb_id);
+                                pack_tile(tile_input_high, input_tensor_output_cb_id);
 
-                                pack_reconfig_data_format(index_tensor_output_cb_index);
-                                pack_tile(tile_index_low, index_tensor_output_cb_index);
-                                pack_tile(tile_index_high, index_tensor_output_cb_index);
+                                pack_reconfig_data_format(index_tensor_output_cb_id);
+                                pack_tile(tile_index_low, index_tensor_output_cb_id);
+                                pack_tile(tile_index_high, index_tensor_output_cb_id);
                                 tile_regs_release();
 
-                                cb_push_back(input_tensor_output_cb_index, 2 * one_tile);
-                                cb_push_back(index_tensor_output_cb_index, 2 * one_tile);
+                                input_tensor_output_cb.push_back(2 * one_tile);
+                                index_tensor_output_cb.push_back(2 * one_tile);
                             }
 
                             if constexpr (is_row_major) {
                                 // 2 tiles arranged 1-wide × 2-tall; block_ct_dim=1, block_rt_dim=2
                                 // → produces 2*TILE_H RM output rows, each 1 tile wide.
-                                pack_untilize_init<1>(input_tensor_output_cb_index, rm_output_value_cb_index);
-                                cb_wait_front(input_tensor_output_cb_index, 2);
-                                cb_reserve_back(rm_output_value_cb_index, 2 * TILE_H);
-                                pack_untilize_block<1>(input_tensor_output_cb_index, 2, rm_output_value_cb_index);
-                                cb_pop_front(input_tensor_output_cb_index, 2);
-                                cb_push_back(rm_output_value_cb_index, 2 * TILE_H);
-                                pack_untilize_uninit(rm_output_value_cb_index);
+                                pack_untilize_init<1>(input_tensor_output_cb_id, rm_output_value_cb_id);
+                                input_tensor_output_cb.wait_front(2);
+                                rm_output_value_cb.reserve_back(2 * TILE_H);
+                                pack_untilize_block<1>(input_tensor_output_cb_id, 2, rm_output_value_cb_id);
+                                input_tensor_output_cb.pop_front(2);
+                                rm_output_value_cb.push_back(2 * TILE_H);
+                                pack_untilize_uninit(rm_output_value_cb_id);
                                 binary_op_init_common(
-                                    rm_input_index_cb_index, rm_input_index_cb_index, index_tensor_output_cb_index);
+                                    rm_input_index_cb_id, rm_input_index_cb_id, index_tensor_output_cb_id);
 
-                                pack_untilize_init<1>(index_tensor_output_cb_index, rm_output_index_cb_index);
-                                cb_wait_front(index_tensor_output_cb_index, 2);
-                                cb_reserve_back(rm_output_index_cb_index, 2 * TILE_H);
-                                pack_untilize_block<1>(index_tensor_output_cb_index, 2, rm_output_index_cb_index);
-                                cb_pop_front(index_tensor_output_cb_index, 2);
-                                cb_push_back(rm_output_index_cb_index, 2 * TILE_H);
-                                pack_untilize_uninit(rm_output_index_cb_index);
+                                pack_untilize_init<1>(index_tensor_output_cb_id, rm_output_index_cb_id);
+                                index_tensor_output_cb.wait_front(2);
+                                rm_output_index_cb.reserve_back(2 * TILE_H);
+                                pack_untilize_block<1>(index_tensor_output_cb_id, 2, rm_output_index_cb_id);
+                                index_tensor_output_cb.pop_front(2);
+                                rm_output_index_cb.push_back(2 * TILE_H);
+                                pack_untilize_uninit(rm_output_index_cb_id);
                                 // Reset compute state for the next pair's tilize.
-                                binary_op_init_common(
-                                    rm_input_value_cb_index, rm_input_index_cb_index, input_tensor_cb_index);
+                                binary_op_init_common(rm_input_value_cb_id, rm_input_index_cb_id, input_tensor_cb_id);
                             }
 
                             processing_pair_id += number_of_available_cores;

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/compute/sort_single_row_single_core.cpp
@@ -11,6 +11,7 @@
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tilize.h"
 #include "api/compute/pack_untilize.h"
+#include "api/dataflow/circular_buffer.h"
 
 #include "sort_common.hpp"
 
@@ -74,31 +75,43 @@ void kernel_main() {
     const uint32_t core_loop_count = get_arg_val<uint32_t>(0);
 
     // Compile time args
-    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
-    constexpr uint32_t index_tensor_cb_index = get_compile_time_arg_val(1);
-    constexpr uint32_t input_tensor_transposed_cb_index = get_compile_time_arg_val(2);
-    constexpr uint32_t index_tensor_transposed_cb_index = get_compile_time_arg_val(3);
-    constexpr uint32_t value_tensor_cb_index = get_compile_time_arg_val(4);
-    constexpr uint32_t index_tensor_output_cb_index = get_compile_time_arg_val(5);
+    constexpr uint32_t input_tensor_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t index_tensor_cb_id = get_compile_time_arg_val(1);
+    constexpr uint32_t input_tensor_transposed_cb_id = get_compile_time_arg_val(2);
+    constexpr uint32_t index_tensor_transposed_cb_id = get_compile_time_arg_val(3);
+    constexpr uint32_t value_tensor_cb_id = get_compile_time_arg_val(4);
+    constexpr uint32_t index_tensor_output_cb_id = get_compile_time_arg_val(5);
     constexpr uint32_t Wt = get_compile_time_arg_val(6);
     constexpr bool descending = get_compile_time_arg_val(7);
     constexpr bool stable =
         get_compile_time_arg_val(8);  // TODO: In the future change LLK to have the option or add additional step with
                                       // checking values and indexes after the sorting
                                       // Issue: https://github.com/tenstorrent/tt-metal/issues/20625
-    constexpr uint32_t synchronization_cb_index = get_compile_time_arg_val(9);
+    constexpr uint32_t synchronization_cb_id = get_compile_time_arg_val(9);
     constexpr bool is_row_major = get_compile_time_arg_val(10) == 1;
-    constexpr uint32_t rm_input_cb_index = get_compile_time_arg_val(11);
-    constexpr uint32_t rm_value_output_cb_index = get_compile_time_arg_val(12);
-    constexpr uint32_t rm_index_output_cb_index = get_compile_time_arg_val(13);
+    constexpr uint32_t rm_input_cb_id = get_compile_time_arg_val(11);
+    constexpr uint32_t rm_value_output_cb_id = get_compile_time_arg_val(12);
+    constexpr uint32_t rm_index_output_cb_id = get_compile_time_arg_val(13);
     // PACK-only CB that holds the un-transposed sorted index tiles between the
     // sort phase and the index pack_untilize_block.  Using a separate CB here
-    // (rather than reusing index_tensor_cb_index, which is BRISC-pushed by the
+    // (rather than reusing index_tensor_cb_id, which is BRISC-pushed by the
     // writer) avoids a mixed-producer counter race: BRISC uses += into the L1
     // receive counter, while PACK overwrites it with PACK's own local counter,
     // so PACK's pushes silently clobber BRISC's pushes and cb_wait_front spins
     // forever.
-    constexpr uint32_t rm_post_sort_index_cb_index = get_compile_time_arg_val(14);
+    constexpr uint32_t rm_post_sort_index_cb_id = get_compile_time_arg_val(14);
+
+    CircularBuffer input_tensor_cb(input_tensor_cb_id);
+    CircularBuffer index_tensor_cb(index_tensor_cb_id);
+    CircularBuffer input_tensor_transposed_cb(input_tensor_transposed_cb_id);
+    CircularBuffer index_tensor_transposed_cb(index_tensor_transposed_cb_id);
+    CircularBuffer value_tensor_cb(value_tensor_cb_id);
+    CircularBuffer index_tensor_output_cb(index_tensor_output_cb_id);
+    CircularBuffer synchronization_cb(synchronization_cb_id);
+    CircularBuffer rm_input_cb(rm_input_cb_id);
+    CircularBuffer rm_value_output_cb(rm_value_output_cb_id);
+    CircularBuffer rm_index_output_cb(rm_index_output_cb_id);
+    CircularBuffer rm_post_sort_index_cb(rm_post_sort_index_cb_id);
 
     constexpr uint32_t one_tile = 1;
 
@@ -116,10 +129,10 @@ void kernel_main() {
     // internal llk_math_wait_for_dest_available() does not spin forever.
     // Without this call the kernel deadlocks on the first tilize_block invocation.
     if constexpr (is_row_major) {
-        compute_kernel_hw_startup(rm_input_cb_index, index_tensor_cb_index, input_tensor_cb_index);
+        compute_kernel_hw_startup(rm_input_cb_id, index_tensor_cb_id, input_tensor_cb_id);
     } else {
         ckernel::topk_tile_init();
-        transpose_wh_init(input_tensor_cb_index, input_tensor_transposed_cb_index);
+        transpose_wh_init(input_tensor_cb_id, input_tensor_transposed_cb_id);
     }
 
     for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
@@ -140,13 +153,13 @@ void kernel_main() {
         // ------------------------------------------------------------------
         if constexpr (is_row_major) {
             constexpr uint32_t TILE_H = 32;  // TILE_HEIGHT (tt::constants not available in device kernels)
-            tilize_init(rm_input_cb_index, Wt, input_tensor_cb_index);
-            cb_wait_front(rm_input_cb_index, TILE_H);
-            cb_reserve_back(input_tensor_cb_index, Wt);
-            tilize_block(rm_input_cb_index, Wt, input_tensor_cb_index);
-            cb_push_back(input_tensor_cb_index, Wt);
-            cb_pop_front(rm_input_cb_index, TILE_H);
-            tilize_uninit(rm_input_cb_index, input_tensor_cb_index);
+            tilize_init(rm_input_cb_id, Wt, input_tensor_cb_id);
+            rm_input_cb.wait_front(TILE_H);
+            input_tensor_cb.reserve_back(Wt);
+            tilize_block(rm_input_cb_id, Wt, input_tensor_cb_id);
+            input_tensor_cb.push_back(Wt);
+            rm_input_cb.pop_front(TILE_H);
+            tilize_uninit(rm_input_cb_id, input_tensor_cb_id);
 
             // Re-initialise compute hardware for the sort phase.
             //
@@ -161,24 +174,24 @@ void kernel_main() {
             // work correctly.  Unlike compute_kernel_hw_startup this function
             // is safe to call multiple times per kernel invocation (same pattern
             // as layernorm_large_tensor.cpp's TILIZE_IN path).
-            binary_op_init_common(input_tensor_cb_index, index_tensor_cb_index, input_tensor_transposed_cb_index);
+            binary_op_init_common(input_tensor_cb_id, index_tensor_cb_id, input_tensor_transposed_cb_id);
             ckernel::topk_tile_init();
-            transpose_wh_init(input_tensor_cb_index, input_tensor_transposed_cb_index);
+            transpose_wh_init(input_tensor_cb_id, input_tensor_transposed_cb_id);
         }
 
         sort_Wt_tiles_row_to_bitonic_sequence(
-            input_tensor_cb_index,
-            index_tensor_cb_index,
-            input_tensor_transposed_cb_index,
-            index_tensor_transposed_cb_index,
+            input_tensor_cb,
+            index_tensor_cb,
+            input_tensor_transposed_cb,
+            index_tensor_transposed_cb,
             Wt,
             /*switch_dir=*/true,
             ascending,
             /*end_phase(log2(K))=*/5);
 
         // Wait for bitonic sequence of Wt tiles
-        cb_wait_front(input_tensor_transposed_cb_index, Wt);
-        cb_wait_front(index_tensor_transposed_cb_index, Wt);
+        input_tensor_transposed_cb.wait_front(Wt);
+        index_tensor_transposed_cb.wait_front(Wt);
 
         // Sort and merge step of bitonic merge sort
         uint32_t stages = 0;
@@ -186,8 +199,8 @@ void kernel_main() {
             stages++;
         }
 
-        cb_reserve_back(synchronization_cb_index, one_tile);
-        cb_push_back(synchronization_cb_index, one_tile);
+        synchronization_cb.reserve_back(one_tile);
+        synchronization_cb.push_back(one_tile);
 
         for (uint32_t stage = 2; stage <= stages; stage++) {
             const uint32_t m_iter = stage - 1;
@@ -206,19 +219,19 @@ void kernel_main() {
 
                         tile_regs_acquire();
 
-                        cb_wait_front(synchronization_cb_index, one_tile);
-                        cb_pop_front(synchronization_cb_index, one_tile);
-                        cb_reserve_back(synchronization_cb_index, one_tile);
+                        synchronization_cb.wait_front(one_tile);
+                        synchronization_cb.pop_front(one_tile);
+                        synchronization_cb.reserve_back(one_tile);
 
                         copy_tile_to_dst_init_short_with_dt(
-                            input_tensor_transposed_cb_index, index_tensor_transposed_cb_index);
-                        copy_tile(index_tensor_transposed_cb_index, left_tile_id, index_dest_start);
-                        copy_tile(index_tensor_transposed_cb_index, right_tile_id, index_dest_end);
+                            input_tensor_transposed_cb_id, index_tensor_transposed_cb_id);
+                        copy_tile(index_tensor_transposed_cb_id, left_tile_id, index_dest_start);
+                        copy_tile(index_tensor_transposed_cb_id, right_tile_id, index_dest_end);
 
                         copy_tile_to_dst_init_short_with_dt(
-                            index_tensor_transposed_cb_index, input_tensor_transposed_cb_index);
-                        copy_tile(input_tensor_transposed_cb_index, left_tile_id, input_dest_start);
-                        copy_tile(input_tensor_transposed_cb_index, right_tile_id, input_dest_end);
+                            index_tensor_transposed_cb_id, input_tensor_transposed_cb_id);
+                        copy_tile(input_tensor_transposed_cb_id, left_tile_id, input_dest_start);
+                        copy_tile(input_tensor_transposed_cb_id, right_tile_id, input_dest_end);
 
                         uint32_t tile_input_low = input_dest_start;
                         uint32_t tile_input_high = input_dest_end;
@@ -244,15 +257,15 @@ void kernel_main() {
                         tile_regs_commit();
                         tile_regs_wait();
 
-                        pack_reconfig_data_format(input_tensor_transposed_cb_index);
-                        pack_tile<true>(tile_input_low, input_tensor_transposed_cb_index, left_tile_id);
-                        pack_tile<true>(tile_input_high, input_tensor_transposed_cb_index, right_tile_id);
+                        pack_reconfig_data_format(input_tensor_transposed_cb_id);
+                        pack_tile<true>(tile_input_low, input_tensor_transposed_cb_id, left_tile_id);
+                        pack_tile<true>(tile_input_high, input_tensor_transposed_cb_id, right_tile_id);
 
-                        pack_reconfig_data_format(index_tensor_transposed_cb_index);
-                        pack_tile<true>(tile_index_low, index_tensor_transposed_cb_index, left_tile_id);
-                        pack_tile<true>(tile_index_high, index_tensor_transposed_cb_index, right_tile_id);
+                        pack_reconfig_data_format(index_tensor_transposed_cb_id);
+                        pack_tile<true>(tile_index_low, index_tensor_transposed_cb_id, left_tile_id);
+                        pack_tile<true>(tile_index_high, index_tensor_transposed_cb_id, right_tile_id);
 
-                        cb_push_back(synchronization_cb_index, one_tile);
+                        synchronization_cb.push_back(one_tile);
 
                         tile_regs_release();
                     }
@@ -260,29 +273,29 @@ void kernel_main() {
             }
         }
 
-        cb_wait_front(synchronization_cb_index, one_tile);
-        cb_pop_front(synchronization_cb_index, one_tile);
+        synchronization_cb.wait_front(one_tile);
+        synchronization_cb.pop_front(one_tile);
 
-        cb_reserve_back(input_tensor_transposed_cb_index, Wt);
-        cb_reserve_back(index_tensor_transposed_cb_index, Wt);
+        input_tensor_transposed_cb.reserve_back(Wt);
+        index_tensor_transposed_cb.reserve_back(Wt);
 
-        cb_pop_front(input_tensor_transposed_cb_index, Wt);
-        cb_pop_front(index_tensor_transposed_cb_index, Wt);
+        input_tensor_transposed_cb.pop_front(Wt);
+        index_tensor_transposed_cb.pop_front(Wt);
 
-        cb_push_back(input_tensor_transposed_cb_index, Wt);
-        cb_push_back(index_tensor_transposed_cb_index, Wt);
+        input_tensor_transposed_cb.push_back(Wt);
+        index_tensor_transposed_cb.push_back(Wt);
 
         // TILE path: transpose-and-pack to 2-tile streaming CBs so the reader
         // and writer can stream tiles one-by-one to DRAM (existing behaviour).
         //
         // ROW_MAJOR path: transpose-and-pack to the now-empty Wt-tile CBs
-        // (input_tensor_cb_index for values, index_tensor_cb_index for
+        // (input_tensor_cb_id for values, index_tensor_cb_id for
         // indices), then untilize the full row back to RM pages.
         if constexpr (!is_row_major) {
             // Values tensor → 2-tile streaming CB (writer drains to DRAM)
-            transpose_and_pack(input_tensor_transposed_cb_index, value_tensor_cb_index, Wt);
+            transpose_and_pack(input_tensor_transposed_cb, value_tensor_cb, Wt);
             // Index tensor → 2-tile streaming CB (reader drains to DRAM)
-            transpose_and_pack(index_tensor_transposed_cb_index, index_tensor_output_cb_index, Wt);
+            transpose_and_pack(index_tensor_transposed_cb, index_tensor_output_cb, Wt);
         } else {
             constexpr uint32_t TILE_H = 32;
 
@@ -294,35 +307,35 @@ void kernel_main() {
             constexpr uint32_t NUM_SUB_BLOCKS = Wt / SUB_BLOCK_DIM;
             static_assert(Wt % SUB_BLOCK_DIM == 0, "Wt must be divisible by SUB_BLOCK_DIM");
 
-            // Un-transpose sorted value tiles → input_tensor_cb_index (Wt tiles).
-            transpose_and_pack(input_tensor_transposed_cb_index, input_tensor_cb_index, Wt);
+            // Un-transpose sorted value tiles → input_tensor_cb_id (Wt tiles).
+            transpose_and_pack(input_tensor_transposed_cb, input_tensor_cb, Wt);
 
-            // Un-transpose sorted index tiles → rm_post_sort_index_cb_index (Wt tiles).
-            transpose_and_pack(index_tensor_transposed_cb_index, rm_post_sort_index_cb_index, Wt);
+            // Un-transpose sorted index tiles → rm_post_sort_index_cb_id (Wt tiles).
+            transpose_and_pack(index_tensor_transposed_cb, rm_post_sort_index_cb, Wt);
 
             // Untilize values: Wt tiles → TILE_HEIGHT RM pages in rm_value_output_cb.
-            binary_op_init_common(input_tensor_cb_index, index_tensor_cb_index, rm_value_output_cb_index);
-            pack_untilize_init<SUB_BLOCK_DIM, Wt>(input_tensor_cb_index, rm_value_output_cb_index);
-            cb_wait_front(input_tensor_cb_index, Wt);
-            cb_reserve_back(rm_value_output_cb_index, TILE_H);
+            binary_op_init_common(input_tensor_cb_id, index_tensor_cb_id, rm_value_output_cb_id);
+            pack_untilize_init<SUB_BLOCK_DIM, Wt>(input_tensor_cb_id, rm_value_output_cb_id);
+            input_tensor_cb.wait_front(Wt);
+            rm_value_output_cb.reserve_back(TILE_H);
             for (uint32_t b = 0; b < NUM_SUB_BLOCKS; ++b) {
-                pack_untilize_block<SUB_BLOCK_DIM, Wt>(input_tensor_cb_index, 1, rm_value_output_cb_index, b);
-                cb_pop_front(input_tensor_cb_index, SUB_BLOCK_DIM);
+                pack_untilize_block<SUB_BLOCK_DIM, Wt>(input_tensor_cb_id, 1, rm_value_output_cb_id, b);
+                input_tensor_cb.pop_front(SUB_BLOCK_DIM);
             }
-            cb_push_back(rm_value_output_cb_index, TILE_H);
-            pack_untilize_uninit(rm_value_output_cb_index);
+            rm_value_output_cb.push_back(TILE_H);
+            pack_untilize_uninit(rm_value_output_cb_id);
 
             // Untilize indices: same chunked pack_untilize pattern but operating on the PACK-only rm_post_sort_index_cb
-            binary_op_init_common(rm_post_sort_index_cb_index, input_tensor_cb_index, rm_index_output_cb_index);
-            pack_untilize_init<SUB_BLOCK_DIM, Wt>(rm_post_sort_index_cb_index, rm_index_output_cb_index);
-            cb_wait_front(rm_post_sort_index_cb_index, Wt);
-            cb_reserve_back(rm_index_output_cb_index, TILE_H);
+            binary_op_init_common(rm_post_sort_index_cb_id, input_tensor_cb_id, rm_index_output_cb_id);
+            pack_untilize_init<SUB_BLOCK_DIM, Wt>(rm_post_sort_index_cb_id, rm_index_output_cb_id);
+            rm_post_sort_index_cb.wait_front(Wt);
+            rm_index_output_cb.reserve_back(TILE_H);
             for (uint32_t b = 0; b < NUM_SUB_BLOCKS; ++b) {
-                pack_untilize_block<SUB_BLOCK_DIM, Wt>(rm_post_sort_index_cb_index, 1, rm_index_output_cb_index, b);
-                cb_pop_front(rm_post_sort_index_cb_index, SUB_BLOCK_DIM);
+                pack_untilize_block<SUB_BLOCK_DIM, Wt>(rm_post_sort_index_cb_id, 1, rm_index_output_cb_id, b);
+                rm_post_sort_index_cb.pop_front(SUB_BLOCK_DIM);
             }
-            cb_push_back(rm_index_output_cb_index, TILE_H);
-            pack_untilize_uninit(rm_index_output_cb_index);
+            rm_index_output_cb.push_back(TILE_H);
+            pack_untilize_uninit(rm_index_output_cb_id);
         }
     }  // Ht loop
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/sort_dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sort/device/kernels/dataflow/sort_dataflow_common.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
 
 template <typename T = uint16_t>
 FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
@@ -12,10 +13,11 @@ FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
     constexpr uint32_t one_tile = 1;
 
     // Reserve space
-    cb_reserve_back(cb_id, one_tile);
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(one_tile);
 
     // Writer config
-    const uint32_t writer_addr = get_write_ptr(cb_id);
+    const uint32_t writer_addr = cb.get_write_ptr();
     volatile tt_l1_ptr T* ptr = reinterpret_cast<volatile tt_l1_ptr T*>(writer_addr);
     const uint32_t w = wt << 5;  // wt * 2^(5)
 
@@ -41,5 +43,5 @@ FORCE_INLINE void generate_index_tile(const uint32_t cb_id, const uint32_t wt) {
     }  // i loop
 
     // Push the tile
-    cb_push_back(cb_id, one_tile);
+    cb.push_back(one_tile);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_multicore_both_dims.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_multicore_both_dims.cpp
@@ -157,6 +157,7 @@ void kernel_main() {
                 }
 
                 tt_memmove<false, false, true, 0>(
+                    noc,
                     l1_write_addr,
                     temp_addr + ((src_noc_addr + (uint64_t)start_column_id) & dram_align_offset),
                     width_size);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
@@ -44,7 +44,7 @@ void kernel_main() {
         // when the buffer is BLOCK/WIDTH-sharded. TILE-layout path below must keep the
         // original single-page transfer since each tile is one indivisible NOC unit.
         const uint32_t cb_write_ptr = cb.get_write_ptr();
-        tt::data_movement::common::noc_async_read_sharded(cb_write_ptr, s, page_idx, 0, read_size);
+        tt::data_movement::common::noc_async_read_sharded(noc, cb_write_ptr, s, page_idx, 0, read_size);
 #else
         noc.async_read(s, cb, page_size, {.page_id = page_idx}, {.offset_bytes = 0});
 #endif

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
@@ -44,7 +44,7 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_read_per_barrier; ++i) {
             // Restored native sharded multi-page split (see common.hpp helper).
             tt::data_movement::common::noc_async_read_sharded(
-                cb_write_ptr + l1_write_offset, s, i_stick, 0, stick_size_bytes);
+                noc, cb_write_ptr + l1_write_offset, s, i_stick, 0, stick_size_bytes);
             l1_write_offset += stick_size_bytes;
 
             curr_c++;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -49,7 +49,7 @@ void kernel_main() {
             uint32_t H_curr = h == Ht - 1 ? H_per_tile_last : H_per_tile;
             for (uint32_t h_datum = 0; h_datum < H_curr; ++h_datum) {
                 tt::data_movement::common::noc_async_read_sharded(
-                    cb_write_ptr + l1_write_offset, s, i_stick, 0, stick_size_bytes);
+                    noc, cb_write_ptr + l1_write_offset, s, i_stick, 0, stick_size_bytes);
                 l1_write_offset += l1_write_offset_bytes;
                 i_stick += 1;
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp
@@ -31,7 +31,7 @@ void kernel_main() {
         // Restored native sharded multi-page split (see common.hpp helper).
         // RM-only: see reader kernel for rationale; TILE-layout below uses original API.
         const uint32_t cb_read_ptr = cb.get_read_ptr();
-        tt::data_movement::common::noc_async_write_sharded(cb_read_ptr, s, i, 0, write_size);
+        tt::data_movement::common::noc_async_write_sharded(noc, cb_read_ptr, s, i, 0, write_size);
 #else
         noc.async_write(cb, s, page_size, {.offset_bytes = 0}, {.page_id = i});
 #endif

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
@@ -34,7 +34,7 @@ void kernel_main() {
         for (uint32_t i = 0; i < num_read_per_barrier; ++i) {
             // Restored native sharded multi-page split (see common.hpp helper).
             tt::data_movement::common::noc_async_write_sharded(
-                cb_read_ptr + l1_read_offset, s, i_stick, 0, stick_size_bytes);
+                noc, cb_read_ptr + l1_read_offset, s, i_stick, 0, stick_size_bytes);
             l1_read_offset += stick_size_bytes;
             i_stick += 1;
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -45,7 +45,7 @@ void kernel_main() {
             uint32_t W_curr = w == Wt - 1 ? W_per_tile_last : W_per_tile;
             for (uint32_t w_datum = 0; w_datum < W_curr; ++w_datum) {
                 tt::data_movement::common::noc_async_write_sharded(
-                    cb_read_ptr + l1_read_offset, s, i_stick, 0, stick_size_bytes);
+                    noc, cb_read_ptr + l1_read_offset, s, i_stick, 0, stick_size_bytes);
                 l1_read_offset += l1_read_offset_bytes;
                 i_stick += 1;
             }


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
 Relates to https://github.com/tenstorrent/tt-metal/issues/45003.
 
 Migrate the shared common.hpp NoC-helper library onto the Device 2.0 API for every consumer under ttnn/cpp/ttnn/operations/data_movement/. Then migrate the remaining legacy compute and helper kernels in the data_movement subtree.
  Dual-overload strategy for common.hpp. Each of the 5 NoC helpers gets a Device 2.0 overload that takes a leading Noc noc parameter and routes through noc.async_read / noc.async_write. The 1.x overloads stay so the non-data_movement consumers keep working unchanged.

### Notes for reviewers
- No algorithmic or semantic change anywhere. Every overload's if constexpr decision tree in common.hpp mirrors the corresponding 1.x body's branches exactly. Compute-side migrations only rename identifiers and swap free-fn for wrapper-method;

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/dm-common-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/dm-common-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/dm-common-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/dm-common-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/dm-common-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/dm-common-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/dm-common-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/dm-common-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/dm-common-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/dm-common-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/dm-common-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/dm-common-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/dm-common-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/dm-common-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/dm-common-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/dm-common-device-2-0)