### PR TITLE
[SDPA] Fix non-causal partial-K prefill regression on streaming compute (#47065)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_prefill.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_prefill.py
@@ -2029,3 +2029,90 @@ def test_sdpa_with_attention_sink_gpt_oss_prefill_sampled_accuracy(device, dtype
     logger.debug(f"sampled rmse: {rmse}")
     assert rmse < 0.02, f"RMSE {rmse} exceeds threshold 0.02"
     assert out_pass, f"PCC check failed: {out_pcc}"
+
+
+def run_sdpa_noncausal_partial_k_near_uniform(device, sk, d, q_chunk_size=None, k_chunk_size=None):
+    """Issue #47065 (streaming compute, non-causal prefill, Sk % 32 != 0, no mask).
+
+    The streaming path must mask the last (partial) K tile's padding columns even when the chunk
+    has no fully-padded tile (Sk_chunk_t divides valid_Skt, e.g. valid_Skt prime). Otherwise those
+    zero-K padding columns produce score 0 and, under near-uniform attention, get softmax weight
+    exp(-row_max*scale), inflating the denominator while zero-V-padding adds nothing to the
+    numerator. The result is a per-row scale f_q = D_q / (D_q + P_q) on the output. fa_rand hides
+    this (peaked attention means f_q is close to 1), and a uniformly near-uniform input hides it
+    from PCC too because constant f_q is just a global scale, which PCC ignores. The real ViT
+    regime has attention sharpness that *varies across query rows*, so f_q varies and PCC drops.
+    Reproduce that with a per-row sharpness sweep. Pre-fix PCC drops well below 0.999; legacy
+    (fp32_dest_acc_en=True) is fine.
+    """
+    torch.manual_seed(0)
+    b, nh = 1, 4
+    sq = sk
+    scale = 1.0 / math.sqrt(d)
+
+    # Bimodal per-row attention sharpness: half the query rows are near-uniform, so the zero-K
+    # padding columns get near-equal weight and max padding dilution f_q = Sk/padded_Sk. The other
+    # half are sharply peaked (f_q close to 1, no dilution). PCC is scale-invariant, so a
+    # *constant* f_q is invisible to it; the cross-row variance from this split is what makes PCC
+    # collapse.
+    row_sharpness = torch.where(torch.arange(sq) < sq // 2, 0.01, 6.0).reshape(1, 1, sq, 1).float()
+    Q = (torch.randn(b, nh, sq, d) * row_sharpness).bfloat16().float()
+    K = (torch.randn(b, nh, sk, d) * 0.7).bfloat16().float()
+    # Large V outliers so the leaked padding weight on near-uniform rows visibly corrupts the output.
+    V = torch.randn(b, nh, sk, d)
+    V[:, :, ::5, :] *= 50.0
+    V = V.bfloat16().float()
+
+    # Default compute config -> streaming path (fp32_dest_acc_en=False).
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+    program_config = None
+    if q_chunk_size is not None:
+        program_config = ttnn.SDPAProgramConfig(
+            compute_with_storage_grid_size=device.compute_with_storage_grid_size(),
+            q_chunk_size=q_chunk_size,
+            k_chunk_size=k_chunk_size,
+            exp_approx_mode=True,
+        )
+
+    tt_Q = ttnn.from_torch(Q, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_K = ttnn.from_torch(K, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_V = ttnn.from_torch(V, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_back = ttnn.transformer.scaled_dot_product_attention(
+        tt_Q,
+        tt_K,
+        tt_V,
+        is_causal=False,
+        scale=scale,
+        program_config=program_config,
+        compute_kernel_config=compute_kernel_config,
+    )
+    tt_back = ttnn.to_torch(tt_back)[:, :, :sq, :].float()
+
+    gt = torch.nn.functional.scaled_dot_product_attention(Q, K, V, is_causal=False, scale=scale)
+
+    out_pass, out_pcc = comp_pcc(gt, tt_back, 0.999)
+    logger.info(f"[sk={sk} d={d}] streaming non-causal partial-K PCC: {out_pcc}")
+    assert out_pass, f"sk={sk} d={d}: streaming SDPA PCC {out_pcc} < 0.999"
+
+
+@pytest.mark.parametrize("d", [64, 128], ids=["d64", "d128"])
+@pytest.mark.parametrize("sk", [33, 65], ids=["sk33", "sk65"])
+def test_sdpa_noncausal_partial_k_near_uniform(device, sk, d):
+    # Default chunking -> Sk_chunk_t == 1, no fully-padded tile: the geometry that regressed in #47065.
+    run_sdpa_noncausal_partial_k_near_uniform(device, sk, d)
+
+
+@pytest.mark.parametrize("d", [64], ids=["d64"])
+@pytest.mark.parametrize("sk", [250], ids=["sk250"])
+def test_sdpa_noncausal_partial_k_reduce_trigger(device, sk, d):
+    # q/k chunk 256 -> Sk_chunk_t == 8 with qkt_subblock_w == 4, which enables the streaming
+    # reduce_trigger (split row-max reduce). sk=250 (valid_Skt=8) divides the chunk evenly, so there
+    # is no fully-padded tile and active_Sk is NOT shrunk, exercising reduce_trigger together with
+    # the partial-tile mask stamp. Coverage for that interaction (the row-max reduce only sets the
+    # softmax stability offset, so the partial mask need not gate the trigger); must stay correct.
+    run_sdpa_noncausal_partial_k_near_uniform(device, sk, d, q_chunk_size=256, k_chunk_size=256)

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/compute_streaming.hpp
@@ -1998,7 +1998,11 @@ void sdpa_standard_v2(
             bool apply_causal_mask = is_causal_sdpa;
             uint32_t target_active_Sk = chunk_active_Sk;
             if constexpr (use_padded_mask && !is_causal_sdpa && !use_provided_mask) {
-                if (is_padded && lw_mask.global_n_partial_col > 0) {
+                // Stamp the partial-tile vertical mask whenever the tensor's last K chunk carries a
+                // partial tile (Sk % TILE != 0), independent of fully padded tiles. When there are no
+                // fully padded tiles, global_n_padded_tiles is 0, so target_active_Sk remains
+                // Sk_chunk_t and only the vertical mask stamp is added.
+                if ((k_chunk == k_num_chunks - 1) && lw_mask.global_n_partial_col > 0) {
                     target_active_Sk = Sk_chunk_t - lw_mask.global_n_padded_tiles;
                     apply_partial_mask = true;
                 }


### PR DESCRIPTION
## Summary
Fixes a correctness regression in the **streaming** SDPA prefill compute path for **non-causal attention with `Sk % 32 != 0` and no mask** (e.g. ViT-Base `[1,12,197,64]`, `is_causal=False`).

ViT-Base layers 10/11 drop to PCC ≈ 0.989 / 0.953 vs a torch reference on the streaming path (`fp32_dest_acc_en=False`); the legacy path (`fp32_dest_acc_en=True`) stays ≈ 0.9999. The error is data-dependent — only near-uniform attention (real ViT activations) exposes it; random / `fa_rand` inputs stay ≈ 0.999.

Fixes #47065.

## Where it regressed
#46281 ("Support streaming SDPA sliding-window prefill", commit 64891006194) changed the partial-tile mask gate in `sdpa_standard_v2` (`compute_streaming.hpp`) from `is_last && global_n_partial_col > 0` to `is_padded && global_n_partial_col > 0`. `is_padded` additionally requires `padded_k_tiles_inner > 0` (a *fully-padded* K tile in the last chunk).

When the K-chunk size divides `valid_Skt` evenly (ViT: `valid_Skt = ceil(197/32) = 7`, default `Sk_chunk_t = 1`) the last tile is the *partial* one with **no** fully-padded tile, so `is_padded == false` and the partial-tile mask was never stamped. The partial tile's padding columns (K rows beyond `Sk`, zero-padded in DRAM) then produced QKᵀ score 0 and, under near-uniform attention, received ~equal softmax weight — inflating the denominator while zero-padded V added nothing to the numerator. The net effect is a per-row output scale `Sk/padded_Sk` that **varies across query rows**, collapsing PCC (a constant scale wouldn't, since PCC is scale-invariant — which is why random inputs hide the bug). The non-causal partial-K case had no test coverage in #46281 (its parametrizations are all `seq % 32 == 0`).

## What changed
- `compute_streaming.hpp`: stamp the partial-tile mask whenever the tensor's final K chunk carries a partial tile (`k_chunk == k_num_chunks - 1 && global_n_partial_col > 0`), independent of fully-padded tiles. `global_n_padded_tiles` is 0 in that case, so `target_active_Sk` stays `Sk_chunk_t` — the matmul still covers the partial tile and only the vertical `-inf` mask at the last tile is added. Gating on `k_num_chunks - 1` (vs the original `is_last`) is also correct under #46281's sliding-window loop narrowing, where the loop's last chunk may not be the tensor's final K chunk.
- `reduce_trigger` is intentionally **not** coupled to the mask: the row-max reduce only produces the softmax stability offset (shift-invariant) and `sub_exp` reads the masked scores regardless, so an early-triggered reduce racing the mask stamp cannot change the result.

## Tests
Adds to the nightly SDPA prefill suite (`tests/ttnn/nightly/unit_tests/operations/sdpa/test_sdpa_prefill.py`):
- `test_sdpa_noncausal_partial_k_near_uniform` — default chunking (the regressed geometry).
- `test_sdpa_noncausal_partial_k_reduce_trigger` — `q/k_chunk = 256` → `Sk_chunk_t = 8`, exercising `reduce_trigger` together with the partial-tile mask.

Bimodal per-row sharpness + V outliers reproduce the cross-row dilution variance PCC is sensitive to. Pre-fix the near-uniform test drops to ≈ 0.99; post-fix all pass ≥ 0.9997.

Local validation (silicon): full `tests/ttnn/unit_tests/operations/sdpa/test_sdpa_prefill.py` and `test_windowed_sdpa.py` pass; no prior-passing case regressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/sdpa-noncausal-partialk-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/sdpa-noncausal-partialk-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/sdpa-noncausal-partialk-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/sdpa-noncausal-partialk-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/sdpa-noncausal-partialk-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/sdpa-noncausal-partialk-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sdpa-noncausal-partialk-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/sdpa-noncausal-partialk-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/sdpa-noncausal-partialk-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/sdpa-noncausal-partialk-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/sdpa-noncausal-partialk-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/sdpa-noncausal-partialk-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/sdpa-noncausal-partialk-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/sdpa-noncausal-partialk-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/sdpa-noncausal-partialk-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/sdpa-noncausal-partialk-fix)