### PR TITLE
[Cleanup]: Adding accessors for compile time dfb metadata generated during kernel compilation

### DIFF
--- a/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
+++ b/tt_metal/hw/inc/api/dataflow/dataflow_buffer.h
@@ -25,6 +25,11 @@
 #include "api/debug/waypoint.h"
 #include "api/lock.h"
 
+#if __has_include("chlkc_descriptors.h")
+#include "chlkc_descriptors.h"
+#define DFB_DESCRIPTORS_DEFINED
+#endif
+
 // Opaque handle for a DataflowBuffer binding (declared in kernel_bindings_generated.h).
 // The user will never directly interact with this type.
 //
@@ -91,16 +96,121 @@ public:
     void pop_front(uint16_t num_entries) { pop_front_impl(num_entries); }
     // Explicit sync APIs end
 
-#ifndef ARCH_QUASAR
 #ifndef COMPILE_FOR_TRISC
+#ifndef ARCH_QUASAR
     bool pages_reservable_at_back(int32_t num_pages) const;
     bool pages_available_at_front(int32_t num_pages) const;
-#ifdef DATA_FORMATS_DEFINED
-    uint32_t get_tile_size() const;
-    uint32_t get_tile_hw() const;
-    DataFormat get_dataformat() const;
 #endif
-#else  // trisc
+#endif
+
+#ifdef DFB_DESCRIPTORS_DEFINED
+    // JIT descriptor values from chlkc_descriptors.h (indexed by logical_dfb_id_).
+    // PACK TRISC uses pack_* arrays; UNPACK/MATH TRISC and DM use unpack_*.
+    constexpr uint32_t get_tile_size() const {
+#if defined(UCK_CHLKC_PACK)
+        return pack_tile_size[logical_dfb_id_];
+#else
+        return unpack_tile_size[logical_dfb_id_];
+#endif
+    }
+
+    constexpr uint32_t get_tile_r_dim() const {
+#if defined(UCK_CHLKC_PACK)
+        return pack_tile_r_dim[logical_dfb_id_];
+#else
+        return unpack_tile_r_dim[logical_dfb_id_];
+#endif
+    }
+
+    constexpr uint32_t get_tile_c_dim() const {
+#if defined(UCK_CHLKC_PACK)
+        return pack_tile_c_dim[logical_dfb_id_];
+#else
+        return unpack_tile_c_dim[logical_dfb_id_];
+#endif
+    }
+
+    constexpr uint32_t get_tile_hw() const { return get_tile_r_dim() * get_tile_c_dim(); }
+
+    constexpr uint32_t get_tile_num_faces() const {
+#if defined(UCK_CHLKC_PACK)
+        return pack_tile_num_faces[logical_dfb_id_];
+#else
+        return unpack_tile_num_faces[logical_dfb_id_];
+#endif
+    }
+
+    constexpr uint32_t get_face_r_dim() const {
+#if defined(UCK_CHLKC_PACK)
+        return pack_tile_face_r_dim[logical_dfb_id_];
+#else
+        return unpack_tile_face_r_dim[logical_dfb_id_];
+#endif
+    }
+
+    constexpr uint32_t get_partial_face() const {
+#if defined(UCK_CHLKC_PACK)
+        return pack_partial_face[logical_dfb_id_];
+#else
+        return unpack_partial_face[logical_dfb_id_];
+#endif
+    }
+
+    constexpr uint32_t get_narrow_tile() const {
+#if defined(UCK_CHLKC_PACK)
+        return pack_narrow_tile[logical_dfb_id_];
+#else
+        return unpack_narrow_tile[logical_dfb_id_];
+#endif
+    }
+
+    constexpr uint32_t get_num_faces_r_dim() const {
+#if defined(UCK_CHLKC_PACK)
+        return pack_num_faces_r_dim[logical_dfb_id_];
+#else
+        return unpack_num_faces_r_dim[logical_dfb_id_];
+#endif
+    }
+
+    constexpr uint32_t get_num_faces_c_dim() const {
+#if defined(UCK_CHLKC_PACK)
+        return pack_num_faces_c_dim[logical_dfb_id_];
+#else
+        return unpack_num_faces_c_dim[logical_dfb_id_];
+#endif
+    }
+
+    constexpr DataFormat get_dataformat() const {
+#if defined(UCK_CHLKC_PACK)
+        return static_cast<DataFormat>(pack_dst_format[logical_dfb_id_]);
+#else
+        return static_cast<DataFormat>(unpack_src_format[logical_dfb_id_]);
+#endif
+    }
+
+#if !defined(UCK_CHLKC_PACK)
+    constexpr DataFormat get_unpack_dst_format() const {
+        return static_cast<DataFormat>(unpack_dst_format[logical_dfb_id_]);
+    }
+#endif
+
+// pack_* format arrays are only emitted for PACK TRISC and DM (see genfiles.cpp).
+#if defined(UCK_CHLKC_PACK) || (!defined(UCK_CHLKC_MATH) && !defined(UCK_CHLKC_UNPACK))
+    constexpr DataFormat get_pack_src_format() const {
+        return static_cast<DataFormat>(pack_src_format[logical_dfb_id_]);
+    }
+#endif
+
+#if !defined(UCK_CHLKC_MATH) && !defined(UCK_CHLKC_UNPACK)
+    constexpr DataFormat get_pack_dst_format() const {
+        return static_cast<DataFormat>(pack_dst_format[logical_dfb_id_]);
+    }
+#endif
+
+#endif // DFB_DESCRIPTORS_DEFINED
+
+#ifdef COMPILE_FOR_TRISC
+#ifndef ARCH_QUASAR
     uint32_t get_tile_address(uint32_t tile_index);
     uint32_t read_tile_value(uint32_t tile_index, uint32_t element_offset);
 #endif

--- a/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
+++ b/tt_metal/hw/inc/internal/tt-1xx/dataflow_buffer.inl
@@ -95,12 +95,8 @@ inline uint32_t DataflowBuffer::read_tile_value(uint32_t tile_index, uint32_t el
 
     return value;
 }
+
 #else
-#ifdef DATA_FORMATS_DEFINED
-inline uint32_t DataflowBuffer::get_tile_size() const { return ::get_tile_size(logical_dfb_id_); }
-inline uint32_t DataflowBuffer::get_tile_hw() const { return ::get_tile_hw(logical_dfb_id_); }
-inline DataFormat DataflowBuffer::get_dataformat() const { return ::get_dataformat(logical_dfb_id_); }
-#endif
 
 inline bool DataflowBuffer::pages_reservable_at_back(int32_t num_pages) const { return cb_pages_reservable_at_back(logical_dfb_id_, num_pages); }
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Headers generated by compilation generate dfb tile metadata that compute accesses. Part of the Metal 2.0 effort will be to have compute APIs accept DFB objects rather than ids and query the DFB rather than directly access the arrays.

FYI @rtawfik01 and @bbradelTT. these can be used when we get to state of passing DFB object into apis

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=abhullar/dfb-cb-convert)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:abhullar/dfb-cb-convert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=abhullar/dfb-cb-convert)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:abhullar/dfb-cb-convert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=abhullar/dfb-cb-convert)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:abhullar/dfb-cb-convert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=abhullar/dfb-cb-convert)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:abhullar/dfb-cb-convert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=abhullar/dfb-cb-convert)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:abhullar/dfb-cb-convert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=abhullar/dfb-cb-convert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:abhullar/dfb-cb-convert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=abhullar/dfb-cb-convert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:abhullar/dfb-cb-convert)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=abhullar/dfb-cb-convert)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:abhullar/dfb-cb-convert)