### PR TITLE
[Cleanup] experimental/deepseek_prefill: migrate kernels to Device 2.0

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/compute/untilize_combine.cpp
@@ -7,6 +7,7 @@
 #include "api/compute/common.h"
 #include "api/compute/cb_api.h"
 #include "api/compute/pack_untilize.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "api/debug/dprint.h"
@@ -44,8 +45,11 @@
 //   5: total_untilizers                - G, total untilizer cores across all senders (global stride)
 void kernel_main() {
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(0);
+    CircularBuffer cb_untilize(cb_untilize_id);
     constexpr uint32_t cb_in_id = get_compile_time_arg_val(1);
+    CircularBuffer cb_in(cb_in_id);
     constexpr uint32_t cb_experts_tok_counter_id = get_compile_time_arg_val(2);
+    CircularBuffer cb_experts_tok_counter(cb_experts_tok_counter_id);
     constexpr uint32_t experts_tok_counter_pages = get_compile_time_arg_val(3);
     constexpr uint32_t experts_per_chip = get_compile_time_arg_val(4);
     constexpr uint32_t counter_offset = get_compile_time_arg_val(5);
@@ -77,7 +81,7 @@ void kernel_main() {
     // core pushes the counter CB once after counter_ready_sem fires, so cb_wait_front here
     // doubles as the gate for "counter data is live in L1".  The CB is never popped — both
     // this kernel and writer_untilize rely on the data staying resident.
-    cb_wait_front(cb_experts_tok_counter_id, cb_counter_total_pages);
+    cb_experts_tok_counter.wait_front(cb_counter_total_pages);
 
     // Snapshot per-expert token counts.  read_tile_value has UNPACK read from L1 and broadcast
     // to MATH / PACK via mailbox, so all three TRISCs end up with identical counts and walk the
@@ -111,16 +115,16 @@ void kernel_main() {
         // expert (G = total_untilizers across all senders).  Must match reader_untilize /
         // writer_untilize exactly so the c_0 / c_2 producer-consumer protocol stays in lockstep.
         for (uint32_t batch_idx = untilizer_global_pos; batch_idx < actual_batches; batch_idx += total_untilizers) {
-            cb_reserve_back(cb_untilize_id, read_batch_size);
+            cb_untilize.reserve_back(read_batch_size);
             for (uint32_t block = 0; block < num_blocks; block++) {
-                cb_wait_front(cb_in_id, block_ct_dim);
+                cb_in.wait_front(block_ct_dim);
                 {
                     // DeviceZoneScopedN("UNTILIZING");
                     pack_untilize_block<block_ct_dim, full_ct_dim>(cb_in_id, 1, cb_untilize_id, block);
                 }
-                cb_pop_front(cb_in_id, block_ct_dim);
+                cb_in.pop_front(block_ct_dim);
             }
-            cb_push_back(cb_untilize_id, read_batch_size);
+            cb_untilize.push_back(read_batch_size);
         }
         start_page_tiled += ((expert_tokens + tile_height - 1) / tile_height) * tiles_per_batch;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/reader_untilize.cpp
@@ -30,6 +30,9 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/debug/dprint.h"
 
 #define ENABLE_COMBINE_DEBUG 0
@@ -65,10 +68,12 @@ void kernel_main() {
     //                                              used for cb_reserve_back / cb_push_back / cb_wait_front
     //  18+: TensorAccessorArgs for dispatched_buffer, then TensorAccessorArgs for dispatched_metadata
     constexpr uint32_t cb_experts_tok_counter_id = get_compile_time_arg_val(0);
+    CircularBuffer cb_experts_tok_counter(cb_experts_tok_counter_id);
     constexpr uint32_t experts_tok_counter_pages = get_compile_time_arg_val(1);
     constexpr uint32_t experts_per_chip = get_compile_time_arg_val(2);
     constexpr uint32_t counter_offset = get_compile_time_arg_val(3);
     constexpr uint32_t cb_dispatched_buffer_id = get_compile_time_arg_val(4);
+    CircularBuffer cb_dispatched_buffer(cb_dispatched_buffer_id);
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(5);
     constexpr uint32_t hidden_size = get_compile_time_arg_val(6);
     constexpr uint32_t read_batch_size = get_compile_time_arg_val(7);
@@ -79,9 +84,12 @@ void kernel_main() {
     constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(12);
     constexpr uint32_t aligned_experts_tok_counter_page_size = get_compile_time_arg_val(13);
     constexpr uint32_t cb_metadata_batch_id = get_compile_time_arg_val(14);
+    CircularBuffer cb_metadata_batch(cb_metadata_batch_id);
     constexpr uint32_t aligned_dispatched_metadata_page_size = get_compile_time_arg_val(15);
     constexpr uint32_t block_ct_dim = get_compile_time_arg_val(16);
     constexpr uint32_t cb_counter_total_pages = get_compile_time_arg_val(17);
+
+    Noc noc;
     constexpr auto dispatched_buffer_args = TensorAccessorArgs<18>();
     constexpr auto dispatched_metadata_args =
         TensorAccessorArgs<dispatched_buffer_args.next_compile_time_args_offset()>();
@@ -115,19 +123,18 @@ void kernel_main() {
     // Note: don't reset counter_ready_sem — writer_untilize on this same core also waits on it
     // to read the sender's receive_buf_addr from c_1. Since neither kernel re-uses the sem within
     // a single invocation, leaving it latched at >=1 is safe.
-    cb_reserve_back(cb_experts_tok_counter_id, cb_counter_total_pages);
+    cb_experts_tok_counter.reserve_back(cb_counter_total_pages);
 
-    volatile tt_l1_ptr uint32_t* counter_ready_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(counter_ready_semaphore_id));
-    noc_semaphore_wait(counter_ready_sem_ptr, 1);
+    Semaphore<> counter_ready_sem(counter_ready_semaphore_id);
+    counter_ready_sem.wait(1);
 
-    cb_push_back(cb_experts_tok_counter_id, cb_counter_total_pages);
+    cb_experts_tok_counter.push_back(cb_counter_total_pages);
 
     // ===== Step 2: Read per-expert token counts =====
     // writer_untilize independently reads the sender's receive_buf_addr from c_1 at offset
     // experts_tok_counter_pages * aligned_experts_tok_counter_page_size (same L1 layout).
-    cb_wait_front(cb_experts_tok_counter_id, cb_counter_total_pages);
-    uint32_t token_counter_base = get_read_ptr(cb_experts_tok_counter_id);
+    cb_experts_tok_counter.wait_front(cb_counter_total_pages);
+    uint32_t token_counter_base = cb_experts_tok_counter.get_read_ptr();
     const volatile tt_l1_ptr uint32_t* counter_l1_src =
         reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(token_counter_base) + counter_offset;
     uint32_t local_expert_counts[experts_per_chip];
@@ -196,19 +203,20 @@ void kernel_main() {
                 // wrap).  Only the first batch_count pages contain valid metadata read from
                 // DRAM; the trailing (read_batch_size - batch_count) pages are unused and
                 // will not be read by the consumer.
-                cb_reserve_back(cb_metadata_batch_id, read_batch_size);
-                uint32_t metadata_base = get_write_ptr(cb_metadata_batch_id);
+                cb_metadata_batch.reserve_back(read_batch_size);
                 {
                     // DeviceZoneScopedN("METADATA-read");
                     for (uint32_t t = 0; t < batch_count; t++) {
-                        noc_async_read_page(
-                            metadata_batch_start + t,
+                        noc.async_read(
                             dispatched_metadata_addr_gen,
-                            metadata_base + t * aligned_dispatched_metadata_page_size);
+                            cb_metadata_batch,
+                            aligned_dispatched_metadata_page_size,
+                            {.page_id = metadata_batch_start + t},
+                            {.offset_bytes = t * aligned_dispatched_metadata_page_size});
                     }
-                    noc_async_read_barrier();
+                    noc.async_read_barrier();
                 }
-                cb_push_back(cb_metadata_batch_id, read_batch_size);
+                cb_metadata_batch.push_back(read_batch_size);
             }
 
 #if IS_TILE_LAYOUT
@@ -222,19 +230,20 @@ void kernel_main() {
                 constexpr uint32_t num_blocks = tiles_per_batch / block_ct_dim;
                 for (uint32_t cnt = 0; cnt < num_blocks; cnt++) {
                     uint32_t batch_tile = batch_tile_start + cnt * block_ct_dim;
-                    cb_reserve_back(cb_dispatched_buffer_id, block_ct_dim);
-                    uint32_t buffer_base = get_write_ptr(cb_dispatched_buffer_id);
+                    cb_dispatched_buffer.reserve_back(block_ct_dim);
                     {
                         // DeviceZoneScopedN("DISPATCHED-BUFFER-read");
                         for (uint32_t t = 0; t < block_ct_dim; t++) {
-                            noc_async_read_page(
-                                batch_tile + t,
+                            noc.async_read(
                                 dispatched_buffer_addr_gen,
-                                buffer_base + t * aligned_dispatched_buffer_page_size);
+                                cb_dispatched_buffer,
+                                aligned_dispatched_buffer_page_size,
+                                {.page_id = batch_tile + t},
+                                {.offset_bytes = t * aligned_dispatched_buffer_page_size});
                         }
-                        noc_async_read_barrier();
+                        noc.async_read_barrier();
                     }
-                    cb_push_back(cb_dispatched_buffer_id, block_ct_dim);
+                    cb_dispatched_buffer.push_back(block_ct_dim);
                 }
                 // Steps 3-7 (wait for untilize, wait for sender's send signal, NOC-write to
                 // sender, signal sender, pop untilize CB) now run on writer_untilize.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
@@ -25,6 +25,9 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/zero_init_common.hpp"
 
 // Sentinel used by compute to tell this kernel to exit its send loop.
@@ -104,14 +107,17 @@ void kernel_main() {
     //                                              used for cb_wait_front on the multicasted CB
     //  +14: SLOTS_PER_UNTILIZER                    - per-untilizer ring depth on the sender's receive_buf
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset());
+    CircularBuffer cb_untilize(cb_untilize_id);
     constexpr uint32_t cb_experts_tok_counter_id =
         get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 1);
+    CircularBuffer cb_experts_tok_counter(cb_experts_tok_counter_id);
     constexpr uint32_t experts_tok_counter_pages =
         get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 2);
     constexpr uint32_t aligned_experts_tok_counter_page_size =
         get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 3);
     constexpr uint32_t read_batch_size = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 4);
     constexpr uint32_t cb_metadata_batch_id = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 5);
+    CircularBuffer cb_metadata_batch(cb_metadata_batch_id);
     constexpr uint32_t num_experts_per_tok = get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 6);
     constexpr uint32_t aligned_dispatched_metadata_page_size =
         get_compile_time_arg_val(output_args.next_compile_time_args_offset() + 7);
