### PR TITLE
[Cleanup] Migrate moreh borrowed helper functions to Device 2.0 API

### DIFF
--- a/ttnn/cpp/ttnn/kernel/compute/dest_format_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel/compute/dest_format_helpers.hpp
@@ -1,0 +1,179 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstdint>
+
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/pack.h"
+#include "api/compute/reg_api.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
+
+// Dest-format-aware LLK wrappers and binary tile->CB orchestrators. The *_with_dt thin wrappers
+// prepend reconfig_data_format* / pack_reconfig_data_format when FP32_DEST_ACC_EN is set, otherwise
+// no-op. The *_to_cb wrappers chain a binary tile op through a single DST register and push the
+// result to ocb.
+//
+// CB operations migrated to Device 2.0 CircularBuffer method form. LLK primitives (mul_tiles,
+// add_tiles, sub_tiles, pack_tile, tile_regs_*, *_init, *reconfig*) remain raw — they are LLK
+// surface, not D1.x dataflow.
+//
+// Namespace placement is split intentionally so callers do not need to add any qualification when
+// swapping the include source.
+
+// File-scope wrappers.
+
+ALWI void pack_tile_with_dt(uint32_t ifrom_dst, uint32_t icb) {
+#if defined FP32_DEST_ACC_EN
+    pack_reconfig_data_format(icb);
+#endif
+    pack_tile(ifrom_dst, icb);
+}
+
+ALWI void copy_tile_init_with_dt(uint32_t icb, uint32_t transpose = 0) {
+#if defined FP32_DEST_ACC_EN
+    reconfig_data_format_srca(icb);
+#endif
+    copy_tile_to_dst_init_short(icb, transpose);
+}
+
+ALWI void add_tiles_init_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+#if defined FP32_DEST_ACC_EN
+    reconfig_data_format(icb0, icb1);
+#endif
+    add_tiles_init(icb0, icb1);
+}
+
+ALWI void sub_tiles_init_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+#if defined FP32_DEST_ACC_EN
+    reconfig_data_format(icb0, icb1);
+#endif
+    sub_tiles_init(icb0, icb1);
+}
+
+ALWI void mul_tiles_init_with_dt(uint32_t icb0 = 0, uint32_t icb1 = 1) {
+#if defined FP32_DEST_ACC_EN
+    reconfig_data_format(icb0, icb1);
+#endif
+    mul_tiles_init(icb0, icb1);
+}
+
+// Binary tile->CB orchestrators (in namespace ckernel).
+namespace ckernel {
+
+ALWI void mul_tiles_to_cb(
+    uint32_t icb0,
+    uint32_t icb1,
+    uint32_t ocb,
+    uint32_t itile0 = 0,
+    uint32_t itile1 = 0,
+    uint32_t pop0 = 1,
+    uint32_t pop1 = 1) {
+    constexpr uint32_t onetile = 1;
+    constexpr int dst0 = 0;
+    CircularBuffer cb_in0(icb0);
+    CircularBuffer cb_in1(icb1);
+    CircularBuffer cb_out(ocb);
+
+    cb_out.reserve_back(onetile);
+    cb_in0.wait_front(itile0 + 1);
+    cb_in1.wait_front(itile1 + 1);
+
+    tile_regs_acquire();
+    mul_tiles_init_with_dt(icb0, icb1);
+    mul_tiles(icb0, icb1, itile0, itile1, dst0);
+    tile_regs_commit();
+
+    tile_regs_wait();
+    pack_tile_with_dt(dst0, ocb);
+    tile_regs_release();
+
+    if (pop0) {
+        cb_in0.pop_front(pop0);
+    }
+    if (pop1) {
+        cb_in1.pop_front(pop1);
+    }
+
+    cb_out.push_back(onetile);
+}
+
+ALWI void add_tiles_to_cb(
+    uint32_t icb0,
+    uint32_t icb1,
+    uint32_t ocb,
+    uint32_t itile0 = 0,
+    uint32_t itile1 = 0,
+    uint32_t pop0 = 1,
+    uint32_t pop1 = 1) {
+    constexpr uint32_t onetile = 1;
+    constexpr int dst0 = 0;
+    CircularBuffer cb_in0(icb0);
+    CircularBuffer cb_in1(icb1);
+    CircularBuffer cb_out(ocb);
+
+    cb_out.reserve_back(onetile);
+    cb_in0.wait_front(itile0 + 1);
+    cb_in1.wait_front(itile1 + 1);
+
+    tile_regs_acquire();
+    add_tiles_init_with_dt(icb0, icb1);
+    add_tiles(icb0, icb1, itile0, itile1, dst0);
+    tile_regs_commit();
+
+    tile_regs_wait();
+    pack_tile_with_dt(dst0, ocb);
+    tile_regs_release();
+
+    if (pop0) {
+        cb_in0.pop_front(pop0);
+    }
+    if (pop1) {
+        cb_in1.pop_front(pop1);
+    }
+
+    cb_out.push_back(onetile);
+}
+
+ALWI void sub_tiles_to_cb(
+    uint32_t icb0,
+    uint32_t icb1,
+    uint32_t ocb,
+    uint32_t itile0 = 0,
+    uint32_t itile1 = 0,
+    uint32_t pop0 = 1,
+    uint32_t pop1 = 1) {
+    constexpr uint32_t onetile = 1;
+    constexpr int dst0 = 0;
+    CircularBuffer cb_in0(icb0);
+    CircularBuffer cb_in1(icb1);
+    CircularBuffer cb_out(ocb);
+
+    cb_out.reserve_back(onetile);
+    cb_in0.wait_front(itile0 + 1);
+    cb_in1.wait_front(itile1 + 1);
+
+    tile_regs_acquire();
+    sub_tiles_init_with_dt(icb0, icb1);
+    sub_tiles(icb0, icb1, itile0, itile1, dst0);
+    tile_regs_commit();
+
+    tile_regs_wait();
+    pack_tile_with_dt(dst0, ocb);
+    tile_regs_release();
+
+    if (pop0) {
+        cb_in0.pop_front(pop0);
+    }
+    if (pop1) {
+        cb_in1.pop_front(pop1);
+    }
+
+    cb_out.push_back(onetile);
+}
+
+}  // namespace ckernel

