### PR TITLE
Add mpi interface auto-detection to exabox scripts

### DIFF
--- a/tools/scaleout/exabox/recover.sh
+++ b/tools/scaleout/exabox/recover.sh
@@ -2,6 +2,10 @@
 
 set -eo pipefail
 
+# Source MPI interface validation utility
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
+
 # Function to display help
 show_help() {
     cat << EOF
@@ -22,9 +26,8 @@ Optional:
     --skip-validation                       Skip validation, only run tt-smi reset
     --no-send-traffic                       Disable --send-traffic in cluster validation
     --check                                 Dry run: verify MPI can reach all hosts via hostname, then exit
-    --mpi-if <interface>                    Network interface for MPI TCP transport (default: ens5f0np0)
-                                            Use a specific interface name to avoid virtual interfaces
-                                            (Kubernetes CNI, flannel, docker) being selected by MPI
+    --mpi-if <interface>                    Network interface for MPI TCP transport
+                                            (auto-detected if not specified)
     --mpi-args <args>                       Extra arguments passed directly to mpirun (quoted string)
                                             e.g. --mpi-args "--tag-output"
     --output <directory>                    Output directory for logs and validation artifacts (default: recover-logs).
@@ -84,7 +87,8 @@ SKIP_RESET=false
 SKIP_VALIDATION=false
 SEND_TRAFFIC=true
 CHECK=false
-MPI_IF="ens5f0np0"
+MPI_IF=""
+MPI_IF_EXPLICIT=false
 MPI_EXTRA_ARGS=()
 OUTPUT_DIR="recover-logs"
 RERUN_ON_RETRAIN=false
@@ -177,6 +181,7 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             MPI_IF="$2"
+            MPI_IF_EXPLICIT=true
             shift 2
             ;;
         --mpi-args)
@@ -280,6 +285,15 @@ fi
 if [[ "$SKIP_RESET" == true && "$SKIP_VALIDATION" == true ]]; then
     echo "Error: cannot use both --skip-reset and --skip-validation"
     exit 1
+fi
+
+# Validate/auto-detect MPI interface with first host from the list
+FIRST_HOST="${HOSTS%%,*}"
+if [[ "$MPI_IF_EXPLICIT" == "true" ]]; then
+    validate_mpi_interface "$MPI_IF" "true" "$FIRST_HOST"
+else
+    MPI_IF=$(validate_mpi_interface "" "false" "$FIRST_HOST")
+    echo "Auto-detected MPI interface: $MPI_IF"
 fi
 
 # Set log file path inside output directory (captures actual start time).

