### PR TITLE
Bug fix: make trace_region_size the total trace budget across DRAM banks

### DIFF
--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -69,13 +69,21 @@ void MeshTrace::populate_mesh_buffer(
         buffer_type = BufferType::DRAM;
         bottom_up = false;  // Top-down allocation
     } else {
-        // Traditional mode: use dedicated trace region
+        // Traditional mode: use dedicated trace region. trace_region_size is reserved per DRAM bank
+        // (see AllocatorImpl::init_one_bank_per_channel), whereas get_trace_buffers_size() tracks the
+        // total interleaved size across all banks. Compare against the total reserved budget
+        // (trace_region_size * num_banks) so the full region is usable.
+        const uint32_t num_trace_banks = mesh_cq.device()->allocator()->get_num_banks(BufferType::TRACE);
+        const auto trace_region_total = static_cast<uint64_t>(trace_region_size) * num_trace_banks;
         TT_FATAL(
-            mesh_cq.device()->get_trace_buffers_size() <= trace_region_size,
-            "Creating trace buffers of size {}B on MeshDevice {}, but only {}B is allocated for trace region.",
+            mesh_cq.device()->get_trace_buffers_size() <= trace_region_total,
+            "Creating trace buffers of size {}B on MeshDevice {}, but only {}B ({}B per bank x {} banks) is "
+            "allocated for trace region.",
             mesh_cq.device()->get_trace_buffers_size(),
             mesh_cq.device()->id(),
-            trace_region_size);
+            trace_region_total,
+            trace_region_size,
+            num_trace_banks);
     }
 
     DeviceLocalBufferConfig device_local_trace_buf_config = {

--- a/tt_metal/distributed/mesh_trace.cpp
+++ b/tt_metal/distributed/mesh_trace.cpp
@@ -69,21 +69,15 @@ void MeshTrace::populate_mesh_buffer(
         buffer_type = BufferType::DRAM;
         bottom_up = false;  // Top-down allocation
     } else {
-        // Traditional mode: use dedicated trace region. trace_region_size is reserved per DRAM bank
-        // (see AllocatorImpl::init_one_bank_per_channel), whereas get_trace_buffers_size() tracks the
-        // total interleaved size across all banks. Compare against the total reserved budget
-        // (trace_region_size * num_banks) so the full region is usable.
-        const uint32_t num_trace_banks = mesh_cq.device()->allocator()->get_num_banks(BufferType::TRACE);
-        const auto trace_region_total = static_cast<uint64_t>(trace_region_size) * num_trace_banks;
+        // Traditional mode: use dedicated trace region. trace_region_size is the TOTAL trace budget across all
+        // DRAM banks (see AllocatorImpl::init_one_bank_per_channel), matching get_trace_buffers_size(), which
+        // tracks the total interleaved size across all banks.
         TT_FATAL(
-            mesh_cq.device()->get_trace_buffers_size() <= trace_region_total,
-            "Creating trace buffers of size {}B on MeshDevice {}, but only {}B ({}B per bank x {} banks) is "
-            "allocated for trace region.",
+            mesh_cq.device()->get_trace_buffers_size() <= trace_region_size,
+            "Creating trace buffers of size {}B on MeshDevice {}, but only {}B is allocated for trace region.",
             mesh_cq.device()->get_trace_buffers_size(),
             mesh_cq.device()->id(),
-            trace_region_total,
-            trace_region_size,
-            num_trace_banks);
+            trace_region_size);
     }
 
     DeviceLocalBufferConfig device_local_trace_buf_config = {

--- a/tt_metal/impl/allocator/allocator.cpp
+++ b/tt_metal/impl/allocator/allocator.cpp
@@ -36,7 +36,17 @@ void AllocatorImpl::validate_bank_assignments() const {
 
 void AllocatorImpl::init_one_bank_per_channel() {
     // DRAM bank is between unreserved start and trace_region start: UNRESERVED | DRAM BANK | TRACE REGION
-    DeviceAddr dram_bank_size = config_->dram_bank_size - config_->dram_unreserved_base - config_->trace_region_size;
+    // trace_region_size is the TOTAL trace budget across all DRAM banks (not per-bank). Trace buffers are
+    // interleaved evenly across banks, so each bank reserves ceil(trace_region_size / num_banks), rounded up
+    // to dram_alignment. The aggregate reserved capacity (per_bank_trace_size * num_banks) is therefore >=
+    // trace_region_size, so a trace whose total size fits the budget also fits per-bank after interleaving.
+    DeviceAddr per_bank_trace_size = 0;
+    if (config_->trace_region_size > 0) {
+        per_bank_trace_size = round_up(
+            div_up(config_->trace_region_size, static_cast<size_t>(config_->num_dram_channels)),
+            config_->dram_alignment);
+    }
+    DeviceAddr dram_bank_size = config_->dram_bank_size - config_->dram_unreserved_base - per_bank_trace_size;
     std::vector<int64_t> bank_offsets(config_->num_dram_channels);
     for (uint32_t channel_id = 0; channel_id < config_->num_dram_channels; channel_id++) {
         bank_offsets.at(channel_id) = static_cast<int32_t>(config_->dram_bank_offsets.at(channel_id));
@@ -60,7 +70,7 @@ void AllocatorImpl::init_one_bank_per_channel() {
     trace_buffer_manager_ = std::make_unique<BankManager>(
         BufferType::TRACE,
         bank_offsets,
-        config_->trace_region_size,
+        per_bank_trace_size,
         config_->dram_alignment,
         config_->dram_alignment,
         dram_bank_size + config_->dram_unreserved_base,


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`trace_region_size` was interpreted inconsistently. In `AllocatorImpl::init_one_bank_per_channel` (`tt_metal/impl/allocator/allocator.cpp`) it was reserved **per DRAM bank** — subtracted from each bank's usable DRAM and used as the per-bank size of the `TRACE` `BankManager` — so physical trace capacity was `trace_region_size * num_banks`. But the validation in `MeshTrace::populate_mesh_buffer` (`tt_metal/distributed/mesh_trace.cpp`) compared the **total** interleaved trace size (`get_trace_buffers_size()`) directly against `trace_region_size`, treating it as a total. The two interpretations disagreed by a factor of `num_banks` (8x on Blackhole's 8 GDDR views): the check `TT_FATAL`'d once the total exceeded a single bank's worth, leaving `(num_banks-1)/num_banks` of the reserved region unusable, and the error message was misleading.

This change makes `trace_region_size` mean the **total** trace budget across all DRAM banks. Each bank now reserves `ceil(trace_region_size / num_banks)` rounded up to `dram_alignment`, so the aggregate reservation stays `>= trace_region_size` and an interleaved trace whose total size fits the budget also fits per-bank. The per-bank space that used to be over-reserved is returned to the general DRAM pool. The budget check becomes a straightforward total-vs-total comparison.

### Behavior change
This is an API-semantics change to `trace_region_size` (per-bank → total), not just a bounds fix:
- **No currently-running app regresses.** The old (over-strict) check already constrained total trace to `<= trace_region_size`, which is exactly the new total capacity, so anything that passed before still passes. General DRAM gains room because each bank reserves `~1/num_banks` of what it did before.
- Callers that set `trace_region_size` now reserve `num_banks`x less physical trace DRAM than before — intended, since the previous extra capacity was unreachable through the mesh-trace path anyway.

### Notes for reviewers
- Allocator change: per-bank reservation is now `round_up(div_up(trace_region_size, num_dram_channels), dram_alignment)`; the trace `BankManager` and the `UNRESERVED | DRAM | TRACE` boundary move accordingly. The dynamic-allocation path (`trace_region_size == 0`) is unchanged.
- Known limitation (inherent to the total semantics): the `total <= trace_region_size` check no longer guarantees per-bank fit for workloads with many traces each smaller than `num_banks * page_size`, since each such trace biases its first page onto bank 0. For typical large traces (>> `num_banks * page_size`) the skew is at most `num_banks-1` pages and is absorbed by the ceil/align slack.
- Verified with a C++ build (`build_metal_cpp.sh`). On-device mesh-trace tests were not run; happy to add/run one if desired.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/fix-trace-region-per-bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/fix-trace-region-per-bank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/fix-trace-region-per-bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/fix-trace-region-per-bank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/fix-trace-region-per-bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/fix-trace-region-per-bank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/fix-trace-region-per-bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/fix-trace-region-per-bank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/fix-trace-region-per-bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/fix-trace-region-per-bank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/fix-trace-region-per-bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/fix-trace-region-per-bank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/fix-trace-region-per-bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/fix-trace-region-per-bank)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/fix-trace-region-per-bank)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/fix-trace-region-per-bank)
