### PR TITLE
SDXL: Lora fusion Perf threshold fixed

### DIFF
--- a/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_perf.py
+++ b/models/demos/stable_diffusion_xl_base/lora/tests/test_lora_perf.py
@@ -98,7 +98,7 @@ def test_lora_fuse(
     [
         (
             "pytest models/demos/stable_diffusion_xl_base/lora/tests/test_lora_perf.py::test_lora_fuse",
-            166_329_976 if is_wormhole_b0() else 71_935_194,
+            165_621_931 if is_wormhole_b0() else 71_935_194,
             "sdxl_lora_fuse",
             "sdxl_lora_fuse",
             1,


### PR DESCRIPTION
## Problem description
Flaky lora_fusion perf fails in metal CI: [example_link](https://github.com/tenstorrent/tt-metal/actions/runs/27536190215/job/81387729417)

Current threshold range:

| Metric | Value |
|----------|----------:|
| Lower Bound | 163,835,026 |
| Upper Bound | 168,824,926 |
| Current Average | 166,329,975.5 |

Recent runs:
| Timestamp | Duration | Status |
|------------|----------:|:------:|
| Jun 15, 2:06 PM | 167,049,100 | ✅ |
| Jun 15, 11:15 AM | 163,697,083 | ❌ |
| Jun 15, 5:21 AM | 165,707,166 | ✅ |
| Jun 15, 1:33 AM | 164,824,860 | ✅ |
| Jun 14, 10:35 PM | 165,647,814 | ✅ |
| Jun 14, 7:34 PM | 165,660,770 | ✅ |
| Jun 14, 4:51 PM | 167,092,966 | ✅ |
| Jun 14, 1:03 PM | 167,108,818 | ✅ |
| Jun 14, 10:25 AM | 163,782,205 | ❌ |
| Jun 14, 5:19 AM | 165,648,532 | ✅ |

Statistics over the last 10 runs:

| Metric | Value |
|----------|----------:|
| Average | 165,621,931 |
| 3σ | 3,761,209 |
| New Lower Bound | 163,137,602.4 |
| New Upper Bound | 168,106,260.4 |

## What is changed
Previous average: **166,329,975** -> New average: **165,621,931**

## Checklist
- [x] [SDXL Device Perf](https://github.com/tenstorrent/tt-metal/actions/runs/27554809716) passed✅