### PR TITLE
[LLK][Quasar] Add separate SFPU math data format to test harness

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
@@ -401,8 +401,11 @@ def infer_data_formats(
     if chip_arch is None:
         chip_arch = get_chip_architecture()
 
-    # On Quasar the math and SFPU data formats can differ: route math through the Int16 path
-    # and carry the real format in sfpu_math to test SFPU support for it.
+    # On Quasar the math and SFPU data formats can differ. Quasar has only one 16-bit integer HW
+    # encoding, Int16 -- the unpacker, the SrcA/SrcB/dest register files, and the packer all lack a
+    # UInt16 encoding, so UInt16 is pass-through as Int16 across the whole unpack/math/pack datapath.
+    # The unsigned-16 semantics exist only as an SFPU access mode (sfpmem::UINT16), so we carry the
+    # real UInt16 intent in sfpu_math to still test SFPU support for it.
     sfpu_math_override = None
     if chip_arch == ChipArchitecture.QUASAR:
         if input_format == DataFormat.UInt16:
@@ -459,8 +462,9 @@ def infer_data_formats(
     if math == DataFormat.Fp8_e4m3:
         math = DataFormat.Float16
 
-    # SFPU-side math format: same as math unless the SFPU operates in a format with no native
-    # register/dest representation (UInt16 on Quasar, remapped to an Int16 data path above).
+    # SFPU-side math format: same as math unless the SFPU operates in a format with no Tensix HW
+    # encoding (UInt16 on Quasar), in which case the unpack/math/pack datapath was defaulted to Int16
+    # above and only sfpu_math retains the UInt16 intent (via the sfpmem::UINT16 SFPU access mode).
     sfpu_math = sfpu_math_override if sfpu_math_override is not None else math
 
     pack_in = infer_pack_in(
@@ -619,8 +623,9 @@ def data_formats(
             math_format = input_format
             pack_src_format = input_format
 
-        # Even with inference disabled, UInt16 must ride the Int16 data path on Quasar (no native
-        # UInt16 register/dest format); only sfpu_math keeps the uint16 intent. See infer_data_formats.
+        # Even with inference disabled, UInt16 must ride the Int16 data path on Quasar: there is no
+        # UInt16 HW encoding in the unpacker, the register files/dest, or the packer, so the whole
+        # datapath defaults to Int16 and only sfpu_math keeps the UInt16 intent. See infer_data_formats.
         sfpu_math_format = math_format
         resolved_arch = chip_arch if chip_arch is not None else get_chip_architecture()
         if (

--- a/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/data_format_inference.py
@@ -398,6 +398,23 @@ def infer_data_formats(
         input_format_B is not provided or equals input_format), and False otherwise.
     """
 
+    if chip_arch is None:
+        chip_arch = get_chip_architecture()
+
+    # On Quasar the math and SFPU data formats can differ: route math through the Int16 path
+    # and carry the real format in sfpu_math to test SFPU support for it.
+    sfpu_math_override = None
+    if chip_arch == ChipArchitecture.QUASAR:
+        if input_format == DataFormat.UInt16:
+            input_format = DataFormat.Int16
+            sfpu_math_override = DataFormat.UInt16
+        if input_format_B == DataFormat.UInt16:
+            input_format_B = DataFormat.Int16
+            sfpu_math_override = DataFormat.UInt16
+        if output_format == DataFormat.UInt16:
+            output_format = DataFormat.Int16
+            sfpu_math_override = DataFormat.UInt16
+
     # Determine the intermediate formats
     unpack_out_A = infer_unpack_out(
         input_format,
@@ -441,6 +458,10 @@ def infer_data_formats(
     # source registers. The ALU and packer must see Float16, not Lf8/Fp8_e4m3.
     if math == DataFormat.Fp8_e4m3:
         math = DataFormat.Float16
+
+    # SFPU-side math format: same as math unless the SFPU operates in a format with no native
+    # register/dest representation (UInt16 on Quasar, remapped to an Int16 data path above).
+    sfpu_math = sfpu_math_override if sfpu_math_override is not None else math
 
     pack_in = infer_pack_in(
         input_format,
@@ -487,6 +508,7 @@ def infer_data_formats(
         pack_src=pack_in,
         pack_dst=output_format,
         math=math,
+        sfpu_math=sfpu_math,
         same_src_format=same_src_format,
         unpack_B_src=input_format_B,
         unpack_B_dst=unpack_out_B,
@@ -597,6 +619,27 @@ def data_formats(
             math_format = input_format
             pack_src_format = input_format
 
+        # Even with inference disabled, UInt16 must ride the Int16 data path on Quasar (no native
+        # UInt16 register/dest format); only sfpu_math keeps the uint16 intent. See infer_data_formats.
+        sfpu_math_format = math_format
+        resolved_arch = chip_arch if chip_arch is not None else get_chip_architecture()
+        if (
+            resolved_arch == ChipArchitecture.QUASAR
+            and input_format == DataFormat.UInt16
+        ):
+            unpack_dst = DataFormat.Int16
+            math_format = DataFormat.Int16
+            pack_src_format = DataFormat.Int16
+            sfpu_math_format = DataFormat.UInt16
+            input_format = DataFormat.Int16
+            output_format = (
+                DataFormat.Int16
+                if output_format == DataFormat.UInt16
+                else output_format
+            )
+            if input_format_B == DataFormat.UInt16:
+                input_format_B = DataFormat.Int16
+
         same_src_format = (input_format_B is None) or (input_format_B == input_format)
         unpack_B_src_val = (
             input_format_B if input_format_B is not None else input_format
@@ -616,6 +659,7 @@ def data_formats(
                 pack_src=pack_src_format,
                 pack_dst=output_format,
                 math=math_format,
+                sfpu_math=sfpu_math_format,
                 same_src_format=same_src_format,
                 unpack_B_src=unpack_B_src_val,
                 unpack_B_dst=unpack_B_dst_val,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/format_config.py
@@ -421,6 +421,7 @@ class FormatConfig:
     pack_S_src: DataFormat
     pack_S_dst: DataFormat
     math: DataFormat
+    sfpu_math: DataFormat
 
     def __init__(
         self,
@@ -429,6 +430,9 @@ class FormatConfig:
         pack_src: DataFormat,
         pack_dst: DataFormat,
         math: DataFormat,
+        sfpu_math: Optional[
+            DataFormat
+        ] = None,  # SFPU-side math format; defaults to `math`. Differs only when the SFPU operates in a format with no native register/dest representation (e.g. UInt16 on Quasar, routed through an Int16 data path).
         same_src_format: bool = True,  # If True, A and B share unpack formats; omit unpack_B_src / unpack_B_dst (they are set from A).
         # Optional unpack_S_* and pack_S_* default to the A and main pack paths when omitted (mirrors common "S same as A" usage).
         unpack_B_src: Optional[DataFormat] = None,
@@ -444,6 +448,7 @@ class FormatConfig:
         self.pack_src = pack_src
         self.pack_dst = pack_dst
         self.math = math
+        self.sfpu_math = sfpu_math if sfpu_math is not None else math
         if same_src_format:
             self.unpack_B_src = unpack_A_src
             self.unpack_B_dst = unpack_A_dst
@@ -477,6 +482,7 @@ class FormatConfig:
             ("unpack_S_src", self.unpack_S_src),
             ("unpack_S_dst", self.unpack_S_dst),
             ("math", self.math),
+            ("sfpu_math", self.sfpu_math),
             ("pack_src", self.pack_src),
             ("pack_dst", self.pack_dst),
             ("pack_S_src", self.pack_S_src),
@@ -513,6 +519,7 @@ struct FormatConfig
     std::uint32_t unpack_B_dst = 0;
     std::uint32_t unpack_S_dst = 0;
     std::uint32_t math = 0;
+    std::uint32_t sfpu_math = 0;
     std::uint32_t pack_src = 0;
     std::uint32_t pack_dst = 0;
     std::uint32_t pack_S_src = 0;
@@ -532,6 +539,7 @@ FORMATS_CONFIG_STRUCT_COMPILETIME = [
     "    const std::uint32_t unpack_B_dst;",
     "    const std::uint32_t unpack_S_dst;",
     "    const std::uint32_t math;",
+    "    const std::uint32_t sfpu_math;",
     "    const std::uint32_t pack_src;",
     "    const std::uint32_t pack_dst;",
     "    const std::uint32_t pack_S_src;",
@@ -545,6 +553,7 @@ FORMATS_CONFIG_STRUCT_COMPILETIME = [
     "        std::uint32_t unpack_B_dst_,",
     "        std::uint32_t unpack_S_dst_,",
     "        std::uint32_t math_,",
+    "        std::uint32_t sfpu_math_,",
     "        std::uint32_t pack_src_,",
     "        std::uint32_t pack_dst_,",
     "        std::uint32_t pack_S_src_,",
@@ -556,6 +565,7 @@ FORMATS_CONFIG_STRUCT_COMPILETIME = [
     "        unpack_B_dst(unpack_B_dst_),",
     "        unpack_S_dst(unpack_S_dst_),",
     "        math(math_),",
+    "        sfpu_math(sfpu_math_),",
     "        pack_src(pack_src_),",
     "        pack_dst(pack_dst_),",
     "        pack_S_src(pack_S_src_),",

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -694,15 +694,15 @@ class TestConfig:
 
         if not self.compile_time_formats:
             # Append struct.pack format for each FormatConfig to L1. Each "I" encodes one
-            # uint32_t DataFormat enum. Eleven I's = eleven fields appended in
+            # uint32_t DataFormat enum. Twelve I's = twelve fields appended in
             # write_runtimes_to_L1 (same order as argument_data). struct.pack encodes
             # those values using runtime_format into bytes for RuntimeParams on device.
             if self.L1_to_L1_iterations == 1:
                 lines.append("FormatConfig formats;")
-                self.runtime_format += "IIIIIIIIIII"
+                self.runtime_format += "IIIIIIIIIIII"
             else:
                 lines.append(f"FormatConfig formats[{self.L1_to_L1_iterations}];")
-                self.runtime_format += self.L1_to_L1_iterations * "IIIIIIIIIII"
+                self.runtime_format += self.L1_to_L1_iterations * "IIIIIIIIIIII"
 
         if self.variant_stimuli:
             stimuli_fields, stimuli_pack_format = (
@@ -741,6 +741,7 @@ class TestConfig:
                         TestConfig.DATA_FORMAT_ENUM[format_tuple.unpack_B_dst],
                         TestConfig.DATA_FORMAT_ENUM[format_tuple.unpack_S_dst],
                         TestConfig.DATA_FORMAT_ENUM[format_tuple.math],
+                        TestConfig.DATA_FORMAT_ENUM[format_tuple.sfpu_math],
                         TestConfig.DATA_FORMAT_ENUM[format_tuple.pack_src],
                         TestConfig.DATA_FORMAT_ENUM[format_tuple.pack_dst],
                         TestConfig.DATA_FORMAT_ENUM[format_tuple.pack_S_src],
@@ -968,6 +969,10 @@ class TestConfig:
                 f"ckernel::to_underlying(DataFormat::{fmt.math.name})"
                 for fmt in self.formats_config
             ]
+            sfpu_math_values = [
+                f"ckernel::to_underlying(DataFormat::{fmt.sfpu_math.name})"
+                for fmt in self.formats_config
+            ]
             pack_in_values = [
                 f"ckernel::to_underlying(DataFormat::{fmt.pack_src.name})"
                 for fmt in self.formats_config
@@ -994,14 +999,15 @@ class TestConfig:
                     f"constexpr std::array<std::underlying_type_t<DataFormat>, L1_to_L1_ITERATIONS> UNPACK_B_OUT_LIST = {{{', '.join(unpack_b_out_values)}}};",
                     f"constexpr std::array<std::underlying_type_t<DataFormat>, L1_to_L1_ITERATIONS> UNPACK_S_OUT_LIST = {{{', '.join(unpack_s_out_values)}}};",
                     f"constexpr std::array<std::underlying_type_t<DataFormat>, L1_to_L1_ITERATIONS> MATH_FORMAT_LIST = {{{', '.join(math_values)}}};",
+                    f"constexpr std::array<std::underlying_type_t<DataFormat>, L1_to_L1_ITERATIONS> SFPU_MATH_FORMAT_LIST = {{{', '.join(sfpu_math_values)}}};",
                     f"constexpr std::array<std::underlying_type_t<DataFormat>, L1_to_L1_ITERATIONS> PACK_IN_LIST = {{{', '.join(pack_in_values)}}};",
                     f"constexpr std::array<std::underlying_type_t<DataFormat>, L1_to_L1_ITERATIONS> PACK_OUT_LIST = {{{', '.join(pack_out_values)}}};",
                     f"constexpr std::array<std::underlying_type_t<DataFormat>, L1_to_L1_ITERATIONS> PACK_S_IN_LIST = {{{', '.join(pack_s_in_values)}}};",
                     f"constexpr std::array<std::underlying_type_t<DataFormat>, L1_to_L1_ITERATIONS> PACK_S_OUT_LIST = {{{', '.join(pack_s_out_values)}}};",
                     "constexpr std::array<FormatConfig, L1_to_L1_ITERATIONS> formats_array = {",
-                    "{FormatConfig(UNPACK_A_IN_LIST[0], UNPACK_B_IN_LIST[0], UNPACK_S_IN_LIST[0], UNPACK_A_OUT_LIST[0], UNPACK_B_OUT_LIST[0], UNPACK_S_OUT_LIST[0], MATH_FORMAT_LIST[0], PACK_IN_LIST[0], PACK_OUT_LIST[0], PACK_S_IN_LIST[0], PACK_S_OUT_LIST[0]),",
+                    "{FormatConfig(UNPACK_A_IN_LIST[0], UNPACK_B_IN_LIST[0], UNPACK_S_IN_LIST[0], UNPACK_A_OUT_LIST[0], UNPACK_B_OUT_LIST[0], UNPACK_S_OUT_LIST[0], MATH_FORMAT_LIST[0], SFPU_MATH_FORMAT_LIST[0], PACK_IN_LIST[0], PACK_OUT_LIST[0], PACK_S_IN_LIST[0], PACK_S_OUT_LIST[0]),",
                     "FormatConfig(",
-                    "UNPACK_A_IN_LIST[1], UNPACK_B_IN_LIST[1], UNPACK_S_IN_LIST[1], UNPACK_A_OUT_LIST[1], UNPACK_B_OUT_LIST[1], UNPACK_S_OUT_LIST[1], MATH_FORMAT_LIST[1], PACK_IN_LIST[1], PACK_OUT_LIST[1], PACK_S_IN_LIST[1], PACK_S_OUT_LIST[1])}};",
+                    "UNPACK_A_IN_LIST[1], UNPACK_B_IN_LIST[1], UNPACK_S_IN_LIST[1], UNPACK_A_OUT_LIST[1], UNPACK_B_OUT_LIST[1], UNPACK_S_OUT_LIST[1], MATH_FORMAT_LIST[1], SFPU_MATH_FORMAT_LIST[1], PACK_IN_LIST[1], PACK_OUT_LIST[1], PACK_S_IN_LIST[1], PACK_S_OUT_LIST[1])}};",
                 ]
             )
 
@@ -1019,11 +1025,12 @@ class TestConfig:
                     f"constexpr auto UNPACK_B_OUT = ckernel::to_underlying(DataFormat::{formats_config.unpack_B_dst.name});",
                     f"constexpr auto UNPACK_S_OUT = ckernel::to_underlying(DataFormat::{formats_config.unpack_S_dst.name});",
                     f"constexpr auto MATH_FORMAT = ckernel::to_underlying(DataFormat::{formats_config.math.name});",
+                    f"constexpr auto SFPU_MATH_FORMAT = ckernel::to_underlying(DataFormat::{formats_config.sfpu_math.name});",
                     f"constexpr auto PACK_IN = ckernel::to_underlying(DataFormat::{formats_config.pack_src.name});",
                     f"constexpr auto PACK_OUT = ckernel::to_underlying(DataFormat::{formats_config.pack_dst.name});",
                     f"constexpr auto PACK_S_IN = ckernel::to_underlying(DataFormat::{formats_config.pack_S_src.name});",
                     f"constexpr auto PACK_S_OUT = ckernel::to_underlying(DataFormat::{formats_config.pack_S_dst.name});",
-                    "constexpr FormatConfig formats = FormatConfig(UNPACK_A_IN, UNPACK_B_IN, UNPACK_S_IN, UNPACK_A_OUT, UNPACK_B_OUT, UNPACK_S_OUT, MATH_FORMAT, PACK_IN, PACK_OUT, PACK_S_IN, PACK_S_OUT);",
+                    "constexpr FormatConfig formats = FormatConfig(UNPACK_A_IN, UNPACK_B_IN, UNPACK_S_IN, UNPACK_A_OUT, UNPACK_B_OUT, UNPACK_S_OUT, MATH_FORMAT, SFPU_MATH_FORMAT, PACK_IN, PACK_OUT, PACK_S_IN, PACK_S_OUT);",
                 ]
             )
 


### PR DESCRIPTION
### What

On Quasar the SFPU can operate in a data format that has no native register/dest representation (e.g. `UInt16`), so the math/unpack/pack data path and the SFPU-side format must be allowed to differ.

This adds an `sfpu_math` format to the test harness:
- `FormatConfig` gains an `sfpu_math` field (defaults to `math` when not given).
- `data_format_inference` routes a Quasar `UInt16` request through the known-good Int16 16-bit container for unpack/math/pack, while carrying the real format in `sfpu_math`.
- `test_config` plumbs `sfpu_math` through to the device-side `FormatConfig` (runtime and compile-time paths).

### Why

The math and SFPU data formats are not always the same on Quasar. A test can keep the data path in a container format the unpack/pack/dest datapath handles correctly, while telling the SFPU to load/store in the actual format under test. Currently scoped to `UInt16`; more formats can reuse the same mechanism later.

### Notes

- [x] No consumer in this PR, it is tested on #46829
- [x] All SFPU ops tests pass emulation (proves that this is not braking other tests)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=njokovic/quasar-sfpu-math-format)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:njokovic/quasar-sfpu-math-format)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=njokovic/quasar-sfpu-math-format)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:njokovic/quasar-sfpu-math-format)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=njokovic/quasar-sfpu-math-format)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:njokovic/quasar-sfpu-math-format)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=njokovic/quasar-sfpu-math-format)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:njokovic/quasar-sfpu-math-format)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=njokovic/quasar-sfpu-math-format)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:njokovic/quasar-sfpu-math-format)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=njokovic/quasar-sfpu-math-format)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:njokovic/quasar-sfpu-math-format)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=njokovic/quasar-sfpu-math-format)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:njokovic/quasar-sfpu-math-format)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=njokovic/quasar-sfpu-math-format)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:njokovic/quasar-sfpu-math-format)