### PR TITLE
Revert Blitz decode eth-coord column invariant from #43384

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -1404,31 +1404,6 @@ void validate_sp5_blitz_decode_pipeline_stages(
             << coord_str(s.entry_node_coord);
     }
 
-    // 1b. Entry and exit on different columns: for 2D meshes coord[1] is the LINE axis (second MGD dim, width 2 in
-    // blitz decode 4x2); endpoints must not share the same column. Skip when an adjacent hop in the ring is
-    // intra-mesh (previous stage shares stage_index with this stage, or this stage shares stage_index with next):
-    // that leg completes on one logical mesh while the next hop stays on the same mesh (typical mesh-0 bookends),
-    // where LINE separation may be infeasible given hop/unclaimed constraints.
-    const std::size_t num_stages = stages.size();
-    for (std::size_t i = 0; i < num_stages; i++) {
-        const auto& s = stages[i];
-        if (s.entry_node_coord.dims() < 2) {
-            continue;
-        }
-        const std::size_t prev_i = (i + num_stages - 1) % num_stages;
-        const std::size_t next_i = (i + 1) % num_stages;
-        const bool incoming_intra_mesh = stages[prev_i].stage_index == s.stage_index;
-        const bool outgoing_intra_mesh = s.stage_index == stages[next_i].stage_index;
-        if (incoming_intra_mesh || outgoing_intra_mesh) {
-            continue;
-        }
-        EXPECT_NE(s.entry_node_coord[1], s.exit_node_coord[1])
-            << "Stage [" << i << "] (stage_index=" << s.stage_index
-            << ") entry and exit must use different mesh "
-               "columns (coord[1]): entry "
-            << coord_str(s.entry_node_coord) << " exit " << coord_str(s.exit_node_coord);
-    }
-
     // 2. No coord is reused across stages
     std::set<std::pair<std::size_t, std::pair<uint32_t, uint32_t>>> used_coords;
     for (std::size_t i = 0; i < stages.size(); i++) {
@@ -2266,57 +2241,6 @@ TEST_F(ControlPlaneFixture, TestBlitzDecodePipelineBuilder) {
         {static_cast<std::size_t>(*mesh_ids[0]),
          fn_to_coord(hops[num_meshes - 1].second),
          fn_to_coord(*loopback_exit_fn)});
-
-    const auto& topology_mapper = control_plane.get_topology_mapper();
-
-    for (std::size_t si = 0; si < stages.size(); si++) {
-        const auto& s = stages[si];
-        MeshId stage_mesh_id{static_cast<uint32_t>(s.stage_index)};
-        const FabricNodeId entry_fn(stage_mesh_id, mesh_graph.coordinate_to_chip(stage_mesh_id, s.entry_node_coord));
-        const FabricNodeId exit_fn(stage_mesh_id, mesh_graph.coordinate_to_chip(stage_mesh_id, s.exit_node_coord));
-
-        fmt::print(
-            "stage{}: stage_index={} entry_mesh_coord=[{}, {}] exit_mesh_coord=[{}, {}]\n",
-            si,
-            s.stage_index,
-            s.entry_node_coord[0],
-            s.entry_node_coord[1],
-            s.exit_node_coord[0],
-            s.exit_node_coord[1]);
-
-        auto print_endpoint = [&](std::string_view label, const MeshCoordinate& coord, const FabricNodeId& fn) {
-            const std::string hostname = topology_mapper.get_hostname_for_fabric_node_id(fn);
-            tt::tt_metal::TrayID tray_id = topology_mapper.get_tray_id_for_fabric_node_id(fn);
-            tt::tt_metal::ASICLocation asic_location = topology_mapper.get_asic_location_for_fabric_node_id(fn);
-            fmt::print(
-                "             {:9} mesh_coord=[{}, {}] fabric_node={} chip_id={} hostname={} mesh_id={} tray_id={} "
-                "asic_location={}\n",
-                label,
-                coord[0],
-                coord[1],
-                fn,
-                fn.chip_id,
-                hostname,
-                *fn.mesh_id,
-                *tray_id,
-                *asic_location);
-        };
-
-        for (const auto& [label, coord, fn] :
-             {std::tuple<std::string_view, const MeshCoordinate&, const FabricNodeId&>{
-                  "entry", s.entry_node_coord, entry_fn},
-              {"exit", s.exit_node_coord, exit_fn}}) {
-            print_endpoint(label, coord, fn);
-        }
-
-        for (const auto& coord : mesh_graph.get_coord_range(stage_mesh_id)) {
-            if (coord == s.entry_node_coord || coord == s.exit_node_coord) {
-                continue;
-            }
-            const FabricNodeId fn(stage_mesh_id, mesh_graph.coordinate_to_chip(stage_mesh_id, coord));
-            print_endpoint("other", coord, fn);
-        }
-    }
 
     validate_sp5_blitz_decode_pipeline_stages(control_plane, mesh_graph, mesh_ids, stages);
 }

