### PR TITLE
[LTX] Runtime LoRA load/fuse/unload for the base pipeline

### DIFF
--- a/models/tt_dit/pipelines/ltx/pipeline_ltx.py
+++ b/models/tt_dit/pipelines/ltx/pipeline_ltx.py
@@ -283,6 +283,10 @@ class LTXPipeline:
         # ``_prepare_transformer(idx)``.
         self.transformer: LTXTransformerModel | None = None
         self.transformer_states: list[TransformerState] = []
+        # LoRA adaptors fused into variant 0 at runtime via ``load_lora_weights()``.
+        # Empty means the unmodified base is loaded (non-LoRA path untouched). The active
+        # specs drive every ``_prepare_transformer(0)`` so dynamic_load evictions re-fuse.
+        self._active_lora_specs: list[LoraSpec] = []
         self.vae_decoder = None
         self.upsampler: LTXLatentUpsampler | None = None
         # On-device audio decode chain (Stage A mel-VAE + Stage B/C vocoder+BWE).
@@ -630,16 +634,91 @@ class LTXPipeline:
 
     def _prepare_transformer(self, idx: int = 0) -> None:
         state = self.transformer_states[idx]
+        # Variant 0 is the runtime-swappable base: it honours any LoRA loaded post-init via
+        # load_lora_weights() (``self._active_lora_specs``). Because every reload of variant 0
+        # — including the ones forced by dynamic_load eviction — goes through here, the active
+        # LoRA is automatically re-fused. Extra variants (idx>0) keep their construction-time
+        # specs. The cache name is LoRA-tagged so fused weights cache separately from the base.
+        if idx == 0:
+            specs = self._active_lora_specs
+            cache_name = self._build_transformer_cache_name(self.checkpoint_name, specs)
+            provider = lambda: self._build_transformer_state_dict(self.checkpoint_name, specs)  # noqa: E731
+        else:
+            cache_name = state.cache_name
+            provider = state.state_dict_provider
         cache_module.load_model(
             state.model,
-            model_name=state.cache_name,
+            model_name=cache_name,
             subfolder="transformer",
             parallel_config=self.parallel_config,
             mesh_shape=tuple(self.mesh_device.shape),
             is_fsdp=self.is_fsdp,
-            get_torch_state_dict=state.state_dict_provider,
+            get_torch_state_dict=provider,
         )
         self.transformer = state.model