@@ -159,6 +165,8 @@ void kernel_main() {
     uint32_t untilizer_global_pos = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t total_untilizers = get_arg_val<uint32_t>(rt_args_idx++);
 
+    Noc noc;
+
     uint64_t sender_data_ready_noc_addr =
         get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
     uint32_t credits_sem_l1 = get_semaphore(credits_semaphore_id);
@@ -174,8 +182,8 @@ void kernel_main() {
     // for the next invocation.
     volatile tt_l1_ptr uint32_t* counter_ready_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(counter_ready_semaphore_id));
-    cb_wait_front(cb_experts_tok_counter_id, cb_counter_total_pages);
-    uint32_t counter_cb_base = get_read_ptr(cb_experts_tok_counter_id);
+    cb_experts_tok_counter.wait_front(cb_counter_total_pages);
+    uint32_t counter_cb_base = cb_experts_tok_counter.get_read_ptr();
     const volatile tt_l1_ptr uint32_t* trailer =
         reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(counter_cb_base + counter_data_total_size);
     uint32_t sender_receive_buf_l1_offset = trailer[0];
@@ -244,11 +252,11 @@ void kernel_main() {
             // the corresponding metadata pages.  cb_metadata_batch_id is pushed/popped in
             // fixed read_batch_size chunks (only the first batch_count entries are valid),
             // so its fifo pointers wrap cleanly even when batch_count < read_batch_size.
-            cb_wait_front(cb_untilize_id, read_batch_size);
-            cb_wait_front(cb_metadata_batch_id, read_batch_size);
+            cb_untilize.wait_front(read_batch_size);
+            cb_metadata_batch.wait_front(read_batch_size);
 
-            uint32_t untilize_read_ptr = get_read_ptr(cb_untilize_id);
-            uint32_t metadata_read_ptr = get_read_ptr(cb_metadata_batch_id);
+            uint32_t untilize_read_ptr = cb_untilize.get_read_ptr();
+            uint32_t metadata_read_ptr = cb_metadata_batch.get_read_ptr();
 
             for (uint32_t t = 0; t < batch_count; t++) {
                 const volatile tt_l1_ptr uint32_t* metadata = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(
@@ -261,7 +269,12 @@ void kernel_main() {
                     uint32_t dst_token_idx = metadata[1];
                     uint32_t dst_topk_indice = metadata[2];
                     uint32_t output_page_idx = dst_token_idx * num_experts_per_tok + dst_topk_indice;
-                    noc_async_write_page(output_page_idx, output_addr_gen, untilize_row_addr);
+                    noc.async_write(
+                        cb_untilize,
+                        output_addr_gen,
+                        aligned_output_page_size,
+                        {.offset_bytes = t * aligned_output_page_size},
+                        {.page_id = output_page_idx});
 
                 } else {
                     if (local_credits == 0) {
@@ -303,10 +316,10 @@ void kernel_main() {
             // Make sure any local writes that hit only the writes-flushed path complete before
             // we release the CBs (sender's per-row handshake already barriered the non-local
             // writes).
-            noc_async_write_barrier();
+            noc.async_write_barrier();
 
-            cb_pop_front(cb_metadata_batch_id, read_batch_size);
-            cb_pop_front(cb_untilize_id, read_batch_size);
+            cb_metadata_batch.pop_front(read_batch_size);
+            cb_untilize.pop_front(read_batch_size);
         }
         start_page_tiled += ((expert_tokens + tile_height - 1) / tile_height) * tiles_per_batch;
     }
@@ -325,5 +338,5 @@ void kernel_main() {
     noc_async_write_barrier();
     noc_semaphore_inc(sender_data_ready_noc_addr, 1);
     noc_async_atomic_barrier();
-    cb_pop_front(cb_experts_tok_counter_id, cb_counter_total_pages);
+    cb_experts_tok_counter.pop_front(cb_counter_total_pages);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
@@ -78,7 +78,7 @@ void kernel_main() {
         noc_semaphore_inc(sender_sem_noc_addrs[c], 1);
     }
 
-    noc_async_atomic_barrier();
+    noc.async_atomic_barrier();
 #endif
 
     // ===== Untilized-data send path (runs for both TILE_LAYOUT and ROW_MAJOR) =====
@@ -166,6 +166,8 @@ void kernel_main() {
     uint32_t total_untilizers = get_arg_val<uint32_t>(rt_args_idx++);
 
     Noc noc;
+    Semaphore<> credits_sem(credits_semaphore_id);
+    Semaphore<> counter_ready_sem(counter_ready_semaphore_id);
 
     uint64_t sender_data_ready_noc_addr =
         get_noc_addr(sender_noc_x, sender_noc_y, get_semaphore(data_ready_semaphore_id));
@@ -278,10 +280,10 @@ void kernel_main() {
 
                 } else {
                     if (local_credits == 0) {
-                        noc_semaphore_wait_min(credits_sem_ptr, 1);
+                        credits_sem.wait_min(1);
                         uint32_t n = *credits_sem_ptr;
                         noc_semaphore_inc(self_credits_noc_addr, (uint32_t)(-(int32_t)n));
-                        noc_async_atomic_barrier();
+                        noc.async_atomic_barrier();
                         local_credits += n;
                     }
                     // Write routing metadata (dst_chip, dst_token_idx, dst_topk_indice) to
@@ -327,16 +329,16 @@ void kernel_main() {
     // All batches processed — send job-done sentinel to sender so it knows this untilizer
     // core has finished completely.  Uses one ring slot (credit consumed, data_ready++).
 
-    noc_semaphore_wait_min(credits_sem_ptr, SLOTS_PER_UNTILIZER - local_credits);
+    credits_sem.wait_min(SLOTS_PER_UNTILIZER - local_credits);
     uint32_t n = *credits_sem_ptr;
     noc_semaphore_inc(self_credits_noc_addr, (uint32_t)(-(int32_t)n));
-    noc_semaphore_set(counter_ready_sem_ptr, 0);
-    noc_async_atomic_barrier();
+    counter_ready_sem.set(0);
+    noc.async_atomic_barrier();
 
     uint64_t done_meta_noc = our_metadata_slice_noc_addr + write_slot * aligned_dispatched_metadata_page_size;
     noc_inline_dw_write(done_meta_noc, ROUTE_INFO_SENTINEL);
-    noc_async_write_barrier();
+    noc.async_write_barrier();
     noc_semaphore_inc(sender_data_ready_noc_addr, 1);
-    noc_async_atomic_barrier();
+    noc.async_atomic_barrier();
     cb_experts_tok_counter.pop_front(cb_counter_total_pages);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/device/kernels/dataflow/writer_untilize.cpp
@@ -50,6 +50,8 @@ void kernel_main() {
     uint32_t rt_args_idx = 0;
     uint32_t output_addr = get_arg_val<uint32_t>(rt_args_idx++);
 
+    Noc noc;
+
 #if INIT_ZEROS
     uint32_t page_start = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t page_end = get_arg_val<uint32_t>(rt_args_idx++);
@@ -165,7 +167,6 @@ void kernel_main() {
     uint32_t untilizer_global_pos = get_arg_val<uint32_t>(rt_args_idx++);
     uint32_t total_untilizers = get_arg_val<uint32_t>(rt_args_idx++);
 
-    Noc noc;
     Semaphore<> credits_sem(credits_semaphore_id);
     Semaphore<> counter_ready_sem(counter_ready_semaphore_id);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/compute/untilize_dispatch.cpp
@@ -7,6 +7,7 @@
 #include "api/compute/common.h"
 #include "api/compute/cb_api.h"
 #include "api/compute/pack_untilize.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "api/debug/dprint.h"
@@ -31,8 +32,11 @@ constexpr uint32_t ROUTE_INFO_SENTINEL = 0xFFFFFFFF;
 
 void kernel_main() {
     constexpr uint32_t cb_signal_id = get_compile_time_arg_val(0);
+    CircularBuffer cb_signal(cb_signal_id);
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(1);
+    CircularBuffer cb_untilize(cb_untilize_id);
     constexpr uint32_t cb_in_id = get_compile_time_arg_val(2);
+    CircularBuffer cb_in(cb_in_id);
     constexpr uint32_t hidden_size = get_compile_time_arg_val(3);
     constexpr uint32_t read_batch_size = get_compile_time_arg_val(4);
     constexpr uint32_t block_ct_dim = get_compile_time_arg_val(5);
@@ -44,22 +48,22 @@ void kernel_main() {
     pack_untilize_init<block_ct_dim, full_ct_dim>(cb_in_id, cb_untilize_id);
 
     while (true) {
-        cb_reserve_back(cb_untilize_id, read_batch_size);
+        cb_untilize.reserve_back(read_batch_size);
 
-        cb_wait_front(cb_signal_id, 1);
+        cb_signal.wait_front(1);
         uint32_t val = read_tile_value(cb_signal_id, 0, 0);
-        cb_pop_front(cb_signal_id, 1);
+        cb_signal.pop_front(1);
         if (val == ROUTE_INFO_SENTINEL) {
             break;
         }
 
         for (uint32_t block = 0; block < num_blocks; block++) {
-            cb_wait_front(cb_in_id, block_ct_dim);
+            cb_in.wait_front(block_ct_dim);
             pack_untilize_block<block_ct_dim, full_ct_dim>(cb_in_id, 1, cb_untilize_id, block);
-            cb_pop_front(cb_in_id, block_ct_dim);
+            cb_in.pop_front(block_ct_dim);
         }
 
-        cb_push_back(cb_untilize_id, read_batch_size);
+        cb_untilize.push_back(read_batch_size);
     }
     pack_untilize_uninit(cb_untilize_id);
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
@@ -142,6 +142,7 @@ void kernel_main() {
     // space_avail lives in our local L1; the sender increments it remotely once per slot it has
     // finished forwarding.  We poll it as a per-entry credit (wait for produced_count+1) before
     // overwriting a slot, so the sender's in-flight fabric send is never clobbered.
+    Semaphore<> space_avail_sem(space_avail_semaphore_id);
     volatile tt_l1_ptr uint32_t* space_avail_sem_ptr =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(space_avail_semaphore_id));
 
@@ -270,7 +271,7 @@ void kernel_main() {
                         produced_count + 1,
                         (uint32_t)(*space_avail_sem_ptr),
                         route);
-                    noc_semaphore_wait_min(space_avail_sem_ptr, produced_count + 1);
+                    space_avail_sem.wait_min(produced_count + 1);
 
                     uint32_t slot = produced_count % writer_cb_size;
 
@@ -323,7 +324,7 @@ void kernel_main() {
 
         // Drain all local NOC writes issued during this batch before the scratch ring or
         // untilize CB get reused. Cross-device entries already barriered per-entry.
-        noc_async_writes_flushed();
+        noc.async_writes_flushed();
         local_count = 0;
 
         cb_plan.pop_front(1);
@@ -344,7 +345,7 @@ void kernel_main() {
         (uint32_t)core_id,
         produced_count + 1,
         (uint32_t)(*space_avail_sem_ptr));
-    noc_semaphore_wait_min(space_avail_sem_ptr, produced_count + 1);
+    space_avail_sem.wait_min(produced_count + 1);
     DPRINT_DISPATCH("[W c={}] sending SENTINEL (produced total={})\n", (uint32_t)core_id, produced_count);
 
     uint32_t sentinel_slot = produced_count % writer_cb_size;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/writer_untilize_dispatch.cpp
@@ -42,6 +42,9 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "api/debug/dprint.h"
 #include "ttnn/operations/experimental/deepseek_prefill/dispatch/device/kernels/dataflow/dispatch_plan.hpp"
 
@@ -58,6 +61,7 @@ constexpr uint32_t TRID_NON_LOCAL_WRITE = 1;
 void kernel_main() {
     // ===== Compile-time args =====
     constexpr uint32_t cb_untilize_id = get_compile_time_arg_val(0);
+    CircularBuffer cb_untilize(cb_untilize_id);
     constexpr uint32_t read_batch_size = get_compile_time_arg_val(1);
     constexpr uint32_t aligned_output_page_size = get_compile_time_arg_val(2);
     constexpr uint32_t total_batches = get_compile_time_arg_val(3);
@@ -65,15 +69,20 @@ void kernel_main() {
     constexpr uint32_t total_workers = get_compile_time_arg_val(5);
 
     constexpr uint32_t cb_metadata_scratch_id = get_compile_time_arg_val(6);
+    CircularBuffer cb_metadata_scratch(cb_metadata_scratch_id);
     constexpr uint32_t aligned_metadata_page_size = get_compile_time_arg_val(7);
     constexpr uint32_t cb_plan_id = get_compile_time_arg_val(8);
+    CircularBuffer cb_plan(cb_plan_id);
     constexpr uint32_t linearized_mesh_coord = get_compile_time_arg_val(9);
 
     // Per-entry CB protocol on sender side (sender writer CBs, writer_cb_size slots deep).
     constexpr uint32_t route_info_slot_stride = get_compile_time_arg_val(10);    // l1_alignment
     constexpr uint32_t writer_cb_size = get_compile_time_arg_val(11);            // = read_batch_size = 32
     constexpr uint32_t cb_route_info_scratch_id = get_compile_time_arg_val(12);  // 16B local scratch
+    CircularBuffer cb_route_info_scratch(cb_route_info_scratch_id);
     constexpr uint32_t meta_scratch_slots = get_compile_time_arg_val(13);
+
+    Noc noc;
 
     constexpr auto output_args = TensorAccessorArgs<14>();
     constexpr auto metadata_args = TensorAccessorArgs<output_args.next_compile_time_args_offset()>();
@@ -110,10 +119,9 @@ void kernel_main() {
     // sender barriers those address writes before the inc, so once addr_ready fires the packed
     // addresses are already in our local L1 and the read below is safe.  We reset addr_ready to 0
     // so the slot is clean for the next program launch.
-    volatile tt_l1_ptr uint32_t* addr_ready_sem_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_semaphore(addr_ready_semaphore_id));
-    noc_semaphore_wait(addr_ready_sem_ptr, 1);
-    noc_semaphore_set(addr_ready_sem_ptr, 0);
+    Semaphore<> addr_ready_sem(addr_ready_semaphore_id);
+    addr_ready_sem.wait(1);
+    addr_ready_sem.set(0);
 
     // All three base addresses arrive packed in the single mailbox slot (words [0],[1],[2]).
     volatile tt_l1_ptr uint32_t* cross_addr_ptr =
@@ -142,9 +150,9 @@ void kernel_main() {
     // stage into the single trailing slot (xdev_metadata_scratch_addr) before the NOC write to c_6.
     // route_info_scratch is a tiny local buffer where the 4×u32 route_info word group is assembled
     // before being pushed to the sender's c_4 in one NOC write.
-    uint32_t metadata_scratch_addr = get_write_ptr(cb_metadata_scratch_id);
+    uint32_t metadata_scratch_addr = cb_metadata_scratch.get_write_ptr();
     uint32_t xdev_metadata_scratch_addr = metadata_scratch_addr + meta_scratch_slots * aligned_metadata_page_size;
-    uint32_t route_info_scratch_addr = get_write_ptr(cb_route_info_scratch_id);
+    uint32_t route_info_scratch_addr = cb_route_info_scratch.get_write_ptr();
     volatile tt_l1_ptr uint32_t* route_info_scratch =
         reinterpret_cast<volatile tt_l1_ptr uint32_t*>(route_info_scratch_addr);
     uint32_t produced_count = 0;
@@ -178,13 +186,13 @@ void kernel_main() {
     // ===== Per-batch loop — drains the route plan published by the reader RISC =====
     for (uint32_t batch_idx = core_id; batch_idx < effective_total_batches; batch_idx += total_workers) {
         // Wait for compute to finish untilizing this batch
-        cb_wait_front(cb_untilize_id, read_batch_size);
+        cb_untilize.wait_front(read_batch_size);
 
-        uint32_t untilize_read_ptr = get_read_ptr(cb_untilize_id);
+        uint32_t untilize_read_ptr = cb_untilize.get_read_ptr();
 
         // Wait for reader to publish the per-batch route plan
-        cb_wait_front(cb_plan_id, 1);
-        uint32_t plan_addr = get_read_ptr(cb_plan_id);
+        cb_plan.wait_front(1);
+        uint32_t plan_addr = cb_plan.get_read_ptr();
         volatile tt_l1_ptr PlanHeader* plan = reinterpret_cast<volatile tt_l1_ptr PlanHeader*>(plan_addr);
         volatile tt_l1_ptr PlanEntry* entries =
             reinterpret_cast<volatile tt_l1_ptr PlanEntry*>(plan_addr + sizeof(PlanHeader));
@@ -220,7 +228,12 @@ void kernel_main() {
                     //  No in-loop flush — payload source (src_addr) is unique per token,
                     //  and metadata source rotates through meta_scratch_slots ring slots.
                     //  Single noc_async_writes_flushed() at batch end covers reuse.
-                    noc_async_write_page(page_idx, output_addr_gen, src_addr);
+                    noc.async_write(
+                        cb_untilize,
+                        output_addr_gen,
+                        aligned_output_page_size,
+                        {.offset_bytes = token_t * aligned_output_page_size},
+                        {.page_id = page_idx});
                     // Per-token metadata layout (5 × int32): [src chip, global token idx, top-k
                     // slot, routed expert, routing weight].  Built into the next ring slot, then
                     // written to the same DRAM page index as the payload.
@@ -232,7 +245,12 @@ void kernel_main() {
                     meta[2] = (int32_t)k;
                     meta[3] = (int32_t)routed_expert;
                     meta[4] = (int32_t)weight;
-                    noc_async_write_page(page_idx, metadata_addr_gen, meta_addr);
+                    noc.async_write(
+                        cb_metadata_scratch,
+                        metadata_addr_gen,
+                        aligned_metadata_page_size,
+                        {.offset_bytes = (local_count % meta_scratch_slots) * aligned_metadata_page_size},
+                        {.page_id = page_idx});
                     local_count++;
                 } else {
                     // Cross-device: stage this token into one sender slot as three NOC writes —
@@ -308,14 +326,14 @@ void kernel_main() {
         noc_async_writes_flushed();
         local_count = 0;
 
-        cb_pop_front(cb_plan_id, 1);
-        cb_pop_front(cb_untilize_id, read_batch_size);
+        cb_plan.pop_front(1);
+        cb_untilize.pop_front(read_batch_size);
     }
 
     // Teardown: the reader pushes one extra end-of-plan sentinel page after the last batch.
     // Consume it (its entry_count is 0, so nothing was drained above for it).
-    cb_wait_front(cb_plan_id, 1);
-    cb_pop_front(cb_plan_id, 1);
+    cb_plan.wait_front(1);
+    cb_plan.pop_front(1);
 
     // Then send ROUTE_INFO_SENTINEL as one final route_info entry into the next sender slot.
     // It takes a real slot, so wait for a space_avail credit just like any data entry; the

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/reader_extract.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/reader_extract.cpp
@@ -27,6 +27,8 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/debug/assert.h"
 
 constexpr uint32_t TILE_HEIGHT = 32;
@@ -46,6 +48,13 @@ void kernel_main() {
     constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(1);
     constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(2);
     constexpr uint32_t cb_global_expert_idx_scratch = get_compile_time_arg_val(3);
+
+    Noc noc;
+    CircularBuffer cb_tile_buf(cb_tile);
+    CircularBuffer cb_start_scratch_buf(cb_start_scratch);
+    CircularBuffer cb_counts_scratch_buf(cb_counts_scratch);
+    CircularBuffer cb_global_expert_idx_scratch_buf(cb_global_expert_idx_scratch);
+    const uint32_t cb_tile_bytes = cb_tile_buf.get_tile_size();
     // Index into global_expert_idx_table. The actual global_expert_id is looked
     // up at runtime via global_expert_idx_table[local_expert_id].
     constexpr uint32_t local_expert_id = get_compile_time_arg_val(4);
@@ -72,18 +81,32 @@ void kernel_main() {
     const auto global_expert_idx_accessor = TensorAccessor(global_expert_idx_args, global_expert_idx_table_addr);
 
     // Fetch start, counts, and global_expert_idx_table (small, 1 page each) into L1 scratch.
-    const uint32_t start_l1 = get_write_ptr(cb_start_scratch);
-    const uint32_t counts_l1 = get_write_ptr(cb_counts_scratch);
-    const uint32_t global_expert_idx_l1 = get_write_ptr(cb_global_expert_idx_scratch);
-    noc_async_read_page(0, start_accessor, start_l1);
-    noc_async_read_page(0, counts_accessor, counts_l1);
-    noc_async_read_page(0, global_expert_idx_accessor, global_expert_idx_l1);
-    noc_async_read_barrier();
+    noc.async_read(
+        start_accessor,
+        cb_start_scratch_buf,
+        start_accessor.get_aligned_page_size(),
+        {.page_id = 0},
+        {.offset_bytes = 0});
+    noc.async_read(
+        counts_accessor,
+        cb_counts_scratch_buf,
+        counts_accessor.get_aligned_page_size(),
+        {.page_id = 0},
+        {.offset_bytes = 0});
+    noc.async_read(
+        global_expert_idx_accessor,
+        cb_global_expert_idx_scratch_buf,
+        global_expert_idx_accessor.get_aligned_page_size(),
+        {.page_id = 0},
+        {.offset_bytes = 0});
+    noc.async_read_barrier();
 
-    const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_l1);
-    const volatile tt_l1_ptr uint32_t* counts_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counts_l1);
+    const volatile tt_l1_ptr uint32_t* start_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_start_scratch_buf.get_write_ptr());
+    const volatile tt_l1_ptr uint32_t* counts_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_counts_scratch_buf.get_write_ptr());
     const volatile tt_l1_ptr uint32_t* global_expert_idx_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_expert_idx_l1);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_global_expert_idx_scratch_buf.get_write_ptr());
     // Look up the runtime global_expert_id from the table at local_expert_id.
     const uint32_t global_expert_id = global_expert_idx_ptr[local_expert_id];
     const uint32_t start_value = start_ptr[global_expert_id];
@@ -110,22 +133,23 @@ void kernel_main() {
     const uint32_t my_num_tiles = my_rows * tiles_per_row;
     const uint32_t my_start_tile = start_tile_idx + my_row_start * tiles_per_row;
 
-    const uint32_t tile_bytes = get_tile_size(cb_tile);
-
     uint32_t tile_idx = my_start_tile;
     const uint32_t end_tile_idx = my_start_tile + my_num_tiles;
     while (tile_idx < end_tile_idx) {
         const uint32_t remaining = end_tile_idx - tile_idx;
         const uint32_t batch = remaining < READ_BATCH ? remaining : READ_BATCH;
 
-        cb_reserve_back(cb_tile, batch);
-        uint32_t l1_write_addr = get_write_ptr(cb_tile);
+        cb_tile_buf.reserve_back(batch);
         for (uint32_t i = 0; i < batch; ++i) {
-            noc_async_read_page(tile_idx + i, global_accessor, l1_write_addr);
-            l1_write_addr += tile_bytes;
+            noc.async_read(
+                global_accessor,
+                cb_tile_buf,
+                cb_tile_bytes,
+                {.page_id = tile_idx + i},
+                {.offset_bytes = i * cb_tile_bytes});
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_tile, batch);
+        noc.async_read_barrier();
+        cb_tile_buf.push_back(batch);
 
         tile_idx += batch;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/writer_extract.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/extract/device/kernels/dataflow/writer_extract.cpp
@@ -22,6 +22,8 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/debug/assert.h"
 
 constexpr uint32_t TILE_HEIGHT = 32;
@@ -39,6 +41,12 @@ void kernel_main() {
     constexpr uint32_t cb_tile = get_compile_time_arg_val(0);
     constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(1);
     constexpr uint32_t cb_global_expert_idx_scratch = get_compile_time_arg_val(2);
+
+    Noc noc;
+    CircularBuffer cb_tile_buf(cb_tile);
+    CircularBuffer cb_counts_scratch_buf(cb_counts_scratch);
+    CircularBuffer cb_global_expert_idx_scratch_buf(cb_global_expert_idx_scratch);
+    const uint32_t cb_tile_bytes = cb_tile_buf.get_tile_size();
     // Index into global_expert_idx_table. The actual global_expert_id is looked
     // up at runtime via global_expert_idx_table[local_expert_id].
     constexpr uint32_t local_expert_id = get_compile_time_arg_val(3);
@@ -60,15 +68,24 @@ void kernel_main() {
     const auto global_expert_idx_accessor = TensorAccessor(global_expert_idx_args, global_expert_idx_table_addr);
 
     // Fetch counts and global_expert_idx_table (small, 1 page each) into L1 scratch.
-    const uint32_t counts_l1 = get_write_ptr(cb_counts_scratch);
-    const uint32_t global_expert_idx_l1 = get_write_ptr(cb_global_expert_idx_scratch);
-    noc_async_read_page(0, counts_accessor, counts_l1);
-    noc_async_read_page(0, global_expert_idx_accessor, global_expert_idx_l1);
-    noc_async_read_barrier();
+    noc.async_read(
+        counts_accessor,
+        cb_counts_scratch_buf,
+        counts_accessor.get_aligned_page_size(),
+        {.page_id = 0},
+        {.offset_bytes = 0});
+    noc.async_read(
+        global_expert_idx_accessor,
+        cb_global_expert_idx_scratch_buf,
+        global_expert_idx_accessor.get_aligned_page_size(),
+        {.page_id = 0},
+        {.offset_bytes = 0});
+    noc.async_read_barrier();
 
-    const volatile tt_l1_ptr uint32_t* counts_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counts_l1);
+    const volatile tt_l1_ptr uint32_t* counts_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_counts_scratch_buf.get_write_ptr());
     const volatile tt_l1_ptr uint32_t* global_expert_idx_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_expert_idx_l1);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_global_expert_idx_scratch_buf.get_write_ptr());
     // Look up the runtime global_expert_id from the table at local_expert_id.
     const uint32_t global_expert_id = global_expert_idx_ptr[local_expert_id];
     const uint32_t counts_value = counts_ptr[global_expert_id];
@@ -92,22 +109,23 @@ void kernel_main() {
     const uint32_t my_num_tiles = my_rows * tiles_per_row;
     const uint32_t my_start_tile = my_row_start * tiles_per_row;
 
-    const uint32_t tile_bytes = get_tile_size(cb_tile);
-
     uint32_t tile_idx = my_start_tile;
     const uint32_t end_tile_idx = my_start_tile + my_num_tiles;
     while (tile_idx < end_tile_idx) {
         const uint32_t remaining = end_tile_idx - tile_idx;
         const uint32_t batch = remaining < WRITE_BATCH ? remaining : WRITE_BATCH;
 
-        cb_wait_front(cb_tile, batch);
-        uint32_t l1_read_addr = get_read_ptr(cb_tile);
+        cb_tile_buf.wait_front(batch);
         for (uint32_t i = 0; i < batch; ++i) {
-            noc_async_write_page(tile_idx + i, output_accessor, l1_read_addr);
-            l1_read_addr += tile_bytes;
+            noc.async_write(
+                cb_tile_buf,
+                output_accessor,
+                cb_tile_bytes,
+                {.offset_bytes = i * cb_tile_bytes},
+                {.page_id = tile_idx + i});
         }
-        noc_async_write_barrier();
-        cb_pop_front(cb_tile, batch);
+        noc.async_write_barrier();
+        cb_tile_buf.pop_front(batch);
 
         tile_idx += batch;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/reader_insert.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/reader_insert.cpp
@@ -20,6 +20,8 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/debug/assert.h"
 
 constexpr uint32_t TILE_HEIGHT = 32;
@@ -37,6 +39,12 @@ void kernel_main() {
     constexpr uint32_t cb_tile = get_compile_time_arg_val(0);
     constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(1);
     constexpr uint32_t cb_global_expert_idx_scratch = get_compile_time_arg_val(2);
+
+    Noc noc;
+    CircularBuffer cb_tile_buf(cb_tile);
+    CircularBuffer cb_counts_scratch_buf(cb_counts_scratch);
+    CircularBuffer cb_global_expert_idx_scratch_buf(cb_global_expert_idx_scratch);
+    const uint32_t cb_tile_bytes = cb_tile_buf.get_tile_size();
     // Index into global_expert_idx_table. The actual global_expert_id is looked
     // up at runtime via global_expert_idx_table[local_expert_id].
     constexpr uint32_t local_expert_id = get_compile_time_arg_val(3);
@@ -57,15 +65,24 @@ void kernel_main() {
     const auto global_expert_idx_accessor = TensorAccessor(global_expert_idx_args, global_expert_idx_table_addr);
 
     // Fetch counts and global_expert_idx_table (small, 1 page each) into L1 scratch.
-    const uint32_t counts_l1 = get_write_ptr(cb_counts_scratch);
-    const uint32_t global_expert_idx_l1 = get_write_ptr(cb_global_expert_idx_scratch);
-    noc_async_read_page(0, counts_accessor, counts_l1);
-    noc_async_read_page(0, global_expert_idx_accessor, global_expert_idx_l1);
-    noc_async_read_barrier();
+    noc.async_read(
+        counts_accessor,
+        cb_counts_scratch_buf,
+        counts_accessor.get_aligned_page_size(),
+        {.page_id = 0},
+        {.offset_bytes = 0});
+    noc.async_read(
+        global_expert_idx_accessor,
+        cb_global_expert_idx_scratch_buf,
+        global_expert_idx_accessor.get_aligned_page_size(),
+        {.page_id = 0},
+        {.offset_bytes = 0});
+    noc.async_read_barrier();
 
-    const volatile tt_l1_ptr uint32_t* counts_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counts_l1);
+    const volatile tt_l1_ptr uint32_t* counts_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_counts_scratch_buf.get_write_ptr());
     const volatile tt_l1_ptr uint32_t* global_expert_idx_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_expert_idx_l1);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_global_expert_idx_scratch_buf.get_write_ptr());
     // Look up the runtime global_expert_id from the table at local_expert_id.
     const uint32_t global_expert_id = global_expert_idx_ptr[local_expert_id];
     const uint32_t counts_value = counts_ptr[global_expert_id];
@@ -87,22 +104,23 @@ void kernel_main() {
     const uint32_t my_num_tiles = my_rows * tiles_per_row;
     const uint32_t my_start_tile = my_row_start * tiles_per_row;
 
-    const uint32_t tile_bytes = get_tile_size(cb_tile);
-
     uint32_t tile_idx = my_start_tile;
     const uint32_t end_tile_idx = my_start_tile + my_num_tiles;
     while (tile_idx < end_tile_idx) {
         const uint32_t remaining = end_tile_idx - tile_idx;
         const uint32_t batch = remaining < READ_BATCH ? remaining : READ_BATCH;
 
-        cb_reserve_back(cb_tile, batch);
-        uint32_t l1_write_addr = get_write_ptr(cb_tile);
+        cb_tile_buf.reserve_back(batch);
         for (uint32_t i = 0; i < batch; ++i) {
-            noc_async_read_page(tile_idx + i, local_accessor, l1_write_addr);
-            l1_write_addr += tile_bytes;
+            noc.async_read(
+                local_accessor,
+                cb_tile_buf,
+                cb_tile_bytes,
+                {.page_id = tile_idx + i},
+                {.offset_bytes = i * cb_tile_bytes});
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_tile, batch);
+        noc.async_read_barrier();
+        cb_tile_buf.push_back(batch);
 
         tile_idx += batch;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/writer_insert.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/insert/device/kernels/dataflow/writer_insert.cpp
@@ -21,6 +21,8 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include "api/debug/assert.h"
 
 constexpr uint32_t TILE_HEIGHT = 32;
@@ -40,6 +42,13 @@ void kernel_main() {
     constexpr uint32_t cb_start_scratch = get_compile_time_arg_val(1);
     constexpr uint32_t cb_counts_scratch = get_compile_time_arg_val(2);
     constexpr uint32_t cb_global_expert_idx_scratch = get_compile_time_arg_val(3);
+
+    Noc noc;
+    CircularBuffer cb_tile_buf(cb_tile);
+    CircularBuffer cb_start_scratch_buf(cb_start_scratch);
+    CircularBuffer cb_counts_scratch_buf(cb_counts_scratch);
+    CircularBuffer cb_global_expert_idx_scratch_buf(cb_global_expert_idx_scratch);
+    const uint32_t cb_tile_bytes = cb_tile_buf.get_tile_size();
     // Index into global_expert_idx_table. The actual global_expert_id is looked
     // up at runtime via global_expert_idx_table[local_expert_id].
     constexpr uint32_t local_expert_id = get_compile_time_arg_val(4);
@@ -64,18 +73,32 @@ void kernel_main() {
     const auto global_expert_idx_accessor = TensorAccessor(global_expert_idx_args, global_expert_idx_table_addr);
 
     // Fetch start, counts, and global_expert_idx_table (small, 1 page each) into L1 scratch.
-    const uint32_t start_l1 = get_write_ptr(cb_start_scratch);
-    const uint32_t counts_l1 = get_write_ptr(cb_counts_scratch);
-    const uint32_t global_expert_idx_l1 = get_write_ptr(cb_global_expert_idx_scratch);
-    noc_async_read_page(0, start_accessor, start_l1);
-    noc_async_read_page(0, counts_accessor, counts_l1);
-    noc_async_read_page(0, global_expert_idx_accessor, global_expert_idx_l1);
-    noc_async_read_barrier();
+    noc.async_read(
+        start_accessor,
+        cb_start_scratch_buf,
+        start_accessor.get_aligned_page_size(),
+        {.page_id = 0},
+        {.offset_bytes = 0});
+    noc.async_read(
+        counts_accessor,
+        cb_counts_scratch_buf,
+        counts_accessor.get_aligned_page_size(),
+        {.page_id = 0},
+        {.offset_bytes = 0});
+    noc.async_read(
+        global_expert_idx_accessor,
+        cb_global_expert_idx_scratch_buf,
+        global_expert_idx_accessor.get_aligned_page_size(),
+        {.page_id = 0},
+        {.offset_bytes = 0});
+    noc.async_read_barrier();
 
-    const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_l1);
-    const volatile tt_l1_ptr uint32_t* counts_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counts_l1);
+    const volatile tt_l1_ptr uint32_t* start_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_start_scratch_buf.get_write_ptr());
+    const volatile tt_l1_ptr uint32_t* counts_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_counts_scratch_buf.get_write_ptr());
     const volatile tt_l1_ptr uint32_t* global_expert_idx_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(global_expert_idx_l1);
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_global_expert_idx_scratch_buf.get_write_ptr());
     // Look up the runtime global_expert_id from the table at local_expert_id.
     const uint32_t global_expert_id = global_expert_idx_ptr[local_expert_id];
     const uint32_t start_value = start_ptr[global_expert_id];
@@ -100,21 +123,22 @@ void kernel_main() {
     const uint32_t my_num_tiles = my_rows * tiles_per_row;
     const uint32_t my_dst_start = start_tile_idx + my_row_start * tiles_per_row;
 
-    const uint32_t tile_bytes = get_tile_size(cb_tile);
-
     uint32_t offset = 0;
     while (offset < my_num_tiles) {
         const uint32_t remaining = my_num_tiles - offset;
         const uint32_t batch = remaining < WRITE_BATCH ? remaining : WRITE_BATCH;
 
-        cb_wait_front(cb_tile, batch);
-        uint32_t l1_read_addr = get_read_ptr(cb_tile);
+        cb_tile_buf.wait_front(batch);
         for (uint32_t i = 0; i < batch; ++i) {
-            noc_async_write_page(my_dst_start + offset + i, global_accessor, l1_read_addr);
-            l1_read_addr += tile_bytes;
+            noc.async_write(
+                cb_tile_buf,
+                global_accessor,
+                cb_tile_bytes,
+                {.offset_bytes = i * cb_tile_bytes},
+                {.page_id = my_dst_start + offset + i});
         }
-        noc_async_write_barrier();
-        cb_pop_front(cb_tile, batch);
+        noc.async_write_barrier();
+        cb_tile_buf.pop_front(batch);
 
         offset += batch;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
@@ -93,9 +93,14 @@ void kernel_main() {
     constexpr auto mask_args_ct = TensorAccessorArgs<mask_accessor_offset>();
     const auto mask_accessor = TensorAccessor(mask_args_ct, mask_addr);
 
-    uint32_t in_base_addr = get_write_ptr(cb_id_in);
-    uint32_t out_addr = get_write_ptr(cb_id_out);
-    uint32_t mask_l1_addr = get_write_ptr(cb_mask);
+    CircularBuffer cb_in(cb_id_in);
+    CircularBuffer cb_out(cb_id_out);
+    CircularBuffer cb_mask_obj(cb_mask);
+    CircularBuffer cb_gather_tmp_obj(cb_gather_tmp);
+
+    uint32_t in_base_addr = cb_in.get_write_ptr();
+    uint32_t out_addr = cb_out.get_write_ptr();
+    uint32_t mask_l1_addr = cb_mask_obj.get_write_ptr();
 
     // Phase 1: Read this core's shard pages
     for (uint32_t h = 0; h < h_count; h++) {
@@ -163,7 +168,7 @@ void kernel_main() {
 
         Semaphore<> gather_sem(gather_sem_idx);
 
-        uint32_t tmp_addr = get_write_ptr(cb_gather_tmp);
+        uint32_t tmp_addr = cb_gather_tmp_obj.get_write_ptr();
         volatile tt_l1_ptr uint32_t* local_hist = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_addr);
 
         // Wait for ALL children to signal before reading any.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/kernels/reader_masked_bincount.cpp
@@ -52,8 +52,15 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 
 void kernel_main() {
+    Noc noc;
+
     uint32_t src_addr = get_arg_val<uint32_t>(0);
     uint32_t dst_addr = get_arg_val<uint32_t>(1);
     uint32_t mask_addr = get_arg_val<uint32_t>(2);
@@ -72,6 +79,7 @@ void kernel_main() {
     constexpr uint32_t gather_sem_idx = get_compile_time_arg_val(10);
     constexpr uint32_t cb_gather_tmp = get_compile_time_arg_val(11);
     constexpr uint32_t cb_mask = get_compile_time_arg_val(15);
+    constexpr uint32_t mask_page_size = get_compile_time_arg_val(16);
 
     constexpr uint32_t src_accessor_offset = 17;
     constexpr auto src_args = TensorAccessorArgs<src_accessor_offset>();
@@ -91,57 +99,69 @@ void kernel_main() {
 
     // Phase 1: Read this core's shard pages
     for (uint32_t h = 0; h < h_count; h++) {
-        noc_async_read_page(h_start + h, src_accessor, in_base_addr + h * input_page_size);
+        noc.async_read(
+            src_accessor,
+            CoreLocalMem<uint32_t>(in_base_addr + h * input_page_size),
+            input_page_size,
+            {.page_id = h_start + h},
+            {});
     }
 
     // Phase 2: Local histogram counting (BRISC/NCRISC cooperate on same core)
-    uint32_t init_sem_addr = get_semaphore(init_sem_idx);
-    volatile tt_l1_ptr uint32_t* init_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(init_sem_addr);
+    Semaphore<> init_sem(init_sem_idx);
 
     if constexpr (is_initializer) {
         volatile tt_l1_ptr uint32_t* counts = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_addr);
         for (uint32_t i = 0; i < n_routed_experts; i++) {
             counts[i] = 0;
         }
-        noc_async_read_page(0, mask_accessor, mask_l1_addr);
-        noc_async_read_barrier();
-        noc_semaphore_set(init_sem_ptr, 1);
+        noc.async_read(mask_accessor, CoreLocalMem<uint32_t>(mask_l1_addr), mask_page_size, {.page_id = 0}, {});
+        noc.async_read_barrier();
+        init_sem.set(1);
     } else {
-        noc_async_read_barrier();
-        noc_semaphore_wait(init_sem_ptr, 1);
+        noc.async_read_barrier();
+        init_sem.wait(1);
     }
 
     volatile tt_l1_ptr int32_t* mask = reinterpret_cast<volatile tt_l1_ptr int32_t*>(mask_l1_addr);
 
+    const uint8_t my_noc_id = noc.get_noc_id();
+    const uint32_t my_noc_x = my_x[my_noc_id];
+    const uint32_t my_noc_y = my_y[my_noc_id];
     for (uint32_t h = 0; h < h_count; h++) {
         volatile tt_l1_ptr uint16_t* row =
             reinterpret_cast<volatile tt_l1_ptr uint16_t*>(in_base_addr + h * input_page_size);
         for (uint32_t w = 0; w < num_experts_per_token; w++) {
             uint32_t expert_idx = row[w];
             if (expert_idx < n_routed_experts && mask[expert_idx] >= 0) {
-                uint64_t noc_addr = get_noc_addr(out_addr + expert_idx * sizeof(uint32_t));
+                // TODO: D2.0 has no wrapper for atomic-increment on an arbitrary L1 word
+                // (the target here is a histogram bin, not a registered semaphore). The
+                // NoC atomic-inc primitive is exposed only via Semaphore<>::up(noc, x, y, val),
+                // which resolves a semaphore-id to an L1 address. Keeping the legacy free
+                // function for this specific case is documented as an acceptable fallback.
+                uint64_t noc_addr = get_noc_addr(my_noc_x, my_noc_y, out_addr + expert_idx * sizeof(uint32_t));
                 noc_semaphore_inc(noc_addr, 1);
             }
         }
     }
-    noc_async_atomic_barrier();
+    noc.async_atomic_barrier();
 
-    uint32_t done_sem_addr = get_semaphore(done_sem_idx);
-    uint64_t done_sem_noc_addr = get_noc_addr(done_sem_addr);
-    noc_semaphore_inc(done_sem_noc_addr, 1);
-    noc_async_atomic_barrier();
+    // Atomically bump the local done_sem on this core. up(noc, x, y, val) performs a NoC
+    // atomic increment even when the target is the current core, which is needed because
+    // BRISC and NCRISC both increment the same semaphore.
+    Semaphore<> done_sem(done_sem_idx);
+    done_sem.up(noc, my_noc_x, my_noc_y, 1);
+    noc.async_atomic_barrier();
 
     // Phase 3: Tree reduction — BRISC only
     if constexpr (is_initializer) {
-        volatile tt_l1_ptr uint32_t* done_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(done_sem_addr);
-        noc_semaphore_wait_min(done_sem_ptr, 2);
+        done_sem.wait_min(2);
 
         uint32_t num_receive = get_arg_val<uint32_t>(4);
         uint32_t parent_noc_x = get_arg_val<uint32_t>(5);
         uint32_t parent_noc_y = get_arg_val<uint32_t>(6);
 
-        uint32_t gather_sem_addr = get_semaphore(gather_sem_idx);
-        volatile tt_l1_ptr uint32_t* gather_sem_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(gather_sem_addr);
+        Semaphore<> gather_sem(gather_sem_idx);
 
         uint32_t tmp_addr = get_write_ptr(cb_gather_tmp);
         volatile tt_l1_ptr uint32_t* local_hist = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_addr);
@@ -150,14 +170,18 @@ void kernel_main() {
         // A single gather_sem counter does not identify WHICH child signaled,
         // so we must wait for all num_receive increments to guarantee every
         // child's histogram is finalized before reading.
-        noc_semaphore_wait_min(gather_sem_ptr, num_receive);
+        gather_sem.wait_min(num_receive);
         for (uint32_t level = 0; level < num_receive; level++) {
             uint32_t child_noc_x = get_arg_val<uint32_t>(7 + level * 2);
             uint32_t child_noc_y = get_arg_val<uint32_t>(7 + level * 2 + 1);
 
-            uint64_t child_hist_noc = get_noc_addr(child_noc_x, child_noc_y, out_addr);
-            noc_async_read(child_hist_noc, tmp_addr, output_page_size);
-            noc_async_read_barrier();
+            noc.async_read(
+                UnicastEndpoint{},
+                CoreLocalMem<uint32_t>(tmp_addr),
+                output_page_size,
+                {.noc_x = child_noc_x, .noc_y = child_noc_y, .addr = out_addr},
+                {});
+            noc.async_read_barrier();
 
             volatile tt_l1_ptr uint32_t* remote_hist = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(tmp_addr);
             for (uint32_t i = 0; i < n_routed_experts; i++) {
@@ -166,13 +190,12 @@ void kernel_main() {
         }
 
         if (parent_noc_x != 0xFFFFFFFF) {
-            uint64_t parent_gather_noc = get_noc_addr(parent_noc_x, parent_noc_y, gather_sem_addr);
-            noc_semaphore_inc(parent_gather_noc, 1);
-            noc_async_atomic_barrier();
+            // Bump parent's gather_sem (a real semaphore id resolved on each core).
+            gather_sem.up(noc, parent_noc_x, parent_noc_y, 1);
+            noc.async_atomic_barrier();
         } else {
-            uint64_t dst_noc_addr = dst_accessor.get_noc_addr(0);
-            noc_async_write(out_addr, dst_noc_addr, output_page_size);
-            noc_async_write_barrier();
+            noc.async_write(CoreLocalMem<uint32_t>(out_addr), dst_accessor, output_page_size, {}, {.page_id = 0});
+            noc.async_write_barrier();
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/compute/moe_grouped_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/compute/moe_grouped_topk.cpp
@@ -18,108 +18,119 @@
 #include "api/compute/eltwise_unary/recip.h"
 #include "api/compute/bcast.h"
 #include "api/compute/eltwise_binary_sfpu.h"
+#include "api/dataflow/circular_buffer.h"
 
 namespace blocks {
-void sigmoid(uint32_t cb_in_scores, uint32_t cb_sigmoid_scores, uint32_t width_tiles) {
+void sigmoid(uint32_t cb_in_scores_id, uint32_t cb_sigmoid_scores_id, uint32_t width_tiles) {
+    CircularBuffer cb_in_scores(cb_in_scores_id);
+    CircularBuffer cb_sigmoid_scores(cb_sigmoid_scores_id);
     // Perform sigmoid on scores
     // Reconfigure pack/unpack for float32 after topk operations used UInt16
     for (uint32_t width_tile = 0; width_tile < width_tiles; width_tile++) {
-        cb_wait_front(cb_in_scores, 1);
+        cb_in_scores.wait_front(1);
         tile_regs_acquire();
-        reconfig_data_format_srca(cb_in_scores);
+        reconfig_data_format_srca(cb_in_scores_id);
         // copy tile from scores cb to destination register 0
-        copy_tile_to_dst_init_short(cb_in_scores);
-        copy_tile(cb_in_scores, 0, 0);
+        copy_tile_to_dst_init_short(cb_in_scores_id);
+        copy_tile(cb_in_scores_id, 0, 0);
         // perform sigmoid on tile
         sigmoid_tile_init();
         sigmoid_tile(0);
         tile_regs_commit();
-        cb_pop_front(cb_in_scores, 1);
+        cb_in_scores.pop_front(1);
 
-        cb_reserve_back(cb_sigmoid_scores, 1);
+        cb_sigmoid_scores.reserve_back(1);
         tile_regs_wait();
-        pack_reconfig_data_format(cb_sigmoid_scores);
-        pack_tile(0, cb_sigmoid_scores);
+        pack_reconfig_data_format(cb_sigmoid_scores_id);
+        pack_tile(0, cb_sigmoid_scores_id);
         tile_regs_release();
-        cb_push_back(cb_sigmoid_scores, 1);
+        cb_sigmoid_scores.push_back(1);
     }
 }
 
-void add_bias(uint32_t cb_sigmoid_scores, uint32_t cb_in_bias, uint32_t cb_biased_scores, uint32_t width_tiles) {
+void add_bias(
+    uint32_t cb_sigmoid_scores_id, uint32_t cb_in_bias_id, uint32_t cb_biased_scores_id, uint32_t width_tiles) {
+    CircularBuffer cb_sigmoid_scores(cb_sigmoid_scores_id);
+    CircularBuffer cb_in_bias(cb_in_bias_id);
+    CircularBuffer cb_biased_scores(cb_biased_scores_id);
     // Perform add bias on sigmoid scores
-    add_tiles_init(cb_sigmoid_scores, cb_in_bias, false);
-    cb_wait_front(cb_sigmoid_scores, width_tiles);
+    add_tiles_init(cb_sigmoid_scores_id, cb_in_bias_id, false);
+    cb_sigmoid_scores.wait_front(width_tiles);
     for (uint32_t width_tile = 0; width_tile < width_tiles; width_tile++) {
-        cb_wait_front(cb_in_bias, 1);
+        cb_in_bias.wait_front(1);
         tile_regs_acquire();
-        add_tiles(cb_sigmoid_scores, cb_in_bias, width_tile, 0, 0);
+        add_tiles(cb_sigmoid_scores_id, cb_in_bias_id, width_tile, 0, 0);
         tile_regs_commit();
-        cb_pop_front(cb_in_bias, 1);
+        cb_in_bias.pop_front(1);
 
-        cb_reserve_back(cb_biased_scores, 1);
+        cb_biased_scores.reserve_back(1);
         tile_regs_wait();
-        pack_reconfig_data_format(cb_biased_scores);
-        pack_tile(0, cb_biased_scores);
+        pack_reconfig_data_format(cb_biased_scores_id);
+        pack_tile(0, cb_biased_scores_id);
         tile_regs_release();
-        cb_push_back(cb_biased_scores, 1);
+        cb_biased_scores.push_back(1);
     }
 }
 
 template <bool stable_sort = false>
 void process_and_sort_tiles(
-    uint32_t cb_biased_scores,
-    uint32_t cb_expert_index_template,
-    uint32_t cb_sorted_group_scores,
-    uint32_t cb_sorted_expert_indices_temp,
+    uint32_t cb_biased_scores_id,
+    uint32_t cb_expert_index_template_id,
+    uint32_t cb_sorted_group_scores_id,
+    uint32_t cb_sorted_expert_indices_temp_id,
     uint32_t Wt,
     bool switch_dir,
     bool ascending,
     int end_phase) {
+    CircularBuffer cb_biased_scores(cb_biased_scores_id);
+    CircularBuffer cb_expert_index_template(cb_expert_index_template_id);
+    CircularBuffer cb_sorted_group_scores(cb_sorted_group_scores_id);
+    CircularBuffer cb_sorted_expert_indices_temp(cb_sorted_expert_indices_temp_id);
     topk_tile_init();
     // streaming in input and index tiles to transpose and bitonic local sort them, two tiles at a time
-    cb_wait_front(cb_expert_index_template, Wt);
-    cb_wait_front(cb_biased_scores, Wt);
+    cb_expert_index_template.wait_front(Wt);
+    cb_biased_scores.wait_front(Wt);
     for (uint32_t wt = 0; wt < Wt; wt += 2) {
         tile_regs_acquire();
         // transpose and unpack into dest regs
-        reconfig_data_format_srca(cb_biased_scores);
-        transpose_wh_init_short(cb_biased_scores);
-        transpose_wh_tile(cb_biased_scores, wt, 0);
-        transpose_wh_tile(cb_biased_scores, wt + 1, 1);
+        reconfig_data_format_srca(cb_biased_scores_id);
+        transpose_wh_init_short(cb_biased_scores_id);
+        transpose_wh_tile(cb_biased_scores_id, wt, 0);
+        transpose_wh_tile(cb_biased_scores_id, wt + 1, 1);
 
         // transpose and unpack into dest regs
-        reconfig_data_format_srca(cb_expert_index_template);
-        transpose_wh_init_short(cb_expert_index_template);
-        transpose_wh_tile(cb_expert_index_template, wt, 2);
-        transpose_wh_tile(cb_expert_index_template, wt + 1, 3);
+        reconfig_data_format_srca(cb_expert_index_template_id);
+        transpose_wh_init_short(cb_expert_index_template_id);
+        transpose_wh_tile(cb_expert_index_template_id, wt, 2);
+        transpose_wh_tile(cb_expert_index_template_id, wt + 1, 3);
 
         // llk_topk_sort -> inplace
         ckernel::topk_local_sort<stable_sort>(0, (int)ascending, end_phase);
 
         // pack sorted score tiles
-        pack_reconfig_data_format(cb_sorted_group_scores);
-        cb_reserve_back(cb_sorted_group_scores, 1);
+        pack_reconfig_data_format(cb_sorted_group_scores_id);
+        cb_sorted_group_scores.reserve_back(1);
         tile_regs_commit();
         tile_regs_wait();
-        pack_tile(0, cb_sorted_group_scores);
-        cb_push_back(cb_sorted_group_scores, 1);
+        pack_tile(0, cb_sorted_group_scores_id);
+        cb_sorted_group_scores.push_back(1);
 
-        cb_reserve_back(cb_sorted_group_scores, 1);
-        pack_tile(1, cb_sorted_group_scores);
-        cb_push_back(cb_sorted_group_scores, 1);
+        cb_sorted_group_scores.reserve_back(1);
+        pack_tile(1, cb_sorted_group_scores_id);
+        cb_sorted_group_scores.push_back(1);
 
         // pack sorted index tiles
-        pack_reconfig_data_format(cb_sorted_expert_indices_temp);
-        cb_reserve_back(cb_sorted_expert_indices_temp, 1);
-        pack_tile(2, cb_sorted_expert_indices_temp);
-        cb_push_back(cb_sorted_expert_indices_temp, 1);
+        pack_reconfig_data_format(cb_sorted_expert_indices_temp_id);
+        cb_sorted_expert_indices_temp.reserve_back(1);
+        pack_tile(2, cb_sorted_expert_indices_temp_id);
+        cb_sorted_expert_indices_temp.push_back(1);
 
-        cb_reserve_back(cb_sorted_expert_indices_temp, 1);
-        pack_tile(3, cb_sorted_expert_indices_temp);
-        cb_push_back(cb_sorted_expert_indices_temp, 1);
+        cb_sorted_expert_indices_temp.reserve_back(1);
+        pack_tile(3, cb_sorted_expert_indices_temp_id);
+        cb_sorted_expert_indices_temp.push_back(1);
 
-        cb_wait_front(cb_sorted_expert_indices_temp, 2);
-        cb_pop_front(cb_sorted_expert_indices_temp, 2);
+        cb_sorted_expert_indices_temp.wait_front(2);
+        cb_sorted_expert_indices_temp.pop_front(2);
 
         tile_regs_release();
         ascending = switch_dir ? !ascending : ascending;
@@ -127,49 +138,56 @@ void process_and_sort_tiles(
 }
 
 void sum_top_experts_per_group(
-    const uint32_t cb_top_experts_per_group, const uint32_t cb_group_summed_scores, uint32_t summed_experts_per_group) {
+    const uint32_t cb_top_experts_per_group_id,
+    const uint32_t cb_group_summed_scores_id,
+    uint32_t summed_experts_per_group) {
+    CircularBuffer cb_top_experts_per_group(cb_top_experts_per_group_id);
+    CircularBuffer cb_group_summed_scores(cb_group_summed_scores_id);
     // sum the top experts_per_group rows for each group
-    binary_op_init_common(cb_top_experts_per_group, cb_top_experts_per_group, cb_group_summed_scores);
-    add_tiles_init(cb_top_experts_per_group, cb_top_experts_per_group, true);
-    cb_wait_front(cb_top_experts_per_group, summed_experts_per_group);
+    binary_op_init_common(cb_top_experts_per_group_id, cb_top_experts_per_group_id, cb_group_summed_scores_id);
+    add_tiles_init(cb_top_experts_per_group_id, cb_top_experts_per_group_id, true);
+    cb_top_experts_per_group.wait_front(summed_experts_per_group);
 
-    cb_reserve_back(cb_group_summed_scores, 1);
+    cb_group_summed_scores.reserve_back(1);
     tile_regs_acquire();
     for (uint32_t i = 0; i < summed_experts_per_group; i += 2) {
-        add_tiles(cb_top_experts_per_group, cb_top_experts_per_group, i, i + 1, 0);
+        add_tiles(cb_top_experts_per_group_id, cb_top_experts_per_group_id, i, i + 1, 0);
     }
     tile_regs_commit();
     tile_regs_wait();
-    pack_reconfig_data_format(cb_group_summed_scores);
-    pack_tile(0, cb_group_summed_scores);
+    pack_reconfig_data_format(cb_group_summed_scores_id);
+    pack_tile(0, cb_group_summed_scores_id);
     tile_regs_release();
 
-    cb_push_back(cb_group_summed_scores, 1);
-    cb_pop_front(cb_top_experts_per_group, summed_experts_per_group);
+    cb_group_summed_scores.push_back(1);
+    cb_top_experts_per_group.pop_front(summed_experts_per_group);
 }
 
 template <bool stable_sort = false>
 void topk_group_scores(
-    const uint32_t cb_group_summed_scores,
-    const uint32_t cb_group_index_template,
-    const uint32_t cb_sorted_group_order,
+    const uint32_t cb_group_summed_scores_id,
+    const uint32_t cb_group_index_template_id,
+    const uint32_t cb_sorted_group_order_id,
     bool switch_dir,
     bool ascending,
     int log_topk_groups) {
+    CircularBuffer cb_group_summed_scores(cb_group_summed_scores_id);
+    CircularBuffer cb_group_index_template(cb_group_index_template_id);
+    CircularBuffer cb_sorted_group_order(cb_sorted_group_order_id);
     topk_tile_init();
-    cb_reserve_back(cb_sorted_group_order, 1);
+    cb_sorted_group_order.reserve_back(1);
 
     // Sort single input and index tile that have already ben transposed.
     tile_regs_acquire();
     // local sort into k groups
-    cb_wait_front(cb_group_summed_scores, 1);
-    cb_wait_front(cb_group_index_template, 1);
+    cb_group_summed_scores.wait_front(1);
+    cb_group_index_template.wait_front(1);
 
     // copy scores tiles to dest reg 0 and index tiles to dest reg 2
-    copy_tile_to_dst_init_short(cb_group_summed_scores);
-    copy_tile(cb_group_summed_scores, 0, 0);
-    copy_tile_to_dst_init_short_with_dt(cb_group_summed_scores, cb_group_index_template);
-    copy_tile(cb_group_index_template, 0, 2);
+    copy_tile_to_dst_init_short(cb_group_summed_scores_id);
+    copy_tile(cb_group_summed_scores_id, 0, 0);
+    copy_tile_to_dst_init_short_with_dt(cb_group_summed_scores_id, cb_group_index_template_id);
+    copy_tile(cb_group_index_template_id, 0, 2);
 
     // llk_topk_sort -> inplace
     ckernel::topk_local_sort<stable_sort>(0, (int)ascending, log_topk_groups);
@@ -177,66 +195,71 @@ void topk_group_scores(
     tile_regs_commit();
     tile_regs_wait();
     // pack index tile into cb_sorted_group_order
-    pack_reconfig_data_format(cb_sorted_group_order);
-    pack_tile(2, cb_sorted_group_order);
-    cb_pop_front(cb_group_summed_scores, 1);
+    pack_reconfig_data_format(cb_sorted_group_order_id);
+    pack_tile(2, cb_sorted_group_order_id);
+    cb_group_summed_scores.pop_front(1);
     // don't pop group indices as it gets reused for the next tile heights
     tile_regs_release();
 
-    cb_push_back(cb_sorted_group_order, 1);
+    cb_sorted_group_order.push_back(1);
 }
 
 void transpose_and_pack(const uint32_t input_cb_index, const uint32_t output_cb_index, const uint32_t tiles) {
+    CircularBuffer input_cb(input_cb_index);
+    CircularBuffer output_cb(output_cb_index);
     reconfig_data_format_srca(input_cb_index);
     transpose_wh_init_short(input_cb_index);
     pack_reconfig_data_format(output_cb_index);
     for (uint32_t i = 0; i < tiles; i++) {
         tile_regs_acquire();
-        cb_wait_front(input_cb_index, 1);
+        input_cb.wait_front(1);
         transpose_wh_tile(input_cb_index, 0, 0);
         tile_regs_commit();
         tile_regs_wait();
-        cb_reserve_back(output_cb_index, 1);
+        output_cb.reserve_back(1);
 
         pack_tile(0, output_cb_index);
         tile_regs_release();
-        cb_push_back(output_cb_index, 1);
+        output_cb.push_back(1);
 
-        cb_pop_front(input_cb_index, 1);
+        input_cb.pop_front(1);
     }
 }
 
 template <bool stable_sort = false>
 void topk(
-    const uint32_t cb_winning_group_scores,
-    const uint32_t cb_winning_group_indices,
-    const uint32_t cb_final_indices_transposed,
-    const uint32_t cb_out_indices,
+    const uint32_t cb_winning_group_scores_id,
+    const uint32_t cb_winning_group_indices_id,
+    const uint32_t cb_final_indices_transposed_id,
+    const uint32_t cb_out_indices_id,
     const uint32_t tiles,
     const uint32_t log_tiles,
     const uint32_t k,
     const uint32_t logk) {
+    CircularBuffer cb_winning_group_scores(cb_winning_group_scores_id);
+    CircularBuffer cb_winning_group_indices(cb_winning_group_indices_id);
+    CircularBuffer cb_final_indices_transposed(cb_final_indices_transposed_id);
     bool switch_dir = (k == 64);
     bool ascending = false;
     int end_phase = (tiles <= 2) ? log_tiles - 1 : 5;
 
     topk_tile_init();
     tile_regs_acquire();
-    cb_wait_front(cb_winning_group_scores, tiles);
-    cb_wait_front(cb_winning_group_indices, tiles);
+    cb_winning_group_scores.wait_front(tiles);
+    cb_winning_group_indices.wait_front(tiles);
     // local sort first two tiles:
 
     // transpose and unpack into dest regs
-    reconfig_data_format_srca(cb_winning_group_scores);
-    transpose_wh_init_short(cb_winning_group_scores);
-    transpose_wh_tile(cb_winning_group_scores, 0, 0);
-    transpose_wh_tile(cb_winning_group_scores, 1, 1);
+    reconfig_data_format_srca(cb_winning_group_scores_id);
+    transpose_wh_init_short(cb_winning_group_scores_id);
+    transpose_wh_tile(cb_winning_group_scores_id, 0, 0);
+    transpose_wh_tile(cb_winning_group_scores_id, 1, 1);
 
     // transpose and unpack into dest regs
-    reconfig_data_format_srca(cb_winning_group_indices);
-    transpose_wh_init_short(cb_winning_group_indices);
-    transpose_wh_tile(cb_winning_group_indices, 0, 2);
-    transpose_wh_tile(cb_winning_group_indices, 1, 3);
+    reconfig_data_format_srca(cb_winning_group_indices_id);
+    transpose_wh_init_short(cb_winning_group_indices_id);
+    transpose_wh_tile(cb_winning_group_indices_id, 0, 2);
+    transpose_wh_tile(cb_winning_group_indices_id, 1, 3);
     // llk_topk_sort -> inplace
     ckernel::topk_local_sort<stable_sort>(0, (int)ascending, 4);
     ckernel::topk_merge<false, stable_sort>(0, 0, 32);
@@ -244,13 +267,13 @@ void topk(
     // Use insertion sort; discard lower half and keep upper half
     // Compare upper half with the next tile; insert into correct position
     for (uint32_t j = 2; j < tiles; j++) {
-        reconfig_data_format_srca(cb_winning_group_scores);
-        transpose_wh_init_short(cb_winning_group_scores);
-        transpose_wh_tile(cb_winning_group_scores, j, 1);
+        reconfig_data_format_srca(cb_winning_group_scores_id);
+        transpose_wh_init_short(cb_winning_group_scores_id);
+        transpose_wh_tile(cb_winning_group_scores_id, j, 1);
 
-        reconfig_data_format_srca(cb_winning_group_indices);
-        transpose_wh_init_short(cb_winning_group_indices);
-        transpose_wh_tile(cb_winning_group_indices, j, 3);
+        reconfig_data_format_srca(cb_winning_group_indices_id);
+        transpose_wh_init_short(cb_winning_group_indices_id);
+        transpose_wh_tile(cb_winning_group_indices_id, j, 3);
 
         ckernel::topk_local_sort<stable_sort>(0, (int)ascending, 4);
         ckernel::topk_merge<false, stable_sort>(0, 0, 32);
@@ -258,106 +281,117 @@ void topk(
     ckernel::topk_rebuild<stable_sort>(0, (int)ascending, 0, 32, 5, true);
     tile_regs_commit();
     tile_regs_wait();
-    cb_reserve_back(cb_final_indices_transposed, 1);
-    pack_reconfig_data_format(cb_final_indices_transposed);
-    pack_tile(2, cb_final_indices_transposed);
+    cb_final_indices_transposed.reserve_back(1);
+    pack_reconfig_data_format(cb_final_indices_transposed_id);
+    pack_tile(2, cb_final_indices_transposed_id);
     tile_regs_release();
-    cb_push_back(cb_final_indices_transposed, 1);
+    cb_final_indices_transposed.push_back(1);
 
-    transpose_and_pack(cb_final_indices_transposed, cb_out_indices, 1);
+    transpose_and_pack(cb_final_indices_transposed_id, cb_out_indices_id, 1);
 
-    cb_pop_front(cb_winning_group_scores, tiles);
-    cb_pop_front(cb_winning_group_indices, tiles);
+    cb_winning_group_scores.pop_front(tiles);
+    cb_winning_group_indices.pop_front(tiles);
 }
 
 void normalize_scores(
-    const uint32_t cb_gathered_sigmoid,
-    const uint32_t cb_reduce_ones_scalar,
-    const uint32_t cb_reduce_intermediate,
-    const uint32_t cb_reciprocal_sums,
-    const uint32_t cb_epsilon_scalar,
-    const uint32_t cb_normalized_scores) {
-    reconfig_data_format(cb_gathered_sigmoid, cb_reduce_ones_scalar);
-    pack_reconfig_data_format(cb_normalized_scores);
+    const uint32_t cb_gathered_sigmoid_id,
+    const uint32_t cb_reduce_ones_scalar_id,
+    const uint32_t cb_reduce_intermediate_id,
+    const uint32_t cb_reciprocal_sums_id,
+    const uint32_t cb_epsilon_scalar_id,
+    const uint32_t cb_normalized_scores_id) {
+    CircularBuffer cb_gathered_sigmoid(cb_gathered_sigmoid_id);
+    CircularBuffer cb_reduce_ones_scalar(cb_reduce_ones_scalar_id);
+    CircularBuffer cb_reduce_intermediate(cb_reduce_intermediate_id);
+    CircularBuffer cb_reciprocal_sums(cb_reciprocal_sums_id);
+    CircularBuffer cb_epsilon_scalar(cb_epsilon_scalar_id);
+    CircularBuffer cb_normalized_scores(cb_normalized_scores_id);
+    reconfig_data_format(cb_gathered_sigmoid_id, cb_reduce_ones_scalar_id);
+    pack_reconfig_data_format(cb_normalized_scores_id);
     reduce_init<PoolType::SUM, ReduceDim::REDUCE_ROW>(
-        cb_gathered_sigmoid, cb_reduce_ones_scalar, cb_reduce_intermediate);
+        cb_gathered_sigmoid_id, cb_reduce_ones_scalar_id, cb_reduce_intermediate_id);
 
-    cb_wait_front(cb_gathered_sigmoid, 1);
-    cb_wait_front(cb_reduce_ones_scalar, 1);
+    cb_gathered_sigmoid.wait_front(1);
+    cb_reduce_ones_scalar.wait_front(1);
 
     // 1. Sum row (experts) to get row vector of sums [1, 32]
     tile_regs_acquire();
-    reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_gathered_sigmoid, cb_reduce_ones_scalar, 0, 0, 0);
+    reduce_tile<PoolType::SUM, ReduceDim::REDUCE_ROW>(cb_gathered_sigmoid_id, cb_reduce_ones_scalar_id, 0, 0, 0);
     tile_regs_commit();
     reduce_uninit();
 
     // 2. Pack sums to intermediate to add epsilon
     tile_regs_wait();
-    cb_reserve_back(cb_reduce_intermediate, 1);
-    pack_reconfig_data_format(cb_reduce_intermediate);
-    pack_tile(0, cb_reduce_intermediate);
+    cb_reduce_intermediate.reserve_back(1);
+    pack_reconfig_data_format(cb_reduce_intermediate_id);
+    pack_tile(0, cb_reduce_intermediate_id);
     tile_regs_release();
-    cb_push_back(cb_reduce_intermediate, 1);
+    cb_reduce_intermediate.push_back(1);
     // 3. Add epsilon
     tile_regs_acquire();
-    cb_wait_front(cb_epsilon_scalar, 1);
-    cb_wait_front(cb_reduce_intermediate, 1);
+    cb_epsilon_scalar.wait_front(1);
+    cb_reduce_intermediate.wait_front(1);
 
-    reconfig_data_format(cb_reduce_intermediate, cb_epsilon_scalar);
-    pack_reconfig_data_format(cb_reciprocal_sums);
+    reconfig_data_format(cb_reduce_intermediate_id, cb_epsilon_scalar_id);
+    pack_reconfig_data_format(cb_reciprocal_sums_id);
 
-    add_bcast_scalar_init_short(cb_reduce_intermediate, cb_epsilon_scalar);
-    add_tiles_bcast<BroadcastType::SCALAR>(cb_reduce_intermediate, cb_epsilon_scalar, 0, 0, 0);
+    add_bcast_scalar_init_short(cb_reduce_intermediate_id, cb_epsilon_scalar_id);
+    add_tiles_bcast<BroadcastType::SCALAR>(cb_reduce_intermediate_id, cb_epsilon_scalar_id, 0, 0, 0);
 
     // 4. Recip
     recip_tile_init();
     recip_tile(0);
     tile_regs_commit();
 
-    cb_pop_front(cb_reduce_intermediate, 1);
+    cb_reduce_intermediate.pop_front(1);
 
     // 5. Pack reciprocals
     tile_regs_wait();
-    cb_reserve_back(cb_reciprocal_sums, 1);
-    pack_tile(0, cb_reciprocal_sums);
-    cb_push_back(cb_reciprocal_sums, 1);
+    cb_reciprocal_sums.reserve_back(1);
+    pack_tile(0, cb_reciprocal_sums_id);
+    cb_reciprocal_sums.push_back(1);
     tile_regs_release();
 
     // 6. Broadcast multiply
     tile_regs_acquire();
-    cb_wait_front(cb_reciprocal_sums, 1);
-    mul_bcast_cols_init_short(cb_gathered_sigmoid, cb_reciprocal_sums);
-    mul_tiles_bcast<BroadcastType::COL>(cb_gathered_sigmoid, cb_reciprocal_sums, 0, 0, 0);  // tile *= 1/(sum_col(tile))
+    cb_reciprocal_sums.wait_front(1);
+    mul_bcast_cols_init_short(cb_gathered_sigmoid_id, cb_reciprocal_sums_id);
+    mul_tiles_bcast<BroadcastType::COL>(
+        cb_gathered_sigmoid_id, cb_reciprocal_sums_id, 0, 0, 0);  // tile *= 1/(sum_col(tile))
     tile_regs_commit();
-    cb_pop_front(cb_reciprocal_sums, 1);
-    cb_pop_front(cb_gathered_sigmoid, 1);
+    cb_reciprocal_sums.pop_front(1);
+    cb_gathered_sigmoid.pop_front(1);
 
     tile_regs_wait();
-    cb_reserve_back(cb_normalized_scores, 1);
-    pack_reconfig_data_format(cb_normalized_scores);
-    pack_tile(0, cb_normalized_scores);
-    cb_push_back(cb_normalized_scores, 1);
+    cb_normalized_scores.reserve_back(1);
+    pack_reconfig_data_format(cb_normalized_scores_id);
+    pack_tile(0, cb_normalized_scores_id);
+    cb_normalized_scores.push_back(1);
     tile_regs_release();
 }
 
-void scale(const uint32_t cb_normalized_scores, const uint32_t cb_route_scale_scalar, const uint32_t cb_out_weights) {
-    cb_wait_front(cb_normalized_scores, 1);
-    cb_wait_front(cb_route_scale_scalar, 1);
-    mul_tiles_bcast_scalar_init_short(cb_normalized_scores, cb_route_scale_scalar);
+void scale(
+    const uint32_t cb_normalized_scores_id, const uint32_t cb_route_scale_scalar_id, const uint32_t cb_out_weights_id) {
+    CircularBuffer cb_normalized_scores(cb_normalized_scores_id);
+    CircularBuffer cb_route_scale_scalar(cb_route_scale_scalar_id);
+    CircularBuffer cb_out_weights(cb_out_weights_id);
+    cb_normalized_scores.wait_front(1);
+    cb_route_scale_scalar.wait_front(1);
+    mul_tiles_bcast_scalar_init_short(cb_normalized_scores_id, cb_route_scale_scalar_id);
 
     tile_regs_acquire();
 
-    mul_tiles_bcast<BroadcastType::SCALAR>(cb_normalized_scores, cb_route_scale_scalar, 0, 0, 0);
+    mul_tiles_bcast<BroadcastType::SCALAR>(cb_normalized_scores_id, cb_route_scale_scalar_id, 0, 0, 0);
     tile_regs_commit();
 
-    cb_reserve_back(cb_out_weights, 1);
+    cb_out_weights.reserve_back(1);
     tile_regs_wait();
-    pack_reconfig_data_format(cb_out_weights);
-    pack_tile(0, cb_out_weights);
-    cb_push_back(cb_out_weights, 1);
+    pack_reconfig_data_format(cb_out_weights_id);
+    pack_tile(0, cb_out_weights_id);
+    cb_out_weights.push_back(1);
     tile_regs_release();
 
-    cb_pop_front(cb_normalized_scores, 1);
+    cb_normalized_scores.pop_front(1);
 }
 
 }  // namespace blocks

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/dataflow/reader_moe_grouped_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/dataflow/reader_moe_grouped_topk.cpp
@@ -4,9 +4,12 @@
 
 #include <cstdint>
 
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+
 void kernel_main() {
-    constexpr uint32_t cb_in_scores = get_named_compile_time_arg_val("cb_in_scores");
-    constexpr uint32_t cb_in_bias = get_named_compile_time_arg_val("cb_in_bias");
+    constexpr uint32_t cb_in_scores_id = get_named_compile_time_arg_val("cb_in_scores");
+    constexpr uint32_t cb_in_bias_id = get_named_compile_time_arg_val("cb_in_bias");
     constexpr uint32_t width_tiles = get_named_compile_time_arg_val("width_tiles");
     constexpr uint32_t scores_page_size = get_named_compile_time_arg_val("scores_page_size");
     constexpr uint32_t bias_page_size = get_named_compile_time_arg_val("bias_page_size");
@@ -23,17 +26,23 @@ void kernel_main() {
     const auto scores_accessor = TensorAccessor(scores_args, scores_addr, scores_page_size);
     const auto bias_accessor = TensorAccessor(bias_args, bias_addr, bias_page_size);
 
+    Noc noc;
+    CircularBuffer cb_in_scores(cb_in_scores_id);
+    CircularBuffer cb_in_bias(cb_in_bias_id);
+    const uint32_t scores_tile_bytes = cb_in_scores.get_tile_size();
+    const uint32_t bias_tile_bytes = cb_in_bias.get_tile_size();
+
     for (uint32_t height_tile = start_height_tile; height_tile < end_height_tile; height_tile++) {
         uint32_t base_page = height_tile * width_tiles;
         for (uint32_t width_tile = 0; width_tile < width_tiles; width_tile++) {
             uint32_t page = base_page + width_tile;
-            cb_reserve_back(cb_in_scores, 1);
-            cb_reserve_back(cb_in_bias, 1);
-            noc_async_read_page(page, scores_accessor, get_write_ptr(cb_in_scores));
-            noc_async_read_page(page, bias_accessor, get_write_ptr(cb_in_bias));
-            noc_async_read_barrier();
-            cb_push_back(cb_in_scores, 1);
-            cb_push_back(cb_in_bias, 1);
+            cb_in_scores.reserve_back(1);
+            cb_in_bias.reserve_back(1);
+            noc.async_read(scores_accessor, cb_in_scores, scores_tile_bytes, {.page_id = page}, {.offset_bytes = 0});
+            noc.async_read(bias_accessor, cb_in_bias, bias_tile_bytes, {.page_id = page}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb_in_scores.push_back(1);
+            cb_in_bias.push_back(1);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/dataflow/writer_moe_grouped_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/dataflow/writer_moe_grouped_topk.cpp
@@ -5,6 +5,7 @@
 #include <cstdint>
 
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc.h"
 
 constexpr uint32_t rows_per_face = 16;
 constexpr uint32_t columns_per_face = 16;
@@ -29,7 +30,8 @@ constexpr uint32_t tile_size_bytes = elements_per_tile * bytes_per_element;  // 
 
 FORCE_INLINE void generate_index_tile(
     const uint32_t cb_expert_index_template, const uint32_t index_write_addr, uint32_t start_expert_index) {
-    cb_reserve_back(cb_expert_index_template, 1);
+    CircularBuffer cb(cb_expert_index_template);
+    cb.reserve_back(1);
     for (uint32_t width_face = 0; width_face < 2; width_face++) {
         uint32_t current_index = start_expert_index + width_face * columns_per_face;
         uint32_t index_write_face_offset = index_write_addr + width_face * index_tile::face_size_bytes;
@@ -55,21 +57,23 @@ FORCE_INLINE void generate_index_tile(
     noc_async_read(
         index_noc_addr_base, index_write_addr + 2 * index_tile::face_size_bytes, 2 * index_tile::face_size_bytes);
     noc_async_read_barrier();
-    cb_push_back(cb_expert_index_template, 1);
+    cb.push_back(1);
 }
 
 FORCE_INLINE void generate_index_tiles(
     const uint32_t cb_expert_index_template, uint32_t width_tiles, uint32_t page_size) {
+    CircularBuffer cb(cb_expert_index_template);
     for (uint32_t i = 0; i < width_tiles; i++) {
-        generate_index_tile(cb_expert_index_template, get_write_ptr(cb_expert_index_template), columns_per_tile * i);
+        generate_index_tile(cb_expert_index_template, cb.get_write_ptr(), columns_per_tile * i);
     }
 }
 
 // Vertically along each tile, write index 0, ..., n_groups - 1
 FORCE_INLINE void generate_group_indices_tiles(
     const uint32_t cb_group_index_template, uint32_t width_tiles, uint32_t n_groups) {
-    cb_reserve_back(cb_group_index_template, 1);
-    uint32_t base_write_addr = get_write_ptr(cb_group_index_template);
+    CircularBuffer cb(cb_group_index_template);
+    cb.reserve_back(1);
+    uint32_t base_write_addr = cb.get_write_ptr();
     volatile tt_l1_ptr uint32_t* write_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(base_write_addr);
     for (uint32_t group_index = 0; group_index < n_groups; group_index++) {
         for (uint32_t i = 0; i < columns_per_face / 2; i++) {
@@ -92,14 +96,16 @@ FORCE_INLINE void generate_group_indices_tiles(
     noc_async_read(dm_engine_index_write_offset_face_3, face_4_l1_write_addr, index_tile::face_size_bytes);
     uint32_t tile_write_addr = base_write_addr + index_tile::tile_size_bytes;
     noc_async_read_barrier();
-    cb_push_back(cb_group_index_template, 1);
+    cb.push_back(1);
 }
 
 FORCE_INLINE void generate_reduce_scalar(
     const uint32_t cb_reduce_ones_scalar, const uint32_t packed_scalar, const uint32_t n_activated_experts) {
-    cb_reserve_back(cb_reduce_ones_scalar, 1);
+    Noc noc;
+    CircularBuffer reduce_cb(cb_reduce_ones_scalar);
+    reduce_cb.reserve_back(1);
 
-    uint32_t write_addr = get_write_ptr(cb_reduce_ones_scalar);
+    uint32_t write_addr = reduce_cb.get_write_ptr();
     tt_l1_ptr uint32_t* write_ptr = reinterpret_cast<tt_l1_ptr uint32_t*>(write_addr);
     uint32_t scalar = packed_scalar;
     for (uint32_t i = 0; i < n_activated_experts; i++) {
@@ -108,8 +114,6 @@ FORCE_INLINE void generate_reduce_scalar(
             write_ptr[i + elements_per_face - columns_per_face + 1] = scalar;
         }
     }
-    Noc noc;
-    CircularBuffer reduce_cb(cb_reduce_ones_scalar);
     for (uint32_t i = n_activated_experts; i < rows_per_tile; i++) {
         write_ptr[i] = 0;
         if (i == rows_per_face) {
@@ -126,7 +130,7 @@ FORCE_INLINE void generate_reduce_scalar(
         get_noc_addr(write_addr + score_tile::face_size_bytes), face_4_write_addr, score_tile::face_line_bytes);
     noc_async_read_barrier();
 
-    cb_push_back(cb_reduce_ones_scalar, 1);
+    reduce_cb.push_back(1);
 }
 
 FORCE_INLINE void generate_summed_experts_tiles(
@@ -142,23 +146,24 @@ FORCE_INLINE void generate_summed_experts_tiles(
     // faces in our case, for now, width_tiles = n_groups
 
     // for each group, copy the top experts_per_group rows to cb_top_experts_per_group
-    cb_reserve_back(cb_top_experts_per_group, summed_experts_per_group);
+    CircularBuffer top_cb(cb_top_experts_per_group);
+    CircularBuffer sorted_cb(cb_sorted_group_scores);
+    top_cb.reserve_back(summed_experts_per_group);
     for (uint32_t width_tile = 0; width_tile < width_tiles; width_tile++) {
-        cb_wait_front(cb_sorted_group_scores, 1);
-        uint64_t group_sorted_tile_ptr = get_noc_addr(get_read_ptr(cb_sorted_group_scores));
+        sorted_cb.wait_front(1);
+        uint64_t group_sorted_tile_ptr = get_noc_addr(sorted_cb.get_read_ptr());
 
         if (width_tile % 2 == 0) {
             for (uint32_t i = 0; i < summed_experts_per_group; i++) {
                 noc_async_read(
                     group_sorted_tile_ptr + i * score_tile::face_line_bytes,
-                    get_write_ptr(cb_top_experts_per_group) + i * score_tile::tile_size_bytes +
-                        width_tile * score_tile::face_line_bytes,
+                    top_cb.get_write_ptr() + i * score_tile::tile_size_bytes + width_tile * score_tile::face_line_bytes,
                     score_tile::face_line_bytes);
                 if (tokens_per_tile > rows_per_face) {
                     noc_async_read(
                         group_sorted_tile_ptr + score_tile::face_size_bytes + i * score_tile::face_line_bytes,
-                        get_write_ptr(cb_top_experts_per_group) + score_tile::face_size_bytes +
-                            i * score_tile::tile_size_bytes + width_tile * score_tile::face_line_bytes,
+                        top_cb.get_write_ptr() + score_tile::face_size_bytes + i * score_tile::tile_size_bytes +
+                            width_tile * score_tile::face_line_bytes,
                         score_tile::face_line_bytes);
                 }
             }
@@ -167,23 +172,22 @@ FORCE_INLINE void generate_summed_experts_tiles(
             for (uint32_t i = 0; i < summed_experts_per_group; i++) {
                 noc_async_read(
                     group_sorted_tile_ptr + (rows_per_face - 1 - i) * score_tile::face_line_bytes,
-                    get_write_ptr(cb_top_experts_per_group) + i * score_tile::tile_size_bytes +
-                        width_tile * score_tile::face_line_bytes,
+                    top_cb.get_write_ptr() + i * score_tile::tile_size_bytes + width_tile * score_tile::face_line_bytes,
                     score_tile::face_line_bytes);
                 if (tokens_per_tile > rows_per_face) {
                     noc_async_read(
                         group_sorted_tile_ptr + score_tile::face_size_bytes +
                             (rows_per_face - 1 - i) * score_tile::face_line_bytes,
-                        get_write_ptr(cb_top_experts_per_group) + score_tile::face_size_bytes +
-                            i * score_tile::tile_size_bytes + width_tile * score_tile::face_line_bytes,
+                        top_cb.get_write_ptr() + score_tile::face_size_bytes + i * score_tile::tile_size_bytes +
+                            width_tile * score_tile::face_line_bytes,
                         score_tile::face_line_bytes);
                 }
             }
         }
         noc_async_read_barrier();
-        cb_pop_front(cb_sorted_group_scores, 1);
+        sorted_cb.pop_front(1);
     }
-    cb_push_back(cb_top_experts_per_group, summed_experts_per_group);
+    top_cb.push_back(summed_experts_per_group);
 }
 
 template <
@@ -196,20 +200,26 @@ template <
     uint32_t topk_groups,
     uint32_t num_group_tiles>
 FORCE_INLINE void generate_winning_group_tiles(uint32_t tokens_per_tile) {
-    cb_wait_front(cb_biased_scores, width_tiles);
-    cb_wait_front(cb_expert_index_template, width_tiles);
-    cb_wait_front(cb_sorted_group_order, num_group_tiles);
+    CircularBuffer biased_cb(cb_biased_scores);
+    CircularBuffer expert_idx_cb(cb_expert_index_template);
+    CircularBuffer sorted_order_cb(cb_sorted_group_order);
+    CircularBuffer winning_scores_cb(cb_winning_group_scores);
+    CircularBuffer winning_indices_cb(cb_winning_group_indices);
 
-    cb_reserve_back(cb_winning_group_scores, topk_groups);
-    cb_reserve_back(cb_winning_group_indices, topk_groups);
+    biased_cb.wait_front(width_tiles);
+    expert_idx_cb.wait_front(width_tiles);
+    sorted_order_cb.wait_front(num_group_tiles);
 
-    uint64_t scores_base_noc_addr = get_noc_addr(get_read_ptr(cb_biased_scores));
-    uint64_t indices_base_noc_addr = get_noc_addr(get_read_ptr(cb_expert_index_template));
-    uint32_t scores_dest_base_addr = get_write_ptr(cb_winning_group_scores);
-    uint32_t indices_dest_base_addr = get_write_ptr(cb_winning_group_indices);
+    winning_scores_cb.reserve_back(topk_groups);
+    winning_indices_cb.reserve_back(topk_groups);
+
+    uint64_t scores_base_noc_addr = get_noc_addr(biased_cb.get_read_ptr());
+    uint64_t indices_base_noc_addr = get_noc_addr(expert_idx_cb.get_read_ptr());
+    uint32_t scores_dest_base_addr = winning_scores_cb.get_write_ptr();
+    uint32_t indices_dest_base_addr = winning_indices_cb.get_write_ptr();
 
     volatile tt_l1_ptr uint16_t* sorted_indices_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_read_ptr(cb_sorted_group_order));
+        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(sorted_order_cb.get_read_ptr());
 
     for (uint32_t k = 0; k < topk_groups; k++) {
         uint32_t scores_dest_addr = scores_dest_base_addr + k * score_tile::tile_size_bytes;
@@ -293,19 +303,20 @@ FORCE_INLINE void generate_winning_group_tiles(uint32_t tokens_per_tile) {
 
     noc_async_read_barrier();
 
-    cb_pop_front(cb_biased_scores, width_tiles);
-    cb_pop_front(cb_sorted_group_order, num_group_tiles);
+    biased_cb.pop_front(width_tiles);
+    sorted_order_cb.pop_front(num_group_tiles);
 
-    cb_push_back(cb_winning_group_scores, topk_groups);
-    cb_push_back(cb_winning_group_indices, topk_groups);
+    winning_scores_cb.push_back(topk_groups);
+    winning_indices_cb.push_back(topk_groups);
 }
 
 void write_single_scalar(const uint32_t cb_scalar, const uint32_t packed_scalar) {
-    cb_reserve_back(cb_scalar, 1);
-    uint32_t write_addr = get_write_ptr(cb_scalar);
+    CircularBuffer cb(cb_scalar);
+    cb.reserve_back(1);
+    uint32_t write_addr = cb.get_write_ptr();
     tt_l1_ptr uint32_t* write_ptr = reinterpret_cast<tt_l1_ptr uint32_t*>(write_addr);
     write_ptr[0] = packed_scalar;
-    cb_push_back(cb_scalar, 1);
+    cb.push_back(1);
 }
 
 template <
@@ -316,14 +327,18 @@ template <
     uint32_t n_activated_experts,
     uint32_t n_activated_expert_tiles>
 FORCE_INLINE void gather(uint32_t tokens_per_tile) {
-    cb_wait_front(cb_sigmoid_scores, width_tiles);
-    cb_wait_front(cb_out_indices, 1);
+    CircularBuffer sigmoid_cb(cb_sigmoid_scores);
+    CircularBuffer out_indices_cb(cb_out_indices);
+    CircularBuffer gathered_cb(cb_gathered_sigmoid);
 
-    cb_reserve_back(cb_gathered_sigmoid, n_activated_expert_tiles);
+    sigmoid_cb.wait_front(width_tiles);
+    out_indices_cb.wait_front(1);
 
-    uint32_t sigmoid_base_addr = get_read_ptr(cb_sigmoid_scores);
-    uint32_t indices_addr = get_read_ptr(cb_out_indices);
-    uint32_t gathered_addr = get_write_ptr(cb_gathered_sigmoid);
+    gathered_cb.reserve_back(n_activated_expert_tiles);
+
+    uint32_t sigmoid_base_addr = sigmoid_cb.get_read_ptr();
+    uint32_t indices_addr = out_indices_cb.get_read_ptr();
+    uint32_t gathered_addr = gathered_cb.get_write_ptr();
 
     volatile tt_l1_ptr uint16_t* indices_ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(indices_addr);
     volatile tt_l1_ptr uint32_t* sigmoid_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(sigmoid_base_addr);
@@ -361,9 +376,9 @@ FORCE_INLINE void gather(uint32_t tokens_per_tile) {
         }
     }
 
-    cb_pop_front(cb_sigmoid_scores, width_tiles);
+    sigmoid_cb.pop_front(width_tiles);
 
-    cb_push_back(cb_gathered_sigmoid, n_activated_expert_tiles);
+    gathered_cb.push_back(n_activated_expert_tiles);
 }
 
 // Overwrite all n_activated_experts index entries for a single (tile-local) row with SENTINEL.
@@ -452,6 +467,10 @@ void kernel_main() {
         pad_side = padding_config_ptr[1];
     }
 
+    Noc noc;
+    CircularBuffer out_indices_cb(cb_out_indices);
+    CircularBuffer out_weights_cb(cb_out_weights);
+
     // while reader and compute kernels are applying the sigmoid, we can create the topk indices
     // I see no performance difference generating these internally inside the writer kernel
     generate_reduce_scalar(cb_reduce_ones_scalar, packed_one_scalar, n_activated_experts);
@@ -489,7 +508,7 @@ void kernel_main() {
                 num_group_tiles>(tokens_per_tile);
         }
 
-        cb_wait_front(cb_out_indices, 1);
+        out_indices_cb.wait_front(1);
 
         // Gather unbiased sigmoid scores using the final expert indices
         gather<
@@ -506,7 +525,7 @@ void kernel_main() {
             constexpr uint16_t sentinel = static_cast<uint16_t>(experts);
             uint32_t tile_start_row = height_tile * tile_height;
             volatile tt_l1_ptr uint16_t* idx_ptr =
-                reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_read_ptr(cb_out_indices));
+                reinterpret_cast<volatile tt_l1_ptr uint16_t*>(out_indices_cb.get_read_ptr());
 
             for (uint32_t row = 0; row < tokens_per_tile; row++) {
                 uint32_t global_row = tile_start_row + row;
@@ -518,12 +537,12 @@ void kernel_main() {
             }
         }
 
-        noc_async_write_page(height_tile, indices_accessor, get_read_ptr(cb_out_indices));
-        cb_wait_front(cb_out_weights, 1);
-        noc_async_write_page(height_tile, weights_accessor, get_read_ptr(cb_out_weights));
+        noc.async_write(out_indices_cb, indices_accessor, indices_page_size, {}, {.page_id = height_tile});
+        out_weights_cb.wait_front(1);
+        noc.async_write(out_weights_cb, weights_accessor, weights_page_size, {}, {.page_id = height_tile});
         noc_async_writes_flushed();
-        cb_pop_front(cb_out_indices, 1);
-        cb_pop_front(cb_out_weights, 1);
+        out_indices_cb.pop_front(1);
+        out_weights_cb.pop_front(1);
     }
-    noc_async_write_barrier();
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/dataflow/writer_moe_grouped_topk.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/moe_grouped_topk/device/kernels/dataflow/writer_moe_grouped_topk.cpp
@@ -540,7 +540,7 @@ void kernel_main() {
         noc.async_write(out_indices_cb, indices_accessor, indices_page_size, {}, {.page_id = height_tile});
         out_weights_cb.wait_front(1);
         noc.async_write(out_weights_cb, weights_accessor, weights_page_size, {}, {.page_id = height_tile});
-        noc_async_writes_flushed();
+        noc.async_writes_flushed();
         out_indices_cb.pop_front(1);
         out_weights_cb.pop_front(1);
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/kernels/reader_offset_cumsum_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/kernels/reader_offset_cumsum_interleaved.cpp
@@ -28,6 +28,8 @@
 
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 #include <tt-metalium/constants.hpp>
 
 void kernel_main() {
@@ -40,6 +42,11 @@ void kernel_main() {
     constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
     constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
     constexpr uint32_t cb_id_local = get_compile_time_arg_val(2);
+
+    Noc noc;
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_out0(cb_id_out0);
+    CircularBuffer cb_local(cb_id_local);
     constexpr bool src_is_dram = (bool)get_compile_time_arg_val(3);
     constexpr bool dst_offsets_is_dram = (bool)get_compile_time_arg_val(4);
     constexpr bool dst_totals_is_dram = (bool)get_compile_time_arg_val(5);
@@ -69,25 +76,21 @@ void kernel_main() {
     const auto dst_expert_region_accessor = TensorAccessor(dst_expert_region_args, dst_expert_region_addr);
 
     // running_sum accumulates totals across all H rows
-    uint32_t out_cb_addr = get_write_ptr(cb_id_out0);
-    volatile tt_l1_ptr uint32_t* running_sum = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(out_cb_addr);
+    volatile tt_l1_ptr uint32_t* running_sum = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_out0.get_write_ptr());
 
     // local_off stores the local offsets (sum of rows 0..row_idx-1) for later combination
-    uint32_t local_cb_addr = get_write_ptr(cb_id_local);
-    volatile tt_l1_ptr uint32_t* local_off = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(local_cb_addr);
+    volatile tt_l1_ptr uint32_t* local_off = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_local.get_write_ptr());
 
     for (uint32_t i = 0; i < W; i++) {
         running_sum[i] = 0;
         local_off[i] = 0;
     }
 
-    uint32_t in_cb_addr = get_write_ptr(cb_id_in0);
-
     for (uint32_t h = 0; h < H; h++) {
-        noc_async_read_page(h, src_accessor, in_cb_addr);
-        noc_async_read_barrier();
+        noc.async_read(src_accessor, cb_in0, input_page_size, {.page_id = h}, {.offset_bytes = 0});
+        noc.async_read_barrier();
 
-        volatile tt_l1_ptr uint32_t* stick = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in_cb_addr);
+        volatile tt_l1_ptr uint32_t* stick = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_in0.get_write_ptr());
         for (uint32_t i = 0; i < W; i++) {
             running_sum[i] += stick[i];
         }
@@ -103,8 +106,8 @@ void kernel_main() {
     // --- Post-loop: running_sum now contains totals ---
 
     // 1. Write totals to DRAM
-    noc_async_write(out_cb_addr, dst_totals_accessor.get_noc_addr(0), totals_page_size);
-    noc_async_write_barrier();
+    noc.async_write(cb_out0, dst_totals_accessor, totals_page_size, {}, {.page_id = 0});
+    noc.async_write_barrier();
 
     // 2. Compute exclusive prefix sum of tile-aligned totals, grouped by experts_per_chip
     //    Pad each expert's count to TILE_HEIGHT so each expert starts at a tile boundary
@@ -121,8 +124,8 @@ void kernel_main() {
     }
 
     // 3. Write expert region offsets (shared component, before adding local offset) to DRAM
-    noc_async_write(out_cb_addr, dst_expert_region_accessor.get_noc_addr(0), expert_region_page_size);
-    noc_async_write_barrier();
+    noc.async_write(cb_out0, dst_expert_region_accessor, expert_region_page_size, {}, {.page_id = 0});
+    noc.async_write_barrier();
 
     // 4. Add saved local offsets to get global offsets
     for (uint32_t i = 0; i < W; i++) {
@@ -130,6 +133,6 @@ void kernel_main() {
     }
 
     // 5. Write global offsets to DRAM
-    noc_async_write(out_cb_addr, dst_offsets_accessor.get_noc_addr(0), offsets_page_size);
-    noc_async_write_barrier();
+    noc.async_write(cb_out0, dst_offsets_accessor, offsets_page_size, {}, {.page_id = 0});
+    noc.async_write_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/compute/compute_per_token_cast_back.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_back/device/kernels/compute/compute_per_token_cast_back.cpp
@@ -25,14 +25,21 @@
 #include "api/compute/untilize.h"
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/bcast.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
-    constexpr uint32_t cb_input_e4m3 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_in_rm = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_in_tile = get_compile_time_arg_val(2);
-    constexpr uint32_t cb_scale_bcast = get_compile_time_arg_val(3);
-    constexpr uint32_t cb_out_tile = get_compile_time_arg_val(4);
-    constexpr uint32_t cb_out_fp32 = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_input_e4m3_id = get_compile_time_arg_val(0);
+    CircularBuffer cb_input_e4m3(cb_input_e4m3_id);
+    constexpr uint32_t cb_in_rm_id = get_compile_time_arg_val(1);
+    CircularBuffer cb_in_rm(cb_in_rm_id);
+    constexpr uint32_t cb_in_tile_id = get_compile_time_arg_val(2);
+    CircularBuffer cb_in_tile(cb_in_tile_id);
+    constexpr uint32_t cb_scale_bcast_id = get_compile_time_arg_val(3);
+    CircularBuffer cb_scale_bcast(cb_scale_bcast_id);
+    constexpr uint32_t cb_out_tile_id = get_compile_time_arg_val(4);
+    CircularBuffer cb_out_tile(cb_out_tile_id);
+    constexpr uint32_t cb_out_fp32_id = get_compile_time_arg_val(5);
+    CircularBuffer cb_out_fp32(cb_out_fp32_id);
     // Tile dims from the tensor's tile spec.
     constexpr uint32_t tile_h = get_compile_time_arg_val(6);
     constexpr uint32_t tile_w = get_compile_time_arg_val(7);
@@ -45,73 +52,73 @@ void kernel_main() {
 
     uint32_t num_blocks = get_arg_val<uint32_t>(0);  // tile_h x 128 blocks for this core
 
-    compute_kernel_hw_startup(cb_input_e4m3, cb_out_fp32);
+    compute_kernel_hw_startup(cb_input_e4m3_id, cb_out_fp32_id);
 
     for (uint32_t blk = 0; blk < num_blocks; ++blk) {
         {
             // ----- Phase 1: input_e4m3 row-major -> fp32 row-major (one tile at a time, index 0) -----
-            reconfig_data_format_srca(cb_input_e4m3);
-            pack_reconfig_data_format(cb_in_rm);
-            copy_tile_init(cb_input_e4m3);
+            reconfig_data_format_srca(cb_input_e4m3_id);
+            pack_reconfig_data_format(cb_in_rm_id);
+            copy_tile_init(cb_input_e4m3_id);
             // One input_e4m3 page is one 32x32 row-major tile. A 128-wide block contains
             // tiles_per_block such pages.
             for (uint32_t s = 0; s < tiles_per_block; ++s) {
-                cb_wait_front(cb_input_e4m3, 1);
-                cb_reserve_back(cb_in_rm, 1);
+                cb_input_e4m3.wait_front(1);
+                cb_in_rm.reserve_back(1);
                 tile_regs_acquire();
-                copy_tile(cb_input_e4m3, 0, IDST0);
+                copy_tile(cb_input_e4m3_id, 0, IDST0);
                 tile_regs_commit();
                 tile_regs_wait();
-                pack_tile(IDST0, cb_in_rm);
+                pack_tile(IDST0, cb_in_rm_id);
                 tile_regs_release();
-                cb_push_back(cb_in_rm, 1);
-                cb_pop_front(cb_input_e4m3, 1);
+                cb_in_rm.push_back(1);
+                cb_input_e4m3.pop_front(1);
             }
 
             // ----- Phase 2a: tilize fp32 input row-major -> tile -----
-            reconfig_data_format_srca(cb_in_rm);
-            pack_reconfig_data_format(cb_in_tile);
-            tilize_init(cb_in_rm, tiles_per_block, cb_in_tile);
-            cb_wait_front(cb_in_rm, tiles_per_block);
-            cb_reserve_back(cb_in_tile, tiles_per_block);
-            tilize_block(cb_in_rm, tiles_per_block, cb_in_tile);
-            cb_push_back(cb_in_tile, tiles_per_block);
-            cb_pop_front(cb_in_rm, tiles_per_block);
-            tilize_uninit(cb_in_rm, cb_in_tile);
+            reconfig_data_format_srca(cb_in_rm_id);
+            pack_reconfig_data_format(cb_in_tile_id);
+            tilize_init(cb_in_rm_id, tiles_per_block, cb_in_tile_id);
+            cb_in_rm.wait_front(tiles_per_block);
+            cb_in_tile.reserve_back(tiles_per_block);
+            tilize_block(cb_in_rm_id, tiles_per_block, cb_in_tile_id);
+            cb_in_tile.push_back(tiles_per_block);
+            cb_in_rm.pop_front(tiles_per_block);
+            tilize_uninit(cb_in_rm_id, cb_in_tile_id);
 
             // ----- Phase 2c: block broadcast multiply -----
             // cb_scale_bcast holds block_ht tiles; tile block_h_idx has column 0 = scale[:, block_h_idx].
-            reconfig_data_format(cb_in_tile, cb_scale_bcast);
-            pack_reconfig_data_format(cb_out_tile);
-            mul_bcast_cols_init_short(cb_in_tile, cb_scale_bcast);
-            cb_wait_front(cb_in_tile, tiles_per_block);
-            cb_wait_front(cb_scale_bcast, block_ht);
-            cb_reserve_back(cb_out_tile, tiles_per_block);
+            reconfig_data_format(cb_in_tile_id, cb_scale_bcast_id);
+            pack_reconfig_data_format(cb_out_tile_id);
+            mul_bcast_cols_init_short(cb_in_tile_id, cb_scale_bcast_id);
+            cb_in_tile.wait_front(tiles_per_block);
+            cb_scale_bcast.wait_front(block_ht);
+            cb_out_tile.reserve_back(tiles_per_block);
             for (uint32_t block_h_idx = 0; block_h_idx < block_ht; ++block_h_idx) {
                 for (uint32_t k = 0; k < block_wt; ++k) {
                     uint32_t in_idx = block_h_idx * block_wt + k;
                     tile_regs_acquire();
-                    mul_tiles_bcast_cols(cb_in_tile, cb_scale_bcast, in_idx, block_h_idx, IDST0);
+                    mul_tiles_bcast_cols(cb_in_tile_id, cb_scale_bcast_id, in_idx, block_h_idx, IDST0);
                     tile_regs_commit();
                     tile_regs_wait();
-                    pack_tile(IDST0, cb_out_tile);
+                    pack_tile(IDST0, cb_out_tile_id);
                     tile_regs_release();
                 }
             }
-            cb_push_back(cb_out_tile, tiles_per_block);
-            cb_pop_front(cb_in_tile, tiles_per_block);
-            cb_pop_front(cb_scale_bcast, block_ht);
+            cb_out_tile.push_back(tiles_per_block);
+            cb_in_tile.pop_front(tiles_per_block);
+            cb_scale_bcast.pop_front(block_ht);
 
             // ----- Phase 3: untilize cb_out_tile -> fp32 row-major output -----
-            reconfig_data_format_srca(cb_out_tile);
-            pack_reconfig_data_format(cb_out_fp32);
-            untilize_init(cb_out_tile);
-            cb_wait_front(cb_out_tile, tiles_per_block);
-            cb_reserve_back(cb_out_fp32, tiles_per_block);
-            untilize_block(cb_out_tile, tiles_per_block, cb_out_fp32);
-            cb_push_back(cb_out_fp32, tiles_per_block);
-            cb_pop_front(cb_out_tile, tiles_per_block);
-            untilize_uninit(cb_out_tile);
+            reconfig_data_format_srca(cb_out_tile_id);
+            pack_reconfig_data_format(cb_out_fp32_id);
+            untilize_init(cb_out_tile_id);
+            cb_out_tile.wait_front(tiles_per_block);
+            cb_out_fp32.reserve_back(tiles_per_block);
+            untilize_block(cb_out_tile_id, tiles_per_block, cb_out_fp32_id);
+            cb_out_fp32.push_back(tiles_per_block);
+            cb_out_tile.pop_front(tiles_per_block);
+            untilize_uninit(cb_out_tile_id);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/kernels/compute/compute_per_token_cast_to_fp8.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/kernels/compute/compute_per_token_cast_to_fp8.cpp
@@ -30,16 +30,25 @@
 #include "api/compute/eltwise_unary/recip.h"
 #include "api/compute/eltwise_unary/clamp.h"
 #include "api/compute/eltwise_unary/binop_with_scalar.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
-    constexpr uint32_t cb_in = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_tile = get_compile_time_arg_val(1);
-    constexpr uint32_t cb_scaler = get_compile_time_arg_val(2);
-    constexpr uint32_t cb_abs = get_compile_time_arg_val(3);
-    constexpr uint32_t cb_scale_tiles = get_compile_time_arg_val(4);
-    constexpr uint32_t cb_inv_scale_tiles = get_compile_time_arg_val(5);
-    constexpr uint32_t cb_out_tile = get_compile_time_arg_val(6);
-    constexpr uint32_t cb_output_e4m3 = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_in_id = get_compile_time_arg_val(0);
+    CircularBuffer cb_in(cb_in_id);
+    constexpr uint32_t cb_tile_id = get_compile_time_arg_val(1);
+    CircularBuffer cb_tile(cb_tile_id);
+    constexpr uint32_t cb_scaler_id = get_compile_time_arg_val(2);
+    CircularBuffer cb_scaler(cb_scaler_id);
+    constexpr uint32_t cb_abs_id = get_compile_time_arg_val(3);
+    CircularBuffer cb_abs(cb_abs_id);
+    constexpr uint32_t cb_scale_tiles_id = get_compile_time_arg_val(4);
+    CircularBuffer cb_scale_tiles(cb_scale_tiles_id);
+    constexpr uint32_t cb_inv_scale_tiles_id = get_compile_time_arg_val(5);
+    CircularBuffer cb_inv_scale_tiles(cb_inv_scale_tiles_id);
+    constexpr uint32_t cb_out_tile_id = get_compile_time_arg_val(6);
+    CircularBuffer cb_out_tile(cb_out_tile_id);
+    constexpr uint32_t cb_output_e4m3_id = get_compile_time_arg_val(7);
+    CircularBuffer cb_output_e4m3(cb_output_e4m3_id);
     constexpr uint32_t clamp_min_bits = get_compile_time_arg_val(8);
     constexpr uint32_t clamp_max_bits = get_compile_time_arg_val(9);
     constexpr uint32_t inv_448_bits = get_compile_time_arg_val(10);
@@ -59,55 +68,55 @@ void kernel_main() {
     // Configure the unpacker hw on the fp32 reduce/abs operand so num_faces / tile dims are full
     // (4 faces). Configuring on a bf16 cb_in instead leaves the fp32 reduce reading only 2 faces
     // (within-tile column reduce sees cols 0-15) for bf16 input; tilize_init re-inits for cb_in.
-    compute_kernel_hw_startup(cb_abs, cb_output_e4m3);
-    cb_wait_front(cb_scaler, 1);  // reader-filled 1.0 scaler, reused for every reduce
+    compute_kernel_hw_startup(cb_abs_id, cb_output_e4m3_id);
+    cb_scaler.wait_front(1);  // reader-filled 1.0 scaler, reused for every reduce
 
     for (uint32_t blk = 0; blk < num_blocks; ++blk) {
         {
             // ----- 1. tilize input row-major -> tile -----
-            reconfig_data_format_srca(cb_in);
-            pack_reconfig_data_format(cb_tile);
-            tilize_init(cb_in, tiles_per_block, cb_tile);
-            cb_wait_front(cb_in, tiles_per_block);
-            cb_reserve_back(cb_tile, tiles_per_block);
-            tilize_block(cb_in, tiles_per_block, cb_tile);
-            cb_push_back(cb_tile, tiles_per_block);
-            cb_pop_front(cb_in, tiles_per_block);
-            tilize_uninit(cb_in, cb_tile);
+            reconfig_data_format_srca(cb_in_id);
+            pack_reconfig_data_format(cb_tile_id);
+            tilize_init(cb_in_id, tiles_per_block, cb_tile_id);
+            cb_in.wait_front(tiles_per_block);
+            cb_tile.reserve_back(tiles_per_block);
+            tilize_block(cb_in_id, tiles_per_block, cb_tile_id);
+            cb_tile.push_back(tiles_per_block);
+            cb_in.pop_front(tiles_per_block);
+            tilize_uninit(cb_in_id, cb_tile_id);
 
             // ----- 2. block amax -> scale (col 0) and 1/scale (col 0) -----
-            cb_wait_front(cb_tile, tiles_per_block);  // read by index; popped after the divide
+            cb_tile.wait_front(tiles_per_block);  // read by index; popped after the divide
             for (uint32_t block_h_idx = 0; block_h_idx < block_ht; ++block_h_idx) {
                 // Abs the block row's tiles into cb_abs. Force the SrcA tile-dim/stride reconfig
                 // (is_tile_dim_reconfig_en=true): the default reconfig keeps the prior element
                 // stride, so after a bf16 tilize the fp32 cb_tile would be read with a 2-byte
                 // stride and copy_tile would misread it (corrupting the amax for bf16 input).
-                reconfig_data_format_srca<false, true>(cb_tile);
-                pack_reconfig_data_format(cb_abs);
-                copy_tile_init(cb_tile);
-                cb_reserve_back(cb_abs, block_wt);
+                reconfig_data_format_srca<false, true>(cb_tile_id);
+                pack_reconfig_data_format(cb_abs_id);
+                copy_tile_init(cb_tile_id);
+                cb_abs.reserve_back(block_wt);
                 abs_tile_init();
                 for (uint32_t k = 0; k < block_wt; ++k) {
                     tile_regs_acquire();
-                    copy_tile(cb_tile, block_h_idx * block_wt + k, IDST0);
+                    copy_tile(cb_tile_id, block_h_idx * block_wt + k, IDST0);
                     abs_tile(IDST0);
                     tile_regs_commit();
                     tile_regs_wait();
-                    pack_tile(IDST0, cb_abs);
+                    pack_tile(IDST0, cb_abs_id);
                     tile_regs_release();
                 }
-                cb_push_back(cb_abs, block_wt);
+                cb_abs.push_back(block_wt);
 
                 // reduce -> per-row max (col 0), accumulate, clamp, *1/448 -> scale (slot 0);
                 // copy to slot 1 and recip -> 1/scale (slot 1). One acquire produces both, so each
                 // block row's 1/scale is its own scale (no CB reload, which would always read row 0).
-                cb_wait_front(cb_abs, block_wt);
-                cb_reserve_back(cb_scale_tiles, 1);
-                cb_reserve_back(cb_inv_scale_tiles, 1);
+                cb_abs.wait_front(block_wt);
+                cb_scale_tiles.reserve_back(1);
+                cb_inv_scale_tiles.reserve_back(1);
                 tile_regs_acquire();
-                reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_abs, cb_scaler, cb_scale_tiles);
+                reduce_init<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_abs_id, cb_scaler_id, cb_scale_tiles_id);
                 for (uint32_t k = 0; k < block_wt; ++k) {
-                    reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_abs, cb_scaler, k, 0, k);
+                    reduce_tile<PoolType::MAX, ReduceDim::REDUCE_ROW>(cb_abs_id, cb_scaler_id, k, 0, k);
                 }
                 reduce_uninit();
 
@@ -127,46 +136,47 @@ void kernel_main() {
                 tile_regs_commit();
 
                 tile_regs_wait();
-                pack_tile(IDST0, cb_scale_tiles);      // scale output
-                pack_tile(IDST1, cb_inv_scale_tiles);  // 1/scale for the divide (same fp32 format)
+                pack_tile(IDST0, cb_scale_tiles_id);      // scale output
+                pack_tile(IDST1, cb_inv_scale_tiles_id);  // 1/scale for the divide (same fp32 format)
                 tile_regs_release();
 
-                cb_push_back(cb_scale_tiles, 1);
-                cb_push_back(cb_inv_scale_tiles, 1);
+                cb_scale_tiles.push_back(1);
+                cb_inv_scale_tiles.push_back(1);
 
-                cb_pop_front(cb_abs, block_wt);
+                cb_abs.pop_front(block_wt);
             }
 
             // ----- 3. divide: cb_out_tile = cb_tile * bcast_col(1/scale) -----
-            reconfig_data_format(cb_tile, cb_inv_scale_tiles);
-            pack_reconfig_data_format(cb_out_tile);
-            mul_bcast_cols_init_short(cb_tile, cb_inv_scale_tiles);
-            cb_wait_front(cb_inv_scale_tiles, block_ht);
-            cb_reserve_back(cb_out_tile, tiles_per_block);
+            reconfig_data_format(cb_tile_id, cb_inv_scale_tiles_id);
+            pack_reconfig_data_format(cb_out_tile_id);
+            mul_bcast_cols_init_short(cb_tile_id, cb_inv_scale_tiles_id);
+            cb_inv_scale_tiles.wait_front(block_ht);
+            cb_out_tile.reserve_back(tiles_per_block);
             for (uint32_t block_h_idx = 0; block_h_idx < block_ht; ++block_h_idx) {
                 for (uint32_t k = 0; k < block_wt; ++k) {
                     tile_regs_acquire();
-                    mul_tiles_bcast_cols(cb_tile, cb_inv_scale_tiles, block_h_idx * block_wt + k, block_h_idx, IDST0);
+                    mul_tiles_bcast_cols(
+                        cb_tile_id, cb_inv_scale_tiles_id, block_h_idx * block_wt + k, block_h_idx, IDST0);
                     tile_regs_commit();
                     tile_regs_wait();
-                    pack_tile(IDST0, cb_out_tile);
+                    pack_tile(IDST0, cb_out_tile_id);
                     tile_regs_release();
                 }
             }
-            cb_push_back(cb_out_tile, tiles_per_block);
-            cb_pop_front(cb_tile, tiles_per_block);
-            cb_pop_front(cb_inv_scale_tiles, block_ht);
+            cb_out_tile.push_back(tiles_per_block);
+            cb_tile.pop_front(tiles_per_block);
+            cb_inv_scale_tiles.pop_front(block_ht);
 
             // ----- 4. untilize cb_out_tile -> output e4m3 (scaled) -----
-            reconfig_data_format_srca(cb_out_tile);
-            pack_reconfig_data_format(cb_output_e4m3);
-            untilize_init(cb_out_tile);
-            cb_wait_front(cb_out_tile, tiles_per_block);
-            cb_reserve_back(cb_output_e4m3, tiles_per_block);
-            untilize_block(cb_out_tile, tiles_per_block, cb_output_e4m3);
-            cb_push_back(cb_output_e4m3, tiles_per_block);
-            cb_pop_front(cb_out_tile, tiles_per_block);
-            untilize_uninit(cb_out_tile);
+            reconfig_data_format_srca(cb_out_tile_id);
+            pack_reconfig_data_format(cb_output_e4m3_id);
+            untilize_init(cb_out_tile_id);
+            cb_out_tile.wait_front(tiles_per_block);
+            cb_output_e4m3.reserve_back(tiles_per_block);
+            untilize_block(cb_out_tile_id, tiles_per_block, cb_output_e4m3_id);
+            cb_output_e4m3.push_back(tiles_per_block);
+            cb_out_tile.pop_front(tiles_per_block);
+            untilize_uninit(cb_out_tile_id);
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/kernels/dataflow/reader_per_token_cast_to_fp8.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/per_token_cast_to_fp8/device/kernels/dataflow/reader_per_token_cast_to_fp8.cpp
@@ -15,7 +15,6 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/noc.h"
 #include "api/tensor/noc_traits.h"
-#include "ttnn/operations/experimental/minimal_matmul/device/kernels/matmul_dataflow_common.hpp"
 
 void kernel_main() {
     uint32_t src_addr = get_arg_val<uint32_t>(0);
@@ -49,7 +48,7 @@ void kernel_main() {
     // Fill the reduce scaler tile: zero, then 1.0 in row 0 of each face (reduce MAX layout).
     cb_scaler_obj.reserve_back(1);
     CoreLocalMem<volatile uint32_t> sc(cb_scaler_obj.get_write_ptr());
-    fill_zeros_async(noc, cb_scaler_obj, get_tile_size(cb_scaler));
+    noc.async_write_zeros(cb_scaler_obj, get_tile_size(cb_scaler), {.offset_bytes = 0});
     noc.write_zeros_l1_barrier();
 
     for (uint32_t f = 0; f < num_faces; ++f) {

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_compute.cpp
@@ -7,14 +7,15 @@
 #include "api/compute/tile_move_copy.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/bcast.h"
+#include "api/dataflow/circular_buffer.h"
 #include "ttnn/kernel_lib/tilize_helpers.hpp"
 
-constexpr uint32_t cb_combine_input = tt::CBIndex::c_0;
-constexpr uint32_t cb_weights = tt::CBIndex::c_1;
-constexpr uint32_t cb_dispatch_table = tt::CBIndex::c_2;
-constexpr uint32_t cb_indices = tt::CBIndex::c_3;
-constexpr uint32_t cb_output = tt::CBIndex::c_16;
-constexpr uint32_t cb_rowmajor = tt::CBIndex::c_17;
+constexpr uint32_t cb_combine_input_id = tt::CBIndex::c_0;
+constexpr uint32_t cb_weights_id = tt::CBIndex::c_1;
+constexpr uint32_t cb_dispatch_table_id = tt::CBIndex::c_2;
+constexpr uint32_t cb_indices_id = tt::CBIndex::c_3;
+constexpr uint32_t cb_output_id = tt::CBIndex::c_16;
+constexpr uint32_t cb_rowmajor_id = tt::CBIndex::c_17;
 
 constexpr uint32_t num_experts = get_compile_time_arg_val(0);
 constexpr uint32_t emb_dim_cb_tiles = get_compile_time_arg_val(1);
@@ -54,25 +55,32 @@ void kernel_main() {
     uint32_t num_chunks = get_arg_val<uint32_t>(1);
     constexpr uint32_t total_token_tiles = TOKENS_PER_CHUNK * emb_dim_cb_tiles;
 
+    CircularBuffer cb_combine_input(cb_combine_input_id);
+    CircularBuffer cb_weights(cb_weights_id);
+    CircularBuffer cb_dispatch_table(cb_dispatch_table_id);
+    CircularBuffer cb_indices(cb_indices_id);
+    CircularBuffer cb_output(cb_output_id);
+    CircularBuffer cb_rowmajor(cb_rowmajor_id);
+
     if constexpr (use_dispatch_table_skip) {
         // Wait for writer to finish pre-loading dispatch table (loaded once for all chunks)
-        cb_wait_front(cb_dispatch_table, dispatch_table_num_pages);
+        cb_dispatch_table.wait_front(dispatch_table_num_pages);
     }
 
-    binary_op_init_common(cb_combine_input, cb_weights, cb_output);
+    binary_op_init_common(cb_combine_input_id, cb_weights_id, cb_output_id);
 
     for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
         if constexpr (use_dispatch_table_skip) {
             // Wait for writer to load this chunk's indices (one chunk at a time)
-            cb_wait_front(cb_indices, TOKENS_PER_CHUNK);
+            cb_indices.wait_front(TOKENS_PER_CHUNK);
         }
 
-        cb_reserve_back(cb_rowmajor, total_token_tiles);
+        cb_rowmajor.reserve_back(total_token_tiles);
 
         // Process one expert at a time: both input (c_0) and weight (c_1) are streamed
         // one expert at a time by reader and writer respectively.
         for (uint32_t i = 0; i < TOKENS_PER_CHUNK; ++i) {
-            mul_tiles_bcast_scalar_init_short(cb_combine_input, cb_weights);
+            mul_tiles_bcast_scalar_init_short(cb_combine_input_id, cb_weights_id);
 
             // first_active tracks whether we've picked the accumulator-initializing
             // expert yet: the DeepSeek path looks for a locally-mapped expert via
@@ -81,15 +89,15 @@ void kernel_main() {
             // the last expert is forced through to initialise the accumulator.
             bool first_active = true;
             for (uint32_t expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
-                cb_wait_front(cb_combine_input, emb_dim_cb_tiles);
-                cb_wait_front(cb_weights, 1);
+                cb_combine_input.wait_front(emb_dim_cb_tiles);
+                cb_weights.wait_front(1);
 
                 bool skip_expert = false;
                 bool must_zero_init = false;
                 if constexpr (use_dispatch_table_skip) {
-                    uint32_t expert_id = read_tile_value_uint16(cb_indices, i, expert_idx);
+                    uint32_t expert_id = read_tile_value_uint16(cb_indices_id, i, expert_idx);
                     // Check dispatch table: -1 (0xFFFFFFFF) means non-local
-                    uint32_t chip_id = read_tile_value(cb_dispatch_table, 0, expert_id);
+                    uint32_t chip_id = read_tile_value(cb_dispatch_table_id, 0, expert_id);
                     bool is_local = (chip_id != 0xFFFFFFFF);
 
                     // On the last expert, if none were local, we must process it to
@@ -101,13 +109,13 @@ void kernel_main() {
                 } else {
                     // Read weight value — if zero, skip (but always process at least one
                     // expert so the accumulator gets initialized with valid data)
-                    uint32_t weight_val = read_tile_value(cb_weights, 0, 0);
+                    uint32_t weight_val = read_tile_value(cb_weights_id, 0, 0);
                     skip_expert = (weight_val == 0) && !first_active;
                 }
 
                 if (skip_expert) {
-                    cb_pop_front(cb_combine_input, emb_dim_cb_tiles);
-                    cb_pop_front(cb_weights, 1);
+                    cb_combine_input.pop_front(emb_dim_cb_tiles);
+                    cb_weights.pop_front(1);
                     continue;
                 }
 
@@ -121,31 +129,31 @@ void kernel_main() {
                 tile_regs_acquire();
 
                 for (uint32_t j = 0; j < emb_dim_cb_tiles; j++) {
-                    mul_tiles_bcast<BroadcastType::SCALAR>(cb_combine_input, cb_weights, j, 0, j);
+                    mul_tiles_bcast<BroadcastType::SCALAR>(cb_combine_input_id, cb_weights_id, j, 0, j);
                 }
 
                 tile_regs_commit();
                 tile_regs_wait();
 
                 for (uint32_t j = 0; j < emb_dim_cb_tiles; j++) {
-                    pack_tile<true>(j, cb_rowmajor, i * emb_dim_cb_tiles + j);
+                    pack_tile<true>(j, cb_rowmajor_id, i * emb_dim_cb_tiles + j);
                 }
 
                 tile_regs_release();
 
-                cb_pop_front(cb_combine_input, emb_dim_cb_tiles);
-                cb_pop_front(cb_weights, 1);
+                cb_combine_input.pop_front(emb_dim_cb_tiles);
+                cb_weights.pop_front(1);
             }
             pack_reconfig_l1_acc(0);
         }
 
         if constexpr (use_dispatch_table_skip) {
             // Release this chunk's indices so writer can load the next chunk's
-            cb_pop_front(cb_indices, TOKENS_PER_CHUNK);
+            cb_indices.pop_front(TOKENS_PER_CHUNK);
         }
 
-        cb_push_back(cb_rowmajor, total_token_tiles);
+        cb_rowmajor.push_back(total_token_tiles);
 
-        compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor, cb_output>(1);
+        compute_kernel_lib::tilize<total_token_tiles, cb_rowmajor_id, cb_output_id>(1);
     }
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_reader.cpp
@@ -4,8 +4,10 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 
-constexpr uint32_t cb_combine_input = tt::CBIndex::c_0;
+constexpr uint32_t cb_combine_input_id = tt::CBIndex::c_0;
 
 constexpr uint32_t num_experts = get_compile_time_arg_val(0);
 // Number of tile-sized CB pages needed to hold one row of emb_dim elements
@@ -23,6 +25,9 @@ void kernel_main() {
     uint32_t token_start_idx = get_arg_val<uint32_t>(1);
     uint32_t num_chunks = get_arg_val<uint32_t>(2);
 
+    Noc noc;
+    CircularBuffer cb_combine_input(cb_combine_input_id);
+
     const auto combine_addrg = TensorAccessor(combine_accessor_args, combine_addr);
 
     for (uint32_t chunk = 0; chunk < num_chunks; ++chunk) {
@@ -30,14 +35,13 @@ void kernel_main() {
             uint32_t global_token_idx = token_start_idx + token_idx;
 
             for (uint32_t expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
-                cb_reserve_back(cb_combine_input, emb_dim_cb_tiles);
-                uint32_t cb_write_addr = get_write_ptr(cb_combine_input);
+                cb_combine_input.reserve_back(emb_dim_cb_tiles);
 
                 uint32_t expert_page_idx = global_token_idx * num_experts + expert_idx;
-                uint64_t noc_addr = combine_addrg.get_noc_addr(expert_page_idx);
-                noc_async_read(noc_addr, cb_write_addr, emb_dim_bytes);
-                noc_async_read_barrier();
-                cb_push_back(cb_combine_input, emb_dim_cb_tiles);
+                noc.async_read(
+                    combine_addrg, cb_combine_input, emb_dim_bytes, {.page_id = expert_page_idx}, {.offset_bytes = 0});
+                noc.async_read_barrier();
+                cb_combine_input.push_back(emb_dim_cb_tiles);
             }
         }
         token_start_idx += TOKENS_PER_CHUNK;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/post_combine_reduce/device/kernels/deepseek_moe_post_combine_reduce_writer.cpp
@@ -4,11 +4,13 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 
-constexpr uint32_t cb_weights = tt::CBIndex::c_1;
-constexpr uint32_t cb_dispatch_table = tt::CBIndex::c_2;
-constexpr uint32_t cb_indices = tt::CBIndex::c_3;
-constexpr uint32_t cb_output = tt::CBIndex::c_16;
+constexpr uint32_t cb_weights_id = tt::CBIndex::c_1;
+constexpr uint32_t cb_dispatch_table_id = tt::CBIndex::c_2;
+constexpr uint32_t cb_indices_id = tt::CBIndex::c_3;
+constexpr uint32_t cb_output_id = tt::CBIndex::c_16;
 
 // Fixed CT arg layout for both paths. The dispatch_table / indices metadata
 // and accessor args are always emitted by the program factory; when the
@@ -59,8 +61,14 @@ void kernel_main() {
         num_chunks = get_arg_val<uint32_t>(3);
     }
 
-    constexpr uint32_t weight_tile_size = get_tile_size(cb_weights);
-    constexpr uint32_t output_tile_size = get_tile_size(cb_output);
+    Noc noc;
+    CircularBuffer cb_weights(cb_weights_id);
+    CircularBuffer cb_dispatch_table(cb_dispatch_table_id);
+    CircularBuffer cb_indices(cb_indices_id);
+    CircularBuffer cb_output(cb_output_id);
+
+    const uint32_t weight_tile_size = cb_weights.get_tile_size();
+    const uint32_t output_tile_size = cb_output.get_tile_size();
 
     const auto weight_addrg = TensorAccessor(weight_accessor_args, weight_addr);
     const auto output_addrg = TensorAccessor(output_accessor_args, output_addr);
@@ -72,14 +80,18 @@ void kernel_main() {
             TensorAccessor(dispatch_table_accessor_args, dispatch_table_addr, dispatch_table_page_size);
 
         // Pre-load dispatch table into CB (c_2) — read once, used by compute for all chunks
-        cb_reserve_back(cb_dispatch_table, dispatch_table_num_pages);
-        dispatch_table_write_addr = get_write_ptr(cb_dispatch_table);
+        cb_dispatch_table.reserve_back(dispatch_table_num_pages);
+        dispatch_table_write_addr = cb_dispatch_table.get_write_ptr();
         for (uint32_t i = 0; i < dispatch_table_num_pages; i++) {
-            noc_async_read_page(
-                i, dispatch_table_addrg, dispatch_table_write_addr + i * dispatch_table_aligned_page_size);
+            noc.async_read(
+                dispatch_table_addrg,
+                cb_dispatch_table,
+                dispatch_table_aligned_page_size,
+                {.page_id = i},
+                {.offset_bytes = i * dispatch_table_aligned_page_size});
         }
-        noc_async_read_barrier();
-        cb_push_back(cb_dispatch_table, dispatch_table_num_pages);
+        noc.async_read_barrier();
+        cb_dispatch_table.push_back(dispatch_table_num_pages);
     }
 
     constexpr uint32_t cb_output_tiles = emb_dim_cb_tiles * TOKENS_PER_CHUNK;
@@ -89,16 +101,20 @@ void kernel_main() {
         uint32_t indices_write_addr = 0;
         if constexpr (use_dispatch_table_skip) {
             const auto indices_addrg = TensorAccessor(indices_accessor_args, indices_addr, indices_page_size);
-            cb_reserve_back(cb_indices, TOKENS_PER_CHUNK);
-            indices_write_addr = get_write_ptr(cb_indices);
+            cb_indices.reserve_back(TOKENS_PER_CHUNK);
+            indices_write_addr = cb_indices.get_write_ptr();
             for (uint32_t i = 0; i < TOKENS_PER_CHUNK; i++) {
-                noc_async_read_page(
-                    token_start_idx + i, indices_addrg, indices_write_addr + i * indices_aligned_page_size);
+                noc.async_read(
+                    indices_addrg,
+                    cb_indices,
+                    indices_aligned_page_size,
+                    {.page_id = token_start_idx + i},
+                    {.offset_bytes = i * indices_aligned_page_size});
             }
-            noc_async_read_barrier();
+            noc.async_read_barrier();
             // Indices stay as uint16 in the CB — the compute kernel reads them
             // directly via read_tile_value_uint16.
-            cb_push_back(cb_indices, TOKENS_PER_CHUNK);
+            cb_indices.push_back(TOKENS_PER_CHUNK);
         }
 
         // Phase 1: Stream one weight per expert per token for this chunk
@@ -121,8 +137,7 @@ void kernel_main() {
             }
 
             for (uint32_t expert_idx = 0; expert_idx < num_experts; ++expert_idx) {
-                cb_reserve_back(cb_weights, 1);
-                uint32_t cb_write_addr = get_write_ptr(cb_weights);
+                cb_weights.reserve_back(1);
 
                 if constexpr (use_dispatch_table_skip) {
                     bool is_last = (expert_idx == num_experts - 1);
@@ -130,21 +145,27 @@ void kernel_main() {
                         // No local experts for this token — zero the weight tile so compute's
                         // must_zero_init multiply produces zeros regardless of combine_output.
                         volatile tt_l1_ptr uint32_t* ptr =
-                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_write_addr);
+                            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_weights.get_write_ptr());
                         for (uint32_t w = 0; w < weight_tile_size / sizeof(uint32_t); w++) {
                             ptr[w] = 0;
                         }
                     } else {
                         uint32_t weight_page_idx = global_token_idx * num_experts + expert_idx;
-                        noc_async_read_page(weight_page_idx, weight_addrg, cb_write_addr);
-                        noc_async_read_barrier();
+                        noc.async_read(
+                            weight_addrg,
+                            cb_weights,
+                            weight_tile_size,
+                            {.page_id = weight_page_idx},
+                            {.offset_bytes = 0});
+                        noc.async_read_barrier();
                     }
                 } else {
                     uint32_t weight_page_idx = global_token_idx * num_experts + expert_idx;
-                    noc_async_read_page(weight_page_idx, weight_addrg, cb_write_addr);
-                    noc_async_read_barrier();
+                    noc.async_read(
+                        weight_addrg, cb_weights, weight_tile_size, {.page_id = weight_page_idx}, {.offset_bytes = 0});
+                    noc.async_read_barrier();
                 }
-                cb_push_back(cb_weights, 1);
+                cb_weights.push_back(1);
             }
         }
 
@@ -152,21 +173,23 @@ void kernel_main() {
         // The output CB holds TOKENS_PER_CHUNK * emb_dim_cb_tiles tile-sized pages
         // (including padding when emb_dim is not 1024-aligned); only the first
         // emb_dim_out_tiles of them hold real data for this 32-token block.
-        cb_wait_front(cb_output, cb_output_tiles);
-
-        uint32_t cb_read_addr = get_read_ptr(cb_output);
+        cb_output.wait_front(cb_output_tiles);
 
         uint32_t tile_row = token_start_idx / TOKENS_PER_CHUNK;
         uint32_t start_tile_idx = tile_row * emb_dim_out_tiles;
 
         for (uint32_t tile_idx = 0; tile_idx < emb_dim_out_tiles; ++tile_idx) {
-            noc_async_write_page(start_tile_idx + tile_idx, output_addrg, cb_read_addr);
-            cb_read_addr += output_tile_size;
+            noc.async_write(
+                cb_output,
+                output_addrg,
+                output_tile_size,
+                {.offset_bytes = tile_idx * output_tile_size},
+                {.page_id = start_tile_idx + tile_idx});
         }
 
-        noc_async_write_barrier();
+        noc.async_write_barrier();
 
-        cb_pop_front(cb_output, cb_output_tiles);
+        cb_output.pop_front(cb_output_tiles);
 
         token_start_idx += TOKENS_PER_CHUNK;
     }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/compute/fused_swiglu.cpp
@@ -105,9 +105,14 @@ FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t 
     // cost of down-matmul efficiency. The fused gate/up phase escapes the race
     // because its two interleaved matmuls already separate consecutive same-slot
     // packs. Keeping the perf-optimal wide subblock here is now safe.
+    CircularBuffer in0_cb(in0_cb_id);
+    CircularBuffer in1_cb(in1_cb_id);
+    CircularBuffer partials_cb(partials_cb_id);
+    CircularBuffer final_cb(final_cb_id);
+
     for (uint32_t block = 0; block < num_blocks; ++block) {
-        cb_wait_front(in0_cb_id, in0_block_num_tiles);
-        cb_wait_front(in1_cb_id, in1_block_num_tiles);
+        in0_cb.wait_front(in0_block_num_tiles);
+        in1_cb.wait_front(in1_block_num_tiles);
 
         int in0_index_subblock_offset = 0;
         for (uint32_t sb_m = 0; sb_m < in0_num_subblocks; ++sb_m) {
@@ -134,11 +139,11 @@ FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t 
                 }
 
                 tile_regs_commit();
-                cb_reserve_back(partials_cb_id, out_subblock_num_tiles);
+                partials_cb.reserve_back(out_subblock_num_tiles);
                 tile_regs_wait();
                 pack_tile_block(0, partials_cb_id, out_subblock_num_tiles);
                 tile_regs_release();
-                cb_push_back(partials_cb_id, out_subblock_num_tiles);
+                partials_cb.push_back(out_subblock_num_tiles);
 
                 in1_index_subblock_offset += out_subblock_w;
             }
@@ -152,8 +157,8 @@ FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t 
         }
 #endif
 
-        cb_pop_front(in0_cb_id, in0_block_num_tiles);
-        cb_pop_front(in1_cb_id, in1_block_num_tiles);
+        in0_cb.pop_front(in0_block_num_tiles);
+        in1_cb.pop_front(in1_block_num_tiles);
 
         // Drain all but the last K-block (see header comment): forces the
         // packer's writes visible before the next block's L1_ACC RMW and wraps
@@ -161,8 +166,8 @@ FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t 
         // left pushed for the second-pass copy below.
         if (block + 1 < num_blocks) {
             for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
-                cb_wait_front(partials_cb_id, out_subblock_num_tiles);
-                cb_pop_front(partials_cb_id, out_subblock_num_tiles);
+                partials_cb.wait_front(out_subblock_num_tiles);
+                partials_cb.pop_front(out_subblock_num_tiles);
             }
         }
     }
@@ -183,11 +188,11 @@ FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t 
 
     for (uint32_t sb = 0; sb < (out_block_num_tiles / out_subblock_num_tiles); ++sb) {
         tile_regs_acquire();
-        cb_wait_front(partials_cb_id, out_subblock_num_tiles);
+        partials_cb.wait_front(out_subblock_num_tiles);
         for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
             copy_tile(partials_cb_id, i, i);
         }
-        cb_pop_front(partials_cb_id, out_subblock_num_tiles);
+        partials_cb.pop_front(out_subblock_num_tiles);
 
         tile_regs_commit();
 
@@ -197,11 +202,11 @@ FORCE_INLINE void matmul_phase(uint32_t in0_cb_id, uint32_t in1_cb_id, uint32_t 
             tile_regs_wait();
         }
 
-        cb_reserve_back(final_cb_id, out_subblock_num_tiles);
+        final_cb.reserve_back(out_subblock_num_tiles);
         for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
             pack_tile(i, final_cb_id);
         }
-        cb_push_back(final_cb_id, out_subblock_num_tiles);
+        final_cb.push_back(out_subblock_num_tiles);
 
         tile_regs_release();
     }
@@ -245,18 +250,25 @@ FORCE_INLINE void matmul_phase_fused_gu(
     PACK((llk_pack_reconfig_l1_acc(0)));
 #endif
 
+    CircularBuffer x_cb(x_cb_id);
+    CircularBuffer gate_cb(gate_cb_id);
+    CircularBuffer up_cb(up_cb_id);
+    CircularBuffer partials_gu_cb(partials_gu_cb_id);
+    CircularBuffer partials_up_cb(partials_up_cb_id);
+    CircularBuffer gate_intermed_cb(gate_intermed_cb_id);
+
     // Reserve both partials CBs once for the full per-core block. pack_tile
     // with output_tile_index writes to absolute slots; WrPtr doesn't advance
     // until cb_push_back below. Across K-blocks 1..N-1, L1_ACC packs land
     // back in the SAME L1 slots — accumulating physically — which is what
     // we want. No per-K-block pop+repush needed.
-    cb_reserve_back(partials_gu_cb_id, out_block_num_tiles);
-    cb_reserve_back(partials_up_cb_id, out_block_num_tiles);
+    partials_gu_cb.reserve_back(out_block_num_tiles);
+    partials_up_cb.reserve_back(out_block_num_tiles);
 
     for (uint32_t block = 0; block < num_blocks; ++block) {
-        cb_wait_front(x_cb_id, in0_block_num_tiles);
-        cb_wait_front(gate_cb_id, in1_block_num_tiles);
-        cb_wait_front(up_cb_id, in1_block_num_tiles);
+        x_cb.wait_front(in0_block_num_tiles);
+        gate_cb.wait_front(in1_block_num_tiles);
+        up_cb.wait_front(in1_block_num_tiles);
 
         int in0_index_subblock_offset = 0;
         uint32_t partials_slot_idx = 0;
@@ -329,13 +341,13 @@ FORCE_INLINE void matmul_phase_fused_gu(
         }
 #endif
 
-        cb_pop_front(x_cb_id, in0_block_num_tiles);
-        cb_pop_front(gate_cb_id, in1_block_num_tiles);
-        cb_pop_front(up_cb_id, in1_block_num_tiles);
+        x_cb.pop_front(in0_block_num_tiles);
+        gate_cb.pop_front(in1_block_num_tiles);
+        up_cb.pop_front(in1_block_num_tiles);
     }
     // Make the accumulated partials visible to the second-pass copy loops.
-    cb_push_back(partials_gu_cb_id, out_block_num_tiles);
-    cb_push_back(partials_up_cb_id, out_block_num_tiles);
+    partials_gu_cb.push_back(out_block_num_tiles);
+    partials_up_cb.push_back(out_block_num_tiles);
 
     // After K-loop: partials_gu holds gate-matmul accumulator,
     // partials_up holds up-matmul accumulator. Copy each to its intermed
@@ -357,22 +369,22 @@ FORCE_INLINE void matmul_phase_fused_gu(
     copy_tile_to_dst_init_short_with_dt(up_cb_id, partials_gu_cb_id);
     for (uint32_t sb = 0; sb < (out_block_num_tiles / out_subblock_num_tiles); ++sb) {
         tile_regs_acquire();
-        cb_wait_front(partials_gu_cb_id, out_subblock_num_tiles);
+        partials_gu_cb.wait_front(out_subblock_num_tiles);
         for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
             copy_tile(partials_gu_cb_id, i, i);
         }
-        cb_pop_front(partials_gu_cb_id, out_subblock_num_tiles);
+        partials_gu_cb.pop_front(out_subblock_num_tiles);
         // MATH-thread SFPU pass: apply silu to each dst tile before pack.
         for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
             silu_tile(i);
         }
         tile_regs_commit();
         tile_regs_wait();
-        cb_reserve_back(gate_intermed_cb_id, out_subblock_num_tiles);
+        gate_intermed_cb.reserve_back(out_subblock_num_tiles);
         for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
             pack_tile(i, gate_intermed_cb_id);
         }
-        cb_push_back(gate_intermed_cb_id, out_subblock_num_tiles);
+        gate_intermed_cb.push_back(out_subblock_num_tiles);
         tile_regs_release();
     }
 
@@ -385,8 +397,12 @@ FORCE_INLINE void matmul_phase_fused_gu(
 
 template <uint32_t out_block_num_tiles, uint32_t out_subblock_num_tiles>
 FORCE_INLINE void multiply_phase(uint32_t gate_cb_id, uint32_t up_cb_id, uint32_t activated_cb_id) {
-    cb_wait_front(gate_cb_id, out_block_num_tiles);
-    cb_wait_front(up_cb_id, out_block_num_tiles);
+    CircularBuffer gate_cb(gate_cb_id);
+    CircularBuffer up_cb(up_cb_id);
+    CircularBuffer activated_cb(activated_cb_id);
+
+    gate_cb.wait_front(out_block_num_tiles);
+    up_cb.wait_front(out_block_num_tiles);
 
     // Reconfigure packer for activated format and unpacker for both
     // gate_cb (SrcA) and up_cb (SrcB). After phase 2's second pass the
@@ -408,16 +424,16 @@ FORCE_INLINE void multiply_phase(uint32_t gate_cb_id, uint32_t up_cb_id, uint32_
         }
         tile_regs_commit();
         tile_regs_wait();
-        cb_reserve_back(activated_cb_id, out_subblock_num_tiles);
+        activated_cb.reserve_back(out_subblock_num_tiles);
         for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
             pack_tile(i, activated_cb_id);
         }
-        cb_push_back(activated_cb_id, out_subblock_num_tiles);
+        activated_cb.push_back(out_subblock_num_tiles);
         tile_regs_release();
         base += out_subblock_num_tiles;
     }
-    cb_pop_front(gate_cb_id, out_block_num_tiles);
-    cb_pop_front(up_cb_id, out_block_num_tiles);
+    gate_cb.pop_front(out_block_num_tiles);
+    up_cb.pop_front(out_block_num_tiles);
 }
 
 }  // namespace
@@ -482,14 +498,17 @@ void kernel_main() {
     constexpr uint32_t cb_counts_scratch = get_named_compile_time_arg_val("cb_counts_scratch");
     constexpr uint32_t cb_idx_scratch = get_named_compile_time_arg_val("cb_idx_scratch");
 
+    CircularBuffer counts_scratch_cb(cb_counts_scratch);
+    CircularBuffer idx_scratch_cb(cb_idx_scratch);
+
     // Wait for the reader (BRISC) to push the per-expert counts/idx into
     // shared L1. UNPACK reads the L1 via LocalCBInterface and broadcasts
     // count_value to MATH and PACK via the inter-thread mailbox (MATH cannot
     // access get_local_cb_interface symbols at link time). Production matmul
     // uses the same UNPACK→mailbox→MATH/PACK pattern (see
     // circular_buffer.h::read_tile_value).
-    cb_wait_front(cb_counts_scratch, 1);
-    cb_wait_front(cb_idx_scratch, 1);
+    counts_scratch_cb.wait_front(1);
+    idx_scratch_cb.wait_front(1);
     uint32_t count_value = 0;
     UNPACK(({
         const uint32_t counts_l1_addr = get_local_cb_interface(cb_counts_scratch).fifo_rd_ptr << 4;

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_reader.cpp
@@ -23,6 +23,11 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
 
 void kernel_main() {
     // -------------------------- runtime args ------------------------------
@@ -49,8 +54,6 @@ void kernel_main() {
     const uint32_t in1_mcast_ny_end = get_arg_val<uint32_t>(16);
     const uint32_t in1_sender_nx = get_arg_val<uint32_t>(17);
     const uint32_t in1_sender_ny = get_arg_val<uint32_t>(18);
-    const uint32_t in1_ready_sem_addr = get_semaphore(in1_ready_sem_id);
-    const uint32_t in1_valid_sem_addr = get_semaphore(in1_valid_sem_id);
 
     // x (in0) multicast runtime args (indices 19..28).
     const uint32_t is_in0_sender_u32 = get_arg_val<uint32_t>(19);
@@ -64,8 +67,6 @@ void kernel_main() {
     const uint32_t in0_mcast_ny_end = get_arg_val<uint32_t>(26);
     const uint32_t in0_sender_nx = get_arg_val<uint32_t>(27);
     const uint32_t in0_sender_ny = get_arg_val<uint32_t>(28);
-    const uint32_t in0_ready_sem_addr = get_semaphore(in0_ready_sem_id);
-    const uint32_t in0_valid_sem_addr = get_semaphore(in0_valid_sem_id);
 
     // Activated L1 mcast sems. Sender (gx == kb at phase-4 K-block kb) waits
     // on its act_ready_sem for GRID_X - 1 incs from the receivers; then
@@ -73,8 +74,6 @@ void kernel_main() {
     // mcasts act_valid_sem to release receivers.
     const uint32_t act_ready_sem_id = get_arg_val<uint32_t>(29);
     const uint32_t act_valid_sem_id = get_arg_val<uint32_t>(30);
-    const uint32_t act_ready_sem_addr = get_semaphore(act_ready_sem_id);
-    const uint32_t act_valid_sem_addr = get_semaphore(act_valid_sem_id);
 
     // UP_SPLIT local handshake (reader <-> writer): up_go = slot reserved,
     // up_done = up block landed in L1. Monotonic; gy=0 in1-sender cores only.
@@ -153,25 +152,53 @@ void kernel_main() {
     constexpr auto idx_args = TensorAccessorArgs<idx_accessor_offset>();
     const auto idx_acc = TensorAccessor(idx_args, idx_table_addr);
 
+    // D2.0 NoC handles. `noc` uses default noc_index for mcasts/sem ops.
+    // `noc_read` forces NoC 0 for DRAM weight/page reads — the kernel issues
+    // those concurrently with mcast traffic on the kernel's default NoC for
+    // dual-NoC parallelism (see in1_down + activated mcast in phase 4).
+    Noc noc;
+    Noc noc_read(0);
+
+    // D2.0 CircularBuffer wrappers for method-form access. Compile-time CB
+    // indices are unchanged.
+    CircularBuffer cb_in0_x_obj(cb_in0_x);
+    CircularBuffer cb_in1_gate_obj(cb_in1_gate);
+    CircularBuffer cb_in1_up_obj(cb_in1_up);
+    CircularBuffer cb_in1_down_obj(cb_in1_down);
+    CircularBuffer cb_in0_down_full_obj(cb_in0_down_full);
+    CircularBuffer cb_counts_scratch_obj(cb_counts_scratch);
+    CircularBuffer cb_idx_scratch_obj(cb_idx_scratch);
+    CircularBuffer cb_activated_obj(cb_activated);
+
+    // D2.0 Semaphore wrappers.
+    Semaphore<> in1_ready_sem(in1_ready_sem_id);
+    Semaphore<> in1_valid_sem(in1_valid_sem_id);
+    Semaphore<> in0_ready_sem(in0_ready_sem_id);
+    Semaphore<> in0_valid_sem(in0_valid_sem_id);
+    Semaphore<> act_ready_sem(act_ready_sem_id);
+    Semaphore<> act_valid_sem(act_valid_sem_id);
+
     // Look up active token count for this expert from device-side buffers.
     // Reserve+read+push so the compute kernel (TRISC) and writer kernel
     // (NCRISC) can cb_wait_front on these CBs and read the same L1 data.
     //
     // Each scratch CB is a single page sized (host-side) to hold up to
     // MAX_GLOBAL_EXPERTS UINT32 entries, so `1` here is the whole buffer and a
-    // single noc_async_read_page lands the entire counts / idx vector. The
+    // single async_read lands the entire counts / idx vector. The
     // later counts_ptr[global_expert_id] / idx_ptr[local_expert_id] indexing
     // therefore stays in-bounds for any model up to MAX_GLOBAL_EXPERTS experts
     // (DeepSeek V3 256, Kimi 384, ... up to 1024).
-    cb_reserve_back(cb_counts_scratch, 1);
-    cb_reserve_back(cb_idx_scratch, 1);
-    const uint32_t counts_l1 = get_write_ptr(cb_counts_scratch);
-    const uint32_t idx_l1 = get_write_ptr(cb_idx_scratch);
-    noc_async_read_page(0, counts_acc, counts_l1);
-    noc_async_read_page(0, idx_acc, idx_l1);
-    noc_async_read_barrier();
-    cb_push_back(cb_counts_scratch, 1);
-    cb_push_back(cb_idx_scratch, 1);
+    cb_counts_scratch_obj.reserve_back(1);
+    cb_idx_scratch_obj.reserve_back(1);
+    const uint32_t counts_l1 = cb_counts_scratch_obj.get_write_ptr();
+    const uint32_t idx_l1 = cb_idx_scratch_obj.get_write_ptr();
+    const uint32_t counts_page_size = counts_acc.get_aligned_page_size();
+    const uint32_t idx_page_size = idx_acc.get_aligned_page_size();
+    noc_read.async_read(counts_acc, CoreLocalMem<uint32_t>(counts_l1), counts_page_size, {.page_id = 0}, {});
+    noc_read.async_read(idx_acc, CoreLocalMem<uint32_t>(idx_l1), idx_page_size, {.page_id = 0}, {});
+    noc_read.async_read_barrier();
+    cb_counts_scratch_obj.push_back(1);
+    cb_idx_scratch_obj.push_back(1);
 
     const volatile tt_l1_ptr uint32_t* counts_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(counts_l1);
     const volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_l1);
@@ -218,18 +245,7 @@ void kernel_main() {
     // Both sender and receiver finish with the K-block of in1 in their own
     // cb_in1 L1, ready for cb_push_back/compute.
     constexpr uint32_t IN1_VALID = 1;
-    volatile tt_l1_ptr uint32_t* in1_ready_local = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_ready_sem_addr);
-    volatile tt_l1_ptr uint32_t* in1_valid_local = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in1_valid_sem_addr);
-    const uint64_t in1_sender_ready_noc = get_noc_addr(in1_sender_nx, in1_sender_ny, in1_ready_sem_addr);
-    const uint64_t in1_mcast_valid_noc = get_noc_multicast_addr(
-        in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, in1_valid_sem_addr);
-
     constexpr uint32_t IN0_VALID = 1;
-    volatile tt_l1_ptr uint32_t* in0_ready_local = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_ready_sem_addr);
-    volatile tt_l1_ptr uint32_t* in0_valid_local = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(in0_valid_sem_addr);
-    const uint64_t in0_sender_ready_noc = get_noc_addr(in0_sender_nx, in0_sender_ny, in0_ready_sem_addr);
-    const uint64_t in0_mcast_valid_noc = get_noc_multicast_addr(
-        in0_mcast_nx_start, in0_mcast_ny_start, in0_mcast_nx_end, in0_mcast_ny_end, in0_valid_sem_addr);
 
     // UP_SPLIT handshake counter, kept in lockstep with the writer's.
     uint32_t up_seq = 0;
@@ -250,10 +266,10 @@ void kernel_main() {
         if (is_in0_sender) {
             const uint32_t this_core_last_row = this_core_first_row + per_core_M;
             if (this_core_last_row > M_bound) {
-                const uint32_t slot_size_bytes = g_in0_block_num_tiles * get_tile_size(cb_in0_x);
+                const uint32_t slot_size_bytes = g_in0_block_num_tiles * cb_in0_x_obj.get_tile_size();
                 const uint32_t both_slots_bytes = 2 * slot_size_bytes;
                 volatile tt_l1_ptr uint64_t* zero_dst =
-                    reinterpret_cast<volatile tt_l1_ptr uint64_t*>(get_write_ptr(cb_in0_x));
+                    reinterpret_cast<volatile tt_l1_ptr uint64_t*>(cb_in0_x_obj.get_write_ptr());
                 const size_t num_u64_words = both_slots_bytes / sizeof(uint64_t);
                 for (size_t word = 0; word < num_u64_words; ++word) {
                     zero_dst[word] = 0;
@@ -275,10 +291,10 @@ void kernel_main() {
         //   per-K-block elapsed time at small per_core_M where mcast/handshake
         //   overhead dominates compute.
         for (uint32_t kb = 0; kb < num_blocks_gu; ++kb) {
-            cb_reserve_back(cb_in0_x, g_in0_block_num_tiles);
-            cb_reserve_back(cb_in1_gate, g_in1_block_num_tiles);
+            cb_in0_x_obj.reserve_back(g_in0_block_num_tiles);
+            cb_in1_gate_obj.reserve_back(g_in1_block_num_tiles);
             if constexpr (reader_mcasts_up) {
-                cb_reserve_back(cb_in1_up, g_in1_block_num_tiles);
+                cb_in1_up_obj.reserve_back(g_in1_block_num_tiles);
             }
 
             // UP_SPLIT: slot reserved -> release writer to read `up` on NoC 1,
@@ -295,12 +311,12 @@ void kernel_main() {
             // cores; the only core that's both senders is (0,0) which doesn't
             // self-inc (it's its own sender for both).
             if (!is_in0_sender) {
-                *in0_valid_local = 0;
-                noc_semaphore_inc(in0_sender_ready_noc, 1);
+                in0_valid_sem.set(0);
+                in0_ready_sem.up(noc, in0_sender_nx, in0_sender_ny, 1);
             }
             if (!is_in1_sender) {
-                *in1_valid_local = 0;
-                noc_semaphore_inc(in1_sender_ready_noc, 1);
+                in1_valid_sem.set(0);
+                in1_ready_sem.up(noc, in1_sender_nx, in1_sender_ny, 1);
             }
 
             // Step 2: senders run their work. in0 sender path and in1 sender
@@ -309,10 +325,10 @@ void kernel_main() {
             // work begins immediately. For core (0,0) (both senders), in0
             // runs first then in1, ~60µs sequentially — same as before.
             if (is_in0_sender) {
-                noc_semaphore_wait(in0_ready_local, in0_num_receivers);
-                *in0_ready_local = 0;
+                in0_ready_sem.wait(in0_num_receivers);
+                in0_ready_sem.set(0);
 
-                uint32_t l1_x = get_write_ptr(cb_in0_x);
+                uint32_t l1_x = cb_in0_x_obj.get_write_ptr();
                 const uint32_t block_start = l1_x;
                 for (uint32_t m = 0; m < per_core_M; ++m) {
                     const uint32_t row = this_core_first_row + m;
@@ -329,7 +345,8 @@ void kernel_main() {
                         for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
                             const uint32_t col = kb * in0_block_w_gu + k;
                             const uint32_t tile_idx = row * K_gate_tiles + col;
-                            noc_async_read_page(tile_idx, x_acc, l1_x, /*offset=*/0, /*noc=*/0);
+                            noc_read.async_read(
+                                x_acc, CoreLocalMem<uint32_t>(l1_x), x_tile_bytes, {.page_id = tile_idx}, {});
                             l1_x += x_tile_bytes;
                         }
                     } else {
@@ -337,10 +354,8 @@ void kernel_main() {
                         l1_x += in0_block_w_gu * x_tile_bytes;
                     }
                 }
-                noc_async_read_barrier(/*noc=*/0);
+                noc_read.async_read_barrier();
 
-                const uint64_t mcast_data_noc = get_noc_multicast_addr(
-                    in0_mcast_nx_start, in0_mcast_ny_start, in0_mcast_nx_end, in0_mcast_ny_end, block_start);
                 const uint32_t block_bytes = g_in0_block_num_tiles * x_tile_bytes;
                 // linked=true keeps the multicast path RESERVED so the in0_valid
                 // sem multicast below travels the SAME path and is delivered
@@ -352,20 +367,32 @@ void kernel_main() {
                 // matmul output for that core (rare, timing-dependent). A write
                 // barrier does NOT fix this on Blackhole (multicast writes are
                 // posted; no completion ack). Mirrors the phase-4 activated mcast.
-                noc_async_write_multicast(block_start, mcast_data_noc, block_bytes, in0_num_receivers, /*linked=*/true);
-                cb_push_back(cb_in0_x, g_in0_block_num_tiles);
+                noc.async_write_multicast(
+                    CoreLocalMem<uint32_t>(block_start),
+                    MulticastEndpoint{},
+                    block_bytes,
+                    in0_num_receivers,
+                    {.offset_bytes = 0},
+                    {.noc_x_start = in0_mcast_nx_start,
+                     .noc_y_start = in0_mcast_ny_start,
+                     .noc_x_end = in0_mcast_nx_end,
+                     .noc_y_end = in0_mcast_ny_end,
+                     .addr = block_start},
+                    /*linked=*/true);
+                cb_in0_x_obj.push_back(g_in0_block_num_tiles);
 
-                noc_async_writes_flushed();
-                *in0_valid_local = IN0_VALID;
-                noc_semaphore_set_multicast(in0_valid_sem_addr, in0_mcast_valid_noc, in0_num_receivers);
+                noc.async_writes_flushed();
+                in0_valid_sem.set(IN0_VALID);
+                in0_valid_sem.set_multicast<NocOptions::DEFAULT>(
+                    noc, in0_mcast_nx_start, in0_mcast_ny_start, in0_mcast_nx_end, in0_mcast_ny_end, in0_num_receivers);
             }
 
             if (is_in1_sender) {
-                noc_semaphore_wait(in1_ready_local, in1_num_receivers);
-                *in1_ready_local = 0;
+                in1_ready_sem.wait(in1_num_receivers);
+                in1_ready_sem.set(0);
 
                 // DRAM read gate region first.
-                uint32_t l1_w_gate = get_write_ptr(cb_in1_gate);
+                uint32_t l1_w_gate = cb_in1_gate_obj.get_write_ptr();
                 const uint32_t gate_block_start = l1_w_gate;
                 for (uint32_t k = 0; k < in0_block_w_gu; ++k) {
                     for (uint32_t n = 0; n < per_core_N_gu; ++n) {
@@ -373,7 +400,12 @@ void kernel_main() {
                         const uint32_t col = my_nt_gu * per_core_N_gu + n;
                         if (col < N_gate_tiles_full) {
                             const uint32_t tile_idx = row * N_gate_tiles_full + col;
-                            noc_async_read_page(tile_idx, gate_acc, l1_w_gate, /*offset=*/0, /*noc=*/0);
+                            noc_read.async_read(
+                                gate_acc,
+                                CoreLocalMem<uint32_t>(l1_w_gate),
+                                gate_tile_bytes,
+                                {.page_id = tile_idx},
+                                {});
                         } else {
                             volatile tt_l1_ptr uint64_t* p = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(l1_w_gate);
                             for (uint32_t i = 0; i < gate_tile_bytes / 8; ++i) {
@@ -388,7 +420,7 @@ void kernel_main() {
                 // waits on up_done (below) before mcasting.
                 uint32_t up_block_start = 0;
                 if constexpr (reader_mcasts_up) {
-                    up_block_start = get_write_ptr(cb_in1_up);
+                    up_block_start = cb_in1_up_obj.get_write_ptr();
                 }
                 if constexpr (reader_reads_up) {
                     uint32_t l1_w_up = up_block_start;
@@ -410,7 +442,7 @@ void kernel_main() {
                         }
                     }
                 }
-                noc_async_read_barrier(/*noc=*/0);
+                noc_read.async_read_barrier();
 
                 // UP_SPLIT: wait for the writer's NoC-1 `up` read before mcast.
                 if constexpr (up_split) {
@@ -420,8 +452,6 @@ void kernel_main() {
                 // GRID_Y == 1: no column receivers — skip mcast/valid-sem; the
                 // locally-read weights go straight to compute via cb_push_back.
                 if (in1_num_receivers > 0) {
-                    const uint64_t gate_mcast_noc = get_noc_multicast_addr(
-                        in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, gate_block_start);
                     const uint32_t gate_block_bytes = g_in1_block_num_tiles * gate_tile_bytes;
                     // The LAST in1 data multicast before the in1_valid sem must
                     // be linked=true so the (posted) valid-sem multicast travels
@@ -436,45 +466,60 @@ void kernel_main() {
                     // links into it and up holds the path for the sem; in the
                     // retired UP_WRITER_MCAST mode (no up mcast) gate is last and
                     // holds the path itself.
-                    noc_async_write_multicast(
-                        gate_block_start,
-                        gate_mcast_noc,
+                    noc.async_write_multicast(
+                        CoreLocalMem<uint32_t>(gate_block_start),
+                        MulticastEndpoint{},
                         gate_block_bytes,
                         in1_num_receivers,
+                        {.offset_bytes = 0},
+                        {.noc_x_start = in1_mcast_nx_start,
+                         .noc_y_start = in1_mcast_ny_start,
+                         .noc_x_end = in1_mcast_nx_end,
+                         .noc_y_end = in1_mcast_ny_end,
+                         .addr = gate_block_start},
                         /*linked=*/true);
 
                     if constexpr (reader_mcasts_up) {
-                        const uint64_t up_mcast_noc = get_noc_multicast_addr(
-                            in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, up_block_start);
                         const uint32_t up_block_bytes = g_in1_block_num_tiles * up_tile_bytes;
-                        noc_async_write_multicast(
-                            up_block_start, up_mcast_noc, up_block_bytes, in1_num_receivers, /*linked=*/true);
+                        noc.async_write_multicast(
+                            CoreLocalMem<uint32_t>(up_block_start),
+                            MulticastEndpoint{},
+                            up_block_bytes,
+                            in1_num_receivers,
+                            {.offset_bytes = 0},
+                            {.noc_x_start = in1_mcast_nx_start,
+                             .noc_y_start = in1_mcast_ny_start,
+                             .noc_x_end = in1_mcast_nx_end,
+                             .noc_y_end = in1_mcast_ny_end,
+                             .addr = up_block_start},
+                            /*linked=*/true);
                     }
                 }
 
-                cb_push_back(cb_in1_gate, g_in1_block_num_tiles);
+                cb_in1_gate_obj.push_back(g_in1_block_num_tiles);
                 if constexpr (reader_mcasts_up) {
-                    cb_push_back(cb_in1_up, g_in1_block_num_tiles);
+                    cb_in1_up_obj.push_back(g_in1_block_num_tiles);
                 }
 
                 if (in1_num_receivers > 0) {
-                    noc_async_writes_flushed();
+                    noc.async_writes_flushed();
 
-                    *in1_valid_local = IN1_VALID;
-                    noc_semaphore_set_multicast(in1_valid_sem_addr, in1_mcast_valid_noc, in1_num_receivers);
+                    in1_valid_sem.set(IN1_VALID);
+                    in1_valid_sem.set_multicast<NocOptions::DEFAULT>(
+                        noc, in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, in1_num_receivers);
                 }
             }
 
             // Step 3: receivers wait for both valid semaphores and push.
             if (!is_in0_sender) {
-                noc_semaphore_wait(in0_valid_local, IN0_VALID);
-                cb_push_back(cb_in0_x, g_in0_block_num_tiles);
+                in0_valid_sem.wait(IN0_VALID);
+                cb_in0_x_obj.push_back(g_in0_block_num_tiles);
             }
             if (!is_in1_sender) {
-                noc_semaphore_wait(in1_valid_local, IN1_VALID);
-                cb_push_back(cb_in1_gate, g_in1_block_num_tiles);
+                in1_valid_sem.wait(IN1_VALID);
+                cb_in1_gate_obj.push_back(g_in1_block_num_tiles);
                 if constexpr (reader_mcasts_up) {
-                    cb_push_back(cb_in1_up, g_in1_block_num_tiles);
+                    cb_in1_up_obj.push_back(g_in1_block_num_tiles);
                 }
             }
         }
@@ -497,17 +542,13 @@ void kernel_main() {
         const uint32_t mrow_last_nx = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * (GRID_X_NOC - 1) + 0);
         const uint32_t mrow_last_ny = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * (GRID_X_NOC - 1) + 1);
         constexpr uint32_t ACT_VALID = 1;
-        volatile tt_l1_ptr uint32_t* act_ready_local =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_ready_sem_addr);
-        volatile tt_l1_ptr uint32_t* act_valid_local =
-            reinterpret_cast<volatile tt_l1_ptr uint32_t*>(act_valid_sem_addr);
-        const uint32_t intermed_tile_bytes = get_tile_size(cb_in0_down_full);
+        const uint32_t intermed_tile_bytes = cb_in0_down_full_obj.get_tile_size();
 
         for (uint32_t kb = 0; kb < num_blocks_d; ++kb) {
             const bool is_act_sender = (my_nt_d == kb);
 
-            cb_reserve_back(cb_in1_down, d_in1_block_num_tiles);
-            cb_reserve_back(cb_in0_down_full, d_in0_block_num_tiles);
+            cb_in1_down_obj.reserve_back(d_in1_block_num_tiles);
+            cb_in0_down_full_obj.reserve_back(d_in0_block_num_tiles);
 
             // Step 1: receivers ack BOTH senders (in1_down and act) at the
             // top of the K-block iter. The in1_down ack lets the in1_down
@@ -516,15 +557,14 @@ void kernel_main() {
             // Without the early act ack the sender would only see receivers
             // after the in1_down section finishes, serializing the two paths.
             if (!is_in1_sender) {
-                *in1_valid_local = 0;
-                noc_semaphore_inc(in1_sender_ready_noc, 1);
+                in1_valid_sem.set(0);
+                in1_ready_sem.up(noc, in1_sender_nx, in1_sender_ny, 1);
             }
             if (!is_act_sender) {
-                *act_valid_local = 0;
+                act_valid_sem.set(0);
                 const uint32_t sender_nx = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * kb + 0);
                 const uint32_t sender_ny = get_arg_val<uint32_t>(M_ROW_NOC_RT_OFFSET + 2 * kb + 1);
-                const uint64_t sender_ready_noc = get_noc_addr(sender_nx, sender_ny, act_ready_sem_addr);
-                noc_semaphore_inc(sender_ready_noc, 1);
+                act_ready_sem.up(noc, sender_nx, sender_ny, 1);
             }
 
             // Step 2: in1_down sender kicks off DRAM reads (NoC 0) without
@@ -532,9 +572,9 @@ void kernel_main() {
             // below on NoC 1.
             uint32_t in1_block_start = 0;
             if (is_in1_sender) {
-                noc_semaphore_wait(in1_ready_local, in1_num_receivers);
-                *in1_ready_local = 0;
-                uint32_t l1_w = get_write_ptr(cb_in1_down);
+                in1_ready_sem.wait(in1_num_receivers);
+                in1_ready_sem.set(0);
+                uint32_t l1_w = cb_in1_down_obj.get_write_ptr();
                 in1_block_start = l1_w;
                 for (uint32_t k = 0; k < in0_block_w_d; ++k) {
                     for (uint32_t n = 0; n < per_core_N_d; ++n) {
@@ -542,7 +582,8 @@ void kernel_main() {
                         const uint32_t col = my_nt_d * per_core_N_d + n;
                         if (row < K_down_tiles && col < N_down_tiles_full) {
                             const uint32_t tile_idx = row * N_down_tiles_full + col;
-                            noc_async_read_page(tile_idx, down_acc, l1_w, /*offset=*/0, /*noc=*/0);
+                            noc_read.async_read(
+                                down_acc, CoreLocalMem<uint32_t>(l1_w), down_tile_bytes, {.page_id = tile_idx}, {});
                         } else {
                             volatile tt_l1_ptr uint64_t* p = reinterpret_cast<volatile tt_l1_ptr uint64_t*>(l1_w);
                             for (uint32_t i = 0; i < down_tile_bytes / 8; ++i) {
@@ -558,15 +599,13 @@ void kernel_main() {
             // act_sender starts as soon as compute pushes cb_activated AND
             // the ready acks are in (already done in step 1).
             if (is_act_sender) {
-                cb_wait_front(cb_activated, d_in0_block_num_tiles);
-                noc_semaphore_wait(act_ready_local, GRID_X_NOC - 1);
-                *act_ready_local = 0;
+                cb_activated_obj.wait_front(d_in0_block_num_tiles);
+                act_ready_sem.wait(GRID_X_NOC - 1);
+                act_ready_sem.set(0);
 
-                const uint32_t src_l1 = get_read_ptr(cb_activated);
-                const uint32_t dst_l1 = get_write_ptr(cb_in0_down_full);
+                const uint32_t src_l1 = cb_activated_obj.get_read_ptr();
+                const uint32_t dst_l1 = cb_in0_down_full_obj.get_write_ptr();
                 const uint32_t mcast_bytes = d_in0_block_num_tiles * intermed_tile_bytes;
-                const uint64_t data_mcast_noc =
-                    get_noc_multicast_addr(mrow_first_nx, mrow_first_ny, mrow_last_nx, mrow_last_ny, dst_l1);
                 // linked=true keeps the multicast path RESERVED so the
                 // valid-semaphore multicast below travels the SAME path and is
                 // delivered AFTER the data at every receiver. With linked=false
@@ -579,55 +618,73 @@ void kernel_main() {
                 // wait on) — only path-linking orders the sem behind the data.
                 // Mirrors the canonical matmul in0 sender
                 // (reader_bmm_tile_layout_in0_sender_padding.cpp).
-                noc_async_write_multicast_loopback_src(
-                    src_l1, data_mcast_noc, mcast_bytes, GRID_X_NOC, /*linked=*/true);
-                noc_async_writes_flushed();
+                noc.async_write_multicast<NocOptions::MCAST_INCL_SRC>(
+                    CoreLocalMem<uint32_t>(src_l1),
+                    MulticastEndpoint{},
+                    mcast_bytes,
+                    GRID_X_NOC,
+                    {.offset_bytes = 0},
+                    {.noc_x_start = mrow_first_nx,
+                     .noc_y_start = mrow_first_ny,
+                     .noc_x_end = mrow_last_nx,
+                     .noc_y_end = mrow_last_ny,
+                     .addr = dst_l1},
+                    /*linked=*/true);
+                noc.async_writes_flushed();
 
-                *act_valid_local = ACT_VALID;
-                const uint64_t valid_mcast_noc = get_noc_multicast_addr(
-                    mrow_first_nx, mrow_first_ny, mrow_last_nx, mrow_last_ny, act_valid_sem_addr);
-                noc_semaphore_set_multicast_loopback_src(act_valid_sem_addr, valid_mcast_noc, GRID_X_NOC);
+                act_valid_sem.set(ACT_VALID);
+                act_valid_sem.set_multicast<NocOptions::MCAST_INCL_SRC>(
+                    noc, mrow_first_nx, mrow_first_ny, mrow_last_nx, mrow_last_ny, GRID_X_NOC);
 
-                cb_pop_front(cb_activated, d_in0_block_num_tiles);
+                cb_activated_obj.pop_front(d_in0_block_num_tiles);
             }
 
             // Step 4: in1_down sender finishes — barrier on DRAM reads (NoC 0,
             // in flight during step 3 activated mcast on NoC 1), then mcast.
             if (is_in1_sender) {
-                noc_async_read_barrier(/*noc=*/0);
+                noc_read.async_read_barrier();
                 // GRID_Y == 1: no column receivers — skip mcast/valid-sem; this
                 // core consumes the locally-read down weight directly.
                 if (in1_num_receivers > 0) {
-                    const uint64_t mcast_data_noc = get_noc_multicast_addr(
-                        in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, in1_block_start);
                     const uint32_t block_bytes = d_in1_block_num_tiles * down_tile_bytes;
                     // linked=true so the in1_valid-sem multicast is ordered behind
                     // the weight data on the same reserved path (see the activated
                     // mcast above for the full rationale).
-                    noc_async_write_multicast(
-                        in1_block_start, mcast_data_noc, block_bytes, in1_num_receivers, /*linked=*/true);
-                    noc_async_writes_flushed();
+                    noc.async_write_multicast(
+                        CoreLocalMem<uint32_t>(in1_block_start),
+                        MulticastEndpoint{},
+                        block_bytes,
+                        in1_num_receivers,
+                        {.offset_bytes = 0},
+                        {.noc_x_start = in1_mcast_nx_start,
+                         .noc_y_start = in1_mcast_ny_start,
+                         .noc_x_end = in1_mcast_nx_end,
+                         .noc_y_end = in1_mcast_ny_end,
+                         .addr = in1_block_start},
+                        /*linked=*/true);
+                    noc.async_writes_flushed();
 
-                    *in1_valid_local = IN1_VALID;
-                    noc_semaphore_set_multicast(in1_valid_sem_addr, in1_mcast_valid_noc, in1_num_receivers);
+                    in1_valid_sem.set(IN1_VALID);
+                    in1_valid_sem.set_multicast<NocOptions::DEFAULT>(
+                        noc, in1_mcast_nx_start, in1_mcast_ny_start, in1_mcast_nx_end, in1_mcast_ny_end, in1_num_receivers);
                 }
             }
 
             // Step 5: receivers wait for both valid sems and push.
             if (!is_act_sender) {
-                noc_semaphore_wait(act_valid_local, ACT_VALID);
+                act_valid_sem.wait(ACT_VALID);
             }
-            cb_push_back(cb_in0_down_full, d_in0_block_num_tiles);
+            cb_in0_down_full_obj.push_back(d_in0_block_num_tiles);
 
             if (!is_in1_sender) {
-                noc_semaphore_wait(in1_valid_local, IN1_VALID);
+                in1_valid_sem.wait(IN1_VALID);
             }
-            cb_push_back(cb_in1_down, d_in1_block_num_tiles);
+            cb_in1_down_obj.push_back(d_in1_block_num_tiles);
         }
     }  // end chunk loop
 
-    // The last in-flight noc_semaphore_set_multicast (act_valid / in1_valid)
+    // The last in-flight Semaphore<>::set_multicast (act_valid / in1_valid)
     // is a posted atomic; without an explicit barrier it can still be in
     // flight at kernel exit, leading to timing-dependent corruption.
-    noc_async_atomic_barrier();
+    noc.async_atomic_barrier();
 }

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/kernels/dataflow/unified_routed_expert_ffn_writer.cpp
@@ -37,11 +37,16 @@
 #include <cstdint>
 
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
 #include "api/debug/assert.h"
 
 constexpr uint32_t TILE_HEIGHT = 32;
 
 void kernel_main() {
+    Noc noc;
+
     const uint32_t output_addr = get_arg_val<uint32_t>(0);
     const uint32_t my_mt = get_arg_val<uint32_t>(1);
     const uint32_t my_nt_d = get_arg_val<uint32_t>(2);
@@ -98,13 +103,18 @@ void kernel_main() {
     constexpr uint32_t num_blocks_gu = K_gate_tiles / in0_block_w_gu;
     constexpr uint32_t g_in1_block_num_tiles = per_core_N_gu * in0_block_w_gu;
 
+    CircularBuffer cb_out_buf(cb_out);
+    CircularBuffer cb_counts_scratch_buf(cb_counts_scratch);
+    CircularBuffer cb_idx_scratch_buf(cb_idx_scratch);
+    CircularBuffer cb_start_scratch_buf(cb_start_scratch);
+
     // Accessor compile-arg stream order (host appends in this exact order):
     // out, then start (direct-write), then up (UP_SPLIT). The accessors are
     // constructed unconditionally; start_acc is used only when direct_write,
     // up_acc only when writer_split_up.
     constexpr uint32_t out_accessor_offset = 24;
     constexpr auto out_args = TensorAccessorArgs<out_accessor_offset>();
-    const auto out_acc = TensorAccessor(out_args, output_addr, get_tile_size(cb_out));
+    const auto out_acc = TensorAccessor(out_args, output_addr, cb_out_buf.get_tile_size());
 
     constexpr uint32_t start_accessor_offset = out_args.next_compile_time_args_offset();
     constexpr auto start_args = TensorAccessorArgs<start_accessor_offset>();
@@ -114,18 +124,18 @@ void kernel_main() {
     constexpr auto up_args = TensorAccessorArgs<up_accessor_offset>();
     const auto up_acc = TensorAccessor(up_args, up_addr, get_tile_size(cb_in1_up));
 
-    const uint32_t out_tile_bytes = get_tile_size(cb_out);
+    const uint32_t out_tile_bytes = cb_out_buf.get_tile_size();
 
     // Wait for the reader's counts/idx push and compute effective_chunks =
     // ceil(count / chunk_M_tiles). The writer drains cb_out per chunk;
     // bounding the loop here is required because the reader and compute
     // bound theirs too — without this, the writer would wait forever on
     // cb_out for chunks the compute never pushes.
-    cb_wait_front(cb_counts_scratch, 1);
-    cb_wait_front(cb_idx_scratch, 1);
+    cb_counts_scratch_buf.wait_front(1);
+    cb_idx_scratch_buf.wait_front(1);
     const volatile tt_l1_ptr uint32_t* counts_ptr =
-        reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(get_read_ptr(cb_counts_scratch));
-    const uint32_t idx_l1 = get_read_ptr(cb_idx_scratch);
+        reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(cb_counts_scratch_buf.get_read_ptr());
+    const uint32_t idx_l1 = cb_idx_scratch_buf.get_read_ptr();
     const volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(idx_l1);
     const uint32_t global_expert_id = idx_ptr[local_expert_id];
     const uint32_t count_value = counts_ptr[global_expert_id];
@@ -139,9 +149,10 @@ void kernel_main() {
     // Mirrors ttnn::insert's writer: start_tile_row = start_value / TILE.
     uint32_t row_offset_tiles = 0;
     if constexpr (direct_write != 0) {
-        const uint32_t start_l1 = get_write_ptr(cb_start_scratch);
-        noc_async_read_page(0, start_acc, start_l1);
-        noc_async_read_barrier();
+        const uint32_t start_l1 = cb_start_scratch_buf.get_write_ptr();
+        const uint32_t start_page_size = start_acc.get_aligned_page_size();
+        noc.async_read(start_acc, CoreLocalMem<uint32_t>(start_l1), start_page_size, {.page_id = 0}, {});
+        noc.async_read_barrier();
         const volatile tt_l1_ptr uint32_t* start_ptr = reinterpret_cast<const volatile tt_l1_ptr uint32_t*>(start_l1);
         const uint32_t start_value = start_ptr[global_expert_id];
         row_offset_tiles = start_value / TILE_HEIGHT;
@@ -211,8 +222,8 @@ void kernel_main() {
         const uint32_t col0 = my_nt_d * per_core_N_d;
         for (uint32_t sb_m = 0; sb_m < d_in1_num_subblocks_M; ++sb_m) {
             for (uint32_t sb_n = 0; sb_n < d_in1_num_subblocks_N; ++sb_n) {
-                cb_wait_front(cb_out, d_out_subblock_num_tiles);
-                uint32_t l1_read = get_read_ptr(cb_out);
+                cb_out_buf.wait_front(d_out_subblock_num_tiles);
+                uint32_t subblock_tile_offset = 0;
                 for (uint32_t i = 0; i < d_out_subblock_h; ++i) {
                     for (uint32_t j = 0; j < d_out_subblock_w; ++j) {
                         const uint32_t row = row0 + sb_m * d_out_subblock_h + i;
@@ -244,24 +255,29 @@ void kernel_main() {
                             ASSERT(dst_row < dst_M_tiles);
                             if (dst_row < dst_M_tiles) {
                                 const uint32_t tile_idx = dst_row * N_down_tiles_full + col;
-                                noc_async_write_page(tile_idx, out_acc, l1_read);
+                                noc.async_write(
+                                    cb_out_buf,
+                                    out_acc,
+                                    out_tile_bytes,
+                                    {.offset_bytes = subblock_tile_offset},
+                                    {.page_id = tile_idx});
                             }
                         }
-                        l1_read += out_tile_bytes;
+                        subblock_tile_offset += out_tile_bytes;
                     }
                 }
                 // Wait for the writes to LEAVE this core (departed sender);
                 // doesn't wait for the DRAM round-trip. Safe to reuse the L1
                 // slot now — the NoC has captured the data. ~10x faster than
                 // noc_async_write_barrier per subblock at small per_core_M.
-                noc_async_writes_flushed();
-                cb_pop_front(cb_out, d_out_subblock_num_tiles);
+                noc.async_writes_flushed();
+                cb_out_buf.pop_front(d_out_subblock_num_tiles);
             }
         }
     }
     // Ensure all outstanding writes complete at the destination before the
     // kernel returns (the next dispatched op may read this output).
-    noc_async_write_barrier();
+    noc.async_write_barrier();
     // UP_SPLIT issues only per-K-block-barriered NoC-1 `up` reads (no NoC-1
     // worker multicast and no NoC-1 atomics), so no extra NoC-1 drain is needed
     // here — which is exactly why it is safe beside the fabric CCL ops.

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/reader_update_padded_kv_cache.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/reader_update_padded_kv_cache.cpp
@@ -1,0 +1,46 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// D2.0 fork of ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_interleaved_start_id.cpp
+// for the deepseek_prefill update_padded_kv_cache op. The kv_cache version is still on Device 1.x; this fork lets
+// deepseek_prefill flip cleanly to D2.0 without dragging the entire kv_cache op along.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+
+void kernel_main() {
+    uint32_t src_addr = get_arg_val<uint32_t>(0);
+    uint32_t num_tiles = get_arg_val<uint32_t>(1);
+    uint32_t start_id = get_arg_val<uint32_t>(2);
+
+    constexpr auto src_args = TensorAccessorArgs<0>();
+
+    constexpr uint32_t cb_id_in0 = 0;
+    CircularBuffer cb_in0(cb_id_in0);
+
+#ifdef INPUT_SHARDED
+    cb_in0.reserve_back(num_tiles);
+    cb_in0.push_back(num_tiles);
+#else
+    constexpr uint32_t onetile = 1;
+    const auto s = TensorAccessor(src_args, src_addr);
+    Noc noc;
+    const uint32_t src_tile_bytes = cb_in0.get_tile_size();
+
+#ifdef BACKWARDS
+    uint32_t end_id = start_id - num_tiles;
+    for (uint32_t i = start_id; i != end_id; --i) {
+#else
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+#endif
+        cb_in0.reserve_back(onetile);
+        noc.async_read(s, cb_in0, src_tile_bytes, {.page_id = i}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in0.push_back(onetile);
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/update_padded_kv_cache_device_operation.cpp
@@ -29,7 +29,8 @@ namespace {
 // MeshWorkloadFactory::override_runtime_arguments, so the buffer-binding fast cache-hit path stays
 // correct while those values remain out of the program hash.
 constexpr auto kReaderKernelPath =
-    "ttnn/cpp/ttnn/operations/kv_cache/device/kernels/dataflow/reader_fill_cache_interleaved_start_id.cpp";
+    "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/"
+    "reader_update_padded_kv_cache.cpp";
 constexpr auto kWriterKernelPath =
     "ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/update_padded_kv_cache/device/kernels/dataflow/"
     "writer_update_padded_kv_cache.cpp";


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Relates to issue #45003

Migrates 23 kernel files across the sub-ops of `experimental/deepseek_prefill` to the Device 2.0 dataflow API (`Noc` / `CircularBuffer` / `Semaphore<>` / `UnicastEndpoint` / `MulticastEndpoint`).

### Notes for reviewers

- `update_padded_kv_cache`: the sub-op borrowed `kv_cache/.../reader_fill_cache_interleaved_start_id.cpp`; that file has two consumers (kv_cache itself + this sub-op). Forked the 41-line reader into a local migrated copy under `update_padded_kv_cache/device/kernels/dataflow/`; updated the program-factory `kernel_source` path. No changes under `kv_cache/`.

- `masked_bincount`: one legacy `noc_semaphore_inc` call retained for the histogram bin atomic-increment. The increment target is an arbitrary L1 word (not a registered semaphore id), and `Semaphore<>::up(noc, x, y, val)` only resolves from a registered id. Marked with `// TODO: D2.0 has no equivalent` comment.
- `moe_grouped_topk` writer: the cross-face L1 duplication uses ~30 `noc_async_read(get_noc_addr(local_l1_addr), ...)` self-reads. Restructuring would be a substantive refactor. Left as-is with the rest of the kernel migrated.

**Host-side change**: one (`update_padded_kv_cache_device_operation.cpp`): two lines repointing `kReaderKernelPath` from the kv_cache borrowed path to the local fork. Behaviourally identical.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/deepseek-prefill-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/deepseek-prefill-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/deepseek-prefill-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/deepseek-prefill-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/deepseek-prefill-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/deepseek-prefill-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/deepseek-prefill-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/deepseek-prefill-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/deepseek-prefill-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/deepseek-prefill-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/deepseek-prefill-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/deepseek-prefill-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/deepseek-prefill-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/deepseek-prefill-device-2-0)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/deepseek-prefill-device-2-0)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/deepseek-prefill-device-2-0)