### PR TITLE
[Cleanup] migrate SDPA shared headers + decode tail to Device 2.0

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_common.hpp
@@ -23,6 +23,7 @@
 #include "api/compute/matmul.h"
 #include "api/compute/reduce.h"
 #include "api/compute/reduce_custom.h"
+#include "api/dataflow/circular_buffer.h"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/q_chunk_remapping.hpp"
 #include "cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/chunked_prefill_utils.hpp"
 #include "cpp/ttnn/kernel_lib/dest_helpers.hpp"
@@ -44,14 +45,16 @@ ALWI void sdpa_reduce_copy_tile_to_dst_init_short(uint32_t cbid, uint32_t transp
  */
 template <uint32_t num_tiles>
 void max_block_inplace(uint32_t in0, uint32_t in1) {
+    CircularBuffer cb_in0(in0);
+    CircularBuffer cb_in1(in1);
     // inputs come in full, outputs go out full
     copy_tile_to_dst_init_short(in0);
     copy_tile_to_dst_init_short(in1);
     binary_max_tile_init();
     constexpr uint32_t dst_reg_0 = 0;
     constexpr uint32_t dst_reg_1 = 1;
-    cb_wait_front(in0, num_tiles);
-    cb_wait_front(in1, num_tiles);
+    cb_in0.wait_front(num_tiles);
+    cb_in1.wait_front(num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
         tile_regs_acquire();
         copy_tile(in0, i, dst_reg_0);
@@ -62,9 +65,9 @@ void max_block_inplace(uint32_t in0, uint32_t in1) {
         pack_tile(dst_reg_0, in0);
         tile_regs_release();
     }
-    cb_pop_front(in0, num_tiles);
-    cb_reserve_back(in0, num_tiles);
-    cb_push_back(in0, num_tiles);
+    cb_in0.pop_front(num_tiles);
+    cb_in0.reserve_back(num_tiles);
+    cb_in0.push_back(num_tiles);
 }
 
 /**
@@ -72,15 +75,18 @@ void max_block_inplace(uint32_t in0, uint32_t in1) {
  */
 template <VectorMode vector_mode = VectorMode::RC>
 void max_block(uint32_t in0, uint32_t in1, uint32_t out_cb, uint32_t num_tiles) {
+    CircularBuffer cb_in0(in0);
+    CircularBuffer cb_in1(in1);
+    CircularBuffer cb_out(out_cb);
     // inputs come in full, outputs go out full
     copy_tile_to_dst_init_short(in0);
     binary_max_tile_init();
 
     constexpr uint32_t dst_reg_0 = 0;
     constexpr uint32_t dst_reg_1 = 1;
-    cb_wait_front(in0, num_tiles);
-    cb_wait_front(in1, num_tiles);
-    cb_reserve_back(out_cb, num_tiles);
+    cb_in0.wait_front(num_tiles);
+    cb_in1.wait_front(num_tiles);
+    cb_out.reserve_back(num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
         tile_regs_acquire();
         copy_tile(in0, i, dst_reg_0);
@@ -91,7 +97,7 @@ void max_block(uint32_t in0, uint32_t in1, uint32_t out_cb, uint32_t num_tiles) 
         pack_tile(dst_reg_0, out_cb, i);
         tile_regs_release();
     }
-    cb_push_back(out_cb, num_tiles);
+    cb_out.push_back(num_tiles);
 }
 
 /**
@@ -106,6 +112,10 @@ template <
     uint32_t cols,
     VectorMode vector_mode = VectorMode::C>
 void reduce_c(uint32_t out_cb, uint32_t prev_cb, bool do_eltwise_max = false) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_scale(scale_cb);
+    CircularBuffer cb_out(out_cb);
+    CircularBuffer cb_prev(prev_cb);
     // Precondition: in0_cb has rows*cols produced. in0_cb has tiles in row-major order
     // Precondition: scale_cb has 1 produced
     // Precondition: out_cb has rows free
@@ -124,19 +134,19 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, bool do_eltwise_max = false) {
     constexpr uint32_t granularity = rows;
 #endif
 
-    cb_wait_front(scale_cb, 1);
-    cb_reserve_back(out_cb, rows);
+    cb_scale.wait_front(1);
+    cb_out.reserve_back(rows);
 
     const uint32_t num_tiles_to_wait = dst_tiles * cols;
     uint32_t in0_wait_tiles = num_tiles_to_wait;
 
     uint32_t row_start_idx = 0;
     for (uint32_t g = 0; g < granularity; g++) {
-        cb_wait_front(in0_cb, in0_wait_tiles);
+        cb_in0.wait_front(in0_wait_tiles);
         tile_regs_acquire();
 
         if (do_eltwise_max) {
-            cb_wait_front(prev_cb, g * dst_tiles);
+            cb_prev.wait_front(g * dst_tiles);
             /**
              * Copy previous max values into DST register.
              * Note that this special invocation of copy_tile is necessary to produce
@@ -171,7 +181,7 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, bool do_eltwise_max = false) {
         in0_wait_tiles += num_tiles_to_wait;
     }
 
-    cb_push_back(out_cb, rows);
+    cb_out.push_back(rows);
 }
 
 /**
@@ -187,6 +197,9 @@ template <
     uint32_t rows,
     VectorMode vector_mode = VectorMode::C>
 void reduce_c(uint32_t out_cb, uint32_t prev_cb, uint32_t cols, bool do_eltwise_max = false) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_scale(scale_cb);
+    CircularBuffer cb_out(out_cb);
     // Precondition: in0_cb has rows*cols produced. in0_cb has tiles in row-major order
     // Precondition: scale_cb has 1 produced
     // Precondition: out_cb has rows free
@@ -195,9 +208,9 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, uint32_t cols, bool do_eltwise_
     // Postcondition: out_cb has rows produced
 
     uint32_t num_tiles = rows * cols;
-    cb_wait_front(scale_cb, 1);
-    cb_wait_front(in0_cb, num_tiles);
-    cb_reserve_back(out_cb, rows);
+    cb_scale.wait_front(1);
+    cb_in0.wait_front(num_tiles);
+    cb_out.reserve_back(rows);
 
     binary_max_tile_init();
     constexpr uint32_t reduce_dst_idx = 0;
@@ -222,7 +235,7 @@ void reduce_c(uint32_t out_cb, uint32_t prev_cb, uint32_t cols, bool do_eltwise_
         tile_regs_release();
     }
 
-    cb_push_back(out_cb, rows);
+    cb_out.push_back(rows);
 }
 
 #ifdef TRISC_MATH
@@ -277,6 +290,7 @@ void recip_tile_first_column(uint32_t idst) {
  * in_cb = 1 / in_cb
  */
 void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
+    CircularBuffer cb_in(in_cb);
     // Precondition: in_cb has num_tiles produced
     // Postcondition: in_cb has num_tiles produced
     copy_tile_to_dst_init_short(in_cb);
@@ -284,7 +298,7 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
     reconfig_data_format_srca(in_cb);
     pack_reconfig_data_format(in_cb);
 
-    cb_wait_front(in_cb, num_tiles);
+    cb_in.wait_front(num_tiles);
     for (uint32_t i = 0; i < num_tiles; ++i) {
         tile_regs_acquire();
         copy_tile(in_cb, i, 0);
@@ -294,9 +308,9 @@ void recip_block_inplace(uint32_t in_cb, uint32_t num_tiles) {
         pack_tile(0, in_cb);
         tile_regs_release();
     }
-    cb_pop_front(in_cb, num_tiles);
-    cb_reserve_back(in_cb, num_tiles);
-    cb_push_back(in_cb, num_tiles);
+    cb_in.pop_front(num_tiles);
+    cb_in.reserve_back(num_tiles);
+    cb_in.push_back(num_tiles);
 }
 
 /**
@@ -310,6 +324,9 @@ template <
     bool do_reduce = true,
     VectorMode vector_mode = VectorMode::RC>
 void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, uint32_t cols) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
+    CircularBuffer cb_reduce(reduce_cb);
     // Precondition: in0_cb has rows*cols produced
     // Precondition: in1_cb has rows produced
     // Postcondition: in0_cb has rows*cols produced
@@ -322,10 +339,10 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, uint3
     exp_tile_init<true /* approx */, scale_fp32, InputClamping::None>();
     PACK((llk_pack_relu_config(ReluConfig::zero())));
 
-    cb_wait_front(in0_cb, rows * cols);
-    cb_wait_front(in1_cb, rows);
+    cb_in0.wait_front(rows * cols);
+    cb_in1.wait_front(rows);
     if constexpr (do_reduce) {
-        cb_reserve_back(reduce_cb, rows);
+        cb_reduce.reserve_back(rows);
     }
 
 #ifdef SUB_EXP_GRANULARITY
@@ -348,8 +365,8 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, uint3
             tile_regs_commit();
 
             if constexpr (write_result_inplace) {
-                cb_pop_front(in0_cb, dst_tiles);
-                cb_reserve_back(in0_cb, dst_tiles);
+                cb_in0.pop_front(dst_tiles);
+                cb_in0.reserve_back(dst_tiles);
             }
 
             tile_regs_wait();
@@ -359,7 +376,7 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, uint3
                     pack_tile(j, in0_cb);
                 }
                 // Granular write output to enable following matmul unpack to start early.
-                cb_push_back(in0_cb, dst_tiles);
+                cb_in0.push_back(dst_tiles);
             }
 
             if constexpr (do_reduce) {
@@ -384,7 +401,7 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, uint3
         }
     }
     if constexpr (do_reduce) {
-        cb_push_back(reduce_cb, rows);
+        cb_reduce.push_back(rows);
     }
 
     PACK((llk_pack_relu_config(ReluConfig::none())));
@@ -402,6 +419,9 @@ void sub_exp_block_bcast_cols_inplace(uint32_t in1_cb, uint32_t reduce_cb, uint3
  */
 template <uint32_t rows, uint32_t cols, bool immediate_pop, bool pack_accumulate>
 void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
+    CircularBuffer cb_out(out_cb);
     // Precondition: in0_cb has rows*cols produced
     // Precondition: in1_cb has rows produced
     // Precondition: out_cb has rows*cols produced
@@ -412,8 +432,8 @@ void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb) {
     constexpr uint32_t num_tiles = rows * cols;
 
     mul_bcast_cols_init_short(in0_cb, in1_cb);
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_cb, rows);
+    cb_in0.wait_front(num_tiles);
+    cb_in1.wait_front(rows);
 
     if constexpr (immediate_pop) {
         static_assert(!pack_accumulate, "Unsupported parameter configuration");
@@ -422,15 +442,15 @@ void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb) {
                 tile_regs_acquire();
                 mul_tiles_bcast_cols(in0_cb, in1_cb, 0, i, 0);
                 tile_regs_commit();
-                cb_pop_front(in0_cb, 1);
-                cb_reserve_back(out_cb, 1);
+                cb_in0.pop_front(1);
+                cb_out.reserve_back(1);
                 tile_regs_wait();
                 pack_tile(0, out_cb);
                 tile_regs_release();
-                cb_push_back(out_cb, 1);
+                cb_out.push_back(1);
             }
         }