--- a/tools/scaleout/exabox/run_dispatch_tests.sh
+++ b/tools/scaleout/exabox/run_dispatch_tests.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Source MPI interface validation utility
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
+
 # Function to display help
 show_help() {
     cat << EOF
@@ -15,7 +19,8 @@ Optional:
     --output <directory>                Output directory for log files (default: dispatch_test_logs)
     --mesh-graph-desc-path <path>       Path to mesh graph descriptor file
                                         (default: tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto)
-    --mpi-if <interface>                Network interface for MPI TCP transport (default: ens5f0np0)
+    --mpi-if <interface>                Network interface for MPI TCP transport
+                                        (auto-detected if not specified)
     --help                              Display this help message and exit
 
 Example:
@@ -29,7 +34,8 @@ HOSTS=""
 DOCKER_IMAGE=""
 OUTPUT_DIR="dispatch_test_logs"
 MESH_GRAPH_DESC_PATH="tt_metal/fabric/mesh_graph_descriptors/single_bh_galaxy_mesh_graph_descriptor.textproto"
-MPI_IF="ens5f0np0"
+MPI_IF=""
+MPI_IF_EXPLICIT=false
 
 while [[ $# -gt 0 ]]; do
     case $1 in
@@ -71,6 +77,7 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             MPI_IF="$2"
+            MPI_IF_EXPLICIT=true
             shift 2
             ;;
         --help)
@@ -99,6 +106,15 @@ if [[ -z "$DOCKER_IMAGE" ]]; then
     echo ""
     show_help
     exit 1
+fi
+
+# Validate/auto-detect MPI interface with first host from the list
+FIRST_HOST="${HOSTS%%,*}"
+if [[ "$MPI_IF_EXPLICIT" == "true" ]]; then
+    validate_mpi_interface "$MPI_IF" "true" "$FIRST_HOST"
+else
+    MPI_IF=$(validate_mpi_interface "" "false" "$FIRST_HOST")
+    echo "Auto-detected MPI interface: $MPI_IF"
 fi
 
 # Create output directory if it doesn't exist

--- a/tools/scaleout/exabox/run_fabric_tests.sh
+++ b/tools/scaleout/exabox/run_fabric_tests.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Source MPI interface validation utility
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
+
 # Function to display help
 show_help() {
     cat << EOF
@@ -49,7 +53,8 @@ Optional:
                                         (4x8z/2x4x4z/4x32z/8x4x4z default: test_fabric_multi_mesh_sanity_common.yaml, whose
                                          neighbor_exchange/all_to_all patterns route across mesh boundaries / Z links)
     --filter <pattern>                  Filter pattern passed to test_tt_fabric --filter
-    --mpi-if <interface>                Network interface for MPI TCP transport (default: ens5f0np0)
+    --mpi-if <interface>                Network interface for MPI TCP transport
+                                        (auto-detected if not specified)
     --mpi-args <args>                   Extra arguments passed directly to mpirun (quoted string)
                                         e.g. --mpi-args "--tag-output"
     --skip-reorder                      Use --hosts exactly as given; skip the canonical ring
@@ -95,7 +100,8 @@ TEST_CONFIG_EXPLICIT=false
 # datamover buffer-index assert), so it must not be the default here.
 TEST_CONFIG_Z="tests/tt_metal/tt_metal/perf_microbenchmark/routing/test_fabric_multi_mesh_sanity_common.yaml"
 FILTER=""
-MPI_IF="ens5f0np0"
+MPI_IF=""
+MPI_IF_EXPLICIT=false
 MPI_EXTRA_ARGS=()
 SKIP_REORDER=false
 
@@ -180,6 +186,7 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             MPI_IF="$2"
+            MPI_IF_EXPLICIT=true
             shift 2
             ;;
         --mpi-args)
@@ -221,6 +228,15 @@ if [[ -z "$DOCKER_IMAGE" ]]; then
     echo ""
     show_help
     exit 1
+fi
+
+# Validate/auto-detect MPI interface with first host from the list
+FIRST_HOST="${HOSTS%%,*}"
+if [[ "$MPI_IF_EXPLICIT" == "true" ]]; then
+    validate_mpi_interface "$MPI_IF" "true" "$FIRST_HOST"
+else
+    MPI_IF=$(validate_mpi_interface "" "false" "$FIRST_HOST")
+    echo "Auto-detected MPI interface: $MPI_IF"
 fi
 
 # For the Nx32x4 family, capture the mesh/host count N (empty for all other configs).

--- a/tools/scaleout/exabox/run_validation.sh
+++ b/tools/scaleout/exabox/run_validation.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Source MPI interface validation utility
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/utils/mpi_if_selection.sh"
+
 # Function to display help
 show_help() {
     cat << EOF
@@ -26,7 +30,8 @@ Optional:
                                             /data/scaleout_configs is mounted by default when it exists on
                                             the host; each host path is mounted at the same path inside
                                             the container
-    --mpi-if <interface>                    Network interface for MPI TCP transport (default: ens5f0np0)
+    --mpi-if <interface>                    Network interface for MPI TCP transport
+                                            (auto-detected if not specified)
     --mpi-args <args>                       Extra arguments passed directly to mpirun (quoted string)
                                             e.g. --mpi-args "--tag-output"
     --validation-args <args>                Extra arguments passed verbatim to run_cluster_validation (quoted string)
@@ -65,7 +70,8 @@ OUTPUT_DIR="validation_output"
 # pass them via --volume / the descriptor path flags.
 EXTRA_VOLUMES=()
 [[ -d /data/scaleout_configs ]] && EXTRA_VOLUMES+=(/data/scaleout_configs)
-MPI_IF="ens5f0np0"
+MPI_IF=""
+MPI_IF_EXPLICIT=false
 MPI_EXTRA_ARGS=()
 VALIDATION_EXTRA_ARGS=()
 
@@ -145,6 +151,7 @@ while [[ $# -gt 0 ]]; do
                 exit 1
             fi
             MPI_IF="$2"
+            MPI_IF_EXPLICIT=true
             shift 2
             ;;
         --mpi-args)
@@ -206,6 +213,15 @@ if [[ -z "$DOCKER_IMAGE" ]]; then
     echo ""
     show_help
     exit 1
+fi
+
+# Validate/auto-detect MPI interface with first host from the list
+FIRST_HOST="${HOSTS%%,*}"
+if [[ "$MPI_IF_EXPLICIT" == "true" ]]; then
+    validate_mpi_interface "$MPI_IF" "true" "$FIRST_HOST"
+else
+    MPI_IF=$(validate_mpi_interface "" "false" "$FIRST_HOST")
+    echo "Auto-detected MPI interface: $MPI_IF"
 fi
 
 run_cluster_validation() {

--- a/tools/scaleout/exabox/utils/mpi_if_selection.sh
+++ b/tools/scaleout/exabox/utils/mpi_if_selection.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+# MPI network interface validation and auto-detection utility
+# Used by exabox cluster scripts to ensure valid MPI interface selection
+
+# Function to test if a given network interface works for MPI communication
+test_mpi_interface() {
+    local interface="$1"
+    local test_host="${2:-$(hostname)}"
+
+    # Quick local test: does the interface exist?
+    if ! ip link show "$interface" &>/dev/null; then
+        return 1
+    fi
+
+    # MPI OOB (out-of-band) connectivity test
+    timeout 3 mpirun --host "$test_host" \
+        --mca oob_tcp_if_include "$interface" \
+        --mca btl_tcp_if_include "$interface" \
+        -np 1 hostname &>/dev/null
+
+    return $?
+}
+
+# Function to validate and auto-detect MPI network interface
+validate_mpi_interface() {
+    local interface="$1"
+    local explicit="$2"
+    local first_host="${3:-$(hostname)}"
+
+    # Get list of available interfaces (excluding loopback)
+    local available_interfaces
+    available_interfaces=$(ip link show | grep -E '^[0-9]+:' | awk -F': ' '{print $2}' | cut -d'@' -f1 | grep -v '^lo$' || true)
+
+    # Check if explicitly provided interface exists and works
+    if [[ "$explicit" == "true" ]]; then
+        if ! echo "$available_interfaces" | grep -qx "$interface"; then
+            echo "Error: Specified MPI interface '$interface' not found on this system" >&2
+            echo "" >&2
+            echo "Available network interfaces:" >&2
+            echo "$available_interfaces" | sed 's/^/  - /' >&2
+            echo "" >&2
+            echo "Use --mpi-if <interface> to specify a different interface" >&2
+            echo "Example: --mpi-if enp2s0f0np0" >&2
+            exit 1
+        fi
+
+        # Test if the interface actually works for MPI
+        if ! test_mpi_interface "$interface" "$first_host"; then
+            echo "Error: Specified MPI interface '$interface' exists but cannot be used for MPI communication" >&2
+            echo "" >&2
+            echo "This usually means the interface is down or misconfigured." >&2
+            echo "Check interface status with: ip link show $interface" >&2
+            echo "" >&2
+
+            # Try to auto-detect a working interface to suggest to the user
+            echo "Attempting to find a working alternative interface..." >&2
+            local suggested_interface=""
+            local candidate_interfaces
+            candidate_interfaces=$(echo "$available_interfaces" | grep -vE '^(docker|flannel|cali|veth|br-|virbr)' || true)
+            [[ -z "$candidate_interfaces" ]] && candidate_interfaces="$available_interfaces"
+
+            while IFS= read -r iface; do
+                [[ -z "$iface" ]] && continue
+                if test_mpi_interface "$iface" "$first_host"; then
+                    suggested_interface="$iface"
+                    break
+                fi
+            done <<< "$candidate_interfaces"
+
+            if [[ -n "$suggested_interface" ]]; then
+                echo "Suggested working interface: $suggested_interface" >&2
+                echo "Try: --mpi-if $suggested_interface" >&2
+                echo "Or remove --mpi-if to use auto-detection" >&2
+            else
+                echo "No working MPI interface found on this system." >&2
+            fi
+
+            exit 1
+        fi
+
+        return 0
+    fi
+
+    # Auto-detect: Prioritize physical-looking interfaces (exclude known virtual patterns)
+    local candidate_interfaces
+    candidate_interfaces=$(echo "$available_interfaces" | grep -vE '^(docker|flannel|cali|veth|br-|virbr)' || true)
+
+    if [[ -z "$candidate_interfaces" ]]; then
+        candidate_interfaces="$available_interfaces"
+    fi
+
+    # Build priority list: UP interfaces first, sorted by speed if ethtool available
+    local priority_interfaces=()
+
+    if command -v ethtool &> /dev/null; then
+        # Get UP interfaces with speed info
+        while IFS= read -r iface; do
+            if ip link show "$iface" 2>/dev/null | grep -q 'state UP'; then
+                local speed
+                speed=$(ethtool "$iface" 2>/dev/null | awk '/Speed:/ {print $2}' | sed 's/Mb\/s//;s/Gb\/s/000/' | grep -E '^[0-9]+$')
+                if [[ -n "$speed" ]]; then
+                    priority_interfaces+=("$speed:$iface")
+                else
+                    priority_interfaces+=("0:$iface")
+                fi
+            fi
+        done <<< "$candidate_interfaces"
+
+        # Sort by speed (descending) and extract interface names
+        local sorted_interfaces=()
+        while IFS= read -r entry; do
+            sorted_interfaces+=("${entry#*:}")
+        done < <(printf '%s\n' "${priority_interfaces[@]}" | sort -t: -k1 -rn)
+
+        # Add DOWN interfaces at the end
+        while IFS= read -r iface; do
+            if ! ip link show "$iface" 2>/dev/null | grep -q 'state UP'; then
+                sorted_interfaces+=("$iface")
+            fi
+        done <<< "$candidate_interfaces"
+
+        candidate_interfaces=$(printf '%s\n' "${sorted_interfaces[@]}")
+    fi
+
+    # Test each candidate interface with actual MPI connectivity
+    local best_interface=""
+    while IFS= read -r iface; do
+        [[ -z "$iface" ]] && continue
+
+        if test_mpi_interface "$iface" "$first_host"; then
+            best_interface="$iface"
+            break
+        fi
+    done <<< "$candidate_interfaces"
+
+    if [[ -z "$best_interface" ]]; then
+        if [[ -z "$interface" ]]; then
+            echo "Error: No suitable MPI network interface could be auto-detected" >&2
+        else
+            echo "Error: No suitable MPI network interface found (default '$interface' not available)" >&2
+        fi
+        echo "" >&2
+        echo "Available network interfaces:" >&2
+        echo "$available_interfaces" | sed 's/^/  - /' >&2
+        echo "" >&2
+        echo "None of the available interfaces passed MPI connectivity test." >&2
+        echo "Use --mpi-if <interface> to specify an interface explicitly" >&2
+        echo "Example: --mpi-if <interface-name>" >&2
+        exit 1
+    fi
+
+    echo "$best_interface"
+}


### PR DESCRIPTION
### Feature: Add mpi interface auto-detection

### Summary
Closes: [DCAMP-741](https://tenstorrent.atlassian.net/browse/DCAMP-741)

In an effort to continue improving our mpi interface selection logic for the exabox validation scripts, this PR implements a common utils script that auto detects the available mpi interfaces, filters out known virtual interfaces and validates to find a working alternative (if any).

The auto-detection can still be overwritten with the `--mpi-if` flag 

This detection logic was added to `run_validation.sh` , `run_fabric_tests.sh` , `run_dispatch_tests.sh` and `recover.sh`

When ` --mpi-if <interface> ` is specified:
- Validates interface exists on system
-  Tests actual MPI connectivity
-  Fails with clear error + suggested working alternative
    Example: 
```
Suggested working interface: enp194s0f0np0
Try: --mpi-if enp194s0f0np0
Or remove --mpi-if to use auto-detection
```

When no --mpi-if specified:
- Auto-detects best working interface
- Tests candidates in priority order
- Uses the first interface that passes MPI connectivity test
-  Shows: `Auto-detected MPI interface: enp194s0f0np0` for reference

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=gsarabando-mpi_interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:gsarabando-mpi_interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=gsarabando-mpi_interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:gsarabando-mpi_interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=gsarabando-mpi_interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:gsarabando-mpi_interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=gsarabando-mpi_interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:gsarabando-mpi_interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=gsarabando-mpi_interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:gsarabando-mpi_interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=gsarabando-mpi_interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:gsarabando-mpi_interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=gsarabando-mpi_interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:gsarabando-mpi_interface)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=gsarabando-mpi_interface)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:gsarabando-mpi_interface)