### PR TITLE
ttnn MetalV2: op-owned tensors (create_owned_tensors) + halo migration

### DIFF
--- a/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_launch_operation.cpp
@@ -156,7 +156,9 @@ struct MissingPerEnqueueFactory {
         return {};
     }
 };
-struct MissingInvariantArgsFactory {
+// The minimal valid spec factory: just create_program_spec + create_per_enqueue_args. create_invariant_run_args
+// is optional, so omitting it (meaning "no enqueue-invariant run-args") is well-formed, not a missing method.
+struct MinimalSpecFactory {
     static tt::tt_metal::experimental::ProgramSpec create_program_spec(
         const OperationAttributes&, const Tensor&, Tensor&) {
         return {};
@@ -167,10 +169,30 @@ struct MissingInvariantArgsFactory {
     }
 };
 
+// A spec factory MAY additionally define the optional create_owned_tensors (op-allocated internal tensors).
+struct OwnedTensorsFactory {
+    static tt::tt_metal::experimental::ProgramSpec create_program_spec(
+        const OperationAttributes&, const Tensor&, Tensor&) {
+        return {};
+    }
+    static tt::tt_metal::experimental::ProgramRunArgs create_invariant_run_args(
+        const OperationAttributes&, const Tensor&, Tensor&) {
+        return {};
+    }
+    static tt::tt_metal::experimental::ProgramRunArgs create_per_enqueue_args(
+        const OperationAttributes&, const Tensor&, Tensor&, const std::optional<ttnn::MeshCoordinate>&) {
+        return {};
+    }
+    static tt::tt_metal::experimental::Table<tt::tt_metal::experimental::TensorParamName, Tensor>
+    create_owned_tensors(const OperationAttributes&, const Tensor&, Tensor&) {
+        return {};
+    }
+};
+
 namespace concepts = ttnn::device_operation;
 
-// Each factory satisfies exactly one spec-factory concept, distinguished by the cache key; both carry all
-// three mandatory build methods.
+// Each factory satisfies exactly one spec-factory concept, distinguished by the cache key; both carry the two
+// mandatory build methods (create_program_spec + create_per_enqueue_args).
 static_assert(concepts::ProgramSpecFactoryConcept<SpecKeyedFactory>);
 static_assert(!concepts::AdvancedProgramSpecFactoryConcept<SpecKeyedFactory>);
 static_assert(!concepts::HasImmutableInfoExtraction<SpecKeyedFactory>);
@@ -180,11 +202,21 @@ static_assert(concepts::HasImmutableInfoExtraction<ImmutableInfoFactory>);
 static_assert(concepts::MetalV2SpecFactoryConcept<SpecKeyedFactory>);
 static_assert(concepts::MetalV2SpecFactoryConcept<ImmutableInfoFactory>);
 
-// All three build methods are required — missing any one means it is not a MetalV2 spec factory.
+// create_program_spec and create_per_enqueue_args are required — missing create_per_enqueue_args means it is
+// not a MetalV2 spec factory.
 static_assert(!concepts::MetalV2SpecFactoryConcept<MissingPerEnqueueFactory>);
-static_assert(!concepts::MetalV2SpecFactoryConcept<MissingInvariantArgsFactory>);
 static_assert(!concepts::HasCreatePerEnqueueArgs<MissingPerEnqueueFactory>);
-static_assert(!concepts::HasCreateInvariantRunArgs<MissingInvariantArgsFactory>);
+
+// create_invariant_run_args is OPTIONAL: a factory with only spec + per-enqueue is the minimal valid shape.
+static_assert(concepts::ProgramSpecFactoryConcept<MinimalSpecFactory>);
+static_assert(concepts::MetalV2SpecFactoryConcept<MinimalSpecFactory>);
+static_assert(!concepts::HasCreateInvariantRunArgs<MinimalSpecFactory>);
+
+// create_owned_tensors is OPTIONAL: a factory that defines it is still a valid base spec factory, and one
+// that omits it (SpecKeyedFactory) is equally valid — the spec concepts do not require it.
+static_assert(concepts::ProgramSpecFactoryConcept<OwnedTensorsFactory>);
+static_assert(concepts::HasCreateOwnedTensors<OwnedTensorsFactory>);
+static_assert(!concepts::HasCreateOwnedTensors<SpecKeyedFactory>);
 
 // A spec factory is none of the prior factory shapes (and vice versa).
 static_assert(!concepts::ProgramFactoryConcept<SpecKeyedFactory>);

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -630,9 +630,13 @@ public:
     // -----------------------------------------------------------------------
     template <MetalV2SpecFactoryConcept ProgramSpecFactory>
     struct ProgramSpecMeshWorkloadFactoryAdapter {
-        // No per-coordinate state is cached: a hit re-derives the per-enqueue args from
-        // create_per_enqueue_args, so there is nothing to stash between calls.
-        struct shared_variables_t {};
+        // Op-owned internal tensors (from create_owned_tensors), kept alive for the cached program's
+        // lifetime so their device buffers stay allocated; shared across coordinate ranges. Empty/null for
+        // ops that allocate no internal tensors (the common case). Nothing else is cached — a hit
+        // re-derives the per-enqueue args from create_per_enqueue_args.
+        struct shared_variables_t {
+            std::shared_ptr<std::vector<tt::tt_metal::Tensor>> owned_tensors;
+        };
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
         // MakeProgramFromSpec needs a MeshDevice; pull it from the first device tensor reachable from
@@ -665,34 +669,64 @@ public:
             // The Advanced concept builds the spec + invariant args from the extracted ImmutableInfo (so a
             // mutable value such as a seed is never visible to either builder); the spec-keyed concept takes
             // (attrs, tensor_args, tensor_return_value). Both are built once, here, on the cache miss.
+            // create_invariant_run_args is optional: a factory that omits it has no enqueue-invariant
+            // run-args, so we start from an empty set (the simplest factory is just spec + per-enqueue).
             constexpr bool kImmutable = HasImmutableInfoExtraction<ProgramSpecFactory>;
+            constexpr bool kHasInvariant = HasCreateInvariantRunArgs<ProgramSpecFactory>;
             auto [spec, invariant_run_args] = [&] {
                 if constexpr (kImmutable) {
                     auto info = ProgramSpecFactory::extract_immutable_info(attrs, tensor_args);
-                    return std::pair{
-                        ProgramSpecFactory::create_program_spec(info),
-                        ProgramSpecFactory::create_invariant_run_args(info)};
+                    auto program_spec = ProgramSpecFactory::create_program_spec(info);
+                    if constexpr (kHasInvariant) {
+                        return std::pair{std::move(program_spec), ProgramSpecFactory::create_invariant_run_args(info)};
+                    } else {
+                        return std::pair{std::move(program_spec), tt::tt_metal::experimental::ProgramRunArgs{}};
+                    }
                 } else {
-                    return std::pair{
-                        ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value),
-                        ProgramSpecFactory::create_invariant_run_args(attrs, tensor_args, tensor_return_value)};
+                    auto program_spec =
+                        ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
+                    if constexpr (kHasInvariant) {
+                        return std::pair{
+                            std::move(program_spec),
+                            ProgramSpecFactory::create_invariant_run_args(attrs, tensor_args, tensor_return_value)};
+                    } else {
+                        return std::pair{std::move(program_spec), tt::tt_metal::experimental::ProgramRunArgs{}};
+                    }
                 }
             }();
+
+            // Optional op-owned internal tensors (config / lookup tables the op allocates, not passed by the
+            // caller). Built once; kept alive for the cached program's lifetime and bound enqueue-invariant
+            // by name. Empty for the common case. The framework holds the Tensors (not just buffers) so
+            // ~Tensor can't force-deallocate them out from under the cached program.
+            auto owned_tensors = std::make_shared<std::vector<tt::tt_metal::Tensor>>();
+            tt::tt_metal::experimental::ProgramRunArgs owned_run_args;
+            if constexpr (HasCreateOwnedTensors<ProgramSpecFactory>) {
+                for (auto& [name, tensor] :
+                     ProgramSpecFactory::create_owned_tensors(attrs, tensor_args, tensor_return_value)) {
+                    owned_tensors->push_back(tensor);
+                    owned_run_args.tensor_args.emplace(
+                        name,
+                        tt::tt_metal::experimental::ProgramRunArgs::TensorArgument{
+                            std::cref(owned_tensors->back().mesh_tensor())});
+                }
+            }
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
 
-            // One Program per coordinate range. The per-enqueue args are built per coordinate (so a
-            // per-device value such as a seed offset can vary across the mesh) and merged with the
-            // enqueue-invariant set for the initial SetProgramRunArgs.
+            // One Program per coordinate range. Run-args = the enqueue-invariant set, merged with the
+            // op-owned tensor bindings (also invariant) and the per-coordinate per-enqueue set. The
+            // per-enqueue set is built per coordinate so a per-device value (e.g. a seed offset) can vary.
             for (const auto& range : tensor_coords.ranges()) {
                 const std::optional<ttnn::MeshCoordinate> coord(*range.begin());
-                std::array<tt::tt_metal::experimental::ProgramRunArgs, 1> per_enqueue{
+                std::array<tt::tt_metal::experimental::ProgramRunArgs, 2> appended{
+                    owned_run_args,
                     ProgramSpecFactory::create_per_enqueue_args(attrs, tensor_args, tensor_return_value, coord)};
-                auto run_params = tt::tt_metal::experimental::MergeProgramRunArgs(invariant_run_args, per_enqueue);
+                auto run_params = tt::tt_metal::experimental::MergeProgramRunArgs(invariant_run_args, appended);
                 auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, spec);
                 tt::tt_metal::experimental::SetProgramRunArgs(program, run_params);
-                shared_variables.emplace(range, shared_variables_t{});
+                shared_variables.emplace(range, shared_variables_t{.owned_tensors = owned_tensors});
                 mesh_workload.add_program(range, std::move(program));
             }
             return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};

--- a/ttnn/api/ttnn/operation_concepts.hpp
+++ b/ttnn/api/ttnn/operation_concepts.hpp
@@ -76,21 +76,33 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 //  MetalV2 ProgramSpec factory concepts
 // ============================================================================
 //
-// A MetalV2 op factory is built from three methods, each with a single job:
+// A MetalV2 op factory is built from two required methods plus two optional ones, each with a single job:
 //
 //   - create_program_spec       -> ProgramSpec     : the immutable blueprint (kernels, DFBs, work-units,
 //                                                     argument schemas). Built once, on a cache miss.
-//   - create_invariant_run_args -> ProgramRunArgs  : the enqueue-invariant run-args (work splits, shape
-//                                                     scalars). Set once on a miss and retained across hits.
 //   - create_per_enqueue_args   -> ProgramRunArgs  : the per-enqueue run-args (tensor addresses, seeds).
 //                                                     Rebuilt on EVERY dispatch and re-applied via
 //                                                     UpdateProgramRunArgs.
+//   - create_invariant_run_args -> ProgramRunArgs  (OPTIONAL): the enqueue-invariant run-args (work splits,
+//                                                     shape scalars). Set once on a miss and retained across
+//                                                     hits. Omitting it means "no invariant run-args" — the
+//                                                     simplest functional-and-correct factory is just
+//                                                     create_program_spec + create_per_enqueue_args. Add this
+//                                                     method as a perf step, when some args can move out of
+//                                                     the per-enqueue bucket. (Optional, not a stub, so that
+//                                                     "haven't gotten to it" stays distinct from "considered
+//                                                     it; nothing is invariant".)
+//   - create_owned_tensors      -> Table<name,Tensor> (OPTIONAL): device tensors the op allocates for its
+//                                                     own internal use (config / lookup tables not passed
+//                                                     by the caller), keyed by the TensorParameter each
+//                                                     binds to. Built once on a miss; the framework keeps
+//                                                     them alive for the cached program's lifetime and
+//                                                     binds them enqueue-invariant. Most ops omit it.
 //
-// On a miss the framework merges the invariant + per-enqueue sets for the initial SetProgramRunArgs. On a
-// hit it rebuilds neither the spec nor the invariant args — it re-runs only create_per_enqueue_args and
-// re-applies it. Splitting the run-args across two methods is what forces the author to decide, per arg,
-// what is enqueue-invariant vs per-enqueue; the metal runtime then validates that every arg omitted from
-// the per-enqueue set was declared enqueue_invariant in the spec — a forgotten per-enqueue value is a hard
+// On a miss the framework merges the invariant (if present) + per-enqueue sets for the initial
+// SetProgramRunArgs. On a hit it rebuilds neither the spec nor the invariant args — it re-runs only
+// create_per_enqueue_args and re-applies it. The metal runtime validates that every arg omitted from the
+// per-enqueue set was declared enqueue_invariant in the spec — a forgotten per-enqueue value is a hard
 // error, not silently-stale data.
 //
 // There are exactly TWO concepts, distinguished by ONE thing — the cache key:
@@ -106,10 +118,16 @@ concept ProgramDescriptorFactoryConcept = (requires { &T::create_descriptor; } |
 // --- method-surface building blocks ---
 template <typename T>
 concept HasCreateProgramSpec = requires { &T::create_program_spec; };
+// Optional — a factory may omit it to mean "no enqueue-invariant run-args"; the spec-factory concepts below
+// do NOT require it.
 template <typename T>
 concept HasCreateInvariantRunArgs = requires { &T::create_invariant_run_args; };
 template <typename T>
 concept HasCreatePerEnqueueArgs = requires { &T::create_per_enqueue_args; };
+// Optional — only ops that allocate internal device tensors define it; the spec-factory concepts below do
+// NOT require it.
+template <typename T>
+concept HasCreateOwnedTensors = requires { &T::create_owned_tensors; };
 template <typename T>
 concept HasImmutableInfoExtraction = requires { &T::extract_immutable_info; };
 // Shared exclusion: a MetalV2 spec factory is none of the legacy factory shapes.
@@ -117,19 +135,17 @@ template <typename T>
 concept NotALegacyFactory =
     !ProgramFactoryConcept<T> && !MeshWorkloadFactoryConcept<T> && !ProgramDescriptorFactoryConcept<T>;
 
-// All three build methods are mandatory; the cache key is the default reflection hash
-// (op type + attributes + tensor args).
+// create_program_spec and create_per_enqueue_args are mandatory; create_invariant_run_args is optional. The
+// cache key is the default reflection hash (op type + attributes + tensor args).
 template <typename T>
-concept ProgramSpecFactoryConcept =
-    HasCreateProgramSpec<T> && HasCreateInvariantRunArgs<T> && HasCreatePerEnqueueArgs<T> &&
-    !HasImmutableInfoExtraction<T> && NotALegacyFactory<T>;
+concept ProgramSpecFactoryConcept = HasCreateProgramSpec<T> && HasCreatePerEnqueueArgs<T> &&
+                                    !HasImmutableInfoExtraction<T> && NotALegacyFactory<T>;
 
 // ImmutableInfo-keyed factory: extract_immutable_info -> ImmutableInfo is BOTH the cache key and the sole
 // input to create_program_spec, so a mutable value (e.g. an RNG seed) cannot leak into the key or the spec.
 template <typename T>
-concept AdvancedProgramSpecFactoryConcept =
-    HasCreateProgramSpec<T> && HasCreateInvariantRunArgs<T> && HasCreatePerEnqueueArgs<T> &&
-    HasImmutableInfoExtraction<T> && NotALegacyFactory<T>;
+concept AdvancedProgramSpecFactoryConcept = HasCreateProgramSpec<T> && HasCreatePerEnqueueArgs<T> &&
+                                            HasImmutableInfoExtraction<T> && NotALegacyFactory<T>;
 
 // Umbrella: either MetalV2 spec factory shape (exactly one is satisfied by construction).
 template <typename T>

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp
@@ -12,13 +12,16 @@ constexpr uint32_t NUM_RISCV_DATA_MOVEMENT_CORES = 2;
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
 
 void kernel_main() {
-    constexpr uint32_t src_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t out_cb_id0 = get_compile_time_arg_val(1);
-    constexpr uint32_t out_cb_id1 = get_compile_time_arg_val(2);
-    constexpr uint32_t tiles_per_row = get_compile_time_arg_val(3);  // number of tiles along width of shard
-    constexpr uint32_t block_size = get_compile_time_arg_val(4);  // number of tiles along height that make up a block
+    // MetalV2 bindings only — device logic unchanged. CB ids come from the DFB tokens, the per-shard tile
+    // geometry from host defines (they're untilize<> template params, so must be compile-time), and the
+    // per-core block count from the named-arg namespace.
+    constexpr uint32_t src_cb_id = dfb::src;
+    constexpr uint32_t out_cb_id0 = dfb::untilize_out0;
+    constexpr uint32_t out_cb_id1 = dfb::untilize_out1;
+    constexpr uint32_t tiles_per_row = TILES_PER_ROW;  // number of tiles along width of shard
+    constexpr uint32_t block_size = BLOCK_SIZE;        // number of tiles along height that make up a block
 
-    const uint32_t total_blocks = get_arg_val<uint32_t>(0);
+    const uint32_t total_blocks = get_arg(args::total_blocks);
 
     compute_kernel_hw_startup(src_cb_id, out_cb_id0);
 

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp
@@ -255,24 +255,36 @@ static inline void run_halo_gather(
 }
 
 void kernel_main() {
-    constexpr uint32_t padding_config_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t gather_config_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t src_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t in_cb_id = get_compile_time_arg_val(3);
-    constexpr uint32_t out_cb_id = get_compile_time_arg_val(4);
-    constexpr uint32_t pad_cb_id = get_compile_time_arg_val(5);
-    constexpr uint32_t pad_val_u32 = get_compile_time_arg_val(6);
-    constexpr uint32_t in_nsticks = get_compile_time_arg_val(7);
-    constexpr uint32_t aligned_stick_nbytes = get_compile_time_arg_val(8);
-    constexpr bool is_block_sharded = get_compile_time_arg_val(9) == 1;
-    constexpr bool remote_read = get_compile_time_arg_val(10) == 1;
-    constexpr bool is_col_major = get_compile_time_arg_val(11) == 1;
-    constexpr bool is_width_sharded = get_compile_time_arg_val(12) == 1;
-    constexpr bool skip_untilize = get_compile_time_arg_val(13) == 1;
-    constexpr uint32_t block_size_height = get_compile_time_arg_val(14);
-    constexpr uint32_t block_size_width_tiles = get_compile_time_arg_val(15);
-    constexpr uint32_t block_start_offset = get_compile_time_arg_val(16);
-    constexpr uint32_t block_stride = get_compile_time_arg_val(17);
+    // MetalV2 bindings only — the halo-gather device logic below is unchanged. CB ids come from the DFB
+    // tokens, the compile-time geometry/selectors from host defines (they are template parameters of
+    // copy_padding<>/run_halo_gather<>), the DRAM config tensors from the ta:: accessors, and the per-core
+    // config page index from the named-arg namespace. The optional padding-config resource is bound (and
+    // referenced) only when ENABLE_PADDING is set, so its dfb token is never referenced unbound.
+    constexpr uint32_t gather_config_cb_id = dfb::gather_config;
+    // The pushing reader (block_start_offset==0) holds the producer binding for src, so it uses dfb::src.
+    // In row-major skip-untilize, src and in are the same borrowed buffer; the non-pushing reader has only
+    // the `in` consumer binding, so it aliases src to dfb::in (a second dfb::src binding would be rejected).
+    // The other reader in tiled mode never references src at all.
+#if (BLOCK_START_OFFSET == 0)
+    constexpr uint32_t src_cb_id = dfb::src;
+#elif (SKIP_UNTILIZE == 1)
+    constexpr uint32_t src_cb_id = dfb::in;
+#endif
+    constexpr uint32_t in_cb_id = dfb::in;
+    constexpr uint32_t out_cb_id = dfb::out;
+    constexpr uint32_t pad_cb_id = dfb::pad;
+    constexpr uint32_t pad_val_u32 = PAD_VAL;
+    constexpr uint32_t in_nsticks = IN_NSTICKS;
+    constexpr uint32_t aligned_stick_nbytes = ALIGNED_STICK_NBYTES;
+    constexpr bool is_block_sharded = IS_BLOCK_SHARDED == 1;
+    constexpr bool remote_read = REMOTE_READ == 1;
+    constexpr bool is_col_major = IS_COL_MAJOR == 1;
+    constexpr bool is_width_sharded = IS_WIDTH_SHARDED == 1;
+    constexpr bool skip_untilize = SKIP_UNTILIZE == 1;
+    constexpr uint32_t block_size_height = BLOCK_SIZE_HEIGHT;
+    constexpr uint32_t block_size_width_tiles = BLOCK_SIZE_WIDTH_TILES;
+    constexpr uint32_t block_start_offset = BLOCK_START_OFFSET;
+    constexpr uint32_t block_stride = BLOCK_STRIDE;
 
     static_assert(!remote_read, "Remote read is not supported in this kernel");
 
@@ -280,30 +292,32 @@ void kernel_main() {
     constexpr bool enable_blocking = !skip_untilize;
 
     Noc noc;
-    experimental::CB padding_config_cb(padding_config_cb_id);
     experimental::CB gather_config_cb(gather_config_cb_id);
+    // src is only touched by the pushing reader (block_start_offset == 0) and, in row-major mode, by the
+    // skip-untilize wait below. The other reader never references it, so it must not be declared there:
+    // an unbound dfb:: token would not compile. (These are #if, not `if constexpr`, because kernel_main is
+    // not a template — the discarded branch of `if constexpr` is still compiled and would need the binding.)
+#if (BLOCK_START_OFFSET == 0) || (SKIP_UNTILIZE == 1)
     experimental::CB src_cb(src_cb_id);
+#endif
     experimental::CB in_cb(in_cb_id);
     experimental::CB out_cb(out_cb_id);
     experimental::CB pad_cb(pad_cb_id);
+#ifdef ENABLE_PADDING
+    constexpr uint32_t padding_config_cb_id = dfb::padding_config;
+    experimental::CB padding_config_cb(padding_config_cb_id);
+#endif
 
 #ifdef CONFIG_TENSOR_IN_DRAM
-    constexpr uint32_t padding_config_dram_addr = get_compile_time_arg_val(18);
-    constexpr uint32_t padding_config_page_size = get_compile_time_arg_val(19);
-    constexpr uint32_t gather_config_dram_addr = get_compile_time_arg_val(20);
-    constexpr uint32_t gather_config_page_size = get_compile_time_arg_val(21);
-
-    constexpr auto padding_config_tensor_args = TensorAccessorArgs<22>();
-    constexpr auto gather_config_tensor_args =
-        TensorAccessorArgs<padding_config_tensor_args.next_compile_time_args_offset()>();
-
-    const auto padding_config_accessor = TensorAccessor(padding_config_tensor_args, padding_config_dram_addr);
-    const auto gather_config_accessor = TensorAccessor(gather_config_tensor_args, gather_config_dram_addr);
-
-    uint32_t config_read_index = get_arg_val<uint32_t>(0);
-
+    constexpr uint32_t gather_config_page_size = GATHER_CONFIG_PAGE_SIZE;
+    const auto gather_config_accessor = TensorAccessor(ta::gather_config_dram);
+    const uint32_t config_read_index = get_arg(args::config_read_index);
+#ifdef ENABLE_PADDING
+    constexpr uint32_t padding_config_page_size = PADDING_CONFIG_PAGE_SIZE;
+    const auto padding_config_accessor = TensorAccessor(ta::padding_config_dram);
     noc.async_read(
         padding_config_accessor, padding_config_cb, padding_config_page_size, {.page_id = config_read_index}, {});
+#endif
     noc.async_read(
         gather_config_accessor, gather_config_cb, gather_config_page_size, {.page_id = config_read_index}, {});
     noc.async_read_barrier();
@@ -313,12 +327,13 @@ void kernel_main() {
     const uint16_t my_noc_y = my_y[noc.get_noc_id()];
 
     // Only one of the cores should push the input
-    if constexpr (block_start_offset == 0) {
-        src_cb.reserve_back(in_nsticks);
-        src_cb.push_back(in_nsticks);
-    }
+#if (BLOCK_START_OFFSET == 0)
+    src_cb.reserve_back(in_nsticks);
+    src_cb.push_back(in_nsticks);
+#endif
 
-    if constexpr (padding_config_cb_id != 0) {
+#ifdef ENABLE_PADDING
+    {
         if constexpr (pad_val_u32 == 0) {
             // Use MEM_ZEROS_BASE if we are zero padded
             constexpr uint32_t padding_region_size = MEM_ZEROS_SIZE;
@@ -335,10 +350,11 @@ void kernel_main() {
                 noc, padding_config_cb, out_cb, pad_cb.get_read_ptr());
         }
     }
+#endif
 
-    if constexpr (skip_untilize) {
-        src_cb.wait_front(in_nsticks);
-    }
+#if (SKIP_UNTILIZE == 1)
+    src_cb.wait_front(in_nsticks);
+#endif
 
     const uint32_t config_data_l1_addr = gather_config_cb.get_read_ptr();
     const tt_l1_ptr uint16_t* config_data = reinterpret_cast<const tt_l1_ptr uint16_t*>(config_data_l1_addr);

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -6,412 +6,115 @@
 
 #include <cstdint>
 #include <optional>
-#include <cmath>
+#include <string>
+#include <vector>
 
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
+#include <tt-metalium/tt_align.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
-#include "ttnn/common/constants.hpp"
-#include "ttnn/types.hpp"
+#include "ttnn/operations/sliding_window/sliding_window.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 
 namespace ttnn::prim {
 
-// TODO: Look into increasing this to tradeoff some L1 for performance (#19980)
-constexpr int UNTILIZE_BLOCK_SIZE = 32;
-
-// In order to make circular buffer indices sequential, we use variable to keep track of the next available index.
-// Circular buffer indices should be assigned right before their creation.
-struct CBIndices {
-    // Invalid value for cb id is 32, number greater than the maximum number of index circular buffer can have.
-    // Not assigning get_next_cb_index() value before creating cb will throw exception in circular_buffer_config.cpp
-    // which can be used as a reminder.
-    uint32_t src_cb_id = 32;
-    uint32_t pad_cb_id0 = 32;
-    uint32_t pad_cb_id1 = 32;
-    uint32_t out_cb_id = 32;
-
-    // Additional CBs for sharded data kernel configs
-    uint32_t padding_config0 = 32;
-    uint32_t padding_config1 = 32;
-    uint32_t gather_config0 = 32;
-    uint32_t gather_config1 = 32;
-    uint32_t untilize_out_cb_id0 = 32;
-    uint32_t untilize_out_cb_id1 = 32;
-    uint32_t get_next_cb_id() { return next_cb_id++; }
-
-private:
-    uint32_t next_cb_id = tt::CBIndex::c_0;
-};
-
-constexpr bool ENABLE_UNTILIZE_DOUBLE_BUFFERING = true;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace {
 
-// Append a CBDescriptor for a single-format circular buffer.  When `buffer`
-// is non-null the CB is globally-allocated against that buffer so address
-// patching on cache hit works via the framework's dynamic CB update path.
-void add_cb(
-    ProgramDescriptor& desc,
-    const CoreRangeSet& cores,
-    uint32_t cb_id,
-    tt::DataFormat df,
-    uint32_t npages,
-    uint32_t pagesize,
-    Buffer* buffer = nullptr) {
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = npages * pagesize,
-        .core_ranges = cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(cb_id),
-            .data_format = df,
-            .page_size = pagesize,
-        }}},
-        .buffer = buffer,
-    });
-}
+// TODO: Look into increasing this to tradeoff some L1 for performance (#19980)
+constexpr int UNTILIZE_BLOCK_SIZE = 32;
+constexpr bool ENABLE_UNTILIZE_DOUBLE_BUFFERING = true;
+constexpr uint32_t EMPTY_PADDING_CONFIG_BUFFER_SIZE = 4;
 
-// Build the per-coord halo ProgramDescriptor.  All workload-scoped
-// intermediate buffers (the four halo config tensors) are passed in by
-// pointer — their owning Tensors live on the WorkloadDescriptor.
-ProgramDescriptor build_halo_program(
-    const HaloParams& operation_attributes,
-    const Tensor& input_tensor,
-    Tensor& output_tensor,
-    Buffer* padding_config_buffer0,
-    Buffer* padding_config_buffer1,
-    Buffer* gather_config_buffer0,
-    Buffer* gather_config_buffer1,
-    const std::vector<uint16_t>& number_of_blocks_per_core) {
-    const auto& pad_val = operation_attributes.pad_val;
-    const int block_size = UNTILIZE_BLOCK_SIZE;
-    const uint32_t ncores_nhw = operation_attributes.config.num_cores_nhw;
-    const uint32_t max_out_nsticks_per_core = operation_attributes.max_out_nsticks_per_core;
-    const bool config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
-    const bool remote_read = operation_attributes.remote_read;
-    const bool transpose_mcast = operation_attributes.transpose_mcast;
+constexpr const char* READER_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp";
+constexpr const char* COMPUTE_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp";
 
-    const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+// DFB unique-ids (kernels reference these via dfb::<name>).
+constexpr const char* DFB_SRC = "halo_src";
+constexpr const char* DFB_OUT = "halo_out";
+constexpr const char* DFB_PAD0 = "halo_pad0";
+constexpr const char* DFB_PAD1 = "halo_pad1";
+constexpr const char* DFB_PAD_CFG0 = "halo_padding_config0";
+constexpr const char* DFB_PAD_CFG1 = "halo_padding_config1";
+constexpr const char* DFB_GATHER_CFG0 = "halo_gather_config0";
+constexpr const char* DFB_GATHER_CFG1 = "halo_gather_config1";
+constexpr const char* DFB_UNTILIZE_OUT0 = "halo_untilize_out0";
+constexpr const char* DFB_UNTILIZE_OUT1 = "halo_untilize_out1";
 
-    Buffer* src_buffer = input_tensor.buffer();
-    Buffer* dst_buffer = output_tensor.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+// Tensor-parameter names (kernels access via ta::<name>; borrowed DFBs reference them by name).
+constexpr const char* TP_INPUT = "input";
+constexpr const char* TP_OUTPUT = "output";
+constexpr const char* TP_PAD_CFG0 = "padding_config0";
+constexpr const char* TP_PAD_CFG1 = "padding_config1";
+constexpr const char* TP_GATHER_CFG0 = "gather_config0";
+constexpr const char* TP_GATHER_CFG1 = "gather_config1";
 
-    const bool skip_untilize = input_tensor.layout() == Layout::ROW_MAJOR;
+// Everything the spec / run-args / owned-tensor builders share, computed from the request. All inputs
+// (attrs.config, shard specs, layouts) are part of the cache key, so this is a pure function of the key.
+struct HaloGeometry {
+    // The four host-built config tensors (uploaded to device by create_owned_tensors).
+    Tensor pad_config0;
+    Tensor pad_config1;
+    Tensor gather_config0;
+    Tensor gather_config1;
+    std::vector<uint16_t> number_of_blocks_per_core;
 
-    const auto& input_shape = input_tensor.padded_shape();
+    CoreRangeSet all_cores;
+    std::vector<CoreCoord> cores;
+    bool is_rm_orientation = false;
 
-    const tt::DataFormat in_df = datatype_to_dataformat_converter(input_tensor.dtype());
-    const tt::DataFormat out_df = datatype_to_dataformat_converter(output_tensor.dtype());
-    const uint32_t out_nbytes = datum_size(out_df);
+    bool skip_untilize = false;
+    bool config_tensors_in_dram = false;
+    bool is_block_sharded = false;
+    bool is_height_sharded = false;
+    bool is_width_sharded = false;
 
-    const CoreRangeSet all_cores = output_tensor.shard_spec().value().grid;
+    tt::DataFormat in_df = tt::DataFormat::Invalid;
+    tt::DataFormat out_df = tt::DataFormat::Invalid;
+    uint32_t in_page_size = 0;
+    uint32_t input_npages = 0;
+    uint32_t out_cb_pagesize = 0;
+    uint32_t out_cb_npages = 0;
+    uint32_t pad_cb_pagesize = 0;
+    uint32_t out_tile_size = 0;
+    uint32_t ntiles_per_block = 0;
+    uint32_t clamped_block_size_height = 0;
+    uint32_t untilize_out_cb_num_pages = 0;
+    uint32_t aligned_stick_nbytes = 0;
+    uint32_t pad_val = 0;
+};
 
-    const ShardOrientation shard_orientation = output_tensor.shard_spec().value().orientation;
-    const auto input_shard_shape = input_tensor.shard_spec().value().shape;
-    const auto output_shard_shape = output_tensor.shard_spec().value().shape;
-    TT_ASSERT(input_shard_shape[1] == output_shard_shape[1], "Expected input and output shard widths to match");
-
-    const uint32_t input_nhw_height = input_shape[0] * input_shape[1] * input_shape[2];
-    const uint32_t remapped_input_shard_shape_for_output_grid = tt::div_up(input_nhw_height, ncores_nhw);
-
-    uint32_t ntiles_per_block = tt::div_up(input_shard_shape[1], TILE_WIDTH);
-    uint32_t input_nblocks_per_core = tt::div_up(remapped_input_shard_shape_for_output_grid, TILE_HEIGHT);
-    uint32_t input_npages = ntiles_per_block * input_nblocks_per_core;
-
-    uint32_t in_page_size = tt::tile_size(in_df);
-
-    // Calculate aligned stick size - used for both input and output since channels don't change
-    const uint32_t stick_nbytes = output_shard_shape[1] * out_nbytes;
-    uint32_t aligned_stick_nbytes = stick_nbytes;
-    if (stick_nbytes % input_tensor.buffer()->alignment() != 0) {
-        aligned_stick_nbytes = tt::round_up(stick_nbytes, input_tensor.buffer()->alignment());
-    }
-    const uint32_t out_tile_size = tt::tile_size(out_df);
-
-    // For ROW_MAJOR input the kernel reads with aligned_stick_nbytes stride
-    // across the full input shard, so the CB must match the actual buffer layout:
-    // page size = aligned stick width, npages = actual shard height.
-    if (skip_untilize) {
-        in_page_size = aligned_stick_nbytes;
-        input_npages = input_shard_shape[0];
-    }
-
-    ProgramDescriptor desc;
-
-    CBIndices cb_indices = CBIndices();
-
-    // The input CB can either be tiled or row-major
-    cb_indices.src_cb_id = cb_indices.get_next_cb_id();
-    add_cb(desc, all_cores, cb_indices.src_cb_id, in_df, input_npages, in_page_size, src_buffer);
-
-    // We need to clamp in the case that the block size is larger than the nhw input size
-    TT_FATAL(block_size % TILE_HEIGHT == 0, "Block size must be a multiple of tile height (was {})", block_size);
-    const uint32_t clamped_block_size_height =
-        std::min(static_cast<uint32_t>(block_size), input_nblocks_per_core * TILE_HEIGHT);
-    TT_FATAL(
-        clamped_block_size_height % TILE_HEIGHT == 0,
-        "Block size must be a multiple of tile height (was {})",
-        clamped_block_size_height);
-
-    const uint32_t out_cb_pagesize = aligned_stick_nbytes;
-    const uint32_t out_cb_npages = max_out_nsticks_per_core;
-    cb_indices.out_cb_id = cb_indices.get_next_cb_id();
-    add_cb(desc, all_cores, cb_indices.out_cb_id, out_df, out_cb_npages, out_cb_pagesize, dst_buffer);
-
-    // Used for storing padding immediate values (only used if not zero padding)
-    const uint32_t pad_cb_pagesize = aligned_stick_nbytes;
-    const uint32_t pad_cb_npages = 1;
-    cb_indices.pad_cb_id0 = cb_indices.get_next_cb_id();
-    add_cb(desc, all_cores, cb_indices.pad_cb_id0, out_df, pad_cb_npages, pad_cb_pagesize);
-    cb_indices.pad_cb_id1 = cb_indices.get_next_cb_id();
-    add_cb(desc, all_cores, cb_indices.pad_cb_id1, out_df, pad_cb_npages, pad_cb_pagesize);
-
-    const tt::DataFormat kernel_config_df = tt::DataFormat::RawUInt16;  // NOTE: UInt16 is not supported for CB types
-
-    uint32_t input_to_writer_cb_id0 = cb_indices.src_cb_id;
-    uint32_t input_to_writer_cb_id1 = cb_indices.src_cb_id;
-    const bool is_rm_orientation = shard_orientation == ShardOrientation::ROW_MAJOR;
-    const auto cores = corerange_to_cores(all_cores, std::nullopt, is_rm_orientation);
-
-    if (!skip_untilize) {
-        cb_indices.untilize_out_cb_id0 = cb_indices.get_next_cb_id();
-        cb_indices.untilize_out_cb_id1 = cb_indices.get_next_cb_id();
-        input_to_writer_cb_id0 = cb_indices.untilize_out_cb_id0;
-        input_to_writer_cb_id1 = cb_indices.untilize_out_cb_id1;
-        const uint32_t output_ntiles = (clamped_block_size_height / TILE_HEIGHT) * ntiles_per_block;
-        const uint32_t untilize_out_cb_num_pages = ENABLE_UNTILIZE_DOUBLE_BUFFERING ? 2 * output_ntiles : output_ntiles;
-        add_cb(desc, all_cores, cb_indices.untilize_out_cb_id0, out_df, untilize_out_cb_num_pages, out_tile_size);
-        add_cb(desc, all_cores, cb_indices.untilize_out_cb_id1, out_df, untilize_out_cb_num_pages, out_tile_size);
-
-        const std::vector<uint32_t> compute_ct_args = {
-            cb_indices.src_cb_id,
-            input_to_writer_cb_id0,
-            input_to_writer_cb_id1,
-            ntiles_per_block,                        // number of tiles in the width dimension (channels)
-            clamped_block_size_height / TILE_HEIGHT  // number of tiles in height dimension that make up a block
-
-        };
-        auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
-            get_compute_kernel_config_args(input_tensor.device()->arch(), operation_attributes.compute_kernel_config);
-
-        KernelDescriptor compute_desc;
-        compute_desc.kernel_source =
-            "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/compute/pack_untilize.cpp";
-        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_desc.core_ranges = all_cores;
-        compute_desc.compile_time_args = compute_ct_args;
-        compute_desc.config = ComputeConfigDescriptor{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = dst_full_sync_en,
-            .math_approx_mode = math_approx_mode,
-        };
-
-        for (size_t core_id = 0; core_id < cores.size(); core_id++) {
-            compute_desc.runtime_args.emplace_back(
-                cores[core_id], std::vector<uint32_t>{number_of_blocks_per_core[core_id]});
-        }
-
-        desc.kernels.push_back(std::move(compute_desc));
-    }
-
-    TT_ASSERT(padding_config_buffer0 != nullptr);
-    TT_ASSERT(padding_config_buffer1 != nullptr);
-    TT_ASSERT(gather_config_buffer0 != nullptr);
-    TT_ASSERT(gather_config_buffer1 != nullptr);
-
-    cb_indices.padding_config0 = cb_indices.get_next_cb_id();
-    add_cb(
-        desc,
-        all_cores,
-        cb_indices.padding_config0,
-        kernel_config_df,
-        1,
-        padding_config_buffer0->page_size(),
-        config_tensors_in_dram ? nullptr : padding_config_buffer0);
-
-    cb_indices.padding_config1 = cb_indices.get_next_cb_id();
-    add_cb(
-        desc,
-        all_cores,
-        cb_indices.padding_config1,
-        kernel_config_df,
-        1,
-        padding_config_buffer1->page_size(),
-        config_tensors_in_dram ? nullptr : padding_config_buffer1);
-
-    cb_indices.gather_config0 = cb_indices.get_next_cb_id();
-    add_cb(
-        desc,
-        all_cores,
-        cb_indices.gather_config0,
-        kernel_config_df,
-        1,
-        gather_config_buffer0->page_size(),
-        config_tensors_in_dram ? nullptr : gather_config_buffer0);
-
-    cb_indices.gather_config1 = cb_indices.get_next_cb_id();
-    add_cb(
-        desc,
-        all_cores,
-        cb_indices.gather_config1,
-        kernel_config_df,
-        1,
-        gather_config_buffer1->page_size(),
-        config_tensors_in_dram ? nullptr : gather_config_buffer1);
-
-    const bool is_height_sharded = output_tensor.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
-    const bool is_width_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
-
-    const uint32_t block_stride = 2;  // Skip every 2nd block because of split reader
-    const std::string reader_kernel_name =
-        "ttnn/cpp/ttnn/operations/sliding_window/halo/device/kernels/dataflow/halo_gather.cpp";
-    std::vector<uint32_t> common_reader_ct_args = {
-        0,  // padding config cb
-        0,  // gather config cb
-        cb_indices.src_cb_id,
-        input_to_writer_cb_id0,
-        cb_indices.out_cb_id,
-        0,  // padding value cb
-        pad_val,
-        input_npages,
-        aligned_stick_nbytes,
-        is_block_sharded,
-        remote_read,
-        (uint32_t)(transpose_mcast ? 1 : 0),
-        is_width_sharded,
-        skip_untilize,
-        clamped_block_size_height,  // Block size in sticks
-        ntiles_per_block,
-        0,            // Block start offset
-        block_stride  // Block stride
-    };
-    KernelDescriptor::Defines reader_defines;
-    std::vector<uint32_t> core_0_reader_ct_args = common_reader_ct_args;
-    std::vector<uint32_t> core_1_reader_ct_args = common_reader_ct_args;
-
-    if (config_tensors_in_dram) {
-        reader_defines.emplace_back("CONFIG_TENSOR_IN_DRAM", "1");
-        // NOTE: the config-buffer addresses are baked into compile-time args
-        // here.  The buffers themselves are parked on the WorkloadDescriptor,
-        // so their device allocations stay valid for the cached workload's
-        // lifetime — the address embedded below remains correct on cache hit
-        // because the buffers are not re-allocated.
-        core_0_reader_ct_args.push_back(padding_config_buffer0->address());
-        core_0_reader_ct_args.push_back(padding_config_buffer0->page_size());
-
-        core_0_reader_ct_args.push_back(gather_config_buffer0->address());
-        core_0_reader_ct_args.push_back(gather_config_buffer0->page_size());
-
-        core_1_reader_ct_args.push_back(padding_config_buffer1->address());
-        core_1_reader_ct_args.push_back(padding_config_buffer1->page_size());
-
-        core_1_reader_ct_args.push_back(gather_config_buffer1->address());
-        core_1_reader_ct_args.push_back(gather_config_buffer1->page_size());
-
-        tt::tt_metal::TensorAccessorArgs(padding_config_buffer0).append_to(core_0_reader_ct_args);
-        tt::tt_metal::TensorAccessorArgs(gather_config_buffer0).append_to(core_0_reader_ct_args);
-
-        tt::tt_metal::TensorAccessorArgs(padding_config_buffer1).append_to(core_1_reader_ct_args);
-        tt::tt_metal::TensorAccessorArgs(gather_config_buffer1).append_to(core_1_reader_ct_args);
-    }
-    const uint32_t EMPTY_PADDING_CONFIG_BUFFER_SIZE = 4;
-    const bool enable_padding = config_tensors_in_dram ||
-                                padding_config_buffer0->page_size() != EMPTY_PADDING_CONFIG_BUFFER_SIZE ||
-                                padding_config_buffer1->page_size() != EMPTY_PADDING_CONFIG_BUFFER_SIZE;
-
-    core_0_reader_ct_args[0] = enable_padding ? cb_indices.padding_config0 : 0;
-    core_0_reader_ct_args[1] = cb_indices.gather_config0;
-    core_0_reader_ct_args[5] = cb_indices.pad_cb_id0;
-
-    core_1_reader_ct_args[0] = enable_padding ? cb_indices.padding_config1 : 0;
-    core_1_reader_ct_args[1] = cb_indices.gather_config1;
-    core_1_reader_ct_args[3] = input_to_writer_cb_id1;
-    core_1_reader_ct_args[5] = cb_indices.pad_cb_id1;
-    core_1_reader_ct_args[16] = 1;  // Block start offset
-
-    KernelDescriptor reader_0_desc;
-    reader_0_desc.kernel_source = reader_kernel_name;
-    reader_0_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_0_desc.core_ranges = all_cores;
-    reader_0_desc.compile_time_args = std::move(core_0_reader_ct_args);
-    reader_0_desc.defines = reader_defines;
-    reader_0_desc.config = DataMovementConfigDescriptor{
-        .processor = DataMovementProcessor::RISCV_0,
-        .noc = NOC::RISCV_0_default,
-    };
-
-    KernelDescriptor reader_1_desc;
-    reader_1_desc.kernel_source = reader_kernel_name;
-    reader_1_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_1_desc.core_ranges = all_cores;
-    reader_1_desc.compile_time_args = std::move(core_1_reader_ct_args);
-    reader_1_desc.defines = std::move(reader_defines);
-    reader_1_desc.config = DataMovementConfigDescriptor{
-        .processor = DataMovementProcessor::RISCV_1,
-        .noc = NOC::RISCV_1_default,
-    };
-
-    if (config_tensors_in_dram) {
-        uint32_t core_index = 0;
-        for (const auto& core : cores) {
-            if (is_height_sharded) {
-                reader_0_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{core_index});
-                reader_1_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{core_index});
-            } else if (is_width_sharded) {
-                reader_0_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{0});
-                reader_1_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{0});
-            } else if (is_block_sharded) {
-                const auto nhw_index = is_rm_orientation ? core.y : core.x;
-                reader_0_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{nhw_index});
-                reader_1_desc.runtime_args.emplace_back(core, std::vector<uint32_t>{nhw_index});
-            }
-            core_index++;
-        }
-    }
-
-    desc.kernels.push_back(std::move(reader_0_desc));
-    desc.kernels.push_back(std::move(reader_1_desc));
-
-    return desc;
-}
-
-}  // namespace
-
-tt::tt_metal::WorkloadDescriptor UntilizeWithHaloProgramFactory::create_workload_descriptor(
-    const HaloParams& operation_attributes,
-    const Tensor& tensor_args,
-    Tensor& output_tensor,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
-    const auto& input_tensor = tensor_args;
-    auto* device = input_tensor.device();
-
-    const bool is_in_tiled = input_tensor.layout() == Layout::TILE;
-    const bool is_block_sharded = input_tensor.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
-    const bool remote_read = operation_attributes.remote_read;
-    const bool transpose_mcast = operation_attributes.transpose_mcast;
-
+HaloGeometry compute_geometry(const HaloParams& attrs, const Tensor& input, const Tensor& output) {
     using namespace ttnn::operations;
-    auto pad_metadata = sliding_window::generate_pad_metadata(operation_attributes.config);
-    auto op_trace_metadata = sliding_window::generate_op_trace_metadata(operation_attributes.config);
-    auto shard_boundaries = sliding_window::generate_shard_boundaries(operation_attributes.config);
-    const uint32_t input_shard_height = input_tensor.memory_config().shard_spec()->shape[0];
-    auto tensor_metadata =
-        sliding_window::generate_tensor_metadata(pad_metadata, operation_attributes.config, input_shard_height);
+    HaloGeometry g;
+    auto* device = input.device();
 
-    const uint32_t num_cores_x = input_tensor.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
+    g.config_tensors_in_dram = attrs.config_tensors_in_dram;
+    g.is_block_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    g.is_height_sharded = output.memory_config().memory_layout() == TensorMemoryLayout::HEIGHT_SHARDED;
+    g.is_width_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+    g.pad_val = attrs.pad_val;
+    const bool is_in_tiled = input.layout() == Layout::TILE;
+    const bool remote_read = attrs.remote_read;
+    const bool transpose_mcast = attrs.transpose_mcast;
 
+    // --- host metadata + the four config tensors (uploaded to device) ---
+    auto pad_metadata = sliding_window::generate_pad_metadata(attrs.config);
+    auto shard_boundaries = sliding_window::generate_shard_boundaries(attrs.config);
+    const uint32_t input_shard_height = input.memory_config().shard_spec()->shape[0];
+    auto tensor_metadata = sliding_window::generate_tensor_metadata(pad_metadata, attrs.config, input_shard_height);
+    const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
     auto kernel_config = sliding_window::generate_halo_kernel_config_tensors(
         tensor_metadata,
         shard_boundaries,
-        is_block_sharded,
+        g.is_block_sharded,
         transpose_mcast,
         remote_read,
         device,
@@ -419,99 +122,352 @@ tt::tt_metal::WorkloadDescriptor UntilizeWithHaloProgramFactory::create_workload
         is_in_tiled,
         UNTILIZE_BLOCK_SIZE);
 
-    const auto& pad_config0 = kernel_config.pad_config0;
-    const auto& pad_config1 = kernel_config.pad_config1;
-    const auto& gather_config0 = kernel_config.gather_config0;
-    const auto& gather_config1 = kernel_config.gather_config1;
+    auto to_device = [&](const auto& cfg) {
+        auto host = sliding_window::construct_on_host_config_tensor(cfg, attrs.parallel_config, g.config_tensors_in_dram);
+        return sliding_window::move_config_tensor_to_device(
+            host, attrs.parallel_config, g.is_block_sharded, device, g.config_tensors_in_dram);
+    };
+    g.pad_config0 = to_device(kernel_config.pad_config0);
+    g.pad_config1 = to_device(kernel_config.pad_config1);
+    g.gather_config0 = to_device(kernel_config.gather_config0);
+    g.gather_config1 = to_device(kernel_config.gather_config1);
+    g.number_of_blocks_per_core =
+        sliding_window::remap_nhw_scalar_argument_across_full_grid(kernel_config.number_of_blocks_per_core, attrs.parallel_config);
 
-    const auto pad_config_tensor0 = sliding_window::construct_on_host_config_tensor(
-        pad_config0, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
-    const auto pad_config_tensor1 = sliding_window::construct_on_host_config_tensor(
-        pad_config1, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
-    const auto gather_config_tensor0 = sliding_window::construct_on_host_config_tensor(
-        gather_config0, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
-    const auto gather_config_tensor1 = sliding_window::construct_on_host_config_tensor(
-        gather_config1, operation_attributes.parallel_config, operation_attributes.config_tensors_in_dram);
+    // --- CB / work geometry (mirrors build_halo_program) ---
+    const uint32_t ncores_nhw = attrs.config.num_cores_nhw;
+    g.in_df = datatype_to_dataformat_converter(input.dtype());
+    g.out_df = datatype_to_dataformat_converter(output.dtype());
+    const uint32_t out_nbytes = datum_size(g.out_df);
 
-    Tensor pad_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
-        pad_config_tensor0,
-        operation_attributes.parallel_config,
-        is_block_sharded,
-        device,
-        operation_attributes.config_tensors_in_dram);
-    Tensor pad_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
-        pad_config_tensor1,
-        operation_attributes.parallel_config,
-        is_block_sharded,
-        device,
-        operation_attributes.config_tensors_in_dram);
-    Tensor gather_config_device_tensor0 = sliding_window::move_config_tensor_to_device(
-        gather_config_tensor0,
-        operation_attributes.parallel_config,
-        is_block_sharded,
-        device,
-        operation_attributes.config_tensors_in_dram);
-    Tensor gather_config_device_tensor1 = sliding_window::move_config_tensor_to_device(
-        gather_config_tensor1,
-        operation_attributes.parallel_config,
-        is_block_sharded,
-        device,
-        operation_attributes.config_tensors_in_dram);
+    g.all_cores = output.shard_spec().value().grid;
+    const ShardOrientation shard_orientation = output.shard_spec().value().orientation;
+    g.is_rm_orientation = shard_orientation == ShardOrientation::ROW_MAJOR;
+    g.cores = corerange_to_cores(g.all_cores, std::nullopt, g.is_rm_orientation);
 
-    TT_ASSERT(pad_config_device_tensor0.dtype() == DataType::UINT16);
-    TT_ASSERT(pad_config_device_tensor1.dtype() == DataType::UINT16);
-    TT_ASSERT(gather_config_device_tensor0.dtype() == DataType::UINT16);
-    TT_ASSERT(gather_config_device_tensor1.dtype() == DataType::UINT16);
+    const auto& input_shape = input.padded_shape();
+    const auto input_shard_shape = input.shard_spec().value().shape;
+    const auto output_shard_shape = output.shard_spec().value().shape;
 
-    tt::tt_metal::WorkloadDescriptor workload_descriptor;
+    const uint32_t input_nhw_height = input_shape[0] * input_shape[1] * input_shape[2];
+    const uint32_t remapped_input_shard_shape_for_output_grid = tt::div_up(input_nhw_height, ncores_nhw);
+    g.ntiles_per_block = tt::div_up(input_shard_shape[1], TILE_WIDTH);
+    const uint32_t input_nblocks_per_core = tt::div_up(remapped_input_shard_shape_for_output_grid, TILE_HEIGHT);
+    g.input_npages = g.ntiles_per_block * input_nblocks_per_core;
+    g.in_page_size = tt::tile_size(g.in_df);
 
-    // Park each intermediate halo-config Tensor on the WorkloadDescriptor.
-    // The Tensor itself (not just shared_ptr<MeshBuffer>) must outlive the
-    // cached workload: ~Tensor force-deallocates the underlying device memory
-    // via DeviceStorage::deallocate regardless of other shared owners.  See
-    // pool_multi_core_program_factory.cpp for the lifetime rationale.
-    auto pad0_owner = std::make_shared<Tensor>(std::move(pad_config_device_tensor0));
-    Buffer* pad0_buf = pad0_owner->buffer();
-    workload_descriptor.buffers.push_back({pad0_owner, pad0_buf});
-
-    auto pad1_owner = std::make_shared<Tensor>(std::move(pad_config_device_tensor1));
-    Buffer* pad1_buf = pad1_owner->buffer();
-    workload_descriptor.buffers.push_back({pad1_owner, pad1_buf});
-
-    auto gather0_owner = std::make_shared<Tensor>(std::move(gather_config_device_tensor0));
-    Buffer* gather0_buf = gather0_owner->buffer();
-    workload_descriptor.buffers.push_back({gather0_owner, gather0_buf});
-
-    auto gather1_owner = std::make_shared<Tensor>(std::move(gather_config_device_tensor1));
-    Buffer* gather1_buf = gather1_owner->buffer();
-    workload_descriptor.buffers.push_back({gather1_owner, gather1_buf});
-
-    const auto number_of_blocks_per_core = sliding_window::remap_nhw_scalar_argument_across_full_grid(
-        kernel_config.number_of_blocks_per_core, operation_attributes.parallel_config);
-
-    // Single-device op: the kernel program is structurally identical for every
-    // coord in `tensor_coords` (halo doesn't depend on cluster position).
-    // Build the per-coord ProgramDescriptor ONCE and copy it into each
-    // coord-range entry to avoid redundant work on multi-coord workloads.
-    auto desc = build_halo_program(
-        operation_attributes,
-        input_tensor,
-        output_tensor,
-        pad0_buf,
-        pad1_buf,
-        gather0_buf,
-        gather1_buf,
-        number_of_blocks_per_core);
-
-    auto ranges = tensor_coords.ranges();
-    workload_descriptor.programs.reserve(ranges.size());
-    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
-        workload_descriptor.programs.push_back({ranges[i], desc});
+    const uint32_t stick_nbytes = output_shard_shape[1] * out_nbytes;
+    g.aligned_stick_nbytes = stick_nbytes;
+    if (stick_nbytes % input.buffer()->alignment() != 0) {
+        g.aligned_stick_nbytes = tt::round_up(stick_nbytes, input.buffer()->alignment());
     }
-    if (!ranges.empty()) {
-        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
+    g.out_tile_size = tt::tile_size(g.out_df);
+
+    g.skip_untilize = input.layout() == Layout::ROW_MAJOR;
+    if (g.skip_untilize) {
+        g.in_page_size = g.aligned_stick_nbytes;
+        g.input_npages = input_shard_shape[0];
     }
-    return workload_descriptor;
+
+    g.out_cb_pagesize = g.aligned_stick_nbytes;
+    g.out_cb_npages = attrs.max_out_nsticks_per_core;
+    g.pad_cb_pagesize = g.aligned_stick_nbytes;
+
+    g.clamped_block_size_height =
+        std::min(static_cast<uint32_t>(UNTILIZE_BLOCK_SIZE), input_nblocks_per_core * TILE_HEIGHT);
+    if (!g.skip_untilize) {
+        const uint32_t output_ntiles = (g.clamped_block_size_height / TILE_HEIGHT) * g.ntiles_per_block;
+        g.untilize_out_cb_num_pages = ENABLE_UNTILIZE_DOUBLE_BUFFERING ? 2 * output_ntiles : output_ntiles;
+    }
+    return g;
+}
+
+// A scratch (own-L1) DFB.
+m2::DataflowBufferSpec scratch_dfb(const char* id, tt::DataFormat df, uint32_t entry_size, uint32_t num_entries) {
+    return m2::DataflowBufferSpec{
+        .unique_id = m2::DFBSpecName{id},
+        .entry_size = entry_size,
+        .num_entries = num_entries,
+        .data_format_metadata = df,
+    };
+}
+
+// A DFB borrowed from a tensor parameter (its backing buffer is the bound tensor).
+m2::DataflowBufferSpec borrowed_dfb(
+    const char* id, const char* tensor_param, tt::DataFormat df, uint32_t entry_size, uint32_t num_entries) {
+    auto dfb = scratch_dfb(id, df, entry_size, num_entries);
+    dfb.borrowed_from = m2::TensorParamName{tensor_param};
+    return dfb;
+}
+
+}  // namespace
+
+// create_owned_tensors — the four host-built sliding-window config tensors. The framework keeps them alive
+// for the cached program's lifetime and binds each (via its TensorParameter) to the reader's config CB /
+// accessor. They are a pure function of the cache key (the sliding-window config), so they're invariant.
+m2::Table<m2::TensorParamName, Tensor> UntilizeWithHaloProgramFactory::create_owned_tensors(
+    const HaloParams& attrs, const Tensor& input, Tensor& output) {
+    const auto g = compute_geometry(attrs, input, output);
+    m2::Table<m2::TensorParamName, Tensor> owned;
+    owned.emplace(m2::TensorParamName{TP_PAD_CFG0}, g.pad_config0);
+    owned.emplace(m2::TensorParamName{TP_PAD_CFG1}, g.pad_config1);
+    owned.emplace(m2::TensorParamName{TP_GATHER_CFG0}, g.gather_config0);
+    owned.emplace(m2::TensorParamName{TP_GATHER_CFG1}, g.gather_config1);
+    return owned;
+}
+
+// create_program_spec — the immutable blueprint: the DFBs (src/out borrowed from the sharded I/O tensors,
+// the four config CBs borrowed from the owned config tensors, scratch pad/untilize CBs) and the kernels
+// (the split halo_gather reader on RISCV0/1, plus the pack_untilize compute when the input is tiled).
+m2::ProgramSpec UntilizeWithHaloProgramFactory::create_program_spec(
+    const HaloParams& attrs, const Tensor& input, Tensor& output) {
+    const auto g = compute_geometry(attrs, input, output);
+    const tt::DataFormat cfg_df = tt::DataFormat::RawUInt16;
+
+    const bool enable_padding = g.config_tensors_in_dram ||
+                                g.pad_config0.buffer()->page_size() != EMPTY_PADDING_CONFIG_BUFFER_SIZE ||
+                                g.pad_config1.buffer()->page_size() != EMPTY_PADDING_CONFIG_BUFFER_SIZE;
+
+    m2::ProgramSpec spec;
+    spec.name = "untilize_with_halo";
+
+    // Tensor parameters: I/O + the four config tensors. The config tensors are op-owned (create_owned_tensors)
+    // and bound once at program-build time; mark them enqueue-invariant so the cache-hit path may omit them
+    // from the per-enqueue args and retain the bound tensor. I/O are re-specified on every enqueue.
+    const m2::TensorParameterAdvancedOptions invariant_tp{.enqueue_invariant = true};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{TP_INPUT}, .spec = input.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{TP_OUTPUT}, .spec = output.tensor_spec()},
+        m2::TensorParameter{
+            .unique_id = m2::TensorParamName{TP_PAD_CFG0},
+            .spec = g.pad_config0.tensor_spec(),
+            .advanced_options = invariant_tp},
+        m2::TensorParameter{
+            .unique_id = m2::TensorParamName{TP_PAD_CFG1},
+            .spec = g.pad_config1.tensor_spec(),
+            .advanced_options = invariant_tp},
+        m2::TensorParameter{
+            .unique_id = m2::TensorParamName{TP_GATHER_CFG0},
+            .spec = g.gather_config0.tensor_spec(),
+            .advanced_options = invariant_tp},
+        m2::TensorParameter{
+            .unique_id = m2::TensorParamName{TP_GATHER_CFG1},
+            .spec = g.gather_config1.tensor_spec(),
+            .advanced_options = invariant_tp},
+    };
+
+    // DFBs. src/out are borrowed from the sharded I/O tensors; the four config CBs are borrowed from the
+    // owned config tensors when they live in L1 (DRAM config is read via ta:: instead, no CB backing).
+    std::vector<m2::DataflowBufferSpec> dfbs;
+    dfbs.push_back(borrowed_dfb(DFB_SRC, TP_INPUT, g.in_df, g.in_page_size, g.input_npages));
+    dfbs.push_back(borrowed_dfb(DFB_OUT, TP_OUTPUT, g.out_df, g.out_cb_pagesize, g.out_cb_npages));
+    dfbs.push_back(scratch_dfb(DFB_PAD0, g.out_df, g.pad_cb_pagesize, 1));
+    dfbs.push_back(scratch_dfb(DFB_PAD1, g.out_df, g.pad_cb_pagesize, 1));
+    if (g.config_tensors_in_dram) {
+        dfbs.push_back(scratch_dfb(DFB_PAD_CFG0, cfg_df, g.pad_config0.buffer()->page_size(), 1));
+        dfbs.push_back(scratch_dfb(DFB_PAD_CFG1, cfg_df, g.pad_config1.buffer()->page_size(), 1));
+        dfbs.push_back(scratch_dfb(DFB_GATHER_CFG0, cfg_df, g.gather_config0.buffer()->page_size(), 1));
+        dfbs.push_back(scratch_dfb(DFB_GATHER_CFG1, cfg_df, g.gather_config1.buffer()->page_size(), 1));
+    } else {
+        dfbs.push_back(borrowed_dfb(DFB_PAD_CFG0, TP_PAD_CFG0, cfg_df, g.pad_config0.buffer()->page_size(), 1));
+        dfbs.push_back(borrowed_dfb(DFB_PAD_CFG1, TP_PAD_CFG1, cfg_df, g.pad_config1.buffer()->page_size(), 1));
+        dfbs.push_back(borrowed_dfb(DFB_GATHER_CFG0, TP_GATHER_CFG0, cfg_df, g.gather_config0.buffer()->page_size(), 1));
+        dfbs.push_back(borrowed_dfb(DFB_GATHER_CFG1, TP_GATHER_CFG1, cfg_df, g.gather_config1.buffer()->page_size(), 1));
+    }
+    if (!g.skip_untilize) {
+        dfbs.push_back(scratch_dfb(DFB_UNTILIZE_OUT0, g.out_df, g.out_tile_size, g.untilize_out_cb_num_pages));
+        dfbs.push_back(scratch_dfb(DFB_UNTILIZE_OUT1, g.out_df, g.out_tile_size, g.untilize_out_cb_num_pages));
+    }
+    spec.dataflow_buffers = std::move(dfbs);
+
+    // The reader writes into the untilize-out CB (tiled) or straight to src (row-major).
+    const char* input_to_writer0 = g.skip_untilize ? DFB_SRC : DFB_UNTILIZE_OUT0;
+    const char* input_to_writer1 = g.skip_untilize ? DFB_SRC : DFB_UNTILIZE_OUT1;
+
+    std::vector<m2::KernelSpec> kernels;
+
+    // Compute kernel (tiled input only): untilizes src into the two untilize-out CBs.
+    if (!g.skip_untilize) {
+        auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+            ttnn::get_compute_kernel_config_args(input.device()->arch(), attrs.compute_kernel_config);
+        m2::KernelSpec::CompilerOptions copts;
+        copts.defines.emplace("TILES_PER_ROW", std::to_string(g.ntiles_per_block));
+        copts.defines.emplace("BLOCK_SIZE", std::to_string(g.clamped_block_size_height / TILE_HEIGHT));
+        kernels.push_back(m2::KernelSpec{
+            .unique_id = m2::KernelSpecName{"compute"},
+            .source = std::filesystem::path{COMPUTE_KERNEL_PATH},
+            .compiler_options = std::move(copts),
+            .dfb_bindings =
+                {m2::ConsumerOf(m2::DFBSpecName{DFB_SRC}, "src"),
+                 m2::ProducerOf(m2::DFBSpecName{DFB_UNTILIZE_OUT0}, "untilize_out0"),
+                 m2::ProducerOf(m2::DFBSpecName{DFB_UNTILIZE_OUT1}, "untilize_out1")},
+            .runtime_arg_schema = {.runtime_arg_names = {"total_blocks"}},
+            .hw_config =
+                m2::ComputeHardwareConfig{
+                    .math_fidelity = math_fidelity,
+                    .fp32_dest_acc_en = fp32_dest_acc_en,
+                    .dst_full_sync_en = dst_full_sync_en,
+                    .math_approx_mode = math_approx_mode,
+                },
+            .advanced_options = m2::KernelAdvancedOptions{.enqueue_invariant_runtime_args = {"total_blocks"}},
+        });
+    }
+
+    // The two split-reader kernels (RISCV0 / RISCV1). Compile-time selectors become defines; the per-core
+    // config_read_index (DRAM config only) is an enqueue-invariant named arg.
+    auto reader_defines = [&](bool is_reader1) {
+        m2::KernelSpec::CompilerOptions copts;
+        auto def = [&](const char* k, uint32_t v) { copts.defines.emplace(k, std::to_string(v)); };
+        def("PAD_VAL", g.pad_val);
+        def("IN_NSTICKS", g.input_npages);
+        def("ALIGNED_STICK_NBYTES", g.aligned_stick_nbytes);
+        def("IS_BLOCK_SHARDED", g.is_block_sharded ? 1 : 0);
+        def("REMOTE_READ", attrs.remote_read ? 1 : 0);
+        def("IS_COL_MAJOR", attrs.transpose_mcast ? 1 : 0);
+        def("IS_WIDTH_SHARDED", g.is_width_sharded ? 1 : 0);
+        def("SKIP_UNTILIZE", g.skip_untilize ? 1 : 0);
+        def("BLOCK_SIZE_HEIGHT", g.clamped_block_size_height);
+        def("BLOCK_SIZE_WIDTH_TILES", g.ntiles_per_block);
+        def("BLOCK_START_OFFSET", is_reader1 ? 1u : 0u);
+        def("BLOCK_STRIDE", 2u);
+        def("ENABLE_PADDING", enable_padding ? 1 : 0);
+        if (g.config_tensors_in_dram) {
+            copts.defines.emplace("CONFIG_TENSOR_IN_DRAM", "1");
+            def("PADDING_CONFIG_PAGE_SIZE",
+                (is_reader1 ? g.pad_config1 : g.pad_config0).buffer()->page_size());
+            def("GATHER_CONFIG_PAGE_SIZE",
+                (is_reader1 ? g.gather_config1 : g.gather_config0).buffer()->page_size());
+        }
+        return copts;
+    };
+    auto reader_dfb_bindings = [&](bool is_reader1) {
+        const char* in_dfb = is_reader1 ? input_to_writer1 : input_to_writer0;
+        const char* pad_dfb = is_reader1 ? DFB_PAD1 : DFB_PAD0;
+        const char* gather_dfb = is_reader1 ? DFB_GATHER_CFG1 : DFB_GATHER_CFG0;
+        const char* padcfg_dfb = is_reader1 ? DFB_PAD_CFG1 : DFB_PAD_CFG0;
+        // The reader streams the untilized (or row-major) input from `in`. src is pushed by reader0 and out
+        // is written by both readers — assign reader0 the producer role and reader1 the consumer role so
+        // each borrowed DFB has one of each (the role only shapes the dep graph; both readers still write).
+        // The scratch pad CB and the config CBs are both filled and read by this same reader.
+        std::vector<m2::KernelSpec::DFBBinding> b{
+            m2::ConsumerOf(m2::DFBSpecName{in_dfb}, "in"),
+            is_reader1 ? m2::ConsumerOf(m2::DFBSpecName{DFB_OUT}, "out")
+                       : m2::ProducerOf(m2::DFBSpecName{DFB_OUT}, "out"),
+            m2::ProducerOf(m2::DFBSpecName{pad_dfb}, "pad"),
+            m2::ConsumerOf(m2::DFBSpecName{pad_dfb}, "pad"),
+            m2::ProducerOf(m2::DFBSpecName{gather_dfb}, "gather_config"),
+            m2::ConsumerOf(m2::DFBSpecName{gather_dfb}, "gather_config")};
+        // src is pushed only by the block_start_offset==0 reader, which holds the sole producer binding.
+        // The other reader never binds src separately: in tiled mode it doesn't touch src; in row-major
+        // skip-untilize src == in, so its `in` consumer binding already covers DFB_SRC (the kernel aliases
+        // src to dfb::in there). A second src binding on that reader would be a duplicate consumer.
+        if (!is_reader1) {
+            b.push_back(m2::ProducerOf(m2::DFBSpecName{DFB_SRC}, "src"));
+        }
+        if (enable_padding) {
+            b.push_back(m2::ProducerOf(m2::DFBSpecName{padcfg_dfb}, "padding_config"));
+            b.push_back(m2::ConsumerOf(m2::DFBSpecName{padcfg_dfb}, "padding_config"));
+        }
+        return b;
+    };
+    auto reader_tensor_bindings = [&](bool is_reader1) {
+        std::vector<m2::TensorBinding> tb;
+        if (g.config_tensors_in_dram) {
+            tb.push_back(m2::TensorBinding{
+                .tensor_parameter_name = m2::TensorParamName{is_reader1 ? TP_PAD_CFG1 : TP_PAD_CFG0},
+                .accessor_name = "padding_config_dram"});
+            tb.push_back(m2::TensorBinding{
+                .tensor_parameter_name = m2::TensorParamName{is_reader1 ? TP_GATHER_CFG1 : TP_GATHER_CFG0},
+                .accessor_name = "gather_config_dram"});
+        }
+        return tb;
+    };
+
+    kernels.push_back(m2::KernelSpec{
+        .unique_id = m2::KernelSpecName{"reader0"},
+        .source = std::filesystem::path{READER_KERNEL_PATH},
+        .compiler_options = reader_defines(false),
+        .dfb_bindings = reader_dfb_bindings(false),
+        .tensor_bindings = reader_tensor_bindings(false),
+        .runtime_arg_schema = {.runtime_arg_names = {"config_read_index"}},
+        .hw_config = m2::DataMovementHardwareConfig{
+            .gen1_config = m2::DataMovementHardwareConfig::Gen1Config{
+                .processor = DataMovementProcessor::RISCV_0, .noc = NOC::RISCV_0_default}},
+        .advanced_options = m2::KernelAdvancedOptions{.enqueue_invariant_runtime_args = {"config_read_index"}},
+    });
+    kernels.push_back(m2::KernelSpec{
+        .unique_id = m2::KernelSpecName{"reader1"},
+        .source = std::filesystem::path{READER_KERNEL_PATH},
+        .compiler_options = reader_defines(true),
+        .dfb_bindings = reader_dfb_bindings(true),
+        .tensor_bindings = reader_tensor_bindings(true),
+        .runtime_arg_schema = {.runtime_arg_names = {"config_read_index"}},
+        .hw_config = m2::DataMovementHardwareConfig{
+            .gen1_config = m2::DataMovementHardwareConfig::Gen1Config{
+                .processor = DataMovementProcessor::RISCV_1, .noc = NOC::RISCV_1_default}},
+        .advanced_options = m2::KernelAdvancedOptions{.enqueue_invariant_runtime_args = {"config_read_index"}},
+    });
+
+    spec.kernels = std::move(kernels);
+
+    // Tiled splits across reader0/reader1 (each consuming its own untilize_out half) plus the compute kernel.
+    // Row-major skip-untilize uses the same two readers, but both consume the single borrowed src CB on the
+    // same core — a same-core broadcast the local-DFB model can't yet express, so the skip path is blocked
+    // pending metal support for multiple same-core consumers on a local DFB.
+    std::vector<m2::KernelSpecName> work_kernels = {m2::KernelSpecName{"reader0"}, m2::KernelSpecName{"reader1"}};
+    if (!g.skip_untilize) {
+        work_kernels.insert(work_kernels.begin(), m2::KernelSpecName{"compute"});
+    }
+    spec.work_units = {m2::WorkUnitSpec{.name = "halo_work", .kernels = work_kernels, .target_nodes = g.all_cores}};
+    return spec;
+}
+
+// create_invariant_run_args — the per-core work scalars: the compute kernel's per-core block count, and
+// (DRAM config only) the per-core config_read_index used to index the shared config tensors.
+m2::ProgramRunArgs UntilizeWithHaloProgramFactory::create_invariant_run_args(
+    const HaloParams& attrs, const Tensor& input, Tensor& output) {
+    const auto g = compute_geometry(attrs, input, output);
+    m2::ProgramRunArgs args;
+
+    if (!g.skip_untilize) {
+        m2::ProgramRunArgs::KernelRunArgs compute_args{.kernel = m2::KernelSpecName{"compute"}};
+        for (size_t i = 0; i < g.cores.size(); ++i) {
+            compute_args.runtime_arg_values.push_back(
+                {g.cores[i], {{"total_blocks", g.number_of_blocks_per_core[i]}}});
+        }
+        args.kernel_run_args.push_back(std::move(compute_args));
+    }
+
+    auto reader_index = [&](const char* kernel) {
+        m2::ProgramRunArgs::KernelRunArgs ra{.kernel = m2::KernelSpecName{kernel}};
+        for (size_t i = 0; i < g.cores.size(); ++i) {
+            uint32_t idx = 0;
+            if (g.config_tensors_in_dram) {
+                if (g.is_height_sharded) {
+                    idx = static_cast<uint32_t>(i);
+                } else if (g.is_block_sharded) {
+                    idx = g.is_rm_orientation ? g.cores[i].y : g.cores[i].x;
+                }
+            }
+            ra.runtime_arg_values.push_back({g.cores[i], {{"config_read_index", idx}}});
+        }
+        return ra;
+    };
+    args.kernel_run_args.push_back(reader_index("reader0"));
+    args.kernel_run_args.push_back(reader_index("reader1"));
+    return args;
+}
+
+// create_per_enqueue_args — the per-call tensor bindings: the sharded input and output shards. The config
+// tensors are op-owned (create_owned_tensors) and bound invariant, so they are not re-applied here.
+m2::ProgramRunArgs UntilizeWithHaloProgramFactory::create_per_enqueue_args(
+    const HaloParams&, const Tensor& input, Tensor& output, const std::optional<ttnn::MeshCoordinate>&) {
+    m2::ProgramRunArgs args;
+    args.tensor_args.emplace(
+        m2::TensorParamName{TP_INPUT}, m2::ProgramRunArgs::TensorArgument{std::cref(input.mesh_tensor())});
+    args.tensor_args.emplace(
+        m2::TensorParamName{TP_OUTPUT}, m2::ProgramRunArgs::TensorArgument{std::cref(output.mesh_tensor())});
+    return args;
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.cpp
@@ -122,15 +122,16 @@ HaloGeometry compute_geometry(const HaloParams& attrs, const Tensor& input, cons
         is_in_tiled,
         UNTILIZE_BLOCK_SIZE);
 
-    auto to_device = [&](const auto& cfg) {
-        auto host = sliding_window::construct_on_host_config_tensor(cfg, attrs.parallel_config, g.config_tensors_in_dram);
-        return sliding_window::move_config_tensor_to_device(
-            host, attrs.parallel_config, g.is_block_sharded, device, g.config_tensors_in_dram);
+    // Build the four config tensors on HOST only; create_owned_tensors performs the single device upload.
+    // create_program_spec derives their device specs via config_device_spec (no upload), and
+    // create_invariant_run_args needs only number_of_blocks_per_core below — so nothing here materializes.
+    auto on_host = [&](const auto& cfg) {
+        return sliding_window::construct_on_host_config_tensor(cfg, attrs.parallel_config, g.config_tensors_in_dram);
     };
-    g.pad_config0 = to_device(kernel_config.pad_config0);
-    g.pad_config1 = to_device(kernel_config.pad_config1);
-    g.gather_config0 = to_device(kernel_config.gather_config0);
-    g.gather_config1 = to_device(kernel_config.gather_config1);
+    g.pad_config0 = on_host(kernel_config.pad_config0);
+    g.pad_config1 = on_host(kernel_config.pad_config1);
+    g.gather_config0 = on_host(kernel_config.gather_config0);
+    g.gather_config1 = on_host(kernel_config.gather_config1);
     g.number_of_blocks_per_core =
         sliding_window::remap_nhw_scalar_argument_across_full_grid(kernel_config.number_of_blocks_per_core, attrs.parallel_config);
 
@@ -200,6 +201,34 @@ m2::DataflowBufferSpec borrowed_dfb(
     return dfb;
 }
 
+// Device memory config a sliding-window config tensor WOULD get on upload — mirrors the memcfg in
+// sliding_window.cpp::move_config_tensor_to_device (which create_owned_tensors calls to do the actual upload).
+// This lets create_program_spec derive the device TensorSpec + page size WITHOUT materializing the tensor, so
+// the config tensors are uploaded exactly once (in create_owned_tensors) instead of once per factory method.
+MemoryConfig config_device_memcfg(
+    const Tensor& host, const ttnn::operations::sliding_window::ParallelConfig& p_config, bool is_block_sharded) {
+    std::array<uint32_t, 2> shard_shape{1, static_cast<uint32_t>(host.logical_shape()[-1])};
+    auto orientation = is_block_sharded ? (p_config.shard_orientation == ShardOrientation::COL_MAJOR
+                                               ? ShardOrientation::ROW_MAJOR
+                                               : ShardOrientation::COL_MAJOR)
+                                        : ShardOrientation::ROW_MAJOR;
+    ShardSpec shard_spec(p_config.grid, shard_shape, orientation);
+    return MemoryConfig{TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1_SMALL, shard_spec};
+}
+
+// The device TensorSpec a host config tensor would have once uploaded (DRAM-interleaved or L1_SMALL sharded).
+TensorSpec config_device_spec(
+    const Tensor& host,
+    const ttnn::operations::sliding_window::ParallelConfig& p_config,
+    bool is_block_sharded,
+    bool in_dram) {
+    MemoryConfig memcfg = in_dram ? MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM}
+                                  : config_device_memcfg(host, p_config, is_block_sharded);
+    // with_memory_config is exactly the transform to_device applies to the spec (data moves, layout
+    // preserved, memory_config swapped), so the declared spec matches the uploaded tensor's spec exactly.
+    return host.tensor_spec().with_memory_config(memcfg);
+}
+
 }  // namespace
 
 // create_owned_tensors — the four host-built sliding-window config tensors. The framework keeps them alive
