### PR TITLE
[Cleanup] copy/typecast: migrate RM chunked dataflow + compute kernels to Device 2.0

### DIFF
--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/compute/eltwise_typecast.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/compute/eltwise_typecast.cpp
@@ -6,6 +6,7 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/typecast.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     constexpr uint32_t per_core_block_cnt = get_compile_time_arg_val(0);
@@ -13,14 +14,17 @@ void kernel_main() {
     constexpr uint32_t input_cb = get_compile_time_arg_val(2);
     constexpr uint32_t output_cb = get_compile_time_arg_val(3);
 
+    CircularBuffer cb_in(input_cb);
+    CircularBuffer cb_out(output_cb);
+
     init_sfpu(input_cb, output_cb);
     for (uint32_t block_index = 0; block_index < per_core_block_cnt; block_index++) {
-        cb_reserve_back(output_cb, per_core_block_dim);
+        cb_out.reserve_back(per_core_block_dim);
         for (uint32_t tile_index = 0; tile_index < per_core_block_dim; ++tile_index) {
             tile_regs_acquire();
 
             // Pop tile after tile, copy to DST and pack
-            cb_wait_front(input_cb, 1);
+            cb_in.wait_front(1);
 
             copy_tile(input_cb, 0, 0);
 
@@ -33,10 +37,10 @@ void kernel_main() {
 
             pack_tile(0, output_cb);
 
-            cb_pop_front(input_cb, 1);
+            cb_in.pop_front(1);
 
             tile_regs_release();
         }
-        cb_push_back(output_cb, per_core_block_dim);
+        cb_out.push_back(per_core_block_dim);
     }
 }

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/reader_typecast_rm_chunked.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/reader_typecast_rm_chunked.cpp
@@ -2,7 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
+
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     const uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -18,6 +24,9 @@ void kernel_main() {
 
     constexpr uint32_t onepage = 1;
 
+    Noc noc;
+    CircularBuffer cb_in(cb_id_in);
+
     const auto s = TensorAccessor(src_args, src_addr);
 
     const uint32_t end_row_id = start_row_id + num_rows;
@@ -25,28 +34,36 @@ void kernel_main() {
     for (uint32_t row_id = start_row_id; row_id < end_row_id; ++row_id) {
         // Process all full chunks for this row
         for (uint32_t chunk_idx = 0; chunk_idx < full_chunks_per_row; ++chunk_idx) {
-            cb_reserve_back(cb_id_in, onepage);
-            const uint32_t l1_write_addr = get_write_ptr(cb_id_in);
+            cb_in.reserve_back(onepage);
+            const uint32_t l1_write_addr = cb_in.get_write_ptr();
 
             const uint32_t byte_offset = chunk_idx * full_chunk_size_bytes;
-            const uint64_t chunk_noc_addr = s.get_noc_addr(row_id, byte_offset);
-            noc_async_read(chunk_noc_addr, l1_write_addr, full_chunk_size_bytes);
+            noc.async_read(
+                s,
+                CoreLocalMem<uint32_t>(l1_write_addr),
+                full_chunk_size_bytes,
+                {.page_id = row_id, .offset_bytes = byte_offset},
+                {});
 
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in, onepage);
+            noc.async_read_barrier();
+            cb_in.push_back(onepage);
         }
 
         // Process partial chunk if it exists
         if constexpr (partial_chunks_per_row > 0) {
-            cb_reserve_back(cb_id_in, onepage);
-            const uint32_t l1_write_addr = get_write_ptr(cb_id_in);
+            cb_in.reserve_back(onepage);
+            const uint32_t l1_write_addr = cb_in.get_write_ptr();
 
             const uint32_t byte_offset = full_chunks_per_row * full_chunk_size_bytes;
-            const uint64_t chunk_noc_addr = s.get_noc_addr(row_id, byte_offset);
-            noc_async_read(chunk_noc_addr, l1_write_addr, partial_chunk_size_bytes);
+            noc.async_read(
+                s,
+                CoreLocalMem<uint32_t>(l1_write_addr),
+                partial_chunk_size_bytes,
+                {.page_id = row_id, .offset_bytes = byte_offset},
+                {});
 
-            noc_async_read_barrier();
-            cb_push_back(cb_id_in, onepage);
+            noc.async_read_barrier();
+            cb_in.push_back(onepage);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/writer_typecast_rm_chunked.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/kernels/dataflow/writer_typecast_rm_chunked.cpp
@@ -2,7 +2,13 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <stdint.h>
+
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
 
 void kernel_main() {
     const uint32_t dst_addr = get_arg_val<uint32_t>(0);
@@ -18,6 +24,9 @@ void kernel_main() {
 
     constexpr uint32_t onepage = 1;
 
+    Noc noc;
+    CircularBuffer cb_out(cb_id_out);
+
     const auto s = TensorAccessor(dst_args, dst_addr);
 
     const uint32_t end_row_id = start_row_id + num_rows;
@@ -25,29 +34,37 @@ void kernel_main() {
     for (uint32_t row_id = start_row_id; row_id < end_row_id; ++row_id) {
         // Process all full chunks for this row
         for (uint32_t chunk_idx = 0; chunk_idx < full_chunks_per_row; ++chunk_idx) {
-            cb_wait_front(cb_id_out, onepage);
-            const uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+            cb_out.wait_front(onepage);
+            const uint32_t l1_read_addr = cb_out.get_read_ptr();
 
             const uint32_t byte_offset = chunk_idx * full_chunk_size_bytes;
-            const uint64_t chunk_noc_addr = s.get_noc_addr(row_id, byte_offset);
-            noc_async_write(l1_read_addr, chunk_noc_addr, full_chunk_size_bytes);
+            noc.async_write(
+                CoreLocalMem<uint32_t>(l1_read_addr),
+                s,
+                full_chunk_size_bytes,
+                {},
+                {.page_id = row_id, .offset_bytes = byte_offset});
 
-            noc_async_writes_flushed();
-            cb_pop_front(cb_id_out, onepage);
+            noc.async_writes_flushed();
+            cb_out.pop_front(onepage);
         }
 
         // Process partial chunk if it exists
         if constexpr (partial_chunks_per_row > 0) {
-            cb_wait_front(cb_id_out, onepage);
-            const uint32_t l1_read_addr = get_read_ptr(cb_id_out);
+            cb_out.wait_front(onepage);
+            const uint32_t l1_read_addr = cb_out.get_read_ptr();
 
             const uint32_t byte_offset = full_chunks_per_row * full_chunk_size_bytes;
-            const uint64_t chunk_noc_addr = s.get_noc_addr(row_id, byte_offset);
-            noc_async_write(l1_read_addr, chunk_noc_addr, partial_chunk_size_bytes);
+            noc.async_write(
+                CoreLocalMem<uint32_t>(l1_read_addr),
+                s,
+                partial_chunk_size_bytes,
+                {},
+                {.page_id = row_id, .offset_bytes = byte_offset});
 
-            noc_async_writes_flushed();
-            cb_pop_front(cb_id_out, onepage);
+            noc.async_writes_flushed();
+            cb_out.pop_front(onepage);
         }
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }


### PR DESCRIPTION
### PR Category
Cleanup

### Summary

  Relates to #45003.

  Migrate three kernels of the row-major chunked typecast path in `operations/copy/typecast/device/kernels/` to the Device 2.0 API.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/typecast-rm-chunked-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/typecast-rm-chunked-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/typecast-rm-chunked-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/typecast-rm-chunked-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/typecast-rm-chunked-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/typecast-rm-chunked-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/typecast-rm-chunked-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/typecast-rm-chunked-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/typecast-rm-chunked-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/typecast-rm-chunked-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/typecast-rm-chunked-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/typecast-rm-chunked-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/typecast-rm-chunked-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/typecast-rm-chunked-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/typecast-rm-chunked-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/typecast-rm-chunked-device-2-0)