### PR TITLE
[skip ci] Temporarily skip test_sampling_topk_single_device on Blackhole

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sampling.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sampling.py
@@ -9,6 +9,7 @@ import torch
 from loguru import logger
 
 import ttnn
+from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_b1.micro_ops.sampling.op import SamplingOp
 from models.demos.deepseek_v3_b1.utils import float_to_uint32
 
@@ -690,6 +691,12 @@ def test_sampling_topk_single_device(
     device, seed, p, temperature, final_core_idx, num_internal_iterations, k, from_metadata, copy_probabilities
 ):
     # skip test_3
+    if is_blackhole():
+        pytest.skip(
+            "[SKIP REASON]: "
+            "test_sampling_topk_single_device produces wrong token selection and overflowed p_scores on Blackhole "
+            "(slow dispatch). Temporarily disabled until fix lands. Issue: #46981"
+        )
     """
     Test k=32 top-K sampling path for a single device and 101 cores.
 

--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_sampling.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_sampling.py
@@ -691,12 +691,6 @@ def test_sampling_topk_single_device(
     device, seed, p, temperature, final_core_idx, num_internal_iterations, k, from_metadata, copy_probabilities
 ):
     # skip test_3
-    if is_blackhole():
-        pytest.skip(
-            "[SKIP REASON]: "
-            "test_sampling_topk_single_device produces wrong token selection and overflowed p_scores on Blackhole "
-            "(slow dispatch). Temporarily disabled until fix lands. Issue: #46981"
-        )
     """
     Test k=32 top-K sampling path for a single device and 101 cores.
 
@@ -704,6 +698,13 @@ def test_sampling_topk_single_device(
     The kernel must select a token from within this set, proving that the
     full pipeline (local top-K, global merge, softmax, temperature) works.
     """
+    if is_blackhole():
+        pytest.skip(
+            "[SKIP REASON]: "
+            "test_sampling_topk_single_device produces wrong token selection and overflowed p_scores on Blackhole "
+            "(slow dispatch). Temporarily disabled until fix lands. "
+            "https://github.com/tenstorrent/tt-metal/issues/46981"
+        )
     _run_sampling_topk_single_device(
         device,
         seed=seed,


### PR DESCRIPTION
## Summary

Temporarily disables `test_sampling_topk_single_device` (test_1, test_2, test_4) on Blackhole hardware while the fix is being developed.

Tracked by #46981

## What changed

- Added `is_blackhole()` guard with `pytest.skip` in `test_sampling_topk_single_device`
- Added `is_blackhole` import from `models.common.utility_functions`

## Why

The sampling kernel produces grossly overflowed p_scores (~9.9e35 instead of [0,1]) on Blackhole (P150b) slow dispatch mode, causing wrong token selection. Regression introduced between 2026-06-06T00:23Z and 2026-06-06T05:13Z. Fix owner (alingTT) returns 2026-06-19.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ebanerjee/skip-sampling-topk-blackhole-46981)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ebanerjee/skip-sampling-topk-blackhole-46981)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ebanerjee/skip-sampling-topk-blackhole-46981)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ebanerjee/skip-sampling-topk-blackhole-46981)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/skip-sampling-topk-blackhole-46981)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/skip-sampling-topk-blackhole-46981)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/skip-sampling-topk-blackhole-46981)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/skip-sampling-topk-blackhole-46981)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ebanerjee/skip-sampling-topk-blackhole-46981)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ebanerjee/skip-sampling-topk-blackhole-46981)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ebanerjee/skip-sampling-topk-blackhole-46981)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ebanerjee/skip-sampling-topk-blackhole-46981)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ebanerjee/skip-sampling-topk-blackhole-46981)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ebanerjee/skip-sampling-topk-blackhole-46981)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ebanerjee/skip-sampling-topk-blackhole-46981)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ebanerjee/skip-sampling-topk-blackhole-46981)