@@ -208,11 +237,16 @@ m2::DataflowBufferSpec borrowed_dfb(
 m2::Table<m2::TensorParamName, Tensor> UntilizeWithHaloProgramFactory::create_owned_tensors(
     const HaloParams& attrs, const Tensor& input, Tensor& output) {
     const auto g = compute_geometry(attrs, input, output);
+    // The single device upload of the host-built config tensors (the only materialization).
+    auto upload = [&](const Tensor& host) {
+        return ttnn::operations::sliding_window::move_config_tensor_to_device(
+            host, attrs.parallel_config, g.is_block_sharded, input.device(), g.config_tensors_in_dram);
+    };
     m2::Table<m2::TensorParamName, Tensor> owned;
-    owned.emplace(m2::TensorParamName{TP_PAD_CFG0}, g.pad_config0);
-    owned.emplace(m2::TensorParamName{TP_PAD_CFG1}, g.pad_config1);
-    owned.emplace(m2::TensorParamName{TP_GATHER_CFG0}, g.gather_config0);
-    owned.emplace(m2::TensorParamName{TP_GATHER_CFG1}, g.gather_config1);
+    owned.emplace(m2::TensorParamName{TP_PAD_CFG0}, upload(g.pad_config0));
+    owned.emplace(m2::TensorParamName{TP_PAD_CFG1}, upload(g.pad_config1));
+    owned.emplace(m2::TensorParamName{TP_GATHER_CFG0}, upload(g.gather_config0));
+    owned.emplace(m2::TensorParamName{TP_GATHER_CFG1}, upload(g.gather_config1));
     return owned;
 }
 
@@ -224,9 +258,20 @@ m2::ProgramSpec UntilizeWithHaloProgramFactory::create_program_spec(
     const auto g = compute_geometry(attrs, input, output);
     const tt::DataFormat cfg_df = tt::DataFormat::RawUInt16;
 
+    // Device specs for the op-owned config tensors, derived from the host tensors WITHOUT uploading
+    // (create_owned_tensors performs the single upload). compute_page_size_bytes() equals the device buffer's
+    // page size, so the borrowed-DFB sizing and the empty-padding sentinel below are unchanged.
+    const auto spec_of = [&](const Tensor& host) {
+        return config_device_spec(host, attrs.parallel_config, g.is_block_sharded, g.config_tensors_in_dram);
+    };
+    const auto pad_cfg0_spec = spec_of(g.pad_config0);
+    const auto pad_cfg1_spec = spec_of(g.pad_config1);
+    const auto gather_cfg0_spec = spec_of(g.gather_config0);
+    const auto gather_cfg1_spec = spec_of(g.gather_config1);
+
     const bool enable_padding = g.config_tensors_in_dram ||
-                                g.pad_config0.buffer()->page_size() != EMPTY_PADDING_CONFIG_BUFFER_SIZE ||
-                                g.pad_config1.buffer()->page_size() != EMPTY_PADDING_CONFIG_BUFFER_SIZE;
+                                pad_cfg0_spec.compute_page_size_bytes() != EMPTY_PADDING_CONFIG_BUFFER_SIZE ||
+                                pad_cfg1_spec.compute_page_size_bytes() != EMPTY_PADDING_CONFIG_BUFFER_SIZE;
 
     m2::ProgramSpec spec;
     spec.name = "untilize_with_halo";
@@ -239,20 +284,16 @@ m2::ProgramSpec UntilizeWithHaloProgramFactory::create_program_spec(
         m2::TensorParameter{.unique_id = m2::TensorParamName{TP_INPUT}, .spec = input.tensor_spec()},
         m2::TensorParameter{.unique_id = m2::TensorParamName{TP_OUTPUT}, .spec = output.tensor_spec()},
         m2::TensorParameter{
-            .unique_id = m2::TensorParamName{TP_PAD_CFG0},
-            .spec = g.pad_config0.tensor_spec(),
-            .advanced_options = invariant_tp},
+            .unique_id = m2::TensorParamName{TP_PAD_CFG0}, .spec = pad_cfg0_spec, .advanced_options = invariant_tp},
         m2::TensorParameter{
-            .unique_id = m2::TensorParamName{TP_PAD_CFG1},
-            .spec = g.pad_config1.tensor_spec(),
-            .advanced_options = invariant_tp},
+            .unique_id = m2::TensorParamName{TP_PAD_CFG1}, .spec = pad_cfg1_spec, .advanced_options = invariant_tp},
         m2::TensorParameter{
             .unique_id = m2::TensorParamName{TP_GATHER_CFG0},
-            .spec = g.gather_config0.tensor_spec(),
+            .spec = gather_cfg0_spec,
             .advanced_options = invariant_tp},
         m2::TensorParameter{
             .unique_id = m2::TensorParamName{TP_GATHER_CFG1},
-            .spec = g.gather_config1.tensor_spec(),
+            .spec = gather_cfg1_spec,
             .advanced_options = invariant_tp},
     };
 