+
+    @staticmethod
+    def _coerce_lora_specs(lora: str | LoraSpec | list[str | LoraSpec] | None, strength: float) -> list[LoraSpec]:
+        """Normalise a LoRA argument (path, ``LoraSpec``, or list of either) to ``list[LoraSpec]``.
+        A bare path/ref uses ``strength``; an explicit ``LoraSpec`` keeps its own strength."""
+        if lora is None:
+            return []
+        items = lora if isinstance(lora, (list, tuple)) else [lora]
+        specs: list[LoraSpec] = []
+        for item in items:
+            if isinstance(item, LoraSpec):
+                specs.append(item)
+            else:
+                specs.append(LoraSpec(path=LTXPipeline._resolve_checkpoint_file(item), strength=strength))
+        return specs
+
+    def load_lora_weights(
+        self,
+        lora: str | LoraSpec | list[str | LoraSpec],
+        *,
+        strength: float = 1.0,
+    ) -> None:
+        """Load + fuse one or more LoRA adaptors into the base transformer at runtime.
+
+        Works after pipeline construction — no need to pre-declare the LoRA via
+        ``extra_transformer_variants``. The transformer Module object is reused, so subsequent
+        ``generate()`` / ``forward()`` calls run with the LoRA fused in without tearing the model
+        down. Call again to switch adaptors, or ``unload_lora_weights()`` to restore the base.
+
+        Fusion happens host-side (``fuse_loras_into``: ``W += Σ strengthᵢ·(Bᵢ@Aᵢ)``) and the fused
+        weights are re-uploaded through the normal sharded load path, so TP/FSDP sharding and the
+        per-device QKV interleave are handled correctly. Fused weights are disk-cached under a
+        LoRA-tagged name for fast warm reloads. There are no performance guarantees on the
+        load/fuse path itself; the non-LoRA path is unaffected (with no LoRA active, variant 0
+        loads the unmodified base).
+
+        Args:
+            lora: A LoRA safetensors path / HF ref, a ``LoraSpec``, or a list of either.
+            strength: Fuse strength applied to bare paths/refs (ignored for explicit ``LoraSpec``).
+        """
+        assert self.checkpoint_name is not None, "no transformer to fuse LoRA into"
+        specs = self._coerce_lora_specs(lora, strength)
+        if not specs:
+            self.unload_lora_weights()
+            return
+        if specs == self._active_lora_specs:
+            logger.info("Requested LoRA already active; skipping reload.")
+            return
+        self._active_lora_specs = specs
+        # Drop current weights so load_model re-fuses from the LoRA-tagged cache / fused state
+        # dict instead of early-returning on is_loaded().
+        self.transformer_states[0].model.deallocate_weights()
+        self._prepare_transformer(0)
+        logger.info("Loaded LoRA into transformer: " f"{[(os.path.basename(s.path), s.strength) for s in specs]}")
+
+    def unload_lora_weights(self) -> None:
+        """Remove any runtime-loaded LoRA, restoring the unmodified base transformer weights."""
+        if not self._active_lora_specs:
+            return
+        self._active_lora_specs = []
+        self.transformer_states[0].model.deallocate_weights()
+        self._prepare_transformer(0)
+        logger.info("Unloaded LoRA; restored base transformer weights.")
 
     def _device_embed_cache_path(self, prompts: list[str]) -> str:
         """Disk-cache path for on-device prompt embeddings. Separate namespace from the

--- a/models/tt_dit/tests/models/ltx/test_ltx_lora_runtime.py
+++ b/models/tt_dit/tests/models/ltx/test_ltx_lora_runtime.py
@@ -1,0 +1,225 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Runtime (post-init) LoRA load / fuse / unload for the base LTX-2.3 pipeline.
+
+Covers the feature requested in the LoRA-serving issue: load, fuse, and unload LoRA
+adaptors *after* the model has been instantiated, running successive forward()/generate()
+calls without tearing the model down, and leaving the non-LoRA path unaffected.
+
+The `test_lora_spec_coercion` case is device-free (CI-safe). The `test_runtime_lora_*`
+cases need the real 22B checkpoint + a LoRA file + a mesh device, so they mirror the
+opt-in style of `test_pipeline_ltx_two_stages.py`.
+"""
+
+import os
+import tempfile
+
+import pytest
+import torch
+from loguru import logger
+from safetensors.torch import save_file
+
+import ttnn
+from models.tt_dit.pipelines.ltx.pipeline_ltx import LTXPipeline, latent_grid
+from models.tt_dit.utils import tensor
+from models.tt_dit.utils.fuse_loras import LoraSpec
+from models.tt_dit.utils.test import line_params
+from models.tt_dit.utils.video import export_video_audio
+
+
+def _default_checkpoint() -> str:
+    explicit = os.environ.get("LTX_CHECKPOINT")
+    if explicit:
+        return explicit
+    local = os.path.expanduser("~/.cache/ltx-checkpoints/ltx-2.3-22b-dev.safetensors")
+    if os.path.exists(local):
+        return local
+    return "Lightricks/LTX-2.3:ltx-2.3-22b-dev.safetensors"
+
+
+def _default_lora() -> str:
+    """Resolve a LoRA to fuse at runtime: env var > local distilled LoRA > HF download."""
+    explicit = os.environ.get("LORA_PATH")
+    if explicit:
+        return explicit
+    local = os.path.expanduser("~/.cache/ltx-checkpoints/ltx-2.3-22b-distilled-lora-384-1.1.safetensors")
+    if os.path.exists(local):
+        return local
+    from huggingface_hub import hf_hub_download
+
+    return hf_hub_download(repo_id="Lightricks/LTX-2.3", filename="ltx-2.3-22b-distilled-lora-384-1.1.safetensors")
+
+
+def _find_param(module, suffix: str, prefix: str = ""):
+    """First Parameter whose dotted name ends with ``suffix`` (depth-first)."""
+    for name, p in module.named_parameters():
+        if f"{prefix}{name}".endswith(suffix):
+            return p
+    for name, child in module.named_children():
+        found = _find_param(child, suffix, f"{prefix}{name}.")
+        if found is not None:
+            return found
+    return None
+
+
+def _read_weight(param) -> torch.Tensor:
+    """Reconstruct a sharded Parameter's full weight on host for comparison."""
+    return tensor.to_torch(param.data, mesh_axes=param.mesh_axes)
+
+
+# ---------------------------------------------------------------------------
+# Device-free logic
+# ---------------------------------------------------------------------------
+
+
+def test_lora_spec_coercion():
+    """`load_lora_weights` argument normalisation + LoRA-tagged cache naming."""
+    with tempfile.TemporaryDirectory() as d:
+        a = os.path.join(d, "styleA.safetensors")
+        b = os.path.join(d, "styleB.safetensors")
+        for p in (a, b):
+            save_file({"dummy": torch.zeros(1)}, p)
+
+        # bare path -> LoraSpec with the given strength
+        specs = LTXPipeline._coerce_lora_specs(a, 0.8)
+        assert specs == [LoraSpec(path=a, strength=0.8)]
+
+        # explicit LoraSpec keeps its own strength; mixed list preserved in order
+        specs = LTXPipeline._coerce_lora_specs([LoraSpec(path=a, strength=0.5), b], 1.0)
+        assert specs == [LoraSpec(path=a, strength=0.5), LoraSpec(path=b, strength=1.0)]
+
+        # None / empty -> no specs
+        assert LTXPipeline._coerce_lora_specs(None, 1.0) == []
+        assert LTXPipeline._coerce_lora_specs([], 1.0) == []
+
+        # the base (no-LoRA) cache name must be a strict prefix of the fused name, so the
+        # unmodified base never collides with a fused variant on disk.
+        base_name = LTXPipeline._build_transformer_cache_name(a, [])
+        fused_name = LTXPipeline._build_transformer_cache_name(a, [LoraSpec(path=a, strength=0.8)])
+        assert fused_name != base_name
+        assert ".lora-" in fused_name
+        assert "@0.8" in fused_name
+
+
+# ---------------------------------------------------------------------------
+# Hardware: load / unload correctness (no teardown, base path unaffected)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(3600)  # one 46 GB load + LoRA fuse(s); override the 300s default
+@pytest.mark.parametrize(
+    "mesh_device, mesh_shape, sp_axis, tp_axis, num_links, dynamic_load, device_params, topology, is_fsdp",
+    [
+        [(2, 2), (2, 2), 0, 1, 2, False, line_params, ttnn.Topology.Linear, True],
+    ],
+    ids=["2x2sp0tp1"],
+    indirect=["mesh_device", "device_params"],
+)
+def test_runtime_lora_load_unload(
+    mesh_device,
+    mesh_shape,
+    sp_axis,
+    tp_axis,
+    num_links,
+    dynamic_load,
+    topology,
+    is_fsdp,
+):
+    """load_lora -> weights change; unload_lora -> weights restored bit-identically; the
+    transformer Module object is reused throughout (no teardown). Optionally runs a
+    generate() in each state when RUN_LORA_GEN=1."""
+    ckpt = _default_checkpoint()
+    lora = _default_lora()
+
+    parent_mesh = mesh_device
+    mesh_device = parent_mesh.create_submesh(ttnn.MeshShape(*mesh_shape))
+
+    num_frames = int(os.environ.get("NUM_FRAMES", "25"))
+    height = int(os.environ.get("HEIGHT", "256"))
+    width = int(os.environ.get("WIDTH", "256"))
+
+    # gemma_path=None -> zero prompt embeddings (Gemma is gated on this box). The LoRA
+    # feature under test is independent of the text encoder; content is noise.
+    pipeline = LTXPipeline.create_pipeline(
+        mesh_device=mesh_device,
+        checkpoint_name=ckpt,
+        gemma_path=None,
+        sp_axis=sp_axis,
+        tp_axis=tp_axis,
+        num_links=num_links,
+        dynamic_load=dynamic_load,
+        topology=topology,
+        is_fsdp=is_fsdp,
+        num_frames=num_frames,
+        height=height,
+        width=width,
+    )
+
+    if int(ttnn.distributed_context_get_rank()) != 0:
+        logger.info("Skipping assertions on non-zero rank")
+        return
+
+    transformer_id = id(pipeline.transformer)
+    assert not pipeline._active_lora_specs, "fresh pipeline must have no active LoRA"
+
+    # A LoRA-affected fused-QKV weight; snapshot the pristine base.
+    param = _find_param(pipeline.transformer, "to_qkv.weight")
+    assert param is not None, "could not locate a to_qkv weight to probe"
+    base_w = _read_weight(param).clone()
+
+    # --- load + fuse -------------------------------------------------------
+    pipeline.load_lora_weights(lora, strength=1.0)
+    assert pipeline._active_lora_specs == [LoraSpec(path=lora, strength=1.0)]
+    assert id(pipeline.transformer) == transformer_id, "model object was rebuilt, not reused"
+    fused_w = _read_weight(param)
+    assert not torch.equal(fused_w, base_w), "LoRA fuse did not change the weight"
+
+    # idempotent re-request is a no-op (weights unchanged)
+    pipeline.load_lora_weights(lora, strength=1.0)
+    assert torch.equal(_read_weight(param), fused_w)
+
+    # --- unload ------------------------------------------------------------
+    pipeline.unload_lora_weights()
+    assert pipeline._active_lora_specs == []
+    assert id(pipeline.transformer) == transformer_id, "model object was rebuilt, not reused"
+    restored_w = _read_weight(param)
+    assert torch.equal(restored_w, base_w), "unload did not restore base weights bit-identically"
+
+    logger.info("Runtime LoRA load/unload weight checks passed.")
+
+    if os.environ.get("RUN_LORA_GEN", "0") in ("1", "true", "True"):
+        # End-to-end proof that forward() runs in each LoRA state without teardown. Uses the
+        # gemma-free zero-embedding call_av path (mirrors test_ltx_gen_bh_qb); content is noise.
+        steps = int(os.environ.get("STEPS", "6"))
+        seq = pipeline.gemma_encoder_pair.sequence_length
+        v_p = torch.zeros(1, seq, pipeline.gemma_encoder_pair.video_dim)
+        a_p = torch.zeros(1, seq, pipeline.gemma_encoder_pair.audio_dim)
+        for tag, spec in (("base", None), ("lora", lora), ("unloaded", None)):
+            if spec is not None:
+                pipeline.load_lora_weights(spec)
+            else:
+                pipeline.unload_lora_weights()
+            pipeline._prepare_transformer(0)  # active transformer before denoise (mirrors generate())
+            v_lat, a_lat = pipeline.call_av(
+                video_prompt_embeds=v_p,
+                audio_prompt_embeds=a_p,
+                neg_video_prompt_embeds=v_p,
+                neg_audio_prompt_embeds=a_p,
+                num_frames=num_frames,
+                height=height,
+                width=width,
+                num_inference_steps=steps,
+                seed=0,
+                ge_gamma=0.0,
+            )
+            pipeline._prepare_vae()
+            lf, lh, lw = latent_grid(num_frames, height, width)
+            px = pipeline.decode_latents(v_lat, lf, lh, lw)
+            audio = pipeline.decode_audio(a_lat, num_frames, fps=24)
+            out = f"ltx_lora_runtime_{tag}.mp4"
+            export_video_audio(px, out, fps=24, audio=audio)
+            assert os.path.exists(out) and os.path.getsize(out) > 0, f"{tag} generation produced no mp4"
+            logger.info(f"[{tag}] wrote {out} ({os.path.getsize(out)} B), video={tuple(px.shape)}")
+            assert id(pipeline.transformer) == transformer_id, "model object was rebuilt during generation"