--- a/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
+++ b/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
@@ -218,32 +218,6 @@ void validate_pipeline(const std::vector<BlitzDecodePipelineStage>& stages, bool
             coord_str(s.entry_node_coord));
     }
 
-    // 1b. Entry and exit on different mesh columns (coord[1]) when coordinates are 2D: coord[1] is the LINE axis
-    // (second MGD dim, e.g. width 2 in blitz decode 4x2). Skip for 1D meshes (no coord[1]). Skip when an adjacent
-    // hop in the ring is intra-mesh (same stage_index as previous or next stage): LINE-axis separation may be
-    // infeasible for those legs while still satisfying hop and unclaimed-node constraints.
-    const std::size_t n = stages.size();
-    for (std::size_t i = 0; i < check_distinct_until; i++) {
-        const auto& s = stages[i];
-        if (s.entry_node_coord.dims() < 2) {
-            continue;
-        }
-        const std::size_t prev_i = (i + n - 1) % n;
-        const std::size_t next_i = (i + 1) % n;
-        const bool incoming_intra_mesh = stages[prev_i].stage_index == s.stage_index;
-        const bool outgoing_intra_mesh = s.stage_index == stages[next_i].stage_index;
-        if (incoming_intra_mesh || outgoing_intra_mesh) {
-            continue;
-        }
-        TT_FATAL(
-            s.entry_node_coord[1] != s.exit_node_coord[1],
-            "Stage [{}] (stage_index={}) entry and exit must use different mesh columns (coord[1]): entry {} exit {}",
-            i,
-            s.stage_index,
-            coord_str(s.entry_node_coord),
-            coord_str(s.exit_node_coord));
-    }
-
     // 2. No coord is reused across stages (no overlapping nodes).
     // Skip the last stage's exit when !initialize_loopback — it has no downstream exit.
     std::set<std::pair<std::size_t, std::pair<uint32_t, uint32_t>>> used_coords;