@@ -264,15 +305,17 @@ m2::ProgramSpec UntilizeWithHaloProgramFactory::create_program_spec(
     dfbs.push_back(scratch_dfb(DFB_PAD0, g.out_df, g.pad_cb_pagesize, 1));
     dfbs.push_back(scratch_dfb(DFB_PAD1, g.out_df, g.pad_cb_pagesize, 1));
     if (g.config_tensors_in_dram) {
-        dfbs.push_back(scratch_dfb(DFB_PAD_CFG0, cfg_df, g.pad_config0.buffer()->page_size(), 1));
-        dfbs.push_back(scratch_dfb(DFB_PAD_CFG1, cfg_df, g.pad_config1.buffer()->page_size(), 1));
-        dfbs.push_back(scratch_dfb(DFB_GATHER_CFG0, cfg_df, g.gather_config0.buffer()->page_size(), 1));
-        dfbs.push_back(scratch_dfb(DFB_GATHER_CFG1, cfg_df, g.gather_config1.buffer()->page_size(), 1));
+        dfbs.push_back(scratch_dfb(DFB_PAD_CFG0, cfg_df, pad_cfg0_spec.compute_page_size_bytes(), 1));
+        dfbs.push_back(scratch_dfb(DFB_PAD_CFG1, cfg_df, pad_cfg1_spec.compute_page_size_bytes(), 1));
+        dfbs.push_back(scratch_dfb(DFB_GATHER_CFG0, cfg_df, gather_cfg0_spec.compute_page_size_bytes(), 1));
+        dfbs.push_back(scratch_dfb(DFB_GATHER_CFG1, cfg_df, gather_cfg1_spec.compute_page_size_bytes(), 1));
     } else {
-        dfbs.push_back(borrowed_dfb(DFB_PAD_CFG0, TP_PAD_CFG0, cfg_df, g.pad_config0.buffer()->page_size(), 1));
-        dfbs.push_back(borrowed_dfb(DFB_PAD_CFG1, TP_PAD_CFG1, cfg_df, g.pad_config1.buffer()->page_size(), 1));
-        dfbs.push_back(borrowed_dfb(DFB_GATHER_CFG0, TP_GATHER_CFG0, cfg_df, g.gather_config0.buffer()->page_size(), 1));
-        dfbs.push_back(borrowed_dfb(DFB_GATHER_CFG1, TP_GATHER_CFG1, cfg_df, g.gather_config1.buffer()->page_size(), 1));
+        dfbs.push_back(borrowed_dfb(DFB_PAD_CFG0, TP_PAD_CFG0, cfg_df, pad_cfg0_spec.compute_page_size_bytes(), 1));
+        dfbs.push_back(borrowed_dfb(DFB_PAD_CFG1, TP_PAD_CFG1, cfg_df, pad_cfg1_spec.compute_page_size_bytes(), 1));
+        dfbs.push_back(
+            borrowed_dfb(DFB_GATHER_CFG0, TP_GATHER_CFG0, cfg_df, gather_cfg0_spec.compute_page_size_bytes(), 1));
+        dfbs.push_back(
+            borrowed_dfb(DFB_GATHER_CFG1, TP_GATHER_CFG1, cfg_df, gather_cfg1_spec.compute_page_size_bytes(), 1));
     }
     if (!g.skip_untilize) {
         dfbs.push_back(scratch_dfb(DFB_UNTILIZE_OUT0, g.out_df, g.out_tile_size, g.untilize_out_cb_num_pages));
@@ -334,9 +377,9 @@ m2::ProgramSpec UntilizeWithHaloProgramFactory::create_program_spec(
         if (g.config_tensors_in_dram) {
             copts.defines.emplace("CONFIG_TENSOR_IN_DRAM", "1");
             def("PADDING_CONFIG_PAGE_SIZE",
-                (is_reader1 ? g.pad_config1 : g.pad_config0).buffer()->page_size());
+                (is_reader1 ? pad_cfg1_spec : pad_cfg0_spec).compute_page_size_bytes());
             def("GATHER_CONFIG_PAGE_SIZE",
-                (is_reader1 ? g.gather_config1 : g.gather_config0).buffer()->page_size());
+                (is_reader1 ? gather_cfg1_spec : gather_cfg0_spec).compute_page_size_bytes());
         }
         return copts;
     };

