### PR TITLE
emule: drop unused 'tiles' variable in build_kernel_defines

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -1189,7 +1189,6 @@ static std::map<std::string, std::string> build_kernel_defines(
             tile_c_dim[i] = tt::constants::TILE_WIDTH;
         }
         for (auto& cb_impl : cb_impls) {
-            const auto& tiles = cb_impl->config().tiles();
             for (uint8_t idx : cb_impl->local_buffer_indices()) {
                 if (idx < EMULE_NUM_CBS) {
                     // Calculate tile size from the CB's data format.


### PR DESCRIPTION
`const auto& tiles = cb_impl->config().tiles();` (added in the thin-tile reduce change) is unused. Removed it.
cc @xanderchin

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sgholami/emule-fix-unused-tiles)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sgholami/emule-fix-unused-tiles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sgholami/emule-fix-unused-tiles)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sgholami/emule-fix-unused-tiles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sgholami/emule-fix-unused-tiles)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sgholami/emule-fix-unused-tiles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sgholami/emule-fix-unused-tiles)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sgholami/emule-fix-unused-tiles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sgholami/emule-fix-unused-tiles)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sgholami/emule-fix-unused-tiles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sgholami/emule-fix-unused-tiles)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sgholami/emule-fix-unused-tiles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sgholami/emule-fix-unused-tiles)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sgholami/emule-fix-unused-tiles)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sgholami/emule-fix-unused-tiles)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sgholami/emule-fix-unused-tiles)