### PR DESCRIPTION
## Summary

Adds **runtime (post-init) LoRA loading** to `LTXPipeline`, addressing the feature request to load / fuse / unload LoRA adaptors *after* the model is instantiated — running successive `forward()` / `generate()` calls **without tearing the model down** — for runtime LoRA swapping in serving via tt-inference-server.

The SDXL `TtLoRAWeightsManager` was the reference. The key difference for LTX is that weights are TP- + FSDP-sharded across the mesh and QKV is a single fused parameter with a per-device interleave, so rather than hand-roll the per-shard delta math, this reuses the existing host-fuse + sharded-load path (which already handles all of that correctly).

## API

- `load_lora_weights(lora, *, strength=1.0)` — accepts a path / `LoraSpec` / list of either. Host-fuses (`W += Σ strengthᵢ·Bᵢ@Aᵢ` via the existing `fuse_loras_into`) and re-uploads variant 0 through the normal sharded load path. The transformer `Module` object is reused.
- `unload_lora_weights()` — restores the unmodified base weights.

## Implementation notes

- `_prepare_transformer(0)` now honors `self._active_lora_specs`, so **`dynamic_load` evictions** (DiT evicted before VAE decode) automatically re-fuse the active LoRA on reload. Fused weights cache under a LoRA-tagged name for fast warm swaps.
- **Non-LoRA path is unaffected**: with no LoRA active, variant 0 loads the unmodified base (bit-identical cache name + state-dict provider).
- No performance requirements on the load/fuse/unload path (per the issue). An on-device in-place delta apply (SDXL-style) is a natural follow-up optimization.

