### PR TITLE
[skip pr] Remove Falcon-7B from T3K perf tests

### DIFF
--- a/tests/pipeline_reorg/t3k_perf_tests.yaml
+++ b/tests/pipeline_reorg/t3k_perf_tests.yaml
@@ -11,16 +11,6 @@
 
 # For max allowed timeout refer to .github/time_budget.yaml
 
-- name: t3k_LLM_falcon7b_model_perf_tests
-  cmd: run_t3000_falcon7b_tests
-  skus:
-    wh_llmbox_perf:
-      timeout: 75
-  owner_id: U05RWH3QUPM # Salar Hosseini
-  team: models
-  model-name: falcon7b
-  model-type: LLM
-
 - name: t3k_CNN_resnet50_model_perf_tests
   cmd: run_t3000_resnet50_tests
   skus:

--- a/tests/scripts/t3000/run_t3000_perf_tests.sh
+++ b/tests/scripts/t3000/run_t3000_perf_tests.sh
@@ -3,26 +3,6 @@ set -eo pipefail
 
 TT_CACHE_HOME=/mnt/MLPerf/huggingface/tt_cache
 
-run_t3000_falcon7b_tests() {
-  # Record the start time
-  fail=0
-  start_time=$(date +%s)
-
-  echo "LOG_METAL: Running run_t3000_falcon7b_tests"
-
-  # TODO(ci): Skip prefill_seq2048 until perf gate is stable; merge_perf_results fails on small regressions vs baseline.
-  # Tracking: https://github.com/tenstorrent/tt-metal/issues/40304
-  pytest models/demos/falcon7b_common/tests -m "model_perf_t3000" -k "not prefill_seq2048" ; fail+=$?
-
-  # Record the end time
-  end_time=$(date +%s)
-  duration=$((end_time - start_time))
-  echo "LOG_METAL: run_t3000_falcon7b_tests $duration seconds to complete"
-  if [[ $fail -ne 0 ]]; then
-    exit 1
-  fi
-}
-
 run_t3000_mistral7b_perf_tests() {
   # Record the start time
   fail=0


### PR DESCRIPTION
## What

Cleans up the **(T3K) T3000 perf tests** pipeline:

- Removed the `falcon7b` entry (`t3k_LLM_falcon7b_model_perf_tests`) from `tests/pipeline_reorg/t3k_perf_tests.yaml`.
- Deleted the now-unused `run_t3000_falcon7b_tests()` helper from `tests/scripts/t3000/run_t3000_perf_tests.sh`.

## Why

Falcon-7B perf coverage is being dropped from the T3K perf pipeline. Falcon-7B remains covered by the tier-3 e2e pipeline (`tests/pipeline_reorg/models_e2e_tests.yaml` → `model: falcon-7b`).

## Note

Gemma-3-27B is **kept** in the T3K perf pipeline (perf + op_to_op entries). Although `gemma-3-27b` is also covered by the Tier 2 e2e pipeline, the T3K perf/op-to-op benchmarks are retained intentionally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/t3k-perf-remove-redundant-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/t3k-perf-remove-redundant-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/t3k-perf-remove-redundant-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/t3k-perf-remove-redundant-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/t3k-perf-remove-redundant-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/t3k-perf-remove-redundant-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/t3k-perf-remove-redundant-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/t3k-perf-remove-redundant-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/t3k-perf-remove-redundant-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/t3k-perf-remove-redundant-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/t3k-perf-remove-redundant-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/t3k-perf-remove-redundant-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/t3k-perf-remove-redundant-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/t3k-perf-remove-redundant-models)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/t3k-perf-remove-redundant-models)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/t3k-perf-remove-redundant-models)
