### PR TITLE
[Bug fix] avoid lambda capture-by-reference in normalization compute kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/kernels/compute/layernorm_post_allgather_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/kernels/compute/layernorm_post_allgather_welford.cpp
@@ -70,7 +70,7 @@ void kernel_main() {
             cb_stats,
             cb_stats_reduced,
             num_devices,
-            [&](uint32_t) { return (static_cast<float>(W)); },
+            [W](uint32_t) { return (static_cast<float>(W)); },
             norm::kernel_util::compute::RSqrtPolicy{false, 0});
         cb_stats_reduced.push_back(stats_tile_stride);
         cb_stats_reduced.wait_front(stats_tile_stride);

--- a/ttnn/cpp/ttnn/operations/normalization/kernel_util/compute/numeric.h
+++ b/ttnn/cpp/ttnn/operations/normalization/kernel_util/compute/numeric.h
@@ -70,7 +70,7 @@ inline void accumulate_compute_loop(
     constexpr bool pop_input = input_policy::pop;
     constexpr bool sync_full_block = input_policy::sync_full_block;
 
-    auto accumulate_cb = [&cb_scalar, block_size, &cb_out, num_tiles, last_tile_partial](CircularBuffer& cb) {
+    auto accumulate_cb = [cb_scalar, block_size, cb_out, num_tiles, last_tile_partial](CircularBuffer& cb) {
         reduce_init<reduce_type, reduce_dim, FLOAT32_REDUCTION>(
             cb.get_cb_id(), cb_scalar.get_cb_id(), cb_out.get_cb_id());
         for (auto block : generic::blocks(num_tiles, block_size)) {

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/compute/layernorm_sharded_welford.cpp
@@ -372,7 +372,12 @@ void kernel_main() {
                 cb_ex_external,
                 cb_ex,
                 num_blocks_combine,
-                [&](uint32_t b) {
+                [num_blocks_combine,
+                 is_second_stage_reader,
+                 num_blocks_first_stage,
+                 second_stage_w,
+                 block_w,
+                 last_block_w](uint32_t b) {
                     return get_next_set_size(
                         b,
                         num_blocks_combine,

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/compute/layernorm_post_allgather_welford.cpp
@@ -126,7 +126,7 @@ void kernel_main() {
             cb_stats,
             cb_stats_reduced,
             stats_tiles_cols,
-            [&](uint32_t b) { return (static_cast<float>(W)); },
+            [W](uint32_t b) { return (static_cast<float>(W)); },
             norm::kernel_util::compute::RSqrtPolicy{false, 0});
         cb_stats_reduced.push_back(2);
         cb_stats_reduced.wait_front(2);


### PR DESCRIPTION
**PR Category**
    Bug fix

  **Summary**
    Fixes the Blackhole Post Commit regression: https://github.com/tenstorrent/tt-metal/actions/runs/27547927554
    Replaces `[&]` / `[&cb_scalar, &cb_out]` lambda captures with explicit by-value captures in four normalization compute kernels. The capture-by-reference form is apparently miscompiled by the LLK toolchain (`riscv-tt-elf-g++ 15.1.0`, `-O3 -flto`): inside the lambda body.

    **Notes for reviewers**

    Per-file changes are mechanical:
    - `kernel_util/compute/numeric.h` — `accumulate_compute_loop`'s inner lambda: capture `cb_scalar` and `cb_out` by value instead of by reference. `CircularBuffer` is a 4-byte POD wrapping a single `uint32_t`, so the copy is free.
    - `layernorm/.../layernorm_sharded_welford.cpp` — `combine_welford_partials` lambda: `[&]` → explicit capture list of the six `uint32_t`/`bool` locals it actually uses.
    - `layernorm_distributed/.../layernorm_post_allgather_welford.cpp` —
  `combine_welford_partials` lambda: `[&]` → `[W]`.
    - `experimental/transformer/dit_layernorm_post_all_gather/.../layernorm_post_allgather_welford
  .cpp` — same: `[&]` → `[W]`.

    Other normalization `dataflow/` kernels still use `[&]` captures of `CircularBuffer&` parameters but compile to BRISC/NCRISC, not TRISC, and have not been observed to misbehave — left untouched here.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/fix-norm-lambda-capture-by-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/fix-norm-lambda-capture-by-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/fix-norm-lambda-capture-by-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/fix-norm-lambda-capture-by-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/fix-norm-lambda-capture-by-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/fix-norm-lambda-capture-by-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/fix-norm-lambda-capture-by-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/fix-norm-lambda-capture-by-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/fix-norm-lambda-capture-by-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/fix-norm-lambda-capture-by-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/fix-norm-lambda-capture-by-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/fix-norm-lambda-capture-by-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/fix-norm-lambda-capture-by-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/fix-norm-lambda-capture-by-ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/fix-norm-lambda-capture-by-ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/fix-norm-lambda-capture-by-ref)