### PR TITLE
Add log warning when read/write tile info out of Row Major Config

### DIFF
--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -219,10 +219,12 @@ size_t RowMajorPageConfig::get_page_size_bytes(const Shape2D& page_shape, DataTy
 }
 
 const Tile& RowMajorPageConfig::get_tile() const {
+    bool is_trivial = (tile_ == Tile{});
     log_warning(
         LogMetal,
-        "Attempting to extract tile infomation out of a ROW MAJOR layout, this will be rejected in the future. See "
-        "#18536");
+        "Attempting to extract tile information out of a ROW MAJOR layout, this will be rejected in the future. See "
+        "#18536. (trivial tile: {})",
+        is_trivial);
     return tile_;
 }
 

--- a/tt_metal/impl/tensor/spec/layout/page_config.cpp
+++ b/tt_metal/impl/tensor/spec/layout/page_config.cpp
@@ -2,6 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include <tt-logger/tt-logger.hpp>
 #include <tt_stl/fmt.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
 
@@ -146,7 +147,14 @@ Alignment TilePageConfig::get_required_shard_shape_alignment() const {
     return Alignment({tile_.get_height(), tile_.get_width()});
 }
 
-RowMajorPageConfig::RowMajorPageConfig(const Tile& tile) : tile_(tile) {}
+RowMajorPageConfig::RowMajorPageConfig(const Tile& tile) : tile_(tile) {
+    if (tile != Tile{}) {
+        log_warning(
+            LogMetal,
+            "Configuring a ROW MAJOR page config with a tile configuration, this will be rejected in the future. See "
+            "#18536");
+    }
+}
 
 Alignment RowMajorPageConfig::create_default_alignment(DataType /*dtype*/, const MemoryConfig& memory_config) const {
     if (memory_config.shard_spec().has_value()) {
@@ -210,7 +218,13 @@ size_t RowMajorPageConfig::get_page_size_bytes(const Shape2D& page_shape, DataTy
     return size;
 }
 
-const Tile& RowMajorPageConfig::get_tile() const { return tile_; }
+const Tile& RowMajorPageConfig::get_tile() const {
+    log_warning(
+        LogMetal,
+        "Attempting to extract tile infomation out of a ROW MAJOR layout, this will be rejected in the future. See "
+        "#18536");
+    return tile_;
+}
 
 Alignment RowMajorPageConfig::get_required_shard_shape_alignment() const { return Alignment({1}); }
 

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -127,19 +127,20 @@ std::optional<std::string> get_shard_align_error(
     if (!memory_config.is_sharded() || layout != Layout::TILE) {
         return std::nullopt;
     }
-        const auto& tile_shape = tile.get_tile_shape();
-        if (memory_config.shard_spec().has_value()) {
-            const auto& physical_shard_shape = Shape2D(memory_config.shard_spec().value().shape);
-            if (!(physical_shard_shape.height() % tile_shape[0] == 0 &&
-                  physical_shard_shape.width() % tile_shape[1] == 0)) {
-                return fmt::format("Physical shard shape {} must be tile {} sized!", physical_shard_shape, tile_shape);
-            }
-        } else {
-            const auto& shard_shape = memory_config.nd_shard_spec().value().shard_shape;
-            if (!(shard_shape[-2] % tile_shape[0] == 0 && shard_shape[-1] % tile_shape[1] == 0)) {
-                return fmt::format("Physical shard shape {} must be tile {} sized!", shard_shape, tile_shape);
-            }
+    const auto& tile_shape = tile.get_tile_shape();
+    if (memory_config.shard_spec().has_value()) {
+        const auto& physical_shard_shape = Shape2D(memory_config.shard_spec().value().shape);
+        if (!(physical_shard_shape.height() % tile_shape[0] == 0 &&
+              physical_shard_shape.width() % tile_shape[1] == 0)) {
+            return fmt::format("Physical shard shape {} must be tile {} sized!", physical_shard_shape, tile_shape);
         }
+    } else {
+        const auto& shard_shape = memory_config.nd_shard_spec().value().shard_shape;
+        if (!(shard_shape[-2] % tile_shape[0] == 0 && shard_shape[-1] % tile_shape[1] == 0)) {
+            return fmt::format("Physical shard shape {} must be tile {} sized!", shard_shape, tile_shape);
+        }
+    }
+    return std::nullopt;
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE

--- a/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
+++ b/tt_metal/impl/tensor/spec/layout/tensor_layout.cpp
@@ -124,7 +124,9 @@ void validate_alignment(const TensorLayout& tensor_layout) {
 
 std::optional<std::string> get_shard_align_error(
     const MemoryConfig& memory_config, const Layout& layout, const Tile& tile) {
-    if (memory_config.is_sharded() && layout == Layout::TILE) {
+    if (!memory_config.is_sharded() || layout != Layout::TILE) {
+        return std::nullopt;
+    }
         const auto& tile_shape = tile.get_tile_shape();
         if (memory_config.shard_spec().has_value()) {
             const auto& physical_shard_shape = Shape2D(memory_config.shard_spec().value().shape);
@@ -138,8 +140,6 @@ std::optional<std::string> get_shard_align_error(
                 return fmt::format("Physical shard shape {} must be tile {} sized!", shard_shape, tile_shape);
             }
         }
-    }
-    return std::nullopt;
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE
@@ -155,8 +155,11 @@ TensorLayout::TensorLayout(
     initialize_alignment();
     CMAKE_UNIQUE_NAMESPACE::validate_alignment(*this);
 
-    auto shard_align_error = CMAKE_UNIQUE_NAMESPACE::get_shard_align_error(memory_config_, get_layout(), get_tile());
-    TT_FATAL(!shard_align_error.has_value(), "{}", shard_align_error);
+    if (get_layout() == Layout::TILE) {
+        auto shard_align_error =
+            CMAKE_UNIQUE_NAMESPACE::get_shard_align_error(memory_config_, get_layout(), get_tile());
+        TT_FATAL(!shard_align_error.has_value(), "{}", shard_align_error);
+    }
 }
 
 TensorLayout TensorLayout::fromPaddedShape(


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup?? Path for bug fix?

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Contributes to #18536 .

Currently, a row major tensor can have a tile configuration, which does not make sense at all.

This exist to support the following pattern:
```cpp
Tile tile_config{/* ... */};
// tensor is a row major
auto rm_tensor = HostTensor::from_xxx(data, tile_config);
auto tile_tensor = to_layout(tensor, Layout::tile);
```

We should remove this feature and instead add the tile config to the `to_layout` function.

```
Tile tile_config{/* ... */};
// tensor is a row major
auto rm_tensor = HostTensor::from_xxx(data, tile_config);
auto tile_tensor = to_layout(tensor, Layout::tile, tile_config);
```

This PR adds logging infomation on who and where is using the current system (as there is sufficient evidence noone is using this??).

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/meshtensor-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/meshtensor-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/meshtensor-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/meshtensor-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/meshtensor-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/meshtensor-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/meshtensor-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/meshtensor-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/meshtensor-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/meshtensor-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/meshtensor-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/meshtensor-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/meshtensor-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/meshtensor-logs)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/meshtensor-logs)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/meshtensor-logs)