-        cb_pop_front(in1_cb, rows);
+        cb_in1.pop_front(rows);
     } else {
 #ifdef DHT_GRANULARITY
         constexpr uint32_t dst_tiles = (cols < DHT_GRANULARITY) ? cols : DHT_GRANULARITY;
@@ -441,7 +461,7 @@ void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb) {
 #endif
         PACK((llk_pack_reconfig_l1_acc(pack_accumulate)));
         if (!pack_accumulate) {
-            cb_reserve_back(out_cb, num_tiles);
+            cb_out.reserve_back(num_tiles);
         }
         uint32_t in0_index = 0;
         for (uint32_t i = 0; i < rows; ++i) {
@@ -459,15 +479,15 @@ void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb) {
                 tile_regs_release();
             }
         }
-        cb_pop_front(in1_cb, rows);
-        cb_pop_front(in0_cb, num_tiles);
+        cb_in1.pop_front(rows);
+        cb_in0.pop_front(num_tiles);
         if (pack_accumulate) {
             PACK((llk_pack_reconfig_l1_acc(false)));
-            cb_pop_front(out_cb, num_tiles);
-            cb_reserve_back(out_cb, num_tiles);
-            cb_push_back(out_cb, num_tiles);
+            cb_out.pop_front(num_tiles);
+            cb_out.reserve_back(num_tiles);
+            cb_out.push_back(num_tiles);
         } else {
-            cb_push_back(out_cb, num_tiles);
+            cb_out.push_back(num_tiles);
         }
     }
 }
@@ -477,6 +497,8 @@ void mul_block_bcast_cols(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb) {
  */
 template <uint32_t rows, uint32_t cols>
 void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
     // Precondition: in0_cb has rows*cols produced
     // Precondition: in1_cb has rows produced
     // Postcondition: in0_cb has rows*cols produced
@@ -493,8 +515,8 @@ void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb) {
 #endif
 
     mul_bcast_cols_init_short(in0_cb, in1_cb);
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_cb, rows);
+    cb_in0.wait_front(num_tiles);
+    cb_in1.wait_front(rows);
     for (uint32_t i = 0; i < rows; ++i) {
         for (uint32_t u = 0; u < granularity; ++u) {
             tile_regs_acquire();
@@ -502,21 +524,23 @@ void mul_block_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb) {
                 mul_tiles_bcast_cols(in0_cb, in1_cb, j, i, j);
             }
             tile_regs_commit();
-            cb_pop_front(in0_cb, dst_tiles);
-            cb_reserve_back(in0_cb, dst_tiles);
+            cb_in0.pop_front(dst_tiles);
+            cb_in0.reserve_back(dst_tiles);
             tile_regs_wait();
             for (uint32_t j = 0; j < dst_tiles; ++j) {
                 pack_tile(j, in0_cb);
             }
-            cb_push_back(in0_cb, dst_tiles);
+            cb_in0.push_back(dst_tiles);
             tile_regs_release();
         }
     }
-    cb_pop_front(in1_cb, rows);
+    cb_in1.pop_front(rows);
 }
 
 template <uint32_t in1_scalar_cb, uint32_t num_tiles>
 void mul_block_bcast_scalar_inplace(uint32_t in0_cb) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1_scalar(in1_scalar_cb);
     // Precondition: in0_cb has num_tiles produced
     // Precondition: in1_scalar_cb has 1 produced
     // Postcondition: in0_cb has num_tiles produced
@@ -532,8 +556,8 @@ void mul_block_bcast_scalar_inplace(uint32_t in0_cb) {
 
     reconfig_data_format(in0_cb, in1_scalar_cb);
     mul_tiles_bcast_scalar_init_short(in0_cb, in1_scalar_cb);
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_scalar_cb, 1);
+    cb_in0.wait_front(num_tiles);
+    cb_in1_scalar.wait_front(1);
     uint32_t in0_index = 0;
     for (uint32_t g = 0; g < granularity; ++g) {
         tile_regs_acquire();
@@ -548,9 +572,9 @@ void mul_block_bcast_scalar_inplace(uint32_t in0_cb) {
         }
         tile_regs_release();
     }
-    cb_pop_front(in0_cb, num_tiles);
-    cb_reserve_back(in0_cb, num_tiles);
-    cb_push_back(in0_cb, num_tiles);
+    cb_in0.pop_front(num_tiles);
+    cb_in0.reserve_back(num_tiles);
+    cb_in0.push_back(num_tiles);
 }
 
 /**
@@ -558,13 +582,15 @@ void mul_block_bcast_scalar_inplace(uint32_t in0_cb) {
  */
 template <bool pop_in1 = true>
 void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
     // Precondition: in0_cb and in1_cb have num_tiles produced
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_cb has num_tiles consumed
 
     add_tiles_init(in0_cb, in1_cb);
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_cb, num_tiles);
+    cb_in0.wait_front(num_tiles);
+    cb_in1.wait_front(num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
         tile_regs_acquire();
         add_tiles(in0_cb, in1_cb, i, i, 0);
@@ -574,15 +600,17 @@ void add_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
         tile_regs_release();
     }
 
-    cb_pop_front(in0_cb, num_tiles);
+    cb_in0.pop_front(num_tiles);
     if (pop_in1) {
-        cb_pop_front(in1_cb, num_tiles);
+        cb_in1.pop_front(num_tiles);
     }
-    cb_reserve_back(in0_cb, num_tiles);
-    cb_push_back(in0_cb, num_tiles);
+    cb_in0.reserve_back(num_tiles);
+    cb_in0.push_back(num_tiles);
 }
 
 void mul_tiles_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
     /**
      * Given in0_cb and in1_cb, multiply each tile of in0_cb by the corresponding tile of in1_cb
      * and bcast cols of in1_cb.
@@ -592,18 +620,18 @@ void mul_tiles_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num
     // Postcondition: in1_cb has num_tiles produced
 
     mul_bcast_cols_init_short(in0_cb, in1_cb);
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_cb, num_tiles);
+    cb_in0.wait_front(num_tiles);
+    cb_in1.wait_front(num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
         tile_regs_acquire();
         mul_tiles_bcast_cols(in0_cb, in1_cb, 0, i, 0);
         tile_regs_commit();
-        cb_pop_front(in0_cb, 1);
-        cb_reserve_back(in0_cb, 1);
+        cb_in0.pop_front(1);
+        cb_in0.reserve_back(1);
         tile_regs_wait();
         pack_tile(0, in0_cb);
         tile_regs_release();
-        cb_push_back(in0_cb, 1);
+        cb_in0.push_back(1);
     }
 }
 
@@ -611,24 +639,26 @@ void mul_tiles_bcast_cols_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num
  * in0_cb *= in1_cb
  */
 void mul_block_inplace(uint32_t in0_cb, uint32_t in1_cb, uint32_t num_tiles) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
     // Precondition: in0_cb and in1_cb have num_tiles produced
     // Postcondition: in0_cb has num_tiles produced
     // Postcondition: in1_cb has num_tiles produced
 
     mul_tiles_init(in0_cb, in1_cb);
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_cb, num_tiles);
+    cb_in0.wait_front(num_tiles);
+    cb_in1.wait_front(num_tiles);
     for (uint32_t i = 0; i < num_tiles; i++) {
         invalidate_l1_cache();
         tile_regs_acquire();
         mul_tiles(in0_cb, in1_cb, 0, i, 0);
         tile_regs_commit();
-        cb_pop_front(in0_cb, 1);
-        cb_reserve_back(in0_cb, 1);
+        cb_in0.pop_front(1);
+        cb_in0.reserve_back(1);
         tile_regs_wait();
         pack_tile(0, in0_cb);
         tile_regs_release();
-        cb_push_back(in0_cb, 1);
+        cb_in0.push_back(1);
     }
 }
 
@@ -878,15 +908,18 @@ void exp_tile_first_column(uint32_t idst) {
  */
 template <uint32_t scale_fp32>
 void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_tiles) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
+    CircularBuffer cb_out(out_cb);
     // Precondition: in0_cb and in1_cb have num_tiles produced
     // Postcondition: out_cb has num_tiles produced
     // Postcondition: in0_cb and in1_cb has num_tiles produced
 
     sub_tiles_init(in0_cb, in1_cb);
     exp_tile_init<EXP_APPROX_MODE>();
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_cb, num_tiles);
-    cb_reserve_back(out_cb, num_tiles);
+    cb_in0.wait_front(num_tiles);
+    cb_in1.wait_front(num_tiles);
+    cb_out.reserve_back(num_tiles);
 
     // Convert scale_fp32 to bf16 scale
     constexpr uint16_t scale_bf16 = scale_fp32 >> 16;
@@ -900,7 +933,7 @@ void sub_exp_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t n
         tile_regs_wait();
         pack_tile(0, out_cb);
         tile_regs_release();
-        cb_push_back(out_cb, 1);
+        cb_out.push_back(1);
     }
 }
 
@@ -981,15 +1014,23 @@ void correction_block(
     uint32_t cb_exp_max_diff,
     uint32_t cb_exp_max_diff_2,
     uint32_t num_head_tiles) {
-    cb_wait_front(cb_worker_max, num_head_tiles);
-    cb_wait_front(cb_worker_sum, num_head_tiles);
-    cb_wait_front(cb_prev_max, num_head_tiles);
-    cb_wait_front(cb_prev_sum, num_head_tiles);
+    CircularBuffer cb_worker_max_obj(cb_worker_max);
+    CircularBuffer cb_worker_sum_obj(cb_worker_sum);
+    CircularBuffer cb_cur_max_obj(cb_cur_max);
+    CircularBuffer cb_prev_max_obj(cb_prev_max);
+    CircularBuffer cb_cur_sum_obj(cb_cur_sum);
+    CircularBuffer cb_prev_sum_obj(cb_prev_sum);
+    CircularBuffer cb_exp_max_diff_obj(cb_exp_max_diff);
+    CircularBuffer cb_exp_max_diff_2_obj(cb_exp_max_diff_2);
+    cb_worker_max_obj.wait_front(num_head_tiles);
+    cb_worker_sum_obj.wait_front(num_head_tiles);
+    cb_prev_max_obj.wait_front(num_head_tiles);
+    cb_prev_sum_obj.wait_front(num_head_tiles);
 
-    cb_reserve_back(cb_cur_max, num_head_tiles);
-    cb_reserve_back(cb_cur_sum, num_head_tiles);
-    cb_reserve_back(cb_exp_max_diff, num_head_tiles);
-    cb_reserve_back(cb_exp_max_diff_2, num_head_tiles);
+    cb_cur_max_obj.reserve_back(num_head_tiles);
+    cb_cur_sum_obj.reserve_back(num_head_tiles);
+    cb_exp_max_diff_obj.reserve_back(num_head_tiles);
+    cb_exp_max_diff_2_obj.reserve_back(num_head_tiles);
 
     constexpr uint32_t dst_reg_0 = 0;  // dst_reg_0 is used for prev_max
     constexpr uint32_t dst_reg_1 = 1;  // dst_reg_1 is used for worker_max
@@ -1016,13 +1057,13 @@ void correction_block(
         pack_tile(dst_reg_2, cb_cur_max);
         pack_tile(dst_reg_3, cb_cur_sum);
         tile_regs_release();
-        cb_push_back(cb_cur_max, 1);
-        cb_push_back(cb_cur_sum, 1);
-        cb_push_back(cb_exp_max_diff, 1);
-        cb_push_back(cb_exp_max_diff_2, 1);
+        cb_cur_max_obj.push_back(1);
+        cb_cur_sum_obj.push_back(1);
+        cb_exp_max_diff_obj.push_back(1);
+        cb_exp_max_diff_2_obj.push_back(1);
     }
-    cb_pop_front(cb_prev_sum, num_head_tiles);
-    cb_pop_front(cb_worker_sum, num_head_tiles);
+    cb_prev_sum_obj.pop_front(num_head_tiles);
+    cb_worker_sum_obj.pop_front(num_head_tiles);
 }
 
 /**
@@ -1030,6 +1071,8 @@ void correction_block(
  */
 template <bool pop_in_cb>
 void move_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