--- a/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/sliding_window/halo/device/untilize_with_halo_program_factory.hpp
@@ -4,25 +4,35 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
+#include <optional>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/distributed/types.hpp"
 #include "ttnn/operations/sliding_window/halo/device/halo_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
+// MetalV2 base-case factory for untilize-with-halo. The four sliding-window config tensors
+// (pad_config0/1, gather_config0/1) are op-allocated internal tensors: create_owned_tensors builds them on
+// host and the framework keeps them alive for the cached program's lifetime, binding each to a
+// TensorParameter the reader streams from (an L1-borrowed CB, or a DRAM TensorAccessor). create_program_spec
+// is the immutable blueprint; create_invariant_run_args carries the per-core work scalars; the input/output
+// shard addresses ride create_per_enqueue_args.
 struct UntilizeWithHaloProgramFactory {
-    // create_workload_descriptor() allocates the four sliding-window halo
-    // config tensors (pad_config0/1, gather_config0/1) on device and parks
-    // them on the returned WorkloadDescriptor so their backing buffers
-    // outlive the cached programs.  The buffers are bound to the
-    // CBDescriptor entries that the reader kernels stream from.
-    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
-        const HaloParams& operation_attributes,
-        const Tensor& tensor_args,
-        Tensor& output_tensor,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+    static tt::tt_metal::experimental::ProgramSpec create_program_spec(
+        const HaloParams& attrs, const Tensor& input, Tensor& output);
+    static tt::tt_metal::experimental::ProgramRunArgs create_invariant_run_args(
+        const HaloParams& attrs, const Tensor& input, Tensor& output);
+    static tt::tt_metal::experimental::ProgramRunArgs create_per_enqueue_args(
+        const HaloParams& attrs,
+        const Tensor& input,
+        Tensor& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate);
+    static tt::tt_metal::experimental::Table<tt::tt_metal::experimental::TensorParamName, Tensor>
+    create_owned_tensors(const HaloParams& attrs, const Tensor& input, Tensor& output);
 };
 
 }  // namespace ttnn::prim