--- a/tt_metal/fabric/control_plane.cpp
+++ b/tt_metal/fabric/control_plane.cpp
@@ -73,49 +73,6 @@ namespace {
 // topology_mapper_utils.hpp) so that ControlPlane (Phase 2) and generate_rank_bindings (Phase 1) apply the
 // exact same galaxy pin placement.
 
-// Blitz decode pipeline: octet mesh (4x2 device topology, 8 chips) ASIC-position pinnings for chips 0, 1, 2, 5,
-// 6, and 7 on Blackhole Galaxy (QSFP / tray layout vs logical mesh). Only used when cluster is Blackhole Galaxy
-// and the mesh shape matches decode MGDs (dims [4,2]).
-std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>>
-get_blitz_decode_pipeline_asic_position_pinnings_for_mesh(MeshId mesh_id, const MeshShape& mesh_shape) {
-    std::vector<std::pair<FabricNodeId, std::vector<AsicPosition>>> fixed_asic_position_pinnings;
-    if (mesh_shape.mesh_size() != 8 || mesh_shape[0] != 4 || mesh_shape[1] != 2) {
-        return fixed_asic_position_pinnings;
-    }
-
-    std::vector<AsicPosition> node0_positions;
-    node0_positions.emplace_back(AsicPosition{1, 1});
-    node0_positions.emplace_back(AsicPosition{1, 3});
-
-    std::vector<AsicPosition> node1_positions;
-    node1_positions.emplace_back(AsicPosition{1, 2});
-    node1_positions.emplace_back(AsicPosition{1, 4});
-
-    std::vector<AsicPosition> node2_positions;
-    node2_positions.emplace_back(AsicPosition{1, 5});
-    node2_positions.emplace_back(AsicPosition{1, 7});
-
-    std::vector<AsicPosition> node5_positions;
-    node5_positions.emplace_back(AsicPosition{4, 5});
-    node5_positions.emplace_back(AsicPosition{4, 7});
-
-    std::vector<AsicPosition> node6_positions;
-    node6_positions.emplace_back(AsicPosition{4, 2});
-    node6_positions.emplace_back(AsicPosition{4, 4});
-
-    std::vector<AsicPosition> node7_positions;
-    node7_positions.emplace_back(AsicPosition{4, 1});
-    node7_positions.emplace_back(AsicPosition{4, 3});
-
-    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 0}, std::move(node0_positions));
-    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 1}, std::move(node1_positions));
-    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 2}, std::move(node2_positions));
-    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 5}, std::move(node5_positions));
-    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 6}, std::move(node6_positions));
-    fixed_asic_position_pinnings.emplace_back(FabricNodeId{mesh_id, 7}, std::move(node7_positions));
-    return fixed_asic_position_pinnings;
-}
-
 template <typename CONNECTIVITY_MAP_T>
 void build_golden_link_counts(
     CONNECTIVITY_MAP_T const& golden_connectivity_map,
@@ -496,12 +453,8 @@ void ControlPlane::init_control_plane(
                 const bool is_1d = mesh_shape[0] == 1 || mesh_shape[1] == 1;
                 const size_t mesh_chip_count = mesh_shape.mesh_size();
 
-                if (cluster.get_cluster_type() == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY && !is_1d &&
-                    mesh_chip_count == 8 && mesh_shape[0] == 4 && mesh_shape[1] == 2) {
-                    auto mesh_pinnings = get_blitz_decode_pipeline_asic_position_pinnings_for_mesh(mesh_id, mesh_shape);
-                    fixed_asic_position_pinnings.insert(
-                        fixed_asic_position_pinnings.end(), mesh_pinnings.begin(), mesh_pinnings.end());
-                } else if (!is_1d && mesh_chip_count % 32 == 0) {
+                // Only apply galaxy pinnings if mesh has multiple of 32 chips and is not 1D
+                if (!is_1d && mesh_chip_count % 32 == 0) {
                     const bool sub_galaxy_sliced =
                         this->mesh_graph_->get_mesh_shape(mesh_id, MeshHostRankId{0}).mesh_size() < 32;
                     auto mesh_pinnings =
@@ -616,12 +569,8 @@ void ControlPlane::init_control_plane_auto_discovery() {
             const bool is_1d = mesh_shape[0] == 1 || mesh_shape[1] == 1;
             const size_t mesh_chip_count = mesh_shape.mesh_size();
 
-            if (cluster.get_cluster_type() == tt::tt_metal::ClusterType::BLACKHOLE_GALAXY && !is_1d &&
-                mesh_chip_count == 8 && mesh_shape[0] == 4 && mesh_shape[1] == 2) {
-                auto mesh_pinnings = get_blitz_decode_pipeline_asic_position_pinnings_for_mesh(mesh_id, mesh_shape);
-                fixed_asic_position_pinnings.insert(
-                    fixed_asic_position_pinnings.end(), mesh_pinnings.begin(), mesh_pinnings.end());
-            } else if (!is_1d && mesh_chip_count % 32 == 0) {
+            // Only apply galaxy pinnings if mesh has multiple of 32 chips and is not 1D
+            if (!is_1d && mesh_chip_count % 32 == 0) {
                 const bool sub_galaxy_sliced =
                     this->mesh_graph_->get_mesh_shape(mesh_id, MeshHostRankId{0}).mesh_size() < 32;
                 auto mesh_pinnings =

--- a/tt_metal/fabric/topology_mapper_utils.cpp
+++ b/tt_metal/fabric/topology_mapper_utils.cpp
@@ -1890,10 +1890,10 @@ void add_pinning_constraints(
         for (const auto& position : positions) {
             auto it = asic_positions_to_asic_ids.find(position);
             if (it == asic_positions_to_asic_ids.end()) {
-                log_warning(
+                log_critical(
                     tt::LogFabric,
                     "Pinned ASIC position (tray_id: {}, asic_location: {}) to fabric node id (mesh_id: {}, chip_id: "
-                    "{}) from MGD not found in physical topology; skipping this pin",
+                    "{}) from MGD not found in physical topology",
                     position.first.get(),
                     position.second.get(),
                     fabric_node.mesh_id.get(),
@@ -1927,14 +1927,7 @@ void add_pinning_constraints(
             }
         }
     }
-    // TODO: Would like to communicate this to the caller so they can fail the mapping if any pinnings are skipped.
-    // https://github.com/tenstorrent/tt-metal/issues/43451
-    if (!success) {
-        log_warning(
-            tt::LogFabric,
-            "Some pinning constraints were skipped because the ASIC (tray, location) was absent from the physical "
-            "mesh; topology mapping proceeds without those pins");
-    }
+    TT_FATAL(success, "Failed to add pinning constraints");
 }
 
 // Parallel physical inter-mesh edges from one exit ASIC to a destination mesh (each edge is one link / channel).


### PR DESCRIPTION
## Summary
- Reverts the code changes from #43384 ("Standardizing Eth Coords for Blitz Pipeline", synced to blaze-metal-main via #46683) that over-constrained Blitz decode entry/exit node placement.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rsong/revert-blitz-eth-coord-column-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rsong/revert-blitz-eth-coord-column-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rsong/revert-blitz-eth-coord-column-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rsong/revert-blitz-eth-coord-column-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rsong/revert-blitz-eth-coord-column-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rsong/revert-blitz-eth-coord-column-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rsong/revert-blitz-eth-coord-column-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rsong/revert-blitz-eth-coord-column-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rsong/revert-blitz-eth-coord-column-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rsong/revert-blitz-eth-coord-column-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rsong/revert-blitz-eth-coord-column-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rsong/revert-blitz-eth-coord-column-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rsong/revert-blitz-eth-coord-column-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rsong/revert-blitz-eth-coord-column-invariant)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rsong/revert-blitz-eth-coord-column-invariant)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rsong/revert-blitz-eth-coord-column-invariant)