### PR TITLE
Fix deepseek vllm tests

### DIFF
--- a/models/demos/deepseek_v3/tests/test_generator_vllm.py
+++ b/models/demos/deepseek_v3/tests/test_generator_vllm.py
@@ -8,20 +8,26 @@ from pathlib import Path
 
 import pytest
 
-from models.common.model_capabilities import FALLBACK_MAX_TOKENS_ALL_USERS
 from models.demos.deepseek_v3.tt import generator_vllm as generator_vllm_module
 
 pytestmark = pytest.mark.t3k_compat
 
 
-@pytest.mark.skip(reason="Disabled: see #45677")
 def test_initialize_vllm_model_passes_cache_dir_without_enabling_weight_cache(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path, mesh_device
 ):
     captured: dict[str, object] = {}
 
     def fake_init(self, *args, **kwargs):
         captured.update(kwargs)
+
+    # initialize_vllm_model reads mesh_device.shape and validates that
+    # tt_data_parallel == mesh_rows * mesh_cols and max_batch_size % tt_data_parallel == 0
+    # before constructing the model (see PR #45284). Derive both from the actual mesh
+    # so this test works on any MESH_DEVICE (N150/N300/T3K/TG/...).
+    mesh_rows, mesh_cols = mesh_device.shape[0], mesh_device.shape[1]
+    tt_data_parallel = mesh_rows * mesh_cols
+    max_batch_size = tt_data_parallel
 
     monkeypatch.setenv("DEEPSEEK_V3_HF_MODEL", str(tmp_path / "model"))
     monkeypatch.setenv("DEEPSEEK_V3_CACHE", str(tmp_path / "cache"))
@@ -30,22 +36,22 @@ def test_initialize_vllm_model_passes_cache_dir_without_enabling_weight_cache(
 
     generator_vllm_module.DeepseekV3ForCausalLM.initialize_vllm_model(
         hf_config=object(),
-        mesh_device=object(),
-        max_batch_size=1,
+        mesh_device=mesh_device,
+        max_batch_size=max_batch_size,
         max_seq_len=128,
+        tt_data_parallel=tt_data_parallel,
     )
 
+    assert captured["mesh_device"] is mesh_device
     assert captured["model_path"] == Path(tmp_path / "model")
     assert captured["cache_dir"] == Path(tmp_path / "cache")
     assert "use_weight_cache" not in captured
 
 
-def test_deepseek_generator_exposes_max_tokens_all_users_capability() -> None:
-    assert generator_vllm_module.DeepseekGenerator.get_max_tokens_all_users() == FALLBACK_MAX_TOKENS_ALL_USERS
-
-
-@pytest.mark.skip(reason="Disabled: see #45677")
-def test_get_max_tokens_all_users_overrides_deepseek_r1_on_wormhole(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_max_tokens_all_users_returns_max_model_len_times_max_num_seqs_on_wormhole(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Wormhole + DeepSeek-R1-0528 derives the budget from vLLM's max_model_len * max_num_seqs (see #45284)."""
     monkeypatch.setattr(generator_vllm_module, "is_wormhole_b0", lambda: True)
 
     assert (
@@ -53,20 +59,34 @@ def test_get_max_tokens_all_users_overrides_deepseek_r1_on_wormhole(monkeypatch:
             model_name="/models/DeepSeek-R1-0528",
             num_devices=32,
             tt_data_parallel=1,
+            max_model_len=32_768,
+            max_num_seqs=1,
         )
         == 32_768
     )
 
 
-@pytest.mark.skip(reason="Disabled: see #45677")
-def test_get_max_tokens_all_users_uses_fallback_for_other_configs(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.setattr(generator_vllm_module, "is_wormhole_b0", lambda: False)
+def test_get_max_tokens_all_users_requires_max_lens_on_wormhole_deepseek_r1(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without max_model_len/max_num_seqs the Wormhole path raises (vllm plugin must supply them)."""
+    monkeypatch.setattr(generator_vllm_module, "is_wormhole_b0", lambda: True)
 
-    assert (
+    with pytest.raises(ValueError, match="max_model_len and max_num_seqs"):
         generator_vllm_module.DeepseekV3ForCausalLM.get_max_tokens_all_users(
             model_name="/models/DeepSeek-R1-0528",
             num_devices=32,
             tt_data_parallel=1,
         )
-        == FALLBACK_MAX_TOKENS_ALL_USERS
-    )
+
+
+def test_get_max_tokens_all_users_rejects_non_wormhole_deepseek_r1(monkeypatch: pytest.MonkeyPatch) -> None:
+    """DeepSeek-R1-0528 is only supported on Wormhole; non-Wormhole must raise."""
+    monkeypatch.setattr(generator_vllm_module, "is_wormhole_b0", lambda: False)
+
+    with pytest.raises(ValueError, match="not supported on non-Wormhole"):
+        generator_vllm_module.DeepseekV3ForCausalLM.get_max_tokens_all_users(
+            model_name="/models/DeepSeek-R1-0528",
+            num_devices=32,
+            tt_data_parallel=1,
+        )


### PR DESCRIPTION
### Summary
This PR re-enables and updates the deepseek vLLM unit tests that were previously disabled (skip-marked due to issue https://github.com/tenstorrent/tt-metal/issues/45677). The tests are adapted to the current DeepseekV3ForCausalLM API which now validates mesh device shape and requires explicit max_model_len/max_num_seqs parameters.

Changes:

Re-enabled test_initialize_vllm_model_passes_cache_dir_without_enabling_weight_cache by replacing the mocked object() mesh with the real mesh_device fixture and deriving tt_data_parallel/max_batch_size from the actual mesh shape to satisfy the new validation logic.
Updated and expanded get_max_tokens_all_users tests: added tests for the happy path (Wormhole + R1 with required params), the missing-params error path, and the non-Wormhole rejection path.
Removed the now-obsolete test_deepseek_generator_exposes_max_tokens_all_users_capability test and unused FALLBACK_MAX_TOKENS_ALL_USERS import, since DeepseekV3ForCausalLM overrides the base-class fallback.



### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pprajapati/fix_vllm_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pprajapati/fix_vllm_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pprajapati/fix_vllm_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pprajapati/fix_vllm_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pprajapati/fix_vllm_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pprajapati/fix_vllm_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pprajapati/fix_vllm_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pprajapati/fix_vllm_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pprajapati/fix_vllm_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pprajapati/fix_vllm_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pprajapati/fix_vllm_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pprajapati/fix_vllm_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pprajapati/fix_vllm_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pprajapati/fix_vllm_tests)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pprajapati/fix_vllm_tests)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pprajapati/fix_vllm_tests)