### PR TITLE
[skip ci] Skip test_windowed_sdpa_smoke on Blackhole (MOVD2B failure)

### DIFF
--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -63,6 +63,8 @@ blackhole:
   # https://github.com/tenstorrent/tt-metal/issues/41286
   # https://github.com/tenstorrent/tt-metal/issues/40583
   # https://github.com/tenstorrent/tt-metal/issues/43295
+  # https://github.com/tenstorrent/tt-metal/issues/47164
+  - tests/ttnn/unit_tests/operations/sdpa/test_windowed_sdpa.py::test_windowed_sdpa_smoke
   - tests/ttnn/unit_tests/operations/data_movement/test_concat.py::test_tiled_concat
   - tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
   - tests/ttnn/unit_tests/operations/fused/test_layer_norm_sharded.py


### PR DESCRIPTION
## Summary

Adds `test_windowed_sdpa_smoke` to the TTSim Blackhole skip list under the existing MOVD2B failures section.

The test crashes with `UndefinedBehavior: tensix_movd2b` due to incompatible `use_dst32b`/`dest_32b_lo` usage in the windowed SDPA compute kernel path (shared kernel introduced in #46281).

The underlying issue is tracked in #47164 — this PR only disables the test in TTSim; the root cause is not fixed here.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ebanerjee/ttsim-skip-windowed-sdpa-smoke-47164)