+    CircularBuffer cb_in(in_cb);
+    CircularBuffer cb_out(out_cb);
     // Precondition: in_cb has num_tiles produced
     // Precondition: out_cb has num_tiles free
     // Postcondition: in_cb has num_tiles consumed
@@ -1037,8 +1080,8 @@ void move_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
 
     copy_tile_to_dst_init_short(in_cb);
 
-    cb_wait_front(in_cb, num_tiles);
-    cb_reserve_back(out_cb, num_tiles);
+    cb_in.wait_front(num_tiles);
+    cb_out.reserve_back(num_tiles);
 
 #pragma GCC unroll 0
     for (uint32_t i = 0; i < num_tiles; i++) {
@@ -1048,21 +1091,23 @@ void move_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
         tile_regs_wait();
         pack_tile(0, out_cb);
         tile_regs_release();
-        cb_push_back(out_cb, 1);
+        cb_out.push_back(1);
     }
     if (pop_in_cb) {
-        cb_pop_front(in_cb, num_tiles);
+        cb_in.pop_front(num_tiles);
     }
 }
 
 void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
+    CircularBuffer cb_in(in_cb);
+    CircularBuffer cb_out(out_cb);
     // Precondition: in_cb has num_tiles produced
     // Precondition: out_cb has num_tiles free
     // Postcondition: in_cb has num_tiles consumed
     // Postcondition: out_cb has num_tiles produced
     copy_tile_to_dst_init_short(in_cb);
-    cb_wait_front(in_cb, num_tiles);
-    cb_reserve_back(out_cb, num_tiles);
+    cb_in.wait_front(num_tiles);
+    cb_out.reserve_back(num_tiles);
 #pragma GCC unroll 0
     for (uint32_t i = 0; i < num_tiles; i++) {
         tile_regs_acquire();
@@ -1071,16 +1116,18 @@ void copy_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
         tile_regs_wait();
         pack_tile(0, out_cb);
         tile_regs_release();
-        cb_push_back(out_cb, 1);
+        cb_out.push_back(1);
     }
-    cb_pop_front(in_cb, num_tiles);
+    cb_in.pop_front(num_tiles);
 }
 
 void log_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
+    CircularBuffer cb_in(in_cb);
+    CircularBuffer cb_out(out_cb);
     copy_tile_to_dst_init_short(in_cb);
     log_tile_init();
-    cb_wait_front(in_cb, num_tiles);
-    cb_reserve_back(out_cb, num_tiles);
+    cb_in.wait_front(num_tiles);
+    cb_out.reserve_back(num_tiles);
 
     for (uint32_t i = 0; i < num_tiles; i++) {
         tile_regs_acquire();
@@ -1090,11 +1137,14 @@ void log_block(uint32_t in_cb, uint32_t out_cb, uint32_t num_tiles) {
         tile_regs_wait();
         pack_tile(0, out_cb);
         tile_regs_release();
-        cb_push_back(out_cb, 1);
+        cb_out.push_back(1);
     }
 }
 
 void sigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_tiles) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
+    CircularBuffer cb_out(out_cb);
     // out_cb = sigmoid(in0_cb - in1_cb)
     /**
      * sigmoid(x) is accurately implemented as 1 / (1 + exp(-x))
@@ -1102,9 +1152,9 @@ void sigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num
      *
      * Each input tile has only the first column containing valid data, so VectorMode::C is a useful optimization.
      */
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_cb, num_tiles);
-    cb_reserve_back(out_cb, num_tiles);
+    cb_in0.wait_front(num_tiles);
+    cb_in1.wait_front(num_tiles);
+    cb_out.reserve_back(num_tiles);
     sub_tiles_init(in0_cb, in1_cb);
     exp_tile_init<false>();
     // recip_tile_first_column<false>() calls the scalar _sfpu_reciprocal_ path, so initialize exactly
@@ -1138,7 +1188,7 @@ void sigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num
         pack_tile(0, out_cb);
         tile_regs_release();
     }
-    cb_push_back(out_cb, num_tiles);
+    cb_out.push_back(num_tiles);
 }
 
 #ifdef TRISC_MATH
@@ -1164,11 +1214,14 @@ void softplus_tile_first_column(uint32_t idst, uint beta, uint beta_reciprocal, 
 #endif
 
 void logsigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_tiles) {
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
+    CircularBuffer cb_out(out_cb);
     // out_cb = logsigmoid(in0_cb - in1_cb)
     // Implemented as softplus for numerical stability. logsigmoid(x) = -softplus(-x)
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_cb, num_tiles);
-    cb_reserve_back(out_cb, num_tiles);
+    cb_in0.wait_front(num_tiles);
+    cb_in1.wait_front(num_tiles);
+    cb_out.reserve_back(num_tiles);
     sub_tiles_init(in0_cb, in1_cb);
     softplus_tile_init();
     constexpr uint32_t const_1_fp32 = 0x3F800000;
@@ -1194,7 +1247,7 @@ void logsigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t 
         pack_tile(0, out_cb);
         tile_regs_release();
     }
-    cb_push_back(out_cb, num_tiles);
+    cb_out.push_back(num_tiles);
 }
 
 /**
@@ -1202,9 +1255,12 @@ void logsigmoid_sub(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t 
  * Compile with size optimization to prevent binary size exceeding the limit.
  */
 __attribute__((optimize("Os"))) void sub_block(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb, uint32_t num_tiles) {
-    cb_wait_front(in0_cb, num_tiles);
-    cb_wait_front(in1_cb, num_tiles);
-    cb_reserve_back(out_cb, num_tiles);
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
+    CircularBuffer cb_out(out_cb);
+    cb_in0.wait_front(num_tiles);
+    cb_in1.wait_front(num_tiles);
+    cb_out.reserve_back(num_tiles);
     sub_tiles_init(in0_cb, in1_cb);
 
     for (uint32_t i = 0; i < num_tiles; i++) {
@@ -1215,7 +1271,7 @@ __attribute__((optimize("Os"))) void sub_block(uint32_t in0_cb, uint32_t in1_cb,
         pack_tile(0, out_cb);
         tile_regs_release();
     }
-    cb_push_back(out_cb, num_tiles);
+    cb_out.push_back(num_tiles);
 }
 
 /**
@@ -1243,6 +1299,12 @@ ALWI void matmul_blocks(
     // postcondition: in0_cb is full, in1_cb is empty
     // postcondition: out_cb has M*N produced
 
+    CircularBuffer cb_in0(in0_cb);
+    CircularBuffer cb_in1(in1_cb);
+    CircularBuffer cb_out(out_cb);
+    CircularBuffer cb_mask(mask_cb);
+    CircularBuffer cb_zero(zero_cb);
+
     mm_block_init_short(
         in0_cb, in1_cb, transpose /*transpose*/, subblock_w /*ct_dim*/, subblock_h /*rt_dim*/, in0_block_w /*kt_dim*/);
 
@@ -1256,11 +1318,11 @@ ALWI void matmul_blocks(
     uint32_t in0_wait_tiles = in0_subblock_num_tiles;
 
     reconfig_data_format(in1_cb, in0_cb);
-    cb_wait_front(in1_cb, K * N);
-    cb_reserve_back(out_cb, output_num_tiles);
+    cb_in1.wait_front(K * N);
+    cb_out.reserve_back(output_num_tiles);
 
     for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; ++in0_subblock) {
-        cb_wait_front(in0_cb, in0_wait_tiles);
+        cb_in0.wait_front(in0_wait_tiles);
         uint32_t in1_index_offset = 0;
         for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; ++in1_subblock) {
             tile_regs_acquire();
@@ -1276,8 +1338,8 @@ ALWI void matmul_blocks(
                 in1_index += N;
             }
             if (add_mask) {
-                cb_wait_front(mask_cb, out_subblock_num_tiles);
-                cb_wait_front(zero_cb, 1);
+                cb_mask.wait_front(out_subblock_num_tiles);
+                cb_zero.wait_front(1);
                 reconfig_data_format(zero_cb, mask_cb);
                 add_tiles_init(zero_cb, mask_cb, true);
                 for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
@@ -1303,13 +1365,15 @@ ALWI void matmul_blocks(
         in0_index_offset += subblock_h * in0_block_w;
         in0_wait_tiles += in0_subblock_num_tiles;
         // Somewhat granularize the push of in0 subblocks
-        cb_push_back(out_cb, in0_subblock_all_cols_num_tiles);
+        cb_out.push_back(in0_subblock_all_cols_num_tiles);
     }
-    cb_pop_front(in1_cb, K * N);
+    cb_in1.pop_front(K * N);
 }
 
 template <uint32_t M>
 void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
+    CircularBuffer cb_in1(in1_cb);
+    CircularBuffer cb_out(out_cb);
     // precondition: in0_cb has M*K produced
     // precondition: in1_cb has K*N produced
     // postcondition: in0_cb is full, in1_cb is empty
@@ -1338,8 +1402,8 @@ void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
     constexpr uint32_t out_subblock_num_tiles = subblock_h * subblock_w;
 
     reconfig_data_format(in1_cb, out_cb);
-    cb_wait_front(in1_cb, N);
-    cb_wait_front(out_cb, M);
+    cb_in1.wait_front(N);
+    cb_out.wait_front(M);
 
     for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; ++in0_subblock) {
         tile_regs_acquire();
@@ -1351,14 +1415,14 @@ void matmul_reduce(uint32_t in1_cb, const uint32_t& out_cb) {
         matmul_block(out_cb, in1_cb, in0_index, in1_index, dst_index, 0, subblock_w, subblock_h, in0_block_w);
 
         tile_regs_commit();
-        cb_pop_front(out_cb, subblock_h);
+        cb_out.pop_front(subblock_h);
 
         tile_regs_wait();
         for (uint32_t i = 0; i < subblock_h; i++) {
             pack_tile(i, out_cb);
         }
         tile_regs_release();
-        cb_push_back(out_cb, subblock_h);
+        cb_out.push_back(subblock_h);
     }
 }
 