## Tests (`test_ltx_lora_runtime.py`)

- `test_lora_spec_coercion` — device-free: argument coercion + LoRA-tagged cache naming.
- `test_runtime_lora_load_unload` (BH QB 2×2) — load changes weights, unload restores them **bit-identically**, transformer object reused (no teardown), idempotent reload. Optional `RUN_LORA_GEN=1` generates in base/lora/unloaded states via the gemma-free zero-embedding path.

### Verification on BH QB (4-chip 2×2), real HF LoRA (`Lightricks/LTX-2.3` distilled-384)

| State | mp4 size |
|---|---|
| base | 27592 B |
| lora | 27289 B ← LoRA changes the output |
| unloaded | 27592 B ← identical to base (exact round-trip) |

Both hardware and device-free tests pass.

## Draft — open items

- [ ] Visual quality of LoRA output not assessed (Gemma gated on the test box → zero embeddings).
- [ ] Follow-up: on-device in-place delta apply to avoid the host round-trip on swap.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ltx-runtime-lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ltx-runtime-lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ltx-runtime-lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ltx-runtime-lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ltx-runtime-lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ltx-runtime-lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ltx-runtime-lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ltx-runtime-lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ltx-runtime-lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ltx-runtime-lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ltx-runtime-lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ltx-runtime-lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ltx-runtime-lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ltx-runtime-lora)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ltx-runtime-lora)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ltx-runtime-lora)