### PR DESCRIPTION
Adds the **op-owned internal tensors** capability to the MetalV2 op-migration framework and migrates the sliding-window **halo** op as the first consumer. Split out of #46781 so that framework PR stays small and merge-ready.

### Stacking / dependencies
- **Base = `dgomez/metal2-ttnn-framework` (#46781)** — this PR stacks on the framework PR; the diff here is just the three commits below. Retarget to `main` once #46781 lands.
- **Depends on #47037** (metal: borrowed-DFB `L1_SMALL` + same-core broadcast). halo cannot build without those. **CI here will be red until #47037 and #46781 merge.**

### Commits
1. **create_owned_tensors + create_invariant_run_args optional** — `create_owned_tensors` is an optional 4th factory method returning op-allocated internal device tensors (config/lookup tables), keyed by their `TensorParameter`. The framework builds them once on a cache miss, keeps them alive for the cached program's lifetime, and binds them enqueue-invariant. `create_invariant_run_args` is now optional (minimal factory = `create_program_spec` + `create_per_enqueue_args`).
2. **Migrate untilize-with-halo** — the four sliding-window config tensors are op-owned via `create_owned_tensors`; the split `halo_gather` reader (RISCV0/1) and `pack_untilize` compute kernel use `dfb::`/`ta::`/`args::` bindings, device logic unchanged.
3. **Build config tensors on host; upload once** — `create_program_spec` derives the device `TensorSpec` (+ page size) via `TensorSpec::with_memory_config` instead of materializing the config tensors, so they're uploaded exactly once (in `create_owned_tensors`). Addresses the review note that the ProgramSpec should capture only the `TensorSpec`, never force a device allocation.

### Validation (local, N150, with #47037 applied)
- BLOCK_SHARDED conv2d (halo tiled **and** row-major): 49 passed
- HEIGHT/WIDTH-sharded conv2d: 98 passed
- PCC ≥ 0.9997

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metal2-owned-tensors-halo)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metal2-owned-tensors-halo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-owned-tensors-halo)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metal2-owned-tensors-halo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/metal2-owned-tensors-halo)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/metal2-owned-tensors-halo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metal2-owned-tensors-halo)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metal2-owned-tensors-halo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metal2-owned-tensors-halo)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metal2-owned-tensors-halo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metal2-owned-tensors-halo)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metal2-owned-tensors-halo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metal2-owned-tensors-halo)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metal2-owned-tensors-halo)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metal2-owned-tensors-halo)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metal2-owned-tensors-halo)