@@ -1818,6 +1882,16 @@ void sdpa_inner_loop(
     const bool use_zigzag_balancing = false,
     const bool is_last_ring_iter = true,
     const ChunkedContext& chunked = {}) {
+    // Parameter-stable CB locals. Aliases (cb_sum_A/B, cb_max_A/B, cb_out_im_A/B) are
+    // std::swap-mutated below, so they use inline CircularBuffer(alias).method() at the call
+    // sites instead. cb_out is constructed conditionally near its consumer (cur.out target).
+    CircularBuffer cb_q_in_obj(cb_q_in);
+    CircularBuffer cb_k_in_obj(cb_k_in);
+    CircularBuffer cb_v_in_obj(cb_v_in);
+    CircularBuffer cb_qk_im_obj(cb_qk_im);
+    CircularBuffer cb_attention_sink_obj(cb_attention_sink);
+    CircularBuffer cb_lse_in_obj(cb_lse_in);
+    CircularBuffer cb_prev_out_obj(cb_prev_out);
     constexpr uint32_t dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
     uint32_t KV_chunks_processed_in_iter = 0;
     const uint32_t q_per_core = iter_q_end - iter_q_start;
@@ -1902,10 +1976,10 @@ void sdpa_inner_loop(
             // Chunked-prefill: never take this skip (local-frame causal_k_limit doesn't apply —
             // the diag stamp uses absolute coords every k_chunk instead).
             if (sdpa_type == RING && !chunked_enabled && k_chunk >= causal_k_limit && is_causal) {
-                cb_wait_front(cb_k_in, k_chunk_tiles);
-                cb_wait_front(cb_v_in, v_chunk_tiles);
-                cb_pop_front(cb_k_in, k_chunk_tiles);
-                cb_pop_front(cb_v_in, v_chunk_tiles);
+                cb_k_in_obj.wait_front(k_chunk_tiles);
+                cb_v_in_obj.wait_front(v_chunk_tiles);
+                cb_k_in_obj.pop_front(k_chunk_tiles);
+                cb_v_in_obj.pop_front(v_chunk_tiles);
 
                 continue;
             }
@@ -1988,16 +2062,16 @@ void sdpa_inner_loop(
                 if constexpr (lightweight_mask_enabled) {
                     // Re-enter reserved state on cb_qk_im so the lightweight mask can be stamped in-place.
                     // matmul_blocks above already pushed the QK tiles, so tiles_received has been bumped;
-                    // without the pop+push cycle below, reduce_c's cb_wait_front would return immediately
+                    // without the pop+push cycle below, reduce_c's wait-front would return immediately
                     // and unpack could start before the mask stamps land in L1.
-                    // Safe because cb_pop_front only moves rd_ptr (L1 data is untouched), and on a
+                    // Safe because pop-front only moves rd_ptr (L1 data is untouched), and on a
                     // single-buffered CB of size qk_chunk_tiles the re-reserved wr_ptr wraps back to the
                     // same physical region holding the QK scores.
                     // Warning: this won't work if cb_qk_im is double-buffered -- the stamps would land
                     // in the other buffer, leaving the QK scores unmasked.
-                    cb_wait_front(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
-                    cb_pop_front(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
-                    cb_reserve_back(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
+                    cb_qk_im_obj.wait_front(Sk_chunk_t * Sq_chunk_t);
+                    cb_qk_im_obj.pop_front(Sk_chunk_t * Sq_chunk_t);
+                    cb_qk_im_obj.reserve_back(Sk_chunk_t * Sq_chunk_t);
                     // Chunked-prefill: feed abs K (matches abs q_start_tile so diag stamp lines up).
                     uint32_t k_start_tile_for_mask;
                     uint32_t lw_straddle_col = 0;
@@ -2040,7 +2114,7 @@ void sdpa_inner_loop(
                         k_start_tile_for_mask,
                         lw_straddle_col,
                         lw_straddle_jump);
-                    cb_push_back(cb_qk_im, Sk_chunk_t * Sq_chunk_t);
+                    cb_qk_im_obj.push_back(Sk_chunk_t * Sq_chunk_t);
                 } else {
                     add_block_inplace(cb_qk_im, cb_mask_in, qk_chunk_tiles);
                 }
@@ -2090,7 +2164,7 @@ void sdpa_inner_loop(
                 out_subblock_w,
                 false /*transpose*/);
 
-            cb_pop_front(cb_qk_im, qk_chunk_tiles);
+            cb_qk_im_obj.pop_front(qk_chunk_tiles);
             reconfig_data_format(alias_prev_max, alias_cur_max);
 
             /* OUT_ACC += OUT_IM */
@@ -2100,7 +2174,7 @@ void sdpa_inner_loop(
                  * Scale is fused into exp again since max is the max of unscaled scores.
                  */
                 sub_exp_block<scale_fp32>(alias_prev_max, alias_cur_max, cb_exp_max_diff, Sq_chunk_t);
-                cb_pop_front(alias_prev_max, Sq_chunk_t);
+                CircularBuffer(alias_prev_max).pop_front(Sq_chunk_t);
 
                 /**
                  * cb_prev_sum *= cb_exp_max_diff
@@ -2157,7 +2231,7 @@ void sdpa_inner_loop(
 
             // 2. Compute exp((prev_max - cur_max) * scale) to rescale previous statistics
             sub_exp_block<scale_fp32>(alias_prev_max, alias_cur_max, cb_exp_max_diff, Sq_chunk_t);
-            cb_pop_front(alias_prev_max, Sq_chunk_t);
+            CircularBuffer(alias_prev_max).pop_front(Sq_chunk_t);
 
             // 3. Rescale previous sum: prev_sum *= exp(prev_max - cur_max)
             mul_tiles_bcast_cols_inplace(alias_prev_sum, cb_exp_max_diff, Sq_chunk_t);
@@ -2200,8 +2274,8 @@ void sdpa_inner_loop(
                  * out = prev_out - sig * (prev_out - cur_out)
                  * lse = prev_lse - torch.logsigmoid(prev_lse - cur_lse)
                  */
-                cb_wait_front(cb_lse_in, Sq_chunk_t);
-                cb_wait_front(cb_prev_out, out_chunk_tiles);
+                cb_lse_in_obj.wait_front(Sq_chunk_t);
+                cb_prev_out_obj.wait_front(out_chunk_tiles);
 
                 uint32_t alias_cur_lse = alias_prev_max;      // full
                 uint32_t alias_sig = alias_cur_max;           // empty
@@ -2221,9 +2295,9 @@ void sdpa_inner_loop(
                 reconfig_data_format(cb_prev_out, alias_sub);
                 pack_reconfig_data_format(cb_out);
                 sub_block(cb_prev_out, alias_sub, cb_out, out_chunk_tiles);
-                cb_pop_front(cb_prev_out, out_chunk_tiles);
-                cb_pop_front(alias_cur_out, out_chunk_tiles);
-                cb_pop_front(alias_sub, out_chunk_tiles);
+                cb_prev_out_obj.pop_front(out_chunk_tiles);
+                CircularBuffer(alias_cur_out).pop_front(out_chunk_tiles);
+                CircularBuffer(alias_sub).pop_front(out_chunk_tiles);
 
                 // alias_sig = sigmoid(cb_lse_in - alias_cur_lse)
                 // alias_cur_lse = log(alias_sig)
@@ -2232,9 +2306,9 @@ void sdpa_inner_loop(
                 reconfig_data_format(cb_lse_in, alias_cur_lse);
                 logsigmoid_sub(cb_lse_in, alias_cur_lse, alias_sig, Sq_chunk_t);
                 sub_block(cb_lse_in, alias_sig, cb_lse_out, Sq_chunk_t);
-                cb_pop_front(alias_sig, Sq_chunk_t);
-                cb_pop_front(alias_cur_lse, Sq_chunk_t);
-                cb_pop_front(cb_lse_in, Sq_chunk_t);
+                CircularBuffer(alias_sig).pop_front(Sq_chunk_t);
+                CircularBuffer(alias_cur_lse).pop_front(Sq_chunk_t);
+                cb_lse_in_obj.pop_front(Sq_chunk_t);
             } else {
                 pack_reconfig_data_format(cb_out);
                 copy_block(alias_mm2_prev_out, cb_out, out_chunk_tiles);
@@ -2251,29 +2325,29 @@ void sdpa_inner_loop(
             mul_block_bcast_cols<Sq_chunk_t, vDHt, false, false>(alias_mm2_prev_out, alias_prev_sum, cb_out);
 
             // free up cb_prev_max after K chunks
-            cb_pop_front(alias_prev_max, Sq_chunk_t);
+            CircularBuffer(alias_prev_max).pop_front(Sq_chunk_t);
         }
 
         // When q_per_core == 1, Q is identical across ring iterations so we keep it
         // fronted in the CB and only pop on the last iteration to avoid redundant DRAM re-reads.
         if (q_per_core > 1 || is_last_ring_iter) {
-            cb_pop_front(cb_q_in, q_chunk_tiles);
+            cb_q_in_obj.pop_front(q_chunk_tiles);
         }
 
         // Under global Q scheduling the reader pushes one cb_attention_sink slot per Q iter,
         // so we must drain matching slots inside this loop. Pre-PR the push/pop pair was
         // 1:1 outside the loop; the new cadence is 1:1 per iter.
         if constexpr (use_attention_sink) {
-            cb_pop_front(cb_attention_sink, Sq_chunk_t);
+            cb_attention_sink_obj.pop_front(Sq_chunk_t);
         }
     }
 
     if constexpr (sdpa_type == RING) {
         if (KV_chunks_processed_in_iter % 2 == 0) {
-            cb_wait_front(cb_k_in, k_chunk_tiles);
-            cb_wait_front(cb_v_in, v_chunk_tiles);
-            cb_pop_front(cb_k_in, k_chunk_tiles);
-            cb_pop_front(cb_v_in, v_chunk_tiles);
+            cb_k_in_obj.wait_front(k_chunk_tiles);
+            cb_v_in_obj.wait_front(v_chunk_tiles);
+            cb_k_in_obj.pop_front(k_chunk_tiles);
+            cb_v_in_obj.pop_front(v_chunk_tiles);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -19,6 +19,7 @@
 #include "api/compute/experimental/sdpa_sub_custom.h"
 #endif
 #include "api/compute/eltwise_binary_sfpu.h"
+#include "api/dataflow/circular_buffer.h"
 #include "tools/profiler/kernel_profiler.hpp"
 
 // Template-driven profiling: MaybeDeviceZoneScopedN(ENABLED, name)
@@ -42,11 +43,11 @@ struct MaybeProfileScope<true, timer_id> : kernel_profiler::profileScope<timer_i
 #endif
 
 static __attribute__((noinline, noclone)) void sdpa_cb_push_back_out_of_line(uint32_t cb_id, uint32_t num_tiles) {
-    cb_push_back(cb_id, num_tiles);
+    CircularBuffer(cb_id).push_back(num_tiles);
 }
 
 static __attribute__((noinline, noclone)) void sdpa_cb_pop_front_out_of_line(uint32_t cb_id, uint32_t num_tiles) {
-    cb_pop_front(cb_id, num_tiles);
+    CircularBuffer(cb_id).pop_front(num_tiles);
 }
 
 /**
@@ -55,7 +56,7 @@ static __attribute__((noinline, noclone)) void sdpa_cb_pop_front_out_of_line(uin
  * This eliminates the need for separate row buffers.
  */
 ALWI void cb_push_back_hold_wr_ptr(uint32_t cb_id, uint32_t num_tiles) {
-    cb_push_back(cb_id, num_tiles);
+    CircularBuffer(cb_id).push_back(num_tiles);
     PACK(({
         auto& intf = get_local_cb_interface(cb_id);
         intf.fifo_wr_ptr -= num_tiles * intf.fifo_page_size;
@@ -393,12 +394,11 @@ void reduce_c_row_group(
     const uint32_t cumulative_prev_tiles = (row_group_index + 1) * group_size;
 
     // scale_cb assumed ready (waited once at kernel init)
-    // cb_wait_front(scale_cb, 1);
 
     tile_regs_acquire();
 
     if (do_eltwise_max) {
-        cb_wait_front(prev_cb, cumulative_prev_tiles);
+        CircularBuffer(prev_cb).wait_front(cumulative_prev_tiles);
         sdpa_reduce_copy_tile_to_dst_init_short(prev_cb);
         for (uint32_t i = 0; i < group_size; i++) {
             copy_tile(prev_cb, row_start + i, i);
@@ -409,9 +409,9 @@ void reduce_c_row_group(
     // When do_eltwise_max=true, the prev_cb wait + copy_tile work above can overlap
     // with in0_cb data arrival.
     // When respect_trigger=true, the unpack MOP is split into two halves with a
-    // HW semaphore wait in between, so we don't need cb_wait_front here.
+    // HW semaphore wait in between, so we don't need a wait-front here.
     if (!respect_trigger) {
-        cb_wait_front(in0_cb, cumulative_input_tiles);
+        CircularBuffer(in0_cb).wait_front(cumulative_input_tiles);
     }
 
     reduce_block_max_row_init_runtime(out_cb, reduce_cols, respect_trigger);
@@ -464,8 +464,7 @@ void sub_exp_block_bcast_cols(
     }
 
     // inout_cb assumed ready (max_cb was already computed from it)
-    // cb_wait_front(inout_cb, (q_subblock + 1) * tiles_per_row * cols_in_row);
-    cb_wait_front(max_cb, (q_subblock + 1) * tiles_per_row);
+    CircularBuffer(max_cb).wait_front((q_subblock + 1) * tiles_per_row);
 
     tile_regs_acquire();
     {
@@ -547,8 +546,8 @@ void sub_exp_first_col_blocks(uint32_t in0_cb, uint32_t in1_cb, uint32_t out_cb,
 
     sub_tiles_init(in0_cb, in1_cb);
 
-    cb_wait_front(in0_cb, (q_subblock + 1) * tiles_per_row);
-    cb_wait_front(in1_cb, (q_subblock + 1) * tiles_per_row);
+    CircularBuffer(in0_cb).wait_front((q_subblock + 1) * tiles_per_row);
+    CircularBuffer(in1_cb).wait_front((q_subblock + 1) * tiles_per_row);
 
     {
         tile_regs_acquire();
@@ -608,9 +607,9 @@ void salad_correct_fused(
 
     mul_bcast_cols_init_short(out_in_cb, bcast_cb);
 
-    cb_wait_front(out_in_cb, (ob_q_subblock + 1) * tiles_per_row * tiles_per_column);
-    cb_wait_front(sum_in_cb, (sum_q_subblock + 1) * tiles_per_row);
-    cb_wait_front(bcast_cb, (ob_q_subblock + 1) * tiles_per_row);
+    CircularBuffer(out_in_cb).wait_front((ob_q_subblock + 1) * tiles_per_row * tiles_per_column);
+    CircularBuffer(sum_in_cb).wait_front((sum_q_subblock + 1) * tiles_per_row);
+    CircularBuffer(bcast_cb).wait_front((ob_q_subblock + 1) * tiles_per_row);
 
     constexpr uint32_t last_batch_rem = tiles_per_column % col_batch;
     for (uint32_t col_base = 0; col_base < tiles_per_column; col_base += col_batch) {
@@ -686,8 +685,8 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
     // the col-reduced denominator (DST[0]). sbh tiles consumed per call, popped once at end;
     // across all normalize calls for the chunk this consumes exactly Sq_chunk_t tiles.
     if constexpr (use_attention_sink) {
-        cb_wait_front(cb_attention_sink, sbh);
-        cb_wait_front(cur_max_cb_rt, sink_row_offset + sbh);
+        CircularBuffer(cb_attention_sink).wait_front(sbh);
+        CircularBuffer(cur_max_cb_rt).wait_front(sink_row_offset + sbh);
     }
     configure_single_tile_pack(scratch_cb);
     for (uint32_t s = 0; s < sbh; s++) {
@@ -701,10 +700,10 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
             // when scratch and normalized output formats match, and reconfigures after rows that packed output.
             sdpa_maybe_pack_reconfig_data_format<normalized_out_cb, scratch_cb>();
 
-            cb_wait_front(col_identity_cb, N);
-            cb_wait_front(cur_sum_cb, 1);
+            CircularBuffer(col_identity_cb).wait_front(N);
+            CircularBuffer(cur_sum_cb).wait_front(1);
 
-            cb_reserve_back(scratch_cb, 1);
+            CircularBuffer(scratch_cb).reserve_back(1);
             tile_regs_acquire();
             matmul_block(cur_sum_cb, col_identity_cb, 0, 0, 0, 0, N, 1, N);
             if constexpr (use_attention_sink) {
@@ -731,9 +730,9 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
             tile_regs_wait();
             pack_tile(0, scratch_cb);
             tile_regs_release();
-            cb_push_back(scratch_cb, 1);
+            CircularBuffer(scratch_cb).push_back(1);
 
-            cb_pop_front(cur_sum_cb, 1);
+            CircularBuffer(cur_sum_cb).pop_front(1);
         }
 
         // 3. Normalize: multiply output tiles by bcast_cols(1/sum)
@@ -744,10 +743,10 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
             mul_bcast_cols_init_short(cur_out_cb, scratch_cb);
             // Pack output to normalized_out_cb; old/new skips when it has the same format as scratch.
             sdpa_maybe_pack_reconfig_data_format<scratch_cb, normalized_out_cb>();
-            cb_wait_front(cur_out_cb, head_dim_t_);
-            cb_wait_front(scratch_cb, 1);
+            CircularBuffer(cur_out_cb).wait_front(head_dim_t_);
+            CircularBuffer(scratch_cb).wait_front(1);
 
-            cb_reserve_back(normalized_out_cb, head_dim_t_);
+            CircularBuffer(normalized_out_cb).reserve_back(head_dim_t_);
             for (uint32_t base = 0; base < head_dim_t_; base += batch) {
                 constexpr uint32_t last_batch = head_dim_t_ % batch;
                 const uint32_t cur_batch = (base + batch <= head_dim_t_) ? batch : last_batch;
@@ -762,14 +761,14 @@ static __attribute__((noinline, noclone)) void normalize_row_streaming(
                 }
                 tile_regs_release();
             }
-            cb_push_back(normalized_out_cb, head_dim_t_);
+            CircularBuffer(normalized_out_cb).push_back(head_dim_t_);
 
-            cb_pop_front(scratch_cb, 1);
-            cb_pop_front(cur_out_cb, head_dim_t_);
+            CircularBuffer(scratch_cb).pop_front(1);
+            CircularBuffer(cur_out_cb).pop_front(head_dim_t_);
         }
     }
     if constexpr (use_attention_sink) {
-        cb_pop_front(cb_attention_sink, sbh);
+        CircularBuffer(cb_attention_sink).pop_front(sbh);
     }
     // Restore pack format to scratch_cb (im_df = Float16_b) so that subsequent ops
     // (e.g. salad_correct_fused on the next K-chunk's drain row) pack to F16b CBs
@@ -1212,21 +1211,21 @@ static void sdpa_inner_loop_step(
     exp_packthread_tile_init<true, scale_fp32, InputClamping::None>();
 
     // Use KT_stride for cb_qkt_im layout to keep CB pointers aligned across iterations
-    cb_reserve_back(cb_qkt_im, Sq_chunk_t * KT_stride);
+    CircularBuffer(cb_qkt_im).reserve_back(Sq_chunk_t * KT_stride);
 
-    cb_reserve_back(cur.sum, Sq_chunk_t);
+    CircularBuffer(cur.sum).reserve_back(Sq_chunk_t);
     if (save_max_cb != INVALID_CB) {
-        cb_reserve_back(save_max_cb, Sq_chunk_t);
+        CircularBuffer(save_max_cb).reserve_back(Sq_chunk_t);
     }
 
     // ========== PHASE 1: Q@KT directly into cb_qkt_im ==========
     // All matmul output goes to cb_qkt_im at absolute offsets via pack_tile<true>.
     // cb_push_back_hold_wr_ptr makes each row visible to UNPACK without advancing wr_ptr.
-    cb_wait_front(cb_kt_in, DHt * KT_stride);
+    CircularBuffer(cb_kt_in).wait_front(DHt * KT_stride);
 
     for (uint32_t q_subblock = 0; q_subblock < q_num_subblocks; q_subblock++) {
         MaybeDeviceZoneScopedN(profiling_enabled, "Softmax(Q@KT)");
-        cb_wait_front(cb_q_in, q_wait_tiles);
+        CircularBuffer(cb_q_in).wait_front(q_wait_tiles);
         kt_index_offset = 0;
 
         sdpa_maybe_pack_reconfig_data_format<cb_normalized_out, cb_qkt_im>();
@@ -1295,7 +1294,7 @@ static void sdpa_inner_loop_step(
             // subblock's row group so the wait overlaps the reader, and the mask front then sits at
             // this subblock's first row (apply indexes it mask-base 0).
             constexpr uint32_t mask_subblock_tiles = qkt_subblock_h * Sk_chunk_t;
-            cb_wait_front(cb_mask_in, mask_subblock_tiles);
+            CircularBuffer(cb_mask_in).wait_front(mask_subblock_tiles);
             begin_mask_l1_accumulate<true>(cb_qkt_im, cb_mask_in);
             apply_provided_mask_streaming<qkt_subblock_h, KT_stride, Sk_chunk_t>(
                 cb_mask_in,
@@ -1305,7 +1304,7 @@ static void sdpa_inner_loop_step(
             end_mask_l1_accumulate();
             // Restore srcA to fp16 for the following max reduce / next-subblock Q@KT.
             reconfig_data_format_srca(cb_mask_in, cb_qkt_im);
-            cb_pop_front(cb_mask_in, mask_subblock_tiles);
+            CircularBuffer(cb_mask_in).pop_front(mask_subblock_tiles);
         } else if constexpr (uses_lightweight_mask) {
             // Lightweight stamp: causal and/or padding masks. Active for ring, causal non-ring, or
             // non-causal padded with a partial-tile mask (single-chip streaming partial-K case).
@@ -1351,7 +1350,7 @@ static void sdpa_inner_loop_step(
         // Max reduce: reads from cb_qkt_im at q_subblock position
         {
             MaybeDeviceZoneScopedN(profiling_enabled, "Reduce max");
-            cb_reserve_back(cur.max, qkt_subblock_h);
+            CircularBuffer(cur.max).reserve_back(qkt_subblock_h);
             configure_single_tile_pack(cur.max);
             // Use reduce_trigger to enable early reduce start (before all matmul output is ready).
             // When reduce_trigger=true, the packer signals the unpacker via semaphore after partial output.
@@ -1364,9 +1363,9 @@ static void sdpa_inner_loop_step(
                 active_Sk,
                 reduce_trigger,
                 save_max_cb);
-            cb_push_back(cur.max, qkt_subblock_h);
+            CircularBuffer(cur.max).push_back(qkt_subblock_h);
             if (save_max_cb != INVALID_CB) {
-                cb_push_back(save_max_cb, qkt_subblock_h);
+                CircularBuffer(save_max_cb).push_back(qkt_subblock_h);
             }
         }
 
@@ -1377,7 +1376,7 @@ static void sdpa_inner_loop_step(
     // In-place latent-V reads K^T again in Phase 2, so defer the K^T pop until after the
     // softmax@V matmul (handled where the materialized-V pop would normally fire).
     if constexpr (!kt_inplace_v) {
-        cb_pop_front(cb_kt_in, DHt * KT_stride);
+        CircularBuffer(cb_kt_in).pop_front(DHt * KT_stride);
     }
 
     // Q is no longer needed after Phase 1. On the last K chunk, pop early so the
@@ -1418,7 +1417,7 @@ static void sdpa_inner_loop_step(
 
         // V wait deferred: don't block here. The sub_exp drain loop below
         // doesn't touch V, so the reader's V DMA can overlap with the drain.
-        cb_reserve_back(out_cb, qktv_output_num_tiles);
+        CircularBuffer(out_cb).reserve_back(qktv_output_num_tiles);
 
         // q_subblock 0: drain last row's sub_exp in-place + first QKT@V matmul
         {
@@ -1449,8 +1448,8 @@ static void sdpa_inner_loop_step(
                         UNPACK((t6_semaphore_get<>(semaphore::PACK_DONE)));
                     }
                     if (kt_sub == 0) {
-                        cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
-                        cb_wait_front(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
+                        CircularBuffer(cb_qkt_im).wait_front(qktv_in0_wait_tiles);
+                        CircularBuffer(cb_v_in).wait_front(Sk_chunk_t * v_cb_physical_width_t);
                     }
                     if (kt_sub > 0) {
                         PACK((llk_pack_reconfig_l1_acc(1)));
@@ -1512,7 +1511,7 @@ static void sdpa_inner_loop_step(
                     UNPACK((t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE)));
                     UNPACK((t6_semaphore_get<>(semaphore::PACK_DONE)));
                 }
-                cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
+                CircularBuffer(cb_qkt_im).wait_front(qktv_in0_wait_tiles);
                 {
                     MaybeDeviceZoneScopedN(profiling_enabled, "QKT@V MM+Pack");
                     sdpa_maybe_reconfig_data_format<cb_normalized_out, cb_v_in, cb_normalized_out, cb_qkt_im>(
@@ -1546,8 +1545,8 @@ static void sdpa_inner_loop_step(
         [[maybe_unused]] uint32_t sink_row_offset = 0;
         [[maybe_unused]] auto normalize_row = [&](uint32_t& pushed, uint32_t sbh) {
             MaybeDeviceZoneScopedN(profiling_enabled, "ROW_NORM");
-            cb_push_back(cur.sum, sbh);
-            cb_push_back(out_cb, sbh * vDHt);
+            CircularBuffer(cur.sum).push_back(sbh);
+            CircularBuffer(out_cb).push_back(sbh * vDHt);
             normalize_row_streaming<
                 profiling_enabled,
                 vDHt,
@@ -1586,8 +1585,8 @@ static void sdpa_inner_loop_step(
                         prev.out, prev.sum, cb_exp_max_diff, out_cb, cur.sum, 0, salad_row, w_salad);
                 }
             }
-            cb_pop_front(cb_exp_max_diff, sbh);
-            cb_pop_front(prev.out, sbh * vDHt);
+            CircularBuffer(cb_exp_max_diff).pop_front(sbh);
+            CircularBuffer(prev.out).pop_front(sbh * vDHt);
             PACK((llk_pack_reconfig_l1_acc(0)));
         };
 
@@ -1610,17 +1609,17 @@ static void sdpa_inner_loop_step(
 
             // SALAD for previous group (always a full group, h=qktv_h)
             if (!is_first_iter) {
-                cb_reserve_back(cb_exp_max_diff, qktv_h);
+                CircularBuffer(cb_exp_max_diff).reserve_back(qktv_h);
                 sub_exp_first_col_blocks<profiling_enabled, scale_fp32>(
                     prev.max, cur.max, cb_exp_max_diff, salad_row, qktv_h);
-                cb_push_back(cb_exp_max_diff, qktv_h);
+                CircularBuffer(cb_exp_max_diff).push_back(qktv_h);
             }
 
             // V matmul for current row group — cur_h adapts for remainder
             if (is_remainder_iter) {
-                cb_wait_front(cb_qkt_im, Sq_chunk_t * KT_stride);
+                CircularBuffer(cb_qkt_im).wait_front(Sq_chunk_t * KT_stride);
             } else {
-                cb_wait_front(cb_qkt_im, qktv_in0_wait_tiles);
+                CircularBuffer(cb_qkt_im).wait_front(qktv_in0_wait_tiles);
             }
             {
                 MaybeDeviceZoneScopedN(profiling_enabled, "QKT@V MM+Pack");
@@ -1667,17 +1666,17 @@ static void sdpa_inner_loop_step(
                     const uint32_t drain_salad_row =
                         has_qktv_remainder ? (qktv_q_num_subblocks * qktv_h) : (qktv_q_num_subblocks - 1);
 
-                    cb_reserve_back(cb_exp_max_diff, drain_h);
+                    CircularBuffer(cb_exp_max_diff).reserve_back(drain_h);
                     sub_exp_first_col_blocks<profiling_enabled, scale_fp32>(
                         prev.max, cur.max, cb_exp_max_diff, drain_salad_row, drain_h);
-                    cb_push_back(cb_exp_max_diff, drain_h);
+                    CircularBuffer(cb_exp_max_diff).push_back(drain_h);
 
                     salad_correct_row(salad_row, w_salad, qktv_h);
                     if (is_last_iter) {
                         normalize_row(pushed_rows, qktv_h);
                     } else {
-                        cb_push_back(cur.sum, qktv_h);
-                        cb_push_back(out_cb, qktv_h * vDHt);
+                        CircularBuffer(cur.sum).push_back(qktv_h);
+                        CircularBuffer(out_cb).push_back(qktv_h * vDHt);
                         pushed_rows++;
                     }
 
@@ -1687,8 +1686,8 @@ static void sdpa_inner_loop_step(
                     if (is_last_iter) {
                         normalize_row(pushed_rows, drain_h);
                     } else {
-                        cb_push_back(cur.sum, drain_h);
-                        cb_push_back(out_cb, drain_h * vDHt);
+                        CircularBuffer(cur.sum).push_back(drain_h);
+                        CircularBuffer(out_cb).push_back(drain_h * vDHt);
                         pushed_rows++;
                     }
                 } else {
@@ -1696,16 +1695,16 @@ static void sdpa_inner_loop_step(
                     if (is_last_iter) {
                         normalize_row(pushed_rows, qktv_h);
                     } else {
-                        cb_push_back(cur.sum, qktv_h);
-                        cb_push_back(out_cb, qktv_h * vDHt);
+                        CircularBuffer(cur.sum).push_back(qktv_h);
+                        CircularBuffer(out_cb).push_back(qktv_h * vDHt);
                         pushed_rows++;
                     }
                 }
             } else if (is_last_iter) {
                 normalize_row(pushed_rows, qktv_h);
             } else {
-                cb_push_back(cur.sum, qktv_h);
-                cb_push_back(out_cb, qktv_h * vDHt);
+                CircularBuffer(cur.sum).push_back(qktv_h);
+                CircularBuffer(out_cb).push_back(qktv_h * vDHt);
                 pushed_rows++;
             }
 
@@ -1721,17 +1720,17 @@ static void sdpa_inner_loop_step(
                 // perform the full SALAD correction (sub_exp + correct) here.
                 if (!is_first_iter) {
                     constexpr uint32_t drain_salad_row = 0;
-                    cb_reserve_back(cb_exp_max_diff, drain_h);
+                    CircularBuffer(cb_exp_max_diff).reserve_back(drain_h);
                     sub_exp_first_col_blocks<profiling_enabled, scale_fp32>(
                         prev.max, cur.max, cb_exp_max_diff, drain_salad_row, drain_h);
-                    cb_push_back(cb_exp_max_diff, drain_h);
+                    CircularBuffer(cb_exp_max_diff).push_back(drain_h);
                     salad_correct_row(drain_salad_row, 0, drain_h);
                 }
                 if (is_last_iter) {
                     normalize_row(pushed_rows, drain_h);
                 } else {
-                    cb_push_back(cur.sum, drain_h);
-                    cb_push_back(out_cb, drain_h * vDHt);
+                    CircularBuffer(cur.sum).push_back(drain_h);
+                    CircularBuffer(out_cb).push_back(drain_h * vDHt);
                     pushed_rows++;
                 }
             } else {
@@ -1741,8 +1740,8 @@ static void sdpa_inner_loop_step(
                     if (is_last_iter) {
                         normalize_row(pushed_rows, drain_h);
                     } else {
-                        cb_push_back(cur.sum, drain_h);
-                        cb_push_back(out_cb, drain_h * vDHt);
+                        CircularBuffer(cur.sum).push_back(drain_h);
+                        CircularBuffer(out_cb).push_back(drain_h * vDHt);
                         pushed_rows++;
                     }
                 }
@@ -1754,8 +1753,8 @@ static void sdpa_inner_loop_step(
         // For kt_inplace_v this is the deferred K^T pop: cb_v_in aliases cb_kt_in (v_shares_k_buffer),
         // and v_cb_physical_width_t == DHt, so this pops the same Sk_chunk_t*DHt entry that Phase 1
         // skipped. For the materialized path it pops the V entry as usual. Either way: one entry/chunk.
-        cb_pop_front(cb_v_in, KT_stride * v_cb_physical_width_t);
-        cb_pop_front(cb_qkt_im, Sq_chunk_t * KT_stride);
+        CircularBuffer(cb_v_in).pop_front(KT_stride * v_cb_physical_width_t);
+        CircularBuffer(cb_qkt_im).pop_front(Sq_chunk_t * KT_stride);
     }
 }
 
@@ -1842,7 +1841,7 @@ void sdpa_standard_v2(
     // dense mask (with padded positions neginf-filled) per chunk instead.
     constexpr uint32_t padded_k_tiles_inner = (Sk_chunk_t - (Skt % Sk_chunk_t)) % Sk_chunk_t;
     if constexpr (use_padded_mask && padded_k_tiles_inner > 0 && !use_provided_mask) {
-        cb_wait_front(cb_mask_in, 1);
+        CircularBuffer(cb_mask_in).wait_front(1);
     }
 
     constexpr uint32_t last_chunk_Sk = Sk_chunk_t - padded_k_tiles_inner;
@@ -2238,7 +2237,7 @@ void sdpa_ring_v2(
                     cb_normalized_out>(q_prev_norm.sum, q_prev_norm.out, Sq_chunk_t);
                 sdpa_cb_pop_front_out_of_line(q_prev_norm.max, Sq_chunk_t);
                 if (q_per_core > 1) {
-                    cb_reserve_back(cb_signal, 1);
+                    CircularBuffer(cb_signal).reserve_back(1);
                     sdpa_cb_push_back_out_of_line(cb_signal, 1);
                 }
                 return true;
@@ -2266,11 +2265,11 @@ void sdpa_ring_v2(
     auto try_skip_causal_above_diag = [&](uint32_t k_chunk, uint32_t causal_k_limit) -> bool {
         if constexpr (is_causal_sdpa) {
             if (is_causal_iter && k_chunk >= causal_k_limit) {
-                cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
+                CircularBuffer(cb_kt_in).wait_front(DHt * Sk_chunk_t);
                 sdpa_cb_pop_front_out_of_line(cb_kt_in, DHt * Sk_chunk_t);
                 // In-place latent-V never pushes a V entry, so only K^T needs draining.
                 if constexpr (!kt_inplace_v) {
-                    cb_wait_front(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
+                    CircularBuffer(cb_v_in).wait_front(Sk_chunk_t * v_cb_physical_width_t);
                     sdpa_cb_pop_front_out_of_line(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
                 }
                 KV_chunks_processed_in_iter++;
@@ -2361,7 +2360,7 @@ void sdpa_ring_v2(
 
             // Signal writer that last K-chunk is starting (for row-by-row DMA save/restore).
             if (is_last_k && q_per_core > 1) {
-                cb_reserve_back(cb_signal, 1);
+                CircularBuffer(cb_signal).reserve_back(1);
                 sdpa_cb_push_back_out_of_line(cb_signal, 1);
             }
 
@@ -2613,11 +2612,11 @@ void sdpa_ring_v2(
     for (uint32_t dummy_chunk = 0; dummy_chunk < dummy_kv_chunks_for_phase_alignment<v_shares_k_buffer, kt_inplace_v>(
                                                      KV_chunks_processed_in_iter);
          ++dummy_chunk) {
-        cb_wait_front(cb_kt_in, DHt * Sk_chunk_t);
+        CircularBuffer(cb_kt_in).wait_front(DHt * Sk_chunk_t);
         sdpa_cb_pop_front_out_of_line(cb_kt_in, DHt * Sk_chunk_t);
         // In-place latent-V never pushes a V entry, so there is nothing extra to drain.
         if constexpr (!kt_inplace_v) {
-            cb_wait_front(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
+            CircularBuffer(cb_v_in).wait_front(Sk_chunk_t * v_cb_physical_width_t);
             sdpa_cb_pop_front_out_of_line(cb_v_in, Sk_chunk_t * v_cb_physical_width_t);
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/exp_ring_joint_sdpa.cpp
@@ -108,13 +108,16 @@ void kernel_main() {
 
     mm_init(cb_q_in, cb_k_in, cb_qk_im);
 
+    CircularBuffer cb_identity_scale_in_obj(cb_identity_scale_in);
+    CircularBuffer cb_mask_in_obj(cb_mask_in);
+
     // Wait once for identity scale; streaming v2 removes per-call waits inside reduce_c_row_group.
-    cb_wait_front(cb_identity_scale_in, 1);
+    cb_identity_scale_in_obj.wait_front(1);
 
     // Wait for all lightweight mask tiles once before the ring loop.
     // Writer generates them once and they stay permanently fronted.
     if constexpr (needs_lightweight_mask) {
-        cb_wait_front(cb_mask_in, total_mask_tiles);
+        cb_mask_in_obj.wait_front(total_mask_tiles);
     }
 
     // Precompute padded tile counts that are constant across ring iterations

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/ring_joint_sdpa.cpp
@@ -158,13 +158,16 @@ void kernel_main() {
 
     mm_init(cb_q_in, cb_k_in, cb_qk_im);
 
+    CircularBuffer cb_identity_scale_in_obj(cb_identity_scale_in);
+    CircularBuffer cb_mask_in_obj(cb_mask_in);
+
     // Wait once for identity scale; streaming v2 removes per-call waits inside reduce_c_row_group.
-    cb_wait_front(cb_identity_scale_in, 1);
+    cb_identity_scale_in_obj.wait_front(1);
 
     // Wait for all lightweight mask tiles once before the ring loop.
     // Writer generates them once and they stay permanently fronted.
     if constexpr (needs_lightweight_mask) {
-        cb_wait_front(cb_mask_in, total_mask_tiles);
+        cb_mask_in_obj.wait_front(total_mask_tiles);
     }
 
     // Precompute padded tile counts that are constant across ring iterations

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sdpa.cpp
@@ -90,13 +90,16 @@ void kernel_main() {
     constexpr uint32_t cb_sum_B = get_compile_time_arg_val(cb_arg_offset + 16);
     constexpr uint32_t cb_exp_max_diff = get_compile_time_arg_val(cb_arg_offset + 17);
     uint32_t chunked_q_chunk_offset = 0;
+    CircularBuffer cb_chunk_start_idx_obj(cb_chunk_start_idx);
+    CircularBuffer cb_identity_scale_in_obj(cb_identity_scale_in);
+    CircularBuffer cb_mask_in_obj(cb_mask_in);
     mm_init(cb_q_in, cb_k_in, cb_out);
 
     if constexpr (is_chunked) {
         if (use_chunk_start_idx_tensor != 0) {
-            cb_wait_front(cb_chunk_start_idx, 1);
+            cb_chunk_start_idx_obj.wait_front(1);
             uint32_t chunk_start_idx = ckernel::read_tile_value(cb_chunk_start_idx, 0, 0);
-            cb_pop_front(cb_chunk_start_idx, 1);
+            cb_chunk_start_idx_obj.pop_front(1);
             const uint32_t q_chunk_size = Sq_chunk_t * TILE_HEIGHT;
             chunked_q_chunk_offset_phase_1 = chunk_start_idx / q_chunk_size;
             if (num_phases == 2) {
@@ -110,7 +113,7 @@ void kernel_main() {
         // No row buffers needed; a dedicated 1-tile CB is used as recip scratch.
 
         // Wait once for identity scale; v2 removes per-call waits inside reduce_c_row_group
-        cb_wait_front(cb_identity_scale_in, 1);
+        cb_identity_scale_in_obj.wait_front(1);
 
         // Lightweight-mask context: writer pre-generates either [neginf, causal_diag, partial?]
         // or, for sliding, [neginf, trailing_primary, leading_prev, leading_current, trailing_next, partial?].
@@ -141,7 +144,7 @@ void kernel_main() {
         // A user-provided dense mask is streamed per-chunk by the reader and consumed inside the
         // inner loop — it does not use the writer-generated lightweight palette, so skip this wait.
         if constexpr ((is_causal || sliding_window_size > 0 || k_partial_col > 0) && !use_provided_mask) {
-            cb_wait_front(cb_mask_in, lw_mask_tile_count);
+            cb_mask_in_obj.wait_front(lw_mask_tile_count);
         }
 
         // Global Q scheduling: sdpa_standard_v2 walks the per-core flat range over
@@ -198,7 +201,7 @@ void kernel_main() {
             lw_mask.neginf_tile_idx = 0;
             lw_mask.causal_diag_tile_idx = 1;
             lw_mask.primary_diag_tile_idx = lw_mask.causal_diag_tile_idx;
-            cb_wait_front(cb_mask_in, 2);
+            cb_mask_in_obj.wait_front(2);
         }
 
         for (uint32_t phase = 0; phase < num_phases; ++phase) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -510,8 +510,9 @@ void fill_diagonal_edge_tile_bf16(Noc noc, uint32_t cb_id, uint32_t tile_id) {
     constexpr uint32_t uint32_per_face_row = tt::constants::FACE_WIDTH / bf16_per_uint32;  // 8
     constexpr uint32_t uint32_per_face = tt::constants::FACE_HW / bf16_per_uint32;         // 128
 
+    CircularBuffer cb(cb_id);
     volatile tt_l1_ptr uint32_t* ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr() + tile_id * tile_bytes);
 
     constexpr uint32_t face_offsets[4] = {
         0,
@@ -1117,7 +1118,7 @@ inline void issue_block_reads(
 // Zero-fill a (num_rows × cols) tile block in L1. Same dst arithmetic as issue_block_reads.
 // reader is used only to derive the per-tile page size. No periodic barrier: fills source
 // from local L1 (MEM_ZEROS_BASE) and completes fast, so they don't push the NIU outstanding
-// counter the way DRAM reads do. Caller's trailing noc_async_read_barrier() handles visibility.
+// counter the way DRAM reads do. Caller's trailing read barrier handles visibility.
 template <typename ReaderType>
 inline void zero_fill_block(
     const ReaderType& reader,
@@ -1220,8 +1221,8 @@ struct CatAddrGenerator {
         first_seq_padded(first_seq_padded),
         second_seq_padded(second_seq_padded) {}
 
-    // Issue async NoC reads for a slice to L1. No barrier — caller must
-    // noc_async_read_barrier(). Splits [slice.d2_start, slice.d2_end) into up to four segments
+    // Issue async NoC reads for a slice to L1. No barrier — caller must issue a
+    // read barrier. Splits [slice.d2_start, slice.d2_end) into up to four segments
     // (first tensor / gap / second tensor / tail); each valid segment hoists id_of once.
     // end_seq_tile is unused: bounds come from first_shape/second_shape; signature kept for
     // API symmetry with PaddedAddrGenerator (fetch_block dispatches generically).
@@ -1303,8 +1304,8 @@ struct CatAddrGenerator {
         }
     }
 
-    // Issue async NoC writes for a slice from L1. No barrier — caller must
-    // noc_async_write_barrier(). Same segment split as issue_reads; gap and tail produce no
+    // Issue async NoC writes for a slice from L1. No barrier — caller must issue a
+    // write barrier. Same segment split as issue_reads; gap and tail produce no
     // writes (those rows aren't mapped to either tensor). end_seq_tile unused (see issue_reads).
     void issue_writes(
         Noc noc,
@@ -1367,8 +1368,8 @@ struct PaddedAddrGenerator {
     PaddedAddrGenerator(const ReaderType& reader, TensorShapeType tensor_shape) :
         reader(reader), tensor_shape(tensor_shape) {}
 
-    // Issue async NoC reads for a slice to L1. No barrier — caller must
-    // noc_async_read_barrier(). Splits valid rows from the padded tail at loop level (no
+    // Issue async NoC reads for a slice to L1. No barrier — caller must issue a
+    // read barrier. Splits valid rows from the padded tail at loop level (no
     // in_bounds branch in the hot path); valid rows advance tile_id by arithmetic only.
     void issue_reads(
         const Slice& slice,
@@ -1469,7 +1470,7 @@ template <typename ReaderType, typename TensorShapeType>
 PaddedAddrGenerator(const ReaderType&, TensorShapeType) -> PaddedAddrGenerator<ReaderType, TensorShapeType>;
 
 // Fetch tiles via NOC reads into a given L1 address. No CB lifecycle — caller manages
-// cb_reserve_back / cb_push_back. Used by forwarding paths that mcast before pushing.
+// the reserve/push sequence on the destination CB. Used by forwarding paths that mcast before pushing.
 //
 // Dispatches to the generator's issue_reads. PaddedAddrGenerator's overload hoists id_of
 // (4 muls + 3 adds) and the row-only validity check out of the inner col loop;
@@ -1528,7 +1529,7 @@ void read_block(
 }
 
 // Pop a (rows × cols) tile block out of a CB and write it via NoC. Symmetric to read_block:
-// cb_wait_front + dispatch + barrier + cb_pop_front. Dispatches to the generator's issue_writes
+// wait-front + dispatch + barrier + pop-front. Dispatches to the generator's issue_writes
 // (PaddedAddrGenerator hoists id_of out of the inner col loop; CatAddrGenerator keeps per-tile
 // dispatch). Out-of-bound rows are skipped (no zero-fill on writes).
 template <typename CatAddrGeneratorType>
@@ -1588,10 +1589,10 @@ void write_block(
 }
 
 // Single-chip linear-tile-id drain. Iterates total_rows in groups of sbh rows (last group is
-// a smaller remainder if not divisible); per-group cb_wait_front + flush-before-pop lets
+// a smaller remainder if not divisible); per-group wait-front + flush-before-pop lets
 // cb_out be sized to a few groups instead of the full chunk. Rows in [write_rows, total_rows)
 // are padding — popped but not written. Periodic barrier_threshold flushes guard the NoC ack
-// queue; final noc_async_write_barrier ensures DRAM arrival before return. Single-chip never
+// queue; the final write barrier ensures DRAM arrival before return. Single-chip never
 // sets a non-zero trid → drain flushes trid 0 (the default trid all writes here carry).
 template <typename TensorAccessorType>
 void write_block_row_grouped(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/compute/sdpa_flash_decode.cpp
@@ -145,9 +145,9 @@ void kernel_main() {
             cur_pos = cur_pos_arg;
         } else {
             // Read cur_pos from CB using mailbox-based synchronization (issue #27979).
-            cb_wait_front(cb_cur_pos, 1);
+            CircularBuffer(cb_cur_pos).wait_front(1);
             cur_pos = read_tile_value(cb_cur_pos, 0, cur_batch / q_heads_parallel_factor);
-            cb_pop_front(cb_cur_pos, 1);
+            CircularBuffer(cb_cur_pos).pop_front(1);
         }
         if (cur_pos == UINT32_MAX) {
             // cur_pos of -1 indicates that the user should be skipped
@@ -220,12 +220,12 @@ void kernel_main() {
     } else {
         mm_init(cb_q_in, cb_k_in, cb_qk_im);
     }
-    cb_wait_front(cb_q_in, q_chunk_tiles);
+    CircularBuffer(cb_q_in).wait_front(q_chunk_tiles);
 
     // Wait for block padding mask (generated once by writer, reused every chunk without popping)
     if constexpr (has_block_padding) {
         uint32_t block_pad_mask_tiles = Sq_chunk_t * Sk_chunk_t_dynamic;
-        cb_wait_front(cb_block_pad_mask, block_pad_mask_tiles);
+        CircularBuffer(cb_block_pad_mask).wait_front(block_pad_mask_tiles);
     }
 
     // Define dynamic matmul configs
@@ -420,7 +420,7 @@ void kernel_main() {
                  */
                 sub_exp_block_bcast_cols_inplace<cb_qk_im, Sq_chunk_t, scale_fp32, true, false, vector_mode>(
                     cb_cur_max, cb_cur_sum, Sk_chunk_t_dynamic);
-                cb_wait_front(cb_qk_im, qk_chunk_tiles_dynamic);
+                CircularBuffer(cb_qk_im).wait_front(qk_chunk_tiles_dynamic);
 
                 // Reconfig register DF
                 reconfig_data_format(cb_qk_im, cb_identity_scale_in);
@@ -453,7 +453,7 @@ void kernel_main() {
 
                 // Reconfig register DF
                 reconfig_data_format_srca(cb_out_im);
-                cb_pop_front(cb_qk_im, qk_chunk_tiles_dynamic);
+                CircularBuffer(cb_qk_im).pop_front(qk_chunk_tiles_dynamic);
 
                 /* OUT_ACC += OUT_IM */
                 if (k_chunk == k_chunk_start) {
@@ -466,7 +466,7 @@ void kernel_main() {
 
                     /* EXP_MAX_DIFF = exp(PREV_MAX - CUR_MAX) */
                     sub_exp_block<scale_fp32>(cb_prev_max, cb_cur_max, cb_exp_max_diff, Sq_chunk_t);
-                    cb_pop_front(cb_prev_max, Sq_chunk_t);
+                    CircularBuffer(cb_prev_max).pop_front(Sq_chunk_t);
 
                     /* PREV_SUM *= EXP_MAX_DIFF */
                     mul_block_inplace(cb_prev_sum, cb_exp_max_diff, Sq_chunk_t);
@@ -565,8 +565,8 @@ void kernel_main() {
                     // Update prev buffers for next round
                     // PREV_MAX <- CUR_MAX
                     // PREV_SUM <- CUR_SUM
-                    cb_pop_front(cb_prev_max, Sq_chunk_t);
-                    cb_pop_front(cb_m_in, Sq_chunk_t);
+                    CircularBuffer(cb_prev_max).pop_front(Sq_chunk_t);
+                    CircularBuffer(cb_m_in).pop_front(Sq_chunk_t);
                     move_block<true>(cb_cur_max, cb_prev_max, Sq_chunk_t);
                     move_block<true>(cb_cur_sum, cb_prev_sum, Sq_chunk_t);
                 }
@@ -600,7 +600,7 @@ void kernel_main() {
 
                 // exp(sink - m_new)
                 sub_exp_block<scale_fp32>(cb_attention_sink, cb_cur_max, cb_exp_max_diff_2, Sq_chunk_t);
-                cb_pop_front(cb_cur_max, Sq_chunk_t);
+                CircularBuffer(cb_cur_max).pop_front(Sq_chunk_t);
 
                 // l -> l + exp(sink - m_new)
                 add_block_inplace<true>(cb_prev_sum, cb_exp_max_diff_2, Sq_chunk_t);
@@ -622,7 +622,7 @@ void kernel_main() {
             pack_reconfig_data_format(cb_out_final);
 
             // Pop the max buffer that still has data
-            cb_pop_front(cb_prev_max, Sq_chunk_t);
+            CircularBuffer(cb_prev_max).pop_front(Sq_chunk_t);
 
             // Untilize output to ROW MAJOR if input Q was also ROW MAJOR
             if constexpr (untilize_output) {
@@ -656,5 +656,5 @@ void kernel_main() {
     }
 
     // Free up cb_q_in after Q chunks
-    cb_pop_front(cb_q_in, q_chunk_tiles);
+    CircularBuffer(cb_q_in).pop_front(q_chunk_tiles);
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/dataflow_common.hpp
@@ -33,8 +33,9 @@ void fill_tile(uint32_t cb_id, uint32_t tile_id, uint32_t val) {
         noc.write_zeros_l1_barrier();
     } else {
         // Fill 2 uint16 datums in each writes to optimize for performance
+        CircularBuffer cb(cb_id);
         volatile tt_l1_ptr uint32_t* ptr =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr() + tile_id * tile_bytes);
         constexpr int num_uint32_datums_tile = tile_bytes / 4;
         for (int k = 0; k < num_uint32_datums_tile; k++) {
             ptr[k] = val;
@@ -54,10 +55,11 @@ void fill_tile_partial(uint32_t cb_id, uint32_t tile_id, uint32_t cur_pos_in_til
         return;
     }
     const uint16_t datum_val = partial_val >> 16;
+    CircularBuffer cb(cb_id);
     volatile tt_l1_ptr uint16_t* uint16_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb.get_write_ptr() + tile_id * tile_bytes);
     volatile tt_l1_ptr uint32_t* uint32_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr() + tile_id * tile_bytes);
     int face_start = (cur_pos_in_tile < 15) ? 0 : 1;
     uint32_t fill_pos_in_face = (cur_pos_in_tile + 1) % 16;
     if (face_start == 0) {
@@ -116,10 +118,11 @@ void fill_tile_partial_sliding_window(
     }
 
     const uint16_t datum_val = partial_val >> 16;
+    CircularBuffer cb(cb_id);
     volatile tt_l1_ptr uint16_t* uint16_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb.get_write_ptr() + tile_id * tile_bytes);
     volatile tt_l1_ptr uint32_t* uint32_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id) + tile_id * tile_bytes);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr() + tile_id * tile_bytes);
 
     // Determine which faces to fill completely (before the window_start_pos_in_tile)
     int face_start = (window_start_pos_in_tile < 16) ? 0 : 1;  // Last face to fill completely

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -30,7 +30,7 @@ void kernel_main() {
     constexpr uint32_t num_cores = get_compile_time_arg_val(10);                    // num running cores in total
     constexpr uint32_t reducer_semaphore_id = get_compile_time_arg_val(11);         // semaphore ID for reducer
     uint32_t reducer_semaphore_addr = get_semaphore(reducer_semaphore_id);          // semaphore for reducer
-    uint32_t output_semaphore_addr = get_semaphore(get_compile_time_arg_val(12));   // semaphore for sender
+    constexpr uint32_t output_semaphore_id = get_compile_time_arg_val(12);          // semaphore ID for sender
     constexpr bool is_out_sharded = get_compile_time_arg_val(13);
     constexpr uint32_t k_chunk_size = get_compile_time_arg_val(14);
     constexpr uint32_t num_q_heads = get_compile_time_arg_val(15);
@@ -196,9 +196,6 @@ void kernel_main() {
     uint32_t reduce_core_index = (cur_batch * num_cores_per_batch) / num_cores_per_head + cur_head_group;
     uint32_t reduce_core_noc_x = all_reducer_noc_x[reduce_core_index];
     uint32_t reduce_core_noc_y = all_reducer_noc_y[reduce_core_index];
-
-    const uint64_t in0_sender_semaphore_noc_addr =
-        get_noc_addr(reduce_core_noc_x, reduce_core_noc_y, reducer_semaphore_addr);
 
     constexpr uint32_t out_chunk_tiles = PNHt * vDHt;
     uint32_t num_cores_to_wait = num_cores_per_head - 1;
@@ -426,9 +423,7 @@ void kernel_main() {
                 // read from reducer cores
                 constexpr uint32_t num_reducers_per_output = num_reducer_cores / num_output_cores;
                 constexpr uint32_t num_reducers_to_wait = num_reducers_per_output - 1;
-                volatile tt_l1_ptr uint32_t* output_self_semaphore_addr_ptr =
-                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(output_semaphore_addr);
-                noc_semaphore_wait(output_self_semaphore_addr_ptr, num_reducers_to_wait);
+                Semaphore<>(output_semaphore_id).wait(num_reducers_to_wait);
 
                 uint32_t reduce_core_read_index_start = (cur_batch * num_cores_per_batch) / num_cores_per_head;
 
@@ -484,9 +479,7 @@ void kernel_main() {
                 // tell output core that its output is ready
                 uint32_t output_core_noc_x = all_output_noc_x[cur_batch];
                 uint32_t output_core_noc_y = all_output_noc_y[cur_batch];
-                const uint64_t output_core_semaphore_noc_addr =
-                    get_noc_addr(output_core_noc_x, output_core_noc_y, output_semaphore_addr);
-                noc_semaphore_inc(output_core_semaphore_noc_addr, 1);
+                Semaphore<>(output_semaphore_id).up(noc, output_core_noc_x, output_core_noc_y, 1);
             }
         } else {
             // MQA (Multi Query Attention):  we don't need to gather outputs for other heads so we can just write entire


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Relates to https://github.com/tenstorrent/tt-metal/issues/45003.

Migrate the SDPA shared compute and dataflow headers (`compute_common.hpp`, `compute_streaming.hpp`, both `dataflow_common.hpp`) plus the per-kernel consumer call sites onto the Device 2.0 API.

### Notes for reviewers
- No algorithmic or semantic change anywhere. Every helper's logic, dst-reg allocation, push/pop ordering, and `if constexpr` decision tree is preserved
- No host-side changes. CB indices, runtime arg layout, etc. are untouched.
- Out of scope:
  - fabric/CCL borrowed headers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/sdpa-shared-headers-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/sdpa-shared-headers-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/sdpa-shared-headers-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/sdpa-shared-headers-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/sdpa-shared-headers-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/sdpa-shared-headers-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/sdpa-shared-headers-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/sdpa-shared-headers-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/sdpa-shared-headers-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/sdpa-shared-headers-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/sdpa-shared-headers-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/sdpa-shared-headers-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/sdpa-shared-headers-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/sdpa-shared-headers-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/sdpa-shared-headers-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/sdpa-shared-headers-device-2-0)