### PR TITLE
Fix #46862: Stable log1p formulation for SFPU inverse hyperbolic functions

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -12,6 +12,7 @@
 #include "ckernel_sfpu_sqrt_custom.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_log.h"
+#include "ckernel_sfpu_log1p.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
@@ -788,41 +789,90 @@ inline void _calculate_cosine_(const int iterations) {
     }
 }
 
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat log1p_or_log_dispatch(sfpi::vFloat arg, sfpi::vInt use_log1p) {
+    sfpi::vFloat res;
+    v_if(use_log1p) {
+        res = calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+    }
+    v_else {
+        res = _calculate_log_body_no_init_(arg);
+    }
+    v_endif;
+    return res;
+}
+
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_acosh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat res;
-        v_if(inp < sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(inp == sfpi::vConst1) { res = sfpi::vConst0; }
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        v_if(x < sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
+        v_elseif(x == sfpi::vConst1) { sfpi::dst_reg[0] = sfpi::vConst0; }
         v_else {
-            sfpi::vFloat tmp = inp * inp;
-            tmp = tmp - sfpi::vConst1;
-            tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp = tmp + inp;
-            res = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat arg;
+            sfpi::vInt use_log1p;
+            v_if(x < 1.5f) {
+                sfpi::vFloat x_m1 = x - sfpi::vConst1;
+                sfpi::vFloat x_p1 = x + sfpi::vConst1;
+                arg = x_m1 + _calculate_sqrt_body_<APPROXIMATION_MODE>(x_m1 * x_p1);
+                use_log1p = 1;
+            }
+            v_elseif(x < 268435456.0f) {
+                sfpi::vFloat tmp = x * x;
+                tmp = tmp - sfpi::vConst1;
+                arg = x + _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+                use_log1p = 0;
+            }
+            v_else {
+                arg = 2.0f * x;
+                use_log1p = 0;
+            }
+            v_endif;
+            
+            sfpi::vFloat res = log1p_or_log_dispatch<is_fp32_dest_acc_en>(arg, use_log1p);
+            
+            if constexpr (!is_fp32_dest_acc_en) {
+                res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
+            }
+            sfpi::dst_reg[0] = res;
         }
         v_endif;
-        sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_asinh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp = tmp + sfpi::abs(inp);
-        auto res = _calculate_log_body_no_init_(tmp);
-        v_if(inp < sfpi::vConst0) { res = -res; }
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat a = sfpi::abs(x);
+        sfpi::vFloat res;
+        v_if(a < 0.5f) {
+            sfpi::vFloat a2 = a * a;
+            sfpi::vFloat arg = a + a2 * _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(sfpi::vConst1 + _calculate_sqrt_body_<APPROXIMATION_MODE>(sfpi::vConst1 + a2));
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+        }
+        v_elseif(a < 268435456.0f) {
+            sfpi::vFloat arg = a + _calculate_sqrt_body_<APPROXIMATION_MODE>(sfpi::vConst1 + a * a) - sfpi::vConst1;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+        }
+        v_else {
+            sfpi::vFloat ln2 = 0.6931471805599453f; // LOG_TWO
+            res = ln2 + _calculate_log_body_no_init_(a);
+        }
         v_endif;
+        
+        v_if(x < sfpi::vConst0) { res = -res; }
+        v_endif;
+        
+        if constexpr (!is_fp32_dest_acc_en) {
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
+        }
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
@@ -833,42 +883,53 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_atanh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat abs_inp = sfpi::abs(inp);
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat abs_x = sfpi::abs(x);
         sfpi::vFloat res;
-        v_if(abs_inp > sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(abs_inp == sfpi::vConst1) {
+        
+        v_if(abs_x > sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
+        v_elseif(abs_x == sfpi::vConst1) {
             sfpi::vFloat inf = std::numeric_limits<float>::infinity();
-            res = sfpi::copysgn(inf, inp);
+            res = sfpi::copysgn(inf, x);
         }
         v_else {
-            sfpi::vFloat num = sfpi::vConst1 + inp;
-            sfpi::vFloat den = sfpi::vConst1 - inp;
-            sfpi::vFloat tmp = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
-            tmp = sfpi::copysgn(tmp, den);
-            if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
-                den = tmp;
-            } else {
-                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
+            sfpi::vFloat arg;
+            v_if(abs_x < 0.5f) {
+                sfpi::vFloat num = 2.0f * x;
+                sfpi::vFloat den = sfpi::vConst1 - x;
+                arg = num * _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
+                res = 0.5f * calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
             }
-            num = num * den;
-            den = _calculate_log_body_no_init_(num);
-            res = 0.5f * den;
+            v_else {
+                sfpi::vFloat num = 2.0f * abs_x;
+                sfpi::vFloat den = sfpi::vConst1 - abs_x;
+                arg = num * _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
+                res = 0.5f * calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+                v_if(x < sfpi::vConst0) { res = -res; }
+                v_endif;
+            }
+            v_endif;
         }
         v_endif;
+        
+        if constexpr (!is_fp32_dest_acc_en) {
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
+        }
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_inverse_hyperbolic() {
     sqrt_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_atanh() {
     _init_sfpu_reciprocal_<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -12,6 +12,7 @@
 #include "ckernel_sfpu_sqrt_custom.h"
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_log.h"
+#include "ckernel_sfpu_log1p.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
 
@@ -817,21 +818,55 @@ inline void _calculate_cosine_(const int iterations) {
     }
 }
 
+template <bool is_fp32_dest_acc_en>
+sfpi_inline sfpi::vFloat log1p_or_log_dispatch(sfpi::vFloat arg, sfpi::vInt use_log1p) {
+    sfpi::vFloat res;
+    v_if(use_log1p) {
+        res = calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+    }
+    v_else {
+        res = _calculate_log_body_no_init_(arg);
+    }
+    v_endif;
+    return res;
+}
+
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_acosh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        v_if(inp < sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(inp == sfpi::vConst1) { sfpi::dst_reg[0] = sfpi::vConst0; }
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        v_if(x < sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
+        v_elseif(x == sfpi::vConst1) { sfpi::dst_reg[0] = sfpi::vConst0; }
         v_else {
-            sfpi::vFloat tmp = inp * inp;
-            tmp = tmp - sfpi::vConst1;
-            tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp = tmp + inp;
-            sfpi::dst_reg[0] = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat arg;
+            sfpi::vInt use_log1p;
+            v_if(x < 1.5f) {
+                sfpi::vFloat x_m1 = x - sfpi::vConst1;
+                sfpi::vFloat x_p1 = x + sfpi::vConst1;
+                arg = x_m1 + _calculate_sqrt_body_<APPROXIMATION_MODE>(x_m1 * x_p1);
+                use_log1p = 1;
+            }
+            v_elseif(x < 268435456.0f) {
+                sfpi::vFloat tmp = x * x;
+                tmp = tmp - sfpi::vConst1;
+                arg = x + _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+                use_log1p = 0;
+            }
+            v_else {
+                arg = 2.0f * x;
+                use_log1p = 0;
+            }
+            v_endif;
+            
+            sfpi::vFloat res = log1p_or_log_dispatch<is_fp32_dest_acc_en>(arg, use_log1p);
+            
+            if constexpr (!is_fp32_dest_acc_en) {
+                res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
+            }
+            sfpi::dst_reg[0] = res;
         }
         v_endif;
         sfpi::dst_reg++;
@@ -839,17 +874,34 @@ inline void calculate_acosh() {
 }
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_asinh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp = tmp + sfpi::abs(inp);
-        auto res = _calculate_log_body_no_init_(tmp);
-        v_if(inp < sfpi::vConst0) { res = -res; }
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat a = sfpi::abs(x);
+        sfpi::vFloat res;
+        v_if(a < 0.5f) {
+            sfpi::vFloat a2 = a * a;
+            sfpi::vFloat arg = a + a2 * _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(sfpi::vConst1 + _calculate_sqrt_body_<APPROXIMATION_MODE>(sfpi::vConst1 + a2));
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+        }
+        v_elseif(a < 268435456.0f) {
+            sfpi::vFloat arg = a + _calculate_sqrt_body_<APPROXIMATION_MODE>(sfpi::vConst1 + a * a) - sfpi::vConst1;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+        }
+        v_else {
+            sfpi::vFloat ln2 = 0.6931471805599453f; // LOG_TWO
+            res = ln2 + _calculate_log_body_no_init_(a);
+        }
         v_endif;
+        
+        v_if(x < sfpi::vConst0) { res = -res; }
+        v_endif;
+        
+        if constexpr (!is_fp32_dest_acc_en) {
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
+        }
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
@@ -860,42 +912,53 @@ template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_atanh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
-        sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat abs_inp = sfpi::abs(inp);
+        sfpi::vFloat x = sfpi::dst_reg[0];
+        sfpi::vFloat abs_x = sfpi::abs(x);
         sfpi::vFloat res;
-        v_if(abs_inp > sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(abs_inp == sfpi::vConst1) {
+        
+        v_if(abs_x > sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
+        v_elseif(abs_x == sfpi::vConst1) {
             sfpi::vFloat inf = std::numeric_limits<float>::infinity();
-            res = sfpi::copysgn(inf, inp);
+            res = sfpi::copysgn(inf, x);
         }
         v_else {
-            sfpi::vFloat num = sfpi::vConst1 + inp;
-            sfpi::vFloat den = sfpi::vConst1 - inp;
-            sfpi::vFloat tmp = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
-            tmp = sfpi::copysgn(tmp, den);
-            if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
-                den = tmp;
-            } else {
-                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
+            sfpi::vFloat arg;
+            v_if(abs_x < 0.5f) {
+                sfpi::vFloat num = 2.0f * x;
+                sfpi::vFloat den = sfpi::vConst1 - x;
+                arg = num * _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
+                res = 0.5f * calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
             }
-            num = num * den;
-            den = _calculate_log_body_no_init_(num);
-            res = 0.5f * den;
+            v_else {
+                sfpi::vFloat num = 2.0f * abs_x;
+                sfpi::vFloat den = sfpi::vConst1 - abs_x;
+                arg = num * _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
+                res = 0.5f * calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+                v_if(x < sfpi::vConst0) { res = -res; }
+                v_endif;
+            }
+            v_endif;
         }
         v_endif;
+        
+        if constexpr (!is_fp32_dest_acc_en) {
+            res = sfpi::convert<sfpi::vFloat16b>(res, sfpi::RoundMode::NearestEven);
+        }
         sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_inverse_hyperbolic() {
     sqrt_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_atanh() {
     _init_sfpu_reciprocal_<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
@@ -62,7 +62,7 @@ ALWI void cos_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void acosh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(acosh, ckernel::sfpu::init_inverse_hyperbolic, APPROX)); }
+ALWI void acosh_tile_init() { MATH(SFPU_TWO_TEMPLATE_PARAM_INIT(acosh, ckernel::sfpu::init_inverse_hyperbolic, APPROX, DST_ACCUM_MODE)); }
 
 // clang-format off
 /**
@@ -79,7 +79,7 @@ ALWI void acosh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(acosh, ckernel::sfpu::i
  */
 // clang-format on
 ALWI void acosh_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(calculate_acosh, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_acosh, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
@@ -109,7 +109,7 @@ ALWI void tan_tile(uint32_t idst) {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void asinh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(asinh, ckernel::sfpu::init_inverse_hyperbolic, APPROX)); }
+ALWI void asinh_tile_init() { MATH(SFPU_TWO_TEMPLATE_PARAM_INIT(asinh, ckernel::sfpu::init_inverse_hyperbolic, APPROX, DST_ACCUM_MODE)); }
 
 // clang-format off
 /**
@@ -126,13 +126,13 @@ ALWI void asinh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(asinh, ckernel::sfpu::i
  */
 // clang-format on
 ALWI void asinh_tile(uint32_t idst) {
-    MATH(SFPU_TWO_PARAM_KERNEL(calculate_asinh, APPROX, 8 /*ITER*/, idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_asinh, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void atanh_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(atanh, ckernel::sfpu::init_atanh, APPROX)); }
+ALWI void atanh_tile_init() { MATH(SFPU_TWO_TEMPLATE_PARAM_INIT(atanh, ckernel::sfpu::init_atanh, APPROX, DST_ACCUM_MODE)); }
 
 // clang-format off
 /**


### PR DESCRIPTION
Fixes #46862

Implemented the standard libm formulation for `atanh`, `asinh`, and `acosh` routing through the recently merged `calculate_log1p_fp32` SFPU kernel.
- `atanh`: Uses `0.5 * log1p(2*x/(1-x))`
- `asinh`: Uses algebraic identity `x + x^2 / (1 + sqrt(1 + x^2))` for small |x|
- `acosh`: Uses stable `log1p((x - 1) + sqrt((x - 1) * (x + 1)))` near 1.0
- Updated initialization macros in `trigonometry.h` to pass `DST_ACCUM_MODE` for correct `is_fp32_dest_acc_en` propagation.