--- a/ttnn/cpp/ttnn/kernel/dataflow/cb_fill_helpers.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/cb_fill_helpers.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+
+// Format-aware tile fill. Reserves one tile of cb, fills num_of_elems elements with
+// `value` (interpreted per the CB's data format), and pushes the tile.
+//
+//   Float32 / Int32 / UInt32 -> write `value` as-is (32-bit element).
+//   Float16_b (default)      -> write upper 16 bits of `value` (bf16 element).
+FORCE_INLINE void fill_cb_with_value(uint32_t cb_id, uint32_t value, int32_t num_of_elems = 1024) {
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(1);
+    const DataFormat data_format = cb.get_dataformat();
+    switch (static_cast<uint32_t>(data_format) & 0x1F) {
+        case static_cast<uint8_t>(DataFormat::Float32):
+        case static_cast<uint8_t>(DataFormat::Int32):
+        case static_cast<uint8_t>(DataFormat::UInt32): {
+            CoreLocalMem<volatile uint32_t> ptr(cb.get_write_ptr());
+            for (int32_t j = 0; j < num_of_elems; ++j) {
+                ptr[j] = value;
+            }
+            break;
+        }
+        case static_cast<uint8_t>(DataFormat::Float16_b):
+        default: {
+            CoreLocalMem<volatile uint16_t> ptr(cb.get_write_ptr());
+            const uint16_t packed = static_cast<uint16_t>(value >> 16);
+            for (int32_t j = 0; j < num_of_elems; ++j) {
+                ptr[j] = packed;
+            }
+            break;
+        }
+    }
+    cb.push_back(1);
+}

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/kernels/compute/rotary_embedding_hf_sharded.cpp
@@ -7,7 +7,7 @@
 #include "api/compute/common.h"
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/bcast.h"
-#include "ttnn/kernel/compute/moreh_common.hpp"
+#include "ttnn/kernel/compute/dest_format_helpers.hpp"
 
 void kernel_main() {
     constexpr uint32_t onetile = 1;

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/compute/eltwise_binary.h"
-#include "ttnn/kernel/compute/moreh_common.hpp"
+#include "ttnn/kernel/compute/dest_format_helpers.hpp"
 
 #include <cstdint>
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_kernel.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/compute/eltwise_binary.h"
+#include "api/compute/eltwise_unary/rsqrt.h"
 #include "ttnn/kernel/compute/dest_format_helpers.hpp"
 
 #include <cstdint>

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -7,6 +7,7 @@
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/rsqrt.h"
 #include "api/compute/eltwise_unary/typecast.h"
+#include "api/compute/tile_move_copy.h"
 
 #include <cstdint>
 

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/batch_norm_sfpu_kernel.cpp
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "api/compute/eltwise_binary_sfpu.h"
-#include "ttnn/kernel/compute/moreh_common.hpp"
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/rsqrt.h"

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_kernel.cpp
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tile_move_copy.h"
-#include "ttnn/kernel/compute/moreh_common.hpp"
+#include "ttnn/kernel/compute/dest_format_helpers.hpp"
 #include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/compute/running_statistics_sfpu_kernel.cpp
@@ -5,7 +5,7 @@
 #include <cstdint>
 #include "api/compute/eltwise_binary.h"
 #include "api/compute/tile_move_copy.h"
-#include "ttnn/kernel/compute/moreh_common.hpp"
+#include "ttnn/kernel/compute/dest_format_helpers.hpp"
 #include "api/compute/eltwise_binary_sfpu.h"
 #include "api/compute/eltwise_unary/sfpu_split_includes.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_batch_norm.cpp
@@ -9,7 +9,6 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
-#include "ttnn/kernel/dataflow/moreh_common.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/kernels/dataflow/reader_running_statistics.cpp
@@ -9,7 +9,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
-#include "ttnn/kernel/dataflow/moreh_common.hpp"
+#include "ttnn/kernel/dataflow/cb_fill_helpers.hpp"
 #include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/reader_prod_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/reader_prod_nc.cpp
@@ -9,7 +9,7 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
-#include "ttnn/kernel/dataflow/moreh_common.hpp"
+#include "ttnn/kernel/dataflow/cb_fill_helpers.hpp"
 
 void kernel_main() {
     const auto input_addr = get_arg_val<uint32_t>(0);


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Relates to issue https://github.com/tenstorrent/tt-metal/issues/45003

Migrates the helper functions from dataflow and compute moreh_common.hpp, which are used outside of the moreh/* kernels onto the Device 2.0 API. The migrated functions are placed in new header files.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/drop-moreh-common-non-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/drop-moreh-common-non-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/drop-moreh-common-non-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/drop-moreh-common-non-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/drop-moreh-common-non-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/drop-moreh-common-non-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/drop-moreh-common-non-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/drop-moreh-common-non-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/drop-moreh-common-non-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/drop-moreh-common-non-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/drop-moreh-common-non-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/drop-moreh-common-non-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/drop-moreh-common-non-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/drop-moreh-common-non-moreh)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/drop-moreh-common-non-moreh)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/drop-moreh-common-non-moreh)