### PR TITLE
Metal 2.0 migration + host-cost study (rand, matmul, spec-as-key) [DRAFT/WIP]

### DIFF
--- a/tech_reports/Metal2OpMigration/METAL_TEAM_REPORT_AUDREY.md
+++ b/tech_reports/Metal2OpMigration/METAL_TEAM_REPORT_AUDREY.md
@@ -1,0 +1,137 @@
+# Metal 2.0 host-API gaps blocking the TTNN op migration — for Audrey
+
+**From:** Diego (TTNN op migration)
+**Context:** Migrating a batch of TTNN ops to the Metal 2.0 `ProgramSpec`/`create_program_spec` path
+(rand, matmul, transpose, pad, tilize, untilize_with_unpadding, slice, reshard, binary_ng, conv2d,
+halo, pool). 13 factories across 9 ops are ported and PCC-correct; the items below are the metal-side
+(host-API / validator / kernel-codegen) gaps that block the rest. Everything else remaining is TTNN-side
+work on our end.
+
+All references are against the branch state I built/validated on (WH B0).
+
+---
+
+## P0 — the one that gates *production*: in-place run-args update
+
+**`ProgramRunArgsView` / `GetProgramRunArgsView` is declared but not implemented**
+`tt_metal/api/tt-metalium/experimental/metal2_host_api/program.hpp:82` ("Sketch only; not yet implemented").
+
+**Why it matters.** With the spec path, the only correct cache-hit options today are (a) re-run the
+factory + `SetProgramRunArgs` (we do this for ops with dynamic run-args like rand's seed), or (b)
+`UpdateTensorArgs` (tensors only). Both rebuild per-core, string-keyed `ProgramRunArgs` every dispatch.
+Measured host-cost regression vs the legacy descriptor path, 1000 cache-hit calls, identical op calls,
+spec-factory-confirmed-live:
+
+| op | descriptor | spec | ratio |
+|---|---|---|---|
+| transpose WH | 18.6 µs | 85.0 µs | **4.6×** |
+| transpose CN | 18.8 µs | 69.1 µs | 3.7× |
+| rand 512² | 48 µs | 81 µs | 1.7× |
+| pad / untilize | ~19–37 µs | ~40–76 µs | ~2.1× |
+| slice / binary_ng | ~27–48 µs | ~43–74 µs | ~1.6× |
+| matmul (device-bound) | 84.9 µs | 87.7 µs | ~1.0× |
+
+The cost is the per-core string-keyed run-args rebuild + re-apply. Profiling rand's hit path: ~30 µs
+rebuilding run-args that are a pure function of the cache key, <1 µs of genuinely-dynamic values. An
+in-place poke (`ProgramRunArgsView`: overwrite the changed ints at resolved byte offsets, no Table
+rebuild, no re-resolution) collapses this toward the descriptor path's ~5 µs. **This is the difference
+between "migration is host-perf-neutral" and "migration ships a 1.5–4.6× host regression on light ops."**
+
+Related: a relaxation-aware **`std::hash<ProgramSpec>`** (spec-as-cache-key) would also help — we measured
+the current key over-fragmenting 7 cache entries where 2 suffice (same-volume shapes). I prototyped a
+ttnn-side spec hash for measurement; a canonical one belongs in tt_metal.
+
+---
+
+## P1 — small, unblocks two ops immediately
+
+**Borrowed-DFB memory check rejects `L1_SMALL`**
+`tt_metal/impl/metal2_host_api/program_spec.cpp:1265`:
+```cpp
+TT_FATAL(tensor_spec.memory_config().buffer_type() == tt::tt_metal::BufferType::L1, ...);
+```
+conv2d and halo back their borrowed config DFBs with `L1_SMALL` buffers (`sliding_window.cpp` config
+tensors). The validator only accepts `BufferType::L1`. **Suggested fix:** accept `{L1, L1_SMALL}`
+(both are L1-resident). I have a local one-line prototype (relaxed to a two-way check) — needs your
+review/blessing since it's your validator, and confirmation that `AttachBorrowedDFBBuffers`
+(`program_run_args.cpp`) handles an `L1_SMALL` backing buffer's per-bank sizing. **Blocks:** conv2d
+(L1 path), halo.
+
+---
+
+## P1 — `TensorAccessor` binding can't express runtime base-offset / per-shard page-size
+
+`tt_metal/hw/inc/api/tensor/tensor_accessor.h`: the binding-token ctor (`TensorAccessor(ta::name)`,
+~`:99-110`, dynamic twin ~`:390-396`) hard-seats `bank_base_address` from the injected CRTA and
+`aligned_page_size` from the spec's static `AlignedPageSize` (`tensor_accessor_args.h:44`). The flexible
+3-arg ctor `TensorAccessor(args, base, page_size)` (~`:82-87`) is unreachable through `ta::`.
+
+**Use case (slice ROW_MAJOR, sharded path):** the legacy kernel (i) bakes a host-computed offset into the
+accessor base (`start_addr + begins_bytes - misalignment`) then hands the *accessor object* to
+`noc_async_read_sharded` (which derives NoC addresses internally), and (ii) passes a per-shard page size
+(`shard_W * elem_size`) read back via `get_aligned_page_size()`. Neither knob is reachable via the typed
+binding, and the recipe's "host-computed offset" pattern only covers kernels that use a *raw* base+offset,
+not ones that hand the accessor to `noc_async_*_sharded`. **Suggested:** let a `ta::` binding optionally
+carry a runtime page-size and/or a host-computed base offset (route to the 3-arg ctor). **Blocks:**
+slice RM (and likely other sharded RM data-movement ops).
+
+---
+
+## P2 — same-core multi-producer DFB (broadcast)
+
+`tt_metal/impl/metal2_host_api/program_spec.cpp` local-DFB validation (~`:1137-1153`, `TT_FATAL` ~`:1143`;
+self-loop exception ~`:1182-1197`) enforces pairwise-disjoint producers per node.
+
+**Use case (halo):** the split-reader writes one output CB from **both** RISCV_0 and RISCV_1 on the
+**same** core — two PRODUCER bindings on one DFB, same node, same kernel-kind. Not a self-loop, so the
+self-loop exception doesn't apply. This is the broadcast/same-core multi-endpoint case your stacked metal
+prereq (PR #47037) targets. **Blocks:** halo. **Suggested:** the broadcast DFB model from #47037, or an
+explicit "multiple same-kind producers on identical node coverage" allowance.
+
+---
+
+## P2 — buffer-address binding (address through a CTA to a DM kernel)
+
+conv2d and pool, on their **DRAM-config** paths, thread `buffer->address()` (+ `page_size`) through
+compile-time args into a data-movement kernel (e.g. conv `conv_reader_common.hpp` `load_config_tensor_if_in_dram`;
+pool reader CTAs). Metal 2.0 disallows raw addresses through CTAs/RTAs, and a borrowed DFB requires L1
+(so a DRAM-resident config can't borrow). There is no sanctioned way to hand a DM kernel a DRAM buffer's
+base address. **Suggested:** a host-API `BufferParameter`/address-binding, or a DRAM-backed borrowed DFB.
+**Blocks:** conv2d (DRAM-config path), pool (DRAM-config path). (Both ops' L1 paths are unblocked once
+P1-L1_SMALL lands + our TTNN op-owned fix.)
+
+---
+
+## P3 — GlobalCircularBuffer DFB binding
+
+matmul `MatmulMultiCoreReuseMcast1DProgramFactory` uses a `GlobalCircularBuffer` (`global_cb`) path with
+no corresponding DFB binding in the host API. **Blocks:** matmul Mcast1D (one of several matmul mcast
+factories). Lower priority — the 2D mcast factory has no such gap (just large), and we have MultiCore +
+ReuseOptimized ported.
+
+---
+
+## Design feedback on op-owned tensors (FYI, not a blocker for you)
+
+I built the ttnn-side `ProgramArtifacts::op_owned_tensors` channel + cache-hit policy (parked tensors,
+reuse-not-realloc on hit). Two notes from the first real consumers vs the documented design:
+- The docs describe op-owned tensors as **empty scratch** via `MeshTensor::allocate_on_device`
+  (fully-replicated, "untested at runtime"). conv2d/pool need **host-populated** config tensors and
+  **sharded** placement. We can handle this TTNN-side (carry a populated `ttnn::Tensor`), but the
+  documented `allocate_on_device(... fully_replicated ...)` recipe should be widened or annotated.
+- `MeshTensor` being non-copyable + `Tensor::mesh_tensor()` returning `const&` means there's no clean
+  `Tensor`→owned-`MeshTensor` move; we'll add a ttnn extraction helper. Flagging in case you'd prefer a
+  blessed API.
+
+---
+
+## Priority summary
+1. **`ProgramRunArgsView`** — gates production (removes the host regression). Biggest item.
+2. **L1_SMALL borrowed-DFB relax** — one line, unblocks conv2d + halo (L1). Prototype ready for review.
+3. **`ta::` runtime base-offset / page-size** — unblocks slice RM (+ sharded RM family).
+4. **Same-core multi-producer DFB (broadcast, #47037)** — unblocks halo.
+5. **Buffer-address binding / DRAM-borrowed-DFB** — unblocks conv2d + pool DRAM paths.
+6. **GlobalCB DFB binding** — unblocks matmul Mcast1D.
+
+Everything else remaining (multi-program concept for matmul MeshWorkload, host-populated/sharded op-owned
+tensors, binary_ng's kernel-path fan-out, the remaining per-op default factories) is TTNN-side and on us.

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1261,10 +1261,12 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             dfb.unique_id,
             tp_name);
         const TensorSpec& tensor_spec = it->second->spec;
+        const auto borrow_buffer_type = tensor_spec.memory_config().buffer_type();
         TT_FATAL(
-            tensor_spec.memory_config().buffer_type() == tt::tt_metal::BufferType::L1,
-            "DFB '{}' borrows memory from TensorParameter '{}', but its TensorSpec is not L1-resident (L1 is "
-            "required).",
+            borrow_buffer_type == tt::tt_metal::BufferType::L1 ||
+                borrow_buffer_type == tt::tt_metal::BufferType::L1_SMALL,
+            "DFB '{}' borrows memory from TensorParameter '{}', but its TensorSpec is not L1-resident (L1 or "
+            "L1_SMALL is required).",
             dfb.unique_id,
             tp_name);
         // Coarse spec-time sizing check against the TensorSpec's full packed size. No Buffer is

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -675,7 +675,7 @@ public:
             // shared (shared_ptr) across all stamped coordinate-range programs. Empty
             // unless the factory allocated its own tensors; non-empty selects the
             // reuse-parked cache-hit path (no factory re-run, no re-allocation).
-            std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> op_owned_tensors;
+            std::shared_ptr<std::vector<tt::tt_metal::Tensor>> op_owned_tensors;
         };
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
@@ -761,14 +761,13 @@ public:
             // across every stamped coordinate-range program. The std::vector move preserves
             // element addresses, so the run_params TensorArguments the factory built against
             // these elements stay valid (matched by pointer identity below).
-            auto op_owned =
-                std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors));
+            auto op_owned = std::make_shared<std::vector<tt::tt_metal::Tensor>>(std::move(artifacts.op_owned_tensors));
 
             // Candidate list for binding resolution: io tensors first, then op-owned.
             auto candidate_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
             const std::size_t io_tensor_count = candidate_tensors.size();
             for (const auto& owned_tensor : *op_owned) {
-                candidate_tensors.push_back(std::cref(owned_tensor));
+                candidate_tensors.push_back(std::cref(owned_tensor.mesh_tensor()));
             }
             auto bindings = resolve_bindings(artifacts.run_params.tensor_args, candidate_tensors);
 
@@ -823,7 +822,7 @@ public:
                         std::reference_wrapper<const tt::tt_metal::MeshTensor> ref =
                             (b.tensor_idx < sv.io_tensor_count)
                                 ? io[b.tensor_idx]
-                                : std::cref((*sv.op_owned_tensors)[b.tensor_idx - sv.io_tensor_count]);
+                                : std::cref((*sv.op_owned_tensors)[b.tensor_idx - sv.io_tensor_count].mesh_tensor());
                         fresh_tensor_args.emplace(b.tensor_parameter_name, TensorArgument{ref});
                     }
                     tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -14,6 +14,9 @@
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 #include <algorithm>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
 #include <iterator>
 #include <memory>
 #include <optional>
@@ -36,6 +39,124 @@ namespace ttnn::device_operation {
 
 template <typename T>
 using AdaptedCachedMeshWorkload = tt::tt_metal::program_cache::detail::AdaptedCachedMeshWorkload<T>;
+
+// ----------------------------------------------------------------------------
+// PROTOTYPE (measurement-only, env-gated): spec-as-cache-key experiment.
+// Computes a hash of the immutable ProgramSpec — the candidate cache key that
+// would replace per-op custom compute_program_hash. Two variants:
+//   strict  — hashes each TensorParameter's full TensorSpec (shape-sensitive)
+//   relaxed — for TensorParameters the program treats as shape-agnostic, hashes
+//             only (dtype, layout, mem_config, PADDED VOLUME) instead of shape,
+//             modelling TensorParameterAdvancedOptions::dynamic_tensor_shape.
+// Groups are folded order-insensitively (sum) since Group order is semantically
+// meaningless. Used only to MEASURE cache reusability vs the current key; does
+// not change live caching.
+// ----------------------------------------------------------------------------
+namespace metal2_speckey_proto {
+template <typename... Ts>
+inline uint64_t oh(const Ts&... xs) {
+    return static_cast<uint64_t>(ttsl::hash::hash_objects_with_default_seed(xs...));
+}
+inline uint64_t mix(uint64_t h, uint64_t v) { return h ^ (v + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2)); }
+
+inline uint64_t program_spec_cache_key(const tt::tt_metal::experimental::ProgramSpec& spec, bool relax_shape) {
+    namespace m2 = tt::tt_metal::experimental;
+    uint64_t h = oh(spec.name);
+
+    uint64_t dfb = 0;
+    for (const auto& d : spec.dataflow_buffers) {
+        uint64_t e = oh(d.unique_id.get(), d.entry_size, d.num_entries);
+        if (d.data_format_metadata) {
+            e = mix(e, oh(static_cast<uint32_t>(*d.data_format_metadata)));
+        }
+        dfb += e;
+    }
+    h = mix(h, dfb);
+
+    uint64_t kk = 0;
+    for (const auto& k : spec.kernels) {
+        uint64_t e = oh(k.unique_id.get(), k.num_threads);
+        if (std::holds_alternative<std::filesystem::path>(k.source)) {
+            e = mix(e, oh(std::get<std::filesystem::path>(k.source).string()));
+        } else {
+            e = mix(e, oh(std::get<m2::KernelSpec::SourceCode>(k.source).code));
+        }
+        uint64_t df = 0;
+        for (const auto& [dk, dv] : k.compiler_options.defines) {
+            df += oh(dk, dv);
+        }
+        uint64_t ct = 0;
+        for (const auto& [ck, cv] : k.compile_time_args) {
+            ct += oh(ck, cv);
+        }
+        uint64_t rn = 0;
+        for (const auto& n : k.runtime_arg_schema.runtime_arg_names) {
+            rn += oh(n);
+        }
+        for (const auto& n : k.runtime_arg_schema.common_runtime_arg_names) {
+            rn += oh(n) + 1;
+        }
+        uint64_t bb = 0;
+        for (const auto& b : k.dfb_bindings) {
+            bb +=
+                oh(b.dfb_spec_name.get(),
+                   b.accessor_name,
+                   static_cast<int>(b.endpoint_type),
+                   static_cast<int>(b.access_pattern));
+        }
+        uint64_t tb = 0;
+        for (const auto& b : k.tensor_bindings) {
+            tb += oh(b.tensor_parameter_name.get(), b.accessor_name);
+        }
+        e = mix(e, df);
+        e = mix(e, ct);
+        e = mix(e, rn);
+        e = mix(e, bb);
+        e = mix(e, tb);
+        e = mix(e, oh(static_cast<int>(k.hw_config.index())));
+        kk += e;
+    }
+    h = mix(h, kk);
+
+    uint64_t tp = 0;
+    for (const auto& p : spec.tensor_parameters) {
+        const auto& s = p.spec;
+        uint64_t e = oh(p.unique_id.get(), static_cast<uint32_t>(s.data_type()), static_cast<int>(s.layout()));
+        e = mix(e, oh(s.memory_config()));
+        if (relax_shape) {
+            e = mix(e, oh(static_cast<uint64_t>(s.padded_shape().volume())));  // volume only
+        } else {
+            e = mix(e, oh(s.logical_shape(), s.padded_shape()));
+        }
+        tp += e;
+    }
+    h = mix(h, tp);
+
+    uint64_t wu = 0;
+    for (const auto& w : spec.work_units) {
+        uint64_t e = 0;
+        for (const auto& kn : w.kernels) {
+            e += oh(kn.get());
+        }
+        e = mix(e, oh(static_cast<int>(w.target_nodes.index())));
+        std::visit([&](const auto& nodes) { e = mix(e, oh(nodes)); }, w.target_nodes);
+        wu += e;
+    }
+    h = mix(h, wu);
+    return h;
+}
+
+inline void log_keys(const tt::tt_metal::experimental::ProgramSpec& spec) {
+    if (std::getenv("SPECKEY_LOG") == nullptr) {
+        return;
+    }
+    std::fprintf(
+        stderr,
+        "[SPECKEY] strict=%llu relaxed=%llu\n",
+        static_cast<unsigned long long>(program_spec_cache_key(spec, /*relax_shape=*/false)),
+        static_cast<unsigned long long>(program_spec_cache_key(spec, /*relax_shape=*/true)));
+}
+}  // namespace metal2_speckey_proto
 
 // Extracts every Tensor reachable from an aggregate `T` and pushes its buffer()
 // onto `out`.  Generated per-T at compile time so the compiler emits a
@@ -730,6 +851,7 @@ public:
             // factory tensor_args and are identical for every stamped program; copy
             // per range into the cached shared state.
             auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
+            metal2_speckey_proto::log_keys(artifacts.spec);  // PROTOTYPE: spec-as-key measurement (cache miss)
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
             auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
 
@@ -761,9 +883,15 @@ public:
             // the op deliberately excludes from the program hash), which a tensor-only
             // UpdateTensorArgs refresh cannot do. The ProgramSpec the factory also returns is
             // discarded here — no Program is rebuilt and no kernel is re-JITed.
+            //
+            // skip_validation: this is a cache hit, so the program is the same cache entry whose
+            // run-args structure was already validated on the miss (the cache key fixes the spec
+            // shape). Only argument *values* and the output tensor's address differ between hits —
+            // not the structure validation guards — so re-validating every dispatch is redundant.
             auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
+            metal2_speckey_proto::log_keys(artifacts.spec);  // PROTOTYPE: spec-as-key measurement (cache hit)
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params, /*skip_validation=*/true);
             }
         }
     };

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -647,11 +647,8 @@ public:
     // no heap allocation.
     //
     // Limitation: every TensorArgument returned by the factory must reference a
-    // MeshTensor reachable from tensor_args or tensor_return_value.
-    //
-    // TODO: support op-owned resource tensors (the prepare_resources analog
-    // from the descriptor adapter) — will require extending shared_variables_t
-    // and the io_tensor enumeration to include factory-produced tensors.
+    // MeshTensor reachable from tensor_args / tensor_return_value, or one of the
+    // factory's op_owned_tensors (parked in the cache entry — see below).
     //
     // TODO: consider replacing with a general MeshWorkloadSpecFactoryAdapter?
     // -----------------------------------------------------------------------
@@ -661,16 +658,24 @@ public:
         using TensorArgument = tt::tt_metal::experimental::ProgramRunArgs::TensorArgument;
 
         // Stored across cache entries: for each TensorArgument in a program's
-        // ProgramRunArgs, which io_tensor (by index into the deterministic
-        // reflection-driven enumeration) it was bound to. Pointer identity is
-        // only valid within a single call; the index is stable across calls.
+        // ProgramRunArgs, its index into the binding-candidate list (io tensors
+        // first, then the factory's op_owned_tensors). Pointer identity is only
+        // valid within a single call; the index is stable across calls.
         struct ResolvedTensorBinding {
             TensorParamName tensor_parameter_name;
-            std::size_t io_tensor_idx;
+            std::size_t tensor_idx;
         };
 
         struct shared_variables_t {
             std::vector<ResolvedTensorBinding> bindings;
+            // Leading entries of the candidate list that are io tensors
+            // (tensor_args/tensor_return_value); indices >= this select op_owned_tensors.
+            std::size_t io_tensor_count = 0;
+            // Op-owned tensors parked at a stable address for the cached Program's life,
+            // shared (shared_ptr) across all stamped coordinate-range programs. Empty
+            // unless the factory allocated its own tensors; non-empty selects the
+            // reuse-parked cache-hit path (no factory re-run, no re-allocation).
+            std::shared_ptr<std::vector<tt::tt_metal::MeshTensor>> op_owned_tensors;
         };
         using cached_mesh_workload_t = AdaptedCachedMeshWorkload<shared_variables_t>;
 
@@ -704,22 +709,23 @@ public:
         // cached TensorArgument storage pattern. Deferred pending profiling.
         static std::vector<ResolvedTensorBinding> resolve_bindings(
             const tt::tt_metal::experimental::Table<TensorParamName, TensorArgument>& factory_tensor_args,
-            const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& io_mesh_tensors) {
+            const std::vector<std::reference_wrapper<const tt::tt_metal::MeshTensor>>& candidate_tensors) {
             std::vector<ResolvedTensorBinding> bindings;
             bindings.reserve(factory_tensor_args.size());
             // The name is the Table key; the TensorArgument value carries only the tensor ref.
             for (const auto& [tensor_parameter_name, tensor_arg] : factory_tensor_args) {
                 const auto* target = &tt::tt_metal::experimental::mesh_tensor_of(tensor_arg);
-                auto it = std::find_if(io_mesh_tensors.begin(), io_mesh_tensors.end(), [target](const auto& wrapped) {
-                    return &wrapped.get() == target;
-                });
+                auto it =
+                    std::find_if(candidate_tensors.begin(), candidate_tensors.end(), [target](const auto& wrapped) {
+                        return &wrapped.get() == target;
+                    });
                 TT_FATAL(
-                    it != io_mesh_tensors.end(),
-                    "TensorArgument '{}' must reference a MeshTensor reachable from tensor_args or "
-                    "tensor_return_value (got non-io_tensor MeshTensor)",
+                    it != candidate_tensors.end(),
+                    "TensorArgument '{}' must reference a MeshTensor reachable from tensor_args / "
+                    "tensor_return_value or from the factory's op_owned_tensors",
                     tensor_parameter_name);
                 bindings.push_back(
-                    {tensor_parameter_name, static_cast<std::size_t>(std::distance(io_mesh_tensors.begin(), it))});
+                    {tensor_parameter_name, static_cast<std::size_t>(std::distance(candidate_tensors.begin(), it))});
             }
             return bindings;
         }
@@ -750,15 +756,31 @@ public:
             // per range into the cached shared state.
             auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
             log_spec_cache_keys(artifacts.spec);  // measurement-only (SPECKEY_LOG)
-            auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
-            auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
+
+            // Park the factory's op-owned tensors at a stable address, shared (shared_ptr)
+            // across every stamped coordinate-range program. The std::vector move preserves
+            // element addresses, so the run_params TensorArguments the factory built against
+            // these elements stay valid (matched by pointer identity below).
+            auto op_owned =
+                std::make_shared<std::vector<tt::tt_metal::MeshTensor>>(std::move(artifacts.op_owned_tensors));
+
+            // Candidate list for binding resolution: io tensors first, then op-owned.
+            auto candidate_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+            const std::size_t io_tensor_count = candidate_tensors.size();
+            for (const auto& owned_tensor : *op_owned) {
+                candidate_tensors.push_back(std::cref(owned_tensor));
+            }
+            auto bindings = resolve_bindings(artifacts.run_params.tensor_args, candidate_tensors);
 
             tt::tt_metal::distributed::MeshWorkload mesh_workload;
             std::unordered_map<ttnn::MeshCoordinateRange, shared_variables_t> shared_variables;
             for (const auto& range : tensor_coords.ranges()) {
                 auto program = tt::tt_metal::experimental::MakeProgramFromSpec(*mesh_device, artifacts.spec);
                 tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
-                shared_variables.emplace(range, shared_variables_t{.bindings = bindings});
+                shared_variables.emplace(
+                    range,
+                    shared_variables_t{
+                        .bindings = bindings, .io_tensor_count = io_tensor_count, .op_owned_tensors = op_owned});
                 mesh_workload.add_program(range, std::move(program));
             }
             return cached_mesh_workload_t{std::move(mesh_workload), std::move(shared_variables)};
@@ -774,18 +796,41 @@ public:
             const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            // Re-run the factory to obtain fresh ProgramRunArgs, and re-apply ALL of them
-            // (tensor args AND non-tensor runtime args) via SetProgramRunArgs. This is the
-            // Metal 2.0 analog of the descriptor adapter's get_dynamic_runtime_args path: it
-            // keeps per-dispatch-varying runtime args correct on a cache hit (e.g. an RNG seed
-            // the op deliberately excludes from the program hash), which a tensor-only
-            // UpdateTensorArgs refresh cannot do. The ProgramSpec the factory also returns is
-            // discarded here — no Program is rebuilt and no kernel is re-JITed.
+            // Two cache-hit policies, selected by whether the factory allocates op-owned tensors:
             //
-            // skip_validation: this is a cache hit, so the program is the same cache entry whose
-            // run-args structure was already validated on the miss (the cache key fixes the spec
-            // shape). Only argument *values* and the output tensor's address differ between hits —
-            // not the structure validation guards — so re-validating every dispatch is redundant.
+            // (1) Op-owned tensors present → REUSE the parked tensors; do NOT re-run the factory
+            //     (re-running would re-allocate them → freed-then-reused memory). Refresh only the
+            //     io tensor bindings (their addresses change between dispatches) via UpdateTensorArgs;
+            //     op-owned bindings keep the parked tensor. Non-tensor run args are stateful (retained
+            //     from the miss) — correct because such ops have no per-dispatch dynamic run args.
+            //
+            // (2) No op-owned tensors → re-run the factory and re-apply ALL run args via
+            //     SetProgramRunArgs. This is the analog of the descriptor adapter's
+            //     get_dynamic_runtime_args path: it keeps per-dispatch-varying run args correct on a
+            //     hit (e.g. an RNG seed excluded from the program hash), which a tensor-only refresh
+            //     can't. The ProgramSpec the factory also returns is discarded — no Program rebuild,
+            //     no kernel re-JIT. skip_validation: the run-args structure was validated on the miss
+            //     (the cache key fixes the spec), so re-validating every hit is redundant.
+            const auto& any_sv = cached_workload.shared_variables.begin()->second;
+            const bool has_op_owned = any_sv.op_owned_tensors && !any_sv.op_owned_tensors->empty();
+
+            if (has_op_owned) {
+                auto io = collect_mesh_tensors(tensor_args, tensor_return_value);
+                for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
+                    const auto& sv = cached_workload.shared_variables.at(coordinate_range);
+                    tt::tt_metal::experimental::Table<TensorParamName, TensorArgument> fresh_tensor_args;
+                    for (const auto& b : sv.bindings) {
+                        std::reference_wrapper<const tt::tt_metal::MeshTensor> ref =
+                            (b.tensor_idx < sv.io_tensor_count)
+                                ? io[b.tensor_idx]
+                                : std::cref((*sv.op_owned_tensors)[b.tensor_idx - sv.io_tensor_count]);
+                        fresh_tensor_args.emplace(b.tensor_parameter_name, TensorArgument{ref});
+                    }
+                    tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
+                }
+                return;
+            }
+
             auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
             log_spec_cache_keys(artifacts.spec);  // measurement-only (SPECKEY_LOG)
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -30,6 +30,7 @@
 #include "ttnn/distributed/types.hpp"
 #include "ttnn/mesh_device_operation_utils.hpp"
 #include "ttnn/metal2_artifacts.hpp"
+#include "ttnn/metal2_program_spec_hash.hpp"
 #include "ttnn/operation_concepts.hpp"
 #include "ttnn/operation.hpp"
 #include <tt_stl/reflection.hpp>
@@ -40,123 +41,20 @@ namespace ttnn::device_operation {
 template <typename T>
 using AdaptedCachedMeshWorkload = tt::tt_metal::program_cache::detail::AdaptedCachedMeshWorkload<T>;
 
-// ----------------------------------------------------------------------------
-// PROTOTYPE (measurement-only, env-gated): spec-as-cache-key experiment.
-// Computes a hash of the immutable ProgramSpec — the candidate cache key that
-// would replace per-op custom compute_program_hash. Two variants:
-//   strict  — hashes each TensorParameter's full TensorSpec (shape-sensitive)
-//   relaxed — for TensorParameters the program treats as shape-agnostic, hashes
-//             only (dtype, layout, mem_config, PADDED VOLUME) instead of shape,
-//             modelling TensorParameterAdvancedOptions::dynamic_tensor_shape.
-// Groups are folded order-insensitively (sum) since Group order is semantically
-// meaningless. Used only to MEASURE cache reusability vs the current key; does
-// not change live caching.
-// ----------------------------------------------------------------------------
-namespace metal2_speckey_proto {
-template <typename... Ts>
-inline uint64_t oh(const Ts&... xs) {
-    return static_cast<uint64_t>(ttsl::hash::hash_objects_with_default_seed(xs...));
-}
-inline uint64_t mix(uint64_t h, uint64_t v) { return h ^ (v + 0x9e3779b97f4a7c15ULL + (h << 6) + (h >> 2)); }
-
-inline uint64_t program_spec_cache_key(const tt::tt_metal::experimental::ProgramSpec& spec, bool relax_shape) {
-    namespace m2 = tt::tt_metal::experimental;
-    uint64_t h = oh(spec.name);
-
-    uint64_t dfb = 0;
-    for (const auto& d : spec.dataflow_buffers) {
-        uint64_t e = oh(d.unique_id.get(), d.entry_size, d.num_entries);
-        if (d.data_format_metadata) {
-            e = mix(e, oh(static_cast<uint32_t>(*d.data_format_metadata)));
-        }
-        dfb += e;
-    }
-    h = mix(h, dfb);
-
-    uint64_t kk = 0;
-    for (const auto& k : spec.kernels) {
-        uint64_t e = oh(k.unique_id.get(), k.num_threads);
-        if (std::holds_alternative<std::filesystem::path>(k.source)) {
-            e = mix(e, oh(std::get<std::filesystem::path>(k.source).string()));
-        } else {
-            e = mix(e, oh(std::get<m2::KernelSpec::SourceCode>(k.source).code));
-        }
-        uint64_t df = 0;
-        for (const auto& [dk, dv] : k.compiler_options.defines) {
-            df += oh(dk, dv);
-        }
-        uint64_t ct = 0;
-        for (const auto& [ck, cv] : k.compile_time_args) {
-            ct += oh(ck, cv);
-        }
-        uint64_t rn = 0;
-        for (const auto& n : k.runtime_arg_schema.runtime_arg_names) {
-            rn += oh(n);
-        }
-        for (const auto& n : k.runtime_arg_schema.common_runtime_arg_names) {
-            rn += oh(n) + 1;
-        }
-        uint64_t bb = 0;
-        for (const auto& b : k.dfb_bindings) {
-            bb +=
-                oh(b.dfb_spec_name.get(),
-                   b.accessor_name,
-                   static_cast<int>(b.endpoint_type),
-                   static_cast<int>(b.access_pattern));
-        }
-        uint64_t tb = 0;
-        for (const auto& b : k.tensor_bindings) {
-            tb += oh(b.tensor_parameter_name.get(), b.accessor_name);
-        }
-        e = mix(e, df);
-        e = mix(e, ct);
-        e = mix(e, rn);
-        e = mix(e, bb);
-        e = mix(e, tb);
-        e = mix(e, oh(static_cast<int>(k.hw_config.index())));
-        kk += e;
-    }
-    h = mix(h, kk);
-
-    uint64_t tp = 0;
-    for (const auto& p : spec.tensor_parameters) {
-        const auto& s = p.spec;
-        uint64_t e = oh(p.unique_id.get(), static_cast<uint32_t>(s.data_type()), static_cast<int>(s.layout()));
-        e = mix(e, oh(s.memory_config()));
-        if (relax_shape) {
-            e = mix(e, oh(static_cast<uint64_t>(s.padded_shape().volume())));  // volume only
-        } else {
-            e = mix(e, oh(s.logical_shape(), s.padded_shape()));
-        }
-        tp += e;
-    }
-    h = mix(h, tp);
-
-    uint64_t wu = 0;
-    for (const auto& w : spec.work_units) {
-        uint64_t e = 0;
-        for (const auto& kn : w.kernels) {
-            e += oh(kn.get());
-        }
-        e = mix(e, oh(static_cast<int>(w.target_nodes.index())));
-        std::visit([&](const auto& nodes) { e = mix(e, oh(nodes)); }, w.target_nodes);
-        wu += e;
-    }
-    h = mix(h, wu);
-    return h;
-}
-
-inline void log_keys(const tt::tt_metal::experimental::ProgramSpec& spec) {
+// Measurement-only (env-gated, SPECKEY_LOG=1): log the candidate spec-as-cache-key
+// for a freshly built ProgramSpec under two shape policies, so cache reuse can be
+// compared against the current key offline. This does NOT change live caching; the
+// hash itself lives in metal2_program_spec_hash.hpp.
+inline void log_spec_cache_keys(const tt::tt_metal::experimental::ProgramSpec& spec) {
     if (std::getenv("SPECKEY_LOG") == nullptr) {
         return;
     }
     std::fprintf(
         stderr,
-        "[SPECKEY] strict=%llu relaxed=%llu\n",
-        static_cast<unsigned long long>(program_spec_cache_key(spec, /*relax_shape=*/false)),
-        static_cast<unsigned long long>(program_spec_cache_key(spec, /*relax_shape=*/true)));
+        "[SPECKEY] strict=%zu shape_agnostic=%zu\n",
+        metal2::program_spec_cache_key(spec, metal2::ShapeKeyPolicy::Strict),
+        metal2::program_spec_cache_key(spec, metal2::ShapeKeyPolicy::ForceShapeAgnostic));
 }
-}  // namespace metal2_speckey_proto
 
 // Extracts every Tensor reachable from an aggregate `T` and pushes its buffer()
 // onto `out`.  Generated per-T at compile time so the compiler emits a
@@ -851,7 +749,7 @@ public:
             // factory tensor_args and are identical for every stamped program; copy
             // per range into the cached shared state.
             auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
-            metal2_speckey_proto::log_keys(artifacts.spec);  // PROTOTYPE: spec-as-key measurement (cache miss)
+            log_spec_cache_keys(artifacts.spec);  // measurement-only (SPECKEY_LOG)
             auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
             auto bindings = resolve_bindings(artifacts.run_params.tensor_args, io_mesh_tensors);
 
@@ -889,7 +787,7 @@ public:
             // shape). Only argument *values* and the output tensor's address differ between hits —
             // not the structure validation guards — so re-validating every dispatch is redundant.
             auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
-            metal2_speckey_proto::log_keys(artifacts.spec);  // PROTOTYPE: spec-as-key measurement (cache hit)
+            log_spec_cache_keys(artifacts.spec);  // measurement-only (SPECKEY_LOG)
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
                 tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params, /*skip_validation=*/true);
             }

--- a/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
+++ b/ttnn/api/ttnn/mesh_device_operation_adapter.hpp
@@ -711,13 +711,17 @@ public:
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
             // Metal 2.0's MakeProgramFromSpec needs a MeshDevice; pull from the
-            // first device tensor reachable from tensor_args. Op factories
-            // satisfying this concept are tensor-driven, so first_tensor is
-            // always populated for current callers.
+            // first device tensor reachable from tensor_args, falling back to the
+            // output (tensor_return_value) for input-less ops (e.g. rand), whose
+            // only device tensor is the output they allocate.
             auto first_tensor = ttsl::reflection::get_first_object_of_type<tt::tt_metal::Tensor>(tensor_args);
+            if (!first_tensor.has_value()) {
+                first_tensor = ttsl::reflection::get_first_object_of_type<tt::tt_metal::Tensor>(tensor_return_value);
+            }
             TT_FATAL(
                 first_tensor.has_value(),
-                "ProgramSpec factory adapter requires at least one Tensor in tensor_args to source the MeshDevice");
+                "ProgramSpec factory adapter requires at least one Tensor in tensor_args or tensor_return_value to "
+                "source the MeshDevice");
             auto* mesh_device = first_tensor.value().device();
             TT_FATAL(mesh_device != nullptr, "First tensor in tensor_args must be allocated on a MeshDevice");
 
@@ -747,18 +751,19 @@ public:
         // dispatcher's historical naming, not a reference to ProgramDescriptor.
         static void apply_descriptor(
             cached_mesh_workload_t& cached_workload,
-            const operation_attributes_t& /*attrs*/,
+            const operation_attributes_t& attrs,
             const tensor_args_t& tensor_args,
             tensor_return_value_t& tensor_return_value) {
-            auto io_mesh_tensors = collect_mesh_tensors(tensor_args, tensor_return_value);
+            // Re-run the factory to obtain fresh ProgramRunArgs, and re-apply ALL of them
+            // (tensor args AND non-tensor runtime args) via SetProgramRunArgs. This is the
+            // Metal 2.0 analog of the descriptor adapter's get_dynamic_runtime_args path: it
+            // keeps per-dispatch-varying runtime args correct on a cache hit (e.g. an RNG seed
+            // the op deliberately excludes from the program hash), which a tensor-only
+            // UpdateTensorArgs refresh cannot do. The ProgramSpec the factory also returns is
+            // discarded here — no Program is rebuilt and no kernel is re-JITed.
+            auto artifacts = ProgramSpecFactory::create_program_spec(attrs, tensor_args, tensor_return_value);
             for (auto& [coordinate_range, program] : cached_workload.workload.get_programs()) {
-                const auto& sv = cached_workload.shared_variables.at(coordinate_range);
-                tt::tt_metal::experimental::Table<TensorParamName, TensorArgument> fresh_tensor_args;
-                for (const auto& b : sv.bindings) {
-                    fresh_tensor_args.emplace(
-                        b.tensor_parameter_name, TensorArgument{io_mesh_tensors[b.io_tensor_idx]});
-                }
-                tt::tt_metal::experimental::UpdateTensorArgs(program, fresh_tensor_args);
+                tt::tt_metal::experimental::SetProgramRunArgs(program, artifacts.run_params);
             }
         }
     };

--- a/ttnn/api/ttnn/metal2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal2_artifacts.hpp
@@ -8,7 +8,7 @@
 
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
-#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
+#include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::device_operation {
 
@@ -25,21 +25,28 @@ struct ProgramArtifacts {
 
     // Op-owned device tensors: scratch / workspace / config tensors the factory
     // allocates itself (beyond the op's declared io). The adapter parks these in
-    // the cache entry at a stable address for the cached Program's lifetime —
-    // allocated once on a cache miss, reused (never re-allocated) on a hit. A
-    // TensorArgument in run_params may reference one of these exactly as it would
-    // an io tensor (matched by MeshTensor identity).
+    // the cache entry for the cached Program's lifetime — created once on a cache
+    // miss, reused (never re-allocated) on a hit. A TensorArgument in run_params
+    // may reference one of these (via its .mesh_tensor()) exactly as it would an
+    // io tensor (matched by MeshTensor identity).
+    //
+    // These are full ttnn::Tensors (not bare MeshTensors) so the factory can hand
+    // over tensors it has already *populated* with host data (config/index tables,
+    // e.g. conv2d/pool/halo via move_config_tensor_to_device) and with arbitrary
+    // (incl. sharded) placement — not just empty scratch. The ttnn::Tensor also
+    // carries the device-buffer ownership that keeps the allocation alive while parked.
     //
     // FOOTGUN: build the run_params TensorArguments that reference these AGAINST
     // THE ELEMENTS OF THIS VECTOR (after populating it), never against a pre-move
-    // local — the adapter resolves bindings by pointer identity, and a std::vector
-    // move preserves element addresses, so returning the artifact by value is safe.
+    // local — the adapter resolves bindings by pointer identity (on .mesh_tensor()).
+    // ttnn::Tensor is handle-backed, so its .mesh_tensor() address is stable across
+    // vector moves; returning the artifact by value is safe.
     //
     // An op that allocates op-owned tensors is implicitly opted into the
     // "minimize cache-hit cost" hit path: on a cache hit the adapter does NOT
     // re-run the factory (which would re-allocate these); it reuses the parked
     // tensors and refreshes only the io tensor bindings.
-    std::vector<tt::tt_metal::MeshTensor> op_owned_tensors;
+    std::vector<tt::tt_metal::Tensor> op_owned_tensors;
 };
 
 }  // namespace ttnn::device_operation

--- a/ttnn/api/ttnn/metal2_artifacts.hpp
+++ b/ttnn/api/ttnn/metal2_artifacts.hpp
@@ -4,8 +4,11 @@
 
 #pragma once
 
+#include <vector>
+
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/tensor/mesh_tensor.hpp>
 
 namespace ttnn::device_operation {
 
@@ -19,6 +22,24 @@ namespace ttnn::device_operation {
 struct ProgramArtifacts {
     tt::tt_metal::experimental::ProgramSpec spec;
     tt::tt_metal::experimental::ProgramRunArgs run_params;
+
+    // Op-owned device tensors: scratch / workspace / config tensors the factory
+    // allocates itself (beyond the op's declared io). The adapter parks these in
+    // the cache entry at a stable address for the cached Program's lifetime —
+    // allocated once on a cache miss, reused (never re-allocated) on a hit. A
+    // TensorArgument in run_params may reference one of these exactly as it would
+    // an io tensor (matched by MeshTensor identity).
+    //
+    // FOOTGUN: build the run_params TensorArguments that reference these AGAINST
+    // THE ELEMENTS OF THIS VECTOR (after populating it), never against a pre-move
+    // local — the adapter resolves bindings by pointer identity, and a std::vector
+    // move preserves element addresses, so returning the artifact by value is safe.
+    //
+    // An op that allocates op-owned tensors is implicitly opted into the
+    // "minimize cache-hit cost" hit path: on a cache hit the adapter does NOT
+    // re-run the factory (which would re-allocate these); it reuses the parked
+    // tensors and refreshes only the io tensor bindings.
+    std::vector<tt::tt_metal::MeshTensor> op_owned_tensors;
 };
 
 }  // namespace ttnn::device_operation

--- a/ttnn/api/ttnn/metal2_program_spec_hash.hpp
+++ b/ttnn/api/ttnn/metal2_program_spec_hash.hpp
@@ -1,0 +1,203 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Content hash of a Metal 2.0 ProgramSpec, for use as a program-cache key.
+//
+// The ProgramSpec fully defines a compiled Program, so hashing it keys the cache
+// at program identity: specs collide iff the programs are identical. This is the
+// correct-by-construction replacement for hand-maintained per-op compute_program_hash.
+//
+// Two properties the hash must hold:
+//   - Order-insensitive. ProgramSpec's Group<T> members are unordered; element
+//     hashes are folded in sorted order so ordering can't change the key.
+//   - Relaxation-aware. When a TensorParameter declares dynamic_tensor_shape /
+//     match_padded_shape_only, the program is invariant to (part of) the tensor
+//     shape, so the key drops it -- otherwise volume-equivalent shapes (e.g. [2,3]
+//     and [3,2], both one tile) fragment the cache needlessly.
+//
+// Not yet the live cache key; today it backs the cache-reuse measurement. A
+// reflection-based implementation belongs in tt_metal once promoted.
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <variant>
+#include <vector>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt_stl/reflection.hpp>
+
+namespace ttnn::device_operation::metal2 {
+
+namespace detail {
+
+// Boost-style hash combiner.
+inline void hash_combine(std::size_t& seed, std::size_t value) {
+    seed ^= value + 0x9e3779b97f4a7c15ULL + (seed << 6) + (seed >> 2);
+}
+
+// Hash one or more values through ttnn's reflection-aware hasher (handles
+// strings, enums, TensorSpec, CoreRangeSet, MemoryConfig, ... uniformly).
+template <typename... Ts>
+std::size_t hash_of(const Ts&... values) {
+    return ttsl::hash::hash_objects_with_default_seed(values...);
+}
+
+// Fold a collection of per-element hashes order-insensitively: sort, then combine.
+inline std::size_t combine_unordered(std::vector<std::size_t> element_hashes) {
+    std::sort(element_hashes.begin(), element_hashes.end());
+    std::size_t seed = 0;
+    for (std::size_t h : element_hashes) {
+        hash_combine(seed, h);
+    }
+    return seed;
+}
+
+}  // namespace detail
+
+// How the tensor-parameter shape is folded into the key.
+enum class ShapeKeyPolicy {
+    Strict,             // hash the full TensorSpec (logical + padded shape) -- ignores relaxations
+    HonorRelaxations,   // respect each TensorParameter's dynamic_tensor_shape / match_padded_shape_only
+    ForceShapeAgnostic  // treat every TensorParameter as volume-only (measurement upper bound on reuse)
+};
+
+namespace detail {
+
+inline std::size_t hash_dataflow_buffer(const tt::tt_metal::experimental::DataflowBufferSpec& dfb) {
+    std::size_t seed = hash_of(dfb.unique_id.get(), dfb.entry_size, dfb.num_entries);
+    if (dfb.data_format_metadata) {
+        hash_combine(seed, hash_of(static_cast<uint32_t>(*dfb.data_format_metadata)));
+    }
+    return seed;
+}
+
+inline std::size_t hash_kernel_spec(const tt::tt_metal::experimental::KernelSpec& k) {
+    namespace m2 = tt::tt_metal::experimental;
+    std::size_t seed = hash_of(k.unique_id.get(), k.num_threads, static_cast<int>(k.hw_config.index()));
+
+    std::visit(
+        [&](const auto& src) {
+            using S = std::decay_t<decltype(src)>;
+            if constexpr (std::is_same_v<S, std::filesystem::path>) {
+                hash_combine(seed, hash_of(src.string()));
+            } else {
+                hash_combine(seed, hash_of(src.code));
+            }
+        },
+        k.source);
+
+    // Defines and compile-time args are maps -> hash each entry, fold order-insensitively.
+    std::vector<std::size_t> defines;
+    defines.reserve(k.compiler_options.defines.size());
+    for (const auto& [name, value] : k.compiler_options.defines) {
+        defines.push_back(hash_of(name, value));
+    }
+    hash_combine(seed, combine_unordered(std::move(defines)));
+
+    std::vector<std::size_t> cta;
+    cta.reserve(k.compile_time_args.size());
+    for (const auto& [name, value] : k.compile_time_args) {
+        cta.push_back(hash_of(name, value));
+    }
+    hash_combine(seed, combine_unordered(std::move(cta)));
+
+    // Runtime-arg *schema* (names) is part of the program; values are not (they live in ProgramRunArgs).
+    std::vector<std::size_t> arg_names;
+    for (const auto& name : k.runtime_arg_schema.runtime_arg_names) {
+        arg_names.push_back(hash_of(name, /*is_common=*/0));
+    }
+    for (const auto& name : k.runtime_arg_schema.common_runtime_arg_names) {
+        arg_names.push_back(hash_of(name, /*is_common=*/1));
+    }
+    hash_combine(seed, combine_unordered(std::move(arg_names)));
+
+    std::vector<std::size_t> dfb_bindings;
+    dfb_bindings.reserve(k.dfb_bindings.size());
+    for (const auto& b : k.dfb_bindings) {
+        dfb_bindings.push_back(hash_of(
+            b.dfb_spec_name.get(),
+            b.accessor_name,
+            static_cast<int>(b.endpoint_type),
+            static_cast<int>(b.access_pattern)));
+    }
+    hash_combine(seed, combine_unordered(std::move(dfb_bindings)));
+
+    std::vector<std::size_t> tensor_bindings;
+    tensor_bindings.reserve(k.tensor_bindings.size());
+    for (const auto& b : k.tensor_bindings) {
+        tensor_bindings.push_back(hash_of(b.tensor_parameter_name.get(), b.accessor_name));
+    }
+    hash_combine(seed, combine_unordered(std::move(tensor_bindings)));
+
+    return seed;
+}
+
+inline std::size_t hash_tensor_parameter(const tt::tt_metal::experimental::TensorParameter& p, ShapeKeyPolicy policy) {
+    const auto& spec = p.spec;
+    std::size_t seed =
+        hash_of(p.unique_id.get(), static_cast<uint32_t>(spec.data_type()), static_cast<int>(spec.layout()));
+    hash_combine(seed, hash_of(spec.memory_config()));
+
+    const bool drop_logical_shape =
+        policy == ShapeKeyPolicy::ForceShapeAgnostic ||
+        (policy == ShapeKeyPolicy::HonorRelaxations &&
+         (p.advanced_options.dynamic_tensor_shape || p.advanced_options.match_padded_shape_only));
+    const bool drop_padded_shape =
+        policy == ShapeKeyPolicy::ForceShapeAgnostic ||
+        (policy == ShapeKeyPolicy::HonorRelaxations && p.advanced_options.dynamic_tensor_shape);
+
+    if (drop_padded_shape) {
+        // Program depends only on element/page count, not on tensor shape.
+        hash_combine(seed, hash_of(static_cast<uint64_t>(spec.padded_shape().volume())));
+    } else if (drop_logical_shape) {
+        // Logical shape may vary; padded shape (and thus the access pattern) is fixed.
+        hash_combine(seed, hash_of(spec.padded_shape()));
+    } else {
+        hash_combine(seed, hash_of(spec.logical_shape(), spec.padded_shape()));
+    }
+    return seed;
+}
+
+inline std::size_t hash_work_unit(const tt::tt_metal::experimental::WorkUnitSpec& w) {
+    std::vector<std::size_t> kernels;
+    kernels.reserve(w.kernels.size());
+    for (const auto& name : w.kernels) {
+        kernels.push_back(hash_of(name.get()));
+    }
+    std::size_t seed = combine_unordered(std::move(kernels));
+    hash_combine(seed, hash_of(static_cast<int>(w.target_nodes.index())));
+    std::visit([&](const auto& nodes) { hash_combine(seed, hash_of(nodes)); }, w.target_nodes);
+    return seed;
+}
+
+}  // namespace detail
+
+// Content hash of `spec`, suitable as a program-cache key. Combine with the op's
+// type hash at the call site so distinct ops with coincidentally-identical specs
+// don't collide.
+inline std::size_t program_spec_cache_key(
+    const tt::tt_metal::experimental::ProgramSpec& spec, ShapeKeyPolicy policy = ShapeKeyPolicy::HonorRelaxations) {
+    using namespace detail;
+    std::size_t seed = hash_of(spec.name);
+
+    auto fold = [&](const auto& group, auto&& per_element) {
+        std::vector<std::size_t> hashes;
+        hashes.reserve(group.size());
+        for (const auto& element : group) {
+            hashes.push_back(per_element(element));
+        }
+        hash_combine(seed, combine_unordered(std::move(hashes)));
+    };
+
+    fold(spec.dataflow_buffers, [](const auto& d) { return hash_dataflow_buffer(d); });
+    fold(spec.kernels, [](const auto& k) { return hash_kernel_spec(k); });
+    fold(spec.tensor_parameters, [&](const auto& p) { return hash_tensor_parameter(p, policy); });
+    fold(spec.work_units, [](const auto& w) { return hash_work_unit(w); });
+    return seed;
+}
+
+}  // namespace ttnn::device_operation::metal2

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -135,6 +135,12 @@ MeshPartitionDeviceOperation::MeshPartition::create_at(
                 auto descriptor = ttnn::prim::SliceTileProgramFactory::create_descriptor(
                     slice_attrs, slice_tensor_args, tensor_return_value);
                 return Program{descriptor};
+            } else if constexpr (std::is_same_v<Factory, ttnn::prim::SliceTileTensorArgsSpecProgramFactory>) {
+                // The TILE tensor-args path's spec factory has no create_descriptor; reuse the
+                // descriptor variant of the same work for mesh_partition's MeshWorkload build.
+                auto descriptor = ttnn::prim::SliceTileTensorArgsProgramFactory::create_descriptor(
+                    slice_attrs, slice_tensor_args, tensor_return_value);
+                return Program{descriptor};
             } else {
                 auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
                 return Program{descriptor};
@@ -171,6 +177,10 @@ void MeshPartitionDeviceOperation::MeshPartition::override_runtime_arguments(
                 // descriptor variant of the same TILE work for mesh_partition's per-coord rebuild.
                 if constexpr (std::is_same_v<Factory, ttnn::prim::SliceTileSpecProgramFactory>) {
                     auto descriptor = ttnn::prim::SliceTileProgramFactory::create_descriptor(
+                        slice_attrs, slice_tensor_args, tensor_return_value);
+                    tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
+                } else if constexpr (std::is_same_v<Factory, ttnn::prim::SliceTileTensorArgsSpecProgramFactory>) {
+                    auto descriptor = ttnn::prim::SliceTileTensorArgsProgramFactory::create_descriptor(
                         slice_attrs, slice_tensor_args, tensor_return_value);
                     tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
                 } else {

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -127,8 +127,18 @@ MeshPartitionDeviceOperation::MeshPartition::create_at(
     Program program = std::visit(
         [&](auto&& factory) -> Program {
             using Factory = std::decay_t<decltype(factory)>;
-            auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
-            return Program{descriptor};
+            // mesh_partition builds its own MeshWorkload from ProgramDescriptors. The TILE path's
+            // own dispatch went Metal 2.0 (SliceTileSpecProgramFactory has create_program_spec, not
+            // create_descriptor), but the descriptor variant of the same TILE work is still
+            // available on SliceTileProgramFactory — reuse it here so mesh_partition keeps building.
+            if constexpr (std::is_same_v<Factory, ttnn::prim::SliceTileSpecProgramFactory>) {
+                auto descriptor = ttnn::prim::SliceTileProgramFactory::create_descriptor(
+                    slice_attrs, slice_tensor_args, tensor_return_value);
+                return Program{descriptor};
+            } else {
+                auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
+                return Program{descriptor};
+            }
         },
         program_factory);
 
@@ -157,8 +167,16 @@ void MeshPartitionDeviceOperation::MeshPartition::override_runtime_arguments(
         std::visit(
             [&](auto&& program_factory) {
                 using Factory = std::decay_t<decltype(program_factory)>;
-                auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
-                tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
+                // See create_at: the TILE path's spec factory has no create_descriptor; reuse the
+                // descriptor variant of the same TILE work for mesh_partition's per-coord rebuild.
+                if constexpr (std::is_same_v<Factory, ttnn::prim::SliceTileSpecProgramFactory>) {
+                    auto descriptor = ttnn::prim::SliceTileProgramFactory::create_descriptor(
+                        slice_attrs, slice_tensor_args, tensor_return_value);
+                    tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
+                } else {
+                    auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
+                    tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
+                }
             },
             shared_variables.slice_program_factory);
     }

--- a/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/mesh_partition/device/mesh_partition_program_factory.cpp
@@ -141,6 +141,18 @@ MeshPartitionDeviceOperation::MeshPartition::create_at(
                 auto descriptor = ttnn::prim::SliceTileTensorArgsProgramFactory::create_descriptor(
                     slice_attrs, slice_tensor_args, tensor_return_value);
                 return Program{descriptor};
+            } else if constexpr (std::is_same_v<Factory, ttnn::prim::SliceRmShardedSpecProgramFactory>) {
+                // The RM HEIGHT-sharded path's spec factory has no create_descriptor; reuse the
+                // descriptor variant of the same work for mesh_partition's MeshWorkload build.
+                auto descriptor = ttnn::prim::SliceRmShardedProgramFactory::create_descriptor(
+                    slice_attrs, slice_tensor_args, tensor_return_value);
+                return Program{descriptor};
+            } else if constexpr (std::is_same_v<Factory, ttnn::prim::SliceRmStrideSpecProgramFactory>) {
+                // The RM strided path's spec factory has no create_descriptor; reuse the descriptor
+                // variant of the same work for mesh_partition's MeshWorkload build.
+                auto descriptor = ttnn::prim::SliceRmStrideProgramFactory::create_descriptor(
+                    slice_attrs, slice_tensor_args, tensor_return_value);
+                return Program{descriptor};
             } else {
                 auto descriptor = Factory::create_descriptor(slice_attrs, slice_tensor_args, tensor_return_value);
                 return Program{descriptor};
@@ -181,6 +193,14 @@ void MeshPartitionDeviceOperation::MeshPartition::override_runtime_arguments(
                     tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
                 } else if constexpr (std::is_same_v<Factory, ttnn::prim::SliceTileTensorArgsSpecProgramFactory>) {
                     auto descriptor = ttnn::prim::SliceTileTensorArgsProgramFactory::create_descriptor(
+                        slice_attrs, slice_tensor_args, tensor_return_value);
+                    tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
+                } else if constexpr (std::is_same_v<Factory, ttnn::prim::SliceRmShardedSpecProgramFactory>) {
+                    auto descriptor = ttnn::prim::SliceRmShardedProgramFactory::create_descriptor(
+                        slice_attrs, slice_tensor_args, tensor_return_value);
+                    tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
+                } else if constexpr (std::is_same_v<Factory, ttnn::prim::SliceRmStrideSpecProgramFactory>) {
+                    auto descriptor = ttnn::prim::SliceRmStrideProgramFactory::create_descriptor(
                         slice_attrs, slice_tensor_args, tensor_return_value);
                     tt::tt_metal::apply_descriptor_runtime_args(program, descriptor);
                 } else {

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <optional>
 
+#include <tt_stl/assert.hpp>
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
 
 #include "tt-metalium/buffer.hpp"
@@ -15,6 +16,9 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
+
+#include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
+#include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
 
 namespace ttnn::prim {
 
@@ -156,5 +160,56 @@ void post_conv2d_op_memory_checks_descriptor(
     const Conv2dParams& operation_attributes,
     const Conv2dInputs& tensor_args,
     std::optional<uint32_t> reader_indices_actual_page_size = std::nullopt);
+
+// ----------------------------------------------------------------------------
+// Metal 2.0 shared DFB / TensorParameter names (sharded + width-sharded factories)
+//
+// Both conv2d Metal 2.0 program factories (Conv2dShardedProgramFactory and
+// Conv2dWidthShardedProgramFactory) compile into one CMake target and may share a
+// unity translation unit. Defining these constants and dfb_name_for() at namespace
+// scope in BOTH .cpp files would be an ODR redefinition under a unity build, so they
+// live here once as `inline` definitions and are included from both factory .cpp's.
+//
+// The DFBSpecName strings mirror the kernel-side dfb:: accessor tokens; one per
+// (non-zero-page) Conv2dCb the kernels reference.
+// ----------------------------------------------------------------------------
+namespace m2 = tt::tt_metal::experimental;
+
+inline const m2::DFBSpecName DFB_ACT_SHARDED{"act_sharded"};
+inline const m2::DFBSpecName DFB_ACT{"act"};
+inline const m2::DFBSpecName DFB_ACT_ROW_MAJOR{"act_row_major"};
+inline const m2::DFBSpecName DFB_ACT_SECOND_READER{"act_second_reader"};
+inline const m2::DFBSpecName DFB_ACT_TILIZED{"act_tilized"};
+inline const m2::DFBSpecName DFB_WEIGHTS{"weights"};
+inline const m2::DFBSpecName DFB_BIAS{"bias"};
+inline const m2::DFBSpecName DFB_READER_INDICES{"reader_indices"};
+inline const m2::DFBSpecName DFB_L1_ARRAY{"l1_array"};
+inline const m2::DFBSpecName DFB_MATMUL_PARTIALS{"matmul_partials"};
+inline const m2::DFBSpecName DFB_OUT{"out"};
+
+inline const m2::TensorParamName TP_WEIGHTS{"weights"};
+inline const m2::TensorParamName TP_BIAS{"bias"};
+inline const m2::TensorParamName TP_READER_INDICES{"reader_indices"};
+inline const m2::TensorParamName TP_ACT_SHARDED{"act_sharded"};
+inline const m2::TensorParamName TP_OUT{"out"};
+
+// Map a Conv2dCb to the DFBSpecName the kernels reference. Used only for the
+// (non-zero-page) CBs a sharded conv2d path actually allocates.
+inline m2::DFBSpecName dfb_name_for(Conv2dCb cb) {
+    switch (cb) {
+        case Conv2dCb::ACT_SHARDED: return DFB_ACT_SHARDED;
+        case Conv2dCb::ACT: return DFB_ACT;
+        case Conv2dCb::ACT_ROW_MAJOR_BFLOAT16: return DFB_ACT_ROW_MAJOR;
+        case Conv2dCb::ACT_SECOND_READER: return DFB_ACT_SECOND_READER;
+        case Conv2dCb::ACT_TILIZED: return DFB_ACT_TILIZED;
+        case Conv2dCb::WEIGHTS: return DFB_WEIGHTS;
+        case Conv2dCb::BIAS: return DFB_BIAS;
+        case Conv2dCb::READER_INDICES: return DFB_READER_INDICES;
+        case Conv2dCb::L1_ARRAY: return DFB_L1_ARRAY;
+        case Conv2dCb::MATMUL_PARTIALS: return DFB_MATMUL_PARTIALS;
+        case Conv2dCb::OUT: return DFB_OUT;
+        default: TT_THROW("Unexpected Conv2dCb in sharded Metal 2.0 spec: {}", static_cast<int>(cb));
+    }
+}
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/METAL2_PORT_REPORT.md
@@ -1,4 +1,175 @@
-# Metal 2.0 Port Report — conv2d `Conv2dWidthShardedProgramFactory` (L1 config path)
+# Metal 2.0 Port Report — conv2d `Conv2dShardedProgramFactory` (dense / height-sharded, L1 config path)
+
+> A second factory of the same device-op. The earlier
+> `Conv2dWidthShardedProgramFactory` report follows below this section.
+
+## STATUS: PORTED (UNBUILT) — height-sharded 1D-mcast L1 path only
+
+## Summary (dense / height-sharded)
+
+- **Op / factory**: `ttnn::prim::Conv2dShardedProgramFactory` in
+  `ttnn/cpp/ttnn/operations/conv/conv2d`.
+- **Scope ported**: the **HEIGHT_SHARDED, 1D-weights-mcast, L1 config-tensor path
+  only**. Gated OUT via `TT_FATAL` (each a separate Metal 2.0 follow-up):
+  - `config_tensors_in_dram == true` — raw buffer-address-through-CTA blocker.
+  - `BLOCK_SHARDED` — different reader (`*_2d_mcast_padded*`) + 2D weights mcast.
+  - 1D-depthwise (`is_conv_1d_depthwise_conv`) — dedicated reader/compute kernels.
+  - `input_cores != output_cores` — the legacy noop-core "skip_compute" RTA path.
+  - `all_cores != input_cores` — the legacy inactive-grid-core mcast-receiver path
+    (the receiver early-returns via its `noop` RTA on cores outside `input_cores`).
+    Reproducing it under the shared-local-DFB invariant needs extra noop-only work
+    units; gated out so the two work units exactly cover `input_cores`.
+- **Concept transition**: `MeshWorkloadFactoryConcept`
+  (`create_workload_descriptor` returning `WorkloadDescriptor`) →
+  `ProgramSpecFactoryConcept` (`create_program_spec` returning
+  `ttnn::device_operation::ProgramArtifacts`). The legacy
+  `build_program_descriptor_sharded` + `create_workload_descriptor` are removed.
+- **Custom `compute_program_hash`**: KEPT (shared with both factories; per the
+  bulk-port instruction it is preserved, not deleted).
+- **`select_program_factory` / variant**: unchanged — already routes the non-width-
+  sharded layout to this factory; the variant already lists it. The framework
+  dispatches per-factory, so the sibling `Conv2dWidthShardedProgramFactory` (already
+  ported) and this one coexist.
+
+## Kernels (dense / height-sharded)
+
+| kernel | role | disposition |
+|---|---|---|
+| `kernels/conv_bmm_tilize.cpp` | compute | **REUSED FORK** `conv_bmm_tilize_m2.cpp` (already created for width-sharded; shared) |
+| `kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp` | act reader (RISCV_1) | **FORKED** → `..._v2_m2.cpp` |
+| `kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp` | weights reader + writer mcast SENDER (RISCV_0) | **FORKED** → `..._m2.cpp` |
+| `kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp` | weights mcast RECEIVER (RISCV_0) | **FORKED** → `..._m2.cpp` |
+
+All three dataflow kernels are referenced ONLY by this factory (grep-verified), so
+porting in place would also have been valid; they were **forked** (consistent with
+the width-sharded compute fork, and to keep the legacy sources available during the
+bulk-port window). The shared in-op helper header `conv_reader_common.hpp` is
+**unchanged** — its only arg/CB access is inside `load_config_tensor_if_in_dram`
+(`#ifdef CONFIG_TENSOR_IN_DRAM`, never defined on the L1 spec); its other helpers
+take `experimental::CB` / `uint32_t`, into which `dfb::name` converts implicitly.
+
+## Unity-build ODR fix (shared header)
+
+The width-sharded factory `.cpp` previously defined the DFB / TensorParameter
+`*SpecName` constants and `dfb_name_for()` at namespace scope. Both conv2d factory
+`.cpp`s compile into one CMake target (unity TU), so a second namespace-scope
+definition here would be an ODR redefinition. Per the instruction these shared
+symbols were **moved into `conv2d_op_program_factory_common.hpp`** as `inline`
+definitions (`DFB_*`, `TP_*`, `dfb_name_for()` — the latter extended with the
+`ACT_SECOND_READER` case the dense path needs), included from BOTH factory `.cpp`s,
+and removed from the width-sharded `.cpp`. Each factory keeps only its own
+per-factory `K_*` / `SEM_*` names (distinct strings, no clash).
+
+## DFB ↔ CB map (height-sharded L1 path)
+
+One `DataflowBufferSpec` per non-zero-page `CBInfo`. Globally-allocated CBs are
+borrowed-memory DFBs (`borrowed_from` the backing `TensorParameter`).
+
+| Conv2dCb | borrowed_from | endpoints |
+|---|---|---|
+| ACT | — (local) | reader PRODUCER → compute CONSUMER |
+| ACT_TILIZED | — (local) | compute self-loop (tilize in / matmul read) |
+| ACT_ROW_MAJOR_BFLOAT16 | — (placeholder) | **0-page on height-sharded** → 1-entry placeholder DFB, compute self-loop (token must exist for the shared kernel's dead `!height_sharded` branch) |
+| WEIGHTS | — (local) | writers PRODUCER → compute CONSUMER |
+| BIAS | — (local, iff has_bias) | writers PRODUCER → compute CONSUMER |
+| ACT_SECOND_READER | — (local, iff split_reader) | writers PRODUCER + compute CONSUMER |
+| MATMUL_PARTIALS | output (iff globally-alloc) | compute self-loop (real accumulator) |
+| OUT | output | compute self-loop (compute packs directly into sharded output) |
+| ACT_SHARDED | input `a` | self-loop address source on reader + both writers |
+| READER_INDICES | **op-owned** conv_reader_indices | self-loop address source on reader + both writers |
+| L1_ARRAY | — (1-page scratch) | reader self-loop; **no kernel references it** (legacy CTA 26 skipped) — validator-satisfying only |
+
+## Op-owned tensor
+
+`conv_reader_indices` — host-populated index table from
+`construct_on_host_config_tensor` + `move_config_tensor_to_device` (L1-sharded in the
+L1 path; the `(act_block_h_datums, last)` split matches the reader's split exactly,
+reproducing the legacy `create_workload_descriptor` index generation). Pushed into
+`ProgramArtifacts::op_owned_tensors`; backs the READER_INDICES borrowed-memory DFB.
+
+## Semaphores
+
+The legacy 1D path allocates two weights-mcast semaphores (`weights_mcast_sender` /
+`weights_mcast_receiver`) on `output_cores`, skipped when `skip_weights_mcast`.
+Ported as two program-local `SemaphoreSpec`s (init 0) bound on both writer kernels
+via `SemaphoreBinding`; the legacy semaphore-id RTAs are replaced by
+`sem::weights_mcast_sender` / `sem::weights_mcast_receiver`.
+
+## WorkUnits / kernel placement
+
+Legacy 1D placement: reader on `input_cores`, writer-SENDER on the single top-left
+mcast core, writer-RECEIVER on the rest, compute on `input_cores`. The shared-local-DFB
+invariant requires every node hosting a shared local DFB to host both endpoints, so:
+- **WU `conv2d_hs_sender`** = {reader, writer_sender, compute} on `sender_cores`
+  (the top-left core).
+- **WU `conv2d_hs_receiver`** = {reader, writer_receiver, compute} on
+  `all_cores.subtract(sender_cores)` (when weights mcast is not skipped).
+WEIGHTS/BIAS/ACT_SECOND_READER (writer→compute) and ACT (reader→compute) therefore
+have both endpoints present in each WU.
+
+## Dropped plumbing
+
+- **weight / bias buffer-address RTAs** (sender kernel RTA 0 / 1, the legacy
+  `Buffer*` bindings) → `TensorBinding`s (`ta::weights` / `ta::bias`,
+  `TensorAccessor` constructed kernel-side). Only the SENDER reads weights/bias from
+  DRAM (the receiver gets them via mcast), so those tensor bindings are sender-only.
+- **semaphore-id RTAs** (sender/receiver) → `SemaphoreBinding`.
+- **magic CB-index CTAs** → `DFBBinding` (`dfb::name`).
+- **positional CTAs / RTAs** → named `get_arg(args::name)`. Only the slots each
+  kernel actually reads are emitted (the legacy positional list left gaps the
+  height-sharded kernels skip).
+- **`post_conv2d_op_memory_checks_descriptor`** CB-size check — dropped (no
+  descriptor in the spec world); the Metal 2.0 framework does its own L1/DFB
+  validation. Same rationale as the width-sharded port.
+
+## Blockers (precise)
+
+1. **In-DRAM config-tensor path** (`config_tensors_in_dram == true`) — BLOCKED, same
+   as width-sharded: threads `conv_reader_indices_buffer->address()` + `->page_size()`
+   + `TensorAccessorArgs(buffer)` through reader CTAs, consumed under
+   `#ifdef CONFIG_TENSOR_IN_DRAM`. `TT_FATAL`-gated; the L1 spec never defines that
+   macro so the kernels' DRAM branches are dead.
+
+## Open items / risks (UNBUILT — no build dir in this worktree)
+
+1. **ACT_SHARDED / READER_INDICES self-looped on multiple kernels in one WU (top
+   risk).** Both base-pointer DFBs are self-looped on the reader AND both writer
+   kernels (all three genuinely read the base pointer for split-reader). The
+   width-sharded port self-looped these on a single kernel only; whether the
+   validator accepts a borrowed/address-source DFB self-looped on multiple kernels
+   that co-reside on a node is **unverified**. If rejected, the fix is to self-loop
+   each on exactly one kernel per WU and have the others reach the pointer another
+   way — flagged for the framework owner.
+2. **ACT_ROW_MAJOR placeholder DFB.** 0-page on height-sharded; emitted as a 1-entry
+   placeholder + compute self-loop purely so the shared `conv_bmm_tilize_m2.cpp`'s
+   file-scope `dfb::act_row_major` token resolves (it is only used inside the dead
+   `if constexpr (!height_sharded)` branch). Wastes one entry of L1; the real fix is
+   to NTTP-ify the compute CTAs so the discarded branch skips name lookup.
+3. **OUT / MATMUL_PARTIALS / L1_ARRAY self-loops** are interim validator-satisfying
+   devices, not real FIFOs (same caveats as the width-sharded port). L1_ARRAY is bound
+   but referenced by no height-sharded kernel.
+4. **`weights_mcast_num_dests` / `num_cores`** are emitted as RTAs on the sender; the
+   `total_active_num_cores - 1` / `total_num_cores - 1` values reproduce the legacy 1D
+   computation. With `input_cores == output_cores` enforced, `total_active_num_cores`
+   == active nhw cores × 1 weight slice.
+5. **Borrowed-twice OUT / MATMUL_PARTIALS** (when `partials_cb_uses_output`) — two
+   DFBs `borrowed_from = TP_OUT`; same unverified borrowed-twice semantics noted for
+   width-sharded.
+
+## Findings (routed, not changed)
+
+- The legacy `build_program_descriptor_sharded` had extensive BLOCK_SHARDED / 2D-mcast
+  / depthwise / split-reader-cb-shared machinery interleaved with the height-sharded
+  path. The port preserves the shared computation verbatim (gating only at the
+  `TT_FATAL`s) and removes only the descriptor/RTA *emission*. Several legacy locals
+  used only by the gated-out paths are now unreferenced on the height-sharded path
+  (`reader_noc`, `window_inner`, `out_conv_c_blocks`, `last_block_width_datums`,
+  `reader_arg_act_block_h_datums`, `dst_full_sync_en`, `math_approx_mode`,
+  `weight_matrix_height`); they are kept (the computation has side-effecting
+  `TT_FATAL`s) and silenced with `(void)` casts rather than deleted, to keep the diff
+  scope-tight and the validation chain intact.
+
+---
 
 ## Summary
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/METAL2_PORT_REPORT.md
@@ -1,0 +1,172 @@
+# Metal 2.0 Port Report — conv2d `Conv2dWidthShardedProgramFactory` (L1 config path)
+
+## Summary
+
+- **Op / factory**: `ttnn::prim::Conv2dWidthShardedProgramFactory` in
+  `ttnn/cpp/ttnn/operations/conv/conv2d`.
+- **Scope ported**: the **L1 config-tensor path only** (`!config_tensors_in_dram`).
+  The in-DRAM config path stays blocked (see Blockers) and is excluded from the spec build.
+- **Concept transition**: `MeshWorkloadFactoryConcept` (`create_workload_descriptor`
+  returning `tt::tt_metal::WorkloadDescriptor`) → `ProgramSpecFactoryConcept`
+  (`create_program_spec` returning `ttnn::device_operation::ProgramArtifacts`).
+- **Custom `compute_program_hash`**: KEPT (shared across both factories of the
+  device-op variant; the sharded factory is still on the legacy concept). Per the
+  bulk-port instruction, this hash is preserved (NOT deleted).
+
+## Factory chosen
+
+`Conv2dWidthShardedProgramFactory` — the single-program width-sharded factory.
+Selected by `select_program_factory` when the activation memory layout is
+`WIDTH_SHARDED`. The sister `Conv2dShardedProgramFactory` stays on its current
+(WorkloadDescriptor) concept; the variant dispatches per-factory at runtime.
+
+## Kernels
+
+| kernel | role | disposition |
+|---|---|---|
+| `device/kernels/conv_bmm_tilize.cpp` | compute | **FORKED** → `conv_bmm_tilize_m2.cpp` (shared with `Conv2dShardedProgramFactory`) |
+| `device/kernels/activation_reader_width_sharded.cpp` | act reader (RISCV_0) | ported in place (only this factory uses it) |
+| `device/kernels/weights_reader_width_sharded.cpp` | weights/bias reader (RISCV_1) | ported in place (only this factory uses it) |
+
+`conv_reader_common.hpp` (shared helper header, in-op) is referenced by the act
+reader; its `load_config_tensor_if_in_dram` body is entirely under
+`#ifdef CONFIG_TENSOR_IN_DRAM`, never defined on the L1 spec, so it compiles to a
+no-op and pulls in none of the DRAM-only CTAs.
+
+## DFB ↔ CB map (width-sharded L1 path)
+
+One `DataflowBufferSpec` per non-zero-page `CBInfo`. Globally-allocated CBs become
+**borrowed-memory DFBs** (`borrowed_from` the backing `TensorParameter`):
+
+| Conv2dCb | borrowed_from | producer | consumer |
+|---|---|---|---|
+| ACT_SHARDED | input `a` | (reader source only) self-loop on act reader |
+| OUT | output | compute | weights? no — writer is act/compute; OUT produced by compute |
+| MATMUL_PARTIALS | output (iff globally-alloc) OR local | compute self-loop |
+| READER_INDICES | **op-owned** conv_reader_indices | self-loop on act reader |
+| WEIGHTS | — (local) | weights reader → compute |
+| ACT | — (local) | act reader → compute |
+| ACT_ROW_MAJOR_BFLOAT16 | — (local) | act reader → compute(tilize) |
+| ACT_TILIZED | — (local) | act reader (mcast) ↔ compute |
+| BIAS | — (local, conditional) | weights reader → compute |
+| L1_ARRAY | — (local scratchpad) | act reader self-loop |
+| ACT_SECOND_READER | — (always 0-page in width-sharded → omitted) | n/a |
+
+(See "Open items" for the self-loop / borrowed-DFB endpoint subtleties — conv's
+CB usage does not map cleanly onto strict producer/consumer FIFO semantics.)
+
+## Op-owned tensor
+
+`conv_reader_indices` — the host-populated index table from
+`sliding_window::move_config_tensor_to_device(...)`. In the L1 path this is an
+L1-sharded ttnn::Tensor; it is pushed into `ProgramArtifacts::op_owned_tensors`
+and bound as a `TensorParameter` whose buffer backs the READER_INDICES
+borrowed-memory DFB.
+
+## Semaphores
+
+The two legacy `SemaphoreDescriptor`s (act mcast sender/receiver, init 0, on
+`all_cores`) → two `SemaphoreSpec`s (init value 0, so no
+`SemaphoreAdvancedOptions::initial_value` needed). The activation reader binds
+both via `SemaphoreBinding` (sem:: tokens); the legacy CTA-12/13 semaphore-id
+reads are replaced by `sem::act_mcast_sender` / `sem::act_mcast_receiver`.
+
+## Blockers (precise)
+
+1. **In-DRAM config-tensor path (`config_tensors_in_dram == true`) — BLOCKED.**
+   That path threads `conv_reader_indices_buffer->address()` and `->page_size()`
+   through CTAs (`activation_kernel_compile_args.push_back(buffer->address())`,
+   factory line ~569) plus a `TensorAccessorArgs(buffer)` into the activation
+   kernel, consumed by `load_config_tensor_if_in_dram<27,28,29,...>` under
+   `#ifdef CONFIG_TENSOR_IN_DRAM`. A raw `buffer->address()` threaded through a
+   CTA to a kernel is an enumerated framework blocker (PORT_INSTRUCTIONS / recipe
+   §kernel-side rule 5). Excluded from the L1 spec build: the spec never defines
+   `CONFIG_TENSOR_IN_DRAM`, so the kernel's DRAM branch is dead. The L1 spec
+   factory `TT_FATAL`s if invoked with `config_tensors_in_dram == true`.
+
+## Open items / risks (UNBUILT — no build dir in this worktree)
+
+These are faithfully-translated but unverified, and are the things most likely to
+need framework attention or a closer look on first build/run:
+
+1. **Borrowed DFBs on noop cores (top runtime risk).** The single WorkUnit places
+   all three kernels on the **bounding box** of `all_cores` (legacy placed the act
+   reader on the bounding box and weights/compute on `all_cores`; the shared-local-DFB
+   invariant forces one node set). The borrowed DFBs ACT_SHARDED (`a`) and OUT/
+   MATMUL_PARTIALS (output) are then bound on bounding-box nodes that may have **no
+   shard** of the backing tensor (inactive/noop cores). Legacy tolerated this because
+   the kernels early-return on inactive cores before touching those CBs; whether the
+   Metal 2.0 borrowed-from address resolution / validator tolerates a borrowed DFB on
+   a node where the backing tensor has no shard is **unverified**. For contiguous
+   width-sharded grids (the common case) the bounding box == active set and this is
+   moot. Flagged for the framework owner.
+
+2. **OUT / MATMUL_PARTIALS / ACT_SHARDED / READER_INDICES / L1_ARRAY self-loops.**
+   conv's CB usage does not map onto strict producer/consumer FIFO semantics:
+   - OUT is borrowed onto the (sharded) output; compute packs directly into it with
+     no FIFO consumer → bound as a compute self-loop (PRODUCER+CONSUMER).
+   - ACT_SHARDED / READER_INDICES are base-pointer address sources read by the act
+     reader (no FIFO peer) → self-loops on the act reader.
+   - L1_ARRAY is an allocated scratch CB that **no width-sharded kernel references**
+     (legacy passes its index at CTA 24, which the act reader skips). Bound as an act-
+     reader self-loop purely to satisfy the producer+consumer invariant; the kernel
+     never constructs `dfb::l1_array`. Candidate for the forthcoming Metal 2.0
+     scratchpad resource.
+   - MATMUL_PARTIALS is a genuine compute accumulator → self-loop (real).
+   All self-loops are interim validator-satisfying devices, not real FIFOs.
+
+3. **MATMUL_PARTIALS borrowed-twice with OUT.** When `partials_cb_uses_output` is
+   true, MATMUL_PARTIALS is globally-allocated onto the output buffer — so OUT and
+   MATMUL_PARTIALS are two DFBs both `borrowed_from = TP_OUT` (same backing memory).
+   This mirrors the legacy "partials reuse output" aliasing, but two DFBs borrowing
+   the same TensorParameter is not expressed via `advanced_options.alias_with`; the
+   borrowed-twice semantics are unverified.
+
+4. **Activation-reader mcast lookup tables as runtime varargs.** The two variable-
+   length per-core lookup tables (`act_mcast_x/y_lookup`, indexed by a runtime value)
+   are passed as `num_runtime_varargs` after the three named RTAs and accessed by
+   base pointer (`get_arg_addr(3 + ...)`), since the value-returning `get_vararg()`
+   helper cannot return a pointer for runtime-indexed array access. The hard-coded
+   `i = 3` offset = named-RTA count; if the act reader's named RTA list changes, that
+   offset must change. Documented in-kernel.
+
+5. **Dead `get_arg_val<uint32_t>(0)` in compute (skip_compute).** `check_skip_compute`
+   is a CTA, always `false` for width-sharded, so the `if constexpr(check_skip_compute)`
+   body (the only RTA read) is dead. Left as the legacy positional `get_arg_val<uint32_t>(0)`
+   rather than inventing a phantom named RTA the spec would have to declare on every
+   node. Never executed on this path.
+
+6. **Conditionally-bound DFBs (BIAS, ACT_SECOND_READER) via `#ifdef`.** BIAS is bound
+   (+ `FUSE_BIAS` define) only when `has_bias`; ACT_SECOND_READER is never bound on
+   the width-sharded path (`act_block_split_num_tiles == 0`), gated by
+   `SECOND_READER_PRESENT` (kept honest if `get_cb_info` ever changes). Kernel-side
+   `dfb::bias` / `dfb::act_second_reader` tokens are `#ifdef`-gated so they are not
+   name-looked-up on the unbound build; the unbound alias points at a bound DFB to
+   keep derived expressions well-formed (all real uses are inside the matching
+   `if constexpr`).
+
+7. **Dropped `post_conv2d_op_memory_checks_descriptor` CB-size check.** The legacy
+   factory ran a CB-size-equality sanity check against the `ProgramDescriptor`'s
+   `desc.cbs`. There is no descriptor in the spec world, so this host-side check is
+   dropped (same reasoning the original applied for the L1-allocator half of the
+   legacy check, which also needed a realised program). The Metal 2.0 framework does
+   its own L1/DFB validation. Flagged for the owner.
+
+## Findings (routed, not changed)
+
+- **Latent bug preserved:** `writer_mcast_sender_defines["SKIP_MCAST"]` is populated
+  when `skip_weights_mcast` but **never applied to any kernel** — both in the legacy
+  factory and (verbatim) in this port. So `skip_weights_mcast` never reaches the
+  weights kernel. Preserved exactly (scope discipline); flagged here for the op owner
+  to decide whether the define should be wired to the weights kernel.
+
+## Custom compute_program_hash
+
+KEPT (`Conv2dDeviceOperation::compute_program_hash`) — shared with the still-legacy
+`Conv2dShardedProgramFactory`; not deleted, per the bulk-port instruction.
+
+## Pybind
+
+No pybind hook exposes the factory entry point (`conv2d_nanobind.cpp` binds the
+user-facing `conv2d` op, not `create_workload_descriptor`/`create_program_spec`).
+Nothing to remove.

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.cpp
@@ -3,9 +3,13 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <filesystem>
+#include <map>
 #include <memory>
+#include <set>
 #include <string>
 #include <utility>
+#include <vector>
 #include <tt_stl/assert.hpp>
 #include "tt-metalium/circular_buffer_config.hpp"
 #include "tt-metalium/core_coord.hpp"
@@ -24,10 +28,11 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/compute_throttle_utils.hpp"
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 namespace ttnn::prim {
 
@@ -175,39 +180,30 @@ ActivationReuseConfig calculate_activation_reuse_params(
 
 namespace {
 
-// The intermediate conv_reader_indices tensor is allocated once by
-// create_workload_descriptor and parked on the WorkloadDescriptor; we receive
-// the raw Buffer* here and wire it into the READER_INDICES CB and reader CT args.
-tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
-    const Conv2dParams& operation_attributes,
-    const Conv2dInputs& tensor_args,
-    Tensor& output_tensor,
-    tt::tt_metal::Buffer* conv_reader_indices_buffer) {
-    using tt::tt_metal::CBDescriptor;
-    using tt::tt_metal::CBFormatDescriptor;
-    using tt::tt_metal::ComputeConfigDescriptor;
-    using tt::tt_metal::DataMovementConfigDescriptor;
-    using tt::tt_metal::KernelDescriptor;
-    using tt::tt_metal::ProgramDescriptor;
-    using tt::tt_metal::SemaphoreDescriptor;
+namespace m2 = tt::tt_metal::experimental;
 
-    ProgramDescriptor desc;
+// Shared Metal 2.0 DFB / TensorParameter names + dfb_name_for() live in
+// conv2d_op_program_factory_common.hpp (inline) to avoid a unity-build ODR clash
+// with the sibling Conv2dWidthShardedProgramFactory .cpp. Only the per-factory
+// kernel and semaphore names are declared here.
+const m2::KernelSpecName K_READER{"reader"};
+const m2::KernelSpecName K_WRITER_SENDER{"writer_mcast_sender"};
+const m2::KernelSpecName K_WRITER_RECEIVER{"writer_mcast_receiver"};
+const m2::KernelSpecName K_HS_COMPUTE{"compute"};
+
+const m2::SemaphoreSpecName SEM_WEIGHTS_SENDER{"weights_mcast_sender"};
+const m2::SemaphoreSpecName SEM_WEIGHTS_RECEIVER{"weights_mcast_receiver"};
+
+}  // namespace
+
+ttnn::device_operation::ProgramArtifacts Conv2dShardedProgramFactory::create_program_spec(
+    const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor) {
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
 
     const auto& ashape = ttnn::Shape(operation_attributes.input_tensor_shape);
     const auto& bias = tensor_args.bias;
     const auto& sliding_window_config = operation_attributes.sliding_window_config;
-
-    ttnn::operations::sliding_window::ParallelConfig parallel_config{
-        .grid = a.shard_spec().value().grid,
-        .shard_scheme = a.memory_config().memory_layout(),
-        .shard_orientation = a.shard_spec().value().orientation};
-
-    std::vector<uint32_t> op_trace_metadata =
-        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
-    std::vector<sliding_window::ShardBoundary> shard_boundaries =
-        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
 
     const auto output_channels = operation_attributes.output_channels;
     const auto groups = operation_attributes.groups;
@@ -225,6 +221,17 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
     const auto enable_activation_reuse = operation_attributes.enable_activation_reuse;
     const auto config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
     const auto& force_split_reader = operation_attributes.force_split_reader;
+
+    // ---- Metal 2.0 scope gates ----
+    // The in-DRAM config-tensor path threads conv_reader_indices_buffer->address()
+    // and ->page_size() through CTAs + a TensorAccessorArgs(buffer) into the reader
+    // (consumed under #ifdef CONFIG_TENSOR_IN_DRAM). A raw buffer address through a
+    // CTA is an enumerated Metal 2.0 framework blocker; only the L1 config path is
+    // ported.
+    TT_FATAL(
+        !config_tensors_in_dram,
+        "Conv2dShardedProgramFactory::create_program_spec only supports the L1 config-tensor path "
+        "(config_tensors_in_dram == false); the in-DRAM path remains a Metal 2.0 blocker.");
 
     distributed::MeshDevice* device = a.device();
     TT_FATAL(a.layout() == Layout::ROW_MAJOR, "Conv activation should be in row major layout");
@@ -292,7 +299,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
     const bool slice_inner_dim = (height_sharded && !enable_activation_reuse) || (block_sharded && !full_inner_dim);
 
     uint32_t conv_act_c_blocks = 1;
-    uint32_t out_conv_c_blocks = 1;
+    [[maybe_unused]] uint32_t out_conv_c_blocks = 1;
     uint32_t input_channels_padded = shard_shape[1];
     if (block_sharded) {
         TT_ASSERT(input_cores.size() == 1, "Block sharded convs should have only one input core range!");
@@ -343,6 +350,37 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         !coalesce_1d_depthwise_kw_reads || filter_h == 1,
         "Coalesced 1D depthwise reads require filter_h == 1, got {}",
         filter_h);
+
+    // ---- Metal 2.0 scope gates (continued) ----
+    // BLOCK_SHARDED uses a different reader (the *_2d_mcast_padded* source) and 2D
+    // weights mcast; the 1D-depthwise path uses dedicated reader/compute kernels and
+    // dest-reuse accumulation. Neither path is ported here. The input_cores !=
+    // output_cores case enables the legacy "skip_compute" noop-core RTA path on the
+    // compute kernel (height_sharded keeps input_cores == output_cores per the
+    // TT_ASSERT above). Gate them all out so the spec build below only handles the
+    // dense / height-sharded 1D-mcast path.
+    TT_FATAL(
+        height_sharded && !block_sharded,
+        "Conv2dShardedProgramFactory::create_program_spec only supports the HEIGHT_SHARDED 1D-mcast path; "
+        "the BLOCK_SHARDED path remains a Metal 2.0 port follow-up.");
+    TT_FATAL(
+        !is_conv_1d_depthwise_conv,
+        "Conv2dShardedProgramFactory::create_program_spec does not support the 1D-depthwise path "
+        "(dedicated reader/compute kernels); it remains a Metal 2.0 port follow-up.");
+    TT_FATAL(
+        input_cores == output_cores,
+        "Conv2dShardedProgramFactory::create_program_spec requires input_cores == output_cores; the "
+        "noop-core skip-compute path remains a Metal 2.0 port follow-up.");
+    // The legacy 1D path can place the reader/compute on input_cores while the writer
+    // mcast receiver also covers inactive cores in all_cores (the receiver early-returns
+    // via its `noop` RTA). Reproducing that with the shared-local-DFB invariant (which
+    // forces reader+compute+writer to share a node set) requires extra noop-only work
+    // units; to keep this first port faithful and tight, require all_cores == input_cores
+    // (no inactive grid cores) so the two work units below exactly cover input_cores.
+    TT_FATAL(
+        all_cores == input_cores,
+        "Conv2dShardedProgramFactory::create_program_spec requires all_cores == input_cores (no inactive "
+        "grid cores); that noop-core mcast-receiver path remains a Metal 2.0 port follow-up.");
 
     const bool enable_split_reader =
         is_split_reader_supported(a.memory_config().memory_layout(), is_conv_1d_depthwise_conv, act_block_h_ntiles) &&
@@ -514,14 +552,9 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
 
     const uint32_t in0_num_blocks_w = conv_act_c_blocks * num_blocks_act_w;
 
-    // weight
-    tt::tt_metal::Buffer* weights_buffer = b.buffer();
-
     // bias
-    tt::tt_metal::Buffer* bias_buffer = nullptr;
     uint32_t bias_ntiles = 0;
     if (has_bias) {
-        bias_buffer = bias.value().buffer();
         bias_ntiles =
             bias.value().padded_shape()[3] / tt::constants::TILE_WIDTH;  // TODO: support non tile multiple sizes
     }
@@ -549,33 +582,8 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
             num_blocks_weight_w);
     }
     uint32_t num_weight_slices_width = weight_matrix_width_ntiles / per_core_out_matrix_width_ntiles;
-    uint32_t total_num_cores_per_weight_slice = 0;
-    if (block_sharded) {
-        if (transpose_mcast) {
-            TT_FATAL(
-                num_cores_y % num_weight_slices_width == 0,
-                "num_cores_y {} should be divisible by num_weight_slices_width {}",
-                num_cores_y,
-                num_weight_slices_width);
-            uint32_t num_cores_y_per_weight_slice_width = num_cores_y / num_weight_slices_width;
-            total_num_cores_per_weight_slice = num_cores_y_per_weight_slice_width * num_cores_x;
-        } else {
-            TT_FATAL(
-                num_cores_x % num_weight_slices_width == 0,
-                "num_cores_x {} should be divisible by num_weight_slices_width {}",
-                num_cores_x,
-                num_weight_slices_width);
-            uint32_t num_cores_x_per_weight_slice_width = num_cores_x / num_weight_slices_width;
-            total_num_cores_per_weight_slice = num_cores_x_per_weight_slice_width * num_cores_y;
-        }
-        TT_FATAL(
-            total_num_cores_per_weight_slice * per_core_out_matrix_height_ntiles == act_matrix_height_ntiles,
-            "total_num_cores_per_weight_slice {} * per_core_out_matrix_height_ntiles {} should be equal to "
-            "act_matrix_height_ntiles {}",
-            total_num_cores_per_weight_slice,
-            per_core_out_matrix_height_ntiles,
-            act_matrix_height_ntiles);
-    } else {
+    [[maybe_unused]] uint32_t total_num_cores_per_weight_slice = 0;
+    {
         TT_FATAL(
             num_cores_y % num_weight_slices_width == 0,
             "num_cores_y {} should be divisible by num_weight_slices_width {}",
@@ -603,9 +611,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         "Activation matrix height in tiles ({}) must be divisible by per-core output matrix height in tiles ({})",
         act_matrix_height_ntiles,
         per_core_out_matrix_height_ntiles);
-    uint32_t total_noop_cores = total_num_cores_per_weight_slice - parallelization_config.num_cores_nhw;
     uint32_t total_active_num_cores = parallelization_config.num_cores_nhw * num_weight_slices_width;
-    TT_FATAL(!block_sharded || total_noop_cores == 0, "All cores should be active for block sharded convs");
 
     if (has_bias) {
         TT_FATAL(
@@ -653,14 +659,46 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         .enable_weights_double_buffer = enable_weights_double_buffer,
         .enable_activation_reuse = enable_activation_reuse,
         .force_split_reader = force_split_reader};
-    // The conv_reader_indices tensor itself is allocated once in
-    // create_workload_descriptor and parked on workload_descriptor.buffers; we
-    // receive the raw Buffer* and read its page size for the CB sizing below.
-    // Pass the actual DRAM/L1-small config buffer page size into get_cb_info so the predicted
-    // READER_INDICES CB footprint matches the CB this factory creates. Without this, the in-DRAM
-    // path was sized to the worst case (1 uint16 per output row), holding spare L1 that is never
-    // populated by the reader kernel.
+
+    // ---- Op-owned conv_reader_indices tensor ----
+    // The host-populated index table that backs the READER_INDICES borrowed-memory
+    // DFB. Allocated + uploaded here (L1-sharded in the L1 config path) and parked in
+    // ProgramArtifacts::op_owned_tensors so the adapter keeps it alive (stable
+    // address) for the cached Program's life. The (act_block_h_datums, last) split
+    // must agree exactly with the reader kernel's split, since the generated index
+    // tensor is consumed by the reader.
+    sliding_window::ParallelConfig input_parallel_config = {
+        .grid = a.memory_config().shard_spec().value().grid,
+        .shard_scheme = a.memory_config().memory_layout(),
+        .shard_orientation = a.memory_config().shard_spec().value().orientation,
+    };
+    std::vector<uint32_t> op_trace_metadata =
+        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
+    std::vector<sliding_window::ShardBoundary> shard_boundaries =
+        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
+    const uint32_t act_block_h_datums_split_last = act_block_h_nsubblocks_split_last * tt::constants::TILE_HEIGHT;
+    std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
+        ttnn::operations::sliding_window::generate_sliding_window_op_config(
+            op_trace_metadata,
+            shard_boundaries,
+            stride_w,
+            true,
+            enable_split_reader ? act_block_h_datums_split : act_block_h_datums,
+            enable_split_reader ? act_block_h_datums_split_last : 0);
+    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
+        conv_sharded_input_top_left_indices, input_parallel_config, config_tensors_in_dram);
+    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
+        conv_reader_indices_tensor, input_parallel_config, block_sharded, a.device(), config_tensors_in_dram);
+    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
+
+    std::vector<tt::tt_metal::Tensor> op_owned_tensors;
+    op_owned_tensors.reserve(1);
+    op_owned_tensors.push_back(std::move(conv_reader_indices_tensor));
+    // Build all tensor bindings against the VECTOR ELEMENT (identity footgun).
+    const Tensor& conv_reader_indices = op_owned_tensors[0];
+    tt::tt_metal::Buffer* conv_reader_indices_buffer = conv_reader_indices.buffer();
     const uint32_t reader_indices_actual_page_size = conv_reader_indices_buffer->page_size();
+
     std::vector<CBInfo> cb_info = get_cb_info(
         compute_kernel_config,
         block_config,
@@ -680,131 +718,98 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
         input_channels_padded,
         reader_indices_actual_page_size);
 
-    // Emit CBDescriptors directly onto the ProgramDescriptor.  The framework
-    // tracks the globally-allocated CBs (ACT_SHARDED on input, OUT/PARTIALS on
-    // output, READER_INDICES on the workload-scoped indices buffer) and patches
-    // their addresses on cache hits — no per-op UpdateDynamicCircularBufferAddress
-    // override needed.
-    emit_cb_descriptors(cb_info, desc, all_cores, a.buffer(), output.buffer(), conv_reader_indices_buffer);
-
-    const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
-    const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
-
-    const CoreCoord top_left_core = {(std::size_t)0, (std::size_t)0};
-    const CoreCoord top_left_core_plus_one = {(std::size_t)1, (std::size_t)1};
-    const CoreCoord bottom_right_core = {(std::size_t)in_num_cores_x - 1, (std::size_t)in_num_cores_y - 1};
-    const CoreCoord top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
-    const CoreCoord top_left_core_plus_one_physical = device->worker_core_from_logical_core(top_left_core_plus_one);
-    const CoreCoord bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
-
-    CoreRangeSet mcast_sender_cores =
-        CoreRangeSet(CoreRange(top_left_core, top_left_core));  // If single core, this kernel doesn't do mcasting
-    CoreRangeSet mcast_receiver_cores;
-    uint32_t weights_mcast_sender_semaphore_id = 0;
-    uint32_t weights_mcast_receiver_semaphore_id = 0;
-    uint32_t act_mcast_sender_semaphore_id = 0;
-    uint32_t act_mcast_receiver_semaphore_id = 0;
-    uint32_t act_split_reader_reserve_done_semaphore_id = 0;
-    uint32_t act_split_reader_write_done_semaphore_id = 0;
-
-    // Check if we should run BRISC kernels on cores that are not in the output grid ( when split reader is enabled and
-    // the output grid is smaller than the input grid)
-    const bool populate_skipped_work_cores =
-        enable_split_reader && block_sharded && input_cores.num_cores() > output_cores.num_cores();
-
-    const bool overlap_act_cb =
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).overlapped_by_cb.has_value();
-    // When split reader is enabled with overlapped CBs, both readers write to the same circular buffer.
-    // This requires synchronization between the main reader and the second reader to prevent race conditions.
-    const bool split_reader_cb_shared = enable_split_reader && overlap_act_cb && block_sharded;
-
-    // Sequential semaphore IDs match the order in which CreateSemaphore would have
-    // allocated them; the framework realises desc.semaphores in this order on cache miss.
-    auto push_semaphore = [&desc](const CoreRangeSet& cores) -> uint32_t {
-        uint32_t id = static_cast<uint32_t>(desc.semaphores.size());
-        desc.semaphores.push_back(SemaphoreDescriptor{
-            .id = id,
-            .core_ranges = cores,
-            .initial_value = 0,  // 0 == INVALID
-        });
-        return id;
-    };
-
-    if (block_sharded) {
-        const CoreCoord out_bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
-        // 2D mcast
-        if (transpose_mcast) {
-            mcast_sender_cores = CoreRangeSet(CoreRange(top_left_core, CoreCoord(0, num_cores_y - 1)));
-            if (!skip_weights_mcast) {
-                mcast_receiver_cores = CoreRange(CoreCoord(1, 0), out_bottom_right_core);
-            }
-        } else {
-            mcast_sender_cores = CoreRangeSet(CoreRange(top_left_core, CoreCoord(num_cores_x - 1, 0)));
-            if (!skip_weights_mcast) {
-                mcast_receiver_cores = CoreRange(CoreCoord(0, 1), out_bottom_right_core);
-            }
-        }
-        if (populate_skipped_work_cores) {
-            mcast_sender_cores = input_cores.subtract(mcast_receiver_cores);
-        }
-        act_mcast_sender_semaphore_id = push_semaphore(all_cores);
-        act_mcast_receiver_semaphore_id = push_semaphore(all_cores);
-
-        if (split_reader_cb_shared) {
-            weights_mcast_sender_semaphore_id = push_semaphore(all_cores);
-            weights_mcast_receiver_semaphore_id = push_semaphore(all_cores);
-            act_split_reader_reserve_done_semaphore_id = push_semaphore(all_cores);
-            act_split_reader_write_done_semaphore_id = push_semaphore(all_cores);
-        } else {
-            weights_mcast_sender_semaphore_id = push_semaphore(output_cores);
-            weights_mcast_receiver_semaphore_id = push_semaphore(output_cores);
-        }
-    } else {
-        // 1D mcast
-        if (!skip_weights_mcast) {
-            mcast_receiver_cores = all_cores.subtract(mcast_sender_cores);
-            weights_mcast_sender_semaphore_id = push_semaphore(output_cores);
-            weights_mcast_receiver_semaphore_id = push_semaphore(output_cores);
-        }
-    }
-
     // 1D depthwise compute uses dest-reuse for accumulation — no MATMUL_PARTIALS CB is allocated.
     const bool partials_cb_uses_output =
         !is_conv_1d_depthwise_conv && get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
     log_debug(tt::LogOp, "partials_cb_uses_output: {}", partials_cb_uses_output);
 
-    std::string reader_kernel;
-    std::string compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp";
-    std::string writer_mcast_sender_kernel =
-        "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
-        "reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp";
-    std::string writer_mcast_receiver_kernel =
-        "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
-        "reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
+    const bool has_act_second_reader = get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).num_pages != 0;
 
-    if (!is_conv_1d_depthwise_conv && block_sharded) {
-        // Block sharded conv
-        reader_kernel =
-            "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
-            "reader_conv_activations_2d_mcast_padded_with_halo_3x3_weights_v2.cpp";
-        writer_mcast_sender_kernel =
-            "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
-            "writer_tiled_out_2d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp";
-        writer_mcast_receiver_kernel =
-            "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
-            "writer_tiled_out_2d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp";
-    } else if (is_conv_1d_depthwise_conv) {
-        // 1D Depthwise Conv (height sharded)
-        compute_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/compute_depthwise_conv1d.cpp";
-        reader_kernel = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_depthwise_conv1d.cpp";
-    } else {
-        // Height sharded conv
-        reader_kernel =
-            "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
-            "reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp";
+    // ---- DataflowBufferSpecs ----
+    // One DataflowBufferSpec per non-zero-page CBInfo. Globally-allocated CBs become
+    // borrowed-memory DFBs (borrowed_from the backing TensorParameter); the rest are
+    // Program-local L1 DFBs. CB index assignment is irrelevant here — Metal 2.0 derives
+    // indices from bindings — but per-CB entry_size / num_entries / data_format are
+    // taken verbatim from CBInfo.
+    m2::ProgramSpec spec;
+    spec.name = "conv2d_height_sharded";
+    for (const auto& cb : cb_info) {
+        // ACT_ROW_MAJOR has 0 pages on the height-sharded path (it is the width-/block-
+        // sharded pre-tilize buffer). The shared compute kernel conv_bmm_tilize_m2.cpp
+        // still references dfb::act_row_major at file scope (inside a dead
+        // `if constexpr (!height_sharded)` branch), so the token must exist. Emit a
+        // 1-entry placeholder DFB and self-loop it on compute; the kernel never reads/
+        // writes it on this path. All other 0-page CBs are skipped, matching
+        // emit_cb_descriptors / allocate_cbs.
+        const bool act_row_major_placeholder = cb.name == Conv2dCb::ACT_ROW_MAJOR_BFLOAT16 && cb.num_pages == 0;
+        if (cb.num_pages == 0 && !act_row_major_placeholder) {
+            continue;
+        }
+        m2::DataflowBufferSpec dfb{
+            .unique_id = dfb_name_for(cb.name),
+            .entry_size = cb.page_size,
+            .num_entries = act_row_major_placeholder ? 1u : cb.num_pages,
+            .data_format_metadata = cb.data_format};
+        if (cb.is_globally_allocated) {
+            switch (cb.name) {
+                case Conv2dCb::ACT_SHARDED: dfb.borrowed_from = TP_ACT_SHARDED; break;
+                case Conv2dCb::OUT:
+                case Conv2dCb::MATMUL_PARTIALS: dfb.borrowed_from = TP_OUT; break;
+                case Conv2dCb::READER_INDICES: dfb.borrowed_from = TP_READER_INDICES; break;
+                default:
+                    TT_THROW("Unexpected globally-allocated CB {} in height-sharded spec", static_cast<int>(cb.name));
+            }
+        }
+        spec.dataflow_buffers.push_back(std::move(dfb));
     }
 
-    uint32_t reader_arg_act_block_h_datums = (enable_split_reader ? act_block_h_datums_split : act_block_h_datums);
+    // ---- Semaphores (program-local 1D weights mcast) ----
+    // The legacy 1D path allocates the weights mcast sender/receiver semaphores on
+    // output_cores (== all active cores for height sharded). Skip when weights mcast
+    // is skipped (single-core), mirroring the legacy push_semaphore gating.
+    if (!skip_weights_mcast) {
+        spec.semaphores = {
+            m2::SemaphoreSpec{.unique_id = SEM_WEIGHTS_SENDER, .target_nodes = output_cores},
+            m2::SemaphoreSpec{.unique_id = SEM_WEIGHTS_RECEIVER, .target_nodes = output_cores},
+        };
+    }
+
+    // ---- Per-kernel defines (height-sharded 1D path) ----
+    std::map<std::string, std::string> reader_defines;
+    std::map<std::string, std::string> writer_defines;
+    std::map<std::string, std::string> writer_mcast_sender_defines;
+    std::map<std::string, std::string> compute_defines;
+
+    if (skip_activation_mcast) {
+        reader_defines["SKIP_MCAST"] = "1";
+    }
+    if (skip_weights_mcast) {
+        writer_mcast_sender_defines["SKIP_MCAST"] = "1";
+    }
+    bool pack_relu = fused_activation.has_value() && fused_activation.value().op_type == unary::UnaryOpType::RELU;
+    if (fused_activation.has_value() && !pack_relu) {
+        compute_defines.merge(ttnn::operations::unary::utils::get_defines(
+            fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
+    }
+    if (enable_split_reader) {
+        compute_defines["SPLIT_READER"] = "1";
+        reader_defines["SPLIT_READER"] = "1";
+        writer_mcast_sender_defines["SPLIT_READER"] = "1";
+        writer_defines["SPLIT_READER"] = "1";
+    }
+    if (enable_activation_reuse) {
+        reader_defines["ACTIVATION_REUSE"] = "1";
+        writer_mcast_sender_defines["ACTIVATION_REUSE"] = "1";
+        writer_defines["ACTIVATION_REUSE"] = "1";
+    }
+    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
+        device->arch(), output_cores.num_cores(), compute_defines, ttnn::get_throttle_level(compute_kernel_config));
+    for (auto elem : compute_defines) {
+        log_trace(tt::LogOp, "compute_defines: {} = {}", elem.first, elem.second);
+    }
+
+    const uint32_t reader_arg_act_block_h_datums =
+        (enable_split_reader ? act_block_h_datums_split : act_block_h_datums);
     TT_FATAL(reader_arg_act_block_h_datums % 2 == 0, "2 Indices are packed in one uint32_t word.");
 
     ActivationReuseConfig activation_reuse_config;
@@ -830,417 +835,448 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
             batch);
     }
 
-    std::vector<uint32_t> reader_compile_time_args = {
-        (uint32_t)dilation_h,
-        (uint32_t)dilation_w,
-        (uint32_t)stride_w,
-        (uint32_t)conv_act_c_read_bytes,
-        (uint32_t)window_outer,
-        (uint32_t)window_inner,
-        (uint32_t)(enable_split_reader && !split_reader_cb_shared ? act_block_num_tiles_split : act_block_num_tiles),
-        (uint32_t)filter_h,
-        (uint32_t)filter_w,
-        (uint32_t)conv_act_size_w + (pad_w),
-        (uint32_t)act_block_w_extra_align_bytes,                          // only used for 1d systolic variant
-        (uint32_t)num_blocks_act_h_per_core,                              // act_num_blocks_h
-        (uint32_t)act_block_num_tiles,                                    // act_block_num_tiles
-        (uint32_t)conv_act_c_blocks,                                      // act_w_num_outer
-        (uint32_t)(transpose_mcast ? num_cores_y - 1 : num_cores_x - 1),  // act_mcast_num_dests
-        (uint32_t)(transpose_mcast ? num_cores_y - 1 : num_cores_x - 1),  // act_mcast_num_cores
-        (uint32_t)act_mcast_sender_semaphore_id,
-        (uint32_t)act_mcast_receiver_semaphore_id,
-        (uint32_t)tilized_act_tile_size,  // act_mcast_tile_size_bytes
-        (uint32_t)(transpose_mcast ? 1 : 0),
-        (uint32_t)needs_act_block_zero_out,  // zero_out_act_cb
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index,
-        (uint32_t)enable_split_reader,
-        (uint32_t)(is_conv_1d_depthwise_conv ? coalesce_1d_depthwise_kw_reads : enable_activation_reuse)};
-
-    std::map<std::string, std::string> reader_defines;
-    std::map<std::string, std::string> writer_defines;
-    std::map<std::string, std::string> writer_mcast_sender_defines;
-    std::map<std::string, std::string> compute_defines;
-
-    if (config_tensors_in_dram) {
-        reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
-        writer_defines["CONFIG_TENSOR_IN_DRAM"] = "1";               // Needed for split reader
-        writer_mcast_sender_defines["CONFIG_TENSOR_IN_DRAM"] = "1";  // Needed for split reader
-        reader_compile_time_args.push_back(conv_reader_indices_buffer->address());
-        reader_compile_time_args.push_back(conv_reader_indices_buffer->page_size());
-        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_buffer).append_to(reader_compile_time_args);
-    } else {
-        // Put enough 0s so that the offsets of activation reuse args are the same.
-        // TensorAccessorArgs appends 2 CT args (is_dram + aligned_page_size), so we need 4 zeros total
-        // (address + page_size + 2 TensorAccessorArgs) to match the DRAM path.
-        reader_compile_time_args.push_back(0);
-        reader_compile_time_args.push_back(0);
-        reader_compile_time_args.push_back(0);
-        reader_compile_time_args.push_back(0);
-    }
-
-    if (enable_activation_reuse) {
-        std::vector<uint32_t> activation_reuse_args = {
-            activation_reuse_config.act_cb_num_tiles_split,
-            act_block_w_ntiles,
-            static_cast<uint32_t>(activation_reuse_config.readers_process_full_image_widths),
-            activation_reuse_config.image_width_tiles,
-            output_image_width,
-            activation_reuse_config.reuse_window_offset,
-            static_cast<uint32_t>(activation_reuse_config.num_cores_with_non_meaningful_work > 0),
-            static_cast<uint32_t>(activation_reuse_config.single_core_processes_multiple_batches)};
-
-        reader_compile_time_args.insert(
-            reader_compile_time_args.end(), activation_reuse_args.begin(), activation_reuse_args.end());
-    } else if (height_sharded) {
-        // Add dummy activation reuse arguments when not enabled
-        std::vector<uint32_t> activation_reuse_dummy_args(8, 0);
-        reader_compile_time_args.insert(
-            reader_compile_time_args.end(), activation_reuse_dummy_args.begin(), activation_reuse_dummy_args.end());
-    }
-
-    if (split_reader_cb_shared) {
-        reader_compile_time_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
-        reader_compile_time_args.push_back(act_split_reader_reserve_done_semaphore_id);
-        reader_compile_time_args.push_back(act_split_reader_write_done_semaphore_id);
-    } else if (block_sharded) {
-        reader_compile_time_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
-        reader_compile_time_args.push_back(0);
-        reader_compile_time_args.push_back(0);
-    }
-    if (skip_activation_mcast) {
-        reader_defines["SKIP_MCAST"] = "1";
-    }
-    if (skip_weights_mcast) {
-        writer_mcast_sender_defines["SKIP_MCAST"] = "1";
-    }
-    bool pack_relu = fused_activation.has_value() && fused_activation.value().op_type == unary::UnaryOpType::RELU;
-    if (fused_activation.has_value() && !pack_relu) {
-        compute_defines.merge(ttnn::operations::unary::utils::get_defines(
-            fused_activation.value().op_type, fused_activation.value().params, "ACTIVATION", "i"));
-    }
-    if (enable_split_reader) {
-        compute_defines["SPLIT_READER"] = "1";
-        reader_defines["SPLIT_READER"] = "1";
-        writer_mcast_sender_defines["SPLIT_READER"] = "1";
-        writer_defines["SPLIT_READER"] = "1";
-    }
-
-    if (enable_activation_reuse) {
-        reader_defines["ACTIVATION_REUSE"] = "1";
-        writer_mcast_sender_defines["ACTIVATION_REUSE"] = "1";
-        writer_defines["ACTIVATION_REUSE"] = "1";
-    }
-
-    ttnn::operations::compute_throttle_utils::throttle_mm_perf(
-        device->arch(), output_cores.num_cores(), compute_defines, ttnn::get_throttle_level(compute_kernel_config));
-
-    for (auto elem : compute_defines) {
-        log_trace(tt::LogOp, "compute_defines: {} = {}", elem.first, elem.second);
-    }
-
-    std::vector<uint32_t> writer_compile_time_args = {
-        get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
-        (uint32_t)(bias_buffer == nullptr ? 0 : (bias_buffer->buffer_type() == BufferType::DRAM ? 1 : 0)),
-        get_cb_info_by_name(cb_info, (split_reader_cb_shared ? Conv2dCb::ACT : Conv2dCb::ACT_SECOND_READER)).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
-        num_blocks_act_w,
-        weight_block_num_tiles,
-        conv_act_c_blocks,
-        weight_block_h_ntiles,
-        weight_block_w_ntiles,
-        weight_matrix_width_ntiles,
-        weight_matrix_width_ntiles * weight_block_h_ntiles,
-        weight_block_w_ntiles,
-
-        // bias
-        bias_ntiles_per_core,
-
-        num_blocks_act_h_per_core,
-        num_blocks_weight_w_per_core,
-        out_conv_c_blocks,
-        (uint32_t)has_bias,
-        (uint32_t)enable_split_reader,
-        (uint32_t)(enable_activation_reuse && height_sharded)};
-
-    std::vector<uint32_t> split_reader_args = {
-        (uint32_t)act_block_num_tiles_split_last,
-        (uint32_t)conv_act_c_read_bytes,
-        (uint32_t)filter_w,                       // weight_size_w
-        (uint32_t)(conv_act_size_w + pad_w),      // conv_act_size_w_padded
-        (uint32_t)act_block_w_extra_align_bytes,  // only used for 1d systolic variant
-        (uint32_t)needs_act_block_zero_out,
-        (uint32_t)dilation_h,
-        (uint32_t)dilation_w,
-        (uint32_t)stride_w,
-        (uint32_t)filter_h};
-
-    if (block_sharded) {
-        split_reader_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
-    }
-    if (split_reader_cb_shared) {
-        const tt::DataFormat img2col_cb_df = get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).data_format;
-
-        const uint32_t img2col_cb_tile_size = tt::tile_size(img2col_cb_df);
-        const uint32_t act_cb_id_stride =
-            skip_activation_mcast ? 1 : 1 + get_num_cores_channels_from_parallel_config(parallel_config);
-        // get total number of blocks in the ACT CB so that we can compute the loop around when moving write
-        // pointer in second reader
-        const uint32_t act_cb_block_cnt = get_cb_info_by_name(cb_info, Conv2dCb::ACT).num_pages /
-                                          (act_block_num_tiles_split + act_block_num_tiles_split_last);
-
-        // In cases where the overlapped buffer is double buffered and number of push_backs done on NCRISC is odd,
-        // there are two addresses that need to be written to on the BRISC side for the second reader.
-        const bool second_writer_two_addr = (act_cb_block_cnt > 1) && (act_cb_id_stride % 2 == 1);
-        const uint32_t act_write_offset = act_block_num_tiles_split * img2col_cb_tile_size;
-        const uint32_t act_write_offset_last =
-            second_writer_two_addr
-                ? (act_block_num_tiles_split_last + 2 * act_block_num_tiles_split) * img2col_cb_tile_size
-                : act_write_offset;
-        split_reader_args.push_back(act_split_reader_reserve_done_semaphore_id);
-        split_reader_args.push_back(act_split_reader_write_done_semaphore_id);
-        split_reader_args.push_back(act_write_offset);
-        split_reader_args.push_back(act_write_offset_last);
-    } else if (block_sharded) {
-        split_reader_args.push_back(0);
-        split_reader_args.push_back(0);
-        split_reader_args.push_back(0);
-        split_reader_args.push_back(0);
-    }
-
-    if (enable_activation_reuse && height_sharded) {
-        std::vector<uint32_t> activation_reuse_args = {
-            activation_reuse_config.act_cb_num_tiles_split_last,
-            act_block_w_ntiles,
-            static_cast<uint32_t>(activation_reuse_config.readers_process_full_image_widths),
-            activation_reuse_config.image_width_tiles,
-            output_image_width,
-            activation_reuse_config.reuse_window_offset,
-            static_cast<uint32_t>(activation_reuse_config.num_cores_with_non_meaningful_work > 0),
-            static_cast<uint32_t>(activation_reuse_config.single_core_processes_multiple_batches)};
-        split_reader_args.insert(split_reader_args.end(), activation_reuse_args.begin(), activation_reuse_args.end());
-    } else if (height_sharded) {
-        // Add dummy activation reuse arguments when not enabled
-        std::vector<uint32_t> activation_reuse_dummy_args(8, 0);
-        split_reader_args.insert(
-            split_reader_args.end(), activation_reuse_dummy_args.begin(), activation_reuse_dummy_args.end());
-    }
-    writer_compile_time_args.insert(writer_compile_time_args.end(), split_reader_args.begin(), split_reader_args.end());
-    tt::tt_metal::TensorAccessorArgs(b.buffer()).append_to(writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(bias ? bias->buffer() : nullptr).append_to(writer_compile_time_args);
-
-    const bool check_skip_compute = input_cores != output_cores;
-
-    std::vector<uint32_t> compute_kernel_args;
-    if (is_conv_1d_depthwise_conv) {
-        // compute_depthwise_conv1d.cpp uses a specialized dest-reuse accumulation path. The last
-        // two args select the coalesced kernel-width activation layout when the reader can fetch
-        // all kernel-width sticks as one NoC packet.
-        compute_kernel_args = {
-            act_block_w_ntiles,                                         // 0: in0_block_w
-            act_num_subblocks,                                          // 1: in0_num_subblocks
-            act_block_num_tiles,                                        // 2: in0_block_num_tiles
-            num_blocks_act_h_per_core,                                  // 3: in0_num_blocks_h
-            in0_num_blocks_w,                                           // 4: in0_num_blocks_w
-            get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,          // 5: in0_cb_id (raw RM)
-            get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,      // 6: in1_cb_id
-            get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,  // 7: tilized_in0_cb_id
-            get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,          // 8: out_cb_id
-            filter_w,                                                   // 9: kernel_width
-            coalesce_1d_depthwise_kw_reads,                             // 10: coalesced activation block
-        };
-    } else {
-        compute_kernel_args = {
-            act_block_w_ntiles,
-            act_num_subblocks,
-            act_block_num_tiles,
-            act_subblock_num_tiles,
-            enable_split_reader ? act_block_h_ntiles
-                                : act_subblock_h_ntiles * act_num_subblocks,  // reader_num_h_subblocks
-            weight_num_subblocks,
-            weight_block_num_tiles,
-            weight_block_w_ntiles,
-
-            num_blocks_act_h_per_core,
-            in0_num_blocks_w,
-            num_blocks_weight_w_per_core,
-
-            out_subblock_h_ntiles,
-            out_subblock_w_ntiles,
-            out_subblock_num_tiles,
-
-            height_sharded,
-            untilize_out,
-
-            bias_ntiles_per_core,
-
-            get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
-            get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
-            get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
-            get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
-            get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).index,
-            get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).index,
-            get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
-            get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
-            partials_cb_uses_output,
-            conv_act_c_blocks,
-            check_skip_compute,
-            pack_relu,
-            weight_block_w_ntiles <= 8,  // packer_untilize
-            packer_l1_acc_en,
-            has_bias,
-            enable_split_reader,
-            enable_activation_reuse};
-
-        if (enable_activation_reuse) {
-            compute_kernel_args.push_back(activation_reuse_config.image_width_tiles);
-            compute_kernel_args.push_back(activation_reuse_config.reuse_window_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
-            compute_kernel_args.push_back(
-                activation_reuse_config.tilized_cb_row_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
-            compute_kernel_args.push_back(
-                activation_reuse_config.tilized_cb_second_reader_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR);
-        } else {
-            std::vector<uint32_t> activation_reuse_dummy_args = {0, 0, 0, 0};
-            compute_kernel_args.insert(
-                compute_kernel_args.end(), activation_reuse_dummy_args.begin(), activation_reuse_dummy_args.end());
-        }
-        compute_kernel_args.push_back(static_cast<uint32_t>(split_reader_cb_shared));
-    }
-
+    // mcast NoC selection (1D path)
     const tt::tt_metal::NOC writer_mcast_noc = tt::tt_metal::detail::preferred_noc_for_dram_read(device->arch());
     const tt::tt_metal::NOC reader_noc =
         writer_mcast_noc == tt::tt_metal::NOC::NOC_0 ? tt::tt_metal::NOC::NOC_1 : tt::tt_metal::NOC::NOC_0;
 
-    // Build the writer_mcast_sender kernel descriptor (placed on mcast_sender_cores).
-    // We build runtime_args below after kernel placement is fixed.
-    KernelDescriptor writer_mcast_sender_desc;
-    writer_mcast_sender_desc.kernel_source = writer_mcast_sender_kernel;
-    writer_mcast_sender_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_mcast_sender_desc.core_ranges = mcast_sender_cores;
-    writer_mcast_sender_desc.compile_time_args = writer_compile_time_args;
-    for (const auto& [k, v] : writer_mcast_sender_defines) {
-        writer_mcast_sender_desc.defines.emplace_back(k, v);
-    }
-    writer_mcast_sender_desc.config = DataMovementConfigDescriptor{
-        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-        .noc = writer_mcast_noc,
-    };
+    // mcast rect physical coords (1D)
+    const CoreCoord top_left_core = {(std::size_t)0, (std::size_t)0};
+    const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
+    const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
+    const CoreCoord bottom_right_core = {(std::size_t)in_num_cores_x - 1, (std::size_t)in_num_cores_y - 1};
+    const CoreCoord top_left_core_physical = device->worker_core_from_logical_core(top_left_core);
+    const CoreCoord bottom_right_core_physical = device->worker_core_from_logical_core(bottom_right_core);
 
-    // Optional writer_mcast_receiver kernel (created only when weights mcast is not skipped).
-    KernelDescriptor writer_mcast_receiver_desc;
-    const bool create_writer_mcast_receiver = !skip_weights_mcast;
-    if (create_writer_mcast_receiver) {
-        writer_mcast_receiver_desc.kernel_source = writer_mcast_receiver_kernel;
-        writer_mcast_receiver_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        writer_mcast_receiver_desc.core_ranges = mcast_receiver_cores;
-        writer_mcast_receiver_desc.compile_time_args = writer_compile_time_args;
-        for (const auto& [k, v] : writer_defines) {
-            writer_mcast_receiver_desc.defines.emplace_back(k, v);
-        }
-        writer_mcast_receiver_desc.config = DataMovementConfigDescriptor{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-            .noc = writer_mcast_noc,
-        };
-    }
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source = reader_kernel;
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = height_sharded ? input_cores : all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    for (const auto& [k, v] : reader_defines) {
-        reader_desc.defines.emplace_back(k, v);
-    }
-    reader_desc.config = DataMovementConfigDescriptor{
-        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-        .noc = reader_noc,
-    };
-
-    KernelDescriptor compute_kernel_desc;
-    compute_kernel_desc.kernel_source = compute_kernel;
-    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_kernel_desc.core_ranges = height_sharded ? input_cores : all_cores;
-    compute_kernel_desc.compile_time_args = std::move(compute_kernel_args);
-    for (const auto& [k, v] : compute_defines) {
-        compute_kernel_desc.defines.emplace_back(k, v);
-    }
-    compute_kernel_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = math_fidelity,
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-    };
-
-    // Helper lambda to setup mcast arguments
     auto setup_mcast_args = [&](bool is_noc_0, uint32_t start_x, uint32_t start_y, uint32_t end_x, uint32_t end_y) {
-        return is_noc_0 ? std::vector<uint32_t>{start_x, start_y, end_x, end_y}
-                        : std::vector<uint32_t>{end_x, end_y, start_x, start_y};
+        return is_noc_0 ? std::array<uint32_t, 4>{start_x, start_y, end_x, end_y}
+                        : std::array<uint32_t, 4>{end_x, end_y, start_x, start_y};
+    };
+    const std::array<uint32_t, 4> weights_mcast_coords = setup_mcast_args(
+        writer_mcast_noc == tt::tt_metal::NOC::NOC_0,
+        top_left_core_physical.x,
+        top_left_core_physical.y,
+        bottom_right_core_physical.x,
+        bottom_right_core_physical.y);
+
+    // ======================= KernelSpecs =======================
+
+    // ---- Reader (RISCV_1, READER) ----
+    m2::KernelSpec reader_kernel{
+        .unique_id = K_READER,
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
+                                        "reader_conv_activations_padded_with_halo_3x3_weights_v2_m2.cpp"},
+        .compile_time_args =
+            {{"dilation_h", dilation_h},
+             {"dilation_w", dilation_w},
+             {"stride_w", stride_w},
+             {"conv_act_c_read_bytes", conv_act_c_read_bytes},
+             {"window_outer", window_outer},
+             // Reader fills act_block_num_tiles_split when split-reader is on (it does
+             // the first half; the writer does the second half). split_reader_cb_shared
+             // is block-sharded only, so it is always false on this path.
+             {"act_block_num_tiles", enable_split_reader ? act_block_num_tiles_split : act_block_num_tiles},
+             {"weight_size_h", filter_h},
+             {"weight_size_w", filter_w},
+             {"conv_act_size_w_padded", conv_act_size_w + pad_w},
+             {"act_block_w_extra_align_bytes", act_block_w_extra_align_bytes},
+             {"act_num_blocks_h", num_blocks_act_h_per_core},
+             {"needs_act_block_zero_out", (uint32_t)needs_act_block_zero_out},
+             {"split_reader_enabled", (uint32_t)enable_split_reader},
+             {"activation_reuse_enabled", (uint32_t)enable_activation_reuse},
+             // activation-reuse args (dummy 0s when disabled, mirroring the legacy
+             // height-sharded path which still emits 8 reuse slots)
+             {"act_reuse_cb_tiles", enable_activation_reuse ? activation_reuse_config.act_cb_num_tiles_split : 0u},
+             {"act_block_w_tiles", enable_activation_reuse ? act_block_w_ntiles : 0u},
+             {"readers_process_full_image_widths",
+              enable_activation_reuse ? (uint32_t)activation_reuse_config.readers_process_full_image_widths : 0u},
+             {"image_width_tiles", enable_activation_reuse ? activation_reuse_config.image_width_tiles : 0u},
+             {"output_image_width", enable_activation_reuse ? output_image_width : 0u},
+             {"window_reuse_offset", enable_activation_reuse ? activation_reuse_config.reuse_window_offset : 0u},
+             {"need_to_push_remaining_tiles",
+              enable_activation_reuse ? (uint32_t)(activation_reuse_config.num_cores_with_non_meaningful_work > 0)
+                                      : 0u},
+             {"single_core_processes_multiple_batches",
+              enable_activation_reuse ? (uint32_t)activation_reuse_config.single_core_processes_multiple_batches : 0u}},
+        .runtime_arg_schema = {.runtime_arg_names = {"core_index", "remaining_tiles_to_push"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+    reader_kernel.dfb_bindings = {
+        // ACT produced by the reader; consumed by compute.
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT, .accessor_name = "act", .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        // ACT_SHARDED / READER_INDICES: base-pointer address sources (no FIFO peer) ->
+        // self-loop to satisfy the producer+consumer invariant.
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT_SHARDED,
+            .accessor_name = "act_sharded",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT_SHARDED,
+            .accessor_name = "act_sharded",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_READER_INDICES,
+            .accessor_name = "reader_indices",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_READER_INDICES,
+            .accessor_name = "reader_indices",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        // L1_ARRAY is an allocated 1-page scratch CB that no height-sharded kernel
+        // references (legacy CTA 26 is skipped by this reader). Self-loop it on the
+        // reader purely to satisfy the producer+consumer invariant; the kernel never
+        // constructs dfb::l1_array. Candidate for the forthcoming Metal 2.0 scratchpad.
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_L1_ARRAY, .accessor_name = "l1_array", .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_L1_ARRAY, .accessor_name = "l1_array", .endpoint_type = m2::DFBEndpointType::CONSUMER},
+    };
+    reader_kernel.tensor_bindings = {
+        m2::TensorBinding{.tensor_parameter_name = TP_ACT_SHARDED, .accessor_name = "act_sharded"},
+        m2::TensorBinding{.tensor_parameter_name = TP_READER_INDICES, .accessor_name = "reader_indices"},
+    };
+    {
+        m2::KernelSpec::CompilerOptions::Defines d;
+        for (const auto& [k, v] : reader_defines) {
+            d.insert({k, v});
+        }
+        reader_kernel.compiler_options.defines = std::move(d);
+    }
+
+    // ---- Weights/writer mcast sender (RISCV_0, WRITER) ----
+    // Shared writer CT args (sender + receiver). Only the slots each kernel reads are
+    // emitted as named CTAs (the legacy positional list left gaps the kernels skip).
+    auto add_writer_ctas = [&](m2::KernelSpec& k) {
+        k.compile_time_args = {
+            {"num_blocks_weight_h", num_blocks_act_w},
+            {"weight_block_num_tiles", weight_block_num_tiles},
+            {"weight_block_height_num_outer", conv_act_c_blocks},
+            {"weight_block_height_ntiles", weight_block_h_ntiles},
+            {"weight_block_width_ntiles", weight_block_w_ntiles},
+            {"weight_stride_h", weight_matrix_width_ntiles},
+            {"weight_next_block_stride_h", weight_matrix_width_ntiles * weight_block_h_ntiles},
+            {"bias_ntiles", bias_ntiles_per_core},
+            {"out_num_blocks_h", num_blocks_act_h_per_core},
+            {"fuse_bias", (uint32_t)has_bias},
+            {"split_reader_enabled", (uint32_t)enable_split_reader},
+            {"activation_reuse_enabled", (uint32_t)(enable_activation_reuse && height_sharded)},
+            // Split reader args
+            {"act_block_num_tiles", act_block_num_tiles_split_last},
+            {"conv_act_c_read_bytes", conv_act_c_read_bytes},
+            {"weight_size_w", filter_w},
+            {"conv_act_size_w_padded", conv_act_size_w + pad_w},
+            {"act_block_w_extra_align_bytes", act_block_w_extra_align_bytes},
+            {"needs_act_block_zero_out", (uint32_t)needs_act_block_zero_out},
+            {"dilation_h", dilation_h},
+            {"dilation_w", dilation_w},
+            {"stride_w", stride_w},
+            {"weights_size_h", filter_h},
+            // Activation reuse args (dummy 0s when disabled; mirrors legacy height-sharded)
+            {"act_reuse_cb_tiles", enable_activation_reuse ? activation_reuse_config.act_cb_num_tiles_split_last : 0u},
+            {"act_block_w_tiles", enable_activation_reuse ? act_block_w_ntiles : 0u},
+            {"readers_process_full_image_widths",
+             enable_activation_reuse ? (uint32_t)activation_reuse_config.readers_process_full_image_widths : 0u},
+            {"image_width_tiles", enable_activation_reuse ? activation_reuse_config.image_width_tiles : 0u},
+            {"output_image_width", enable_activation_reuse ? output_image_width : 0u},
+            {"window_reuse_offset", enable_activation_reuse ? activation_reuse_config.reuse_window_offset : 0u},
+            {"need_to_push_remaining_tiles",
+             enable_activation_reuse ? (uint32_t)(activation_reuse_config.num_cores_with_non_meaningful_work > 0) : 0u},
+            {"single_core_processes_multiple_batches",
+             enable_activation_reuse ? (uint32_t)activation_reuse_config.single_core_processes_multiple_batches : 0u}};
     };
 
-    // Setup reader runtime arguments
-    if (block_sharded) {
-        const uint32_t in_num_cores_x = input_cores.bounding_box().end_coord.x + 1;
-        const uint32_t in_num_cores_y = input_cores.bounding_box().end_coord.y + 1;
-        std::vector<uint32_t> act_mcast_noc_y;
-        if (transpose_mcast) {
-            act_mcast_noc_y.reserve(in_num_cores_y);
-            for (uint32_t core_idx_y = 0; core_idx_y < in_num_cores_y; ++core_idx_y) {
-                act_mcast_noc_y.push_back(device->worker_core_from_logical_core({0, core_idx_y}).y);
-            }
-        } else {
-            // NOTE: using same var for x as well, this is intentional
-            act_mcast_noc_y.reserve(in_num_cores_x);
-            for (int32_t core_idx_x = 0; core_idx_x < in_num_cores_x; ++core_idx_x) {
-                act_mcast_noc_y.push_back(device->worker_core_from_logical_core({core_idx_x, 0}).x);
+    // Conditional DFB / tensor bindings shared by sender + receiver writers.
+    auto add_writer_bindings = [&](m2::KernelSpec& k, bool is_sender) {
+        k.dfb_bindings = {
+            m2::DFBBinding{
+                .dfb_spec_name = DFB_WEIGHTS,
+                .accessor_name = "weights",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER},
+            // ACT_SHARDED / READER_INDICES base-pointer address sources only when split
+            // reader is enabled; self-loop to satisfy producer+consumer invariant.
+            m2::DFBBinding{
+                .dfb_spec_name = DFB_ACT_SHARDED,
+                .accessor_name = "act_sharded",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER},
+            m2::DFBBinding{
+                .dfb_spec_name = DFB_ACT_SHARDED,
+                .accessor_name = "act_sharded",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER},
+            m2::DFBBinding{
+                .dfb_spec_name = DFB_READER_INDICES,
+                .accessor_name = "reader_indices",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER},
+            m2::DFBBinding{
+                .dfb_spec_name = DFB_READER_INDICES,
+                .accessor_name = "reader_indices",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        };
+        // BIAS / ACT_SECOND_READER CBs are produced by the writer kernels when bound
+        // (conditionally, gated by FUSE_BIAS / SECOND_READER_PRESENT defines on the
+        // kernel side). Both writers reserve/push these CBs.
+        if (has_bias) {
+            k.dfb_bindings.push_back(m2::DFBBinding{
+                .dfb_spec_name = DFB_BIAS, .accessor_name = "bias", .endpoint_type = m2::DFBEndpointType::PRODUCER});
+        }
+        if (has_act_second_reader) {
+            k.dfb_bindings.push_back(m2::DFBBinding{
+                .dfb_spec_name = DFB_ACT_SECOND_READER,
+                .accessor_name = "act_second_reader",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER});
+            k.dfb_bindings.push_back(m2::DFBBinding{
+                .dfb_spec_name = DFB_ACT_SECOND_READER,
+                .accessor_name = "act_second_reader",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER});
+        }
+        // ACT_SHARDED / READER_INDICES base pointers are read by both writers (split
+        // reader); the weights/bias DRAM TensorAccessors are constructed only by the
+        // sender (the receiver gets its weights via mcast), so bind those only there.
+        k.tensor_bindings = {
+            m2::TensorBinding{.tensor_parameter_name = TP_ACT_SHARDED, .accessor_name = "act_sharded"},
+            m2::TensorBinding{.tensor_parameter_name = TP_READER_INDICES, .accessor_name = "reader_indices"},
+        };
+        if (is_sender) {
+            k.tensor_bindings.push_back(
+                m2::TensorBinding{.tensor_parameter_name = TP_WEIGHTS, .accessor_name = "weights"});
+            if (has_bias) {
+                k.tensor_bindings.push_back(
+                    m2::TensorBinding{.tensor_parameter_name = TP_BIAS, .accessor_name = "bias"});
             }
         }
-
-        const CoreCoord out_bottom_right_core = {(std::size_t)num_cores_x - 1, (std::size_t)num_cores_y - 1};
-        const CoreCoord out_bottom_right_core_physical = device->worker_core_from_logical_core(out_bottom_right_core);
-        const bool reader_is_noc_0 = reader_noc == tt::tt_metal::NOC::NOC_0;
-
-        for (const CoreRange& core_range : all_cores.ranges()) {
-            for (const CoreCoord& core : core_range) {
-                const bool is_receiver_core = output_cores.contains(core);
-                const bool is_sender_core = input_cores.contains(core);
-                std::vector<uint32_t> reader_rt_args;
-                if (transpose_mcast) {
-                    CoreCoord bottom_core = {(std::size_t)core.x, (std::size_t)num_cores_y - 1};
-                    CoreCoord bottom_core_physical = device->worker_core_from_logical_core(bottom_core);
-
-                    reader_rt_args = setup_mcast_args(
-                        reader_is_noc_0,
-                        bottom_core_physical.x,
-                        top_left_core_physical.y,
-                        bottom_core_physical.x,
-                        bottom_core_physical.y);
-
-                    reader_rt_args.push_back(core.y);                  // act_mcast_sender_id
-                    reader_rt_args.push_back(bottom_core_physical.x);  // act_mcast_sender_noc_x
-                } else {
-                    CoreCoord core_physical = device->worker_core_from_logical_core(core);
-
-                    reader_rt_args = setup_mcast_args(
-                        reader_is_noc_0,
-                        top_left_core_physical.x,
-                        core_physical.y,
-                        out_bottom_right_core_physical.x,
-                        core_physical.y);
-                    reader_rt_args.push_back(core.x);           // act_mcast_sender_id
-                    reader_rt_args.push_back(core_physical.y);  // act_mcast_sender_noc_x
-                }
-                reader_rt_args.push_back(static_cast<uint32_t>(is_receiver_core));  // is_receiver_core
-                reader_rt_args.push_back(static_cast<uint32_t>(is_sender_core));    // is_receiver_core
-                reader_rt_args.push_back(transpose_mcast ? core.x : core.y);        // dram config reader index
-                reader_rt_args.insert(reader_rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());
-                reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
-            }
+        if (!skip_weights_mcast) {
+            k.semaphore_bindings = {
+                m2::SemaphoreBinding{
+                    .semaphore_spec_name = SEM_WEIGHTS_SENDER, .accessor_name = "weights_mcast_sender"},
+                m2::SemaphoreBinding{
+                    .semaphore_spec_name = SEM_WEIGHTS_RECEIVER, .accessor_name = "weights_mcast_receiver"},
+            };
         }
-    } else {
+    };
+
+    m2::KernelSpec writer_sender_kernel{
+        .unique_id = K_WRITER_SENDER,
+        .source =
+            std::filesystem::path{"ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
+                                  "reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks_m2.cpp"},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"out_start_tile_id_w",
+                  "bias_tile_offset",
+                  "mcast_noc_x_start",
+                  "mcast_noc_y_start",
+                  "mcast_noc_x_end",
+                  "mcast_noc_y_end",
+                  "weights_mcast_num_dests",
+                  "weights_mcast_num_cores"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+    add_writer_ctas(writer_sender_kernel);
+    add_writer_bindings(writer_sender_kernel, /*is_sender=*/true);
+    if (enable_activation_reuse) {
+        writer_sender_kernel.runtime_arg_schema.runtime_arg_names.push_back("remaining_tiles_to_push");
+    }
+    {
+        m2::KernelSpec::CompilerOptions::Defines d;
+        for (const auto& [k, v] : writer_mcast_sender_defines) {
+            d.insert({k, v});
+        }
+        if (has_bias) {
+            d.insert({"FUSE_BIAS", "1"});
+        }
+        if (has_act_second_reader) {
+            d.insert({"SECOND_READER_PRESENT", "1"});
+        }
+        writer_sender_kernel.compiler_options.defines = std::move(d);
+    }
+
+    m2::KernelSpec writer_receiver_kernel{
+        .unique_id = K_WRITER_RECEIVER,
+        .source =
+            std::filesystem::path{
+                "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/"
+                "reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks_m2.cpp"},
+        .runtime_arg_schema =
+            {.runtime_arg_names = {"noop", "weights_mcast_sender_noc_x", "weights_mcast_sender_noc_y"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+    add_writer_ctas(writer_receiver_kernel);
+    add_writer_bindings(writer_receiver_kernel, /*is_sender=*/false);
+    if (enable_activation_reuse) {
+        writer_receiver_kernel.runtime_arg_schema.runtime_arg_names.push_back("remaining_tiles_to_push");
+    }
+    {
+        m2::KernelSpec::CompilerOptions::Defines d;
+        for (const auto& [k, v] : writer_defines) {
+            d.insert({k, v});
+        }
+        if (has_bias) {
+            d.insert({"FUSE_BIAS", "1"});
+        }
+        if (has_act_second_reader) {
+            d.insert({"SECOND_READER_PRESENT", "1"});
+        }
+        writer_receiver_kernel.compiler_options.defines = std::move(d);
+    }
+
+    // ---- Compute (forked: conv_bmm_tilize_m2.cpp) ----
+    m2::KernelSpec compute_kernel{
+        .unique_id = K_HS_COMPUTE,
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_m2.cpp"},
+        .compile_time_args =
+            {{"in0_block_w", act_block_w_ntiles},
+             {"in0_num_subblocks", act_num_subblocks},
+             {"in0_block_num_tiles", act_block_num_tiles},
+             {"in0_subblock_num_tiles", act_subblock_num_tiles},
+             {"reader_num_h_subblocks",
+              enable_split_reader ? act_block_h_ntiles : act_subblock_h_ntiles * act_num_subblocks},
+             {"in1_num_subblocks", weight_num_subblocks},
+             {"in1_block_num_tiles", weight_block_num_tiles},
+             {"in1_block_w", weight_block_w_ntiles},
+             {"in0_num_blocks_h", num_blocks_act_h_per_core},
+             {"in0_num_blocks_w", in0_num_blocks_w},
+             {"in1_num_blocks_w", num_blocks_weight_w_per_core},
+             {"out_subblock_h", out_subblock_h_ntiles},
+             {"out_subblock_w", out_subblock_w_ntiles},
+             {"out_subblock_num_tiles", out_subblock_num_tiles},
+             {"height_sharded", (uint32_t)height_sharded},
+             {"untilize_out", (uint32_t)untilize_out},
+             {"bias_ntiles_w", bias_ntiles_per_core},
+             {"partials_cb_uses_output", (uint32_t)partials_cb_uses_output},
+             {"in0_nblocks_w_tilize", conv_act_c_blocks},
+             {"check_skip_compute", 0u},  // input_cores == output_cores is enforced above
+             {"pack_relu", (uint32_t)pack_relu},
+             {"packer_untilize", (uint32_t)(weight_block_w_ntiles <= 8)},
+             {"packer_l1_acc", (uint32_t)packer_l1_acc_en},
+             {"fuse_bias", (uint32_t)has_bias},
+             {"split_reader", (uint32_t)enable_split_reader},
+             {"activation_reuse", (uint32_t)enable_activation_reuse},
+             {"image_width_in_tiles", enable_activation_reuse ? activation_reuse_config.image_width_tiles : 0u},
+             {"window_reuse_offset",
+              enable_activation_reuse ? activation_reuse_config.reuse_window_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR
+                                      : 0u},
+             {"tilized_cb_row_offset",
+              enable_activation_reuse ? activation_reuse_config.tilized_cb_row_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR
+                                      : 0u},
+             {"tilized_cb_second_reader_offset",
+              enable_activation_reuse
+                  ? activation_reuse_config.tilized_cb_second_reader_offset / COMPUTE_KERNEL_ADDRESS_DIVISOR
+                  : 0u},
+             {"split_reader_cb_shared", 0u}},  // block-sharded only
+        .hw_config =
+            m2::ComputeHardwareConfig{
+                .math_fidelity = math_fidelity,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+            },
+    };
+    compute_kernel.dfb_bindings = {
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT, .accessor_name = "act", .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        // ACT_ROW_MAJOR: dead on the height-sharded path (placeholder DFB) -> self-loop
+        // on compute to satisfy the producer+consumer invariant.
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT_ROW_MAJOR,
+            .accessor_name = "act_row_major",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT_ROW_MAJOR,
+            .accessor_name = "act_row_major",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT_TILIZED,
+            .accessor_name = "act_tilized",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT_TILIZED,
+            .accessor_name = "act_tilized",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_WEIGHTS, .accessor_name = "weights", .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        // MATMUL_PARTIALS is a compute-local accumulator (produced and consumed by compute).
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_MATMUL_PARTIALS,
+            .accessor_name = "matmul_partials",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_MATMUL_PARTIALS,
+            .accessor_name = "matmul_partials",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        // OUT is borrowed onto the (sharded) output tensor: compute packs results
+        // directly into it; no separate writer/FIFO consumer -> self-loop on compute.
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_OUT, .accessor_name = "out", .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_OUT, .accessor_name = "out", .endpoint_type = m2::DFBEndpointType::CONSUMER},
+    };
+    {
+        m2::KernelSpec::CompilerOptions::Defines d;
+        for (const auto& [k, v] : compute_defines) {
+            d.insert({k, v});
+        }
+        if (has_bias) {
+            d.insert({"FUSE_BIAS", "1"});
+            compute_kernel.dfb_bindings.push_back(m2::DFBBinding{
+                .dfb_spec_name = DFB_BIAS, .accessor_name = "bias", .endpoint_type = m2::DFBEndpointType::CONSUMER});
+        }
+        if (has_act_second_reader) {
+            d.insert({"SECOND_READER_PRESENT", "1"});
+            compute_kernel.dfb_bindings.push_back(m2::DFBBinding{
+                .dfb_spec_name = DFB_ACT_SECOND_READER,
+                .accessor_name = "act_second_reader",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER});
+        }
+        compute_kernel.compiler_options.defines = std::move(d);
+    }
+
+    spec.kernels = {reader_kernel, writer_sender_kernel, compute_kernel};
+    if (!skip_weights_mcast) {
+        spec.kernels.push_back(writer_receiver_kernel);
+    }
+
+    // ---- Tensor parameters ----
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = TP_ACT_SHARDED, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = TP_WEIGHTS, .spec = b.tensor_spec()},
+        m2::TensorParameter{.unique_id = TP_OUT, .spec = output.tensor_spec()},
+        m2::TensorParameter{.unique_id = TP_READER_INDICES, .spec = conv_reader_indices.tensor_spec()},
+    };
+    if (has_bias) {
+        spec.tensor_parameters.push_back(m2::TensorParameter{.unique_id = TP_BIAS, .spec = bias.value().tensor_spec()});
+    }
+
+    // ---- WorkUnits ----
+    // Local DFBs (ACT/ACT_ROW_MAJOR/ACT_TILIZED/WEIGHTS/MATMUL_PARTIALS/OUT/BIAS) are
+    // shared by reader+compute and (for weights) the writer kernels, so every kernel
+    // that hosts a local DFB must share a WorkUnitSpec covering the same node set.
+    // Legacy 1D height-sharded placement: reader on input_cores, sender on the single
+    // top-left mcast-sender core, receiver on the rest, compute on input_cores. For the
+    // shared-DFB invariant the reader/compute/writer-sender share input_cores; the
+    // writer-receiver (when present) covers the remaining cores.
+    const CoreRangeSet sender_cores{CoreRange(top_left_core, top_left_core)};
+    const CoreRangeSet receiver_cores = skip_weights_mcast ? CoreRangeSet{} : all_cores.subtract(sender_cores);
+
+    std::vector<m2::WorkUnitSpec> work_units;
+    work_units.push_back(m2::WorkUnitSpec{
+        .name = "conv2d_hs_sender",
+        .kernels = {K_READER, K_WRITER_SENDER, K_HS_COMPUTE},
+        .target_nodes = sender_cores});
+    if (!skip_weights_mcast && receiver_cores.num_cores() > 0) {
+        work_units.push_back(m2::WorkUnitSpec{
+            .name = "conv2d_hs_receiver",
+            .kernels = {K_READER, K_WRITER_RECEIVER, K_HS_COMPUTE},
+            .target_nodes = receiver_cores});
+    }
+    spec.work_units = std::move(work_units);
+
+    // ======================= ProgramRunArgs =======================
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = K_READER};
+    m2::KernelRunArgs sender_run{.kernel = K_WRITER_SENDER};
+    m2::KernelRunArgs receiver_run{.kernel = K_WRITER_RECEIVER};
+    m2::KernelRunArgs compute_run{.kernel = K_HS_COMPUTE};
+
+    // Reader per-core RTAs: core_index (sequential over input_cores) + remaining tiles.
+    {
         uint32_t core_index = 0;
         for (const CoreRange& core_range : input_cores.ranges()) {
             for (const CoreCoord& core : core_range) {
@@ -1252,119 +1288,59 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
                         reader_remaining_tiles_to_push = act_block_h_nsubblocks_split;
                     }
                 }
-                std::vector<uint32_t> reader_rt_args{core_index, reader_remaining_tiles_to_push};
-                reader_desc.runtime_args.emplace_back(core, std::move(reader_rt_args));
+                reader_run.runtime_arg_values.push_back(
+                    {core, {{"core_index", core_index}, {"remaining_tiles_to_push", reader_remaining_tiles_to_push}}});
                 core_index++;
             }
         }
     }
 
-    // Setup writer mcast arguments
-    // Setup sender args first.  runtime_args[0] is the weight buffer address and
-    // runtime_args[1] is the (optional) bias buffer address; both are registered
-    // as Buffer* bindings via emplace_runtime_args so the framework's fast
-    // cache-hit path patches addresses without GetRuntimeArgs.  When bias is
-    // absent we embed a literal 0 — has_bias gates the bias read on the kernel
-    // side.
-    for (const CoreRange& core_range : mcast_sender_cores.ranges()) {
+    // Writer-sender RTAs (1D mcast). weight/bias addresses now flow via TensorBinding,
+    // so they are dropped from the RTA list. out_start_tile_id_w / bias_tile_offset
+    // and the mcast rect + counts + (optional) remaining tiles remain.
+    for (const CoreRange& core_range : sender_cores.ranges()) {
         for (const CoreCoord& core : core_range) {
-            if (populate_skipped_work_cores && !output_cores.contains(core)) {
-                // Pad-out path: 14 zeros with only the semaphore/bias-flag slots
-                // populated.  weight/bias addresses are unused for skipped work
-                // cores so we keep them as literal zeros (no buffer binding).
-                KernelDescriptor::RTArgList args;
-                args.reserve(14);
-                args.push_back(uint32_t{0});  // 0: weight addr (unused for skipped cores)
-                args.push_back(uint32_t{0});  // 1: bias addr (unused)
-                for (int i = 2; i < 10; ++i) {
-                    args.push_back(uint32_t{0});
-                }
-                args.push_back(weights_mcast_sender_semaphore_id);
-                args.push_back(weights_mcast_receiver_semaphore_id);
-                args.push_back(uint32_t{1});  // is_sender_core, always true for input_cores
-                args.push_back(uint32_t{1});  // skip_work
-                writer_mcast_sender_desc.emplace_runtime_args(core, args);
-                continue;
-            }
-            // Calculate weight slice indices
-            uint32_t weight_slice_i = ((block_sharded && transpose_mcast) || !block_sharded) ? core.y : core.x;
-
-            uint32_t out_start_tile_id_w = weight_slice_i * per_core_out_matrix_width_ntiles;
-            uint32_t bias_tile_offset = out_start_tile_id_w;
-
+            const uint32_t weight_slice_i = core.y;  // 1D path
+            const uint32_t out_start_tile_id_w = weight_slice_i * per_core_out_matrix_width_ntiles;
+            const uint32_t bias_tile_offset = out_start_tile_id_w;
             TT_FATAL(
                 bias_tile_offset < bias_ntiles || !has_bias,
                 "bias_tile_offset {} should be less than bias_ntiles {}",
                 bias_tile_offset,
                 bias_ntiles);
 
-            KernelDescriptor::RTArgList sender_rt_args;
-            sender_rt_args.push_back(weights_buffer);  // 0: weight buffer address (Buffer* binding)
-            if (bias_buffer != nullptr) {
-                sender_rt_args.push_back(bias_buffer);  // 1: bias buffer address (Buffer* binding)
-            } else {
-                sender_rt_args.push_back(uint32_t{0});  // 1: bias placeholder (has_bias gates the read)
-            }
-            sender_rt_args.push_back(out_start_tile_id_w);  // 2
-            sender_rt_args.push_back(bias_tile_offset);     // 3
-
-            if (block_sharded) {
-                const bool is_sender_core = input_cores.contains(core);
-                // 2D multicast setup
-                if (transpose_mcast) {
-                    CoreCoord right_core = {(std::size_t)num_cores_x - 1, (std::size_t)core.y};
-                    CoreCoord right_core_physical = device->worker_core_from_logical_core(right_core);
-                    TT_FATAL(core.x == 0, "Expected core.x to be 0 for sender in 2D mcast setup");
-
-                    std::vector<uint32_t> mcast_coords = setup_mcast_args(
-                        writer_mcast_noc == tt::tt_metal::NOC::NOC_0,
-                        top_left_core_plus_one_physical.x,
-                        right_core_physical.y,
-                        bottom_right_core_physical.x,
-                        right_core_physical.y);
-
-                    sender_rt_args.append(mcast_coords);
-                    sender_rt_args.push_back(num_cores_x - 1);  // mcast_num_dests
-                    sender_rt_args.push_back(num_cores_x - 1);  // mcast_num_cores
-                    sender_rt_args.push_back(weights_mcast_sender_semaphore_id);
-                    sender_rt_args.push_back(weights_mcast_receiver_semaphore_id);
-                    sender_rt_args.push_back(static_cast<uint32_t>(is_sender_core));
-                    sender_rt_args.push_back(uint32_t{0});  // skip_work
-                    writer_mcast_sender_desc.emplace_runtime_args(core, sender_rt_args);
-                } else {
-                    CoreCoord top_core = {(std::size_t)core.x, 0};
-                    CoreCoord top_core_physical = device->worker_core_from_logical_core(top_core);
-                    TT_FATAL(core.y == 0, "Expected core.y to be 0 for sender in 2D mcast setup");
-                    std::vector<uint32_t> mcast_coords = setup_mcast_args(
-                        writer_mcast_noc == tt::tt_metal::NOC::NOC_0,
-                        top_core_physical.x,
-                        top_left_core_plus_one_physical.y,
-                        top_core_physical.x,
-                        bottom_right_core_physical.y);
-
-                    sender_rt_args.append(mcast_coords);
-                    sender_rt_args.push_back(num_cores_y - 1);  // mcast_num_dests
-                    sender_rt_args.push_back(num_cores_y - 1);  // mcast_num_cores
-                    sender_rt_args.push_back(weights_mcast_sender_semaphore_id);
-                    sender_rt_args.push_back(weights_mcast_receiver_semaphore_id);
-                    sender_rt_args.push_back(static_cast<uint32_t>(is_sender_core));
-                    sender_rt_args.push_back(uint32_t{0});  // skip_work
-                    writer_mcast_sender_desc.emplace_runtime_args(core, sender_rt_args);
+            m2::KernelRunArgs::RuntimeArgValues vals = {
+                {"out_start_tile_id_w", out_start_tile_id_w},
+                {"bias_tile_offset", bias_tile_offset},
+                {"mcast_noc_x_start", weights_mcast_coords[0]},
+                {"mcast_noc_y_start", weights_mcast_coords[1]},
+                {"mcast_noc_x_end", weights_mcast_coords[2]},
+                {"mcast_noc_y_end", weights_mcast_coords[3]},
+                {"weights_mcast_num_dests", total_active_num_cores - 1},
+                {"weights_mcast_num_cores", total_num_cores - 1}};
+            if (enable_activation_reuse) {
+                uint32_t writer_remaining_tiles_to_push = 0;
+                if (activation_reuse_config.has_partial_core && core == activation_reuse_config.partial_work_core) {
+                    writer_remaining_tiles_to_push =
+                        activation_reuse_config.partial_core_writer_remaining_tiles_to_push_to_push;
+                } else if (activation_reuse_config.cores_with_non_meaningful_work.contains(core)) {
+                    writer_remaining_tiles_to_push = act_block_h_nsubblocks_split_last;
                 }
-            } else {
-                // 1D multicast setup
-                std::vector<uint32_t> mcast_coords = setup_mcast_args(
-                    writer_mcast_noc == tt::tt_metal::NOC::NOC_0,
-                    top_left_core_physical.x,
-                    top_left_core_physical.y,
-                    bottom_right_core_physical.x,
-                    bottom_right_core_physical.y);
+                vals.insert({"remaining_tiles_to_push", writer_remaining_tiles_to_push});
+            }
+            sender_run.runtime_arg_values.push_back({core, std::move(vals)});
+        }
+    }
 
-                sender_rt_args.append(mcast_coords);
-                sender_rt_args.push_back(total_active_num_cores - 1);  // mcast_num_dests
-                sender_rt_args.push_back(total_num_cores - 1);         // mcast_num_cores
-                sender_rt_args.push_back(weights_mcast_sender_semaphore_id);
-                sender_rt_args.push_back(weights_mcast_receiver_semaphore_id);
+    // Writer-receiver RTAs.
+    if (!skip_weights_mcast) {
+        for (const CoreRange& core_range : receiver_cores.ranges()) {
+            for (const CoreCoord& core : core_range) {
+                const bool is_no_op_core = !input_cores.contains(core);
+                m2::KernelRunArgs::RuntimeArgValues vals = {
+                    {"noop", (uint32_t)is_no_op_core},
+                    {"weights_mcast_sender_noc_x", top_left_core_physical.x},
+                    {"weights_mcast_sender_noc_y", top_left_core_physical.y}};
                 if (enable_activation_reuse) {
                     uint32_t writer_remaining_tiles_to_push = 0;
                     if (activation_reuse_config.has_partial_core && core == activation_reuse_config.partial_work_core) {
@@ -1373,219 +1349,34 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor_sharded(
                     } else if (activation_reuse_config.cores_with_non_meaningful_work.contains(core)) {
                         writer_remaining_tiles_to_push = act_block_h_nsubblocks_split_last;
                     }
-                    sender_rt_args.push_back(writer_remaining_tiles_to_push);
+                    vals.insert({"remaining_tiles_to_push", writer_remaining_tiles_to_push});
                 }
-                writer_mcast_sender_desc.emplace_runtime_args(core, sender_rt_args);
+                receiver_run.runtime_arg_values.push_back({core, std::move(vals)});
             }
         }
     }
 
-    // Setup receiver args second
-    if (create_writer_mcast_receiver) {
-        for (const CoreRange& core_range : mcast_receiver_cores.ranges()) {
-            // Helper lambda to create receiver runtime args
-            auto create_receiver_args = [&](uint32_t sender_noc_x, uint32_t sender_noc_y) {
-                return std::vector<uint32_t>{
-                    sender_noc_x, sender_noc_y, weights_mcast_sender_semaphore_id, weights_mcast_receiver_semaphore_id};
-            };
+    (void)compute_run;  // compute kernel has no per-core RTAs on this path
+    // reader_noc was the legacy reader DataMovementConfig NoC; Metal 2.0 derives the
+    // reader's NoC from its DataMovementRoleHint, so the explicit value is unused here.
+    (void)reader_noc;
 
-            for (const CoreCoord& core : core_range) {
-                std::vector<uint32_t> receiver_args;
-                if (block_sharded) {
-                    if (transpose_mcast) {
-                        CoreCoord right_core = {(std::size_t)num_cores_x - 1, (std::size_t)core.y};
-                        CoreCoord right_core_physical = device->worker_core_from_logical_core(right_core);
-                        receiver_args = create_receiver_args(top_left_core_physical.x, right_core_physical.y);
-                    } else {
-                        CoreCoord top_core = {(std::size_t)core.x, 0};
-                        CoreCoord top_core_physical = device->worker_core_from_logical_core(top_core);
-                        receiver_args = create_receiver_args(top_core_physical.x, top_left_core_physical.y);
-                    }
-                    const bool is_sender_core = input_cores.contains(core);
-                    receiver_args.push_back(static_cast<uint32_t>(is_sender_core));
-                } else {
-                    bool is_no_op_core = !input_cores.contains(core);
-                    receiver_args = std::vector<uint32_t>{
-                        static_cast<uint32_t>(is_no_op_core),
-                        top_left_core_physical.x,
-                        top_left_core_physical.y,
-                        weights_mcast_sender_semaphore_id,
-                        weights_mcast_receiver_semaphore_id};
-                    if (enable_activation_reuse) {
-                        uint32_t writer_remaining_tiles_to_push = 0;
-                        if (activation_reuse_config.has_partial_core &&
-                            core == activation_reuse_config.partial_work_core) {
-                            writer_remaining_tiles_to_push =
-                                activation_reuse_config.partial_core_writer_remaining_tiles_to_push_to_push;
-                        } else if (activation_reuse_config.cores_with_non_meaningful_work.contains(core)) {
-                            writer_remaining_tiles_to_push = act_block_h_nsubblocks_split_last;
-                        }
-                        receiver_args.push_back(writer_remaining_tiles_to_push);
-                    }
-                }
-                writer_mcast_receiver_desc.runtime_args.emplace_back(core, std::move(receiver_args));
-            }
-        }
+    run.kernel_run_args = {reader_run, sender_run, compute_run};
+    if (!skip_weights_mcast) {
+        run.kernel_run_args.push_back(receiver_run);
     }
-
-    if (input_cores != output_cores) {
-        CoreCoord bottom_right_core_out = output_cores.bounding_box().end_coord;
-        uint32_t end_coord_x = bottom_right_core_out.x;
-        uint32_t end_coord_y = bottom_right_core_out.y;
-        for (const CoreRange range : all_cores.ranges()) {
-            for (const CoreCoord core : range) {
-                bool skip_compute = transpose_mcast ? core.y > end_coord_y : core.x > end_coord_x;
-                compute_kernel_desc.runtime_args.emplace_back(
-                    core, std::vector<uint32_t>{static_cast<uint32_t>(skip_compute)});
-            }
-        }
-    }
-
-    // Descriptor-path CB-size check (mirrors the legacy post_conv2d_op_memory_checks
-    // CB-sizing equality).  The L1-allocator delta half of the legacy check requires a
-    // realised Program and so isn't reachable here: the framework realises the Program
-    // after this function returns.
-    post_conv2d_op_memory_checks_descriptor(desc, operation_attributes, tensor_args, reader_indices_actual_page_size);
-
-    desc.kernels.push_back(std::move(writer_mcast_sender_desc));
-    if (create_writer_mcast_receiver) {
-        desc.kernels.push_back(std::move(writer_mcast_receiver_desc));
-    }
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(compute_kernel_desc));
-    return desc;
-}
-
-}  // namespace
-
-tt::tt_metal::WorkloadDescriptor Conv2dShardedProgramFactory::create_workload_descriptor(
-    const Conv2dParams& operation_attributes,
-    const Conv2dInputs& tensor_args,
-    Tensor& output_tensor,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
-    tt::tt_metal::WorkloadDescriptor workload_descriptor;
-
-    // Allocate the conv_reader_indices tensor on device once for the whole
-    // workload.  Wrap it in a shared_ptr<Tensor> so ~Tensor doesn't fire when
-    // the local goes out of scope: ~Tensor calls DeviceStorage::deallocate
-    // which force-frees the device buffer regardless of any shared_ptr
-    // ownership of the MeshBuffer (see WorkloadBuffer rationale in
-    // workload_descriptor.hpp).  Holding the Tensor in the WorkloadDescriptor
-    // defers destruction until the cached workload is evicted.
-    const auto& a = tensor_args.a;
-    const auto& sliding_window_config = operation_attributes.sliding_window_config;
-    const auto& block_config = operation_attributes.block_config;
-    const auto& parallelization_config = operation_attributes.parallelization_config;
-    const auto enable_activation_reuse = operation_attributes.enable_activation_reuse;
-    const auto force_split_reader = operation_attributes.force_split_reader;
-    const bool config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
-    const bool block_sharded = a.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
-
-    sliding_window::ParallelConfig input_parallel_config = {
-        .grid = a.memory_config().shard_spec().value().grid,
-        .shard_scheme = a.memory_config().memory_layout(),
-        .shard_orientation = a.memory_config().shard_spec().value().orientation,
+    run.tensor_args = {
+        {TP_ACT_SHARDED, a.mesh_tensor()},
+        {TP_WEIGHTS, b.mesh_tensor()},
+        {TP_OUT, output.mesh_tensor()},
+        {TP_READER_INDICES, conv_reader_indices.mesh_tensor()},
     };
-
-    std::vector<uint32_t> op_trace_metadata =
-        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
-    std::vector<sliding_window::ShardBoundary> shard_boundaries =
-        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
-
-    const uint32_t stride_w = sliding_window_config.is_transpose ? 1 : (uint32_t)sliding_window_config.stride_hw.second;
-    const uint32_t act_block_h_ntiles = block_config.act_block_h_ntiles;
-
-    // Determine the (act_block_h_datums, last) pair for the host-side index
-    // generator.  This must agree exactly with the enable_split_reader path
-    // computed by build_program_descriptor_sharded(), since the generated index tensor
-    // is consumed by the reader kernel.
-    const auto& b = tensor_args.b;
-    const auto output_channels = operation_attributes.output_channels;
-    const auto groups = operation_attributes.groups;
-    const auto has_bias = operation_attributes.has_bias;
-    const uint32_t filter_h = (uint32_t)sliding_window_config.window_hw.first;
-    const uint32_t filter_w = (uint32_t)sliding_window_config.window_hw.second;
-    const uint32_t dilation_w = (uint32_t)sliding_window_config.dilation_hw.second;
-    const ttnn::Shape ashape(operation_attributes.input_tensor_shape);
-    const std::array<uint32_t, 2> shard_shape = a.shard_spec().value().shape;
-
-    uint32_t input_channels_padded = shard_shape[1];
-    if (block_sharded) {
-        const uint32_t in_num_cores_x = input_parallel_config.grid.bounding_box().end_coord.x + 1;
-        const uint32_t in_num_cores_y = input_parallel_config.grid.bounding_box().end_coord.y + 1;
-        const bool transpose_mcast = a.shard_spec().value().orientation == ShardOrientation::COL_MAJOR;
-        input_channels_padded = shard_shape[1] * (transpose_mcast ? in_num_cores_y : in_num_cores_x);
+    if (has_bias) {
+        run.tensor_args.insert({TP_BIAS, bias.value().mesh_tensor()});
     }
-    const bool is_conv_1d_depthwise_conv =
-        is_1d_depthwise_conv(groups, ashape[3], output_channels, filter_h, ashape[1], has_bias);
 
-    auto compute_kernel_config_args =
-        get_compute_kernel_config_args(a.device()->arch(), operation_attributes.compute_kernel_config);
-    const bool fp32_dest_acc_en = std::get<2>(compute_kernel_config_args);
-
-    const bool enable_split_reader =
-        is_split_reader_supported(a.memory_config().memory_layout(), is_conv_1d_depthwise_conv, act_block_h_ntiles) &&
-        force_split_reader.value_or(is_split_reader_viable(
-            a.memory_config().memory_layout(),
-            act_block_h_ntiles,
-            input_channels_padded,
-            filter_w,
-            tt::tt_metal::hal::get_arch(),
-            a.dtype(),
-            parallelization_config.per_core_out_matrix_width_ntile * block_config.act_block_w_ntiles,
-            tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(b.dtype())),
-            dilation_w,
-            parallelization_config.per_core_out_matrix_height_ntile / block_config.act_block_h_ntiles,
-            block_config.act_block_w_ntiles,
-            fp32_dest_acc_en,
-            output_tensor.dtype(),
-            enable_activation_reuse));
-
-    uint32_t act_block_h_nsubblocks_split = block_config.act_block_h_ntiles;
-    uint32_t act_block_h_nsubblocks_split_last = 0;
-    if (enable_split_reader) {
-        act_block_h_nsubblocks_split_last = block_config.act_block_h_ntiles / 2;
-        act_block_h_nsubblocks_split = block_config.act_block_h_ntiles - act_block_h_nsubblocks_split_last;
-    }
-    const uint32_t act_block_h_datums = act_block_h_ntiles * tt::constants::TILE_HEIGHT;
-    const uint32_t act_block_h_datums_split = act_block_h_nsubblocks_split * tt::constants::TILE_HEIGHT;
-    const uint32_t act_block_h_datums_split_last = act_block_h_nsubblocks_split_last * tt::constants::TILE_HEIGHT;
-
-    std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
-        ttnn::operations::sliding_window::generate_sliding_window_op_config(
-            op_trace_metadata,
-            shard_boundaries,
-            stride_w,
-            true,
-            enable_split_reader ? act_block_h_datums_split : act_block_h_datums,
-            enable_split_reader ? act_block_h_datums_split_last : 0);
-
-    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
-        conv_sharded_input_top_left_indices, input_parallel_config, config_tensors_in_dram);
-    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
-        conv_reader_indices_tensor, input_parallel_config, block_sharded, a.device(), config_tensors_in_dram);
-
-    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
-
-    auto conv_reader_indices_tensor_owner = std::make_shared<Tensor>(std::move(conv_reader_indices_tensor));
-    tt::tt_metal::Buffer* conv_reader_indices_buffer = conv_reader_indices_tensor_owner->buffer();
-    workload_descriptor.buffers.push_back({conv_reader_indices_tensor_owner, conv_reader_indices_buffer});
-
-    // Single-device op: per-coord program is structurally identical for every
-    // coord in `tensor_coords` (conv2d doesn't depend on cluster position).
-    // Build the ProgramDescriptor once and copy into each range entry.
-    tt::tt_metal::ProgramDescriptor desc =
-        build_program_descriptor_sharded(operation_attributes, tensor_args, output_tensor, conv_reader_indices_buffer);
-
-    auto ranges = tensor_coords.ranges();
-    workload_descriptor.programs.reserve(ranges.size());
-    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
-        workload_descriptor.programs.push_back({ranges[i], desc});
-    }
-    if (!ranges.empty()) {
-        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
-    }
-    return workload_descriptor;
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec), .run_params = std::move(run), .op_owned_tensors = std::move(op_owned_tensors)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_sharded_program_factory.hpp
@@ -3,23 +3,24 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct Conv2dShardedProgramFactory {
-    // Builds the workload in one call (cache miss).  The intermediate
-    // conv_reader_indices tensor — which must outlive the cached program — is
-    // allocated here and parked on the WorkloadDescriptor's `buffers` vector
-    // (wrapped in `shared_ptr<Tensor>` so `~Tensor` cannot force-deallocate the
-    // device memory while the cached program is still alive).
-    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
-        const Conv2dParams& operation_attributes,
-        const Conv2dInputs& tensor_args,
-        Tensor& output_tensor,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+    // Metal 2.0 program factory (ProgramSpecFactoryConcept). Produces the immutable
+    // ProgramSpec, its mutable ProgramRunArgs, and the op-owned conv_reader_indices
+    // tensor (host-populated index table backing the READER_INDICES borrowed-memory
+    // DFB). Ports the dense / height-sharded L1 config-tensor path only:
+    //   - config_tensors_in_dram == false (the in-DRAM path threads a raw buffer
+    //     address through a CTA -> Metal 2.0 framework blocker; TT_FATALs here).
+    //   - HEIGHT_SHARDED, non-1D-depthwise (BLOCK_SHARDED / depthwise / the
+    //     input_cores != output_cores noop-core path TT_FATAL here; they remain on
+    //     the legacy concept and would be ported separately).
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
+        const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -55,49 +55,16 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activat
 
 namespace {
 
-// Metal 2.0 DFB unique-ids, one per (non-zero-page) Conv2dCb the width-sharded
-// kernels reference. Naming mirrors the kernel-side dfb:: accessor tokens.
-const m2::DFBSpecName DFB_ACT_SHARDED{"act_sharded"};
-const m2::DFBSpecName DFB_ACT{"act"};
-const m2::DFBSpecName DFB_ACT_ROW_MAJOR{"act_row_major"};
-const m2::DFBSpecName DFB_ACT_TILIZED{"act_tilized"};
-const m2::DFBSpecName DFB_WEIGHTS{"weights"};
-const m2::DFBSpecName DFB_BIAS{"bias"};
-const m2::DFBSpecName DFB_READER_INDICES{"reader_indices"};
-const m2::DFBSpecName DFB_L1_ARRAY{"l1_array"};
-const m2::DFBSpecName DFB_MATMUL_PARTIALS{"matmul_partials"};
-const m2::DFBSpecName DFB_OUT{"out"};
-
-const m2::TensorParamName TP_WEIGHTS{"weights"};
-const m2::TensorParamName TP_BIAS{"bias"};
-const m2::TensorParamName TP_READER_INDICES{"reader_indices"};
-const m2::TensorParamName TP_ACT_SHARDED{"act_sharded"};
-const m2::TensorParamName TP_OUT{"out"};
-
+// Shared Metal 2.0 DFB / TensorParameter names + dfb_name_for() live in
+// conv2d_op_program_factory_common.hpp (inline) to avoid a unity-build ODR clash
+// with the sibling Conv2dShardedProgramFactory .cpp. Only the per-factory kernel
+// and semaphore names are declared here.
 const m2::KernelSpecName K_ACT{"act_reader"};
 const m2::KernelSpecName K_WEIGHTS{"weights_reader"};
 const m2::KernelSpecName K_COMPUTE{"compute"};
 
 const m2::SemaphoreSpecName SEM_SENDER{"act_mcast_sender"};
 const m2::SemaphoreSpecName SEM_RECEIVER{"act_mcast_receiver"};
-
-// Map a Conv2dCb to the DFBSpecName the kernels reference. Used only for the
-// (non-zero-page) CBs the width-sharded path actually allocates.
-m2::DFBSpecName dfb_name_for(Conv2dCb cb) {
-    switch (cb) {
-        case Conv2dCb::ACT_SHARDED: return DFB_ACT_SHARDED;
-        case Conv2dCb::ACT: return DFB_ACT;
-        case Conv2dCb::ACT_ROW_MAJOR_BFLOAT16: return DFB_ACT_ROW_MAJOR;
-        case Conv2dCb::ACT_TILIZED: return DFB_ACT_TILIZED;
-        case Conv2dCb::WEIGHTS: return DFB_WEIGHTS;
-        case Conv2dCb::BIAS: return DFB_BIAS;
-        case Conv2dCb::READER_INDICES: return DFB_READER_INDICES;
-        case Conv2dCb::L1_ARRAY: return DFB_L1_ARRAY;
-        case Conv2dCb::MATMUL_PARTIALS: return DFB_MATMUL_PARTIALS;
-        case Conv2dCb::OUT: return DFB_OUT;
-        default: TT_THROW("Unexpected Conv2dCb in width-sharded Metal 2.0 spec: {}", static_cast<int>(cb));
-    }
-}
 
 }  // namespace
 

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.cpp
@@ -3,9 +3,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
+#include <filesystem>
+#include <map>
 #include <memory>
 #include <string>
 #include <utility>
+#include <vector>
 #include "ttnn/operations/conv/conv2d/conv2d_op_program_factory_common.hpp"
 #include "ttnn/operations/eltwise/unary/common/unary_op_utils.hpp"
 #include "ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp"
@@ -16,14 +19,16 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/compute_throttle_utils.hpp"
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 namespace ttnn::prim {
 
 namespace unary = ttnn::operations::unary;
+namespace m2 = tt::tt_metal::experimental;
 using ttnn::operations::conv::conv_skip_mcast;
 using ttnn::operations::conv::SkipMcast;
 
@@ -50,39 +55,60 @@ std::pair<std::vector<uint32_t>, std::vector<uint32_t>> compute_opt_conv_activat
 
 namespace {
 
-// The intermediate conv_reader_indices tensor is allocated once by
-// create_workload_descriptor and parked on the WorkloadDescriptor; we receive
-// the raw Buffer* here and wire it into the READER_INDICES CB and reader CT args.
-tt::tt_metal::ProgramDescriptor build_program_descriptor(
-    const Conv2dParams& operation_attributes,
-    const Conv2dInputs& tensor_args,
-    Tensor& output_tensor,
-    tt::tt_metal::Buffer* conv_reader_indices_buffer) {
-    using tt::tt_metal::CBDescriptor;
-    using tt::tt_metal::CBFormatDescriptor;
-    using tt::tt_metal::ComputeConfigDescriptor;
-    using tt::tt_metal::DataMovementConfigDescriptor;
-    using tt::tt_metal::KernelDescriptor;
-    using tt::tt_metal::ProgramDescriptor;
-    using tt::tt_metal::SemaphoreDescriptor;
+// Metal 2.0 DFB unique-ids, one per (non-zero-page) Conv2dCb the width-sharded
+// kernels reference. Naming mirrors the kernel-side dfb:: accessor tokens.
+const m2::DFBSpecName DFB_ACT_SHARDED{"act_sharded"};
+const m2::DFBSpecName DFB_ACT{"act"};
+const m2::DFBSpecName DFB_ACT_ROW_MAJOR{"act_row_major"};
+const m2::DFBSpecName DFB_ACT_TILIZED{"act_tilized"};
+const m2::DFBSpecName DFB_WEIGHTS{"weights"};
+const m2::DFBSpecName DFB_BIAS{"bias"};
+const m2::DFBSpecName DFB_READER_INDICES{"reader_indices"};
+const m2::DFBSpecName DFB_L1_ARRAY{"l1_array"};
+const m2::DFBSpecName DFB_MATMUL_PARTIALS{"matmul_partials"};
+const m2::DFBSpecName DFB_OUT{"out"};
 
-    ProgramDescriptor desc;
+const m2::TensorParamName TP_WEIGHTS{"weights"};
+const m2::TensorParamName TP_BIAS{"bias"};
+const m2::TensorParamName TP_READER_INDICES{"reader_indices"};
+const m2::TensorParamName TP_ACT_SHARDED{"act_sharded"};
+const m2::TensorParamName TP_OUT{"out"};
+
+const m2::KernelSpecName K_ACT{"act_reader"};
+const m2::KernelSpecName K_WEIGHTS{"weights_reader"};
+const m2::KernelSpecName K_COMPUTE{"compute"};
+
+const m2::SemaphoreSpecName SEM_SENDER{"act_mcast_sender"};
+const m2::SemaphoreSpecName SEM_RECEIVER{"act_mcast_receiver"};
+
+// Map a Conv2dCb to the DFBSpecName the kernels reference. Used only for the
+// (non-zero-page) CBs the width-sharded path actually allocates.
+m2::DFBSpecName dfb_name_for(Conv2dCb cb) {
+    switch (cb) {
+        case Conv2dCb::ACT_SHARDED: return DFB_ACT_SHARDED;
+        case Conv2dCb::ACT: return DFB_ACT;
+        case Conv2dCb::ACT_ROW_MAJOR_BFLOAT16: return DFB_ACT_ROW_MAJOR;
+        case Conv2dCb::ACT_TILIZED: return DFB_ACT_TILIZED;
+        case Conv2dCb::WEIGHTS: return DFB_WEIGHTS;
+        case Conv2dCb::BIAS: return DFB_BIAS;
+        case Conv2dCb::READER_INDICES: return DFB_READER_INDICES;
+        case Conv2dCb::L1_ARRAY: return DFB_L1_ARRAY;
+        case Conv2dCb::MATMUL_PARTIALS: return DFB_MATMUL_PARTIALS;
+        case Conv2dCb::OUT: return DFB_OUT;
+        default: TT_THROW("Unexpected Conv2dCb in width-sharded Metal 2.0 spec: {}", static_cast<int>(cb));
+    }
+}
+
+}  // namespace
+
+ttnn::device_operation::ProgramArtifacts Conv2dWidthShardedProgramFactory::create_program_spec(
+    const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor) {
     const auto& a = tensor_args.a;
     const auto& b = tensor_args.b;
 
     const auto& ashape = ttnn::Shape(operation_attributes.input_tensor_shape);
     const auto& bias = tensor_args.bias;
     const auto& sliding_window_config = operation_attributes.sliding_window_config;
-
-    ttnn::operations::sliding_window::ParallelConfig parallel_config{
-        .grid = a.shard_spec().value().grid,
-        .shard_scheme = a.memory_config().memory_layout(),
-        .shard_orientation = a.shard_spec().value().orientation};
-
-    std::vector<uint32_t> op_trace_metadata =
-        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
-    std::vector<sliding_window::ShardBoundary> shard_boundaries =
-        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
 
     const auto output_channels = operation_attributes.output_channels;
     const auto untilize_out = operation_attributes.untilize_out;
@@ -95,6 +121,15 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
     const auto enable_act_double_buffer = operation_attributes.enable_act_double_buffer;
     const auto enable_weights_double_buffer = operation_attributes.enable_weights_double_buffer;
     const auto config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
+
+    // The in-DRAM config-tensor path threads conv_reader_indices_buffer->address()
+    // and ->page_size() through CTAs into the activation kernel (consumed under
+    // #ifdef CONFIG_TENSOR_IN_DRAM). A raw buffer address through a CTA is an
+    // enumerated Metal 2.0 framework blocker; only the L1 config path is ported.
+    TT_FATAL(
+        !config_tensors_in_dram,
+        "Conv2dWidthShardedProgramFactory::create_program_spec only supports the L1 config-tensor path "
+        "(config_tensors_in_dram == false); the in-DRAM path remains a Metal 2.0 blocker.");
 
     tt::tt_metal::IDevice* device = a.device();
     TT_FATAL(a.layout() == tt::tt_metal::Layout::ROW_MAJOR, "Conv activation should be in row major layout");
@@ -162,7 +197,7 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
 
     uint32_t pad_w = (uint32_t)sliding_window_config.get_pad_w();
 
-    uint32_t input_size_w = conv_act_size_w + pad_w;
+    [[maybe_unused]] uint32_t input_size_w = conv_act_size_w + pad_w;
     if (sliding_window_config.is_transpose) {
         auto input_shape = sliding_window_config.get_transposed_full_input_shape();
         input_size_w = input_shape[2];
@@ -338,12 +373,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
 
     uint32_t conv_act_c_read_bytes = conv_act_size_c * a.element_size() / (input_num_cores * per_core_num_blocks_act_w);
 
-    std::string compute_kernel_path = "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize.cpp";
-    std::string activation_kernel_path =
-        "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp";
-    std::string weights_kernel_path =
-        "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp";
-
     bool tilize_in0 = false;
 
     // Select preferred NoCs for DRAM operations based on architecture
@@ -360,21 +389,6 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
         (uint32_t)act_noc,
         (uint32_t)weights_noc,
         (uint32_t)device->arch());
-
-    // Sequential semaphore IDs match the order in which CreateSemaphore would have
-    // allocated them; the framework realises desc.semaphores in this order on cache miss.
-    uint32_t act_mcast_sender_semaphore = static_cast<uint32_t>(desc.semaphores.size());
-    desc.semaphores.push_back(SemaphoreDescriptor{
-        .id = act_mcast_sender_semaphore,
-        .core_ranges = all_cores,
-        .initial_value = 0,  // 0 == INVALID
-    });
-    uint32_t act_mcast_receiver_semaphore = static_cast<uint32_t>(desc.semaphores.size());
-    desc.semaphores.push_back(SemaphoreDescriptor{
-        .id = act_mcast_receiver_semaphore,
-        .core_ranges = all_cores,
-        .initial_value = 0,  // 0 == INVALID
-    });
 
     CoreCoord act_mcast_start_core_logical(0, 0);
     CoreCoord act_mcast_end_core_logical(all_cores.bounding_box().end_coord.x, all_cores.bounding_box().end_coord.y);
@@ -407,8 +421,13 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
         reader_defines["SKIP_MCAST"] = "1";
     }
     if (skip_weights_mcast) {
+        // NOTE (behavior-preserving): the legacy width-sharded factory populated this
+        // map but never applied it to any kernel — skip_weights_mcast never reaches
+        // the weights kernel. Preserved verbatim (not "fixed"); flagged in the port
+        // report for the op owner.
         writer_mcast_sender_defines["SKIP_MCAST"] = "1";
     }
+    (void)writer_mcast_sender_defines;
 
     bool pack_relu = fused_activation.has_value() && fused_activation.value().op_type == unary::UnaryOpType::RELU;
     if (fused_activation.has_value() && !pack_relu) {
@@ -432,14 +451,36 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
         .enable_act_double_buffer = enable_act_double_buffer,
         .enable_weights_double_buffer = enable_weights_double_buffer};
 
-    // The conv_reader_indices tensor itself is allocated once in
-    // create_workload_descriptor and parked on workload_descriptor.buffers; we
-    // receive the raw Buffer* and read its page size for the CB sizing below.
-    // Pass the actual DRAM/L1-small config buffer page size into get_cb_info so the predicted
-    // READER_INDICES CB footprint matches the CB this factory creates. Without this, the in-DRAM
-    // path was sized to the worst case (1 uint16 per output row), holding spare L1 that is never
-    // populated by the reader kernel.
+    // ---- Op-owned conv_reader_indices tensor ----
+    // The host-populated index table that backs the READER_INDICES borrowed-memory
+    // DFB. Allocated + uploaded here (L1-sharded in the L1 config path) and parked
+    // in ProgramArtifacts::op_owned_tensors so the adapter keeps it alive (stable
+    // address) for the cached Program's life.
+    ttnn::operations::sliding_window::ParallelConfig parallel_config{
+        .grid = a.shard_spec().value().grid,
+        .shard_scheme = a.memory_config().memory_layout(),
+        .shard_orientation = a.shard_spec().value().orientation};
+    std::vector<uint32_t> op_trace_metadata =
+        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
+    std::vector<sliding_window::ShardBoundary> shard_boundaries =
+        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
+    std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
+        ttnn::operations::sliding_window::generate_sliding_window_op_config(
+            op_trace_metadata, shard_boundaries, stride_w, true, act_block_h_datums, 0);
+    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
+        conv_sharded_input_top_left_indices, parallel_config, config_tensors_in_dram);
+    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
+        conv_reader_indices_tensor, parallel_config, false, a.device(), config_tensors_in_dram);
+    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
+
+    std::vector<tt::tt_metal::Tensor> op_owned_tensors;
+    op_owned_tensors.reserve(1);
+    op_owned_tensors.push_back(std::move(conv_reader_indices_tensor));
+    // Build all tensor bindings against the VECTOR ELEMENT (identity footgun).
+    const Tensor& conv_reader_indices = op_owned_tensors[0];
+    tt::tt_metal::Buffer* conv_reader_indices_buffer = conv_reader_indices.buffer();
     const uint32_t reader_indices_actual_page_size = conv_reader_indices_buffer->page_size();
+
     std::vector<CBInfo> cb_info = get_cb_info(
         compute_kernel_config,
         block_config,
@@ -459,297 +500,359 @@ tt::tt_metal::ProgramDescriptor build_program_descriptor(
         input_channels_padded,
         reader_indices_actual_page_size);
 
-    // Emit CBDescriptors directly onto the ProgramDescriptor.  The framework
-    // tracks the globally-allocated CBs (ACT_SHARDED on input, OUT/PARTIALS on
-    // output, READER_INDICES on the workload-scoped indices buffer) and patches
-    // their addresses on cache hits — no per-op UpdateDynamicCircularBufferAddress
-    // override needed.
-    const CoreRangeSet all_reader_cores_set(all_reader_cores);
-    emit_cb_descriptors(cb_info, desc, all_reader_cores_set, a.buffer(), output.buffer(), conv_reader_indices_buffer);
-    // partials_cb_uses_output is still consumed by compute_kernel_args below; the
-    // CB-on-output wiring is handled inline by emit_cb_descriptors (MATMUL_PARTIALS
-    // is mapped to output_buffer when is_globally_allocated is true), so we no
-    // longer need to call UpdateDynamicCircularBufferAddress on cache hit.
     const bool partials_cb_uses_output = get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).is_globally_allocated;
 
-    std::vector<uint32_t> compute_kernel_args = {
-        act_block_w_ntiles,                         // in0_block_w
-        act_num_subblocks,                          // in0_num_sublocks
-        act_block_num_tiles,                        // in0_block_num_tiles,
-        act_subblock_num_tiles,                     // in0_sublock_num_tiles
-        act_subblock_h_ntiles * act_num_subblocks,  // reader_num_h_subblocks
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "conv2d_width_sharded";
 
-        weight_num_subblocks,    // in1_num_sublocks
-        weight_block_num_tiles,  // in1_block_num_tiles,
-        weight_block_w_ntiles,   // in1_block_w
-
-        num_blocks_act_h_per_core,     // in0_num_blocks_h
-        num_blocks_act_w,              // in0_num_blocks_w,
-        num_blocks_weight_w_per_core,  // in1_num_blocks_w
-
-        out_subblock_h_ntiles,   // out_sublock_h
-        out_subblock_w_ntiles,   // out_sublock_w
-        out_subblock_num_tiles,  // out_sublock_num_tiles
-
-        tilize_in0,    // tilize_in0
-        untilize_out,  // untilize_out
-
-        bias_ntiles,
-        get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::MATMUL_PARTIALS).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::OUT).index,
-        partials_cb_uses_output,
-        input_num_cores,  // in0_nblocks_w_tilize. Repeat tilize after all cores have done one round of MCAST.
-        false,            // check_skip_compute; not used in width sharded
-        pack_relu,
-        weight_block_w_ntiles <= 8,  // packer_untilize
-        packer_l1_acc,
-        has_bias,
-        false,  // enable_split_reader (not used in width sharded)
-        false,  // enable_activation_reuse (not used in width sharded)
-        0,
-        0,
-        0,
-        0,                              // activation reuse related arguments
-        static_cast<uint32_t>(false)};  // split_reader_cb_shared (not used in width sharded)
-
-    std::vector<uint32_t> activation_kernel_compile_args = {
-        (uint32_t)stride_w,
-        (uint32_t)dilation_h,
-        (uint32_t)dilation_w,
-        (uint32_t)input_size_w,
-        (uint32_t)conv_act_c_read_bytes,
-        (uint32_t)filter_h,  // Input filter window height
-        (uint32_t)filter_w,  // Input filter window width
-        (uint32_t)act_block_h_datums,
-        (uint32_t)act_block_num_tiles,
-        (uint32_t)input_num_cores,
-        (uint32_t)num_blocks_act_h_per_core,
-        (uint32_t)per_core_num_blocks_act_w,
-        (uint32_t)act_mcast_sender_semaphore,
-        (uint32_t)act_mcast_receiver_semaphore,
-        (uint32_t)act_mcast_start.x,
-        (uint32_t)act_mcast_start.y,
-        (uint32_t)act_mcast_end.x,
-        (uint32_t)act_mcast_end.y,
-        (uint32_t)act_block_num_tiles * tt::tile_size(tilized_act_df),
-        (uint32_t)output_num_cores,
-        (uint32_t)all_reader_cores.size(),
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_SHARDED).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::READER_INDICES).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::L1_ARRAY).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_ROW_MAJOR_BFLOAT16).index,
-        get_cb_info_by_name(cb_info, Conv2dCb::ACT_TILIZED).index};
-
-    std::vector<uint32_t> weights_kernel_compile_args = {
-        get_cb_info_by_name(cb_info, Conv2dCb::WEIGHTS).index,          // cb_id_weight
-        act_block_w_ntiles / (filter_h * filter_w),                     // core_in_channels_ntiles
-        filter_h * filter_w,                                            // window_size_hw
-        weight_block_w_ntiles,                                          // weight_block_width_ntiles
-        weight_block_num_tiles,                                         // weight_block_num_tiles
-        weight_matrix_width_ntiles,                                     // weight_matrix_width_ntiles
-        (weight_matrix_width_ntiles * input_channels_padded) / 32,      // weight_next_channel_stride_h
-        weight_matrix_width_ntiles * weight_block_in_channels_ntiles,   // weight_next_block_this_core_stride_h
-        weight_matrix_width_ntiles * weight_block_in_channels_ntiles *  // weight_next_block_other_core_stride_h
-            per_core_num_blocks_act_w,
-        input_num_cores,            // other_core_weight_height_blocks
-        per_core_num_blocks_act_w,  // this_core_weight_height_blocks
-        num_blocks_act_h_per_core,
-        get_cb_info_by_name(cb_info, Conv2dCb::BIAS).index,
-        (uint32_t)has_bias};
-
-    if (config_tensors_in_dram) {
-        reader_defines["CONFIG_TENSOR_IN_DRAM"] = "1";
-        activation_kernel_compile_args.push_back(conv_reader_indices_buffer->address());
-        activation_kernel_compile_args.push_back(conv_reader_indices_buffer->page_size());
-        tt::tt_metal::TensorAccessorArgs(conv_reader_indices_buffer).append_to(activation_kernel_compile_args);
+    // One DataflowBufferSpec per non-zero-page CBInfo. Globally-allocated CBs become
+    // borrowed-memory DFBs (borrowed_from the backing TensorParameter); the others are
+    // Program-local L1 DFBs. CB index assignment from emit_cb_descriptors is irrelevant
+    // here — Metal 2.0 derives indices from bindings — but the per-CB entry_size /
+    // num_entries / data_format are taken verbatim from CBInfo.
+    for (const auto& cb : cb_info) {
+        if (cb.num_pages == 0) {
+            continue;  // matches emit_cb_descriptors / allocate_cbs skip
+        }
+        m2::DataflowBufferSpec dfb{
+            .unique_id = dfb_name_for(cb.name),
+            .entry_size = cb.page_size,
+            .num_entries = cb.num_pages,
+            .data_format_metadata = cb.data_format};
+        if (cb.is_globally_allocated) {
+            switch (cb.name) {
+                case Conv2dCb::ACT_SHARDED: dfb.borrowed_from = TP_ACT_SHARDED; break;
+                case Conv2dCb::OUT:
+                case Conv2dCb::MATMUL_PARTIALS: dfb.borrowed_from = TP_OUT; break;
+                case Conv2dCb::READER_INDICES: dfb.borrowed_from = TP_READER_INDICES; break;
+                default:
+                    TT_THROW("Unexpected globally-allocated CB {} in width-sharded spec", static_cast<int>(cb.name));
+            }
+        }
+        spec.dataflow_buffers.push_back(std::move(dfb));
     }
 
-    for (uint32_t index = 0; index < activation_kernel_compile_args.size(); index++) {
-        log_debug(tt::LogOp, "activation_kernel_compile_args[{}] = {}", index, activation_kernel_compile_args[index]);
-    }
+    const bool has_act_second_reader = get_cb_info_by_name(cb_info, Conv2dCb::ACT_SECOND_READER).num_pages != 0;
 
-    tt::tt_metal::TensorAccessorArgs(b.buffer()).append_to(weights_kernel_compile_args);
-    tt::tt_metal::TensorAccessorArgs(bias ? bias->buffer() : nullptr).append_to(weights_kernel_compile_args);
-
-    KernelDescriptor act_kernel_desc;
-    act_kernel_desc.kernel_source = activation_kernel_path;
-    act_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    act_kernel_desc.core_ranges = CoreRangeSet(all_reader_cores);
-    act_kernel_desc.compile_time_args = std::move(activation_kernel_compile_args);
-    for (const auto& [k, v] : reader_defines) {
-        act_kernel_desc.defines.emplace_back(k, v);
-    }
-    act_kernel_desc.config = DataMovementConfigDescriptor{
-        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-        .noc = act_noc,
+    // ---- Semaphores (program-local mcast) ----
+    spec.semaphores = {
+        m2::SemaphoreSpec{.unique_id = SEM_SENDER, .target_nodes = all_cores},
+        m2::SemaphoreSpec{.unique_id = SEM_RECEIVER, .target_nodes = all_cores},
     };
 
-    KernelDescriptor weights_kernel_desc;
-    weights_kernel_desc.kernel_source = weights_kernel_path;
-    weights_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    weights_kernel_desc.core_ranges = all_cores;
-    weights_kernel_desc.compile_time_args = std::move(weights_kernel_compile_args);
-    for (const auto& [k, v] : writer_defines) {
-        weights_kernel_desc.defines.emplace_back(k, v);
-    }
-    weights_kernel_desc.config = DataMovementConfigDescriptor{
-        .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-        .noc = weights_noc,
+    // ---- Activation reader kernel (RISCV_0) ----
+    // Named CTAs replace the positional CT args; semaphore-id CTAs become sem::
+    // bindings; CB-id CTAs become dfb:: bindings. The two per-core mcast lookup
+    // tables (variable length) move to runtime varargs after the three named RTAs.
+    m2::KernelSpec act_kernel{
+        .unique_id = K_ACT,
+        .source =
+            std::filesystem::path{
+                "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp"},
+        .compile_time_args =
+            {{"stride_w", stride_w},
+             {"dilation_h", dilation_h},
+             {"dilation_w", dilation_w},
+             {"conv_act_size_w", conv_act_size_w},
+             {"conv_act_c_read_bytes", conv_act_c_read_bytes},
+             {"weight_size_h", filter_h},
+             {"weight_size_w", filter_w},
+             {"act_block_h_datums", act_block_h_datums},
+             {"act_block_num_tiles", act_block_num_tiles},
+             {"num_input_cores", (uint32_t)input_num_cores},
+             {"act_num_blocks_h", num_blocks_act_h_per_core},
+             {"act_num_blocks_w", per_core_num_blocks_act_w},
+             {"mcast_noc_x_start", (uint32_t)act_mcast_start.x},
+             {"mcast_noc_y_start", (uint32_t)act_mcast_start.y},
+             {"mcast_noc_x_end", (uint32_t)act_mcast_end.x},
+             {"mcast_noc_y_end", (uint32_t)act_mcast_end.y},
+             {"act_mcast_sender_size_bytes", (uint32_t)(act_block_num_tiles * tt::tile_size(tilized_act_df))},
+             {"num_output_cores", (uint32_t)output_num_cores},
+             {"num_reader_cores", (uint32_t)all_reader_cores.size()}},
+        .runtime_arg_schema = {.runtime_arg_names = {"this_core_x", "this_core_y", "num_cores_x"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
     };
-
-    KernelDescriptor compute_kernel_desc;
-    compute_kernel_desc.kernel_source = compute_kernel_path;
-    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_kernel_desc.core_ranges = all_cores;
-    compute_kernel_desc.compile_time_args = std::move(compute_kernel_args);
-    for (const auto& [k, v] : compute_defines) {
-        compute_kernel_desc.defines.emplace_back(k, v);
-    }
-    compute_kernel_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = math_fidelity,
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-    };
-
+    // mcast lookup tables: 2 * full_core_grid.x|.y entries appended as varargs.
     auto full_core_grid = device->compute_with_storage_grid_size();
-    std::vector<uint32_t> act_mcast_noc_y;
-    std::vector<uint32_t> act_mcast_noc_x;
+    act_kernel.advanced_options.num_runtime_varargs = full_core_grid.x + full_core_grid.y;
+    {
+        m2::KernelSpec::CompilerOptions::Defines d;
+        for (const auto& [k, v] : reader_defines) {
+            d.insert({k, v});
+        }
+        act_kernel.compiler_options.defines = std::move(d);
+    }
+    // Act reader DFB bindings: produces ACT_ROW_MAJOR (from L1 reads), participates
+    // in the ACT/ACT_TILIZED mcast loop, and consumes READER_INDICES / ACT_SHARDED /
+    // L1_ARRAY as borrowed/scratch address sources (self-loop — no real FIFO peer).
+    act_kernel.dfb_bindings = {
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT_ROW_MAJOR,
+            .accessor_name = "act_row_major",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT, .accessor_name = "act", .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT_TILIZED,
+            .accessor_name = "act_tilized",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        // ACT_SHARDED / READER_INDICES / L1_ARRAY: base-pointer address sources only
+        // (no FIFO peer) -> self-loop to satisfy the producer+consumer invariant.
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT_SHARDED,
+            .accessor_name = "act_sharded",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT_SHARDED,
+            .accessor_name = "act_sharded",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_READER_INDICES,
+            .accessor_name = "reader_indices",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_READER_INDICES,
+            .accessor_name = "reader_indices",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_L1_ARRAY, .accessor_name = "l1_array", .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_L1_ARRAY, .accessor_name = "l1_array", .endpoint_type = m2::DFBEndpointType::CONSUMER},
+    };
+    act_kernel.semaphore_bindings = {
+        m2::SemaphoreBinding{.semaphore_spec_name = SEM_SENDER, .accessor_name = "act_mcast_sender"},
+        m2::SemaphoreBinding{.semaphore_spec_name = SEM_RECEIVER, .accessor_name = "act_mcast_receiver"},
+    };
+    act_kernel.tensor_bindings = {
+        m2::TensorBinding{.tensor_parameter_name = TP_ACT_SHARDED, .accessor_name = "act_sharded"},
+        m2::TensorBinding{.tensor_parameter_name = TP_READER_INDICES, .accessor_name = "reader_indices"},
+    };
 
+    // ---- Weights/bias reader kernel (RISCV_1) ----
+    m2::KernelSpec weights_kernel{
+        .unique_id = K_WEIGHTS,
+        .source =
+            std::filesystem::path{
+                "ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp"},
+        .compile_time_args =
+            {{"core_in_channels_ntiles", act_block_w_ntiles / (filter_h * filter_w)},
+             {"window_size_hw", filter_h * filter_w},
+             {"weight_block_width_ntiles", weight_block_w_ntiles},
+             {"weight_block_num_tiles", weight_block_num_tiles},
+             {"weight_matrix_width_ntiles", weight_matrix_width_ntiles},
+             {"weight_next_channel_stride_h", (weight_matrix_width_ntiles * input_channels_padded) / 32},
+             {"weight_next_block_this_core_stride_h", weight_matrix_width_ntiles * weight_block_in_channels_ntiles},
+             {"weight_next_block_other_core_stride_h",
+              weight_matrix_width_ntiles * weight_block_in_channels_ntiles * per_core_num_blocks_act_w},
+             {"remote_weight_height_blocks", (uint32_t)input_num_cores},
+             {"local_weight_height_blocks", per_core_num_blocks_act_w},
+             {"act_num_blocks_h", num_blocks_act_h_per_core},
+             {"fuse_bias", (uint32_t)has_bias}},
+        .runtime_arg_schema = {.runtime_arg_names = {"init_weight_start_tile_id", "is_active"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+    weights_kernel.dfb_bindings = {
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_WEIGHTS, .accessor_name = "weights", .endpoint_type = m2::DFBEndpointType::PRODUCER},
+    };
+    weights_kernel.tensor_bindings = {
+        m2::TensorBinding{.tensor_parameter_name = TP_WEIGHTS, .accessor_name = "weights"},
+    };
+    {
+        m2::KernelSpec::CompilerOptions::Defines d;
+        for (const auto& [k, v] : writer_defines) {
+            d.insert({k, v});
+        }
+        if (has_bias) {
+            d.insert({"FUSE_BIAS", "1"});
+            weights_kernel.dfb_bindings.push_back(m2::DFBBinding{
+                .dfb_spec_name = DFB_BIAS, .accessor_name = "bias", .endpoint_type = m2::DFBEndpointType::PRODUCER});
+            weights_kernel.tensor_bindings.push_back(
+                m2::TensorBinding{.tensor_parameter_name = TP_BIAS, .accessor_name = "bias"});
+        }
+        weights_kernel.compiler_options.defines = std::move(d);
+    }
+
+    // ---- Compute kernel (forked: conv_bmm_tilize_m2.cpp) ----
+    m2::KernelSpec compute_kernel{
+        .unique_id = K_COMPUTE,
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_m2.cpp"},
+        .compile_time_args =
+            {{"in0_block_w", act_block_w_ntiles},
+             {"in0_num_subblocks", act_num_subblocks},
+             {"in0_block_num_tiles", act_block_num_tiles},
+             {"in0_subblock_num_tiles", act_subblock_num_tiles},
+             {"reader_num_h_subblocks", act_subblock_h_ntiles * act_num_subblocks},
+             {"in1_num_subblocks", weight_num_subblocks},
+             {"in1_block_num_tiles", weight_block_num_tiles},
+             {"in1_block_w", weight_block_w_ntiles},
+             {"in0_num_blocks_h", num_blocks_act_h_per_core},
+             {"in0_num_blocks_w", num_blocks_act_w},
+             {"in1_num_blocks_w", num_blocks_weight_w_per_core},
+             {"out_subblock_h", out_subblock_h_ntiles},
+             {"out_subblock_w", out_subblock_w_ntiles},
+             {"out_subblock_num_tiles", out_subblock_num_tiles},
+             {"height_sharded", (uint32_t)tilize_in0},
+             {"untilize_out", (uint32_t)untilize_out},
+             {"bias_ntiles_w", bias_ntiles},
+             {"partials_cb_uses_output", (uint32_t)partials_cb_uses_output},
+             {"in0_nblocks_w_tilize", (uint32_t)input_num_cores},
+             {"check_skip_compute", 0u},
+             {"pack_relu", (uint32_t)pack_relu},
+             {"packer_untilize", (uint32_t)(weight_block_w_ntiles <= 8)},
+             {"packer_l1_acc", (uint32_t)packer_l1_acc},
+             {"fuse_bias", (uint32_t)has_bias},
+             {"split_reader", 0u},
+             {"activation_reuse", 0u},
+             {"image_width_in_tiles", 0u},
+             {"window_reuse_offset", 0u},
+             {"tilized_cb_row_offset", 0u},
+             {"tilized_cb_second_reader_offset", 0u},
+             {"split_reader_cb_shared", 0u}},
+        .hw_config =
+            m2::ComputeHardwareConfig{
+                .math_fidelity = math_fidelity,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+            },
+    };
+    compute_kernel.dfb_bindings = {
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT, .accessor_name = "act", .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT_ROW_MAJOR,
+            .accessor_name = "act_row_major",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_ACT_TILIZED,
+            .accessor_name = "act_tilized",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_WEIGHTS, .accessor_name = "weights", .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        // MATMUL_PARTIALS is a compute-local accumulator (produced and consumed by compute).
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_MATMUL_PARTIALS,
+            .accessor_name = "matmul_partials",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_MATMUL_PARTIALS,
+            .accessor_name = "matmul_partials",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        // OUT is borrowed onto the (sharded) output tensor: compute packs results
+        // directly into it; there is no separate writer/FIFO consumer, so self-loop
+        // it on compute to satisfy the producer+consumer invariant.
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_OUT, .accessor_name = "out", .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = DFB_OUT, .accessor_name = "out", .endpoint_type = m2::DFBEndpointType::CONSUMER},
+    };
+    {
+        m2::KernelSpec::CompilerOptions::Defines d;
+        for (const auto& [k, v] : compute_defines) {
+            d.insert({k, v});
+        }
+        if (has_bias) {
+            d.insert({"FUSE_BIAS", "1"});
+            compute_kernel.dfb_bindings.push_back(m2::DFBBinding{
+                .dfb_spec_name = DFB_BIAS, .accessor_name = "bias", .endpoint_type = m2::DFBEndpointType::CONSUMER});
+        }
+        if (has_act_second_reader) {
+            // Width-sharded never sets this, but keep the gate honest if get_cb_info ever changes.
+            d.insert({"SECOND_READER_PRESENT", "1"});
+            compute_kernel.dfb_bindings.push_back(m2::DFBBinding{
+                .dfb_spec_name = dfb_name_for(Conv2dCb::ACT_SECOND_READER),
+                .accessor_name = "act_second_reader",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER});
+        }
+        compute_kernel.compiler_options.defines = std::move(d);
+    }
+
+    spec.kernels = {act_kernel, weights_kernel, compute_kernel};
+
+    // ---- Tensor parameters ----
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = TP_ACT_SHARDED, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = TP_WEIGHTS, .spec = b.tensor_spec()},
+        m2::TensorParameter{.unique_id = TP_OUT, .spec = output.tensor_spec()},
+        m2::TensorParameter{.unique_id = TP_READER_INDICES, .spec = conv_reader_indices.tensor_spec()},
+    };
+    if (has_bias) {
+        spec.tensor_parameters.push_back(m2::TensorParameter{.unique_id = TP_BIAS, .spec = bias.value().tensor_spec()});
+    }
+
+    // ---- WorkUnit ----
+    // All three kernels share local DFBs (ACT/ACT_ROW_MAJOR/ACT_TILIZED/WEIGHTS/
+    // MATMUL_PARTIALS/OUT/BIAS), so they must share a single WorkUnitSpec covering
+    // every node that hosts any of those DFBs. Legacy placed the act reader on the
+    // bounding box of all_cores and the weights/compute kernels on all_cores; for
+    // the shared-DFB invariant the Metal 2.0 spec places all three on one node set
+    // (the bounding box of all_cores). Inactive (noop) cores still host the kernels,
+    // which early-return via this_core_id / is_active. Both readers get runtime args
+    // for every node in this set (weights with is_active = 0 on inactive cores).
+    const CoreRangeSet work_nodes{all_reader_cores};
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{.name = "conv2d_ws", .kernels = {K_ACT, K_WEIGHTS, K_COMPUTE}, .target_nodes = work_nodes},
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs act_run{.kernel = K_ACT};
+    m2::KernelRunArgs weights_run{.kernel = K_WEIGHTS};
+    m2::KernelRunArgs compute_run{.kernel = K_COMPUTE};
+
+    std::vector<uint32_t> act_mcast_noc_x;
+    std::vector<uint32_t> act_mcast_noc_y;
     act_mcast_noc_x.reserve(full_core_grid.x);
     for (uint32_t core_index = 0; core_index < full_core_grid.x; core_index++) {
         act_mcast_noc_x.push_back(device->worker_core_from_logical_core(CoreCoord(core_index, 0)).x);
     }
-
     act_mcast_noc_y.reserve(full_core_grid.y);
     for (uint32_t core_index = 0; core_index < full_core_grid.y; core_index++) {
         act_mcast_noc_y.push_back(device->worker_core_from_logical_core(CoreCoord(0, core_index)).y);
     }
 
-    tt::tt_metal::Buffer* weights_buffer = b.buffer();
-    tt::tt_metal::Buffer* bias_buffer = bias ? bias->buffer() : nullptr;
     auto total_num_active_cores = std::max(input_num_cores, output_num_cores);
     auto total_num_cores = all_reader_cores.size();
-    act_kernel_desc.runtime_args.reserve(total_num_cores);
-    weights_kernel_desc.runtime_args.reserve(total_num_active_cores);
     for (uint32_t core_index = 0; core_index < total_num_cores; core_index++) {
         uint32_t core_x = core_index % full_core_grid.x;
         uint32_t core_y = core_index / full_core_grid.x;
-        std::vector<uint32_t> rt_args = {
-            core_x,
-            core_y,
-            full_core_grid.x,  // num_cores_x
-        };
+        CoreCoord core(core_x, core_y);
 
-        // Mcast X Lookup table
-        rt_args.insert(rt_args.end(), act_mcast_noc_x.begin(), act_mcast_noc_x.end());
+        act_run.runtime_arg_values.push_back(
+            {core, {{"this_core_x", core_x}, {"this_core_y", core_y}, {"num_cores_x", (uint32_t)full_core_grid.x}}});
+        // Mcast X/Y lookup tables as runtime varargs (X table then Y table).
+        m2::AdvancedKernelRunArgs::Varargs varargs;
+        varargs.reserve(act_mcast_noc_x.size() + act_mcast_noc_y.size());
+        varargs.insert(varargs.end(), act_mcast_noc_x.begin(), act_mcast_noc_x.end());
+        varargs.insert(varargs.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());
+        act_run.advanced_options.runtime_varargs.insert({core, std::move(varargs)});
 
-        // Mcast Y Lookup Table
-        rt_args.insert(rt_args.end(), act_mcast_noc_y.begin(), act_mcast_noc_y.end());
+        // Weights kernel now shares the WorkUnit node set, so every node needs
+        // weights RTAs. Active cores (core_index < total_num_active_cores) carry the
+        // real per-core start tile id; inactive (noop) cores get a benign start id of
+        // 0 and is_active = 0 (the kernel's `if (is_active)` guard skips all reads).
+        const bool core_is_active = core_index < total_num_active_cores;
+        weights_run.runtime_arg_values.push_back(
+            {core,
+             {{"init_weight_start_tile_id",
+               core_is_active ? static_cast<uint32_t>(core_index * weight_block_w_ntiles) : 0u},
+              {"is_active", static_cast<uint32_t>(core_index < output_num_cores)}}});
+    }
+    (void)compute_run;  // compute kernel has no per-core RTAs
 
-        act_kernel_desc.runtime_args.emplace_back(CoreCoord(core_x, core_y), std::move(rt_args));
-
-        // Weights kernel is not placed on inactive cores.  Weights[1] is the
-        // weight buffer base address and bias[2] is the (optional) bias address;
-        // emplace_runtime_args registers them as buffer bindings so the
-        // framework's fast cache-hit path patches addresses without
-        // GetRuntimeArgs.  When bias is absent we embed a literal 0 — has_bias
-        // gates the bias read on the kernel side.
-        if (core_index < total_num_active_cores) {
-            KernelDescriptor::RTArgList weights_rt_args;
-            weights_rt_args.reserve(4);
-            weights_rt_args.push_back(static_cast<uint32_t>(core_index * weight_block_w_ntiles));
-            weights_rt_args.push_back(weights_buffer);
-            if (bias_buffer != nullptr) {
-                weights_rt_args.push_back(bias_buffer);
-            } else {
-                weights_rt_args.push_back(uint32_t{0});
-            }
-            weights_rt_args.push_back(static_cast<uint32_t>(core_index < output_num_cores));
-            weights_kernel_desc.emplace_runtime_args(CoreCoord(core_x, core_y), weights_rt_args);
-        }
+    run.kernel_run_args = {act_run, weights_run, compute_run};
+    run.tensor_args = {
+        {TP_ACT_SHARDED, a.mesh_tensor()},
+        {TP_WEIGHTS, b.mesh_tensor()},
+        {TP_OUT, output.mesh_tensor()},
+        {TP_READER_INDICES, conv_reader_indices.mesh_tensor()},
+    };
+    if (has_bias) {
+        run.tensor_args.insert({TP_BIAS, bias.value().mesh_tensor()});
     }
 
-    // Descriptor-path CB-size check (mirrors the legacy post_conv2d_op_memory_checks
-    // CB-sizing equality).  The L1-allocator delta half of the legacy check requires a
-    // realised Program and so isn't reachable here: the framework realises the Program
-    // after this function returns.
-    post_conv2d_op_memory_checks_descriptor(desc, operation_attributes, tensor_args, reader_indices_actual_page_size);
-
-    desc.kernels.push_back(std::move(act_kernel_desc));
-    desc.kernels.push_back(std::move(weights_kernel_desc));
-    desc.kernels.push_back(std::move(compute_kernel_desc));
-    return desc;
-}
-
-}  // namespace
-
-tt::tt_metal::WorkloadDescriptor Conv2dWidthShardedProgramFactory::create_workload_descriptor(
-    const Conv2dParams& operation_attributes,
-    const Conv2dInputs& tensor_args,
-    Tensor& output_tensor,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
-    tt::tt_metal::WorkloadDescriptor workload_descriptor;
-
-    // Allocate the conv_reader_indices tensor on device once for the whole
-    // workload.  Wrap it in a shared_ptr<Tensor> so ~Tensor doesn't fire when
-    // the local goes out of scope: ~Tensor calls DeviceStorage::deallocate
-    // which force-frees the device buffer regardless of any shared_ptr
-    // ownership of the MeshBuffer (see WorkloadBuffer rationale in
-    // workload_descriptor.hpp).  Holding the Tensor in the WorkloadDescriptor
-    // defers destruction until the cached workload is evicted.
-    const auto& a = tensor_args.a;
-    const auto& sliding_window_config = operation_attributes.sliding_window_config;
-    const bool config_tensors_in_dram = operation_attributes.config_tensors_in_dram;
-
-    ttnn::operations::sliding_window::ParallelConfig parallel_config{
-        .grid = a.shard_spec().value().grid,
-        .shard_scheme = a.memory_config().memory_layout(),
-        .shard_orientation = a.shard_spec().value().orientation};
-
-    std::vector<uint32_t> op_trace_metadata =
-        ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
-    std::vector<sliding_window::ShardBoundary> shard_boundaries =
-        ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
-    const uint32_t stride_w = sliding_window_config.is_transpose ? 1 : (uint32_t)sliding_window_config.stride_hw.second;
-    const uint32_t act_block_h_ntiles = operation_attributes.block_config.act_block_h_ntiles;
-    const uint32_t act_block_h_datums = act_block_h_ntiles * tt::constants::TILE_HEIGHT;
-
-    std::vector<std::vector<uint16_t>> conv_sharded_input_top_left_indices =
-        ttnn::operations::sliding_window::generate_sliding_window_op_config(
-            op_trace_metadata, shard_boundaries, stride_w, true, act_block_h_datums, 0);
-
-    Tensor conv_reader_indices_tensor = ttnn::operations::sliding_window::construct_on_host_config_tensor(
-        conv_sharded_input_top_left_indices, parallel_config, config_tensors_in_dram);
-    conv_reader_indices_tensor = ttnn::operations::sliding_window::move_config_tensor_to_device(
-        conv_reader_indices_tensor, parallel_config, false, a.device(), config_tensors_in_dram);
-
-    log_trace(tt::LogOp, "Conv2D Config Tensor : {}", conv_reader_indices_tensor);
-
-    auto conv_reader_indices_tensor_owner = std::make_shared<Tensor>(std::move(conv_reader_indices_tensor));
-    tt::tt_metal::Buffer* conv_reader_indices_buffer = conv_reader_indices_tensor_owner->buffer();
-    workload_descriptor.buffers.push_back({conv_reader_indices_tensor_owner, conv_reader_indices_buffer});
-
-    // Single-device op: per-coord program is structurally identical for every
-    // coord in `tensor_coords` (conv2d doesn't depend on cluster position).
-    // Build the ProgramDescriptor once and copy into each range entry.
-    tt::tt_metal::ProgramDescriptor desc =
-        build_program_descriptor(operation_attributes, tensor_args, output_tensor, conv_reader_indices_buffer);
-
-    auto ranges = tensor_coords.ranges();
-    workload_descriptor.programs.reserve(ranges.size());
-    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
-        workload_descriptor.programs.push_back({ranges[i], desc});
-    }
-    if (!ranges.empty()) {
-        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
-    }
-    return workload_descriptor;
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec), .run_params = std::move(run), .op_owned_tensors = std::move(op_owned_tensors)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/conv2d_op_width_sharded_program_factory.hpp
@@ -3,23 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
-#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/conv/conv2d/device/conv2d_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct Conv2dWidthShardedProgramFactory {
-    // Builds the workload in one call (cache miss).  The intermediate
-    // conv_reader_indices tensor — which must outlive the cached program — is
-    // allocated here and parked on the WorkloadDescriptor's `buffers` vector
-    // (wrapped in `shared_ptr<Tensor>` so `~Tensor` cannot force-deallocate the
-    // device memory while the cached program is still alive).
-    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
-        const Conv2dParams& operation_attributes,
-        const Conv2dInputs& tensor_args,
-        Tensor& output_tensor,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+    // Metal 2.0 program factory (ProgramSpecFactoryConcept). Produces the immutable
+    // ProgramSpec, its mutable ProgramRunArgs, and the op-owned conv_reader_indices
+    // tensor (host-populated index table backing the READER_INDICES borrowed-memory
+    // DFB). Ports the L1 config-tensor path only (config_tensors_in_dram == false);
+    // the in-DRAM config path is a Metal 2.0 blocker (raw buffer address through a
+    // CTA) and TT_FATALs here.
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
+        const Conv2dParams& operation_attributes, const Conv2dInputs& tensor_args, Tensor& output_tensor);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/activation_reader_width_sharded.cpp
@@ -5,6 +5,7 @@
 #include <api/dataflow/dataflow_api.h>
 #include "conv_reader_common.hpp"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include "experimental/kernel_args.h"
 
 #define ENABLE_DEBUG 0
 
@@ -13,8 +14,8 @@
 #include "api/debug/dprint_pages.h"
 #endif
 
-constexpr uint32_t weight_size_h = get_compile_time_arg_val(5);
-constexpr uint32_t weight_size_w = get_compile_time_arg_val(6);
+constexpr uint32_t weight_size_h = get_arg(args::weight_size_h);
+constexpr uint32_t weight_size_w = get_arg(args::weight_size_w);
 // Only a part of the total channel depth (width) is used in one block.
 template <int window_height, int window_width>
 FORCE_INLINE void read_channels(
@@ -44,45 +45,48 @@ FORCE_INLINE void read_channels(
 }
 
 void kernel_main() {
-    constexpr uint32_t stride_w = get_compile_time_arg_val(0);
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(1);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(2);
-    constexpr uint32_t conv_act_size_w = get_compile_time_arg_val(3);
-    constexpr uint32_t conv_act_c_read_bytes = get_compile_time_arg_val(4);
-    constexpr uint32_t act_block_h_datums = get_compile_time_arg_val(7);
-    constexpr uint32_t act_block_num_tiles = get_compile_time_arg_val(8);
-    constexpr uint32_t num_input_cores = get_compile_time_arg_val(9);
-    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(10);
-    constexpr uint32_t act_num_blocks_w = get_compile_time_arg_val(11);
-    Semaphore<> act_mcast_sender_sem(get_compile_time_arg_val(12));
-    Semaphore<> act_mcast_receiver_sem(get_compile_time_arg_val(13));
+    constexpr uint32_t stride_w = get_arg(args::stride_w);
+    constexpr uint32_t dilation_h = get_arg(args::dilation_h);
+    constexpr uint32_t dilation_w = get_arg(args::dilation_w);
+    constexpr uint32_t conv_act_size_w = get_arg(args::conv_act_size_w);
+    constexpr uint32_t conv_act_c_read_bytes = get_arg(args::conv_act_c_read_bytes);
+    constexpr uint32_t act_block_h_datums = get_arg(args::act_block_h_datums);
+    constexpr uint32_t act_block_num_tiles = get_arg(args::act_block_num_tiles);
+    constexpr uint32_t num_input_cores = get_arg(args::num_input_cores);
+    constexpr uint32_t act_num_blocks_h = get_arg(args::act_num_blocks_h);
+    constexpr uint32_t act_num_blocks_w = get_arg(args::act_num_blocks_w);
+    Semaphore<> act_mcast_sender_sem(sem::act_mcast_sender);
+    Semaphore<> act_mcast_receiver_sem(sem::act_mcast_receiver);
     constexpr McastRect mcast_rect = {
-        get_compile_time_arg_val(14),
-        get_compile_time_arg_val(15),
-        get_compile_time_arg_val(16),
-        get_compile_time_arg_val(17)};
-    constexpr uint32_t act_mcast_sender_size_bytes = get_compile_time_arg_val(18);
-    constexpr uint32_t num_output_cores = get_compile_time_arg_val(19);
-    constexpr uint32_t num_reader_cores = get_compile_time_arg_val(20);
+        get_arg(args::mcast_noc_x_start),
+        get_arg(args::mcast_noc_y_start),
+        get_arg(args::mcast_noc_x_end),
+        get_arg(args::mcast_noc_y_end)};
+    constexpr uint32_t act_mcast_sender_size_bytes = get_arg(args::act_mcast_sender_size_bytes);
+    constexpr uint32_t num_output_cores = get_arg(args::num_output_cores);
+    constexpr uint32_t num_reader_cores = get_arg(args::num_reader_cores);
 
-    constexpr uint32_t cb_id_act = get_compile_time_arg_val(21);
-    constexpr uint32_t cb_id_sharded_act = get_compile_time_arg_val(22);
-    constexpr uint32_t cb_reader_indices = get_compile_time_arg_val(23);
-    constexpr uint32_t cb_id_act_row_major_bfloat16 = get_compile_time_arg_val(25);
-    constexpr uint32_t tilized_in0_cb_id = get_compile_time_arg_val(26);
+    constexpr uint32_t cb_id_act = dfb::act;
+    constexpr uint32_t cb_id_sharded_act = dfb::act_sharded;
+    constexpr uint32_t cb_reader_indices = dfb::reader_indices;
+    constexpr uint32_t cb_id_act_row_major_bfloat16 = dfb::act_row_major;
+    constexpr uint32_t tilized_in0_cb_id = dfb::act_tilized;
 
     constexpr uint32_t num_mcast_cores = num_input_cores > num_output_cores ? num_input_cores : num_output_cores;
-    uint32_t i = 0;  // Runtime arg index
 
-    uint32_t this_core_x = get_arg_val<uint32_t>(i);
-    i += 1;
-    uint32_t this_core_y = get_arg_val<uint32_t>(i);
-    i += 1;
+    uint32_t this_core_x = get_arg(args::this_core_x);
+    uint32_t this_core_y = get_arg(args::this_core_y);
 
     // Num of cols of compute cores. (Total Cores, not active cores.)
-    uint32_t num_cores_x = get_arg_val<uint32_t>(i);
-    i += 1;
+    uint32_t num_cores_x = get_arg(args::num_cores_x);
 
+    // The two per-core mcast lookup tables are variable-length (num_cores_x entries
+    // each) and indexed by a runtime value, so they are passed as runtime varargs
+    // following the three named RTAs above. They are accessed by base pointer
+    // (get_arg_addr) + runtime index, which the value-returning get_vararg() helper
+    // cannot express; vararg index 0 lives at dispatch-buffer word 3 (= named RTA
+    // count), so we offset the legacy addr lookups by 3.
+    uint32_t i = 3;  // first vararg word (after this_core_x/y, num_cores_x)
     // X and Y lookup are independent.
     // X Lookup table for translating logical to physical cores.
     tt_l1_ptr uint32_t* act_mcast_x_lookup = (tt_l1_ptr uint32_t*)(get_arg_addr(i));

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/conv_bmm_tilize_m2.cpp
@@ -1,0 +1,710 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of conv_bmm_tilize.cpp. Forked (not edited in place) because
+// conv_bmm_tilize.cpp is also bound by Conv2dShardedProgramFactory, which is still
+// on the legacy concept; only Conv2dWidthShardedProgramFactory's compute kernel
+// moves to the Metal 2.0 named-binding form. Numeric logic, loop bounds and
+// #ifdefs are identical to conv_bmm_tilize.cpp — only the argument-access
+// mechanism changed (CB-id CTAs -> dfb::, scalar CTAs -> get_arg(args::)).
+//
+// Conditionally-bound DFBs: BIAS (bound only when has_bias) and ACT_SECOND_READER
+// (never bound on the width-sharded path; act_block_split_num_tiles == 0 there)
+// are referenced only through preprocessor-gated aliases so their dfb:: tokens are
+// not name-looked-up on a build where the host did not bind them. See
+// FUSE_BIAS / SECOND_READER_PRESENT below.
+
+#include <cstdint>
+
+#include "internal/mod_div_lib.h"
+#include "api/compute/bcast.h"
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/matmul.h"
+#include "api/compute/pack_untilize.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/tilize.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include "experimental/kernel_args.h"
+
+// #include "api/debug/dprint.h"
+
+#define DEBUG_PRINT 0
+
+#ifdef SPLIT_READER
+template <
+    uint32_t in_block_w,
+    uint32_t in_cb_id,
+    uint32_t out_cb_id,
+    bool init_tilize = true,
+    bool uninit_tilize = true>
+__attribute__((noinline)) void tilize_in(
+#else
+template <
+    uint32_t in_block_w,
+    uint32_t in_cb_id,
+    uint32_t out_cb_id,
+    bool init_tilize = true,
+    bool uninit_tilize = true>
+void tilize_in(
+#endif
+    uint32_t in_num_subblocks) {
+    constexpr compute_kernel_lib::tilize_config::InitUninitMode init_uninit_mode =
+        init_tilize ? (uninit_tilize ? compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit
+                                     : compute_kernel_lib::tilize_config::InitUninitMode::InitOnly)
+                    : (uninit_tilize ? compute_kernel_lib::tilize_config::InitUninitMode::UninitOnly
+                                     : compute_kernel_lib::tilize_config::InitUninitMode::Neither);
+    // Split-reader fires tilize_in twice back-to-back (first: init=true+uninit=false,
+    // second: init=false+uninit=true). The second call must NOT reconfig datatypes —
+    // doing so clobbers the bf16 SrcA override that fast_tilize_init installs for
+    // fp32 input on BH (see _llk_unpack_fast_tilize_init_), breaking the second
+    // tilize's MOP. Only reconfig on the init call; continuation reuses that state.
+    constexpr auto reconfig_mode =
+        init_tilize ? compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::UnpackReconfigure
+                    : compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure;
+    compute_kernel_lib::tilize<
+        in_block_w,
+        in_cb_id,
+        out_cb_id,
+        init_uninit_mode,
+        compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+        reconfig_mode>(in_num_subblocks);
+}  // tilize_in()
+
+template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id>
+inline void tilize_single_block(experimental::CB in_cb) {
+    in_cb.wait_front(in_block_w);
+    fast_tilize_block(in_cb_id, in_block_w, out_cb_id);
+    in_cb.pop_front(in_block_w);
+}
+
+template <uint32_t in_cb_id, uint32_t window_reuse_offset>
+inline uint32_t update_in_cb(uint32_t in_cb_addr) {
+    UNPACK((get_local_cb_interface(in_cb_id).fifo_rd_ptr = in_cb_addr));
+    return in_cb_addr + window_reuse_offset;
+}
+
+template <uint32_t in_cb_id, uint32_t in_block_w, uint32_t out_cb_id, uint32_t tilized_cb_row_offset>
+inline void tilize_single_block_with_out_cb_update(experimental::CB in_cb, uint32_t& out_cb_addr) {
+    PACK((get_local_cb_interface(out_cb_id).fifo_wr_ptr = out_cb_addr));
+    PACK((out_cb_addr += tilized_cb_row_offset));
+    tilize_single_block<in_cb_id, in_block_w, out_cb_id>(in_cb);
+}
+
+template <
+    uint32_t in1_cb_id,
+    uint32_t in2_cb_id,
+    uint32_t in_block_w,
+    uint32_t in1_num_subblocks,
+    uint32_t in2_num_subblocks,
+    uint32_t out_cb_id,
+    uint32_t out_cb_tiles,
+    uint32_t window_reuse_offset,
+    uint32_t tilized_cb_row_offset,
+    uint32_t tilized_cb_second_reader_offset,
+    uint32_t image_width_in_tiles>
+inline void tilize_in_reuse_split_reader(
+    experimental::CB in1_cb,
+    experimental::CB in2_cb,
+    experimental::CB out_cb,
+    uint32_t act_cb_start_address,
+    uint32_t act_cb_second_reader_start_address) {
+    // with activation reuse, the activation buffers are sized to fit one output image width only,
+    // so we need to interleave waits and pops on the two buffers to allow parallelization;
+    // we reserve back tilized CB to store whole act block h - and then we update write pointers so that
+    // we fill in first row of the first half (NCRISC), first row of the second half (BRISC) and so on
+    out_cb.reserve_back(out_cb_tiles);
+    fast_tilize_init_with_dt(in1_cb_id, in_block_w, out_cb_id);
+
+    uint32_t in1_cb_addr = act_cb_start_address;
+    uint32_t in2_cb_addr = act_cb_second_reader_start_address;
+
+    uint32_t out_cb_addr, out_cb_addr_second_reader, out_cb_addr_init;
+    PACK((out_cb_addr_init = get_local_cb_interface(out_cb_id).fifo_wr_ptr));
+    PACK((out_cb_addr = out_cb_addr_init));
+    PACK((out_cb_addr_second_reader = out_cb_addr_init + tilized_cb_second_reader_offset));
+
+    constexpr uint32_t min_num_subblocks =
+        in1_num_subblocks > in2_num_subblocks ? in2_num_subblocks : in1_num_subblocks;
+    constexpr uint32_t min_num_image_rows = min_num_subblocks / image_width_in_tiles;
+    constexpr uint32_t leftover_in1 = in1_num_subblocks - min_num_image_rows * image_width_in_tiles;
+    constexpr uint32_t leftover_in2 = in2_num_subblocks - min_num_image_rows * image_width_in_tiles;
+    constexpr uint32_t max_leftover = leftover_in1 > leftover_in2 ? leftover_in1 : leftover_in2;
+
+    // process minimum number of image rows for both readers in the same loop
+    for (uint32_t image_row = 0; image_row < min_num_image_rows; ++image_row) {
+        // each time we start processing a new image row, we need to update the read pointer to the appropriate offset
+        // from the start of the CB to match the reader behavior
+        in1_cb_addr = update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
+        in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
+        for (uint32_t image_col = 0; image_col < image_width_in_tiles; ++image_col) {
+            tilize_single_block_with_out_cb_update<in1_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
+                in1_cb, out_cb_addr);
+            tilize_single_block_with_out_cb_update<in2_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
+                in2_cb, out_cb_addr_second_reader);
+        }
+    }
+
+    // leftover image rows if one reader had more rows than the other
+    in1_cb_addr = update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
+    in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
+    for (uint32_t image_col = 0; image_col < max_leftover; ++image_col) {
+        if (image_col < leftover_in1) {
+            tilize_single_block_with_out_cb_update<in1_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
+                in1_cb, out_cb_addr);
+
+            if (image_col == image_width_in_tiles - 1) {
+                in1_cb_addr = update_in_cb<in1_cb_id, window_reuse_offset>(in1_cb_addr);
+            }
+        }
+
+        if (image_col < leftover_in2) {
+            tilize_single_block_with_out_cb_update<in2_cb_id, in_block_w, out_cb_id, tilized_cb_row_offset>(
+                in2_cb, out_cb_addr_second_reader);
+
+            if (image_col == image_width_in_tiles - 1) {
+                in2_cb_addr = update_in_cb<in2_cb_id, window_reuse_offset>(in2_cb_addr);
+            }
+        }
+    }
+
+    // Restore fifo_wr_ptr to the reserved-region base so push_back advances from a
+    // known starting point. Without this, push_back's fifo_wr_ptr += num_words
+    // starts from whichever mid-region offset the last tilize_single_block left
+    // and trips the LLK bounds assert (see GH #42510).
+    PACK((get_local_cb_interface(out_cb_id).fifo_wr_ptr = out_cb_addr_init));
+    out_cb.push_back(out_cb_tiles);
+    fast_tilize_uninit(in2_cb_id, out_cb_id, in_block_w);
+}
+
+template <uint32_t out_subblock_w, uint32_t out_block_w>
+inline void reblock_and_untilize(
+    experimental::CB interm_cb,
+    experimental::CB out_cb,
+    uint32_t num_out_subblocks_in_col,
+    uint32_t out_subblock_num_tiles,
+    uint32_t out_subblock_h) {
+    const uint32_t interm_cb_id = interm_cb.get_cb_id();
+    const uint32_t out_cb_id = out_cb.get_cb_id();
+    uint32_t num_tiles_in_row_of_subblocks = mulsi3(out_subblock_num_tiles, num_out_subblocks_in_col);
+    interm_cb.wait_front(num_tiles_in_row_of_subblocks);
+    uint32_t within_block_index = 0;
+    for (uint32_t h = 0; h < out_subblock_h; h++) {
+        uint32_t block_offset = 0;
+        out_cb.reserve_back(out_block_w);
+        for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
+            tile_regs_acquire();
+            for (uint32_t w = 0; w < out_subblock_w; w++) {
+                uint32_t tile_index = block_offset + within_block_index + w;
+                copy_tile(interm_cb_id, tile_index, w);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_untilize_dest<out_subblock_w, out_block_w>(out_cb_id, 1, n);
+            tile_regs_release();
+            block_offset += out_subblock_num_tiles;
+        }
+        out_cb.push_back(out_block_w);
+        within_block_index += out_subblock_w;
+    }
+    interm_cb.pop_front(num_tiles_in_row_of_subblocks);
+}
+
+void kernel_main() {
+    constexpr uint32_t in0_block_w = get_arg(args::in0_block_w);  // inner block size in tiles
+    constexpr uint32_t in0_num_subblocks =
+        get_arg(args::in0_num_subblocks);  // outer row block size (in inner row blocks)
+    constexpr uint32_t in0_block_num_tiles =
+        get_arg(args::in0_block_num_tiles);  // out_subblock_h*in0_block_w*in0_num_subblocks;
+    constexpr uint32_t in0_subblock_num_tiles = get_arg(args::in0_subblock_num_tiles);  // out_subblock_h*in0_block_w
+    constexpr uint32_t reader_num_h_subblocks = get_arg(args::reader_num_h_subblocks);
+    constexpr uint32_t in1_num_subblocks =
+        get_arg(args::in1_num_subblocks);  // outer column block size (in inner column blocks)
+    constexpr uint32_t in1_block_num_tiles =
+        get_arg(args::in1_block_num_tiles);                       // out_subblock_w*in0_block_w* in1_num_subblocks;
+    constexpr uint32_t in1_block_w = get_arg(args::in1_block_w);  // out_subblock_w*in1_num_subblocks
+    // if these are not defined as volatile, it causes code size for TRISC2 to be too large if num_blocks > 1
+    constexpr uint32_t in0_num_blocks_h = get_arg(args::in0_num_blocks_h);
+    constexpr uint32_t in0_num_blocks_w = get_arg(args::in0_num_blocks_w);
+    constexpr uint32_t in1_num_blocks_w = get_arg(args::in1_num_blocks_w);
+    constexpr uint32_t out_subblock_h = get_arg(args::out_subblock_h);  // inner row block size in tiles
+    constexpr uint32_t out_subblock_w = get_arg(args::out_subblock_w);  // inner column block size in tiles
+    constexpr uint32_t out_subblock_num_tiles =
+        get_arg(args::out_subblock_num_tiles);  // out_subblock_h * out_subblock_w;
+    constexpr bool height_sharded = get_arg(args::height_sharded);
+    constexpr bool untilize_out = get_arg(args::untilize_out);
+    constexpr uint32_t in0_cb_id = dfb::act;
+    constexpr uint32_t in1_cb_id = dfb::weights;
+    constexpr uint32_t in0_pretilize_cb_id = dfb::act_row_major;
+    // ACT_SECOND_READER is never bound on the width-sharded path (split reader off).
+    // Alias it to the main act CB so derived expressions stay well-formed; gated so
+    // dfb::act_second_reader is never name-looked-up when unbound.
+#ifdef SECOND_READER_PRESENT
+    constexpr uint32_t in0_cb_second_reader_id = dfb::act_second_reader;
+#else
+    constexpr uint32_t in0_cb_second_reader_id = dfb::act;
+#endif
+    constexpr uint32_t matmul_partials_cb = dfb::matmul_partials;
+    constexpr uint32_t tilized_in0_cb_id = dfb::act_tilized;
+    constexpr uint32_t out_cb_id = dfb::out;
+    constexpr bool partials_cb_uses_output = get_arg(args::partials_cb_uses_output);
+    constexpr uint32_t in0_nblocks_w_tilize = get_arg(args::in0_nblocks_w_tilize);
+    constexpr bool check_skip_compute = get_arg(args::check_skip_compute);
+    constexpr bool pack_relu = get_arg(args::pack_relu);
+    constexpr bool packer_untilize = get_arg(args::packer_untilize);
+    constexpr bool packer_l1_acc = get_arg(args::packer_l1_acc);
+    constexpr bool fuse_bias = get_arg(args::fuse_bias);
+    constexpr bool split_reader = get_arg(args::split_reader);
+    constexpr bool activation_reuse = get_arg(args::activation_reuse);
+
+    constexpr uint32_t image_width_in_tiles = get_arg(args::image_width_in_tiles);
+    constexpr uint32_t window_reuse_offset = get_arg(args::window_reuse_offset);
+    constexpr uint32_t tilized_cb_row_offset = get_arg(args::tilized_cb_row_offset);
+    constexpr uint32_t tilized_cb_second_reader_offset = get_arg(args::tilized_cb_second_reader_offset);
+    constexpr bool split_reader_cb_shared = get_arg(args::split_reader_cb_shared) == 1;
+
+    constexpr uint32_t out_block_num_tiles = in0_num_subblocks * in1_num_subblocks * out_subblock_num_tiles;
+    constexpr uint32_t out_block_w = in1_block_w;
+    constexpr bool spill = in0_num_blocks_w > 1;
+
+    constexpr uint32_t untilize_mode_out_cb_id = untilize_out ? matmul_partials_cb : out_cb_id;
+
+    uint32_t bias_block_offset = 0;
+    constexpr uint32_t bias_ntiles_w = get_arg(args::bias_ntiles_w);
+    // BIAS DFB is bound only when has_bias; gate the token so it is not
+    // name-looked-up on the no-bias build. When unbound, alias to matmul_partials
+    // (a bound DFB) to keep the cb_bias construction below well-formed; all real
+    // uses of cb_bias are inside `if constexpr (fuse_bias)` so the alias is dead.
+#ifdef FUSE_BIAS
+    constexpr uint32_t bias_cb_id = dfb::bias;
+#else
+    constexpr uint32_t bias_cb_id = dfb::matmul_partials;
+#endif
+    constexpr uint32_t mm_out_cb_id = fuse_bias ? matmul_partials_cb : untilize_mode_out_cb_id;
+
+    constexpr uint32_t mm_in0_cb_id = height_sharded ? tilized_in0_cb_id : in0_cb_id;
+
+    constexpr uint32_t in0_num_subblocks_read_last =
+        (split_reader && !split_reader_cb_shared) ? reader_num_h_subblocks / 2 : 0;
+    constexpr uint32_t in0_num_subblocks_read = reader_num_h_subblocks - in0_num_subblocks_read_last;
+
+    // if activation reuse is enabled, we need to update read pointers of the act buffers
+    // each time we pass on to the new output image row to match the reader behavior
+    uint32_t act_cb_start_address = activation_reuse ? get_local_cb_interface(in0_cb_id).fifo_rd_ptr : 0;
+    const uint32_t out_cb_tiles =
+        activation_reuse ? in0_block_w * (in0_num_subblocks_read + in0_num_subblocks_read_last) : 0;
+    const uint32_t tilized_cb_start_address =
+        activation_reuse ? get_local_cb_interface(tilized_in0_cb_id).fifo_wr_ptr : 0;
+    const uint32_t act_cb_second_reader_start_address =
+        activation_reuse ? get_local_cb_interface(in0_cb_second_reader_id).fifo_rd_ptr : 0;
+
+    // For block sharded conv2d, compute kernels may be scheduled on cores that only need tilize
+    // operations (input grid) while actual matmul occurs on different cores (output grid).
+    // Skip dummy compute operations when possible to reduce di/dt issues, but allow dummy
+    // tilize operations on cores without input data for code simplicity.
+    bool skip_compute = false;
+    if constexpr (check_skip_compute) {
+        skip_compute = (bool)get_arg_val<uint32_t>(0);
+    }
+
+    experimental::CB cb_in0(in0_cb_id);
+    experimental::CB cb_in0_second_reader(in0_cb_second_reader_id);
+    experimental::CB cb_tilized_in0(tilized_in0_cb_id);
+    experimental::CB cb_mm_in0(mm_in0_cb_id);
+    experimental::CB cb_in1(in1_cb_id);
+    experimental::CB cb_matmul_partials(matmul_partials_cb);
+    experimental::CB cb_mm_out(mm_out_cb_id);
+    experimental::CB cb_out(out_cb_id);
+    experimental::CB cb_bias(bias_cb_id);
+    experimental::CB cb_untilize_mode_out(untilize_mode_out_cb_id);
+
+    mm_block_init(mm_in0_cb_id, in1_cb_id, out_cb_id, false, out_subblock_w, out_subblock_h, in0_block_w);
+#ifdef SFPU_OP_INIT_ACTIVATION
+    SFPU_OP_INIT_ACTIVATION
+#endif
+    UNPACK(uint32_t partials_cb_read_ptr = get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr;)
+    PACK(uint32_t partials_cb_write_ptr = get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr;)
+    // in1 num blocks w is the outer loop. Output blocks are computed in col major order.
+    for (uint32_t in1_block_w_i = 0; in1_block_w_i < in1_num_blocks_w; ++in1_block_w_i) {
+        for (uint32_t in0_block_h_i = 0; in0_block_h_i < in0_num_blocks_h; ++in0_block_h_i) {
+            bool enable_reload = false;
+
+            if constexpr (pack_relu) {
+                // for each output block we start we relu disabled so that intermediate results are not relu'd
+                PACK((llk_pack_relu_config(ReluConfig::none())));
+            }
+            if constexpr (partials_cb_uses_output) {
+                UNPACK(partials_cb_read_ptr = get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr;)
+                PACK(partials_cb_write_ptr = get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr;)
+            }
+            uint32_t curr_matmul_out_cb = matmul_partials_cb;
+            for (uint32_t in0_block_w_i = 0; in0_block_w_i < in0_num_blocks_w; ++in0_block_w_i) {
+                bool last_inner_dim_block = (in0_block_w_i == in0_num_blocks_w - 1);
+                if constexpr (!height_sharded) {
+                    if (in0_block_w_i % in0_nblocks_w_tilize == 0) {
+                        if constexpr (pack_relu && !fuse_bias) {
+                            if (last_inner_dim_block) {
+                                // if last block we pack the final result with relu enabled
+                                PACK((llk_pack_relu_config(ReluConfig::none())));
+                            }
+                        }
+                        if constexpr (packer_l1_acc) {
+                            pack_reconfig_data_format(curr_matmul_out_cb, tilized_in0_cb_id);
+                            pack_reconfig_l1_acc(0);
+                        }
+                        tilize_in<
+                            in0_block_w,
+                            in0_pretilize_cb_id,
+                            tilized_in0_cb_id,
+                            true,
+                            !split_reader || split_reader_cb_shared>(in0_num_subblocks_read);
+
+                        if constexpr (split_reader && !split_reader_cb_shared) {
+                            tilize_in<in0_block_w, in0_cb_second_reader_id, tilized_in0_cb_id, false, true>(
+                                in0_num_subblocks_read_last);
+                        }
+                        mm_block_init_short_with_both_dt(
+                            in0_cb_id,
+                            in1_cb_id,
+                            in0_pretilize_cb_id,
+                            in0_pretilize_cb_id,
+                            false,
+                            out_subblock_w,
+                            out_subblock_h,
+                            in0_block_w);
+                    }
+                } else {
+                    if constexpr (pack_relu && !fuse_bias) {
+                        if (last_inner_dim_block) {
+                            // if last block we pack the final result with relu enabled
+                            PACK((llk_pack_relu_config(ReluConfig::none())));
+                        }
+                    }
+                    if constexpr (packer_l1_acc) {
+                        pack_reconfig_data_format(curr_matmul_out_cb, tilized_in0_cb_id);
+                        pack_reconfig_l1_acc(0);
+                    }
+
+                    if constexpr (!activation_reuse) {
+                        tilize_in<in0_block_w, in0_cb_id, tilized_in0_cb_id, true, !split_reader>(
+                            in0_num_subblocks_read);
+                    }
+
+                    if constexpr (split_reader) {
+                        if constexpr (!activation_reuse) {
+                            tilize_in<in0_block_w, in0_cb_second_reader_id, tilized_in0_cb_id, false, true>(
+                                in0_num_subblocks_read_last);
+                        } else {
+                            PACK((get_local_cb_interface(tilized_in0_cb_id).fifo_wr_ptr = tilized_cb_start_address));
+                            tilize_in_reuse_split_reader<
+                                in0_cb_id,
+                                in0_cb_second_reader_id,
+                                in0_block_w,
+                                in0_num_subblocks_read,
+                                in0_num_subblocks_read_last,
+                                tilized_in0_cb_id,
+                                out_cb_tiles,
+                                window_reuse_offset,
+                                tilized_cb_row_offset,
+                                tilized_cb_second_reader_offset,
+                                image_width_in_tiles>(
+                                cb_in0,
+                                cb_in0_second_reader,
+                                cb_tilized_in0,
+                                act_cb_start_address,
+                                act_cb_second_reader_start_address);
+                        }
+                    }
+
+                    mm_block_init_short_with_both_dt(
+                        mm_in0_cb_id,
+                        in1_cb_id,
+                        in0_cb_id,
+                        in0_cb_id,
+                        false,
+                        out_subblock_w,
+                        out_subblock_h,
+                        in0_block_w);
+                }
+
+                cb_mm_in0.wait_front(in0_block_num_tiles);
+
+                uint32_t in0_index_subblock_offset = 0;
+                if constexpr (check_skip_compute) {
+                    if (skip_compute) {
+                        cb_mm_in0.pop_front(in0_block_num_tiles);
+                        continue;
+                    }
+                }
+
+                cb_in1.wait_front(in1_block_num_tiles);
+
+                if (last_inner_dim_block) {
+                    if constexpr (!fuse_bias) {
+                        if constexpr (pack_relu) {
+                            // if last block we pack the final result with relu enabled
+                            PACK((llk_pack_relu_config(ReluConfig::zero())));
+                        }
+                        curr_matmul_out_cb = mm_out_cb_id;
+                    }
+                }
+
+                if constexpr (packer_l1_acc) {
+                    pack_reconfig_data_format(curr_matmul_out_cb);
+                }
+                for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
+                    uint32_t in1_index_subblock_offset = 0;
+                    for (uint32_t in1_subblock_i = 0; in1_subblock_i < in1_num_subblocks; ++in1_subblock_i) {
+                        if (enable_reload) {
+                            // Reconfigure input
+                            copy_tile_to_dst_init_short_with_dt(in1_cb_id, matmul_partials_cb);
+                            cb_matmul_partials.wait_front(out_subblock_num_tiles);
+                            tile_regs_acquire();
+
+                            uint32_t start_dst_index = 0;
+                            uint32_t start_tile_index = 0;
+                            copy_block_matmul_partials(
+                                matmul_partials_cb, start_tile_index, start_dst_index, out_subblock_num_tiles);
+
+                            cb_matmul_partials.pop_front(out_subblock_num_tiles);
+                            // Reconfigure srcA back
+                            mm_block_init_short_with_dt(
+                                mm_in0_cb_id,
+                                in1_cb_id,
+                                matmul_partials_cb,
+                                false,
+                                out_subblock_w,
+                                out_subblock_h,
+                                in0_block_w);
+                        } else {
+                            // just acquire
+                            tile_regs_acquire();
+                        }
+
+                        // Compute output sub-block
+                        uint32_t dst_index =
+                            0;  // start at 0, each call to matmul_block internally increments dst_index
+                        uint32_t in0_index = in0_index_subblock_offset;  // offset into in0 block
+                        uint32_t in1_index = in1_index_subblock_offset;  // offset into in1 block
+                        // inner dim that we accumulate is the inner dim of in0/in1, which is in0_block_w
+                        for (uint32_t inner_dim_idx = 0; inner_dim_idx < in0_block_w; inner_dim_idx++) {
+                            // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
+                            // accumulation is done by iterating matmul_block across inner dim
+                            // in0_block_w is passed as innder dim (kt) to matmul_block, internally used to stride in0
+                            matmul_block(
+                                mm_in0_cb_id,
+                                in1_cb_id,
+                                in0_index,
+                                in1_index,
+                                dst_index,
+                                false,
+                                out_subblock_w,
+                                out_subblock_h,
+                                in0_block_w);
+                            in0_index++;               // stride right by 1
+                            in1_index += in1_block_w;  // to stride down by 1 need to stride by in_per_core_w (should be
+                                                       // called in1_block_w)
+                        }
+
+#ifdef SFPU_OP_INIT_ACTIVATION
+                        if constexpr (!fuse_bias) {
+                            if (last_inner_dim_block) {
+                                for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
+                                    SFPU_OP_FUNC_ACTIVATION
+                                }
+                            }
+                        }
+#endif
+                        tile_regs_commit();
+                        experimental::CB curr_out_cb =
+                            curr_matmul_out_cb == matmul_partials_cb ? cb_matmul_partials : cb_mm_out;
+                        curr_out_cb.reserve_back(out_subblock_num_tiles);
+                        tile_regs_wait();
+
+                        if constexpr (packer_l1_acc) {
+                            // no accumulation for first iteration, last iteration
+                            // accumulation happens with copying tiles to dst
+                            if (in0_block_w_i == 0) {
+                                pack_reconfig_l1_acc(0);
+                            } else if (last_inner_dim_block) {
+                                pack_reconfig_l1_acc(fuse_bias ? 1 : 0);
+                            } else {
+                                pack_reconfig_l1_acc(1);
+                            }
+                        }
+
+                        uint32_t start_dst_index = 0;
+                        pack_tile_block(start_dst_index, curr_matmul_out_cb, out_subblock_num_tiles);
+
+                        tile_regs_release();
+                        curr_out_cb.push_back(out_subblock_num_tiles);
+
+                        in1_index_subblock_offset += out_subblock_w;
+                    }  // for in1_num_subblocks
+                    in0_index_subblock_offset += in0_subblock_num_tiles;
+                }
+                if (curr_matmul_out_cb == matmul_partials_cb) {
+                    if constexpr (!partials_cb_uses_output) {
+                        UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr;)
+                        PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr;)
+                    }
+                }
+                if constexpr (packer_l1_acc) {
+                    if constexpr (fuse_bias) {
+                        if (in0_block_w_i < in0_num_blocks_w - 1) {
+                            // Wait for l1 accumulation to populate interm buffer,
+                            // then pop to update fifo rd pointer
+                            cb_matmul_partials.wait_front(out_block_num_tiles);
+                            cb_matmul_partials.pop_front(out_block_num_tiles);
+                            if constexpr (spill) {
+                                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+                                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
+                            }
+                        }
+                        // never reload when with bias, bias uses interm buffer
+                        enable_reload = false;
+                    } else {
+                        // Last iteration does spill and reload to output buffer
+                        if (in0_block_w_i < in0_num_blocks_w - 2) {
+                            cb_matmul_partials.wait_front(out_block_num_tiles);
+                            cb_matmul_partials.pop_front(out_block_num_tiles);
+                            if constexpr (spill) {
+                                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+                                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
+                            }
+                        }
+                        if (in0_block_w_i == in0_num_blocks_w - 2) {
+                            enable_reload = true;
+                        }
+                    }
+                } else {
+                    if constexpr (spill) {
+                        enable_reload = true;
+
+                        if constexpr (fuse_bias) {
+                            if (!last_inner_dim_block) {
+                                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+                                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
+                            }
+                        } else {
+                            if (!last_inner_dim_block) {
+                                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+                            }
+                            if (in0_block_w_i < in0_num_blocks_w - 2) {
+                                PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
+                            }
+                        }
+                    }
+                }
+
+                cb_mm_in0.pop_front(in0_block_num_tiles);
+                cb_in1.pop_front(in1_block_num_tiles);
+            }  // for in0_num_blocks_w
+            if constexpr (matmul_partials_cb == mm_out_cb_id && partials_cb_uses_output) {
+                UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+            }
+            if constexpr (check_skip_compute) {
+                if (skip_compute) {
+                    continue;
+                }
+            }
+            if constexpr (fuse_bias) {
+                if constexpr (pack_relu) {
+                    // if last block we pack the final result with relu enabled
+                    PACK((llk_pack_relu_config(ReluConfig::zero())));
+                }
+                pack_reconfig_data_format(matmul_partials_cb, untilize_mode_out_cb_id);
+                if constexpr (packer_l1_acc) {
+                    pack_reconfig_l1_acc(0);
+                }
+                reconfig_data_format(in1_cb_id, matmul_partials_cb, mm_in0_cb_id, bias_cb_id);
+                add_bcast_rows_init_short(matmul_partials_cb, bias_cb_id);
+
+                cb_bias.wait_front(bias_ntiles_w);
+                cb_matmul_partials.wait_front(out_block_num_tiles);
+                for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
+                    uint32_t in1_index_subblock_offset = 0;
+                    for (uint32_t in1_subblock_i = 0; in1_subblock_i < in1_num_subblocks; ++in1_subblock_i) {
+                        tile_regs_acquire();
+                        uint32_t i = 0;
+                        for (uint32_t h = 0; h < out_subblock_h; ++h) {
+                            uint32_t bcast_tile_i = bias_block_offset + in1_index_subblock_offset;
+                            for (uint32_t w = 0; w < out_subblock_w; ++w) {
+                                add_tiles_bcast_rows(matmul_partials_cb, bias_cb_id, i, bcast_tile_i, i);
+                                ++bcast_tile_i;
+                                ++i;
+                            }
+                        }
+
+#ifdef SFPU_OP_INIT_ACTIVATION
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; ++i) {
+                            SFPU_OP_FUNC_ACTIVATION
+                        }
+#endif
+                        tile_regs_commit();
+                        // do not pop front bias as it may be used again for subsequent blocks
+                        cb_matmul_partials.pop_front(out_subblock_num_tiles);
+
+                        cb_untilize_mode_out.reserve_back(out_subblock_num_tiles);
+                        tile_regs_wait();
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            pack_tile(i, untilize_mode_out_cb_id);
+                        }
+                        tile_regs_release();
+                        cb_untilize_mode_out.push_back(out_subblock_num_tiles);
+
+                        in1_index_subblock_offset += out_subblock_w;
+                    }  // for in1_num_subblocks
+                }  // in0_num_subblocks
+                if constexpr (untilize_out) {
+                    UNPACK(get_local_cb_interface(matmul_partials_cb).fifo_rd_ptr = partials_cb_read_ptr);
+                    PACK(get_local_cb_interface(matmul_partials_cb).fifo_wr_ptr = partials_cb_write_ptr);
+                }
+            }
+            if constexpr (untilize_out) {
+                if constexpr (packer_l1_acc) {
+                    pack_reconfig_data_format(matmul_partials_cb, out_cb_id);
+                    pack_reconfig_l1_acc(0);
+                }
+                if constexpr (pack_relu) {
+                    PACK((llk_pack_relu_config(ReluConfig::none())));
+                }
+                if constexpr (!fuse_bias) {
+                    reconfig_data_format_srca(in1_cb_id, matmul_partials_cb);
+                }
+
+                if constexpr (packer_untilize) {
+                    pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb_id);
+                    copy_tile_to_dst_init_short(matmul_partials_cb);
+                    for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
+                        reblock_and_untilize<out_subblock_w, out_block_w>(
+                            cb_matmul_partials, cb_out, in1_num_subblocks, out_subblock_num_tiles, out_subblock_h);
+                    }
+                    pack_untilize_uninit(matmul_partials_cb);
+                } else {
+                    // Flatten nested loops into single iteration count: in0_num_subblocks * out_subblock_h
+                    compute_kernel_lib::untilize<
+                        out_block_w,
+                        matmul_partials_cb,
+                        out_cb_id,
+                        compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
+                        compute_kernel_lib::untilize_config::WaitMode::WaitBlock,
+                        compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(
+                        in0_num_subblocks * out_subblock_h);
+                }
+            }
+            if constexpr ((in1_num_blocks_w > 1 || in0_num_blocks_h > 1)) {
+                if constexpr (fuse_bias) {
+                    reconfig_data_format(matmul_partials_cb, in1_cb_id, bias_cb_id, mm_in0_cb_id);
+                } else {
+                    reconfig_data_format_srca(matmul_partials_cb, in1_cb_id);
+                }
+            }
+        }  // for in0_num_blocks_h
+        if constexpr (fuse_bias) {
+            bias_block_offset += in1_block_w;
+        }
+    }  // for in1_num_blocks_w
+}  // void kernel_main()

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_conv_activations_padded_with_halo_3x3_weights_v2_m2.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of reader_conv_activations_padded_with_halo_3x3_weights_v2.cpp.
+// Forked (not edited in place) for the same reason as conv_bmm_tilize_m2.cpp:
+// Conv2dShardedProgramFactory's L1 height-sharded path moves to the Metal 2.0
+// named-binding form while the legacy in-DRAM-config path of the same factory
+// stays on positional args. Numeric logic, loop bounds and #ifdefs are identical
+// to the legacy source — only the argument-access mechanism changed (CB-id CTAs ->
+// dfb::, scalar CTAs -> get_arg(args::), positional RTAs -> get_arg(args::)).
+//
+// The in-DRAM config path (load_config_tensor_if_in_dram, CONFIG_TENSOR_IN_DRAM)
+// is never defined on the Metal 2.0 L1 spec, so its body compiles to a no-op and
+// pulls in none of the DRAM-only CTAs.
+
+#include <api/dataflow/dataflow_api.h>
+#include "conv_reader_common.hpp"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr uint32_t dilation_h = get_arg(args::dilation_h);
+    constexpr uint32_t dilation_w = get_arg(args::dilation_w);
+    constexpr uint32_t stride_w = get_arg(args::stride_w);
+    constexpr uint32_t conv_act_c_read_bytes = get_arg(args::conv_act_c_read_bytes);
+    // need to have these as compile-time, they are inner loop bounds / unroll loops / constexpr conditionals based on
+    // them
+    constexpr uint32_t window_outer = get_arg(args::window_outer);
+    constexpr uint32_t act_block_num_tiles = get_arg(args::act_block_num_tiles);
+    constexpr uint32_t weight_size_h = get_arg(args::weight_size_h);
+    constexpr uint32_t weight_size_w = get_arg(args::weight_size_w);
+    constexpr uint32_t conv_act_size_w_padded = get_arg(args::conv_act_size_w_padded);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_arg(args::act_block_w_extra_align_bytes);
+    constexpr uint32_t act_num_blocks_h = get_arg(args::act_num_blocks_h);
+
+    constexpr bool needs_act_block_zero_out = get_arg(args::needs_act_block_zero_out) == 1;
+    constexpr uint32_t cb_id_act = dfb::act;
+    constexpr uint32_t cb_id_sharded_act = dfb::act_sharded;
+    constexpr uint32_t cb_reader_indices = dfb::reader_indices;
+
+    constexpr bool split_reader_enabled = get_arg(args::split_reader_enabled);
+    constexpr bool activation_reuse_enabled = get_arg(args::activation_reuse_enabled);
+
+    experimental::CB cb_act(cb_id_act);
+    experimental::CB cb_sharded_act(cb_id_sharded_act);
+    experimental::CB cb_reader_idx(cb_reader_indices);
+
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_idx.get_write_ptr());
+
+    uint32_t core_index = get_arg(args::core_index);
+    load_config_tensor_if_in_dram<29, 30, 31, cb_reader_indices>(Noc(), cb_reader_idx, core_index);
+    // Activation reuse args
+    constexpr uint32_t act_reuse_cb_tiles = get_arg(args::act_reuse_cb_tiles);
+    constexpr uint32_t act_block_w_tiles = get_arg(args::act_block_w_tiles);
+    constexpr bool readers_process_full_image_widths = get_arg(args::readers_process_full_image_widths) == 1;
+    constexpr uint32_t image_width_tiles = get_arg(args::image_width_tiles);
+    constexpr uint32_t output_image_width = get_arg(args::output_image_width);
+    constexpr uint32_t window_reuse_offset = get_arg(args::window_reuse_offset);
+    constexpr bool need_to_push_remaining_tiles = get_arg(args::need_to_push_remaining_tiles) == 1;
+    constexpr bool single_core_processes_multiple_batches = get_arg(args::single_core_processes_multiple_batches) == 1;
+
+    uint32_t remaining_tiles_to_push = get_arg(args::remaining_tiles_to_push);
+
+    Noc noc;
+
+    if constexpr (needs_act_block_zero_out) {
+        zero_out_tiles<cb_id_act>(noc, cb_act);
+    }
+
+    constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
+
+    // LOOP TO FILL READER INDICES
+
+    uint32_t reader_idx = 0;
+
+    // TODO: need to make the read coalescing optimization cleaner
+    // pass coalesce_window_inner_reads as a compile time arg and num_coalesced_reads so we can constexpr the if
+    // currently works for the case of num_coalesced_reads == weight_size_w since these reads are contiguous on both
+    // src/dst side we check if window_inner == weight_size_w to make sure coalescing is legal along full window_inner
+    // so the loop can be removed
+    constexpr uint32_t num_coalesced_reads = weight_size_w;
+    constexpr uint32_t coalesced_read_bytes =
+        ((dilation_w == 1) ? num_coalesced_reads * conv_act_c_read_bytes : conv_act_c_read_bytes);
+    // the conditional selecting between coalescing and no-colescing must be constexpr to that compiler can optimized
+    // the other path away this has shown to be a big perf win
+
+    // coalesce reads along weight_size_w
+    uint32_t act_l1_read_addr = cb_sharded_act.get_read_ptr();
+
+    static_assert(coalesced_read_bytes <= NOC_MAX_BURST_SIZE);
+    experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
+
+    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
+    uint32_t start_reader_idx = 0;
+    uint32_t l1_write_addr_act = 0;
+    const uint32_t cb_start_addr = cb_act.get_write_ptr();
+    for (uint32_t bh = 0; bh < act_num_blocks_h; bh++) {
+        if constexpr (activation_reuse_enabled) {
+            l1_write_addr_act = cb_start_addr;
+            get_local_cb_interface(cb_id_act).fifo_wr_ptr = l1_write_addr_act;
+        }
+        uint32_t reader_offset = act_l1_read_addr;
+        for (uint32_t outer = 0; outer < window_outer; outer++) {
+            reader_idx = start_reader_idx;
+
+            if constexpr (!activation_reuse_enabled) {
+                cb_act.reserve_back(act_block_num_tiles);
+                l1_write_addr_act = cb_act.get_write_ptr();
+
+                read_sticks<
+                    dilation_w,
+                    coalesced_read_bytes,
+                    conv_act_c_read_bytes,
+                    act_block_w_extra_align_bytes,
+                    stride_w_bytes,
+                    weight_size_w,
+                    stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+
+                noc.async_read_barrier();
+                cb_act.push_back(act_block_num_tiles);
+                reader_offset += window_outer_offset;
+            } else {
+                read_sticks_activation_reuse<
+                    coalesced_read_bytes,
+                    conv_act_c_read_bytes,
+                    act_block_w_extra_align_bytes,
+                    window_outer_offset,
+                    weight_size_w,
+                    stride_w,
+                    weight_size_h,
+                    cb_id_act,
+                    act_reuse_cb_tiles,
+                    act_block_w_tiles,
+                    readers_process_full_image_widths,
+                    image_width_tiles,
+                    output_image_width,
+                    window_reuse_offset,
+                    single_core_processes_multiple_batches>(
+                    noc,
+                    cb_act,
+                    packed_reader_indices_ptr,
+                    act_l1_read_addr,
+                    l1_write_addr_act,
+                    reader_idx,
+                    cb_start_addr);
+            }
+        }
+
+        start_reader_idx = reader_idx;
+        if constexpr (split_reader_enabled) {
+            // Increment reader index for the next number of segments (number of segments for other reader)
+            start_reader_idx += (static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1);
+        }
+    }
+
+    if constexpr (activation_reuse_enabled) {
+        // Last core sometimes has less work to do, but we still need to push the same number of tiles
+        // to avoid blocking compute kernels
+        if constexpr (need_to_push_remaining_tiles) {
+            push_remaining_tiles<cb_id_act, act_block_w_tiles, image_width_tiles>(
+                cb_act, remaining_tiles_to_push, cb_start_addr);
+        }
+    }
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks_m2.cpp
@@ -1,0 +1,244 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of reader_writer_tiled_out_1d_mcast_receiver_conv_weights_tiled_col_to_rm_blocks.cpp.
+// Forked (not edited in place) for the same reason as conv_bmm_tilize_m2.cpp.
+// Numeric logic, loop bounds and #ifdefs are identical to the legacy source — only
+// the argument-access mechanism changed (CB-id CTAs -> dfb::, scalar CTAs ->
+// get_arg(args::), semaphore-id RTAs -> sem:: (SemaphoreBinding), other positional
+// RTAs -> get_arg(args::)). Conditionally-bound DFBs (BIAS via FUSE_BIAS,
+// ACT_SECOND_READER via SECOND_READER_PRESENT) are preprocessor-gated.
+
+#include <api/dataflow/dataflow_api.h>
+#include "conv_reader_common.hpp"
+#include "debug/debug.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    // This writer is for output tensor in tile format
+    constexpr uint32_t cb_id_weight = dfb::weights;
+#ifdef FUSE_BIAS
+    constexpr uint32_t bias_cb_id = dfb::bias;
+#endif
+#ifdef SECOND_READER_PRESENT
+    constexpr uint32_t cb_id_act_second_reader = dfb::act_second_reader;
+#endif
+    constexpr uint32_t cb_id_sharded_act = dfb::act_sharded;
+    constexpr uint32_t cb_reader_indices = dfb::reader_indices;
+    constexpr uint32_t num_blocks_weight_h = get_arg(args::num_blocks_weight_h);
+    constexpr uint32_t weight_block_num_tiles = get_arg(args::weight_block_num_tiles);
+
+    // Bias arg. Unused if bias fusion is not enabled.
+    constexpr uint32_t bias_ntiles = get_arg(args::bias_ntiles);
+
+    constexpr uint32_t out_num_blocks_h = get_arg(args::out_num_blocks_h);
+
+    constexpr bool fuse_bias = get_arg(args::fuse_bias);
+
+    constexpr bool split_reader_enabled = get_arg(args::split_reader_enabled);
+    constexpr bool activation_reuse_enabled = get_arg(args::activation_reuse_enabled);
+
+    // Split reader args
+    constexpr uint32_t act_block_num_tiles = get_arg(args::act_block_num_tiles);
+    constexpr uint32_t conv_act_c_read_bytes = get_arg(args::conv_act_c_read_bytes);
+    constexpr uint32_t weight_size_w = get_arg(args::weight_size_w);
+    constexpr uint32_t conv_act_size_w_padded = get_arg(args::conv_act_size_w_padded);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_arg(args::act_block_w_extra_align_bytes);
+    constexpr bool needs_act_block_zero_out = get_arg(args::needs_act_block_zero_out) == 1;
+    constexpr uint32_t dilation_h = get_arg(args::dilation_h);
+    constexpr uint32_t dilation_w = get_arg(args::dilation_w);
+    constexpr uint32_t stride_w = get_arg(args::stride_w);
+    constexpr uint32_t weights_size_h = get_arg(args::weights_size_h);
+
+    // Activation reuse args
+    constexpr uint32_t act_reuse_cb_tiles = get_arg(args::act_reuse_cb_tiles);
+    constexpr uint32_t act_block_w_tiles = get_arg(args::act_block_w_tiles);
+    constexpr bool readers_process_full_image_widths = get_arg(args::readers_process_full_image_widths) == 1;
+    constexpr uint32_t image_width_tiles = get_arg(args::image_width_tiles);
+    constexpr uint32_t output_image_width = get_arg(args::output_image_width);
+    constexpr uint32_t window_reuse_offset = get_arg(args::window_reuse_offset);
+    constexpr bool need_to_push_remaining_tiles = get_arg(args::need_to_push_remaining_tiles) == 1;
+    constexpr bool single_core_processes_multiple_batches = get_arg(args::single_core_processes_multiple_batches) == 1;
+
+    uint32_t noop = get_arg(args::noop);
+
+    if (noop) {
+        return;
+    }
+
+    // Experimental API objects
+    Noc noc;
+
+    if constexpr (split_reader_enabled) {
+        if constexpr (needs_act_block_zero_out) {
+#ifdef SECOND_READER_PRESENT
+            zero_out_tiles<cb_id_act_second_reader>(noc, experimental::CB(cb_id_act_second_reader));
+#endif
+        }
+    }
+
+    // mcast args
+    const uint32_t weights_mcast_sender_noc_x = get_arg(args::weights_mcast_sender_noc_x);
+    const uint32_t weights_mcast_sender_noc_y = get_arg(args::weights_mcast_sender_noc_y);
+    Semaphore<> weights_mcast_sender_sem(sem::weights_mcast_sender);
+    Semaphore<> weights_mcast_receiver_sem(sem::weights_mcast_receiver);
+    experimental::CB cb_weight_obj(cb_id_weight);
+#ifdef FUSE_BIAS
+    experimental::CB cb_bias_obj(bias_cb_id);
+#endif
+#ifdef SECOND_READER_PRESENT
+    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
+#endif
+    experimental::CB cb_reader_indices_obj(cb_reader_indices);
+    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+
+    const uint32_t remaining_tiles_to_push =
+        split_reader_enabled && activation_reuse_enabled ? get_arg(args::remaining_tiles_to_push) : 0;
+
+    // Split reader configuration
+    if constexpr (split_reader_enabled) {
+#ifdef CONFIG_TENSOR_IN_DRAM
+        cb_reader_indices_obj.wait_front(1);
+#endif
+    }
+    constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
+                             : nullptr;
+    uint32_t reader_idx = 0;
+    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
+    constexpr uint32_t coalesced_read_bytes =
+        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
+    const uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
+    uint32_t start_reader_idx =
+        split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1 : 0;
+#ifdef SECOND_READER_PRESENT
+    const uint32_t cb_start_addr = split_reader_enabled ? cb_act_second_obj.get_write_ptr() : 0;
+#else
+    const uint32_t cb_start_addr = 0;
+#endif
+
+    // read in bias if enabled (done only once for all batches)
+    [[maybe_unused]] bool load_bias = true;
+    uint32_t l1_write_addr_act = 0;
+    uint32_t reader_offset = 0;
+    for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
+        // MCAST RECEIVE WEIGHTS
+        // read weight blocks inner dim
+        // read weight slice - 1 block of weights in width dim and full weight matrix height
+        // read slice only once for all activation blocks
+
+        if constexpr (split_reader_enabled) {
+            if constexpr (activation_reuse_enabled) {
+#ifdef SECOND_READER_PRESENT
+                l1_write_addr_act = cb_start_addr;
+                get_local_cb_interface(cb_id_act_second_reader).fifo_wr_ptr = l1_write_addr_act;
+#endif
+            }
+            reader_offset = act_l1_read_addr;
+        }
+        for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
+            if constexpr (split_reader_enabled) {
+#ifdef SECOND_READER_PRESENT
+                // Do the second half of the reads for act
+                experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
+                reader_idx = start_reader_idx;
+
+                if constexpr (!activation_reuse_enabled) {
+                    cb_act_second_obj.reserve_back(act_block_num_tiles);
+                    l1_write_addr_act = cb_act_second_obj.get_write_ptr();
+                    read_sticks<
+                        dilation_w,
+                        coalesced_read_bytes,
+                        conv_act_c_read_bytes,
+                        act_block_w_extra_align_bytes,
+                        stride_w_bytes,
+                        weight_size_w,
+                        stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+                    noc.async_read_barrier();
+                    cb_act_second_obj.push_back(act_block_num_tiles);
+
+                    reader_offset += window_outer_offset;
+                } else {
+                    read_sticks_activation_reuse<
+                        coalesced_read_bytes,
+                        conv_act_c_read_bytes,
+                        act_block_w_extra_align_bytes,
+                        window_outer_offset,
+                        weight_size_w,
+                        stride_w,
+                        weights_size_h,
+                        cb_id_act_second_reader,
+                        act_reuse_cb_tiles,
+                        act_block_w_tiles,
+                        readers_process_full_image_widths,
+                        image_width_tiles,
+                        output_image_width,
+                        window_reuse_offset,
+                        single_core_processes_multiple_batches>(
+                        noc,
+                        cb_act_second_obj,
+                        packed_reader_indices_ptr,
+                        act_l1_read_addr,
+                        l1_write_addr_act,
+                        reader_idx,
+                        cb_start_addr);
+
+                    if constexpr (need_to_push_remaining_tiles) {
+                        if (block_weight_h == num_blocks_weight_h - 1) {
+                            // Last core sometimes has less work to do, but we still need to push the same number of
+                            // tiles to avoid blocking compute kernels
+                            push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
+                                cb_act_second_obj, remaining_tiles_to_push, cb_start_addr);
+                        }
+                    }
+                }
+#endif
+            }
+
+            // Receive weights
+            cb_weight_obj.reserve_back(weight_block_num_tiles);
+            if (bh == 0) {
+                // Set weights semaphore value to INVALID
+                weights_mcast_receiver_sem.set(INVALID);
+
+                // Atomic increment source core counter
+                weights_mcast_sender_sem.up(noc, weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, 1);
+
+                // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts
+                // data)
+                weights_mcast_receiver_sem.wait(VALID);
+            }
+
+            cb_weight_obj.push_back(weight_block_num_tiles);
+        }
+
+        if constexpr (fuse_bias) {
+#ifdef FUSE_BIAS
+            if (load_bias) {
+                cb_bias_obj.reserve_back(bias_ntiles);
+
+                // Set weights semaphore value to INVALID
+                weights_mcast_receiver_sem.set(INVALID);
+
+                // Atomic increment source core counter
+                weights_mcast_sender_sem.up(noc, weights_mcast_sender_noc_x, weights_mcast_sender_noc_y, 1);
+
+                // wait on weights semaphore value to become VALID (set by mcast sender after it multicasts data)
+                weights_mcast_receiver_sem.wait(VALID);
+
+                cb_bias_obj.push_back(bias_ntiles);
+                load_bias = false;
+            }
+#endif
+        }
+
+        if constexpr (split_reader_enabled) {
+            // Increment reader index for the next number of segments (number of segments for other reader)
+            start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+        }
+    }  // out_num_blocks_h
+
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks_m2.cpp
@@ -1,0 +1,383 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of reader_writer_tiled_out_1d_mcast_sender_conv_weights_tiled_col_to_rm_blocks.cpp.
+// Forked (not edited in place) for the same reason as conv_bmm_tilize_m2.cpp:
+// Conv2dShardedProgramFactory's L1 height-sharded path moves to the Metal 2.0
+// named-binding form while the legacy in-DRAM-config path of the same factory
+// stays on positional args. Numeric logic, loop bounds and #ifdefs are identical
+// to the legacy source — only the argument-access mechanism changed:
+//   - CB-id CTAs                 -> dfb::name
+//   - scalar CTAs                -> get_arg(args::name)
+//   - weight/bias buffer-addr RTAs -> TensorAccessor(ta::name) (typed TensorBinding)
+//   - semaphore-id RTAs          -> sem::name (SemaphoreBinding)
+//   - other positional RTAs      -> get_arg(args::name)
+// Conditionally-bound DFBs/tensors (BIAS via FUSE_BIAS, ACT_SECOND_READER via
+// SECOND_READER_PRESENT) are referenced only through preprocessor-gated aliases so
+// their dfb::/ta:: tokens are not name-looked-up on a build where the host did not
+// bind them.
+
+#include <api/dataflow/dataflow_api.h>
+#include "conv_reader_common.hpp"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    // This writer is for output tensor in tile format
+    constexpr uint32_t cb_id_weight = dfb::weights;
+#ifdef FUSE_BIAS
+    constexpr uint32_t bias_cb_id = dfb::bias;
+#endif
+#ifdef SECOND_READER_PRESENT
+    constexpr uint32_t cb_id_act_second_reader = dfb::act_second_reader;
+#endif
+    constexpr uint32_t cb_id_sharded_act = dfb::act_sharded;
+    constexpr uint32_t cb_reader_indices = dfb::reader_indices;
+    constexpr uint32_t num_blocks_weight_h = get_arg(args::num_blocks_weight_h);
+    constexpr uint32_t weight_block_num_tiles = get_arg(args::weight_block_num_tiles);
+
+    constexpr uint32_t weight_block_height_num_outer = get_arg(args::weight_block_height_num_outer);
+    constexpr uint32_t weight_block_height_ntiles = get_arg(args::weight_block_height_ntiles);
+    constexpr uint32_t weight_block_width_ntiles = get_arg(args::weight_block_width_ntiles);
+    constexpr uint32_t weight_stride_h = get_arg(args::weight_stride_h);
+    constexpr uint32_t weight_next_block_stride_h = get_arg(args::weight_next_block_stride_h);
+
+    // Bias arg. Unused if bias fusion is not enabled.
+    constexpr uint32_t bias_ntiles = get_arg(args::bias_ntiles);
+
+    constexpr uint32_t out_num_blocks_h = get_arg(args::out_num_blocks_h);
+
+    constexpr bool fuse_bias = get_arg(args::fuse_bias);
+
+    constexpr bool split_reader_enabled = get_arg(args::split_reader_enabled);
+    constexpr bool activation_reuse_enabled = get_arg(args::activation_reuse_enabled);
+
+    // Split reader args
+    constexpr uint32_t act_block_num_tiles = get_arg(args::act_block_num_tiles);
+    constexpr uint32_t conv_act_c_read_bytes = get_arg(args::conv_act_c_read_bytes);
+    constexpr uint32_t weight_size_w = get_arg(args::weight_size_w);
+    constexpr uint32_t conv_act_size_w_padded = get_arg(args::conv_act_size_w_padded);
+    constexpr uint32_t act_block_w_extra_align_bytes = get_arg(args::act_block_w_extra_align_bytes);
+    constexpr bool needs_act_block_zero_out = get_arg(args::needs_act_block_zero_out) == 1;
+    constexpr uint32_t dilation_h = get_arg(args::dilation_h);
+    constexpr uint32_t dilation_w = get_arg(args::dilation_w);
+    constexpr uint32_t stride_w = get_arg(args::stride_w);
+    constexpr uint32_t weights_size_h = get_arg(args::weights_size_h);
+
+    // Activation reuse args
+    constexpr uint32_t act_reuse_cb_tiles = get_arg(args::act_reuse_cb_tiles);
+    constexpr uint32_t act_block_w_tiles = get_arg(args::act_block_w_tiles);
+    constexpr bool readers_process_full_image_widths = get_arg(args::readers_process_full_image_widths) == 1;
+    constexpr uint32_t image_width_tiles = get_arg(args::image_width_tiles);
+    constexpr uint32_t output_image_width = get_arg(args::output_image_width);
+    constexpr uint32_t window_reuse_offset = get_arg(args::window_reuse_offset);
+    constexpr bool need_to_push_remaining_tiles = get_arg(args::need_to_push_remaining_tiles) == 1;
+    constexpr bool single_core_processes_multiple_batches = get_arg(args::single_core_processes_multiple_batches) == 1;
+
+    // Experimental API objects
+    Noc noc;
+
+    if constexpr (split_reader_enabled) {
+        if constexpr (needs_act_block_zero_out) {
+#ifdef SECOND_READER_PRESENT
+            zero_out_tiles<cb_id_act_second_reader>(noc, experimental::CB(cb_id_act_second_reader));
+#endif
+        }
+    }
+
+    // mcast args
+    const McastRect mcast_rect = {
+        get_arg(args::mcast_noc_x_start),
+        get_arg(args::mcast_noc_y_start),
+        get_arg(args::mcast_noc_x_end),
+        get_arg(args::mcast_noc_y_end)};
+    const uint32_t weights_mcast_num_dests = get_arg(args::weights_mcast_num_dests);
+    const uint32_t weights_mcast_num_cores = get_arg(args::weights_mcast_num_cores);
+    Semaphore<> weights_mcast_sender_sem(sem::weights_mcast_sender);
+    Semaphore<> weights_mcast_receiver_sem(sem::weights_mcast_receiver);
+    MulticastEndpoint mcast_ep;
+    experimental::CB cb_weight_obj(cb_id_weight);
+#ifdef FUSE_BIAS
+    experimental::CB cb_bias_obj(bias_cb_id);
+#endif
+#ifdef SECOND_READER_PRESENT
+    experimental::CB cb_act_second_obj(cb_id_act_second_reader);
+#endif
+    experimental::CB cb_reader_indices_obj(cb_reader_indices);
+    experimental::CB cb_sharded_act_obj(cb_id_sharded_act);
+    // Pre-built mcast destination; .addr is updated per mcast call
+    McastDst mcast_dst = {
+        .noc_x_start = mcast_rect.noc_x_start,
+        .noc_y_start = mcast_rect.noc_y_start,
+        .noc_x_end = mcast_rect.noc_x_end,
+        .noc_y_end = mcast_rect.noc_y_end,
+        .addr = 0};
+
+    const uint32_t out_start_tile_id_w = get_arg(args::out_start_tile_id_w);
+    const uint32_t bias_tile_offset = get_arg(args::bias_tile_offset);
+
+    const uint32_t remaining_tiles_to_push =
+        split_reader_enabled && activation_reuse_enabled ? get_arg(args::remaining_tiles_to_push) : 0;
+
+    // Split reader configuration
+    if constexpr (split_reader_enabled) {
+#ifdef CONFIG_TENSOR_IN_DRAM
+        cb_reader_indices_obj.wait_front(1);
+#endif
+    }
+
+    constexpr uint32_t window_outer_offset = conv_act_size_w_padded * conv_act_c_read_bytes * dilation_h;
+    volatile tt_l1_ptr uint32_t* packed_reader_indices_ptr =
+        split_reader_enabled ? reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb_reader_indices_obj.get_write_ptr())
+                             : nullptr;
+    uint32_t reader_idx = 0;
+    constexpr uint32_t stride_w_bytes = dilation_w * conv_act_c_read_bytes;
+    constexpr uint32_t coalesced_read_bytes =
+        ((dilation_w == 1) ? weight_size_w * conv_act_c_read_bytes : conv_act_c_read_bytes);
+    uint32_t act_l1_read_addr = split_reader_enabled ? cb_sharded_act_obj.get_read_ptr() : 0;
+    // coalesce reads along weight_size_w
+    uint32_t start_reader_idx = split_reader_enabled ? (uint32_t)(packed_reader_indices_ptr[0] & 0xffff) + 1 : 0;
+#ifdef SECOND_READER_PRESENT
+    uint32_t cb_start_addr = split_reader_enabled ? cb_act_second_obj.get_write_ptr() : 0;
+#else
+    uint32_t cb_start_addr = 0;
+#endif
+    uint32_t reader_offset = act_l1_read_addr;
+
+#ifndef SKIP_MCAST
+    // Set ur local VALID value, to be mcasted to destinations flag address after the data has been mcasted
+    weights_mcast_receiver_sem.set(VALID);
+    // local address that will be atomically incremented by mcast receivers, to know when all receivers are ready
+    // to receive the mcast
+#endif
+
+    // read in bias if enabled (done only once for all batches)
+#ifdef FUSE_BIAS
+    constexpr uint32_t bias_pagesize =
+        fuse_bias ? get_tile_size(bias_cb_id) : 0;  // dummy but valid value in case bias is not enabled
+    const auto s_bias = TensorAccessor(ta::bias);
+#endif
+    [[maybe_unused]] bool load_bias = true;
+
+    constexpr uint32_t weight_tile_nbytes = get_tile_size(cb_id_weight);
+    const auto s_weight = TensorAccessor(ta::weights);
+
+    // OUTER most loop is looping over out blocks in width dim because blocks from compute are in col major order.
+    // Write out col major blocks in row major layout to output
+    constexpr uint32_t weight_inner_block_stride_h =
+        weight_next_block_stride_h / weight_block_height_num_outer;  // TODO: Pass as args
+
+    uint32_t l1_write_addr_act = 0;
+    for (uint32_t bh = 0; bh < out_num_blocks_h; bh++) {
+        // READ WEIGHTS + MCAST SEND WEIGHTS
+        // read weight blocks inner dim
+        // read weight slice - 1 block of weights in width dim and full weight matrix height
+        // read slice only once for all activation blocks
+        uint32_t weight_h_offset = 0;
+
+        uint32_t weight_current_block_start_tile_id = 0;
+
+        if constexpr (split_reader_enabled) {
+            if constexpr (activation_reuse_enabled) {
+#ifdef SECOND_READER_PRESENT
+                l1_write_addr_act = cb_start_addr;
+                get_local_cb_interface(cb_id_act_second_reader).fifo_wr_ptr = l1_write_addr_act;
+#endif
+            }
+            reader_offset = act_l1_read_addr;
+        }
+
+        for (uint32_t block_weight_h = 0; block_weight_h < num_blocks_weight_h; block_weight_h++) {
+            if constexpr (split_reader_enabled) {
+#ifdef SECOND_READER_PRESENT
+                // Do the second half of the reads for act
+                experimental::set_read_state<coalesced_read_bytes>(noc, act_l1_read_addr);
+                reader_idx = start_reader_idx;
+
+                if constexpr (!activation_reuse_enabled) {
+                    cb_act_second_obj.reserve_back(act_block_num_tiles);
+                    l1_write_addr_act = cb_act_second_obj.get_write_ptr();
+                    read_sticks<
+                        dilation_w,
+                        coalesced_read_bytes,
+                        conv_act_c_read_bytes,
+                        act_block_w_extra_align_bytes,
+                        stride_w_bytes,
+                        weight_size_w,
+                        stride_w>(noc, packed_reader_indices_ptr, reader_offset, l1_write_addr_act, reader_idx);
+                    noc.async_read_barrier();
+                    cb_act_second_obj.push_back(act_block_num_tiles);
+
+                    reader_offset += window_outer_offset;
+                } else {
+                    read_sticks_activation_reuse<
+                        coalesced_read_bytes,
+                        conv_act_c_read_bytes,
+                        act_block_w_extra_align_bytes,
+                        window_outer_offset,
+                        weight_size_w,
+                        stride_w,
+                        weights_size_h,
+                        cb_id_act_second_reader,
+                        act_reuse_cb_tiles,
+                        act_block_w_tiles,
+                        readers_process_full_image_widths,
+                        image_width_tiles,
+                        output_image_width,
+                        window_reuse_offset,
+                        single_core_processes_multiple_batches>(
+                        noc,
+                        cb_act_second_obj,
+                        packed_reader_indices_ptr,
+                        act_l1_read_addr,
+                        l1_write_addr_act,
+                        reader_idx,
+                        cb_start_addr);
+
+                    if constexpr (need_to_push_remaining_tiles) {
+                        if (block_weight_h == num_blocks_weight_h - 1) {
+                            // Last core sometimes has less work to do, but we still need to push the same number of
+                            // tiles to avoid blocking compute kernels
+                            push_remaining_tiles<cb_id_act_second_reader, act_block_w_tiles, image_width_tiles>(
+                                cb_act_second_obj, remaining_tiles_to_push, cb_start_addr);
+                        }
+                    }
+                }
+#endif
+            }
+
+            // Do weights read + mcast
+            cb_weight_obj.reserve_back(weight_block_num_tiles);
+            if (bh == 0) {
+                uint32_t weight_row_start_tile_id = weight_current_block_start_tile_id + weight_h_offset;
+
+                uint32_t weight_write_offset = 0;
+                uint32_t weights_block_size_bytes = 0;
+
+                // loop over weight block tiles along h
+                for (uint32_t weight_tile_h_i = 0; weight_tile_h_i < weight_block_height_ntiles; ++weight_tile_h_i) {
+                    uint32_t weight_tile_id = weight_row_start_tile_id;
+                    // loop over weight block tiles along w
+                    for (uint32_t weight_tile_w_i = 0; weight_tile_w_i < weight_block_width_ntiles; ++weight_tile_w_i) {
+                        // DPRINT("weight_tile_id={}\n", weight_tile_id);
+                        noc.async_read(
+                            s_weight,
+                            cb_weight_obj,
+                            weight_tile_nbytes,
+                            {.page_id = weight_tile_id},
+                            {.offset_bytes = weight_write_offset});
+                        weight_write_offset += weight_tile_nbytes;
+                        weights_block_size_bytes += weight_tile_nbytes;
+                        weight_tile_id += 1;
+                    }  // for weight_block_w
+                    weight_row_start_tile_id += weight_stride_h;
+                }  // for weight_block_h
+                noc.async_read_barrier();
+
+#ifndef SKIP_MCAST
+                // wait until all weights mcast destinations have atomically incremented the weights
+                // semaphore_addr (i.e. its value should be weights_mcast_num_dests), then reset the
+                // semaphore_addr value back to zero for the next block
+                weights_mcast_sender_sem.wait(weights_mcast_num_dests);
+                weights_mcast_sender_sem.set(0);
+
+                // Now we have the block in the CB address, we can mcast to dests!
+                // num_dests must not include source, since we are NOT really doing a local copy!
+                mcast_dst.addr = cb_weight_obj.get_write_ptr();
+                noc.async_write_multicast(
+                    use<experimental::CB::AddrSelector::WRITE_PTR>(cb_weight_obj),
+                    mcast_ep,
+                    weights_block_size_bytes,
+                    weights_mcast_num_cores,
+                    {},
+                    mcast_dst,
+                    true);
+
+                // Note: no need for write barrier, since these two multicasts are done on the same noc id and
+                // same vc even though cmd bufs are different Also, this only works because we are setting VCs
+                // statically (using NOC_CMD_STATIC_VC).
+                // We should also multicast the flag to destinations
+                // num_dests must not include source, since we are NOT really doing a local copy!
+                weights_mcast_receiver_sem.set_multicast(
+                    noc,
+                    mcast_rect.noc_x_start,
+                    mcast_rect.noc_y_start,
+                    mcast_rect.noc_x_end,
+                    mcast_rect.noc_y_end,
+                    weights_mcast_num_cores,
+                    false);
+#endif
+
+                weight_current_block_start_tile_id += weight_next_block_stride_h;
+            }
+
+            cb_weight_obj.push_back(weight_block_num_tiles);
+        }  // for num_blocks_weight_h
+        weight_h_offset += weight_inner_block_stride_h;
+
+        if constexpr (fuse_bias) {
+#ifdef FUSE_BIAS
+            if (load_bias) {
+                cb_bias_obj.reserve_back(bias_ntiles);
+
+                uint32_t bias_write_offset = 0;
+                uint32_t bias_block_size_bytes = 0;
+                for (uint32_t bias_tile = bias_tile_offset; bias_tile < bias_tile_offset + bias_ntiles; ++bias_tile) {
+                    noc.async_read(
+                        s_bias,
+                        cb_bias_obj,
+                        bias_pagesize,
+                        {.page_id = bias_tile},
+                        {.offset_bytes = bias_write_offset});
+                    bias_write_offset += bias_pagesize;
+                    bias_block_size_bytes += bias_pagesize;
+                }
+                noc.async_read_barrier();
+
+// MCAST BIAS (shares some mcast args with weights)
+#ifndef SKIP_MCAST
+                // wait until all weights mcast destinations have atomically incremented the weights semaphore_addr
+                // (i.e. its value should be weights_mcast_num_dests), then reset the semaphore_addr value back to zero
+                // for the next block
+                weights_mcast_sender_sem.wait(weights_mcast_num_dests);
+                weights_mcast_sender_sem.set(0);
+
+                // Now we have the block in the CB address, we can mcast to dests!
+                // num_dests must not include source, since we are NOT really doing a local copy!
+                mcast_dst.addr = cb_bias_obj.get_write_ptr();
+                noc.async_write_multicast(
+                    use<experimental::CB::AddrSelector::WRITE_PTR>(cb_bias_obj),
+                    mcast_ep,
+                    bias_block_size_bytes,
+                    weights_mcast_num_cores,
+                    {},
+                    mcast_dst,
+                    true);
+
+                // Note: no need for write barrier, since these two multicasts are done on the same noc id and same vc
+                // even though cmd bufs are different Also, this only works because we are setting VCs statically (using
+                // NOC_CMD_STATIC_VC).
+                // We should also multicast the flag to destinations
+                // num_dests must not include source, since we are NOT really doing a local copy!
+                weights_mcast_receiver_sem.set_multicast(
+                    noc,
+                    mcast_rect.noc_x_start,
+                    mcast_rect.noc_y_start,
+                    mcast_rect.noc_x_end,
+                    mcast_rect.noc_y_end,
+                    weights_mcast_num_cores,
+                    false);
+#endif
+
+                cb_bias_obj.push_back(bias_ntiles);
+                load_bias = false;
+            }
+#endif
+        }
+        if constexpr (split_reader_enabled) {
+            // Increment reader index for the next number of segments (number of segments for other reader)
+            start_reader_idx = reader_idx + static_cast<uint32_t>(packed_reader_indices_ptr[reader_idx] & 0xffff) + 1;
+        }
+    }  // out_num_blocks_h
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/device/kernels/weights_reader_width_sharded.cpp
@@ -6,43 +6,44 @@
 #include <api/dataflow/dataflow_api.h>
 #include "api/debug/dprint.h"
 #include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t cb_id_weight = get_compile_time_arg_val(0);
-    constexpr uint32_t core_in_channels_ntiles = get_compile_time_arg_val(1);
-    constexpr uint32_t window_size_hw = get_compile_time_arg_val(2);
+    constexpr uint32_t cb_id_weight = dfb::weights;
+    constexpr uint32_t core_in_channels_ntiles = get_arg(args::core_in_channels_ntiles);
+    constexpr uint32_t window_size_hw = get_arg(args::window_size_hw);
 
     // weight_block_width_ntiles corresponds to the full output width of each core.
-    constexpr uint32_t weight_block_width_ntiles = get_compile_time_arg_val(3);
-    constexpr uint32_t weight_block_num_tiles = get_compile_time_arg_val(4);
-    constexpr uint32_t weight_matrix_width_ntiles = get_compile_time_arg_val(5);
-    constexpr uint32_t weight_next_channel_stride_h = get_compile_time_arg_val(6);
-    constexpr uint32_t weight_next_block_this_core_stride_h = get_compile_time_arg_val(7);
-    constexpr uint32_t weight_next_block_other_core_stride_h = get_compile_time_arg_val(8);
-    constexpr uint32_t remote_weight_height_blocks = get_compile_time_arg_val(9);
-    constexpr uint32_t local_weight_height_blocks = get_compile_time_arg_val(10);
-    constexpr uint32_t act_num_blocks_h = get_compile_time_arg_val(11);
-    constexpr uint32_t bias_cb_id = get_compile_time_arg_val(12);
-    constexpr bool fuse_bias = get_compile_time_arg_val(13);
-    constexpr auto s_weight_args = TensorAccessorArgs<14>();
-    constexpr auto s_bias_args = TensorAccessorArgs<s_weight_args.next_compile_time_args_offset()>();
+    constexpr uint32_t weight_block_width_ntiles = get_arg(args::weight_block_width_ntiles);
+    constexpr uint32_t weight_block_num_tiles = get_arg(args::weight_block_num_tiles);
+    constexpr uint32_t weight_matrix_width_ntiles = get_arg(args::weight_matrix_width_ntiles);
+    constexpr uint32_t weight_next_channel_stride_h = get_arg(args::weight_next_channel_stride_h);
+    constexpr uint32_t weight_next_block_this_core_stride_h = get_arg(args::weight_next_block_this_core_stride_h);
+    constexpr uint32_t weight_next_block_other_core_stride_h = get_arg(args::weight_next_block_other_core_stride_h);
+    constexpr uint32_t remote_weight_height_blocks = get_arg(args::remote_weight_height_blocks);
+    constexpr uint32_t local_weight_height_blocks = get_arg(args::local_weight_height_blocks);
+    constexpr uint32_t act_num_blocks_h = get_arg(args::act_num_blocks_h);
+    // BIAS DFB bound only when has_bias; alias to weights when unbound so bias_cb
+    // construction stays well-formed (all real uses are under `if constexpr (fuse_bias)`).
+#ifdef FUSE_BIAS
+    constexpr uint32_t bias_cb_id = dfb::bias;
+#else
+    constexpr uint32_t bias_cb_id = dfb::weights;
+#endif
+    constexpr bool fuse_bias = get_arg(args::fuse_bias);
 
-    uint32_t i = 0;
-    const uint32_t init_weight_start_tile_id = get_arg_val<uint32_t>(i);
-    i += 1;
-    const uint32_t weight_addr_dram_base = get_arg_val<uint32_t>(i);
-    i += 1;
-
-    uint32_t bias_addr_dram_base = get_arg_val<uint32_t>(i);
-    i += 1;
-    const uint32_t is_active = get_arg_val<uint32_t>(i);
-    i += 1;
+    const uint32_t init_weight_start_tile_id = get_arg(args::init_weight_start_tile_id);
+    const uint32_t is_active = get_arg(args::is_active);
 
     const uint32_t weight_tile_nbytes = get_tile_size(cb_id_weight);
-    const auto s_weight = TensorAccessor(s_weight_args, weight_addr_dram_base);
+    // Weight (and optional bias) base addresses now arrive via the typed tensor
+    // binding channel; TensorAccessor(ta::name) packs the per-enqueue base address.
+    const auto s_weight = TensorAccessor(ta::weights);
     const uint32_t bias_pagesize =
         fuse_bias ? get_tile_size(bias_cb_id) : 0;  // dummy but valid value in case bias is not enabled
-    const auto s_bias = TensorAccessor(s_bias_args, bias_addr_dram_base);
+#ifdef FUSE_BIAS
+    const auto s_bias = TensorAccessor(ta::bias);
+#endif
 
     experimental::CB weight_cb(cb_id_weight);
     experimental::CB bias_cb(bias_cb_id);
@@ -104,6 +105,7 @@ void kernel_main() {
             }
             weight_start_tile_id += weight_next_block_this_core_stride_h;
             if (to_load_bias) {
+#ifdef FUSE_BIAS
                 if constexpr (fuse_bias) {
                     bias_cb.reserve_back(weight_block_width_ntiles);
                     uint32_t bias_write_offset = 0;
@@ -120,6 +122,7 @@ void kernel_main() {
                     noc.async_read_barrier();
                     bias_cb.push_back(weight_block_width_ntiles);
                 }
+#endif
                 to_load_bias = false;
             }
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/METAL2_PORT_REPORT.md
@@ -1,0 +1,95 @@
+# Metal 2.0 Port Report — `pad` (PadTileCoreProgramFactory)
+
+## Status: PORTED
+
+One factory ported; the op's other six factories remain on their legacy concepts
+(supported — the `program_factory_t` variant dispatches per-factory by concept, and
+`AllFactoriesValid` in `operation_concepts.hpp` validates each variant alternative
+independently).
+
+## Factory chosen
+
+`PadTileCoreProgramFactory` — the simplest single-program factory in the op:
+
+- Single core `{0,0}` (no work-split, no per-core loop).
+- Two kernels: a tilized reader + the pad writer.
+- Two CBs; no semaphores; no op-owned/scratch device tensors; no `GlobalSemaphore`.
+
+Selected at runtime for TILE-layout, non-multicore pad (`select_program_factory`,
+`pad_device_operation.cpp:104-108`). Unchanged — still returns `PadTileCoreProgramFactory{}`.
+
+## Legacy → Metal 2.0 mapping
+
+| Legacy (ProgramDescriptor)                  | Metal 2.0                                              |
+|---------------------------------------------|-------------------------------------------------------|
+| `create_descriptor` → `ProgramDescriptor`   | `create_program_spec` → `ProgramArtifacts{spec,run}`  |
+| CB c_0 (src0, 2 tiles)                       | DFB `in0` (reader PRODUCER, writer CONSUMER)          |
+| CB c_1 (src1, 1 tile, writer-only scratch)   | DFB `pad` (writer self-loop: PRODUCER + CONSUMER)     |
+| `TensorAccessorArgs(src0)` CTA + addr RTA    | `TensorParameter{src}` + `TensorBinding` on reader    |
+| `TensorAccessorArgs(dst)` CTA + addr RTA     | `TensorParameter{out}` + `TensorBinding` on writer    |
+| writer CTAs `{src0_cb_index, src1_cb_index}` | dropped (DFB bindings carry CB identity)              |
+| positional reader RTAs `{addr, n, 0}`        | named `{num_pages, start_id}`                          |
+| positional writer RTAs (10 slots)            | named (`pad_value` etc.); buffer-addr slot dropped    |
+
+DFBs declared with `entry_size = single_tile_size`, `num_entries = {2, 1}`,
+`data_format_metadata = cb_data_format` — copied 1:1 from the legacy CBs. No
+`tile_format_metadata` (legacy CBs set no `.tile`).
+
+## Local-DFB / WorkUnit structure
+
+Both DFBs are local. `in0` has producer (reader) and consumer (writer); `pad` is a
+writer self-loop. Both kernels run on the single core, so one `WorkUnitSpec`
+(`single_core`) hosts `{reader, writer}` — satisfying the rule that every node hosting
+a DFB hosts both endpoints.
+
+## Kernels
+
+- **Reader — FORKED.** `eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp`
+  is shared by ~12 ops (`grep -rl`), so it was forked to
+  `pad/device/kernels/dataflow/reader_unary_interleaved_start_id_m2.cpp` and the fork
+  ported. Only the access mechanism changed: `cb_id_in0 (=0)` → `dfb::in0`,
+  `TensorAccessor(src_args, src_addr)` → `TensorAccessor(ta::src)`, positional RTAs →
+  `get_arg(args::num_pages/start_id)`. The `#ifdef BACKWARDS` branch (unused on the pad
+  path) is preserved verbatim. (Note: matmul's port forked a *different* shared reader;
+  this pad path uses the eltwise/unary reader, hence a separate fork.)
+
+- **Writer — PORTED IN PLACE.** `pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp`
+  is used only by this factory (`grep -rl` → single hit), so it was ported in place.
+  `cb_id_out0 (=0)` → `dfb::in0` (consumer), `cb_id_out1 (=1)` → `dfb::pad` (self-loop
+  scratch), `TensorAccessor(dst_args, dst_addr)` → `TensorAccessor(ta::out)`, positional
+  RTAs → named. `get_tile_size(dfb::in0)` relies on the `DFBAccessor → uint32_t` implicit
+  conversion. Pad-fill loop / NoC writes / `CoreLocalMem` logic unchanged.
+
+## Device-op-class edits
+
+- **Custom `compute_program_hash`**: NONE on `PadDeviceOperation` — nothing to delete.
+- **Pybind hook**: NONE — pad dispatches through the device-op adapter; there is no
+  direct `create_descriptor` nanobind hook for this factory (verified: no
+  `create_descriptor`/`create_program` references in `pad_nanobind.cpp`).
+- Factory `.hpp` updated: declares `create_program_spec` returning `ProgramArtifacts`;
+  dropped the now-unused `<tt-metalium/program_descriptors.hpp>` include, added
+  `ttnn/metal2_artifacts.hpp`. The `program_factory_t` variant and `select_program_factory`
+  are unchanged.
+
+## Blockers
+
+None. The port is a clean mechanical translation.
+
+## Friction / notes
+
+- **Worktree base mismatch (environmental, not a port blocker).** This worktree is NOT
+  on `dgomez/rand-metal2`; it has the Metal 2.0 API headers but none of the worked
+  example ports. The worked examples (matmul `create_program_spec`, rand
+  `create_program_spec`, the `*_m2` kernels) live on `dgomez/rand-metal2` at commit
+  `01c3e051d27`; I read them via `git show`. The port itself is unaffected.
+- The legacy writer carries an unused local `src_tile_id` variable; preserved verbatim
+  (scope discipline — not the port's concern).
+- The reader's `num_pages` arg semantically equals the legacy `num_unpadded_tiles`, and
+  `start_id` is hard `0`; both are per-core RTAs on the single core, matching the legacy
+  `emplace_runtime_args(CoreCoord{0,0}, {src0_buffer, num_unpadded_tiles, 0})`.
+
+## Verification
+
+NOT built / not run (per instructions — this worktree has no build dir). Self-audited
+against the kernel-side whitelist and the local-DFB rule. A grep for `CBDescriptor` /
+`CircularBuffer` over the three ported files returns zero hits in code.

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/METAL2_PORT_REPORT.md
@@ -191,3 +191,107 @@ NOT built / not run (per instructions). Self-audited against the kernel-side whi
 local-DFB rule. Watch at build time: `common.hpp`'s `advance_tensor_index` now takes plain
 `uint32_t*`; the local stack arrays bind directly (no address-space conversion). A grep for
 `CBDescriptor` / `CircularBuffer` / `TensorAccessorArgs` over the ported files returns zero hits.
+
+---
+
+# Metal 2.0 Port Report — `pad` (remaining RM + sharded factories)
+
+This pass ports the five remaining `pad` factories (the two tile factories were already done).
+After this pass ALL seven factories of `PadDeviceOperation` are on `create_program_spec`. The
+device-op `program_factory_t` variant and `select_program_factory` are UNCHANGED — the framework
+dispatches each factory via the `MetalV2FactoryConcept` adapter now that each exposes
+`create_program_spec`. No custom `compute_program_hash` exists on `PadDeviceOperation` (nothing to
+keep/delete); no pybind `create_descriptor`/`create_workload_descriptor` hooks exist in
+`pad_nanobind.cpp` (verified).
+
+## Per-factory status
+
+### 1. PadRmReaderWriterProgramFactory (single-core RM) — PORTED
+- `create_workload_descriptor` (WorkloadDescriptor variant) → `create_program_spec`.
+- DFB: `in0` (c_0, 16 pages, local) — reader PRODUCER, writer CONSUMER.
+- TensorParameters: `src`, `dst`, and `pad` (the pad-value const tensor). The legacy const tensor
+  was a `WorkloadDescriptor::buffers`-parked Tensor; it is now an **op-owned tensor** in
+  `ProgramArtifacts::op_owned_tensors` (allocated once on a miss, parked at a stable address by the
+  adapter, bound via a TensorParameter + TensorBinding, read kernel-side through `ta::pad`).
+- Kernels FORKED to `*_m2.cpp` (shared with factory #2): `reader_pad_dims_rm_interleaved_m2.cpp`,
+  `writer_pad_dims_rm_interleaved_m2.cpp`. The legacy reader/writer read a single shared 27-slot
+  RTA vector by positional index with gaps; only the slots each kernel actually consumed survive as
+  named RTAs. src/dst/pad addresses (slots 0/1/13) → TensorBindings. Logic unchanged.
+
+### 2. PadRmReaderWriterMultiCoreProgramFactory — PORTED
+- `create_workload_descriptor` → `create_program_spec`; multi-core work loop preserved verbatim
+  (`split_across_cores`, the resnet-shape switch).
+- Same DFB (`in0`), same three TensorParameters incl. the op-owned `pad` const tensor, same forked
+  `*_m2` kernels as #1. Per-core scalar RTAs are now named; the three buffer-address slots are
+  carried by the src/dst/pad TensorBindings.
+- Dropped the `#if 1` debug-log block and the `log_rt_args` helper (their only inputs — the legacy
+  CTA list / buffer `->address()` calls — no longer exist).
+
+### 3. PadRmReaderWriterMultiCoreDefaultProgramFactory (RM `_v2`, default RM path) — PORTED
+- `create_descriptor` (ProgramDescriptor variant) → `create_program_spec`.
+- DFBs: `in0` (c_0, local; reader PRODUCER → writer CONSUMER), `pad` (c_1 pad-fill scratch — fake CB,
+  reader self-loop), `pad_align` (c_2 — fake CB, reader self-loop, **conditionally** bound only when
+  `stick_size_padded_front != 0 || unaligned`, exactly mirroring the legacy conditional c_2 alloc).
+- Kernels PORTED IN PLACE (1:1, used only by this factory):
+  `reader_pad_dims_rm_interleaved_v2.cpp`, `writer_pad_dims_rm_interleaved_v2.cpp`.
+- Conditional-DFB pattern applied: a `FRONT_PAD_OR_UNALIGNED` define gates the kernel's
+  `dfb::pad_align` alias and every reference to it (the `if constexpr(front_padding)` /
+  `else if constexpr(unaligned)` chain plus the file-scope `get_read_ptr()`); the plain-read `else`
+  runs when the define is absent. Promoting the in-kernel `get_read_ptr` of an unallocated CB into
+  the `#ifdef` is a behavior preserve (legacy only *used* it under the same constexpr guards).
+- `start_dim_offset[4]` per-core array → runtime varargs (fixed at 4, matching the kernel's [1]/[2]/[3]
+  indexing and the post-first-iteration 4-element host vector).
+
+### 4. PadRmShardedHeightOnlyProgramFactory — PORTED
+- `create_descriptor` → `create_program_spec`.
+- **Borrowed-memory DFBs**: `in0` `borrowed_from = src` (input shard L1), `out0` `borrowed_from = dst`
+  (output shard L1); plus `pad` (scratch, writer self-loop). `out0` is reader PRODUCER (reserve/push)
+  → writer CONSUMER (base-pointer fill); `in0` is reader base-pointer-only → reader self-loop.
+- Kernels PORTED IN PLACE: `reader_pad_dims_rm_sharded.cpp`, `writer_pad_dims_rm_sharded.cpp`.
+  In-kernel CB ids (c_0/c_16/c_1) → `dfb::in0`/`dfb::out0`/`dfb::pad`.
+- The reader's packed **variable-length** per-core RTA tail (per-core NoC x/y + stick-chunk lists,
+  read via `get_arg_addr` pointer arithmetic in legacy) → runtime varargs. `num_cores_read` is a
+  named RTA; `num_runtime_varargs` is fixed at the **max tail length** across cores and shorter cores
+  are zero-padded (the kernel only indexes within its own `num_cores_read` range, so trailing pad is
+  never read — this avoids the deprecated `num_runtime_varargs_per_node`). Writer `start_dim_offset[4]`
+  → varargs.
+
+### 5. PadRmShardedWidthOnlyProgramFactory (stickwise) — PORTED
+- `create_descriptor` → `create_program_spec`.
+- **Borrowed-memory DFBs**: `in0` `borrowed_from = src`, `out0` `borrowed_from = dst`; plus `pad`
+  (scratch, writer self-loop). `out0` is writer PRODUCER (reserve/push) → reader CONSUMER (in-place
+  fill after wait_front); `in0` is reader base-pointer-only → reader self-loop.
+- Kernels PORTED IN PLACE: `reader_pad_dims_rm_sharded_stickwise.cpp`,
+  `writer_pad_dims_rm_sharded_stickwise.cpp`. In-kernel CB-id CTAs → `dfb::` handles. No RTAs (CTA-only
+  kernels); the borrowed DFBs pull their L1 base from the src/dst tensor args at runtime.
+
+## Blockers
+
+None. No factory hit the slice-RM "runtime base-offset / per-shard page-size that `ta::` can't
+express" gap: the interleaved RM readers/writers use plain page-id/offset `TensorAccessor` access
+(Case-1), and the sharded factories never use `ta::` at all — they use **borrowed-memory DFBs** for
+the input/output shards and base-pointer reads, which the API supports directly.
+
+## Open items for downstream
+
+- **Fake-CB self-loops (interim).** `_v2` reader: `pad` (c_1) and `pad_align` (c_2); height-only
+  writer: `pad` (c_1); width-only writer: `pad`. All are address-source scratch CBs bound as
+  self-loops purely to satisfy the DFB producer+consumer invariant — not real FIFOs. Replace with the
+  forthcoming Metal 2.0 kernel-scratchpad / local-TensorAccessor resource.
+- **Borrowed input shards as self-loops.** `in0` in both sharded factories is read by base pointer
+  only (no FIFO); bound as a reader self-loop on top of the borrowed (`borrowed_from`) input shard.
+- **Retained varargs.** `_v2` (start_dim_offset[4]); height-only (reader packed tail max-padded +
+  writer start_dim_offset[4]). The height-only reader's tail is genuinely variable-length per core —
+  flagged because the max-pad-then-zero workaround is the alternative to the deprecated
+  `num_runtime_varargs_per_node`. Revisit when typed `std::array` kernel args land.
+- **Forked shared kernels** `reader/writer_pad_dims_rm_interleaved_m2.cpp` shadow the legacy
+  `*_interleaved.cpp` (still used by no other op — pad-internal share between factories #1 and #2).
+  Sunset the legacy copies once nothing else references them.
+
+## Verification
+
+NOT built / not run (per instructions — no build dir). Self-audited against the kernel-side whitelist
+and the local-DFB rule. A grep for `CBDescriptor` / `CircularBuffer` / `TensorAccessorArgs` /
+`ProgramDescriptor` / `WorkloadDescriptor` over the five ported factories returns zero hits in code;
+over the eight ported/forked kernels, the only `CircularBuffer`/`get_arg_addr` hits are in comments
+documenting the legacy layout.

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/METAL2_PORT_REPORT.md
@@ -93,3 +93,101 @@ None. The port is a clean mechanical translation.
 NOT built / not run (per instructions — this worktree has no build dir). Self-audited
 against the kernel-side whitelist and the local-DFB rule. A grep for `CBDescriptor` /
 `CircularBuffer` over the three ported files returns zero hits in code.
+
+---
+
+# Metal 2.0 Port Report — `pad` (PadTileMulticoreProgramFactory)
+
+## Status: PORTED
+
+Second factory of the op ported. The remaining five (RM single/multi-core, RM sharded
+height/width, the legacy RM default) stay on their legacy concepts — supported, the
+`program_factory_t` variant dispatches per-factory by concept.
+
+## Factory chosen
+
+`PadTileMulticoreProgramFactory` — the default-selected factory for normal TILE-layout pad
+(`select_program_factory`, `pad_device_operation.cpp:104-106`: TILE layout + `use_multicore`).
+Interleaved, multi-core, work-split over `split_work_to_cores`, two DM kernels (reader +
+writer), no compute kernel, no semaphores, no op-owned tensors. `select_program_factory`
+and the `program_factory_t` variant are UNCHANGED — still return/list
+`PadTileMulticoreProgramFactory{}`; the framework now dispatches it via the
+`MetalV2FactoryConcept` adapter because the factory exposes `create_program_spec`.
+
+## Legacy → Metal 2.0 mapping
+
+| Legacy (ProgramDescriptor)                       | Metal 2.0                                                       |
+|--------------------------------------------------|----------------------------------------------------------------|
+| `create_descriptor` → `ProgramDescriptor`        | `create_program_spec` → `ProgramArtifacts{spec,run}`           |
+| CB c_0 input (2 pages)                           | DFB `in0` (reader PRODUCER, writer CONSUMER)                   |
+| CB c_1 output (2 pages, allocated but unused)    | DFB `out` (writer self-loop PRODUCER+CONSUMER — see note)     |
+| CB c_2 pad-val (1 page, writer scratch)          | DFB `pad` (writer self-loop PRODUCER+CONSUMER)                |
+| `TensorAccessorArgs(input)` CTA + addr RTA slot0 | `TensorParameter{src}` + `TensorBinding` on reader            |
+| `TensorAccessorArgs(output)` CTA + addr RTA slot0| `TensorParameter{dst}` + `TensorBinding` on writer            |
+| reader CTAs `{input_cb, page_size, rank}`        | DFB binding + named CTAs `{page_size, num_dims}`              |
+| writer CTAs `{in_cb,out_cb,pad_cb,page_size,rank,pad_value,elem_size}` | DFB bindings + named CTAs `{page_size,num_dims,pad_value,element_size}` |
+| reader/writer per-core RTAs `{addr, n_pages, offset}` | named `{num_pages_to_write, start_offset}` (addr dropped) |
+| per-core per-dim arrays (4×rank) via `get_arg_addr` | runtime **varargs** (`num_runtime_varargs = num_dims*4`)   |
+
+DFB `entry_size = page_size`, `num_entries = {2, 2, 1}`, `data_format_metadata = cb_data_format`
+— copied 1:1 from the legacy CBs (no `.tile` set legacy-side, so no `tile_format_metadata`).
+
+## Local-DFB / WorkUnit structure
+
+All three DFBs are local. `in0` is reader-PRODUCER → writer-CONSUMER; `out` and `pad` are
+writer self-loops. Both kernels run on `all_cores`, so one `WorkUnitSpec` (`multi_core`) hosts
+`{reader, writer}` — every node hosting a DFB hosts both endpoints.
+
+## Kernels
+
+- **Reader — `reader_pad_tiled.cpp`, PORTED IN PLACE.** Single consumer (`grep -rl` → this
+  factory only). `input_cb_id` → `dfb::in0`; `TensorAccessor(dst_args, input_addr)` →
+  `TensorAccessor(ta::src)` (addr via TensorBinding; the appended `TensorAccessorArgs<3>` CTA
+  is gone); `page_size`/`num_dims` positional CTAs → named; `num_pages_to_write`/`start_offset`
+  positional RTAs → named; the 4 per-dim arrays → runtime varargs read into local stack arrays.
+- **Writer — `writer_pad_tiled.cpp`, PORTED IN PLACE.** Single consumer. `input_cb_id` →
+  `dfb::in0` (CONSUMER); `pad_val_cb_id` → `dfb::pad` (self-loop); `TensorAccessor(dst_args,
+  output_addr)` → `TensorAccessor(ta::dst)`; named CTAs/RTAs as above; per-dim arrays → varargs.
+  The legacy `output_cb_id` CTA is dropped — the kernel never used it; its CB is preserved on
+  the host as the `out` self-loop DFB (see Open items).
+- **`common.hpp` (op-local, used only by these two kernels).** `advance_tensor_index` parameter
+  type changed from `volatile tt_l1_ptr uint32_t*` to plain `uint32_t*` to match the new
+  local-stack-array access mechanism (varargs have no writable L1 pointer). Wrap/carry
+  arithmetic unchanged.
+
+## Device-op-class edits
+
+None. No custom `compute_program_hash`, no pybind `create_descriptor` hook. Only the factory
+`.hpp` changed (now declares `create_program_spec`; dropped `<program_descriptors.hpp>`, added
+`ttnn/metal2_artifacts.hpp`).
+
+## Blockers
+
+None.
+
+## Open items for downstream
+
+- **Fake-CB self-loop (`out` DFB) — interim hack, flag prominently.**
+  `pad_tile_multicore_program_factory.cpp` binds the legacy `output` CB (c_1) as a writer
+  self-loop (PRODUCER + CONSUMER, accessor `out`) purely to satisfy the validator's
+  producer+consumer rule. It is **not** a real FIFO and the kernel never references `dfb::out`;
+  the binding exists only to preserve the legacy L1 allocation (page_size×2). This CB appears
+  unused in the legacy kernel as well — a candidate for outright removal in a follow-up
+  (would change L1 footprint, so left in place here for behavior preservation).
+- **Runtime varargs (`num_runtime_varargs = num_dims*4`)** in both kernels carry the per-dim
+  shape/index arrays. Justified-vararg case (N-dim arrays gated on the `num_dims` CTA), same
+  pattern as the slice tile port. To be revisited when typed `std::array` kernel args land.
+
+## Friction / notes
+
+- Followed the slice tile port (`slice_program_factory_tile.cpp`, `*_m2.cpp`) as the precedent
+  for the per-dim-array → varargs translation and the local-stack-array mutation workaround.
+- The `out` self-loop is the one judgment call: dropping the CB entirely was tempting but would
+  change L1 footprint (not behavior-preserving), so it was preserved as a self-loop and flagged.
+
+## Verification
+
+NOT built / not run (per instructions). Self-audited against the kernel-side whitelist and the
+local-DFB rule. Watch at build time: `common.hpp`'s `advance_tensor_index` now takes plain
+`uint32_t*`; the local stack arrays bind directly (no address-space conversion). A grep for
+`CBDescriptor` / `CircularBuffer` / `TensorAccessorArgs` over the ported files returns zero hits.

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/common.hpp
@@ -6,8 +6,12 @@
 
 // Takes in an id_per_dim and dims array, both of size ndims
 // Advances the id_per_dim by one, wrapping and carrying as needed
-static inline int advance_tensor_index(
-    volatile tt_l1_ptr uint32_t* idx, volatile tt_l1_ptr uint32_t* dims, uint32_t ndims) {
+//
+// Metal 2.0 note: the per-dim arrays now arrive as runtime varargs and are copied into local
+// stack arrays kernel-side (the vararg API has no writable pointer into the dispatch buffer),
+// so the parameters are plain uint32_t* rather than the legacy volatile tt_l1_ptr uint32_t*.
+// The wrap/carry arithmetic is unchanged.
+static inline int advance_tensor_index(uint32_t* idx, uint32_t* dims, uint32_t ndims) {
     // increment least-significant dim first
     for (int32_t d = ndims - 1; d >= 0; d--) {
         uint32_t v = idx[d] + 1;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_m2.cpp
@@ -1,0 +1,125 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of reader_pad_dims_rm_interleaved.cpp, used by the
+// PadRmReaderWriter (single-core) and PadRmReaderWriterMultiCore factories.
+// Forked (rather than edited in place) because both of those factories share this source; the
+// fork lets them move to the Metal 2.0 named-binding form together while the legacy copy stays
+// available for any unmigrated consumer.
+// Logic UNCHANGED from the legacy reader; only the access mechanism moves to named bindings:
+//   - input src tensor address       -> ta::src
+//   - pad-value const tensor address -> ta::pad   (op-owned const tensor)
+//   - input CB id                    -> dfb::in0
+//   - positional runtime args        -> get_arg(args::...)
+// The legacy reader's slot layout had gaps (the same RTA vector was shared with the writer); only
+// the slots this reader actually consumed survive, now as named args.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+template <typename PadAccessor>
+inline __attribute__((always_inline)) void fill_with_val_async(
+    Noc& noc,
+    const PadAccessor& s_const,
+    const uint32_t begin_addr,
+    const uint32_t begin_addr_aligned,
+    uint32_t size_nbytes,
+    uint32_t chunk_nbytes,
+    uint16_t pad_value) {
+    uint32_t curr_addr = begin_addr;
+    while (curr_addr < begin_addr_aligned && size_nbytes > 0) {
+        reinterpret_cast<uint16_t*>(curr_addr)[0] = pad_value;
+        curr_addr += 2;
+        size_nbytes -= 2;
+    }
+    uint32_t nchunks = size_nbytes / chunk_nbytes;
+    uint32_t rem_nbytes = size_nbytes % chunk_nbytes;
+    for (uint32_t i = 0; i < nchunks; ++i) {
+        CoreLocalMem<uint32_t> dst(curr_addr);
+        noc.async_read(s_const, dst, chunk_nbytes, {.page_id = 0, .offset_bytes = 0}, {.offset_bytes = 0});
+        curr_addr += chunk_nbytes;
+    }
+    if (rem_nbytes > 0) {
+        CoreLocalMem<uint32_t> dst(curr_addr);
+        noc.async_read(s_const, dst, rem_nbytes, {.page_id = 0, .offset_bytes = 0}, {.offset_bytes = 0});
+    }
+}
+
+void kernel_main() {
+    const uint32_t num_unpadded_W = get_arg(args::num_unpadded_W);
+    const uint32_t num_total_W = get_arg(args::num_total_W);
+    const uint32_t num_unpadded_Z = get_arg(args::num_unpadded_Z);
+    const uint32_t num_total_Z = get_arg(args::num_total_Z);
+    const uint32_t num_unpadded_Y = get_arg(args::num_unpadded_Y);
+    const uint32_t num_total_Y = get_arg(args::num_total_Y);
+    const uint32_t unpadded_X_nbytes = get_arg(args::unpadded_X_nbytes);
+    const uint32_t padded_X_nbytes = get_arg(args::padded_X_nbytes);
+    const uint32_t padded_X_diff_nbytes = get_arg(args::padded_X_diff_nbytes);
+    const uint32_t pad_value_const_buffer_nbytes =
+        64;  // assumed to be 64 bytes, fails on BH when > 64. TODO: generalize? (Issue #21978)
+    const uint32_t pad_value_packed = get_arg(args::pad_value_packed);
+    const uint32_t start_src_stick_id = get_arg(args::start_src_stick_id);
+    const uint32_t start_src_stick_wi = get_arg(args::start_src_stick_wi);
+    const uint32_t start_src_stick_offset = get_arg(args::start_src_stick_offset);  // == start_src_stick_wi * elem_size
+    const uint32_t num_local_Y = get_arg(args::num_local_Y);
+    const uint32_t num_local_unpadded_Y = get_arg(args::num_local_unpadded_Y);
+    const uint32_t full_unpadded_X_nbytes = get_arg(args::full_unpadded_X_nbytes);
+    const uint32_t num_local_W = get_arg(args::num_local_W);
+
+    constexpr uint32_t cb_id = dfb::in0;
+    DataflowBuffer cb(cb_id);
+    Noc noc;
+
+    // calculate the offset for alignment of padding in rows/sticks
+    uint32_t l1_addr_partial = cb.get_write_ptr() + unpadded_X_nbytes;
+    const uint32_t l1_addr_align_offset =
+        32 - l1_addr_partial % 32;  // NOTE: this is fine with double buffering since offset will be same for each page
+
+    const auto s0 = TensorAccessor(ta::src);
+
+    const auto s_const = TensorAccessor(ta::pad);
+
+    uint16_t pad_value = pad_value_packed >> 16;
+
+    uint32_t src_stick_id = start_src_stick_id;
+    for (uint32_t w = 0; w < num_local_W; ++w) {
+        for (uint32_t z = 0; z < num_total_Z; ++z) {
+            for (uint32_t y = 0; y < num_local_Y; ++y) {
+                cb.reserve_back(1);
+                uint32_t l1_addr = cb.get_write_ptr();
+                if (y >= num_local_unpadded_Y || z >= num_unpadded_Z || w >= num_unpadded_W) {
+                    // this is fully padding
+                    fill_with_val_async(
+                        noc, s_const, l1_addr, l1_addr, padded_X_nbytes, pad_value_const_buffer_nbytes, pad_value);
+                } else {
+                    // this is a data row possibly with padding at end
+                    CoreLocalMem<uint32_t> dst(l1_addr);
+                    noc.async_read(
+                        s0,
+                        dst,
+                        unpadded_X_nbytes,
+                        {.page_id = src_stick_id, .offset_bytes = start_src_stick_offset},
+                        {.offset_bytes = 0});
+                    l1_addr_partial = l1_addr + unpadded_X_nbytes;
+                    fill_with_val_async(
+                        noc,
+                        s_const,
+                        l1_addr_partial,
+                        l1_addr_partial + l1_addr_align_offset,
+                        padded_X_diff_nbytes,
+                        pad_value_const_buffer_nbytes,
+                        pad_value);
+                    ++src_stick_id;
+                }
+                noc.async_read_barrier();
+                cb.push_back(1);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp
@@ -2,6 +2,20 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the PadRmReaderWriterMultiCoreDefault factory).
+// Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - input src tensor address       -> ta::src
+//   - input CB c_0                    -> dfb::in0   (producer; reader fills, writer drains)
+//   - pad-fill scratch CB c_1         -> dfb::pad   (self-loop: address-source scratch only)
+//   - pad-align scratch CB c_2        -> dfb::pad_align (conditional self-loop; bound + referenced
+//                                        only when FRONT_PAD_OR_UNALIGNED, mirroring the host's
+//                                        conditional c_2 allocation)
+//   - positional CTAs/RTAs            -> get_arg(args::...); start_dim_offset array -> varargs
+// c_1 and c_2 are "fake" CBs: the kernel never produces/consumes them as a FIFO, it only grabs a
+// base pointer (get_read_ptr / get_write_ptr) and reads/writes the L1 region directly. They are
+// bound as self-loops (producer + consumer on this reader) to satisfy the DFB producer/consumer
+// invariant — interim, until a Metal 2.0 kernel-scratchpad / local-TensorAccessor resource lands.
+
 #include <stdint.h>
 #include <cstring>
 #include "api/dataflow/dataflow_api.h"
@@ -10,10 +24,11 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 inline __attribute__((always_inline)) void fill_pad_cb_with_val(
     const uint32_t cb_id, const uint32_t num_bytes, const uint32_t val) {
-    CircularBuffer cb(cb_id);
+    DataflowBuffer cb(cb_id);
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
 
     for (uint32_t i = 0; i < num_bytes / 2; ++i) {
@@ -50,55 +65,62 @@ inline __attribute__((always_inline)) void read_input_pages_into_l1(
 }
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(1);
-    uint32_t num_sticks_per_barrier = get_arg_val<uint32_t>(2);
-    uint32_t start_page_id = get_arg_val<uint32_t>(3);
-    uint32_t front_pad_n = get_arg_val<uint32_t>(4);
-    uint32_t front_pad_c = get_arg_val<uint32_t>(5);
-    uint32_t front_pad_h = get_arg_val<uint32_t>(6);
-    tt_l1_ptr uint32_t* start_dim_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(7));
+    uint32_t num_sticks_per_core = get_arg(args::num_sticks_per_core);
+    uint32_t num_sticks_per_barrier = get_arg(args::num_sticks_per_barrier);
+    uint32_t start_page_id = get_arg(args::start_page_id);
+    uint32_t front_pad_n = get_arg(args::front_pad_n);
+    uint32_t front_pad_c = get_arg(args::front_pad_c);
+    uint32_t front_pad_h = get_arg(args::front_pad_h);
+    // start_dim_offset[]: per-core starting dim indices (num_dims long), passed as varargs.
+    uint32_t start_dim_offset[4];
+    for (uint32_t d = 0; d < 4; ++d) {
+        start_dim_offset[d] = get_vararg(d);
+    }
 
-    constexpr uint32_t N = get_compile_time_arg_val(0);
-    constexpr uint32_t H = get_compile_time_arg_val(1);
-    constexpr uint32_t C = get_compile_time_arg_val(2);
-    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(3);
-    constexpr uint32_t N_padded = get_compile_time_arg_val(4);
-    constexpr uint32_t H_padded = get_compile_time_arg_val(5);
-    constexpr uint32_t C_padded = get_compile_time_arg_val(6);
-    constexpr uint32_t stick_size_padded = get_compile_time_arg_val(7);
-    constexpr uint32_t stick_size_padded_front = get_compile_time_arg_val(8);
-    constexpr uint32_t stick_size_padded_end = get_compile_time_arg_val(9);
-    constexpr uint32_t num_zero_pad_sticks_read = get_compile_time_arg_val(10);
-    constexpr uint32_t last_zero_stick_size = get_compile_time_arg_val(11);
-    constexpr uint32_t stick_size_padded_aligned = get_compile_time_arg_val(18);
+    constexpr uint32_t N = get_arg(args::N);
+    constexpr uint32_t H = get_arg(args::H);
+    constexpr uint32_t C = get_arg(args::C);
+    constexpr uint32_t stick_size_bytes = get_arg(args::stick_size_bytes);
+    constexpr uint32_t N_padded = get_arg(args::N_padded);
+    constexpr uint32_t H_padded = get_arg(args::H_padded);
+    constexpr uint32_t C_padded = get_arg(args::C_padded);
+    constexpr uint32_t stick_size_padded = get_arg(args::stick_size_padded);
+    constexpr uint32_t stick_size_padded_front = get_arg(args::stick_size_padded_front);
+    constexpr uint32_t stick_size_padded_end = get_arg(args::stick_size_padded_end);
+    constexpr uint32_t num_zero_pad_sticks_read = get_arg(args::num_zero_pad_sticks_read);
+    constexpr uint32_t last_zero_stick_size = get_arg(args::last_zero_stick_size);
+    constexpr uint32_t stick_size_padded_aligned = get_arg(args::stick_size_padded_aligned);
 
-    constexpr bool not_pad_by_zero = get_compile_time_arg_val(12) == 1;
-    constexpr uint32_t front_padding = get_compile_time_arg_val(8);
-    constexpr bool unaligned = get_compile_time_arg_val(19) == 1;
+    constexpr bool not_pad_by_zero = get_arg(args::not_pad_by_zero) == 1;
+    constexpr uint32_t front_padding = get_arg(args::stick_size_padded_front);
+    constexpr bool unaligned = get_arg(args::unaligned) == 1;
 
-    constexpr uint32_t num_input_pages_in_row = get_compile_time_arg_val(20);
-    constexpr uint32_t input_page_size = get_compile_time_arg_val(21);
-    constexpr uint32_t size_of_valid_data_in_last_input_page_in_row = get_compile_time_arg_val(22);
-    constexpr auto src_args = TensorAccessorArgs<23>();
+    constexpr uint32_t num_input_pages_in_row = get_arg(args::num_input_pages_in_row);
+    constexpr uint32_t input_page_size = get_arg(args::input_page_size);
+    constexpr uint32_t size_of_valid_data_in_last_input_page_in_row =
+        get_arg(args::size_of_valid_data_in_last_input_page_in_row);
 
     uint32_t packed_pad_value = 0;
     if constexpr (not_pad_by_zero) {
-        packed_pad_value = kernel_compile_time_args[13];
+        packed_pad_value = get_arg(args::packed_pad_value);
     }
 
-    constexpr uint32_t cb_in0 = tt::CBIndex::c_0;
-    constexpr uint32_t cb_pad = tt::CBIndex::c_1;
-    constexpr uint32_t cb_pad_align = tt::CBIndex::c_2;
-    CircularBuffer cb_in0_exp(cb_in0);
-    CircularBuffer cb_pad_exp(cb_pad);
-    CircularBuffer cb_pad_align_exp(cb_pad_align);
+    constexpr uint32_t cb_in0 = dfb::in0;
+    constexpr uint32_t cb_pad = dfb::pad;
+    DataflowBuffer cb_in0_exp(cb_in0);
+    DataflowBuffer cb_pad_exp(cb_pad);
+#if defined(FRONT_PAD_OR_UNALIGNED)
+    constexpr uint32_t cb_pad_align = dfb::pad_align;
+    DataflowBuffer cb_pad_align_exp(cb_pad_align);
+#endif
 
-    const auto s = TensorAccessor(src_args, src_addr);
+    const auto s = TensorAccessor(ta::src);
     Noc noc;
 
     const uint32_t pad_val_addr = cb_pad_exp.get_read_ptr();
+#if defined(FRONT_PAD_OR_UNALIGNED)
     const uint32_t pad_align_addr = cb_pad_align_exp.get_read_ptr();
+#endif
 
     fill_pad_cb_with_val(cb_pad, stick_size_padded, packed_pad_value);
 
@@ -124,6 +146,7 @@ void kernel_main() {
                 noc.async_read_barrier();
             }
             if (read_stick) {
+#if defined(FRONT_PAD_OR_UNALIGNED)
                 if constexpr (front_padding) {  // Read noc into cb_pad_align l1
                     uint32_t temp_addr = cb_pad_align_exp.get_write_ptr();
                     read_input_pages_into_l1(
@@ -159,7 +182,9 @@ void kernel_main() {
                          .noc_y = (uint32_t)my_y[noc.get_noc_id()],
                          .addr = pad_align_addr},
                         {.offset_bytes = 0});
-                } else {
+                } else
+#endif
+                {
                     read_input_pages_into_l1(
                         noc,
                         s,

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp
@@ -2,6 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the PadRmShardedHeightOnly factory).
+// Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - input shard CB c_0  -> dfb::in0  (borrowed input shard; read by base pointer only -> self-loop)
+//   - output shard CB c_16 -> dfb::out0 (borrowed output shard; reader produces, writer consumes)
+//   - positional CTAs      -> get_arg(args::...)
+//   - the packed variable-length RTA tail (per-core noc x/y + stick chunks) -> runtime varargs.
+// The legacy reader read this tail via get_arg_addr pointer arithmetic; the same packed layout is
+// preserved, now sourced from varargs (num_cores_read is a named RTA, the rest is the vararg tail).
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -9,22 +18,25 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(0);
-    constexpr uint32_t num_sticks_padded = get_compile_time_arg_val(1);
+    constexpr uint32_t stick_size_bytes = get_arg(args::stick_size_bytes);
+    constexpr uint32_t num_sticks_padded = get_arg(args::num_sticks_padded);
 
-    const uint32_t num_cores_read = get_arg_val<uint32_t>(0);
-    tt_l1_ptr uint32_t* read_noc_x = (tt_l1_ptr uint32_t*)(get_arg_addr(1));
-    tt_l1_ptr uint32_t* read_noc_y = (tt_l1_ptr uint32_t*)(get_arg_addr(2));
-    tt_l1_ptr uint32_t* num_stick_chunks = (tt_l1_ptr uint32_t*)(get_arg_addr(1 + num_cores_read * 2));
-    tt_l1_ptr uint32_t* chunk_start_id = (tt_l1_ptr uint32_t*)(get_arg_addr(1 + num_cores_read * 3));
-    tt_l1_ptr uint32_t* chunk_num_sticks = (tt_l1_ptr uint32_t*)(chunk_start_id + 1);
+    const uint32_t num_cores_read = get_arg(args::num_cores_read);
+    // Packed vararg tail, preserving the legacy get_arg_addr layout:
+    //   [0 .. 2*num_cores)        : read_noc_x / read_noc_y interleaved (stride 2)
+    //   [2*num_cores .. 3*num_cores) : num_stick_chunks (one per core)
+    //   [3*num_cores .. )         : chunk_start_id / chunk_num_sticks interleaved (stride 2)
+    const uint32_t noc_xy_base = 0;
+    const uint32_t num_chunks_base = num_cores_read * 2;
+    const uint32_t chunks_base = num_cores_read * 3;
 
-    constexpr auto cb_in0 = tt::CBIndex::c_0;
-    constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_in0_exp(cb_in0);
-    CircularBuffer cb_out0_exp(cb_out0);
+    constexpr auto cb_in0 = dfb::in0;
+    constexpr auto cb_out0 = dfb::out0;
+    DataflowBuffer cb_in0_exp(cb_in0);
+    DataflowBuffer cb_out0_exp(cb_out0);
 
     Noc noc;
 
@@ -36,14 +48,14 @@ void kernel_main() {
     uint32_t read_noc_xy_ptr_offset = 0;
 
     for (uint32_t curr_core = 0; curr_core < num_cores_read; ++curr_core) {
-        const uint32_t src_noc_x = read_noc_x[read_noc_xy_ptr_offset];
-        const uint32_t src_noc_y = read_noc_y[read_noc_xy_ptr_offset];
+        const uint32_t src_noc_x = get_vararg(noc_xy_base + read_noc_xy_ptr_offset);
+        const uint32_t src_noc_y = get_vararg(noc_xy_base + read_noc_xy_ptr_offset + 1);
 
-        uint32_t curr_core_num_chunks = num_stick_chunks[curr_core];
+        uint32_t curr_core_num_chunks = get_vararg(num_chunks_base + curr_core);
 
         for (uint32_t curr_chunk = 0; curr_chunk < curr_core_num_chunks; ++curr_chunk) {
-            uint32_t curr_start_id = chunk_start_id[chunk_ptr_offset];
-            uint32_t curr_num_sticks = chunk_num_sticks[chunk_ptr_offset];
+            uint32_t curr_start_id = get_vararg(chunks_base + chunk_ptr_offset);
+            uint32_t curr_num_sticks = get_vararg(chunks_base + chunk_ptr_offset + 1);
 
             uint32_t l1_read_offset = curr_start_id * stick_size_bytes;
             uint32_t read_data_size_bytes = curr_num_sticks * stick_size_bytes;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded_stickwise.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded_stickwise.cpp
@@ -2,29 +2,37 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the PadRmShardedWidthOnly factory).
+// Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - input shard CB  -> dfb::in0  (borrowed input shard; read by base pointer only -> self-loop)
+//   - output shard CB -> dfb::out0 (borrowed output shard; reader consumes the padded sticks the
+//                                   writer produced, filling them in-place with input data)
+//   - positional CTAs -> get_arg(args::...)
+
 #include <stdint.h>
 #include <cstring>
 #include "api/dataflow/dataflow_api.h"
 #include "api/debug/dprint_pages.h"
 #include "api/dataflow/circular_buffer.h"
+#include "experimental/kernel_args.h"
 #define u8_l1_ptr volatile tt_l1_ptr uint8_t*
 #define u8_vol_ptr volatile uint8_t*
 #define u8_ptr uint8_t*
 
 void kernel_main() {
-    constexpr uint32_t unpadded_stick_bytes         = get_compile_time_arg_val(0);
-    constexpr uint32_t padded_stick_bytes         = get_compile_time_arg_val(1);
-    constexpr uint32_t unpadded_shard_height        = get_compile_time_arg_val(2);
-    constexpr uint32_t padded_shard_height        = get_compile_time_arg_val(3);
-    constexpr uint32_t W_front_pad_bytes = get_compile_time_arg_val(4);
+    constexpr uint32_t unpadded_stick_bytes = get_arg(args::unpadded_stick_bytes);
+    constexpr uint32_t padded_stick_bytes = get_arg(args::padded_stick_bytes);
+    constexpr uint32_t unpadded_shard_height = get_arg(args::unpadded_shard_height);
+    constexpr uint32_t padded_shard_height = get_arg(args::padded_shard_height);
+    constexpr uint32_t W_front_pad_bytes = get_arg(args::W_front_pad_bytes);
 
-    constexpr uint32_t input_shard_cb = get_compile_time_arg_val(5);
-    constexpr uint32_t output_shard_cb = get_compile_time_arg_val(6);
-    constexpr uint32_t unpadded_stick_step = get_compile_time_arg_val(7);
-    constexpr uint32_t padded_stick_step = get_compile_time_arg_val(8);
+    constexpr uint32_t input_shard_cb = dfb::in0;
+    constexpr uint32_t output_shard_cb = dfb::out0;
+    constexpr uint32_t unpadded_stick_step = get_arg(args::unpadded_stick_step);
+    constexpr uint32_t padded_stick_step = get_arg(args::padded_stick_step);
 
-    CircularBuffer cb_input_shard(input_shard_cb);
-    CircularBuffer cb_output_shard(output_shard_cb);
+    DataflowBuffer cb_input_shard(input_shard_cb);
+    DataflowBuffer cb_output_shard(output_shard_cb);
 
     uint32_t input_shard_base_addr = cb_input_shard.get_write_ptr();
     uint32_t output_shard_base_addr = cb_output_shard.get_write_ptr();

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp
@@ -2,6 +2,22 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port. Used only by the PadTileMulticore factory, so ported in place.
+// Logic, loop bounds and numeric paths are UNCHANGED; only the access mechanism moves to
+// named bindings:
+//   input address              -> ta::src (TensorAccessor)
+//   CB id                      -> dfb::in0
+//   page_size/num_dims CTAs    -> get_arg(args::...)
+//   num_pages_to_write/start_offset RTAs -> get_arg(args::...)
+//   per-dim arrays (input_page_shape, output_page_shape, input_id_per_dim,
+//                   output_id_per_dim) -> runtime varargs (get_vararg)
+//
+// Vararg note: the legacy kernel read the per-dim arrays via in-place tt_l1_ptr pointers and
+// mutated input_id_per_dim / output_id_per_dim through advance_tensor_index. The m2 vararg API
+// exposes value getters only (no writable pointer into the vararg region), so the per-dim
+// arrays are copied into local stack arrays and mutated there. This is purely an access-mechanism
+// change; the index arithmetic is identical.
+
 #include <stdint.h>
 #include <algorithm>
 #include "api/dataflow/dataflow_api.h"
@@ -9,26 +25,33 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
-    constexpr uint32_t num_dims = get_compile_time_arg_val(2);
+    constexpr uint32_t page_size = get_arg(args::page_size);
+    constexpr uint32_t num_dims = get_arg(args::num_dims);
 
-    uint32_t rt_ind = 0;
-    const uint32_t input_addr = get_arg_val<uint32_t>(rt_ind++);
-    const uint32_t num_pages_to_write = get_arg_val<uint32_t>(rt_ind++);
-    const uint32_t start_offset = get_arg_val<uint32_t>(rt_ind++);
-    volatile tt_l1_ptr uint32_t* input_page_shape = (tt_l1_ptr uint32_t*)(get_arg_addr(rt_ind));
-    volatile tt_l1_ptr uint32_t* output_page_shape = input_page_shape + num_dims;
-    volatile tt_l1_ptr uint32_t* input_id_per_dim = output_page_shape + num_dims;
-    volatile tt_l1_ptr uint32_t* output_id_per_dim = input_id_per_dim + num_dims;
+    const uint32_t num_pages_to_write = get_arg(args::num_pages_to_write);
+    const uint32_t start_offset = get_arg(args::start_offset);
 
-    constexpr auto dst_args = TensorAccessorArgs<3>();
+    // Per-dim arrays as runtime varargs (positional):
+    //   [input_page_shape[0..num_dims-1], output_page_shape[0..num_dims-1],
+    //    input_id_per_dim[0..num_dims-1], output_id_per_dim[0..num_dims-1]]
+    // input_id_per_dim / output_id_per_dim are mutated below, so copy all into local stack arrays.
+    uint32_t input_page_shape[num_dims];
+    uint32_t output_page_shape[num_dims];
+    uint32_t input_id_per_dim[num_dims];
+    uint32_t output_id_per_dim[num_dims];
+    for (uint32_t d = 0; d < num_dims; d++) {
+        input_page_shape[d] = get_vararg(d);
+        output_page_shape[d] = get_vararg(num_dims + d);
+        input_id_per_dim[d] = get_vararg(2 * num_dims + d);
+        output_id_per_dim[d] = get_vararg(3 * num_dims + d);
+    }
 
-    const auto s0 = TensorAccessor(dst_args, input_addr);
+    const auto s0 = TensorAccessor(ta::src);
     Noc noc;
-    CircularBuffer cb_input(input_cb_id);
+    DataflowBuffer cb_input(dfb::in0);
 
     bool within_input_region;
     uint32_t input_page_offset = start_offset;

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_unary_interleaved_start_id_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_unary_interleaved_start_id_m2.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp,
+// used by the PadTileCore factory. Forked (rather than edited in place) because the original is a
+// shared kernel reused by ~12 ops; only this pad factory needs the Metal 2.0 named-binding form.
+// Logic unchanged from the legacy reader; only the access mechanism moves to named bindings:
+// tensor address -> ta::src, CB id -> dfb::in0, positional runtime args -> get_arg(args::...).
+// The pad-tile path never defines BACKWARDS, so that branch is preserved verbatim for parity.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t num_pages = get_arg(args::num_pages);
+    const uint32_t start_id = get_arg(args::start_id);
+
+    constexpr uint32_t cb_id_in0 = dfb::in0;
+
+    // Get page size from CB interface (works for both TILE and ROW_MAJOR layouts)
+    const uint32_t page_bytes = get_local_cb_interface(cb_id_in0).fifo_page_size;
+
+    // ublocks size defined in pages (works for both TILE and ROW_MAJOR layouts)
+    constexpr uint32_t onepage = 1;
+
+    const auto s = TensorAccessor(ta::src);
+
+    Noc noc;
+    DataflowBuffer cb(dfb::in0);
+
+// read a ublock of pages from src to CB, and then push the ublock to unpacker
+#ifdef BACKWARDS
+    uint32_t end_id = start_id - num_pages;
+    for (uint32_t i = start_id; i != end_id; --i) {
+#else
+    uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+#endif
+        cb.reserve_back(onepage);
+        noc.async_read(s, cb, page_bytes, {.page_id = i}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb.push_back(onepage);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved_m2.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of writer_pad_dims_rm_interleaved.cpp, used by the
+// PadRmReaderWriter (single-core) and PadRmReaderWriterMultiCore factories.
+// Forked because both factories share this source; the fork lets them move to the Metal 2.0
+// named-binding form together while the legacy copy stays available for unmigrated consumers.
+// Logic UNCHANGED from the legacy writer; only the access mechanism moves to named bindings:
+//   - output dst tensor address -> ta::dst
+//   - input CB id               -> dfb::in0   (consumer of the reader-produced rows)
+//   - positional runtime args   -> get_arg(args::...)
+// The legacy writer read its args from the shared reader/writer RTA vector by positional index;
+// only the slots this writer actually consumed survive, now as named args.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t num_total_W = get_arg(args::num_total_W);
+    const uint32_t num_total_Z = get_arg(args::num_total_Z);
+    const uint32_t num_total_Y = get_arg(args::num_total_Y);
+    const uint32_t num_total_X = get_arg(args::num_total_X);
+    const uint32_t padded_X_nbytes = get_arg(args::padded_X_nbytes);
+    const uint32_t start_dst_stick_id = get_arg(args::start_dst_stick_id);
+    const uint32_t start_dst_stick_wi = get_arg(args::start_dst_stick_wi);
+    const uint32_t num_local_Y = get_arg(args::num_local_Y);
+    const uint32_t num_local_unpadded_Y = get_arg(args::num_local_unpadded_Y);
+    const uint32_t full_padded_X_nbytes = get_arg(args::full_padded_X_nbytes);
+    const uint32_t dst_stick_offset = get_arg(args::dst_stick_offset);  // == start_src_stick_wi * elem_size
+    const uint32_t num_local_W = get_arg(args::num_local_W);
+
+    constexpr uint32_t cb_id = dfb::in0;
+    DataflowBuffer cb(cb_id);
+
+    const auto s1 = TensorAccessor(ta::dst);
+    Noc noc;
+
+    uint32_t dst_stick_id = start_dst_stick_id;
+    uint32_t dst_stick_wi = start_dst_stick_wi;
+    for (uint32_t w = 0; w < num_local_W; ++w) {
+        for (uint32_t z = 0; z < num_total_Z; ++z) {
+            for (uint32_t y = 0; y < num_local_Y; ++y) {
+                // DPRINT("WR: w={} z={} y={}\n", w, z, y);
+                cb.wait_front(1);
+                noc.async_write(
+                    cb,
+                    s1,
+                    padded_X_nbytes,
+                    {.offset_bytes = 0},
+                    {.page_id = dst_stick_id, .offset_bytes = dst_stick_offset});
+                noc.async_write_barrier();
+                ++dst_stick_id;
+                cb.pop_front(1);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved_v2.cpp
@@ -2,28 +2,35 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the PadRmReaderWriterMultiCoreDefault factory).
+// Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - output dst tensor address -> ta::dst
+//   - output CB c_0             -> dfb::in0   (consumer of the reader-produced rows)
+//   - positional CTAs/RTAs      -> get_arg(args::...)
+// The legacy cb_out0 CTA (slot 0) is replaced by the dfb::in0 binding.
+
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(1);
-    uint32_t num_sticks_per_barrier = get_arg_val<uint32_t>(2);
-    uint32_t start_page_id = get_arg_val<uint32_t>(3);
+    uint32_t num_sticks_per_core = get_arg(args::num_sticks_per_core);
+    uint32_t num_sticks_per_barrier = get_arg(args::num_sticks_per_barrier);
+    uint32_t start_page_id = get_arg(args::start_page_id);
 
-    constexpr uint32_t cb_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(1);
-    constexpr uint32_t stick_size_padded_aligned = get_compile_time_arg_val(2);
-    constexpr uint32_t num_output_pages_in_row = get_compile_time_arg_val(3);
-    constexpr uint32_t output_page_size = get_compile_time_arg_val(4);
-    constexpr uint32_t size_of_valid_data_in_last_output_page_in_row = get_compile_time_arg_val(5);
-    constexpr auto dst_args = TensorAccessorArgs<6>();
+    constexpr uint32_t cb_out0 = dfb::in0;
+    constexpr uint32_t stick_size_bytes = get_arg(args::stick_size_bytes);
+    constexpr uint32_t stick_size_padded_aligned = get_arg(args::stick_size_padded_aligned);
+    constexpr uint32_t num_output_pages_in_row = get_arg(args::num_output_pages_in_row);
+    constexpr uint32_t output_page_size = get_arg(args::output_page_size);
+    constexpr uint32_t size_of_valid_data_in_last_output_page_in_row =
+        get_arg(args::size_of_valid_data_in_last_output_page_in_row);
 
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(ta::dst);
     Noc noc;
-    CircularBuffer cb_out0_exp(cb_out0);
+    DataflowBuffer cb_out0_exp(cb_out0);
 
     uint32_t i_page = start_page_id;
     for (uint32_t iter = 0; iter < num_sticks_per_core;) {

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp
@@ -2,6 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the PadRmShardedHeightOnly factory).
+// Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - pad-value scratch CB c_1 -> dfb::pad  (fake CB: address-source scratch only -> self-loop)
+//   - output shard CB c_16     -> dfb::out0 (borrowed output shard; written by base pointer)
+//   - positional CTAs/RTAs     -> get_arg(args::...); start_dim_offset array -> varargs.
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -9,10 +15,11 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 inline __attribute__((always_inline)) void fill_pad_cb_with_val(
     Noc& noc, const uint32_t cb_id, const uint32_t num_bytes_risc, uint32_t num_noc_transfer, const uint32_t val) {
-    CircularBuffer cb(cb_id);
+    DataflowBuffer cb(cb_id);
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
 
     for (uint32_t i = 0; i < num_bytes_risc / 2; ++i) {
@@ -39,43 +46,47 @@ inline __attribute__((always_inline)) void fill_pad_cb_with_val(
 
 inline __attribute__((always_inline)) void fill_pad_cb_with_zero(
     Noc& noc, const uint32_t cb_id, const uint32_t num_bytes_risc, uint32_t num_noc_transfer) {
-    CircularBuffer cb(cb_id);
+    DataflowBuffer cb(cb_id);
     noc.async_write_zeros(cb, num_bytes_risc * num_noc_transfer);
     noc.write_zeros_l1_barrier();
 }
 
 void kernel_main() {
-    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(0);
-    uint32_t start_id = get_arg_val<uint32_t>(1);
-    uint32_t front_pad_n = get_arg_val<uint32_t>(2);
-    uint32_t front_pad_c = get_arg_val<uint32_t>(3);
-    uint32_t front_pad_h = get_arg_val<uint32_t>(4);
-    tt_l1_ptr uint32_t* start_dim_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(5));
+    uint32_t num_sticks_per_core = get_arg(args::num_sticks_per_core);
+    uint32_t start_id = get_arg(args::start_id);
+    uint32_t front_pad_n = get_arg(args::front_pad_n);
+    uint32_t front_pad_c = get_arg(args::front_pad_c);
+    uint32_t front_pad_h = get_arg(args::front_pad_h);
+    // start_dim_offset[]: per-core starting dim indices, passed as varargs (kernel indexes [1],[2],[3]).
+    uint32_t start_dim_offset[4];
+    for (uint32_t d = 0; d < 4; ++d) {
+        start_dim_offset[d] = get_vararg(d);
+    }
 
-    constexpr uint32_t N = get_compile_time_arg_val(0);
-    constexpr uint32_t H = get_compile_time_arg_val(1);
-    constexpr uint32_t C = get_compile_time_arg_val(2);
-    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(3);
-    constexpr uint32_t N_padded = get_compile_time_arg_val(4);
-    constexpr uint32_t H_padded = get_compile_time_arg_val(5);
-    constexpr uint32_t C_padded = get_compile_time_arg_val(6);
-    constexpr uint32_t num_zero_pad_sticks_read = get_compile_time_arg_val(7);
-    constexpr uint32_t zero_pad_stick_size = get_compile_time_arg_val(8);
+    constexpr uint32_t N = get_arg(args::N);
+    constexpr uint32_t H = get_arg(args::H);
+    constexpr uint32_t C = get_arg(args::C);
+    constexpr uint32_t stick_size_bytes = get_arg(args::stick_size_bytes);
+    constexpr uint32_t N_padded = get_arg(args::N_padded);
+    constexpr uint32_t H_padded = get_arg(args::H_padded);
+    constexpr uint32_t C_padded = get_arg(args::C_padded);
+    constexpr uint32_t num_zero_pad_sticks_read = get_arg(args::num_zero_pad_sticks_read);
+    constexpr uint32_t zero_pad_stick_size = get_arg(args::zero_pad_stick_size);
 
-    constexpr bool not_pad_by_zero = get_compile_time_arg_val(9) == 1;
+    constexpr bool not_pad_by_zero = get_arg(args::not_pad_by_zero) == 1;
     uint32_t packed_pad_value = 0;
     uint32_t row_major_min_bytes = 0;
     uint32_t num_sticks_padded_read = 0;
     if constexpr (not_pad_by_zero) {
-        packed_pad_value = kernel_compile_time_args[10];
-        row_major_min_bytes = kernel_compile_time_args[11];
-        num_sticks_padded_read = kernel_compile_time_args[12];
+        packed_pad_value = get_arg(args::packed_pad_value);
+        row_major_min_bytes = get_arg(args::row_major_min_bytes);
+        num_sticks_padded_read = get_arg(args::num_sticks_padded_read);
     }
 
-    constexpr auto cb_pad = tt::CBIndex::c_1;
-    constexpr auto cb_out0 = tt::CBIndex::c_16;
-    CircularBuffer cb_pad_exp(cb_pad);
-    CircularBuffer cb_out0_exp(cb_out0);
+    constexpr auto cb_pad = dfb::pad;
+    constexpr auto cb_out0 = dfb::out0;
+    DataflowBuffer cb_pad_exp(cb_pad);
+    DataflowBuffer cb_out0_exp(cb_out0);
 
     Noc noc;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded_stickwise.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded_stickwise.cpp
@@ -2,6 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the PadRmShardedWidthOnly factory).
+// Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - output shard CB   -> dfb::out0 (borrowed output shard; writer produces padded sticks)
+//   - pad-value CB       -> dfb::pad  (fake CB: address-source scratch only -> self-loop)
+//   - positional CTAs    -> get_arg(args::...)
+
 #include <stdint.h>
 #include <cstring>
 #include "api/dataflow/dataflow_api.h"
@@ -11,6 +17,7 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 #define u16_l1_ptr volatile tt_l1_ptr uint16_t*
 #define u32_l1_ptr volatile tt_l1_ptr uint32_t*
@@ -20,7 +27,7 @@ inline __attribute__((always_inline)) void fill_cb_with_padding_value(
     const uint32_t cb_id, const uint32_t padding_value_as_u32) {
     constexpr uint32_t num_elts =
         num_bytes / padding_value_num_bytes;  // constexpr so that this division happens once on host
-    CircularBuffer cb(cb_id);
+    DataflowBuffer cb(cb_id);
     uint32_t cb_write_addr = cb.get_write_ptr();
 
     if constexpr (padding_value_num_bytes == 4) {
@@ -41,15 +48,15 @@ inline __attribute__((always_inline)) void fill_cb_with_padding_value(
 }
 
 void kernel_main() {
-    constexpr uint32_t padded_stick_bytes         = get_compile_time_arg_val(0);
-    constexpr uint32_t padded_shard_height        = get_compile_time_arg_val(1);
-    constexpr uint32_t padding_value_as_u32         = get_compile_time_arg_val(2);
-    constexpr uint32_t padding_value_num_bytes      = get_compile_time_arg_val(3);
+    constexpr uint32_t padded_stick_bytes = get_arg(args::padded_stick_bytes);
+    constexpr uint32_t padded_shard_height = get_arg(args::padded_shard_height);
+    constexpr uint32_t padding_value_as_u32 = get_arg(args::padding_value_as_u32);
+    constexpr uint32_t padding_value_num_bytes = get_arg(args::padding_value_num_bytes);
 
-    constexpr auto output_shard_cb = get_compile_time_arg_val(4);
-    constexpr auto padding_value_cb = get_compile_time_arg_val(5);
-    CircularBuffer cb_output_shard(output_shard_cb);
-    CircularBuffer cb_padding_value(padding_value_cb);
+    constexpr uint32_t output_shard_cb = dfb::out0;
+    constexpr uint32_t padding_value_cb = dfb::pad;
+    DataflowBuffer cb_output_shard(output_shard_cb);
+    DataflowBuffer cb_padding_value(padding_value_cb);
 
     Noc noc;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp
@@ -2,6 +2,26 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port. Used only by the PadTileMulticore factory, so ported in place.
+// Logic, loop bounds and numeric paths are UNCHANGED; only the access mechanism moves to
+// named bindings:
+//   output address                       -> ta::dst (TensorAccessor)
+//   input CB id                          -> dfb::in0
+//   pad-val CB id                        -> dfb::pad
+//   page_size/num_dims/pad_value/element_size CTAs -> get_arg(args::...)
+//   num_pages_to_write/start_offset RTAs -> get_arg(args::...)
+//   per-dim arrays (input_page_shape, output_page_shape, input_id_per_dim,
+//                   output_id_per_dim)   -> runtime varargs (get_vararg)
+//
+// (The legacy output CB id is now carried by the dfb::out self-loop binding on the host and is
+// not referenced here — the kernel never used it as a FIFO.)
+//
+// Vararg note: the legacy kernel read the per-dim arrays via in-place tt_l1_ptr pointers and
+// mutated input_id_per_dim / output_id_per_dim through advance_tensor_index. The m2 vararg API
+// exposes value getters only (no writable pointer into the vararg region), so the per-dim
+// arrays are copied into local stack arrays and mutated there. This is purely an access-mechanism
+// change; the index arithmetic is identical.
+
 #include <stdint.h>
 #include <algorithm>
 #include "api/dataflow/dataflow_api.h"
@@ -10,6 +30,7 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 // This kernel keeps track of which page (tile) we are on from a logical tensor perspective, and fills the output with
 // either the input or padding respectively
@@ -19,30 +40,34 @@
 // [0:2, 0:2, 0:1, 0:1] we wait for the reader to send us the correct tile, and then write it, otherwise we
 // write padding.
 void kernel_main() {
-    constexpr uint32_t input_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t output_cb_id = get_compile_time_arg_val(1);
-    constexpr uint32_t pad_val_cb_id = get_compile_time_arg_val(2);
-    constexpr uint32_t page_size = get_compile_time_arg_val(3);
-    constexpr uint32_t num_dims = get_compile_time_arg_val(4);
-    constexpr uint32_t pad_value = get_compile_time_arg_val(5);
-    constexpr uint32_t element_size = get_compile_time_arg_val(6);
+    constexpr uint32_t page_size = get_arg(args::page_size);
+    constexpr uint32_t num_dims = get_arg(args::num_dims);
+    constexpr uint32_t pad_value = get_arg(args::pad_value);
+    constexpr uint32_t element_size = get_arg(args::element_size);
     constexpr uint32_t num_elements = page_size / element_size;
 
-    uint32_t rt_ind = 0;
-    const uint32_t output_addr = get_arg_val<uint32_t>(rt_ind++);
-    const uint32_t num_pages_to_write = get_arg_val<uint32_t>(rt_ind++);
-    const uint32_t start_offset = get_arg_val<uint32_t>(rt_ind++);
-    volatile tt_l1_ptr uint32_t* input_page_shape = (tt_l1_ptr uint32_t*)(get_arg_addr(rt_ind));
-    volatile tt_l1_ptr uint32_t* output_page_shape = input_page_shape + num_dims;
-    volatile tt_l1_ptr uint32_t* input_id_per_dim = output_page_shape + num_dims;
-    volatile tt_l1_ptr uint32_t* output_id_per_dim = input_id_per_dim + num_dims;
+    const uint32_t num_pages_to_write = get_arg(args::num_pages_to_write);
+    const uint32_t start_offset = get_arg(args::start_offset);
 
-    constexpr auto dst_args = TensorAccessorArgs<7>();
+    // Per-dim arrays as runtime varargs (positional):
+    //   [input_page_shape[0..num_dims-1], output_page_shape[0..num_dims-1],
+    //    input_id_per_dim[0..num_dims-1], output_id_per_dim[0..num_dims-1]]
+    // input_id_per_dim / output_id_per_dim are mutated below, so copy all into local stack arrays.
+    uint32_t input_page_shape[num_dims];
+    uint32_t output_page_shape[num_dims];
+    uint32_t input_id_per_dim[num_dims];
+    uint32_t output_id_per_dim[num_dims];
+    for (uint32_t d = 0; d < num_dims; d++) {
+        input_page_shape[d] = get_vararg(d);
+        output_page_shape[d] = get_vararg(num_dims + d);
+        input_id_per_dim[d] = get_vararg(2 * num_dims + d);
+        output_id_per_dim[d] = get_vararg(3 * num_dims + d);
+    }
 
-    const auto s0 = TensorAccessor(dst_args, output_addr);
+    const auto s0 = TensorAccessor(ta::dst);
     Noc noc;
-    CircularBuffer cb_input(input_cb_id);
-    CircularBuffer cb_pad_val(pad_val_cb_id);
+    DataflowBuffer cb_input(dfb::in0);
+    DataflowBuffer cb_pad_val(dfb::pad);
 
     // Reserve and push the pad value into the circular buffer, generalized for any contiguous dtype
     cb_pad_val.reserve_back(1);

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp
@@ -2,35 +2,45 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port. Used only by the PadTileCore factory, so ported in place.
+// Logic unchanged from the legacy writer; only the access mechanism moves to named bindings:
+//   - the reader->writer input DFB id  -> dfb::in0   (consumer endpoint)
+//   - the pad-scratch DFB id           -> dfb::pad   (self-loop: producer + consumer)
+//   - the output tensor address        -> ta::out
+//   - positional runtime args          -> get_arg(args::...)
+// The pad DFB has no FIFO peer (the writer is its only user): the writer reserves one entry of L1
+// scratch in it, fills it with the pad value, and reuses it as the NoC source for every padded
+// tile. It is bound as a self-loop (producer + consumer on this writer) to satisfy the
+// producer/consumer invariant.
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const uint32_t num_unpadded_W = get_arg_val<uint32_t>(1);
-    const uint32_t num_padded_Wt = get_arg_val<uint32_t>(2);
-    const uint32_t num_unpadded_Z = get_arg_val<uint32_t>(3);
-    const uint32_t num_padded_Zt = get_arg_val<uint32_t>(4);
-    const uint32_t num_unpadded_Yt = get_arg_val<uint32_t>(5);
-    const uint32_t num_padded_Yt = get_arg_val<uint32_t>(6);
-    const uint32_t num_unpadded_Xt = get_arg_val<uint32_t>(7);
-    const uint32_t num_padded_Xt = get_arg_val<uint32_t>(8);
-    const uint32_t pad_value = get_arg_val<uint32_t>(9);
+    const uint32_t num_unpadded_W = get_arg(args::num_unpadded_W);
+    const uint32_t num_padded_Wt = get_arg(args::num_padded_Wt);
+    const uint32_t num_unpadded_Z = get_arg(args::num_unpadded_Z);
+    const uint32_t num_padded_Zt = get_arg(args::num_padded_Zt);
+    const uint32_t num_unpadded_Yt = get_arg(args::num_unpadded_Yt);
+    const uint32_t num_padded_Yt = get_arg(args::num_padded_Yt);
+    const uint32_t num_unpadded_Xt = get_arg(args::num_unpadded_Xt);
+    const uint32_t num_padded_Xt = get_arg(args::num_padded_Xt);
+    const uint32_t pad_value = get_arg(args::pad_value);
 
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_out1 = get_compile_time_arg_val(1);
-    constexpr auto dst_args = TensorAccessorArgs<2>();
+    constexpr uint32_t cb_id_out0 = dfb::in0;
+    constexpr uint32_t cb_id_out1 = dfb::pad;
 
     const uint32_t tile_size = get_tile_size(cb_id_out0);
 
-    const auto s1 = TensorAccessor(dst_args, dst_addr);
+    const auto s1 = TensorAccessor(ta::out);
     Noc noc;
-    CircularBuffer cb_out0(cb_id_out0);
-    CircularBuffer cb_out1(cb_id_out1);
+    DataflowBuffer cb_out0(dfb::in0);
+    DataflowBuffer cb_out1(dfb::pad);
 
     cb_out1.reserve_back(1);  // in this kernel we are not pushing anything into CBs, just using the space
 

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.cpp
@@ -7,14 +7,17 @@
 #include <algorithm>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/tt_align.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 static const uint32_t max_read_size = 2048;  // max read size in bytes for reader and writer kernels
 
 namespace ttnn::prim {
@@ -29,7 +32,7 @@ uint32_t get_num_stick_per_barrier(uint32_t stick_size_padded_aligned) {
 
 }  // namespace
 
-ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreDefaultProgramFactory::create_program_spec(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& pad_value = operation_attributes.pad_value;
@@ -50,7 +53,7 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
     auto stick_size_padded_end = stick_size_padded - stick_size - stick_size_padded_front;
     uint32_t stick_size_padded_aligned = tt::align(stick_size_padded, hal::get_l1_alignment());
     uint32_t stick_size_padded_DRAM_aligned = tt::align(stick_size_padded, hal::get_dram_alignment());
-    uint32_t row_major_min_bytes = 16;
+    [[maybe_unused]] uint32_t row_major_min_bytes = 16;
 
     // Input page-based addressing
     uint32_t num_input_pages_in_row = 1;
@@ -94,14 +97,10 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
 
     auto cores_in_order = corerange_to_cores(all_cores, num_cores, true);
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-
     // construct const buffer with the pad_value
     bool not_pad_by_zero = pad_value != 0;
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_ASSERT(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -112,103 +111,164 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
     }
 
-    ProgramDescriptor desc;
-
-    // c_1 reused for pad-value scratch on every dispatch.
-    uint32_t src1_cb_index = tt::CBIndex::c_1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = stick_size_padded_DRAM_aligned,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src1_cb_index),
-            .data_format = cb_data_format,
-            .page_size = stick_size_padded_DRAM_aligned,
-        }}},
-    });
-
     bool unaligned = stick_size_padded_aligned % hal::get_dram_alignment() != 0;
-    if (stick_size_padded_front != 0 || unaligned) {
-        uint32_t src2_cb_index = tt::CBIndex::c_2;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = stick_size_padded_DRAM_aligned,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(src2_cb_index),
-                .data_format = cb_data_format,
-                .page_size = stick_size_padded_DRAM_aligned,
-            }}},
-        });
-    }
+    // c_2 (pad_align) is allocated (and bound) only when there is front padding or an unaligned
+    // stick; the kernel references dfb::pad_align only under FRONT_PAD_OR_UNALIGNED to match.
+    bool front_pad_or_unaligned = (stick_size_padded_front != 0 || unaligned);
 
-    std::vector<uint32_t> reader_ct_args = {
-        (std::uint32_t)N + front_pad[-4],
-        (std::uint32_t)H + front_pad[-2],
-        (std::uint32_t)C + front_pad[-3],
-        (std::uint32_t)stick_size,
-        (std::uint32_t)N_padded,
-        (std::uint32_t)H_padded,
-        (std::uint32_t)C_padded,
-        (std::uint32_t)stick_size_padded,
-        (std::uint32_t)stick_size_padded_front,
-        (std::uint32_t)stick_size_padded_end,
-        (std::uint32_t)tt::div_up(stick_size_padded, 512),  // max zero size is 512B
-        (std::uint32_t)(stick_size_padded % 512 == 0 ? 512 : stick_size_padded % 512),
-        (std::uint32_t)not_pad_by_zero,
-        (std::uint32_t)packed_pad_value,
-        (std::uint32_t)row_major_min_bytes,
-        (std::uint32_t)(stick_size_padded_front / row_major_min_bytes),
-        (std::uint32_t)(stick_size_padded_end / row_major_min_bytes),
-        (std::uint32_t)(stick_size_padded / row_major_min_bytes),
-        (std::uint32_t)stick_size_padded_aligned,
-        (std::uint32_t)unaligned,
-        (std::uint32_t)num_input_pages_in_row,
-        (std::uint32_t)input_page_size,
-        (std::uint32_t)size_of_valid_data_in_last_input_page_in_row};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
-
-    std::vector<uint32_t> writer_ct_args = {
-        (std::uint32_t)src0_cb_index,
-        (std::uint32_t)stick_size_padded,
-        (std::uint32_t)stick_size_padded_aligned,
-        (std::uint32_t)num_output_pages_in_row,
-        (std::uint32_t)output_page_size,
-        (std::uint32_t)size_of_valid_data_in_last_output_page_in_row};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved_v2.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved_v2.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    // Build per-core runtime args inline (legacy path called get_runtime_args_rm()
-    // which produced the same data).  Slot 0 of both reader and writer is a raw
-    // buffer base address (no offset) — use Buffer* for BufferBinding so the
-    // framework patches addresses on cache hits.  Idle cores (num_sticks_per_core
-    // == 0) pass 0u to skip the binding since the kernel does nothing.
-    // The legacy helper used input_tensor.padded_shape() for the H/C/N bounds —
-    // mirror that here.  H_padded/C_padded already use the output padded shape.
-    auto input_padded_shape = a.padded_shape();
-    uint32_t H_in = input_padded_shape[2], C_in = input_padded_shape[1], N_in = input_padded_shape[0];
-    std::uint32_t num_dims = static_cast<std::uint32_t>(input_padded_shape.rank());
-    std::vector<uint32_t> start_dim_offset(num_dims, 0);
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "pad_rm_reader_writer_multi_core_default";
 
     uint32_t num_sticks_per_barrier = get_num_stick_per_barrier(stick_size_padded_aligned);
+    const uint32_t buffer_reader_writer_async_factor = 16;
+
+    // c_0 (in0): reader fills, writer drains.
+    // c_1 (pad): pad-value fill scratch — fake CB the reader reads only as an address source.
+    // c_2 (pad_align): pad-align scratch — fake CB, allocated only when front_pad_or_unaligned.
+    spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+        .unique_id = m2::DFBSpecName{"in0"},
+        .entry_size = stick_size_padded_aligned,
+        .num_entries = buffer_reader_writer_async_factor * num_sticks_per_barrier,
+        .data_format_metadata = cb_data_format});
+    spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+        .unique_id = m2::DFBSpecName{"pad"},
+        .entry_size = stick_size_padded_DRAM_aligned,
+        .num_entries = 1,
+        .data_format_metadata = cb_data_format});
+    if (front_pad_or_unaligned) {
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"pad_align"},
+            .entry_size = stick_size_padded_DRAM_aligned,
+            .num_entries = 1,
+            .data_format_metadata = cb_data_format});
+    }
+
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()},
+    };
+
+    // Reader DFB bindings: in0 PRODUCER, pad self-loop, and pad_align self-loop (when allocated).
+    m2::Group<m2::DFBBinding> reader_dfb_bindings = {
+        m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in0"},
+            .accessor_name = "in0",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"pad"},
+            .accessor_name = "pad",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"pad"},
+            .accessor_name = "pad",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+    };
+    if (front_pad_or_unaligned) {
+        reader_dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"pad_align"},
+            .accessor_name = "pad_align",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER});
+        reader_dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"pad_align"},
+            .accessor_name = "pad_align",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    }
+
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "reader_pad_dims_rm_interleaved_v2.cpp"},
+        .compiler_options =
+            {.defines = front_pad_or_unaligned ? m2::Table<std::string, std::string>{{"FRONT_PAD_OR_UNALIGNED", "1"}}
+                                               : m2::Table<std::string, std::string>{}},
+        .dfb_bindings = reader_dfb_bindings,
+        .tensor_bindings = {m2::TensorBinding{
+            .tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"}},
+        .compile_time_args =
+            {{"N", (std::uint32_t)N + front_pad[-4]},
+             {"H", (std::uint32_t)H + front_pad[-2]},
+             {"C", (std::uint32_t)C + front_pad[-3]},
+             {"stick_size_bytes", (std::uint32_t)stick_size},
+             {"N_padded", (std::uint32_t)N_padded},
+             {"H_padded", (std::uint32_t)H_padded},
+             {"C_padded", (std::uint32_t)C_padded},
+             {"stick_size_padded", (std::uint32_t)stick_size_padded},
+             {"stick_size_padded_front", (std::uint32_t)stick_size_padded_front},
+             {"stick_size_padded_end", (std::uint32_t)stick_size_padded_end},
+             {"num_zero_pad_sticks_read", (std::uint32_t)tt::div_up(stick_size_padded, 512)},  // max zero size is 512B
+             {"last_zero_stick_size", (std::uint32_t)(stick_size_padded % 512 == 0 ? 512 : stick_size_padded % 512)},
+             {"not_pad_by_zero", (std::uint32_t)not_pad_by_zero},
+             {"packed_pad_value", (std::uint32_t)packed_pad_value},
+             {"stick_size_padded_aligned", (std::uint32_t)stick_size_padded_aligned},
+             {"unaligned", (std::uint32_t)unaligned},
+             {"num_input_pages_in_row", (std::uint32_t)num_input_pages_in_row},
+             {"input_page_size", (std::uint32_t)input_page_size},
+             {"size_of_valid_data_in_last_input_page_in_row",
+              (std::uint32_t)size_of_valid_data_in_last_input_page_in_row}},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"num_sticks_per_core",
+                  "num_sticks_per_barrier",
+                  "start_page_id",
+                  "front_pad_n",
+                  "front_pad_c",
+                  "front_pad_h"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+    // start_dim_offset[4]: per-core starting dim indices {0, curr_h, curr_c, curr_n}, passed as
+    // runtime varargs (the kernel indexes [1],[2],[3], matching the legacy get_arg_addr layout).
+    constexpr std::uint32_t kNumDimOffsets = 4;
+    reader.advanced_options.num_runtime_varargs = kNumDimOffsets;
+
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "writer_pad_dims_rm_interleaved_v2.cpp"},
+        .dfb_bindings = {m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in0"},
+            .accessor_name = "in0",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER}},
+        .tensor_bindings = {m2::TensorBinding{
+            .tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"}},
+        .compile_time_args =
+            {{"stick_size_bytes", (std::uint32_t)stick_size_padded},
+             {"stick_size_padded_aligned", (std::uint32_t)stick_size_padded_aligned},
+             {"num_output_pages_in_row", (std::uint32_t)num_output_pages_in_row},
+             {"output_page_size", (std::uint32_t)output_page_size},
+             {"size_of_valid_data_in_last_output_page_in_row",
+              (std::uint32_t)size_of_valid_data_in_last_output_page_in_row}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_sticks_per_core", "num_sticks_per_barrier", "start_page_id"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+
+    spec.kernels = {reader, writer};
+
+    // Local/self-loop DFBs require producer and consumer to share a WorkUnitSpec.  Both kernels run
+    // on all_cores, so one WorkUnitSpec hosts both.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "multi_core",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = all_cores},
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+
+    // The legacy helper used input_tensor.padded_shape() for the H/C/N bounds — mirror that here.
+    // H_padded/C_padded already use the output padded shape.
+    auto input_padded_shape = a.padded_shape();
+    uint32_t H_in = input_padded_shape[2], C_in = input_padded_shape[1], N_in = input_padded_shape[0];
+    std::vector<uint32_t> start_dim_offset(kNumDimOffsets, 0);
 
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
     uint32_t curr_sticks_read = 0;
     uint32_t curr_sticks_write = 0;
     for (const auto& core : cores_in_order) {
+        const m2::NodeCoord node{core};
         uint32_t num_sticks_per_core;
         if (core_group_1.contains(core)) {
             num_sticks_per_core = num_sticks_padded_per_core_group_1;
@@ -219,31 +279,29 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
             num_sticks_per_core = 0;
         }
 
-        KernelDescriptor::RTArgList reader_rt_args;
-        KernelDescriptor::RTArgList writer_rt_args;
-        if (num_sticks_per_core != 0) {
-            reader_rt_args.push_back(src0_buffer);
-            writer_rt_args.push_back(dst_buffer);
-        } else {
-            reader_rt_args.push_back(0u);
-            writer_rt_args.push_back(0u);
-        }
-        reader_rt_args.push_back(num_sticks_per_core);
-        reader_rt_args.push_back(num_sticks_per_barrier);
-        reader_rt_args.push_back(curr_sticks_read * num_input_pages_in_row);
-        reader_rt_args.push_back(static_cast<uint32_t>(front_pad[-4]));
-        reader_rt_args.push_back(static_cast<uint32_t>(front_pad[-3]));
-        reader_rt_args.push_back(static_cast<uint32_t>(front_pad[-2]));
+        // The legacy buffer-address RTA slot (0=src/dst; 0u on idle cores) is now carried by the
+        // src/dst TensorBindings; idle cores short-circuit on num_sticks_per_core == 0.
+        reader_run.runtime_arg_values.push_back(
+            {node,
+             {{"num_sticks_per_core", num_sticks_per_core},
+              {"num_sticks_per_barrier", num_sticks_per_barrier},
+              {"start_page_id", curr_sticks_read * num_input_pages_in_row},
+              {"front_pad_n", static_cast<uint32_t>(front_pad[-4])},
+              {"front_pad_c", static_cast<uint32_t>(front_pad[-3])},
+              {"front_pad_h", static_cast<uint32_t>(front_pad[-2])}}});
+
+        m2::AdvancedKernelRunArgs::Varargs reader_varargs;
+        reader_varargs.reserve(kNumDimOffsets);
         for (uint32_t v : start_dim_offset) {
-            reader_rt_args.push_back(v);
+            reader_varargs.push_back(v);
         }
+        reader_run.advanced_options.runtime_varargs[node] = std::move(reader_varargs);
 
-        writer_rt_args.push_back(num_sticks_per_core);
-        writer_rt_args.push_back(num_sticks_per_barrier);
-        writer_rt_args.push_back(curr_sticks_write * num_output_pages_in_row);
-
-        reader_desc.emplace_runtime_args(core, reader_rt_args);
-        writer_desc.emplace_runtime_args(core, writer_rt_args);
+        writer_run.runtime_arg_values.push_back(
+            {node,
+             {{"num_sticks_per_core", num_sticks_per_core},
+              {"num_sticks_per_barrier", num_sticks_per_barrier},
+              {"start_page_id", curr_sticks_write * num_output_pages_in_row}}});
 
         curr_sticks_write += num_sticks_per_core;
 
@@ -268,22 +326,13 @@ ProgramDescriptor PadRmReaderWriterMultiCoreDefaultProgramFactory::create_descri
         start_dim_offset = {0, curr_h, curr_c, curr_n};
     }
 
-    uint32_t cb_npages = get_num_stick_per_barrier(stick_size_padded_aligned);
-    const uint32_t buffer_reader_writer_async_factor = 16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = buffer_reader_writer_async_factor * cb_npages * stick_size_padded_aligned,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = stick_size_padded_aligned,
-        }}},
-    });
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"src"}, a.mesh_tensor()},
+        {m2::TensorParamName{"dst"}, output.mesh_tensor()},
+    };
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_default_program_factory.hpp
@@ -5,15 +5,15 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadRmReaderWriterMultiCoreDefaultProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.cpp
@@ -4,25 +4,21 @@
 
 #include "pad_rm_reader_writer_multi_core_program_factory.hpp"
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::tt_metal;
 using namespace tt::constants;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
 namespace {
-inline void log_rt_args(const CoreCoord& core, std::vector<uint32_t>& args) {
-    for (auto v : args) {
-        log_debug(tt::LogOp, "{},{} :: {}", core.x, core.y, v);
-    }
-}
-
 // This is currently mostly hardcoded for resnet shapes
 inline std::tuple<uint32_t, uint32_t, uint32_t, CoreRangeSet, CoreRangeSet, uint32_t, uint32_t, uint32_t, uint32_t>
 split_across_cores(CoreCoord grid_size, uint32_t nbatch, uint32_t ntiles_h, uint32_t ntiles_w) {
@@ -158,17 +154,17 @@ split_across_cores(CoreCoord grid_size, uint32_t nbatch, uint32_t ntiles_h, uint
         ncores_per_batch_h);
 }
 
-// Allocate the on-device pad-value const tensor.  Pulled out so
-// create_workload_descriptor() can build it once on cache miss and park it on
-// WorkloadDescriptor::buffers, deferring ~Tensor (which force-deallocates the
-// device memory) until the cached workload is evicted (see #44565).
+// Allocate the on-device pad-value const tensor.  Returned as an op-owned tensor in
+// ProgramArtifacts::op_owned_tensors: the framework parks it at a stable address for the cached
+// Program's life (allocated once on a cache miss, reused on a hit).  The kernel reads it through a
+// TensorAccessor (ta::pad) exactly like the io tensors.
+// NOTE: The const buffer is always in L1.
+// TODO: make a local buffer for each core?
 Tensor build_pad_value_const_tensor_mc(const PadInputs& tensor_args, float pad_value) {
     MeshDevice* device = tensor_args.input.device();
     uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
     auto pad_value_const_buffer =
         tt::tt_metal::HostBuffer(std::vector<bfloat16>(pad_value_const_buffer_size, bfloat16(pad_value)));
-    // NOTE: The const buffer is always in L1
-    // TODO: make a local buffer for each core?
     return Tensor(
                std::move(pad_value_const_buffer),
                ttnn::Shape({1, 1, 1, pad_value_const_buffer_size}),
@@ -177,11 +173,10 @@ Tensor build_pad_value_const_tensor_mc(const PadInputs& tensor_args, float pad_v
         .to_device(device, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
 }
 
-ProgramDescriptor build_pad_rm_mc_program_descriptor(
-    const PadParams& operation_attributes,
-    const PadInputs& tensor_args,
-    Tensor& output,
-    Buffer* pad_value_const_buffer) {
+}  // namespace
+
+ttnn::device_operation::ProgramArtifacts PadRmReaderWriterMultiCoreProgramFactory::create_program_spec(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
     const auto& a = tensor_args.input;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
     const auto& pad_value = operation_attributes.pad_value;
@@ -194,9 +189,6 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
         unpadded_row_size_nbytes <= padded_row_size_nbytes, "Padded output tensor size should be >= input tensor size");
 
     distributed::MeshDevice* device = a.device();
-
-    uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
-    uint32_t pad_value_const_buffer_nbytes = pad_value_const_buffer_size * a.element_size();
 
     // uint32_t ntiles_h = output_tensor_shape[0] * output_tensor_shape[1] * output_tensor_shape[2] / TILE_HEIGHT;
     uint32_t ntiles_h = output_padded_shape[2] / TILE_HEIGHT;
@@ -220,33 +212,14 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
     int32_t dst_nbytes_per_core_w = ntiles_per_core_w * TILE_WIDTH * output.element_size();
 
     Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_ASSERT(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
-    ProgramDescriptor desc;
-
-    uint32_t cb_id = tt::CBIndex::c_0;
     uint32_t cb_npages = 16;  // multibuffering for perf
     // uint32_t cb_npages = 1; // multibuffering for perf
     uint32_t cb_page_alignment = std::max(tt::constants::TILE_WIDTH, src0_buffer->alignment());
     uint32_t cb_pagesize =
         static_cast<uint32_t>(std::ceil((float)dst_nbytes_per_core_w / cb_page_alignment)) * cb_page_alignment;
     tt::DataFormat in_df = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_npages * cb_pagesize,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(cb_id),
-            .data_format = in_df,
-            .page_size = cb_pagesize,
-        }}},
-    });
-
-    std::vector<uint32_t> reader_ct_args = {unpadded_row_size_nbytes, padded_row_size_nbytes};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
-    TensorAccessorArgs(*dst_buffer).append_to(reader_ct_args);
-    TensorAccessorArgs(*pad_value_const_buffer).append_to(reader_ct_args);
-    std::vector<uint32_t> writer_ct_args = reader_ct_args;
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -257,53 +230,106 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(0.0f), bfloat16(pad_value)});
     }
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    // ---- Op-owned pad-value const tensor (allocate first; bind against the vector element) ----
+    std::vector<Tensor> op_owned;
+    op_owned.reserve(1);
+    op_owned.push_back(build_pad_value_const_tensor_mc(tensor_args, pad_value));
+    const Tensor& pad_const = op_owned[0];
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
-    // int32_t padded_row_diff_size_nbytes = padded_row_size_nbytes - unpadded_row_size_nbytes;
-    log_rt_args(CoreCoord{0, 0}, reader_desc.compile_time_args);
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "pad_rm_reader_writer_multi_core";
 
-#if 1
-    {
-        log_debug(tt::LogOp, "ncores: {}", ncores);
-        log_debug(tt::LogOp, "ncores_h: {}", ncores_h);
-        log_debug(tt::LogOp, "ncores_w: {}", ncores_w);
-        log_debug(tt::LogOp, "ntiles_per_core_h: {}", ntiles_per_core_h);
-        log_debug(tt::LogOp, "ntiles_per_core_w: {}", ntiles_per_core_w);
-        log_debug(tt::LogOp, "src0_buffer_addr: {}", src0_buffer->address());
-        log_debug(tt::LogOp, "dst_buffer_addr: {}", dst_buffer->address());
-        log_debug(tt::LogOp, "a.shape[0]: {}", a.padded_shape()[0]);
-        log_debug(tt::LogOp, "out.shape[0]: {}", output_shape[0]);
-        log_debug(tt::LogOp, "a.shape[1]: {}", a.padded_shape()[1]);
-        log_debug(tt::LogOp, "out.shape[1]: {}", output_shape[1]);
-        log_debug(tt::LogOp, "a.shape[2]: {}", a.padded_shape()[2]);
-        log_debug(tt::LogOp, "out.shape[2]: {}", output_shape[2]);
-        log_debug(tt::LogOp, "s.shape[3]: {}", a.padded_shape()[3]);
-        log_debug(tt::LogOp, "out.shape[3]: {}", output_shape[3]);
-        log_debug(tt::LogOp, "unpadded_row_size_nbytes: {}", unpadded_row_size_nbytes);
-        log_debug(tt::LogOp, "padded_row_size_nbytes: {}", padded_row_size_nbytes);
-        // log_debug(tt::LogOp, "padded_row_diff_size_nbytes: {}", padded_row_diff_size_nbytes);
-        log_debug(tt::LogOp, "pad_value_const_buffer_addr: {}", pad_value_const_buffer->address());
-        log_debug(tt::LogOp, "pad_value_const_buffer_nbytes: {}", pad_value_const_buffer_nbytes);
-        log_debug(tt::LogOp, "packed_pad_value: {}", packed_pad_value);
-        log_debug(tt::LogOp, "src_nbytes_per_core_w: {}", src_nbytes_per_core_w);
-        log_debug(tt::LogOp, "dst_nbytes_per_core_w: {}", dst_nbytes_per_core_w);
-        log_debug(tt::LogOp, "nbatch_per_core_h: {}", nbatch_per_core_h);
-        log_debug(tt::LogOp, "ncores_per_batch_h: {}", ncores_per_batch_h);
-    }
-#endif
+    // c_0 (in0): row buffer the reader fills (data + pad) and the writer drains to the output.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"in0"},
+            .entry_size = cb_pagesize,
+            .num_entries = cb_npages,
+            .data_format_metadata = in_df},
+    };
+
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"pad"}, .spec = pad_const.tensor_spec()},
+    };
+
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "reader_pad_dims_rm_interleaved_m2.cpp"},
+        .dfb_bindings = {m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in0"},
+            .accessor_name = "in0",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER}},
+        .tensor_bindings =
+            {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"},
+             m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"pad"}, .accessor_name = "pad"}},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"num_unpadded_W",
+                  "num_total_W",
+                  "num_unpadded_Z",
+                  "num_total_Z",
+                  "num_unpadded_Y",
+                  "num_total_Y",
+                  "unpadded_X_nbytes",
+                  "padded_X_nbytes",
+                  "padded_X_diff_nbytes",
+                  "pad_value_packed",
+                  "start_src_stick_id",
+                  "start_src_stick_wi",
+                  "start_src_stick_offset",
+                  "num_local_Y",
+                  "num_local_unpadded_Y",
+                  "full_unpadded_X_nbytes",
+                  "num_local_W"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "writer_pad_dims_rm_interleaved_m2.cpp"},
+        .dfb_bindings = {m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in0"},
+            .accessor_name = "in0",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER}},
+        .tensor_bindings = {m2::TensorBinding{
+            .tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"}},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"num_total_W",
+                  "num_total_Z",
+                  "num_total_Y",
+                  "num_total_X",
+                  "padded_X_nbytes",
+                  "start_dst_stick_id",
+                  "start_dst_stick_wi",
+                  "num_local_Y",
+                  "num_local_unpadded_Y",
+                  "full_padded_X_nbytes",
+                  "dst_stick_offset",
+                  "num_local_W"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+
+    spec.kernels = {reader, writer};
+
+    // Local DFB (in0): reader PRODUCER -> writer CONSUMER.  Both kernels run on all_cores, so a
+    // single WorkUnitSpec hosts both endpoints on every node.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "multi_core",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = all_cores},
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
 
     uint32_t start_src_stick_id = 0;
     uint32_t start_dst_stick_id = 0;
@@ -326,6 +352,7 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
             int32_t rem_src_stick_size_nbytes = unpadded_row_size_nbytes;
             for (uint32_t i = 0; i < ncores_w; ++i) {
                 CoreCoord core = {i, (b * ncores_per_batch_h) + j};
+                const m2::NodeCoord node{core};
                 uint32_t curr_stick_size_nbytes = 0;
                 int32_t curr_stick_diff_nbytes = 0;
                 if (rem_src_stick_size_nbytes - dst_nbytes_per_core_w >= 0) {
@@ -338,53 +365,43 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
                     curr_stick_diff_nbytes = dst_nbytes_per_core_w - curr_stick_size_nbytes;
                     rem_src_stick_size_nbytes = 0;
                 }
-                // Slots 0 (src), 1 (dst) and 13 (pad-value const) are raw buffer base addresses;
-                // bind them as Buffer* so the framework patches the addresses on cache hits
-                // without rebuilding the descriptor.  The const tensor is owned by
-                // WorkloadDescriptor::buffers in create_workload_descriptor() so its address
-                // remains valid across cache hits.
-                KernelDescriptor::RTArgList reader_rt_args;
-                reader_rt_args.reserve(27);
-                reader_rt_args.push_back(src0_buffer);
-                reader_rt_args.push_back(dst_buffer);
-                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[0]));
-                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[0]));
-                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[1]));
-                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[1]));
-                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[2]));
-                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[2]));
-                reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[3]));
-                reader_rt_args.push_back(static_cast<uint32_t>(output_shape[3]));
-                reader_rt_args.push_back(curr_stick_size_nbytes);
-                reader_rt_args.push_back(static_cast<uint32_t>(dst_nbytes_per_core_w));
-                reader_rt_args.push_back(static_cast<uint32_t>(curr_stick_diff_nbytes));
-                reader_rt_args.push_back(pad_value_const_buffer);
-                reader_rt_args.push_back(pad_value_const_buffer_nbytes);
-                reader_rt_args.push_back(packed_pad_value);
-                reader_rt_args.push_back(start_src_stick_id);
-                reader_rt_args.push_back(start_dst_stick_id);
-                reader_rt_args.push_back(start_src_stick_wi);
-                reader_rt_args.push_back(start_dst_stick_wi);
-                reader_rt_args.push_back(start_src_stick_wi * a.element_size());
-                reader_rt_args.push_back(static_cast<uint32_t>(local_nsticks));
-                reader_rt_args.push_back(num_local_unpadded_nsticks);
-                reader_rt_args.push_back(unpadded_row_size_nbytes);
-                reader_rt_args.push_back(padded_row_size_nbytes);
-                reader_rt_args.push_back(start_dst_stick_wi * output.element_size());
-                reader_rt_args.push_back(nbatch_per_core_h);
-                // if (core.x == 0) log_rt_args(core, reader_rt_args);
-                // if (core.x == 0) {
-                //     log_debug(tt::LogOp, "{} :: start_src_stick_id: {}", core.y, start_src_stick_id);
-                //     log_debug(tt::LogOp, "{} :: start_dst_stick_id: {}", core.y, start_dst_stick_id);
-                //     log_debug(tt::LogOp, "{} :: local_nsticks: {}", core.y, local_nsticks);
-                //     log_debug(tt::LogOp, "{} :: num_local_unpadded_nsticks: {}", core.y, num_local_unpadded_nsticks);
-                //     log_debug(tt::LogOp, "{} :: nbatch_per_core_h: {}", core.y, nbatch_per_core_h);
-                //     log_debug(tt::LogOp, "{} :: ncores_per_batch_h: {}", core.y, ncores_per_batch_h);
-                // }
-                // Writer reads the same arg layout (slot 1 = dst addr, slot 13 = pad-value const).
-                KernelDescriptor::RTArgList writer_rt_args = reader_rt_args;
-                reader_desc.emplace_runtime_args(core, reader_rt_args);
-                writer_desc.emplace_runtime_args(core, writer_rt_args);
+                // The legacy buffer-address RTA slots (0=src, 1=dst, 13=pad-value const) are now
+                // carried by the src/dst/pad TensorBindings; only the scalar per-core args survive.
+                reader_run.runtime_arg_values.push_back(
+                    {node,
+                     {{"num_unpadded_W", static_cast<uint32_t>(a.padded_shape()[0])},
+                      {"num_total_W", static_cast<uint32_t>(output_shape[0])},
+                      {"num_unpadded_Z", static_cast<uint32_t>(a.padded_shape()[1])},
+                      {"num_total_Z", static_cast<uint32_t>(output_shape[1])},
+                      {"num_unpadded_Y", static_cast<uint32_t>(a.padded_shape()[2])},
+                      {"num_total_Y", static_cast<uint32_t>(output_shape[2])},
+                      {"unpadded_X_nbytes", curr_stick_size_nbytes},
+                      {"padded_X_nbytes", static_cast<uint32_t>(dst_nbytes_per_core_w)},
+                      {"padded_X_diff_nbytes", static_cast<uint32_t>(curr_stick_diff_nbytes)},
+                      {"pad_value_packed", packed_pad_value},
+                      {"start_src_stick_id", start_src_stick_id},
+                      {"start_src_stick_wi", start_src_stick_wi},
+                      {"start_src_stick_offset", start_src_stick_wi * a.element_size()},
+                      {"num_local_Y", static_cast<uint32_t>(local_nsticks)},
+                      {"num_local_unpadded_Y", num_local_unpadded_nsticks},
+                      {"full_unpadded_X_nbytes", unpadded_row_size_nbytes},
+                      {"num_local_W", nbatch_per_core_h}}});
+
+                writer_run.runtime_arg_values.push_back(
+                    {node,
+                     {{"num_total_W", static_cast<uint32_t>(output_shape[0])},
+                      {"num_total_Z", static_cast<uint32_t>(output_shape[1])},
+                      {"num_total_Y", static_cast<uint32_t>(output_shape[2])},
+                      {"num_total_X", static_cast<uint32_t>(output_shape[3])},
+                      {"padded_X_nbytes", static_cast<uint32_t>(dst_nbytes_per_core_w)},
+                      {"start_dst_stick_id", start_dst_stick_id},
+                      {"start_dst_stick_wi", start_dst_stick_wi},
+                      {"num_local_Y", static_cast<uint32_t>(local_nsticks)},
+                      {"num_local_unpadded_Y", num_local_unpadded_nsticks},
+                      {"full_padded_X_nbytes", padded_row_size_nbytes},
+                      {"dst_stick_offset", start_dst_stick_wi * output.element_size()},
+                      {"num_local_W", nbatch_per_core_h}}});
+
                 start_src_stick_wi += ntiles_per_core_w * TILE_WIDTH;
                 start_dst_stick_wi += ntiles_per_core_w * TILE_WIDTH;
             }  // for ncores_w
@@ -393,41 +410,15 @@ ProgramDescriptor build_pad_rm_mc_program_descriptor(
         }  // for ncores_h
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"src"}, a.mesh_tensor()},
+        {m2::TensorParamName{"dst"}, output.mesh_tensor()},
+        {m2::TensorParamName{"pad"}, pad_const.mesh_tensor()},
+    };
 
-    return desc;
-}
-
-}  // namespace
-
-WorkloadDescriptor PadRmReaderWriterMultiCoreProgramFactory::create_workload_descriptor(
-    const PadParams& operation_attributes,
-    const PadInputs& tensor_args,
-    Tensor& output,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
-    WorkloadDescriptor wd;
-
-    // Build the pad-value const tensor once on cache miss and park it on the
-    // WorkloadDescriptor.  Holding the SOURCE Tensor (not just a
-    // shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates the
-    // device memory through DeviceStorage::deallocate regardless of external
-    // shared_ptr<MeshBuffer> owners (see #44565).
-    Tensor pad_value_const_tensor = build_pad_value_const_tensor_mc(tensor_args, operation_attributes.pad_value);
-    auto pad_value_owner = std::make_shared<Tensor>(std::move(pad_value_const_tensor));
-    Buffer* pad_value_const_buffer = pad_value_owner->buffer();
-    wd.buffers.push_back({pad_value_owner, pad_value_const_buffer});
-
-    auto desc = build_pad_rm_mc_program_descriptor(operation_attributes, tensor_args, output, pad_value_const_buffer);
-
-    auto ranges = tensor_coords.ranges();
-    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
-        wd.programs.push_back({ranges[i], desc});
-    }
-    if (!ranges.empty()) {
-        wd.programs.push_back({ranges.back(), std::move(desc)});
-    }
-    return wd;
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec), .run_params = std::move(run), .op_owned_tensors = std::move(op_owned)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_multi_core_program_factory.hpp
@@ -5,28 +5,18 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
 
 #include "ttnn/device_operation.hpp"
-#include "ttnn/distributed/types.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadRmReaderWriterMultiCoreProgramFactory {
-    // Workload-scoped pad-value const tensor is allocated once on cache miss inside
-    // create_workload_descriptor() and parked on the returned WorkloadDescriptor::buffers
-    // so it outlives the cached workload via the program cache.  Holding the SOURCE
-    // Tensor (not just shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates
-    // the device memory through DeviceStorage::deallocate regardless of external
-    // shared_ptr<MeshBuffer> owners (see #44565).  emplace_runtime_args() with Buffer*
-    // lets the framework patch the const tensor's address on cache hits without rerunning
-    // this factory.
-    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
-        const PadParams& operation_attributes,
-        const PadInputs& tensor_args,
-        Tensor& output,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+    // The pad-value const tensor is allocated once on a cache miss inside create_program_spec()
+    // and returned in ProgramArtifacts::op_owned_tensors; the framework parks it at a stable
+    // address for the cached Program's life and refreshes only the io tensor bindings on a hit.
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.cpp
@@ -4,13 +4,15 @@
 
 #include "pad_rm_reader_writer_program_factory.hpp"
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::tt_metal;
 using namespace tt::constants;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 using ttnn::operations::data_movement::float_to_uint16;
@@ -18,10 +20,10 @@ using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
 namespace {
 
-// Allocate the on-device pad-value const tensor.  Pulled out so
-// create_workload_descriptor() can build it once on cache miss and park it on
-// WorkloadDescriptor::buffers, deferring ~Tensor (which force-deallocates the
-// device memory) until the cached workload is evicted (see #44565).
+// Allocate the on-device pad-value const tensor.  Returned as an op-owned tensor in
+// ProgramArtifacts::op_owned_tensors: the framework parks it at a stable address for the cached
+// Program's life (allocated once on a cache miss, reused on a hit).  The kernel reads it through a
+// TensorAccessor (ta::pad) exactly like the io tensors.
 Tensor build_pad_value_const_tensor_sc(const PadInputs& tensor_args, float pad_value) {
     MeshDevice* device = tensor_args.input.device();
     uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
@@ -35,54 +37,30 @@ Tensor build_pad_value_const_tensor_sc(const PadInputs& tensor_args, float pad_v
         .to_device(device, MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::L1});
 }
 
-ProgramDescriptor build_pad_rm_sc_program_descriptor(
-    const PadParams& operation_attributes,
-    const PadInputs& tensor_args,
-    Tensor& output,
-    Buffer* pad_value_const_buffer) {
+}  // namespace
+
+ttnn::device_operation::ProgramArtifacts PadRmReaderWriterProgramFactory::create_program_spec(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input;
+    Tensor& output = tensor_return_value;
     const auto& pad_value = operation_attributes.pad_value;
 
     auto output_shape = operation_attributes.output_padded_shape;
 
-    uint32_t unpadded_row_size_nbytes = tensor_args.input.padded_shape()[3] * tensor_args.input.element_size();
-    uint32_t padded_row_size_nbytes =
-        output_shape[3] * tensor_args.input.element_size();  // Assuming output is same datatype as input
+    uint32_t unpadded_row_size_nbytes = a.padded_shape()[3] * a.element_size();
+    uint32_t padded_row_size_nbytes = output_shape[3] * a.element_size();  // Assuming output is same datatype as input
     TT_ASSERT(
         unpadded_row_size_nbytes <= padded_row_size_nbytes, "Padded output tensor size should be >= input tensor size");
 
-    // construct const buffer with the pad_value
-    uint32_t pad_value_const_buffer_size = 32;  // noc transfers in chunks of 32
-    uint32_t pad_value_const_buffer_nbytes = pad_value_const_buffer_size * tensor_args.input.element_size();
-
     Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    TT_FATAL(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
-    CoreRange cores({0, 0}, {0, 0});
+    const CoreRangeSet core_ranges{CoreRange{{0, 0}, {0, 0}}};
 
-    ProgramDescriptor desc;
-
-    uint32_t cb_id = tt::CBIndex::c_0;
     uint32_t cb_npages = 16;  // multibuffering
     uint32_t cb_pagesize =
         tt::round_up(padded_row_size_nbytes, std::max(src0_buffer->alignment(), tt::constants::TILE_WIDTH));
     tt::DataFormat in_df = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = cb_npages * cb_pagesize,
-        .core_ranges = cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(cb_id),
-            .data_format = in_df,
-            .page_size = cb_pagesize,
-        }}},
-    });
-
-    std::vector<uint32_t> reader_ct_args = {unpadded_row_size_nbytes, padded_row_size_nbytes};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
-    TensorAccessorArgs(*dst_buffer).append_to(reader_ct_args);
-    TensorAccessorArgs(*pad_value_const_buffer).append_to(reader_ct_args);
-    std::vector<uint32_t> writer_ct_args = reader_ct_args;
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -93,123 +71,154 @@ ProgramDescriptor build_pad_rm_sc_program_descriptor(
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(0.0f), bfloat16(pad_value)});
     }
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_interleaved.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = cores;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_interleaved.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
     uint32_t padded_row_diff_size_nbytes = padded_row_size_nbytes - unpadded_row_size_nbytes;
-
-#if 0
-    {
-        log_debug(tt::LogOp, "src0_buffer_addr: {}", src0_buffer->address());
-        log_debug(tt::LogOp, "dst_buffer_addr: {}", dst_buffer->address());
-        log_debug(tt::LogOp, "a.shape[0]: {}", a.padded_shape()[0]);
-        log_debug(tt::LogOp, "out.shape[0]: {}", output_shape[0]);
-        log_debug(tt::LogOp, "a.shape[1]: {}", a.padded_shape()[1]);
-        log_debug(tt::LogOp, "out.shape[1]: {}", output_shape[1]);
-        log_debug(tt::LogOp, "a.shape[2]: {}", a.padded_shape()[2]);
-        log_debug(tt::LogOp, "out.shape[2]: {}", output_shape[2]);
-        log_debug(tt::LogOp, "s.shape[3]: {}", a.padded_shape()[3]);
-        log_debug(tt::LogOp, "out.shape[3]: {}", output_shape[3]);
-        log_debug(tt::LogOp, "unpadded_row_size_nbytes: {}", unpadded_row_size_nbytes);
-        log_debug(tt::LogOp, "padded_row_size_nbytes: {}", padded_row_size_nbytes);
-        log_debug(tt::LogOp, "padded_row_diff_size_nbytes: {}", padded_row_diff_size_nbytes);
-        log_debug(tt::LogOp, "pad_value_const_buffer_addr: {}", pad_value_const_buffer->address());
-        log_debug(tt::LogOp, "pad_value_const_buffer_nbytes: {}", pad_value_const_buffer_nbytes);
-        log_debug(tt::LogOp, "packed_pad_value: {}", packed_pad_value);
-    }
-#endif
-
     uint32_t start_src_stick_id = 0;
     uint32_t start_dst_stick_id = 0;
-    // Slots 0 (src), 1 (dst) and 13 (pad-value const) are raw buffer base addresses;
-    // bind them as Buffer* so the framework patches the addresses on cache hits
-    // without rebuilding the descriptor.  The const tensor is owned by
-    // WorkloadDescriptor::buffers in create_workload_descriptor() so its address
-    // remains valid across cache hits.
-    KernelDescriptor::RTArgList reader_rt_args;
-    reader_rt_args.reserve(27);
-    reader_rt_args.push_back(src0_buffer);
-    reader_rt_args.push_back(dst_buffer);
-    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[0]));
-    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[0]));
-    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[1]));
-    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[1]));
-    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[2]));
-    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[2]));
-    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[3]));
-    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[3]));
-    reader_rt_args.push_back(unpadded_row_size_nbytes);
-    reader_rt_args.push_back(padded_row_size_nbytes);
-    reader_rt_args.push_back(padded_row_diff_size_nbytes);
-    reader_rt_args.push_back(pad_value_const_buffer);
-    reader_rt_args.push_back(pad_value_const_buffer_nbytes);
-    reader_rt_args.push_back(packed_pad_value);
-    reader_rt_args.push_back(start_src_stick_id);
-    reader_rt_args.push_back(start_dst_stick_id);
-    reader_rt_args.push_back(std::uint32_t{0});
-    reader_rt_args.push_back(std::uint32_t{0});
-    reader_rt_args.push_back(std::uint32_t{0});
-    reader_rt_args.push_back(static_cast<uint32_t>(output_shape[2]));
-    reader_rt_args.push_back(static_cast<uint32_t>(a.padded_shape()[2]));
-    reader_rt_args.push_back(unpadded_row_size_nbytes);
-    reader_rt_args.push_back(padded_row_size_nbytes);
-    reader_rt_args.push_back(std::uint32_t{0});
-    reader_rt_args.push_back(static_cast<uint32_t>(output.padded_shape()[0]));
 
-    // Writer reads the same arg layout (slot 1 = dst addr, slot 13 = pad-value const).
-    KernelDescriptor::RTArgList writer_rt_args = reader_rt_args;
+    // ---- Op-owned pad-value const tensor (allocate first; bind against the vector element) ----
+    std::vector<Tensor> op_owned;
+    op_owned.reserve(1);
+    op_owned.push_back(build_pad_value_const_tensor_sc(tensor_args, pad_value));
+    const Tensor& pad_const = op_owned[0];
 
-    reader_desc.emplace_runtime_args(CoreCoord{0, 0}, reader_rt_args);
-    writer_desc.emplace_runtime_args(CoreCoord{0, 0}, writer_rt_args);
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "pad_rm_reader_writer";
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    // c_0 (in0): row buffer the reader fills (data + pad) and the writer drains to the output.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"in0"},
+            .entry_size = cb_pagesize,
+            .num_entries = cb_npages,
+            .data_format_metadata = in_df},
+    };
 
-    return desc;
-}
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"pad"}, .spec = pad_const.tensor_spec()},
+    };
 
-}  // namespace
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "reader_pad_dims_rm_interleaved_m2.cpp"},
+        .dfb_bindings = {m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in0"},
+            .accessor_name = "in0",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER}},
+        .tensor_bindings =
+            {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"},
+             m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"pad"}, .accessor_name = "pad"}},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"num_unpadded_W",
+                  "num_total_W",
+                  "num_unpadded_Z",
+                  "num_total_Z",
+                  "num_unpadded_Y",
+                  "num_total_Y",
+                  "unpadded_X_nbytes",
+                  "padded_X_nbytes",
+                  "padded_X_diff_nbytes",
+                  "pad_value_packed",
+                  "start_src_stick_id",
+                  "start_src_stick_wi",
+                  "start_src_stick_offset",
+                  "num_local_Y",
+                  "num_local_unpadded_Y",
+                  "full_unpadded_X_nbytes",
+                  "num_local_W"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
 
-WorkloadDescriptor PadRmReaderWriterProgramFactory::create_workload_descriptor(
-    const PadParams& operation_attributes,
-    const PadInputs& tensor_args,
-    Tensor& tensor_return_value,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
-    WorkloadDescriptor wd;
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "writer_pad_dims_rm_interleaved_m2.cpp"},
+        .dfb_bindings = {m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in0"},
+            .accessor_name = "in0",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER}},
+        .tensor_bindings = {m2::TensorBinding{
+            .tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"}},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"num_total_W",
+                  "num_total_Z",
+                  "num_total_Y",
+                  "num_total_X",
+                  "padded_X_nbytes",
+                  "start_dst_stick_id",
+                  "start_dst_stick_wi",
+                  "num_local_Y",
+                  "num_local_unpadded_Y",
+                  "full_padded_X_nbytes",
+                  "dst_stick_offset",
+                  "num_local_W"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
 
-    // Build the pad-value const tensor once on cache miss and park it on the
-    // WorkloadDescriptor.  Holding the SOURCE Tensor (not just a
-    // shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates the
-    // device memory through DeviceStorage::deallocate regardless of external
-    // shared_ptr<MeshBuffer> owners (see #44565).
-    Tensor pad_value_const_tensor = build_pad_value_const_tensor_sc(tensor_args, operation_attributes.pad_value);
-    auto pad_value_owner = std::make_shared<Tensor>(std::move(pad_value_const_tensor));
-    Buffer* pad_value_const_buffer = pad_value_owner->buffer();
-    wd.buffers.push_back({pad_value_owner, pad_value_const_buffer});
+    spec.kernels = {reader, writer};
 
-    auto desc = build_pad_rm_sc_program_descriptor(
-        operation_attributes, tensor_args, tensor_return_value, pad_value_const_buffer);
+    // Local DFB (in0) requires its producer (reader) and consumer (writer) to share the same
+    // WorkUnitSpec.  Both run on the single core {0,0}.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "single_core",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = core_ranges},
+    };
 
-    auto ranges = tensor_coords.ranges();
-    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
-        wd.programs.push_back({ranges[i], desc});
-    }
-    if (!ranges.empty()) {
-        wd.programs.push_back({ranges.back(), std::move(desc)});
-    }
-    return wd;
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    reader_run.runtime_arg_values.push_back(
+        {m2::NodeCoord{CoreCoord{0, 0}},
+         {{"num_unpadded_W", static_cast<uint32_t>(a.padded_shape()[0])},
+          {"num_total_W", static_cast<uint32_t>(output_shape[0])},
+          {"num_unpadded_Z", static_cast<uint32_t>(a.padded_shape()[1])},
+          {"num_total_Z", static_cast<uint32_t>(output_shape[1])},
+          {"num_unpadded_Y", static_cast<uint32_t>(a.padded_shape()[2])},
+          {"num_total_Y", static_cast<uint32_t>(output_shape[2])},
+          {"unpadded_X_nbytes", unpadded_row_size_nbytes},
+          {"padded_X_nbytes", padded_row_size_nbytes},
+          {"padded_X_diff_nbytes", padded_row_diff_size_nbytes},
+          {"pad_value_packed", packed_pad_value},
+          {"start_src_stick_id", start_src_stick_id},
+          {"start_src_stick_wi", 0u},
+          {"start_src_stick_offset", 0u},
+          {"num_local_Y", static_cast<uint32_t>(output_shape[2])},
+          {"num_local_unpadded_Y", static_cast<uint32_t>(a.padded_shape()[2])},
+          {"full_unpadded_X_nbytes", unpadded_row_size_nbytes},
+          {"num_local_W", static_cast<uint32_t>(output.padded_shape()[0])}}});
+
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+    writer_run.runtime_arg_values.push_back(
+        {m2::NodeCoord{CoreCoord{0, 0}},
+         {{"num_total_W", static_cast<uint32_t>(output_shape[0])},
+          {"num_total_Z", static_cast<uint32_t>(output_shape[1])},
+          {"num_total_Y", static_cast<uint32_t>(output_shape[2])},
+          {"num_total_X", static_cast<uint32_t>(output_shape[3])},
+          {"padded_X_nbytes", padded_row_size_nbytes},
+          {"start_dst_stick_id", start_dst_stick_id},
+          {"start_dst_stick_wi", 0u},
+          {"num_local_Y", static_cast<uint32_t>(output_shape[2])},
+          {"num_local_unpadded_Y", static_cast<uint32_t>(a.padded_shape()[2])},
+          {"full_padded_X_nbytes", padded_row_size_nbytes},
+          {"dst_stick_offset", 0u},
+          {"num_local_W", static_cast<uint32_t>(output.padded_shape()[0])}}});
+
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"src"}, a.mesh_tensor()},
+        {m2::TensorParamName{"dst"}, output.mesh_tensor()},
+        {m2::TensorParamName{"pad"}, pad_const.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec), .run_params = std::move(run), .op_owned_tensors = std::move(op_owned)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_reader_writer_program_factory.hpp
@@ -5,28 +5,18 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
 
 #include "ttnn/device_operation.hpp"
-#include "ttnn/distributed/types.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadRmReaderWriterProgramFactory {
-    // Workload-scoped pad-value const tensor is allocated once on cache miss inside
-    // create_workload_descriptor() and parked on the returned WorkloadDescriptor::buffers
-    // so it outlives the cached workload via the program cache.  Holding the SOURCE
-    // Tensor (not just shared_ptr<MeshBuffer>) is required because ~Tensor force-deallocates
-    // the device memory through DeviceStorage::deallocate regardless of external
-    // shared_ptr<MeshBuffer> owners (see #44565).  emplace_runtime_args() with Buffer*
-    // lets the framework patch the const tensor's address on cache hits without rerunning
-    // this factory.
-    static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
-        const PadParams& operation_attributes,
-        const PadInputs& tensor_args,
-        Tensor& tensor_return_value,
-        const ttnn::MeshCoordinateRangeSet& tensor_coords);
+    // The pad-value const tensor is allocated once on a cache miss inside create_program_spec()
+    // and returned in ProgramArtifacts::op_owned_tensors; the framework parks it at a stable
+    // address for the cached Program's life and refreshes only the io tensor bindings on a hit.
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.cpp
@@ -4,12 +4,16 @@
 
 #include "pad_rm_sharded_height_only_program_factory.hpp"
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
 using namespace tt::tt_metal;
 using namespace tt::constants;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 using ttnn::operations::data_movement::float_to_uint16;
@@ -187,7 +191,7 @@ inline std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_
 }
 }  // namespace
 
-ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts PadRmShardedHeightOnlyProgramFactory::create_program_spec(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input;
     Tensor& output = tensor_return_value;
@@ -224,8 +228,6 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
-
-    IDevice* device = a.device();
 
     // input shard spec
     auto shard_spec_unpadded = a.shard_spec().value();
@@ -264,59 +266,11 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
     log_debug(tt::LogOp, "all_cores_unpadded: {}", all_cores_unpadded);
     log_debug(tt::LogOp, "num_cores_unpadded: {}", num_cores_unpadded);
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
-
-    Buffer* src_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-
-    ProgramDescriptor desc;
-
-    // Sharded input CB — globally allocated to the input buffer; framework patches
-    // the CB address on cache hits via cb.buffer.
-    uint32_t src0_cb_index = 0;
-    {
-        CBDescriptor cb_src0;
-        cb_src0.total_size = shard_height_unpadded * stick_size_unpadded;
-        cb_src0.core_ranges = total_cores;
-        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = stick_size_unpadded,
-        });
-        cb_src0.buffer = src_buffer;
-        desc.cbs.push_back(std::move(cb_src0));
-    }
-
-    // Sharded output CB — globally allocated to the output buffer.
-    uint32_t output_cb_index = tt::CBIndex::c_16;
-    {
-        CBDescriptor cb_output;
-        cb_output.total_size = shard_height_padded * stick_size_padded;
-        cb_output.core_ranges = total_cores;
-        cb_output.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = dst_cb_data_format,
-            .page_size = stick_size_padded,
-        });
-        cb_output.buffer = dst_buffer;
-        desc.cbs.push_back(std::move(cb_output));
-    }
+    TT_ASSERT(a.buffer() != nullptr, "Input buffer should be allocated on device!");
+    TT_ASSERT(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
     // construct const buffer with the pad_value
     bool not_pad_by_zero = pad_value != 0;
-    uint32_t src1_cb_index = 1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = stick_size_padded,
-        .core_ranges = total_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src1_cb_index),
-            .data_format = cb_data_format,
-            .page_size = stick_size_padded,
-        }}},
-    });
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -327,38 +281,99 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
         packed_pad_value = pack_two_bfloat16_into_uint32({bfloat16(pad_value), bfloat16(pad_value)});
     }
 
-    std::vector<uint32_t> reader_ct_args = {(std::uint32_t)stick_size_padded, (std::uint32_t)shard_height_padded};
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "pad_rm_sharded_height_only";
 
-    std::vector<uint32_t> writer_ct_args = {
-        (std::uint32_t)N + front_pad[-4],
-        (std::uint32_t)H + front_pad[-2],
-        (std::uint32_t)C + front_pad[-3],
-        (std::uint32_t)stick_size_padded,
-        (std::uint32_t)N_padded,
-        (std::uint32_t)H_padded,
-        (std::uint32_t)C_padded,
-        (std::uint32_t)num_zero_pad_sticks_read,
-        (std::uint32_t)zero_pad_stick_size,
-        (std::uint32_t)not_pad_by_zero,
-        (std::uint32_t)packed_pad_value,
-        (std::uint32_t)row_major_min_bytes,
-        (std::uint32_t)(stick_size_padded / row_major_min_bytes)};
+    // Borrowed-memory DFBs: in0 views the input shard's L1, out0 views the output shard's L1
+    // (both supplied at runtime via the src/dst tensor args).  pad is a fake CB the writer fills
+    // with the pad value and reads by base pointer (self-loop).
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"in0"},
+            .entry_size = stick_size_unpadded,
+            .num_entries = shard_height_unpadded,
+            .data_format_metadata = cb_data_format,
+            .borrowed_from = m2::TensorParamName{"src"}},
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"out0"},
+            .entry_size = stick_size_padded,
+            .num_entries = shard_height_padded,
+            .data_format_metadata = dst_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"dst"}},
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"pad"},
+            .entry_size = stick_size_padded,
+            .num_entries = 1,
+            .data_format_metadata = cb_data_format},
+    };
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores_padded;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()},
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores_padded;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "reader_pad_dims_rm_sharded.cpp"},
+        // in0 is read by base pointer only (no FIFO) -> self-loop; out0 is produced by the reader.
+        .dfb_bindings =
+            {m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"in0"},
+                 .accessor_name = "in0",
+                 .endpoint_type = m2::DFBEndpointType::PRODUCER},
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"in0"},
+                 .accessor_name = "in0",
+                 .endpoint_type = m2::DFBEndpointType::CONSUMER},
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"out0"},
+                 .accessor_name = "out0",
+                 .endpoint_type = m2::DFBEndpointType::PRODUCER}},
+        .compile_time_args =
+            {{"stick_size_bytes", (std::uint32_t)stick_size_padded},
+             {"num_sticks_padded", (std::uint32_t)shard_height_padded}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_cores_read"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "writer_pad_dims_rm_sharded.cpp"},
+        // out0 is consumed (written by base pointer) by the writer; pad is a writer self-loop.
+        .dfb_bindings =
+            {m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"out0"},
+                 .accessor_name = "out0",
+                 .endpoint_type = m2::DFBEndpointType::CONSUMER},
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"pad"},
+                 .accessor_name = "pad",
+                 .endpoint_type = m2::DFBEndpointType::PRODUCER},
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"pad"},
+                 .accessor_name = "pad",
+                 .endpoint_type = m2::DFBEndpointType::CONSUMER}},
+        .compile_time_args =
+            {{"N", (std::uint32_t)N + front_pad[-4]},
+             {"H", (std::uint32_t)H + front_pad[-2]},
+             {"C", (std::uint32_t)C + front_pad[-3]},
+             {"stick_size_bytes", (std::uint32_t)stick_size_padded},
+             {"N_padded", (std::uint32_t)N_padded},
+             {"H_padded", (std::uint32_t)H_padded},
+             {"C_padded", (std::uint32_t)C_padded},
+             {"num_zero_pad_sticks_read", (std::uint32_t)num_zero_pad_sticks_read},
+             {"zero_pad_stick_size", (std::uint32_t)zero_pad_stick_size},
+             {"not_pad_by_zero", (std::uint32_t)not_pad_by_zero},
+             {"packed_pad_value", (std::uint32_t)packed_pad_value},
+             {"row_major_min_bytes", (std::uint32_t)row_major_min_bytes},
+             {"num_sticks_padded_read", (std::uint32_t)(stick_size_padded / row_major_min_bytes)}},
+        .runtime_arg_schema =
+            {.runtime_arg_names = {"num_sticks_per_core", "start_id", "front_pad_n", "front_pad_c", "front_pad_h"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
 
     auto all_runtime_args = get_pad_runtime_args_rm_sharded(
         a,
@@ -372,9 +387,34 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
         num_cores_x_unpadded,
         num_cores_y_unpadded);
 
-    // Sharded readers/writers consume only constant uint32_t per-core args; no
-    // BufferBinding is needed because the CBs themselves carry the buffer
-    // addresses (via cb.buffer).
+    // The reader's packed per-core tail (noc x/y + stick chunks) is variable-length per core.
+    // It rides as runtime varargs; num_runtime_varargs is fixed at the max tail length and
+    // shorter cores are zero-padded (the kernel only indexes within its own num_cores_read range,
+    // so the trailing pad is never read).  The writer's start_dim_offset (4) rides as varargs too.
+    uint32_t max_reader_tail = 0;
+    for (uint32_t i = 0; i < num_cores_padded; i++) {
+        max_reader_tail = std::max<uint32_t>(max_reader_tail, all_runtime_args[i].first.size() - 1);
+    }
+    reader.advanced_options.num_runtime_varargs = max_reader_tail;
+    constexpr uint32_t kNumDimOffsets = 4;
+    writer.advanced_options.num_runtime_varargs = kNumDimOffsets;
+
+    spec.kernels = {reader, writer};
+
+    // out0 (borrowed) is produced by the reader and consumed by the writer; in0/pad self-loops.
+    // All endpoints must share a WorkUnitSpec — both kernels run on all_cores_padded.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "sharded",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = all_cores_padded},
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+
     for (uint32_t i = 0; i < num_cores_padded; i++) {
         CoreCoord core;
         if (row_major) {
@@ -384,24 +424,43 @@ ProgramDescriptor PadRmShardedHeightOnlyProgramFactory::create_descriptor(
             core = {
                 bbox_padded.start_coord.x + i / num_cores_y_padded, bbox_padded.start_coord.y + i % num_cores_y_padded};
         }
-        KernelDescriptor::RTArgList reader_rt_args;
-        reader_rt_args.reserve(all_runtime_args[i].first.size());
-        for (uint32_t v : all_runtime_args[i].first) {
-            reader_rt_args.push_back(v);
+        const m2::NodeCoord node{core};
+
+        // Reader: num_cores_read (named) + packed tail (varargs, zero-padded to max).
+        const auto& reader_args = all_runtime_args[i].first;
+        reader_run.runtime_arg_values.push_back({node, {{"num_cores_read", reader_args[0]}}});
+        m2::AdvancedKernelRunArgs::Varargs reader_tail;
+        reader_tail.reserve(max_reader_tail);
+        for (size_t k = 1; k < reader_args.size(); ++k) {
+            reader_tail.push_back(reader_args[k]);
         }
-        KernelDescriptor::RTArgList writer_rt_args;
-        writer_rt_args.reserve(all_runtime_args[i].second.size());
-        for (uint32_t v : all_runtime_args[i].second) {
-            writer_rt_args.push_back(v);
+        reader_tail.resize(max_reader_tail, 0u);
+        reader_run.advanced_options.runtime_varargs[node] = std::move(reader_tail);
+
+        // Writer: 5 named scalar args + start_dim_offset[4] varargs (legacy slots 5..8).
+        const auto& writer_args = all_runtime_args[i].second;
+        writer_run.runtime_arg_values.push_back(
+            {node,
+             {{"num_sticks_per_core", writer_args[0]},
+              {"start_id", writer_args[1]},
+              {"front_pad_n", writer_args[2]},
+              {"front_pad_c", writer_args[3]},
+              {"front_pad_h", writer_args[4]}}});
+        m2::AdvancedKernelRunArgs::Varargs writer_dims;
+        writer_dims.reserve(kNumDimOffsets);
+        for (uint32_t d = 0; d < kNumDimOffsets; ++d) {
+            writer_dims.push_back(d + 5 < writer_args.size() ? writer_args[d + 5] : 0u);
         }
-        reader_desc.emplace_runtime_args(core, reader_rt_args);
-        writer_desc.emplace_runtime_args(core, writer_rt_args);
+        writer_run.advanced_options.runtime_varargs[node] = std::move(writer_dims);
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"src"}, a.mesh_tensor()},
+        {m2::TensorParamName{"dst"}, output.mesh_tensor()},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_height_only_program_factory.hpp
@@ -5,15 +5,15 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadRmShardedHeightOnlyProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.cpp
@@ -6,18 +6,22 @@
 
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/tensor/tensor_utils.hpp"
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
 using namespace tt::tt_metal;
 using namespace tt::constants;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
-ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts PadRmShardedWidthOnlyProgramFactory::create_program_spec(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input_tensor = tensor_args.input;
     Tensor& output = tensor_return_value;
@@ -36,8 +40,6 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
     auto unpadded_stick_bytes = W * input_tensor.element_size();
     auto padded_stick_bytes = W_padded * input_tensor.element_size();
 
-    IDevice* device = input_tensor.device();
-
     // input shard spec
     auto input_shard_spec = input_tensor.shard_spec().value();
     uint32_t shard_height_unpadded = input_shard_spec.shape[0];
@@ -49,61 +51,12 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
     const auto& ordered_cores_with_data = get_optimal_worker_cores_for_sharded_tensor(output);
     auto all_cores_padded = CoreRangeSet(ttsl::Span<const CoreCoord>(ordered_cores_with_data));
 
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
-
-    Buffer* input_buffer = input_tensor.buffer();
-    Buffer* output_buffer = output.buffer();
-
-    ProgramDescriptor desc;
+    TT_ASSERT(input_tensor.buffer() != nullptr, "Input buffer should be allocated on device!");
+    TT_ASSERT(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    uint32_t input_shard_cb_index = tt::CBIndex::c_0;
-    {
-        // Sharded input CB — globally allocated to the input buffer; framework
-        // patches the CB address on cache hits via cb.buffer.
-        CBDescriptor cb_input;
-        cb_input.total_size = shard_height_unpadded * unpadded_stick_bytes;
-        cb_input.core_ranges = total_cores;
-        cb_input.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(input_shard_cb_index),
-            .data_format = input_cb_data_format,
-            .page_size = unpadded_stick_bytes,
-        });
-        cb_input.buffer = input_buffer;
-        desc.cbs.push_back(std::move(cb_input));
-    }
-
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
-    uint32_t output_shard_cb_index = tt::CBIndex::c_16;
-    {
-        // Sharded output CB — globally allocated to the output buffer.
-        CBDescriptor cb_output;
-        cb_output.total_size = shard_height_padded * padded_stick_bytes;
-        cb_output.core_ranges = total_cores;
-        cb_output.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_shard_cb_index),
-            .data_format = output_cb_data_format,
-            .page_size = padded_stick_bytes,
-        });
-        cb_output.buffer = output_buffer;
-        desc.cbs.push_back(std::move(cb_output));
-    }
-
-    // construct const buffer with the pad_value
     tt::DataFormat pad_val_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
-    uint32_t pad_val_cb_index = tt::CBIndex::c_1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = padded_stick_bytes,
-        .core_ranges = total_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(pad_val_cb_index),
-            .data_format = pad_val_cb_data_format,
-            .page_size = padded_stick_bytes,
-        }}},
-    });
 
     uint32_t W_padding_front_bytes = input_tensor_start[-3] * input_tensor.element_size();
 
@@ -130,55 +83,114 @@ ProgramDescriptor PadRmShardedWidthOnlyProgramFactory::create_descriptor(
         unpadded_stick_bytes,
         l1_alignment_bytes);  // round unpadded_stick bytes to a multiple of l1_alignment_bytes
 
-    std::vector<uint32_t> reader_ct_args = {
-        unpadded_stick_bytes,
-        padded_stick_bytes,
-        shard_height_unpadded,
-        shard_height_padded,
-        W_padding_front_bytes,
-        input_shard_cb_index,
-        output_shard_cb_index,
-        unpadded_stick_step,
-        padded_stick_step};
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "pad_rm_sharded_width_only";
 
-    std::vector<uint32_t> writer_ct_args = {
-        padded_stick_bytes,
-        shard_height_padded,
-        padding_value_as_u32,
-        output.element_size(),
-        output_shard_cb_index,
-        pad_val_cb_index,
-        padded_stick_step};
+    // Borrowed-memory DFBs: in0 views the input shard's L1, out0 views the output shard's L1
+    // (supplied at runtime via the input/output tensor args).  pad is a fake CB the writer fills
+    // with the pad value and reads by base pointer (self-loop).
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"in0"},
+            .entry_size = unpadded_stick_bytes,
+            .num_entries = shard_height_unpadded,
+            .data_format_metadata = input_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"src"}},
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"out0"},
+            .entry_size = padded_stick_bytes,
+            .num_entries = shard_height_padded,
+            .data_format_metadata = output_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"dst"}},
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"pad"},
+            .entry_size = padded_stick_bytes,
+            .num_entries = 1,
+            .data_format_metadata = pad_val_cb_data_format},
+    };
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_dims_rm_sharded_stickwise.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores_padded;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = input_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()},
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_dims_rm_sharded_stickwise.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores_padded;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "reader_pad_dims_rm_sharded_stickwise.cpp"},
+        // in0 read by base pointer only (self-loop); out0 consumed (sticks the writer produced).
+        .dfb_bindings =
+            {m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"in0"},
+                 .accessor_name = "in0",
+                 .endpoint_type = m2::DFBEndpointType::PRODUCER},
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"in0"},
+                 .accessor_name = "in0",
+                 .endpoint_type = m2::DFBEndpointType::CONSUMER},
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"out0"},
+                 .accessor_name = "out0",
+                 .endpoint_type = m2::DFBEndpointType::CONSUMER}},
+        .compile_time_args =
+            {{"unpadded_stick_bytes", unpadded_stick_bytes},
+             {"padded_stick_bytes", padded_stick_bytes},
+             {"unpadded_shard_height", shard_height_unpadded},
+             {"padded_shard_height", shard_height_padded},
+             {"W_front_pad_bytes", W_padding_front_bytes},
+             {"unpadded_stick_step", unpadded_stick_step},
+             {"padded_stick_step", padded_stick_step}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
 
-    // Sharded readers/writers don't consume per-core runtime args (legacy code
-    // called SetRuntimeArgs(..., {}) with empty arg lists).  CB addresses are
-    // patched via cb.buffer on cache hits.  Mirror the legacy behavior by
-    // emitting an empty rtarg list per active core so the kernel reserves slots.
-    for (const auto& core : ordered_cores_with_data) {
-        reader_desc.emplace_runtime_args(core, KernelDescriptor::RTArgList{});
-        writer_desc.emplace_runtime_args(core, KernelDescriptor::RTArgList{});
-    }
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "writer_pad_dims_rm_sharded_stickwise.cpp"},
+        // out0 produced by the writer; pad is a writer self-loop.
+        .dfb_bindings =
+            {m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"out0"},
+                 .accessor_name = "out0",
+                 .endpoint_type = m2::DFBEndpointType::PRODUCER},
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"pad"},
+                 .accessor_name = "pad",
+                 .endpoint_type = m2::DFBEndpointType::PRODUCER},
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"pad"},
+                 .accessor_name = "pad",
+                 .endpoint_type = m2::DFBEndpointType::CONSUMER}},
+        .compile_time_args =
+            {{"padded_stick_bytes", padded_stick_bytes},
+             {"padded_shard_height", shard_height_padded},
+             {"padding_value_as_u32", padding_value_as_u32},
+             {"padding_value_num_bytes", static_cast<uint32_t>(output.element_size())}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    spec.kernels = {reader, writer};
 
-    return desc;
+    // out0 (borrowed) is produced by the writer and consumed by the reader; in0/pad self-loops.
+    // All endpoints share a WorkUnitSpec — both kernels run on all_cores_padded.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "sharded",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = all_cores_padded},
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
+    // The sharded readers/writers consume only CTAs; no per-core runtime args (legacy emitted empty
+    // arg lists).  The borrowed DFBs pull their backing L1 address from the src/dst tensor args.
+    m2::ProgramRunArgs run;
+    run.tensor_args = {
+        {m2::TensorParamName{"src"}, input_tensor.mesh_tensor()},
+        {m2::TensorParamName{"dst"}, output.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_rm_sharded_width_only_program_factory.hpp
@@ -5,15 +5,15 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadRmShardedWidthOnlyProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.cpp
@@ -4,13 +4,16 @@
 
 #include "pad_tile_multicore_program_factory.hpp"
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
 using namespace tt::tt_metal;
 using namespace tt::constants;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 using ttnn::operations::data_movement::get_num_pages;
@@ -28,9 +31,10 @@ static inline int advance_tensor_index(std::vector<uint32_t>& idx, const ttnn::S
     return 0;  // overflowed most-significant dim
 }
 
-ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
-    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output) {
+ttnn::device_operation::ProgramArtifacts PadTileMulticoreProgramFactory::create_program_spec(
+    const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input;
+    Tensor& output = tensor_return_value;
     const auto& pad_value = operation_attributes.pad_value;
     const auto& output_padded_shape = operation_attributes.output_padded_shape;
 
@@ -51,45 +55,6 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t page_size = output.buffer()->page_size();
     uint32_t multi_buffering_size = 2;
-    uint32_t input_cb_index = tt::CBIndex::c_0;
-    uint32_t output_cb_index = tt::CBIndex::c_1;
-    uint32_t pad_val_cb_index = tt::CBIndex::c_2;
-
-    ProgramDescriptor desc;
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = page_size * multi_buffering_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(input_cb_index),
-            .data_format = cb_data_format,
-            .page_size = page_size,
-        }}},
-    });
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = page_size * multi_buffering_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = cb_data_format,
-            .page_size = page_size,
-        }}},
-    });
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = page_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(pad_val_cb_index),
-            .data_format = cb_data_format,
-            .page_size = page_size,
-        }}},
-    });
-
-    Buffer* input_buffer = a.buffer();
-    Buffer* output_buffer = output.buffer();
-    TT_ASSERT(output_buffer != nullptr, "Output buffer should be allocated on device!");
 
     uint32_t packed_pad_value;
     bfloat16 bfloat_pad_value = bfloat16(pad_value);
@@ -113,75 +78,123 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
                 "FLOAT32");
     }
 
-    std::vector<uint32_t> reader_ct_args = {
-        (std::uint32_t)input_cb_index,
-        (std::uint32_t)page_size,
-        (std::uint32_t)output_padded_shape.rank(),
+    const uint32_t num_dims = output_padded_shape.rank();
+
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "pad_tile_multicore";
+
+    // Legacy CB layout, preserved 1:1:
+    //   c_0 input  (2 pages): reader PRODUCER -> writer CONSUMER.
+    //   c_1 output (2 pages): allocated by the legacy descriptor but never used by the kernel
+    //                         as a FIFO; preserved as a writer self-loop so the L1 footprint is
+    //                         unchanged and the validator's producer+consumer rule is satisfied.
+    //   c_2 pad    (1 page) : output-dtype L1 scratch the writer fills with the pad value once
+    //                         and reuses as the NoC source for every padded tile; it has no FIFO
+    //                         peer, so it is a writer self-loop (producer + consumer).
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"in0"},
+            .entry_size = page_size,
+            .num_entries = multi_buffering_size,
+            .data_format_metadata = cb_data_format},
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"out"},
+            .entry_size = page_size,
+            .num_entries = multi_buffering_size,
+            .data_format_metadata = cb_data_format},
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"pad"},
+            .entry_size = page_size,
+            .num_entries = 1,
+            .data_format_metadata = cb_data_format},
     };
-    TensorAccessorArgs(*input_buffer).append_to(reader_ct_args);
 
-    std::vector<uint32_t> writer_ct_args = {
-        (std::uint32_t)input_cb_index,
-        (std::uint32_t)output_cb_index,
-        (std::uint32_t)pad_val_cb_index,
-        (std::uint32_t)page_size,
-        (std::uint32_t)output_padded_shape.rank(),
-        (std::uint32_t)packed_pad_value,
-        (std::uint32_t)output.element_size(),
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()},
     };
-    TensorAccessorArgs(*output_buffer).append_to(writer_ct_args);
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/reader_pad_tiled.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "reader_pad_tiled.cpp"},
+        .dfb_bindings = {m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in0"},
+            .accessor_name = "in0",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER}},
+        .tensor_bindings = {m2::TensorBinding{
+            .tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"}},
+        .compile_time_args = {{"page_size", page_size}, {"num_dims", num_dims}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages_to_write", "start_offset"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+    // Per-core per-dim arrays [input_page_shape, output_page_shape, input_id_per_dim, output_id_per_dim],
+    // each num_dims long, passed as runtime varargs (read positionally in the kernel).
+    reader.advanced_options.num_runtime_varargs = num_dims * 4;
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_pad_tiled.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "writer_pad_tiled.cpp"},
+        .dfb_bindings =
+            {m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"in0"},
+                 .accessor_name = "in0",
+                 .endpoint_type = m2::DFBEndpointType::CONSUMER},
+             // "out" self-loop: legacy output CB, allocated but unused by the kernel as a FIFO.
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"out"},
+                 .accessor_name = "out",
+                 .endpoint_type = m2::DFBEndpointType::PRODUCER},
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"out"},
+                 .accessor_name = "out",
+                 .endpoint_type = m2::DFBEndpointType::CONSUMER},
+             // "pad" self-loop: the writer both reserves (producer) and consumes (consumer) the
+             // pad-scratch DFB; it has no other endpoint.
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"pad"},
+                 .accessor_name = "pad",
+                 .endpoint_type = m2::DFBEndpointType::PRODUCER},
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"pad"},
+                 .accessor_name = "pad",
+                 .endpoint_type = m2::DFBEndpointType::CONSUMER}},
+        .tensor_bindings = {m2::TensorBinding{
+            .tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"}},
+        .compile_time_args =
+            {{"page_size", page_size},
+             {"num_dims", num_dims},
+             {"pad_value", packed_pad_value},
+             {"element_size", static_cast<uint32_t>(output.element_size())}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages_to_write", "start_offset"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+    // Same per-core per-dim varargs as the reader.
+    writer.advanced_options.num_runtime_varargs = num_dims * 4;
+
+    spec.kernels = {reader, writer};
+
+    // Local DFBs (in0, out, pad) require their producer and consumer KernelSpecs to share the
+    // same WorkUnitSpec. Both kernels run on all_cores, so a single WorkUnitSpec hosts both.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "multi_core",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = all_cores},
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
 
     /*
-    As an example, lets say we want to pad a [2, 1, 32, 32] tensor to [2, 3, 64, 64]
-    The input tensor exists as [2, 2, 1, 1] if we reduce by tile (page) size, and the output as [2, 3, 2, 2]
-    we increment through these shapes, and will write a total of 2 * 3 * 2 * 2 = 24 tiles, so we will utilize 24 cores
-    for each core, we calculate if we are within the "input region" of the output. this does a check of
-    if any element in the incremented input_id_per_dim is less than the output_id_per_dim, if so, we are outside
-    the input region, and we will write a padding tile, and we will not increment the input_id_per_dim for that tile.
-    if we are within the input region, we will write the tile from input to the output, and increment the
-    input_id_per_dim. This works because we increment the least-significant dim first, and the input region correctly
-    matches the output after the output wraps around. In this example:
-    Core 0: input_id_per_dim: [0,0,0,0] ; output_id_per_dim: [0,0,0,0], we copy the tile and increment both input and
-    output dims, next ->
-    Core 1: input_id_per_dim: [0,1,0,0] ; output_id_per_dim: [0,0,0,1], the last output dim is
-    greater than input, so we write the pad tile, and increment only output dim, next ->
-    Core 2: input_id_per_dim: [0,1,0,0] ; output_id_per_dim: [0,0,1,0], the second last output dim is greater than
-    input, so we write the pad tile, and increment only output dim, next ->
-    Core 3: input_id_per_dim: [0,1,0,0] ; output_id_per_dim: [0,0,1,1], the last 2 output dims is greater than input,
-    so we write the pad tile, and increment only output dim, next ->
-    Core 4: input_id_per_dim: [0,1,0,0] ; output_id_per_dim: [0,1,0,0], we copy the tile and increment, next ->
-    Core 5: input_id_per_dim: [1,0,0,0] ; output_id_per_dim: [0,1,0,1], Some output dims are greater
-    than input, so we write the pad tile, and increment only output dim. next ->
-    Core 6: input_id_per_dim: [1,0,0,0] ; output_id_per_dim: [0,1,1,0],
-    Core 7, 8, 9, 10, 11, we write pad tiles, incrementing only output dim each time, next ->
-    Core 12: input_id_per_dim: [1,0,0,0] ; output_id_per_dim: [1,0,0,0], we copy the tile and increment, next ->
-    Core 13: input_id_per_dim: [1,1,0,0] ; output_id_per_dim: [1,0,0,1], Core 13, 14, 15, we write pad tiles,
-    incrementing only output dim each time, next -> Core 16: input_id_per_dim: [1,1,0,0] ; output_id_per_dim: [1,1,0,0],
-    we copy the tile and increment, next ->
-    From now on, input_id_per_dim wraps around it's most significant dim, resulting in [0,0,0,0].
-    This means for every output_id_per_dim, an element will always be greater than
-    input_id_per_dim, so every core after core 16 will only write pad tiles, which is correct as we have filled all of
-    the input region, and will always be outside of it from now on.
-
-    As you can see, the input_id_per_dim only increments when we are within the input region of the output,
-    and the output_id_per_dim increments every time, this means that when the output wraps around, the input
-    will be correctly positioned for the next set of output tiles.
+    See the original single-core/legacy comment block: this factory walks the output tile space,
+    deciding per output tile whether it falls inside the input region (copy a tile) or outside it
+    (write a pad tile), and advances the input index only inside the input region. The host
+    pre-computes, per core, the input/output starting indices and page offsets.
     */
 
     std::vector<uint32_t> input_id_per_dim, output_id_per_dim;  // input and output id_per_dims
@@ -201,6 +214,7 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
 
     for (uint32_t i = 0; i < num_cores; i++) {
         CoreCoord core = cores_in_order[i];
+        const m2::NodeCoord node{core};
 
         uint32_t num_pages_per_core;
         if (core_group_1.contains(core)) {
@@ -211,49 +225,31 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
             num_pages_per_core = 0;  // no-op
         }
 
-        // Slot 0 is a raw buffer base address (no offset).  Use Buffer* on active
-        // cores so the framework patches the address on cache hits.  Idle cores
-        // (num_pages_per_core == 0) pass 0u to skip BufferBinding registration —
-        // the kernel short-circuits and never dereferences the address.
-        KernelDescriptor::RTArgList reader_runtime_args;
-        KernelDescriptor::RTArgList writer_runtime_args;
+        // The legacy buffer-address RTA slot (0u on idle cores, Buffer* on active ones) is now
+        // carried by the src/dst TensorBindings; idle cores short-circuit on num_pages_to_write == 0.
+        reader_run.runtime_arg_values.push_back(
+            {node, {{"num_pages_to_write", num_pages_per_core}, {"start_offset", input_page_offset}}});
+        writer_run.runtime_arg_values.push_back(
+            {node, {{"num_pages_to_write", num_pages_per_core}, {"start_offset", output_page_offset}}});
 
-        if (num_pages_per_core != 0) {
-            reader_runtime_args.push_back(input_buffer);
-            writer_runtime_args.push_back(output_buffer);
-        } else {
-            reader_runtime_args.push_back(0u);
-            writer_runtime_args.push_back(0u);
-        }
-
-        reader_runtime_args.push_back(num_pages_per_core);
-        reader_runtime_args.push_back(input_page_offset);
-
-        writer_runtime_args.push_back(num_pages_per_core);
-        writer_runtime_args.push_back(output_page_offset);
-
-        // Every core should get the same input and output tile shapes.
+        // Per-core varargs: [input_page_shape..., output_page_shape..., input_id_per_dim..., output_id_per_dim...].
+        // Every core gets the same input and output tile shapes, plus its own starting indices.
+        m2::AdvancedKernelRunArgs::Varargs per_dim;
+        per_dim.reserve(num_dims * 4);
         for (auto v : input_page_shape) {
-            reader_runtime_args.push_back(v);
-            writer_runtime_args.push_back(v);
+            per_dim.push_back(v);
         }
         for (auto v : output_page_shape) {
-            reader_runtime_args.push_back(v);
-            writer_runtime_args.push_back(v);
+            per_dim.push_back(v);
         }
-
-        // As well as where the core should start writing in the output tensor.
         for (uint32_t v : input_id_per_dim) {
-            reader_runtime_args.push_back(v);
-            writer_runtime_args.push_back(v);
+            per_dim.push_back(v);
         }
         for (uint32_t v : output_id_per_dim) {
-            reader_runtime_args.push_back(v);
-            writer_runtime_args.push_back(v);
+            per_dim.push_back(v);
         }
-
-        reader_desc.emplace_runtime_args(core, reader_runtime_args);
-        writer_desc.emplace_runtime_args(core, writer_runtime_args);
+        reader_run.advanced_options.runtime_varargs[node] = per_dim;
+        writer_run.advanced_options.runtime_varargs[node] = std::move(per_dim);
 
         // We now need to increment the input and output id_per_dims by the number of pages this core is processing
         // Similarly to in the kernel, we only increment the input id_per_dim if we are within the input region
@@ -275,10 +271,13 @@ ProgramDescriptor PadTileMulticoreProgramFactory::create_descriptor(
         // The input and output id_per_dim should now be set correctly for the next core
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"src"}, a.mesh_tensor()},
+        {m2::TensorParamName{"dst"}, output.mesh_tensor()},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_multicore_program_factory.hpp
@@ -5,15 +5,15 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadTileMulticoreProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
-        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& output);
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
+        const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.cpp
@@ -3,19 +3,22 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pad_tile_program_factory.hpp"
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
 
-ProgramDescriptor PadTileCoreProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts PadTileCoreProgramFactory::create_program_spec(
     const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input;
     Tensor& output = tensor_return_value;
@@ -24,13 +27,7 @@ ProgramDescriptor PadTileCoreProgramFactory::create_descriptor(
 
     const CoreRangeSet core_ranges{CoreRange{{0, 0}, {0, 0}}};
 
-    // This should allocate a DRAM buffer on the device
-
     const auto& output_shape = output_padded_shape;
-
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(a.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
@@ -42,31 +39,8 @@ ProgramDescriptor PadTileCoreProgramFactory::create_descriptor(
     log_debug(tt::LogOp, "input_tensor_start: {}", operation_attributes.input_tensor_start);
     log_debug(tt::LogOp, "pad_value: {}", pad_value);
 
-    ProgramDescriptor desc;
-
-    const uint32_t src0_cb_index = 0;
     const uint32_t num_input_tiles = 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * single_tile_size,
-        .core_ranges = core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
-
-    const uint32_t src1_cb_index = 1;  // For pad buffer
-    const uint32_t num_pad_tiles = 1;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_pad_tiles * single_tile_size,
-        .core_ranges = core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src1_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
+    const uint32_t num_pad_tiles = 1;  // src1 / "pad": scratch L1 for the pad-value tile
 
     uint32_t packed_pad_value;
     if (a.dtype() == DataType::INT32 || a.dtype() == DataType::UINT32) {
@@ -92,52 +66,120 @@ ProgramDescriptor PadTileCoreProgramFactory::create_descriptor(
 
     uint32_t num_unpadded_tiles = a.physical_volume() / TILE_HW;
 
-    // Reader compile-time args
-    // Data is 32 byte aligned
-    std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index, src1_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "pad_tile";
 
-    // Tilized reader
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = core_ranges;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    // "in0": input tiles, produced by the (tilized) reader and consumed by the writer.
+    // "pad" (legacy src1 CB): output-dtype L1 scratch the writer fills with the pad value once
+    // and reuses as the NoC source for every padded tile; it has no FIFO peer (the writer is its
+    // only user), so it is bound as a self-loop (producer + consumer on the writer).
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"in0"},
+            .entry_size = single_tile_size,
+            .num_entries = num_input_tiles,
+            .data_format_metadata = cb_data_format},
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"pad"},
+            .entry_size = single_tile_size,
+            .num_entries = num_pad_tiles,
+            .data_format_metadata = cb_data_format},
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/writer_unary_pad_dims_interleaved.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = core_ranges;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"out"}, .spec = output.tensor_spec()},
+    };
 
-    // Slot 0 of both kernels is a raw buffer base address (no offset).  Use Buffer*
-    // for BufferBinding so the framework patches addresses on cache hits without
-    // rebuilding the descriptor.
-    reader_desc.emplace_runtime_args(CoreCoord{0, 0}, {src0_buffer, num_unpadded_tiles, std::uint32_t{0}});
+    // Tilized reader (eltwise/unary reader, forked to *_m2 for the named-binding form).
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "reader_unary_interleaved_start_id_m2.cpp"},
+        .dfb_bindings = {m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in0"},
+            .accessor_name = "in0",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER}},
+        .tensor_bindings = {m2::TensorBinding{
+            .tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
 
-    writer_desc.emplace_runtime_args(
-        CoreCoord{0, 0},
-        {dst_buffer,
-         num_unpadded_W,
-         num_padded_Wt,
-         num_unpadded_Z,
-         num_padded_Zt,
-         num_unpadded_Yt,
-         num_padded_Yt,
-         num_unpadded_Xt,
-         num_padded_Xt,
-         packed_pad_value});
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/pad/device/kernels/dataflow/"
+                                        "writer_unary_pad_dims_interleaved.cpp"},
+        .dfb_bindings =
+            {m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"in0"},
+                 .accessor_name = "in0",
+                 .endpoint_type = m2::DFBEndpointType::CONSUMER},
+             // "pad" self-loop: the writer both reserves (producer) and consumes (consumer) the
+             // pad-scratch DFB; it has no other endpoint.
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"pad"},
+                 .accessor_name = "pad",
+                 .endpoint_type = m2::DFBEndpointType::PRODUCER},
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"pad"},
+                 .accessor_name = "pad",
+                 .endpoint_type = m2::DFBEndpointType::CONSUMER}},
+        .tensor_bindings = {m2::TensorBinding{
+            .tensor_parameter_name = m2::TensorParamName{"out"}, .accessor_name = "out"}},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"num_unpadded_W",
+                  "num_padded_Wt",
+                  "num_unpadded_Z",
+                  "num_padded_Zt",
+                  "num_unpadded_Yt",
+                  "num_padded_Yt",
+                  "num_unpadded_Xt",
+                  "num_padded_Xt",
+                  "pad_value"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    spec.kernels = {reader, writer};
 
-    return desc;
+    // Local DFBs (in0, pad) require their producer and consumer KernelSpecs to share the same
+    // WorkUnitSpec. Both kernels run on the single core {0,0}, so a single WorkUnitSpec hosts both.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "single_core",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = core_ranges},
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    reader_run.runtime_arg_values.push_back({CoreCoord{0, 0}, {{"num_pages", num_unpadded_tiles}, {"start_id", 0u}}});
+
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+    writer_run.runtime_arg_values.push_back(
+        {CoreCoord{0, 0},
+         {{"num_unpadded_W", num_unpadded_W},
+          {"num_padded_Wt", num_padded_Wt},
+          {"num_unpadded_Z", num_unpadded_Z},
+          {"num_padded_Zt", num_padded_Zt},
+          {"num_unpadded_Yt", num_unpadded_Yt},
+          {"num_padded_Yt", num_padded_Yt},
+          {"num_unpadded_Xt", num_unpadded_Xt},
+          {"num_padded_Xt", num_padded_Xt},
+          {"pad_value", packed_pad_value}}});
+
+    run.kernel_run_args = {reader_run, writer_run};
+    const auto& src_mesh = a.mesh_tensor();
+    const auto& out_mesh = output.mesh_tensor();
+    run.tensor_args = {
+        {m2::TensorParamName{"src"}, src_mesh},
+        {m2::TensorParamName{"out"}, out_mesh},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/pad/device/pad_tile_program_factory.hpp
@@ -5,15 +5,15 @@
 #pragma once
 
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "pad_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 struct PadTileCoreProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const PadParams& operation_attributes, const PadInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/METAL2_PORT_PLAN.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/METAL2_PORT_PLAN.md
@@ -1,0 +1,93 @@
+# Port Plan — reshard (NdReshardCopyPagesFactory)
+
+Port plan for the `NdReshardCopyPagesFactory` variant of `reshard`, ported from the
+`ProgramDescriptorFactoryConcept` (`create_descriptor`) to Metal 2.0
+(`ProgramSpecFactoryConcept` / `create_program_spec`).
+
+Scope note: `reshard`'s `program_factory_t` holds **eight** factory variants. Per the
+recipe's atomic-unit rule, this port targets **one** factory — the simplest single-program
+one, `NdReshardCopyPagesFactory` (DRAM→DRAM ND reshard, 124-line factory, one CB, two DM
+kernels). The other seven stay on the legacy concept; the op continues to build and run
+(framework dispatches per-factory).
+
+## Legacy Inventory
+
+### Legacy factory shape
+- Concept: `ProgramDescriptorFactoryConcept` (`create_descriptor` returns `ProgramDescriptor`).
+- Variants (in `program_factory_t`): ReshardSameWidthFactory<true/false>, ReshardSameHeightFactory<true/false>,
+  ReshardGenericFactory, **NdReshardCopyPagesFactory** (this port), NdReshardCopyLocalShardFactory<true/false>.
+- Custom `compute_program_hash`: none — `ReshardDeviceOperation` uses the default reflection-based hash.
+
+### Kernels (NdReshardCopyPagesFactory)
+| unique_id | source | core_ranges | CTAs (positional) | RTAs | CRTAs | config |
+|---|---|---|---|---|---|---|
+| reader | nd_reshard_copy_pages_reader.cpp | full grid | input TensorAccessorArgs..., cb_in0_idx(=c_0), aligned_page_size | start_page, end_page | input_buffer addr (CommonBufferBinding) | ReaderConfigDescriptor |
+| writer | nd_reshard_copy_pages_writer.cpp | full grid | output TensorAccessorArgs..., cb_in0_idx(=c_0), aligned_page_size | start_page, end_page | output_buffer addr (CommonBufferBinding) | WriterConfigDescriptor |
+
+### CBs
+| index | total_size | core_ranges | data_format | page_size |
+|---|---|---|---|---|
+| c_0 | aligned_page_size * 1 | full grid | input dtype | aligned_page_size |
+
+Single-entry CB (num_tiles_in_cb = 1). Real producer (reader) / consumer (writer) FIFO — not a fake CB.
+
+### Semaphores
+none
+
+### Tensor accessors
+| host site | originating Tensor | RTA/CRTA slot | kernel CTA chain |
+|---|---|---|---|
+| `TensorAccessorArgs(*input_buffer)` | input | base addr via CRTA slot 0 | `TensorAccessorArgs<0,0>()` in reader |
+| `TensorAccessorArgs(*output_buffer)` | output | base addr via CRTA slot 0 | `TensorAccessorArgs<0,0>()` in writer |
+
+Both are plain interleaved-style page accessors (`.pages(start,end)`) over ND-sharded DRAM buffers.
+Case-1 bindings: standard page access, no exotic address arithmetic.
+
+### Work split
+- Driver: manual page split — `num_dev_pages = tensor_shape_in_pages().volume()`; `n_pages_per_core = num_dev_pages / cores.size()`,
+  with the remainder distributed one-page-per-core to the first `remainder` cores.
+- num_cores: all cores in the full compute grid (`corerange_to_cores`, orientation from `nd_shard_spec.orientation`).
+- Single core group (per-core page count varies by +1 for the remainder cores, expressed via RTAs not CTAs — correct, page counts are data not loop-unroll dims).
+
+### Cross-op kernels
+none — both kernels live in this op's `device/kernels/` and are used only by this factory
+(`grep -rl nd_reshard_copy_pages_{reader,writer} ttnn/cpp/ttnn/operations` → only this factory).
+Ported in place.
+
+### Flags
+- The other 7 factory variants are untouched and remain on the legacy concept.
+
+## TTNN ProgramFactory
+- **Concept**: `MetalV2FactoryConcept` (`ProgramSpecFactoryConcept`) — `create_program_spec` returning `ttnn::device_operation::ProgramArtifacts`.
+- **Custom `compute_program_hash`**: none to delete.
+- **Implementation notes**: `select_program_factory` already returns `NdReshardCopyPagesFactory{}`; the variant entry is unchanged. The framework's `ProgramSpecMeshWorkloadFactoryAdapter` routes it automatically once the factory exposes `create_program_spec` instead of `create_descriptor`.
+
+## Planned Spec Shape
+- KernelSpecs: 2 — `reader` (DM, role READER, DFB PRODUCER), `writer` (DM, role WRITER, DFB CONSUMER).
+- DataflowBufferSpecs: 1 — `cb_in0` (entry_size = aligned_page_size, num_entries = 1, data_format = input dtype).
+- SemaphoreSpecs: none.
+- TensorParameters: 2 — `input` (input.tensor_spec()), `output` (output.tensor_spec()).
+- WorkUnitSpecs: 1 — `{reader, writer}` on the full grid (local-DFB rule: producer + consumer share the WorkUnitSpec).
+
+## Preserved Multiplicity
+none — single core group; the per-core page-count variation is a runtime value (RTA), never a per-group CTA.
+
+## Dropped Plumbing
+| legacy location | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| reader CRTA slot 0 | `emplace_common_runtime_args({input_buffer})` (base addr) | `TensorBinding`(input) via `ta::input` |
+| writer CRTA slot 0 | `emplace_common_runtime_args({output_buffer})` (base addr) | `TensorBinding`(output) via `ta::output` |
+| reader/writer CTA: `input/output_accessor_args.get_compile_time_args()` + `TensorAccessorArgs<0,0>()` chain | positional TensorAccessorArgs plumbing | `TensorBinding` end-to-end (auto-injected CTA/CRTA) |
+| reader/writer CTA: `cb_in0_idx` (= c_0) | magic CB index in CTA | `DFBBinding`(cb_in0) → `dfb::cb_in0` |
+| reader/writer CTA: `aligned_page_size` | positional CTA | named CTA `page_size` |
+| reader/writer RTA: positional slot 0/1 (`start_page`/`end_page`) | positional RTA | named RTAs `start_page`, `end_page` |
+
+## Applied Patterns
+- Plain reader-produces / writer-consumes DFB — standard local DFB, both endpoints in one WorkUnitSpec (matmul exemplar shape).
+- No self-loop, no conditional binding, no aliasing.
+
+## Deferred / Flagged
+- No audit (`METAL2_PREPORT_AUDIT.md`) was present; this port was performed directly per invoker instruction.
+  The TensorAccessor bindings were self-classified Case-1 (standard page access) — no user override on file.
+- The other 7 reshard factory variants remain to be ported; several involve L1 shard-spec geometry
+  (block/width-sharded shard grids) and may surface shard-shape handling not present in this simplest variant.

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/METAL2_PORT_REPORT.md
@@ -1,0 +1,54 @@
+# Port Report — reshard (NdReshardCopyPagesFactory)
+
+## TTNN ProgramFactory
+
+- **Concept realized**: `MetalV2FactoryConcept` (`ProgramSpecFactoryConcept`). The factory now exposes
+  `create_program_spec(const ReshardParams&, const ReshardInputs&, Tensor&) -> ttnn::device_operation::ProgramArtifacts`,
+  replacing the legacy `create_descriptor` (`ProgramDescriptor`).
+- **Custom `compute_program_hash` deletion**: none — `ReshardDeviceOperation` already uses the default reflection-based hash.
+- **Pybind entry points removed**: none — `reshard_nanobind.cpp` exposes only the user-facing op, no `create_descriptor`/`create_program_descriptor` hook.
+- **Device-op-class edits**: none. `select_program_factory` already returns `NdReshardCopyPagesFactory{}`; the
+  `program_factory_t` variant entry is unchanged. The framework's `ProgramSpecMeshWorkloadFactoryAdapter` routes the
+  factory automatically once it satisfies `ProgramSpecFactoryConcept` (no longer `ProgramDescriptorFactoryConcept`).
+- **Scope**: only the `NdReshardCopyPagesFactory` variant was ported. The other 7 variants in `program_factory_t`
+  (SameWidth<t/f>, SameHeight<t/f>, Generic, CopyLocalShard<t/f>) remain on the legacy concept; the op continues to
+  build and dispatch per-factory.
+
+## Handoff points
+
+none. No `sem::`/`ta::` out-of-op call site, no kernel-lib gap, no removed pybind surface, no framework gap bit during the port.
+
+## Successes
+
+- **Local-DFB rule (recipe §"Local-DFB rule" / matmul exemplar)** steered the WorkUnitSpec design directly: the reader
+  (PRODUCER of `cb_in0`) and writer (CONSUMER) share one `WorkUnitSpec` over the full grid, satisfying the producer+consumer
+  same-node invariant. No self-loop needed — this is a real reader→writer FIFO, not a fake CB.
+- **Kernel-side whitelist rule 3** collapsed the legacy 6-line `TensorAccessorArgs<0,0>()` + offset-chaining + base-addr-RTA
+  dance in each kernel to a single `TensorAccessor(ta::input)` / `TensorAccessor(ta::output)` line. The legacy CRTA carrying
+  the buffer base address (`emplace_common_runtime_args({input_buffer})`) dropped entirely, replaced by the `TensorBinding`.
+
+## Friction
+
+- **Gap (minor)**: the worked-example kernels named in `/tmp/PORT_INSTRUCTIONS.md`
+  (`writer_bmm_8bank_interleaved_start_id_m2.cpp`, `bmm_m2.cpp`, `reader_bmm_8bank_output_tiles_partitioned.cpp`) do not
+  exist on this branch, and there are zero existing `TensorAccessor(ta::...)` / `dfb::` usages anywhere in the tree — no op
+  has actually landed a `create_program_spec` port yet. The `matmul`/`rand` "exemplars" are still `create_descriptor`
+  (ProgramDescriptor) factories. The port shape was reconstructed from the framework headers
+  (`program_spec.hpp`, `kernel_spec.hpp`, `program_run_args.hpp`, `dataflow_buffer.h`, `kernel_args.h`) and the recipe — so
+  the kernel-side `ta::`/`dfb::`/`args::` generated-token usage is **unvalidated by build** (the worktree has no build dir,
+  per instructions). First op to actually compile this concept should treat the generated-header behavior as shakedown.
+
+## Open items for downstream
+
+- **Remaining reshard factories (7)**: SameWidth/SameHeight/Generic/CopyLocalShard. Several read **L1 shard-spec geometry**
+  (`shard_spec().grid()`, block/width-sharded core-count math, `std::gcd` page sizing — see
+  `nd_reshard_program_factory_copy_local.cpp:50-80`) absent from this simplest DRAM→DRAM page-copy variant. Those will exercise
+  shard-spec handling and possibly the templated `local_is_input/local_is_output` variants as multi-variant factories.
+- **Cross-op kernel touches**: none. Both ported kernels
+  (`nd_reshard_copy_pages_{reader,writer}.cpp`) live in this op's dir and are used only by this factory
+  (`grep -rl` confirms), so they were ported **in place**, not forked.
+- **Fake-CB self-loops / compute-pointer escape valves**: none used.
+- **Build/test not run** per instructions (no build dir; do-not-build). Verification is limited to a static
+  anti-pattern sweep (no `create_descriptor`/`CircularBuffer`/`CBDescriptor`/`TensorAccessorArgs`/`buffer()->address()`/
+  positional `get_*_arg_val` survive in the four touched files). A real build + the reshard pytests/gtests are required
+  before merge.

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/METAL2_PORT_REPORT.md
@@ -69,9 +69,67 @@ This section is the authoritative per-factory result after the two porting passe
 |---|---|---|
 | `NdReshardCopyPagesFactory` | **PORTED** (pass 1) | DRAM→DRAM page copy. 1 DFB (reader→writer FIFO), 2 TensorAccessors. |
 | `NdReshardCopyLocalShardFactory<true/false>` | **PORTED** (pass 2) | L1↔DRAM / L1→L1 local-shard copy. No DFB; 2 TensorAccessors. |
-| `ReshardSameHeightFactory<true/false>` | **METAL-BLOCKED** | Raw remote `buffer->address()` through RTA → `AllocatorBank` NOC. |
-| `ReshardSameWidthFactory<true/false>` | **METAL-BLOCKED** | Same remote-address-through-RTA pattern (+ unaligned scratch CB). |
-| `ReshardGenericFactory` | **METAL-BLOCKED** | Raw input `buffer->address()` + manual `UnicastEndpoint` NOC by physical core. |
+| `ReshardSameHeightFactory<true/false>` | **PORTED** (pass 3 — Case-2) | Remote base addr via `TensorAccessor(ta::remote).get_bank_base_address()`; local shard = borrowed self-loop DFB; per-segment tail = varargs. |
+| `ReshardSameWidthFactory<true/false>` | **PORTED** (pass 3 — Case-2) | Same Case-2 remote-addr bridge; + local scratch self-loop DFB on the unaligned reader path (`#ifdef UNALIGNED`). |
+| `ReshardGenericFactory` | **PORTED** (pass 3 — Case-2) | Input base addr via `TensorAccessor(ta::input).get_bank_base_address()`; output = borrowed self-loop DFB; physical-core maps + stride table = varargs. |
+
+### CORRECTION to pass-2 conclusion (pass 3)
+
+Pass 2 marked the three legacy-reshard factories METAL-BLOCKED on the premise that a raw
+`buffer->address()` threaded through an RTA into an `AllocatorBank`/`UnicastEndpoint` NOC primitive
+has no typed channel. **That premise was wrong for data-movement kernels.** Per the updated recipe's
+Case-2 rule, a DM kernel that consumes a tensor's raw base address is **portable**: bind the tensor as a
+normal `TensorParameter`/`TensorBinding` and pull the base kernel-side via
+`TensorAccessor(ta::name).get_bank_base_address()` (which returns the bank-relative base — identical to
+the legacy `buffer->address()` offset, same in every bank), keeping the existing raw `AllocatorBank` +
+`bank_id` / `UnicastEndpoint` + physical-core NOC walk UNCHANGED. None of these reshard kernels are
+COMPUTE (the one Case-2 carve-out that stays blocked), so all three port.
+
+### PORTED — `ReshardSameHeightFactory<local_is_output>` (pass 3)
+
+- **Concept**: `MetalV2FactoryConcept` — `create_program_spec` returning `ProgramArtifacts`. Both template
+  instantiations ported; routing/variant unchanged.
+- **Kernels (forked)**: `reshard_same_height_{reader,writer}.cpp` live in the cross-op dir
+  `sharded/device/kernels/dataflow/` (used only by this factory but outside the op's own dir), so forked
+  to `kernels/reshard_same_height_{reader,writer}_m2.cpp`. Whitelist changes only: positional CTAs/RTAs →
+  `get_arg(args::…)`; local shard CB → `dfb::shard_cb`; remote `base_read_addr`/`base_write_addr` RTA →
+  `TensorAccessor(ta::remote).get_bank_base_address()` (Case-2 bridge). The variable-length per-segment
+  RTA tail (legacy read via `get_arg_addr(5)`) → runtime varargs. All NOC logic, `AllocatorBank`, bank_id,
+  offset arithmetic UNCHANGED.
+- **Spec shape**: 2 KernelSpecs of one source (READER + WRITER role; CT define `read_from_dram`/`write_to_dram`
+  by `local_is_output`), 2 TensorParameters (`local` borrowed, `remote` Case-2), 1 borrowed-memory DFB
+  (`shard_cb`, `borrowed_from = local`) self-looped on both kernels, 1 WorkUnitSpec.
+- **Dropped plumbing**: remote-buffer base-address RTA (slot 3, a `Buffer*`) → Case-2 TensorBinding; CB-index
+  CTA → `dfb::`.
+
+### PORTED — `ReshardSameWidthFactory<local_is_output>` (pass 3)
+
+- Same Case-2 bridge for the remote base address; same borrowed shard self-loop DFB. The **unaligned reader
+  path** uses a second local (non-borrowed) scratch DFB (`scratch_cb`) — bound as a self-loop **only** when
+  `local_is_output && unaligned`, gated kernel-side by `#ifdef UNALIGNED` (the legacy `if constexpr (unaligned)`
+  CTA gate promoted to a preprocessor define so `dfb::scratch_cb` never enters name lookup on the aligned
+  path / the writer source). Per-write tail → varargs.
+- **Spec shape**: 2 KernelSpecs of one source, 2 TensorParameters, 1–2 DFBs (shard always; scratch on the
+  unaligned reader path), 1 WorkUnitSpec.
+- The redundant double `get_bank_ids_from_logical_core` call in the legacy work-split loop was collapsed to
+  the single live call (functionally identical; bank_id recomputed each iteration as before).
+
+### PORTED — `ReshardGenericFactory` (pass 3)
+
+- **Kernels (forked)**: `reshard_reader.cpp` / `reshard_reader_diff_width.cpp` → `kernels/reshard_reader_m2.cpp`
+  / `kernels/reshard_reader_diff_width_m2.cpp`. Input base address (legacy RTA at index `grid.x+grid.y`,
+  back-patched to a `Buffer*`) → `TensorAccessor(ta::input).get_bank_base_address()`. The leading
+  physical-core-coord maps **and** the host-compressed stride(-of-strides) table ride VERBATIM as a runtime
+  vararg block (the kernel still indexes them positionally — `get_arg_val(idx)` → `get_vararg(idx)`); the
+  dropped input-addr slot is erased from the block host-side (`strip_addr`). The manual `UnicastEndpoint{}`
+  NOC reads by physical core coord stay UNCHANGED.
+- **Spec shape**: 2 KernelSpecs of one runtime-selected source (page-size match selects diff-width vs same),
+  2 TensorParameters (`input` Case-2, `output` borrowed), 1 borrowed-memory DFB (`shard_cb`,
+  `borrowed_from = output`) self-looped on both kernels, 1 WorkUnitSpec.
+- **Note**: the legacy `detail::get_runtime_args_for_given_ranges*` helpers (unchanged, out of scope) still
+  take an `input_addr` parameter; the real `input_buffer->address()` is passed in and then immediately
+  stripped before the args reach varargs — it never crosses to the device. The typed binding supplies the
+  base address.
 
 ### PORTED — `NdReshardCopyLocalShardFactory<local_is_input>` (pass 2)
 
@@ -98,57 +156,7 @@ This section is the authoritative per-factory result after the two porting passe
   they hand a raw `buffer->address()` to an `AllocatorBank`/`UnicastEndpoint` NOC primitive, which the
   typed binding cannot supply.
 
-### METAL-BLOCKED — `ReshardSameHeightFactory<local_is_output>`
-
-Raw remote-buffer base address threaded through an RTA into a non-accessor NOC primitive.
-- Host: `reshard_program_factory_same_height.cpp:127,134` push `remote_buffer` (a `Buffer*`) as RTA slot 3.
-- Kernel `…/sharded/device/kernels/dataflow/reshard_same_height_reader.cpp:21,44` and
-  `…/reshard_same_height_writer.cpp:21,44`: `base_read_addr/base_write_addr = get_arg_val<uint32_t>(3)`
-  is fed to `noc.async_read/write(bank, …, {.bank_id=…, .addr=read_offset}, …)` over an
-  `AllocatorBank<bank_type>` — there is no `TensorAccessor` for the remote tensor, so no `ta::` binding can
-  supply the address, and the remote-buffer address is per-dispatch-varying (io tensor), so the
-  CRTA escape valve would go stale on a cache hit. The local sharded CB (`cb.buffer = local_buffer`,
-  `:79`) IS borrowed-memory-DFB-expressible, but the remote address is the hard wall.
-- Off-rules change that would be needed: a kernel-side `TensorAccessor` (or `get_bank_base_address`
-  bridge) for the remote tensor, which would require rewriting the kernel's `AllocatorBank` + bank_id +
-  hand-computed offset NOC loop — outside the kernel-side whitelist.
-
-### METAL-BLOCKED — `ReshardSameWidthFactory<local_is_output>`
-
-Identical remote-address-through-RTA pattern, plus an unaligned-path scratch CB.
-- Host: `reshard_program_factory_same_width.cpp:156` pushes `remote_buffer` as RTA slot 0
-  (`std::vector<std::variant<uint32_t, Buffer*>>` back-patch).
-- Kernel `…/dataflow/reshard_same_width_reader.cpp:24,50,79` / `reshard_same_width_writer.cpp:24,44`:
-  `src_addr/dst_addr = get_arg_val<uint32_t>(0)` → `noc.async_read/write(bank, …, {.bank_id, .addr}, …)`
-  over `AllocatorBank<bank_type>`; no remote `TensorAccessor`. Same stale-on-cache-hit wall as same-height.
-- Additionally the unaligned path uses a second (non-borrowed) scratch CB (`cb_scratch_index`, host `:104`)
-  — that part would self-loop fine, but the remote-address blocker stands.
-
-### METAL-BLOCKED — `ReshardGenericFactory`
-
-Raw input-buffer base address through RTA + fully manual `UnicastEndpoint` NOC by physical core coord.
-- Host: `reshard_program_factory_generic.cpp:785,795` back-patch `input_buffer` (a `Buffer*`) into RTA slot
-  `grid.x + grid.y`; `:746,754,764,774` pass `input_buffer->address()` into the detail RTA builders;
-  `:724-733` precompute physical core x/y coords as leading RTAs.
-- Kernel `…/dataflow/reshard_reader.cpp:23,67` and `reshard_reader_diff_width.cpp:23,85`:
-  `input_shard_addr = get_arg_val<uint32_t>(arg_index)` and `start_x/start_y = get_arg_val(...)` feed
-  `noc.async_read(UnicastEndpoint{}, dst, …, {.noc_x, .noc_y, .addr = input_shard_addr + addr_offset}, …)`.
-  No `TensorAccessor` anywhere; the kernel walks a host-compressed stride table by physical core id and
-  raw base+offset. The typed binding model cannot express the manual physical-core unicast, and the input
-  address is per-dispatch-varying. Output CB (`cb.buffer = output_buffer`, `:692`) is borrowed-memory
-  expressible, but the input-address-by-unicast is the wall.
-- Off-rules change that would be needed: replace the manual `UnicastEndpoint` + packed physical-core RTAs
-  with a `TensorAccessor`-based read, a substantial kernel rewrite far outside the whitelist.
-
-### Common root cause / handoff
-
-All three blocked factories share one shape: a **resident sharded tensor accessed by raw `buffer->address()`
-threaded through an RTA into a non-`TensorAccessor` NOC primitive** (`AllocatorBank` + bank_id, or
-`UnicastEndpoint` + physical core coord). This is the recipe's named genuine blocker ("a raw
-`buffer->address()` threaded through a CTA/RTA to a kernel") and the gaps-doc remote-address blocker. The
-local sharded buffers in all three ARE borrowed-memory-DFB-expressible (`cb.buffer = local/output_buffer`);
-it is exclusively the *remote* tensor's address that has no typed channel. These unblock once a kernel-side
-`TensorAccessor` (or sanctioned bridge) can supply a sharded remote tensor's base address to a bank/unicast
-NOC walk — i.e. a remote-sharded `TensorAccessor` read path. No clever workaround was attempted (per recipe
-§When the discipline doesn't fit); they remain on the legacy `ProgramDescriptorFactoryConcept` and the op
-continues to build and dispatch per-factory.
+> NOTE (superseded by pass 3): the original pass-2 "METAL-BLOCKED" detail sections for SameHeight /
+> SameWidth / Generic that previously followed here have been removed — those three are now **PORTED**
+> via the Case-2 `get_bank_base_address` bridge. See **§Per-factory STATUS (all variants)** above for the
+> authoritative result and the per-factory pass-3 writeups.

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/METAL2_PORT_REPORT.md
@@ -1,5 +1,10 @@
 # Port Report — reshard (NdReshardCopyPagesFactory)
 
+> NOTE (second pass — remaining factories): this report originally covered only
+> `NdReshardCopyPagesFactory`. A follow-up pass ported `NdReshardCopyLocalShardFactory`
+> and assessed the three legacy-reshard factories. See **§Per-factory STATUS (all variants)**
+> at the bottom for the authoritative per-factory result.
+
 ## TTNN ProgramFactory
 
 - **Concept realized**: `MetalV2FactoryConcept` (`ProgramSpecFactoryConcept`). The factory now exposes
@@ -52,3 +57,98 @@ none. No `sem::`/`ta::` out-of-op call site, no kernel-lib gap, no removed pybin
   anti-pattern sweep (no `create_descriptor`/`CircularBuffer`/`CBDescriptor`/`TensorAccessorArgs`/`buffer()->address()`/
   positional `get_*_arg_val` survive in the four touched files). A real build + the reshard pytests/gtests are required
   before merge.
+
+---
+
+## Per-factory STATUS (all variants)
+
+`reshard`'s `program_factory_t` holds 8 factory entries (5 distinct factory types).
+This section is the authoritative per-factory result after the two porting passes.
+
+| Factory | STATUS | Notes |
+|---|---|---|
+| `NdReshardCopyPagesFactory` | **PORTED** (pass 1) | DRAM→DRAM page copy. 1 DFB (reader→writer FIFO), 2 TensorAccessors. |
+| `NdReshardCopyLocalShardFactory<true/false>` | **PORTED** (pass 2) | L1↔DRAM / L1→L1 local-shard copy. No DFB; 2 TensorAccessors. |
+| `ReshardSameHeightFactory<true/false>` | **METAL-BLOCKED** | Raw remote `buffer->address()` through RTA → `AllocatorBank` NOC. |
+| `ReshardSameWidthFactory<true/false>` | **METAL-BLOCKED** | Same remote-address-through-RTA pattern (+ unaligned scratch CB). |
+| `ReshardGenericFactory` | **METAL-BLOCKED** | Raw input `buffer->address()` + manual `UnicastEndpoint` NOC by physical core. |
+
+### PORTED — `NdReshardCopyLocalShardFactory<local_is_input>` (pass 2)
+
+- **Concept**: `MetalV2FactoryConcept` — `create_program_spec` returning `ProgramArtifacts`. Both
+  template instantiations (`<true>`, `<false>`) ported; both already routed by `select_program_factory`
+  and present in `program_factory_t` (no device-op-class edit needed beyond the factory method swap).
+- **Kernel**: `device/kernels/nd_reshard_copy_local_shards.cpp` — ported **in place** (lives in this op's
+  own kernels dir, used only by this factory; `grep -rl` confirms). Whitelist changes only:
+  positional `get_compile_time_arg_val`/`get_common_arg_val`/`get_arg_val` → named `get_arg(args::…)`;
+  the two explicit `TensorAccessor(args, bank_base_address)` (base address read from CRTAs) collapse to
+  `TensorAccessor(ta::input)` / `TensorAccessor(ta::output)`. All logic, `if constexpr (is_reader)`
+  branches, padding math, and `CoreLocalMem` local-shard reads UNCHANGED. (`CoreLocalMem` here derives
+  its address from the accessor's own `page.noc_addr()` — it is NOT a smuggled host address, so it stays.)
+- **Spec shape**: 2 KernelSpecs (`brisc` role READER, `ncrisc` role WRITER) of one source, identical 7
+  scalar CTAs + identical CRTA schema (`num_shards`, `shard_id_stride`); they differ only in DM role and
+  the per-core `first_shard_id` RTA. 2 TensorParameters (`input`, `output`). **No DFB** (`dfb_bindings`
+  empty is legal) — the program moves data directly local-L1↔remote-bank via the two accessors. 1
+  WorkUnitSpec hosting both kernels on the shard-data grid.
+- **Dropped plumbing**: the two CRTA remote-bank base addresses (`bank_base_address_src/dst`) → auto-injected
+  by the `TensorBinding`s; positional CTA TensorAccessorArgs chains → carried by the bindings.
+- **Why this one is portable (unlike the other three)**: the remote side is accessed through a real
+  `TensorAccessor` (constructed from an explicit base address in legacy, now from the binding), so the
+  base address rides the typed channel. The other three never build a `TensorAccessor` for the remote —
+  they hand a raw `buffer->address()` to an `AllocatorBank`/`UnicastEndpoint` NOC primitive, which the
+  typed binding cannot supply.
+
+### METAL-BLOCKED — `ReshardSameHeightFactory<local_is_output>`
+
+Raw remote-buffer base address threaded through an RTA into a non-accessor NOC primitive.
+- Host: `reshard_program_factory_same_height.cpp:127,134` push `remote_buffer` (a `Buffer*`) as RTA slot 3.
+- Kernel `…/sharded/device/kernels/dataflow/reshard_same_height_reader.cpp:21,44` and
+  `…/reshard_same_height_writer.cpp:21,44`: `base_read_addr/base_write_addr = get_arg_val<uint32_t>(3)`
+  is fed to `noc.async_read/write(bank, …, {.bank_id=…, .addr=read_offset}, …)` over an
+  `AllocatorBank<bank_type>` — there is no `TensorAccessor` for the remote tensor, so no `ta::` binding can
+  supply the address, and the remote-buffer address is per-dispatch-varying (io tensor), so the
+  CRTA escape valve would go stale on a cache hit. The local sharded CB (`cb.buffer = local_buffer`,
+  `:79`) IS borrowed-memory-DFB-expressible, but the remote address is the hard wall.
+- Off-rules change that would be needed: a kernel-side `TensorAccessor` (or `get_bank_base_address`
+  bridge) for the remote tensor, which would require rewriting the kernel's `AllocatorBank` + bank_id +
+  hand-computed offset NOC loop — outside the kernel-side whitelist.
+
+### METAL-BLOCKED — `ReshardSameWidthFactory<local_is_output>`
+
+Identical remote-address-through-RTA pattern, plus an unaligned-path scratch CB.
+- Host: `reshard_program_factory_same_width.cpp:156` pushes `remote_buffer` as RTA slot 0
+  (`std::vector<std::variant<uint32_t, Buffer*>>` back-patch).
+- Kernel `…/dataflow/reshard_same_width_reader.cpp:24,50,79` / `reshard_same_width_writer.cpp:24,44`:
+  `src_addr/dst_addr = get_arg_val<uint32_t>(0)` → `noc.async_read/write(bank, …, {.bank_id, .addr}, …)`
+  over `AllocatorBank<bank_type>`; no remote `TensorAccessor`. Same stale-on-cache-hit wall as same-height.
+- Additionally the unaligned path uses a second (non-borrowed) scratch CB (`cb_scratch_index`, host `:104`)
+  — that part would self-loop fine, but the remote-address blocker stands.
+
+### METAL-BLOCKED — `ReshardGenericFactory`
+
+Raw input-buffer base address through RTA + fully manual `UnicastEndpoint` NOC by physical core coord.
+- Host: `reshard_program_factory_generic.cpp:785,795` back-patch `input_buffer` (a `Buffer*`) into RTA slot
+  `grid.x + grid.y`; `:746,754,764,774` pass `input_buffer->address()` into the detail RTA builders;
+  `:724-733` precompute physical core x/y coords as leading RTAs.
+- Kernel `…/dataflow/reshard_reader.cpp:23,67` and `reshard_reader_diff_width.cpp:23,85`:
+  `input_shard_addr = get_arg_val<uint32_t>(arg_index)` and `start_x/start_y = get_arg_val(...)` feed
+  `noc.async_read(UnicastEndpoint{}, dst, …, {.noc_x, .noc_y, .addr = input_shard_addr + addr_offset}, …)`.
+  No `TensorAccessor` anywhere; the kernel walks a host-compressed stride table by physical core id and
+  raw base+offset. The typed binding model cannot express the manual physical-core unicast, and the input
+  address is per-dispatch-varying. Output CB (`cb.buffer = output_buffer`, `:692`) is borrowed-memory
+  expressible, but the input-address-by-unicast is the wall.
+- Off-rules change that would be needed: replace the manual `UnicastEndpoint` + packed physical-core RTAs
+  with a `TensorAccessor`-based read, a substantial kernel rewrite far outside the whitelist.
+
+### Common root cause / handoff
+
+All three blocked factories share one shape: a **resident sharded tensor accessed by raw `buffer->address()`
+threaded through an RTA into a non-`TensorAccessor` NOC primitive** (`AllocatorBank` + bank_id, or
+`UnicastEndpoint` + physical core coord). This is the recipe's named genuine blocker ("a raw
+`buffer->address()` threaded through a CTA/RTA to a kernel") and the gaps-doc remote-address blocker. The
+local sharded buffers in all three ARE borrowed-memory-DFB-expressible (`cb.buffer = local/output_buffer`);
+it is exclusively the *remote* tensor's address that has no typed channel. These unblock once a kernel-side
+`TensorAccessor` (or sanctioned bridge) can supply a sharded remote tensor's base address to a bank/unicast
+NOC walk — i.e. a remote-sharded `TensorAccessor` read path. No clever workaround was attempted (per recipe
+§When the discipline doesn't fit); they remain on the legacy `ProgramDescriptorFactoryConcept` and the op
+continues to build and dispatch per-factory.

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_local_shards.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_local_shards.cpp
@@ -8,6 +8,7 @@
 #include "api/dataflow/noc.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 // Kernel that:
 // if (is_reader) {
@@ -17,29 +18,21 @@
 // }
 
 void kernel_main() {
-    auto args_src = TensorAccessorArgs<0, 0>();
-    auto args_dst =
-        TensorAccessorArgs<args_src.next_compile_time_args_offset(), args_src.next_common_runtime_args_offset()>();
-    constexpr uint32_t base_idx_cta = args_dst.next_compile_time_args_offset();
-    constexpr uint32_t base_idx_crta = args_dst.next_common_runtime_args_offset();
+    constexpr uint32_t src_page_size = get_arg(args::src_page_size);
+    constexpr uint32_t dst_page_size = get_arg(args::dst_page_size);
+    constexpr uint32_t is_reader = get_arg(args::is_reader);
+    constexpr uint32_t logical_width = get_arg(args::logical_width);
+    constexpr uint32_t src_width = get_arg(args::src_width);
+    constexpr uint32_t dst_width = get_arg(args::dst_width);
+    constexpr uint32_t transfer_size = get_arg(args::transfer_size);
 
-    constexpr uint32_t src_page_size = get_compile_time_arg_val(base_idx_cta);
-    constexpr uint32_t dst_page_size = get_compile_time_arg_val(base_idx_cta + 1);
-    constexpr uint32_t is_reader = get_compile_time_arg_val(base_idx_cta + 2);
-    constexpr uint32_t logical_width = get_compile_time_arg_val(base_idx_cta + 3);
-    constexpr uint32_t src_width = get_compile_time_arg_val(base_idx_cta + 4);
-    constexpr uint32_t dst_width = get_compile_time_arg_val(base_idx_cta + 5);
-    constexpr uint32_t transfer_size = get_compile_time_arg_val(base_idx_cta + 6);
+    const uint32_t num_shards = get_arg(args::num_shards);
+    const uint32_t shard_id_stride = get_arg(args::shard_id_stride);
 
-    const uint32_t bank_base_address_src = get_common_arg_val<uint32_t>(base_idx_crta);
-    const uint32_t bank_base_address_dst = get_common_arg_val<uint32_t>(base_idx_crta + 1);
-    const uint32_t num_shards = get_common_arg_val<uint32_t>(base_idx_crta + 2);
-    const uint32_t shard_id_stride = get_common_arg_val<uint32_t>(base_idx_crta + 3);
+    const uint32_t first_shard_id = get_arg(args::first_shard_id);
 
-    const uint32_t first_shard_id = get_arg_val<uint32_t>(0);
-
-    auto accessor_src = TensorAccessor(args_src, bank_base_address_src);
-    auto accessor_dst = TensorAccessor(args_dst, bank_base_address_dst);
+    auto accessor_src = TensorAccessor(ta::input);
+    auto accessor_dst = TensorAccessor(ta::output);
 
     Noc noc;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp
@@ -6,35 +6,29 @@
 #include "api/tensor/tensor_accessor.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 // Simple kernel that copies [start_page, end_page) pages from src to dst.
 void kernel_main() {
-    auto args_src = TensorAccessorArgs<0, 0>();
-    constexpr uint32_t base_idx_cta = args_src.next_compile_time_args_offset();
-    constexpr uint32_t base_idx_crta = args_src.next_common_runtime_args_offset();
+    auto accessor_src = TensorAccessor(ta::input);
 
-    constexpr uint32_t cb_id = get_compile_time_arg_val(base_idx_cta);
-    constexpr uint32_t page_size = get_compile_time_arg_val(base_idx_cta + 1);
+    constexpr uint32_t page_size = get_arg(args::page_size);
 
-    const uint32_t bank_base_address_src = get_common_arg_val<uint32_t>(base_idx_crta);
-
-    const uint32_t start_page = get_arg_val<uint32_t>(0);
-    const uint32_t end_page = get_arg_val<uint32_t>(1);
-
-    auto accessor_src = TensorAccessor(args_src, bank_base_address_src);
+    const uint32_t start_page = get_arg(args::start_page);
+    const uint32_t end_page = get_arg(args::end_page);
 
     Noc noc;
-    CircularBuffer cb(cb_id);
+    DataflowBuffer dfb_in(dfb::cb_in0);
 
     constexpr uint32_t one_tile = 1;
     auto pages = accessor_src.pages(start_page, end_page);
     for (const auto& page : pages) {
-        cb.reserve_back(one_tile);
+        dfb_in.reserve_back(one_tile);
         noc.async_read(
-            accessor_src, cb, page_size, {.page_id = page.page_id(), .offset_bytes = 0}, {.offset_bytes = 0});
+            accessor_src, dfb_in, page_size, {.page_id = page.page_id(), .offset_bytes = 0}, {.offset_bytes = 0});
         noc.async_read_barrier();
-        cb.push_back(one_tile);
+        dfb_in.push_back(one_tile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp
@@ -6,35 +6,29 @@
 #include "api/tensor/tensor_accessor.h"
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 // Simple kernel that copies [start_page, end_page) pages from dst to dst.
 void kernel_main() {
-    auto args_dst = TensorAccessorArgs<0, 0>();
-    constexpr uint32_t base_idx_cta = args_dst.next_compile_time_args_offset();
-    constexpr uint32_t base_idx_crta = args_dst.next_common_runtime_args_offset();
+    auto accessor_dst = TensorAccessor(ta::output);
 
-    constexpr uint32_t cb_id = get_compile_time_arg_val(base_idx_cta);
-    constexpr uint32_t page_size = get_compile_time_arg_val(base_idx_cta + 1);
+    constexpr uint32_t page_size = get_arg(args::page_size);
 
-    const uint32_t bank_base_address_dst = get_common_arg_val<uint32_t>(base_idx_crta);
-
-    const uint32_t start_page = get_arg_val<uint32_t>(0);
-    const uint32_t end_page = get_arg_val<uint32_t>(1);
-
-    auto accessor_dst = TensorAccessor(args_dst, bank_base_address_dst);
+    const uint32_t start_page = get_arg(args::start_page);
+    const uint32_t end_page = get_arg(args::end_page);
 
     Noc noc;
-    CircularBuffer cb(cb_id);
+    DataflowBuffer dfb_in(dfb::cb_in0);
 
     constexpr uint32_t one_tile = 1;
     auto pages = accessor_dst.pages(start_page, end_page);
     for (const auto& page : pages) {
-        cb.wait_front(one_tile);
+        dfb_in.wait_front(one_tile);
         noc.async_write(
-            cb, accessor_dst, page_size, {.offset_bytes = 0}, {.page_id = page.page_id(), .offset_bytes = 0});
+            dfb_in, accessor_dst, page_size, {.offset_bytes = 0}, {.page_id = page.page_id(), .offset_bytes = 0});
         noc.async_write_barrier();
-        cb.pop_front(one_tile);
+        dfb_in.pop_front(one_tile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_reader_diff_width_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_reader_diff_width_m2.cpp
@@ -1,0 +1,118 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port (forked from sharded/device/kernels/dataflow/reshard_reader_diff_width.cpp; used only by
+// ReshardGenericFactory). Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - output shard CB c_16 -> dfb::shard_cb (borrowed output shard; base-pointer access -> self-loop)
+//   - input-buffer base addr (legacy RTA at index num_x_cores+num_y_cores = a Buffer*) -> typed
+//     TensorAccessor channel (Case-2 bridge: TensorAccessor(ta::input).get_bank_base_address()).
+//   - positional CTAs -> get_arg(args::...). The legacy RTA list (leading physical core-coord maps,
+//     then the host-compressed stride-of-strides table) is preserved VERBATIM as a runtime vararg block:
+//     the physical-core maps occupy varargs [0, num_x_cores+num_y_cores); the table follows. The dropped
+//     input-addr slot is no longer present in the vararg block.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr uint32_t num_x_cores = get_arg(args::num_x_cores);
+    constexpr uint32_t num_y_cores = get_arg(args::num_y_cores);
+    constexpr uint32_t page_size = get_arg(args::page_size);
+    constexpr uint32_t unit_size = get_arg(args::unit_size);
+
+    uint32_t y_offset = num_x_cores;
+
+    // Varargs: [physical_core_x (num_x_cores)] [physical_core_y (num_y_cores)] then the stride table.
+    uint32_t arg_index = num_x_cores + num_y_cores;
+    // Input shard base address via the typed binding (Case-2 bridge): same offset in every bank.
+    auto input = TensorAccessor(ta::input);
+    const uint32_t input_shard_addr = input.get_bank_base_address();
+    const uint32_t num_output_pages = get_vararg(arg_index++);
+    const uint32_t num_blocks = get_vararg(arg_index++);
+    const uint32_t output_page_offset = get_vararg(arg_index++);
+
+    Noc noc;
+    DataflowBuffer cb(dfb::shard_cb);
+    uint32_t l1_write_addr = cb.get_write_ptr() + output_page_offset * page_size;
+
+    uint32_t mask_byte = 0xff;
+    uint32_t mask_short = 0xffff;
+
+    for (uint32_t block_id = 0; block_id < num_blocks; block_id++) {
+        const uint32_t num_repeats = get_vararg(arg_index++);
+        const uint32_t pattern_len = get_vararg(arg_index++);
+
+        uint32_t base_pattern_arg_index = arg_index;
+
+        for (uint32_t r = 0; r < num_repeats; r++) {
+            // For each repetition, reset the arg pointer to the start of the base pattern
+            uint32_t current_pattern_arg_index = base_pattern_arg_index;
+            for (uint32_t i = 0; i < pattern_len; i++) {
+                const uint32_t meta_stride_core = get_vararg(current_pattern_arg_index++);
+                const uint32_t meta_stride_data = get_vararg(current_pattern_arg_index++);
+
+                const uint32_t meta_stride_x = (meta_stride_core >> 16);
+                const uint32_t meta_stride_y = (meta_stride_core & mask_short);
+
+                const uint32_t core_start_stride = get_vararg(current_pattern_arg_index++);
+                const uint32_t stride_data_offset = get_vararg(current_pattern_arg_index++);
+                const uint32_t stride_size_num_strides_skip = get_vararg(current_pattern_arg_index++);
+
+                const uint32_t base_start_x_index = (core_start_stride >> 24);
+                const uint32_t base_start_y_index = (core_start_stride >> 16) & mask_byte;
+                const uint32_t stride_x = (core_start_stride >> 8) & mask_byte;
+                const uint32_t stride_y = (core_start_stride)&mask_byte;
+
+                const uint32_t num_strides = (stride_size_num_strides_skip >> 8) & mask_byte;
+                const bool skip = (stride_size_num_strides_skip & mask_byte) == 1;
+
+                const uint32_t stride_data_in_pages = (stride_data_offset >> 16);
+                const uint32_t base_offset_in_pages = (stride_data_offset & mask_short);
+                const uint32_t num_pages_per_stride = (stride_size_num_strides_skip >> 16);
+                const uint32_t stride_size_in_bytes = num_pages_per_stride * unit_size;
+
+                uint32_t current_start_x_index = base_start_x_index + r * meta_stride_x;
+                uint32_t current_start_y_index = base_start_y_index + r * meta_stride_y;
+                uint32_t current_offset_in_pages = base_offset_in_pages + r * meta_stride_data;
+
+                uint32_t addr_offset_in_bytes = current_offset_in_pages * unit_size;
+                uint32_t core_id_x_index = current_start_x_index;
+                uint32_t core_id_y_index = current_start_y_index;
+
+                for (uint32_t stride_idx = 0; stride_idx < num_strides; stride_idx++) {
+                    if (!skip) {
+                        uint32_t core_id_x = get_vararg(core_id_x_index);
+                        uint32_t core_id_y = get_vararg(y_offset + core_id_y_index);
+                        CoreLocalMem<uint32_t> dst(l1_write_addr);
+                        noc.async_read(
+                            UnicastEndpoint{},
+                            dst,
+                            stride_size_in_bytes,
+                            {.noc_x = core_id_x, .noc_y = core_id_y, .addr = input_shard_addr + addr_offset_in_bytes},
+                            {.offset_bytes = 0});
+                    }
+                    l1_write_addr += stride_size_in_bytes;
+
+                    if (stride_x == 0 and stride_y == 0) {
+                        addr_offset_in_bytes += (stride_data_in_pages * unit_size + stride_size_in_bytes);
+                    } else {
+                        addr_offset_in_bytes += (stride_data_in_pages * unit_size);
+                    }
+                    core_id_x_index += stride_x;
+                    core_id_y_index += stride_y;
+                }
+            }
+        }
+        // Advance the main arg_index past the data for this block
+        arg_index = base_pattern_arg_index + (pattern_len * 5);
+    }
+    noc.async_read_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_reader_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_reader_m2.cpp
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port (forked from sharded/device/kernels/dataflow/reshard_reader.cpp; used only by
+// ReshardGenericFactory). Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - output shard CB c_16 -> dfb::shard_cb (borrowed output shard; base-pointer access -> self-loop)
+//   - input-buffer base addr (legacy RTA at index num_x_cores+num_y_cores = a Buffer*) -> typed
+//     TensorAccessor channel (Case-2 bridge: TensorAccessor(ta::input).get_bank_base_address()).
+//   - positional CTAs -> get_arg(args::...). The legacy RTA list (leading physical core-coord maps,
+//     then the host-compressed stride table) is preserved VERBATIM as a runtime vararg block: the
+//     physical-core maps occupy varargs [0, num_x_cores+num_y_cores); the stride table follows. The
+//     dropped input-addr slot is no longer present in the vararg block.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr uint32_t num_x_cores = get_arg(args::num_x_cores);
+    constexpr uint32_t num_y_cores = get_arg(args::num_y_cores);
+    constexpr uint32_t page_size = get_arg(args::page_size);
+    constexpr uint32_t unit_size = get_arg(args::unit_size);
+
+    uint32_t y_offset = num_x_cores;
+
+    // Varargs: [physical_core_x (num_x_cores)] [physical_core_y (num_y_cores)] then the stride table.
+    uint32_t arg_index = num_x_cores + num_y_cores;
+    // Input shard base address via the typed binding (Case-2 bridge): same offset in every bank.
+    auto input = TensorAccessor(ta::input);
+    const uint32_t input_shard_addr = input.get_bank_base_address();
+    const uint32_t num_output_pages = get_vararg(arg_index++);
+    const uint32_t num_ranges = get_vararg(arg_index++);
+    const uint32_t output_page_offset = get_vararg(arg_index++);
+
+    Noc noc;
+    DataflowBuffer cb(dfb::shard_cb);
+    uint32_t l1_write_addr = cb.get_write_ptr() + output_page_offset * page_size;
+
+    uint32_t mask_byte = 0x0ff;     // 8 bits
+    uint32_t mask_short = 0x0ffff;  // 16 bits
+
+    for (uint32_t range_id = 0; range_id < num_ranges; range_id++) {
+        const uint32_t core_start_stride = get_vararg(arg_index++);
+        const uint32_t start_x_index = (core_start_stride >> 24);
+        const uint32_t start_y_index = (core_start_stride >> 16) & mask_byte;
+        const uint32_t stride_x = (core_start_stride >> 8) & mask_byte;
+        const uint32_t stride_y = (core_start_stride)&mask_byte;
+        const uint32_t start_x = get_vararg(start_x_index);
+        const uint32_t start_y = get_vararg(y_offset + start_y_index);
+
+        const uint32_t stride_data_offset = get_vararg(arg_index++);
+        const uint32_t stride_size_num_strides_skip = get_vararg(arg_index++);
+        const uint32_t num_strides = ((stride_size_num_strides_skip)&mask_short) >> 8;
+        const bool skip = (((stride_size_num_strides_skip)&mask_byte) == 1);
+
+        const uint32_t stride_data = ((stride_data_offset >> 16)) * unit_size;
+        const uint32_t offset = ((stride_data_offset)&mask_short) * unit_size;
+        const uint32_t num_pages_per_stride = (stride_size_num_strides_skip >> 16);
+        const uint32_t stride_size = num_pages_per_stride * unit_size;
+
+        uint32_t addr_offset = offset;
+        uint32_t core_id_x_index = start_x_index;
+        uint32_t core_id_y_index = start_y_index;
+
+        for (uint32_t stride_idx = 0; stride_idx < num_strides; stride_idx++) {
+            if (!skip) {
+                uint32_t core_id_x = get_vararg(core_id_x_index);
+                uint32_t core_id_y = get_vararg(y_offset + core_id_y_index);
+                CoreLocalMem<uint32_t> dst(l1_write_addr);
+                noc.async_read(
+                    UnicastEndpoint{},
+                    dst,
+                    stride_size,
+                    {.noc_x = core_id_x, .noc_y = core_id_y, .addr = input_shard_addr + addr_offset},
+                    {.offset_bytes = 0});
+                l1_write_addr += stride_size;
+            } else {
+                l1_write_addr += stride_size;
+            }
+            if (stride_x == 0 and stride_y == 0) {
+                addr_offset += (stride_data + stride_size);
+            } else {
+                addr_offset += (stride_data);
+            }
+            core_id_x_index += stride_x;
+            core_id_y_index += stride_y;
+        }
+    }
+    noc.async_read_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_same_height_reader_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_same_height_reader_m2.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port (forked from sharded/device/kernels/dataflow/reshard_same_height_reader.cpp; used only
+// by ReshardSameHeightFactory). Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - shard CB c_0   -> dfb::shard_cb (borrowed local shard; read/written by base pointer only -> self-loop)
+//   - the remote-buffer base address (legacy RTA slot 3 = a Buffer*) -> the typed TensorAccessor channel
+//     (Case-2 bridge: TensorAccessor(ta::remote).get_bank_base_address()).
+//   - positional CTAs -> get_arg(args::...); the leading scalars stay named RTAs; the variable-length
+//     per-segment tail rides as runtime varargs (preserving the legacy packed [read_size, write_offset,
+//     bank_id, read_offset] layout the legacy reader read via get_arg_addr(5)).
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr bool read_from_dram = get_arg(args::read_from_dram);
+    constexpr AllocatorBankType bank_type = read_from_dram ? AllocatorBankType::DRAM : AllocatorBankType::L1;
+
+    const uint32_t total_num_sticks = get_arg(args::total_num_sticks);
+    const uint32_t local_stride_bytes = get_arg(args::local_stride_bytes);
+    const uint32_t remote_stride_bytes = get_arg(args::remote_stride_bytes);
+    const uint32_t num_segments = get_arg(args::num_segments);
+
+    // Per-segment packed tail: [read_size, write_offset, bank_id, read_offset] * num_segments.
+    uint32_t vararg_idx = 0;
+
+    DataflowBuffer shard_cb(dfb::shard_cb);
+    Noc noc;
+    AllocatorBank<bank_type> bank;
+
+    // Remote buffer base address via the typed binding (Case-2 bridge): same offset in every bank.
+    auto remote = TensorAccessor(ta::remote);
+    const uint32_t base_read_addr = remote.get_bank_base_address();
+
+    uint32_t base_write_addr = shard_cb.get_write_ptr();
+
+    for (uint32_t i = 0; i < num_segments; ++i) {
+        uint32_t read_size = get_vararg(vararg_idx++);
+
+        uint32_t write_offset = get_vararg(vararg_idx++);
+        uint32_t l1_write_addr = base_write_addr + write_offset;
+
+        uint32_t bank_id = get_vararg(vararg_idx++);
+        uint32_t read_offset = base_read_addr + get_vararg(vararg_idx++);
+
+        for (uint32_t j = 0; j < total_num_sticks; ++j) {
+            CoreLocalMem<uint32_t> dst(l1_write_addr);
+            noc.async_read(bank, dst, read_size, {.bank_id = bank_id, .addr = read_offset}, {.offset_bytes = 0});
+            l1_write_addr += local_stride_bytes;
+            read_offset += remote_stride_bytes;
+        }
+    }
+    noc.async_read_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_same_height_writer_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_same_height_writer_m2.cpp
@@ -1,0 +1,63 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port (forked from sharded/device/kernels/dataflow/reshard_same_height_writer.cpp; used only
+// by ReshardSameHeightFactory). Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - shard CB c_0   -> dfb::shard_cb (borrowed local shard; read/written by base pointer only -> self-loop)
+//   - the remote-buffer base address (legacy RTA slot 3 = a Buffer*) -> the typed TensorAccessor channel
+//     (Case-2 bridge: TensorAccessor(ta::remote).get_bank_base_address()).
+//   - positional CTAs -> get_arg(args::...); leading scalars stay named RTAs; the variable-length
+//     per-segment tail rides as runtime varargs (preserving the legacy packed [write_size, read_offset,
+//     bank_id, write_offset] layout the legacy writer read via get_arg_addr(5)).
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr bool write_to_dram = get_arg(args::write_to_dram);
+    constexpr AllocatorBankType bank_type = write_to_dram ? AllocatorBankType::DRAM : AllocatorBankType::L1;
+
+    const uint32_t total_num_sticks = get_arg(args::total_num_sticks);
+    const uint32_t local_stride_bytes = get_arg(args::local_stride_bytes);
+    const uint32_t remote_stride_bytes = get_arg(args::remote_stride_bytes);
+    const uint32_t num_segments = get_arg(args::num_segments);
+
+    // Per-segment packed tail: [write_size, read_offset, bank_id, write_offset] * num_segments.
+    uint32_t vararg_idx = 0;
+
+    DataflowBuffer shard_cb(dfb::shard_cb);
+    Noc noc;
+    AllocatorBank<bank_type> bank;
+
+    // Remote buffer base address via the typed binding (Case-2 bridge): same offset in every bank.
+    auto remote = TensorAccessor(ta::remote);
+    const uint32_t base_write_addr = remote.get_bank_base_address();
+
+    uint32_t base_l1_read_addr = shard_cb.get_read_ptr();
+
+    for (uint32_t i = 0; i < num_segments; ++i) {
+        uint32_t write_size = get_vararg(vararg_idx++);
+
+        uint32_t read_offset = get_vararg(vararg_idx++);
+        uint32_t l1_read_addr = base_l1_read_addr + read_offset;
+
+        uint32_t bank_id = get_vararg(vararg_idx++);
+        uint32_t write_offset = base_write_addr + get_vararg(vararg_idx++);
+
+        for (uint32_t j = 0; j < total_num_sticks; ++j) {
+            CoreLocalMem<uint32_t> src(l1_read_addr);
+            noc.async_write(src, bank, write_size, {.offset_bytes = 0}, {.bank_id = bank_id, .addr = write_offset});
+            l1_read_addr += local_stride_bytes;
+            write_offset += remote_stride_bytes;
+        }
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_same_width_reader_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_same_width_reader_m2.cpp
@@ -1,0 +1,101 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port (forked from sharded/device/kernels/dataflow/reshard_same_width_reader.cpp; used only
+// by ReshardSameWidthFactory). Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - shard CB c_0      -> dfb::shard_cb (borrowed local shard; base-pointer access -> self-loop)
+//   - scratch CB c_1    -> dfb::scratch_cb (local scratch, unaligned path; base-pointer access -> self-loop)
+//   - remote-buffer base addr (legacy RTA slot 0 = a Buffer*) -> typed TensorAccessor channel
+//     (Case-2 bridge: TensorAccessor(ta::remote).get_bank_base_address()).
+//   - positional CTAs/RTAs -> get_arg(args::...); the variable-length per-read tail rides as runtime
+//     varargs (preserving the legacy packed [bank_id, src_offset, units_to_transfer] layout the legacy
+//     reader read via get_arg_addr(3)).
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/debug/dprint_pages.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr bool read_from_dram = get_arg(args::read_from_dram);
+    // The legacy `unaligned` CTA gate is promoted to a preprocessor define (UNALIGNED) so the
+    // conditionally-bound scratch DFB token (dfb::scratch_cb) never enters name lookup on the aligned path.
+    constexpr uint32_t unit_size = get_arg(args::unit_size);
+    constexpr uint32_t local_unit_size_padded = get_arg(args::local_unit_size_padded);
+    constexpr uint32_t remote_unit_size_padded = get_arg(args::remote_unit_size_padded);
+    constexpr AllocatorBankType bank_type = read_from_dram ? AllocatorBankType::DRAM : AllocatorBankType::L1;
+
+    // Remote buffer base address via the typed binding (Case-2 bridge): same offset in every bank.
+    auto remote = TensorAccessor(ta::remote);
+    uint32_t src_addr = remote.get_bank_base_address();
+    uint32_t write_offset = get_arg(args::write_offset);
+    uint32_t num_reads = get_arg(args::num_reads);
+    if (num_reads == 0) {
+        return;
+    }
+    // Per-read packed tail: [bank_id, src_offset, units_to_transfer] * num_reads.
+    uint32_t vararg_idx = 0;
+
+    Noc noc;
+    AllocatorBank<bank_type> bank;
+    DataflowBuffer shard_cb(dfb::shard_cb);
+
+    uint32_t l1_write_addr = shard_cb.get_write_ptr() + write_offset;
+#ifdef UNALIGNED
+    {
+        DataflowBuffer cb_scratch(dfb::scratch_cb);
+        uint32_t l1_scratch_write_addr = cb_scratch.get_write_ptr();
+        uint32_t l1_scratch_read_addr = cb_scratch.get_read_ptr();
+        for (uint32_t i = 0; i < num_reads; ++i) {
+            uint32_t bank_id = get_vararg(vararg_idx++);
+            uint32_t src_offset = get_vararg(vararg_idx++);
+            uint32_t addr = src_addr + src_offset;
+            DPRINT("addr: {}\n", addr);
+            uint32_t units_to_transfer = get_vararg(vararg_idx++);
+            uint32_t read_size = units_to_transfer * remote_unit_size_padded;
+            CoreLocalMem<uint32_t> scratch_dst(l1_scratch_write_addr + src_offset);
+            noc.async_read(bank, scratch_dst, read_size, {.bank_id = bank_id, .addr = addr}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            // tt::data_movement::common::print_bf16_pages(
+            //     l1_scratch_write_addr + src_offset, remote_unit_size_padded / 2, units_to_transfer);
+
+            uint32_t pad_align_addr = l1_scratch_read_addr + src_offset;
+            for (uint32_t j = 0; j < units_to_transfer; ++j) {
+                CoreLocalMem<uint32_t> dst(l1_write_addr);
+                noc.async_read(
+                    UnicastEndpoint{},
+                    dst,
+                    unit_size,
+                    {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
+                     .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+                     .addr = pad_align_addr},
+                    {.offset_bytes = 0});
+                // tt::data_movement::common::print_bf16_pages(l1_write_addr, unit_size / 2, 1);
+                l1_write_addr += unit_size;
+                pad_align_addr += remote_unit_size_padded;
+            }
+            noc.async_read_barrier();
+        }
+    }
+#else
+    {
+        for (uint32_t i = 0; i < num_reads; ++i) {
+            uint32_t bank_id = get_vararg(vararg_idx++);
+            uint32_t addr = src_addr + get_vararg(vararg_idx++);
+            uint32_t units_to_transfer = get_vararg(vararg_idx++);
+            uint32_t read_size = units_to_transfer * unit_size;
+            CoreLocalMem<uint32_t> dst(l1_write_addr);
+            noc.async_read(bank, dst, read_size, {.bank_id = bank_id, .addr = addr}, {.offset_bytes = 0});
+            l1_write_addr += read_size;
+        }
+        noc.async_read_barrier();
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_same_width_writer_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_same_width_writer_m2.cpp
@@ -1,0 +1,58 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port (forked from sharded/device/kernels/dataflow/reshard_same_width_writer.cpp; used only
+// by ReshardSameWidthFactory). Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - shard CB c_0   -> dfb::shard_cb (borrowed local shard; base-pointer access -> self-loop)
+//   - remote-buffer base addr (legacy RTA slot 0 = a Buffer*) -> typed TensorAccessor channel
+//     (Case-2 bridge: TensorAccessor(ta::remote).get_bank_base_address()).
+//   - positional CTAs/RTAs -> get_arg(args::...); the variable-length per-write tail rides as runtime
+//     varargs (preserving the legacy packed [bank_id, dst_offset, units_to_transfer] layout the legacy
+//     writer read via get_arg_addr(3)).
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "api/tensor/tensor_accessor.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr bool write_to_dram = get_arg(args::write_to_dram);
+    constexpr bool unaligned = get_arg(args::unaligned);
+    constexpr uint32_t unit_size = get_arg(args::unit_size);
+    constexpr uint32_t local_unit_size_padded = get_arg(args::local_unit_size_padded);
+    constexpr uint32_t remote_unit_size_padded = get_arg(args::remote_unit_size_padded);
+    constexpr AllocatorBankType bank_type = write_to_dram ? AllocatorBankType::DRAM : AllocatorBankType::L1;
+
+    // Remote buffer base address via the typed binding (Case-2 bridge): same offset in every bank.
+    auto remote = TensorAccessor(ta::remote);
+    uint32_t dst_addr = remote.get_bank_base_address();
+    uint32_t read_offset = get_arg(args::read_offset);
+    uint32_t num_writes = get_arg(args::num_writes);
+    if (num_writes == 0) {
+        return;
+    }
+    // Per-write packed tail: [bank_id, dst_offset, units_to_transfer] * num_writes.
+    uint32_t vararg_idx = 0;
+
+    DataflowBuffer shard_cb(dfb::shard_cb);
+    Noc noc;
+    AllocatorBank<bank_type> bank;
+
+    uint32_t l1_read_addr = shard_cb.get_read_ptr() + read_offset;
+    for (uint32_t i = 0; i < num_writes; ++i) {
+        uint32_t bank_id = get_vararg(vararg_idx++);
+        uint32_t addr = dst_addr + get_vararg(vararg_idx++);
+        uint32_t units_to_transfer = get_vararg(vararg_idx++);
+        uint32_t write_size = units_to_transfer * unit_size;
+        CoreLocalMem<uint32_t> src(l1_read_addr);
+        noc.async_write(src, bank, write_size, {.offset_bytes = 0}, {.bank_id = bank_id, .addr = addr});
+        l1_read_addr += write_size;
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.cpp
@@ -4,25 +4,23 @@
 
 #include "ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.hpp"
 
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include "tt-metalium/host_api.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
 template <bool local_is_input>
-ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descriptor(
+ttnn::device_operation::ProgramArtifacts NdReshardCopyLocalShardFactory<local_is_input>::create_program_spec(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
     const auto& input = tensor_args.input;
     auto& output = output_tensor;
 
     auto* input_buffer = input.buffer();
     auto* output_buffer = output.buffer();
-
-    const auto input_accessor_args = TensorAccessorArgs(*input_buffer);
-    const auto output_accessor_args = TensorAccessorArgs(*output_buffer);
 
     // Choose buffer and aligned page size based on local_is_input flag
     auto* local_buffer = local_is_input ? input_buffer : output_buffer;
@@ -78,59 +76,94 @@ ProgramDescriptor NdReshardCopyLocalShardFactory<local_is_input>::create_descrip
         uint32_t output_page_size = output_buffer->page_size();
         base_page_size = std::gcd(input_page_size, output_page_size);
     }
-    auto compile_time_args = input_accessor_args.get_compile_time_args();
-    output_accessor_args.append_to(compile_time_args);
-    compile_time_args.push_back(aligned_page_size);
-    compile_time_args.push_back(other_aligned_page_size);
-    compile_time_args.push_back(static_cast<uint32_t>(local_is_input));
-    compile_time_args.push_back(logical_width);
-    compile_time_args.push_back(source_width);
-    compile_time_args.push_back(destination_width);
-    compile_time_args.push_back(base_page_size);
+    // Named scalar CTAs (shared by both kernels). The legacy positional
+    // TensorAccessorArgs CTAs for src/dst are now carried by the TensorBindings.
+    const uint32_t src_page_size = static_cast<uint32_t>(aligned_page_size);
+    const uint32_t dst_page_size = static_cast<uint32_t>(other_aligned_page_size);
 
-    ProgramDescriptor desc;
+    const TensorParamName kInput{"input"};
+    const TensorParamName kOutput{"output"};
+    const KernelSpecName kBrisc{"brisc"};
+    const KernelSpecName kNcrisc{"ncrisc"};
 
-    KernelDescriptor brisc_desc;
-    brisc_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    brisc_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_local_shards.cpp";
-    brisc_desc.core_ranges = grid;
-    brisc_desc.config = DataMovementConfigDescriptor{
-        .processor = DataMovementProcessor::RISCV_0,
-        .noc = NOC::RISCV_0_default,
+    const std::filesystem::path kKernelSource(
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_local_shards.cpp");
+
+    ProgramSpec spec;
+    spec.name = "nd_reshard_copy_local_shards";
+
+    // Tensor parameters: both kernels access input (src) and output (dst).
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = kInput, .spec = input.tensor_spec()});
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = kOutput, .spec = output.tensor_spec()});
+
+    // Both kernels share identical CTAs and CRTA schema; they differ only in the
+    // DataMovement processor/role and their per-core first_shard_id RTA value.
+    // No DFB: data moves local-L1 <-> remote-bank directly via the TensorAccessors
+    // (and CoreLocalMem derived from the accessor's own page noc_addr).
+    auto make_kernel = [&](const KernelSpecName& unique_id, DataMovementRoleHint role) {
+        KernelSpec k;
+        k.unique_id = unique_id;
+        k.source = kKernelSource;
+        k.compile_time_args = {
+            {"src_page_size", src_page_size},
+            {"dst_page_size", dst_page_size},
+            {"is_reader", static_cast<uint32_t>(local_is_input)},
+            {"logical_width", logical_width},
+            {"src_width", source_width},
+            {"dst_width", destination_width},
+            {"transfer_size", base_page_size},
+        };
+        k.runtime_arg_schema.runtime_arg_names = {"first_shard_id"};
+        k.runtime_arg_schema.common_runtime_arg_names = {"num_shards", "shard_id_stride"};
+        k.tensor_bindings = {
+            TensorBinding{.tensor_parameter_name = kInput, .accessor_name = "input"},
+            TensorBinding{.tensor_parameter_name = kOutput, .accessor_name = "output"},
+        };
+        k.hw_config = DataMovementHardwareConfig{.role = role};
+        return k;
     };
-    brisc_desc.compile_time_args = compile_time_args;
 
-    KernelDescriptor ncrisc_desc;
-    ncrisc_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    ncrisc_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_local_shards.cpp";
-    ncrisc_desc.core_ranges = grid;
-    ncrisc_desc.config = DataMovementConfigDescriptor{
-        .processor = DataMovementProcessor::RISCV_1,
-        .noc = NOC::RISCV_1_default,
-    };
-    ncrisc_desc.compile_time_args = std::move(compile_time_args);
+    spec.kernels.push_back(make_kernel(kBrisc, DataMovementRoleHint::READER));
+    spec.kernels.push_back(make_kernel(kNcrisc, DataMovementRoleHint::WRITER));
 
-    // Common runtime args: [input_addr, output_addr, num_shards, shard_id_stride]
-    // arg 0 / arg 1 are the buffer base addresses (binding via Buffer*).
-    brisc_desc.emplace_common_runtime_args({input_buffer, output_buffer, num_shards, shard_id_stride});
-    ncrisc_desc.emplace_common_runtime_args({input_buffer, output_buffer, num_shards, shard_id_stride});
+    // Single WorkUnitSpec hosting both kernels on the shard-data grid.
+    spec.work_units.push_back(WorkUnitSpec{
+        .name = "wu",
+        .kernels = {kBrisc, kNcrisc},
+        .target_nodes = grid,
+    });
 
-    // Per-core unique runtime args: [start_shard_id]
+    // Run args.
+    ProgramRunArgs run_args;
+
+    KernelRunArgs brisc_run;
+    brisc_run.kernel = kBrisc;
+    brisc_run.common_runtime_arg_values = {{"num_shards", num_shards}, {"shard_id_stride", shard_id_stride}};
+    KernelRunArgs ncrisc_run;
+    ncrisc_run.kernel = kNcrisc;
+    ncrisc_run.common_runtime_arg_values = {{"num_shards", num_shards}, {"shard_id_stride", shard_id_stride}};
+
+    // Per-core unique runtime args: [first_shard_id]
     // brisc copies shards [0, num_data_cores*2, num_data_cores*4, num_data_cores*6, ...]
     // ncrisc copies shards [num_data_cores, num_data_cores*3, num_data_cores*5, num_data_cores*7, ...]
     uint32_t start_shard_id = 0;
     for (const auto& core : cores_vec) {
-        brisc_desc.emplace_runtime_args(core, {start_shard_id});
-        ncrisc_desc.emplace_runtime_args(core, {start_shard_id + shard_id_stride / 2});
+        brisc_run.runtime_arg_values.push_back(
+            KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"first_shard_id", start_shard_id}}});
+        ncrisc_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = core, .args = {{"first_shard_id", start_shard_id + shard_id_stride / 2}}});
         ++start_shard_id;
     }
 
-    desc.kernels.push_back(std::move(brisc_desc));
-    desc.kernels.push_back(std::move(ncrisc_desc));
+    run_args.kernel_run_args.push_back(std::move(brisc_run));
+    run_args.kernel_run_args.push_back(std::move(ncrisc_run));
 
-    return desc;
+    run_args.tensor_args = {
+        {kInput, input.mesh_tensor()},
+        {kOutput, output.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 // Explicit template instantiations

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_local.hpp
@@ -4,9 +4,8 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "reshard_device_operation_types.hpp"
 
 namespace ttnn::prim {
@@ -14,7 +13,7 @@ namespace ttnn::prim {
 // Factory for L1<->DRAM or L1->L1 nd reshard (read into local pages in L1)
 template <bool local_is_input>
 struct NdReshardCopyLocalShardFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.cpp
@@ -4,98 +4,106 @@
 
 #include "ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.hpp"
 
-#include <tt-metalium/tensor_accessor_args.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include "tt-metalium/host_api.hpp"
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-namespace {
-
-// Anonymous-namespace helper unique to nd_reshard_copy_pages to avoid unity-build collisions.
-void push_reshard_copy_pages_cb(
-    ProgramDescriptor& desc,
-    uint32_t cb_index,
-    tt::DataFormat data_format,
-    uint32_t total_size,
-    uint32_t page_size,
-    const CoreRangeSet& core_ranges) {
-    CBDescriptor cb;
-    cb.total_size = total_size;
-    cb.core_ranges = core_ranges;
-    cb.format_descriptors.push_back(CBFormatDescriptor{
-        .buffer_index = static_cast<uint8_t>(cb_index),
-        .data_format = data_format,
-        .page_size = page_size,
-    });
-    cb.buffer = nullptr;
-    desc.cbs.push_back(std::move(cb));
-}
-
-}  // namespace
-
-ProgramDescriptor NdReshardCopyPagesFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts NdReshardCopyPagesFactory::create_program_spec(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
     const auto& input = tensor_args.input;
     auto& output = output_tensor;
 
     auto* input_buffer = input.buffer();
-    auto* output_buffer = output.buffer();
 
     auto input_nd_shard_spec = input.memory_config().nd_shard_spec().value();
 
-    const auto input_accessor_args = TensorAccessorArgs(*input_buffer);
-    const auto output_accessor_args = TensorAccessorArgs(*output_buffer);
-
-    auto aligned_page_size = input_buffer->aligned_page_size();
+    uint32_t aligned_page_size = static_cast<uint32_t>(input_buffer->aligned_page_size());
 
     // Create grid + cores
     auto grid_size = input.device()->compute_with_storage_grid_size();
     auto grid = CoreRangeSet({CoreRange(CoreCoord(0, 0), CoreCoord(grid_size.x - 1, grid_size.y - 1))});
     auto cores = corerange_to_cores(grid, std::nullopt, input_nd_shard_spec.orientation == ShardOrientation::ROW_MAJOR);
 
-    // Create Circular Buffer
+    // Create Dataflow Buffer (was Circular Buffer)
     const auto data_format = datatype_to_dataformat_converter(input.dtype());
     constexpr uint32_t num_tiles_in_cb = 1;  // TODO: Try double buffering
-    constexpr uint32_t cb_in0_idx = tt::CBIndex::c_0;
 
-    ProgramDescriptor desc;
-    push_reshard_copy_pages_cb(
-        desc, cb_in0_idx, data_format, aligned_page_size * num_tiles_in_cb, aligned_page_size, grid);
+    const TensorParamName kInput{"input"};
+    const TensorParamName kOutput{"output"};
+    const DFBSpecName kCbIn0{"cb_in0"};
+    const KernelSpecName kReader{"reader"};
+    const KernelSpecName kWriter{"writer"};
 
-    // Prepare compile time arguments
-    auto compile_time_args_reader = input_accessor_args.get_compile_time_args();
-    compile_time_args_reader.push_back(cb_in0_idx);  // Circular buffer index
-    compile_time_args_reader.push_back(aligned_page_size);
+    ProgramSpec spec;
+    spec.name = "nd_reshard_copy_pages";
 
-    auto compile_time_args_writer = output_accessor_args.get_compile_time_args();
-    compile_time_args_writer.push_back(cb_in0_idx);
-    compile_time_args_writer.push_back(aligned_page_size);
+    // Tensor parameters: input (read by reader) and output (written by writer).
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = kInput, .spec = input.tensor_spec()});
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = kOutput, .spec = output.tensor_spec()});
 
-    // Create kernels
-    KernelDescriptor reader_desc;
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_reader.cpp";
-    reader_desc.core_ranges = grid;
-    reader_desc.config = ReaderConfigDescriptor{};
-    reader_desc.compile_time_args = std::move(compile_time_args_reader);
+    // Dataflow buffer: reader produces a page, writer consumes it.
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = kCbIn0,
+        .entry_size = aligned_page_size,
+        .num_entries = num_tiles_in_cb,
+        .data_format_metadata = data_format,
+    });
 
-    KernelDescriptor writer_desc;
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/nd_reshard_copy_pages_writer.cpp";
-    writer_desc.core_ranges = grid;
-    writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.compile_time_args = std::move(compile_time_args_writer);
+    // Reader kernel: reads pages from the input tensor, pushes them into the DFB.
+    KernelSpec reader;
+    reader.unique_id = kReader;
+    reader.source = std::filesystem::path(
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/"
+        "nd_reshard_copy_pages_reader.cpp");
+    reader.compile_time_args = {{"page_size", aligned_page_size}};
+    reader.runtime_arg_schema.runtime_arg_names = {"start_page", "end_page"};
+    reader.dfb_bindings = {DFBBinding{
+        .dfb_spec_name = kCbIn0,
+        .accessor_name = "cb_in0",
+        .endpoint_type = DFBEndpointType::PRODUCER,
+    }};
+    reader.tensor_bindings = {TensorBinding{.tensor_parameter_name = kInput, .accessor_name = "input"}};
+    reader.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER};
 
-    // Common runtime args: arg 0 is the buffer base address (binding via Buffer*).
-    // emplace_common_runtime_args registers a CommonBufferBinding for the framework
-    // fast cache-hit path.
-    reader_desc.emplace_common_runtime_args({input_buffer});
-    writer_desc.emplace_common_runtime_args({output_buffer});
+    // Writer kernel: waits on pages from the DFB, writes them to the output tensor.
+    KernelSpec writer;
+    writer.unique_id = kWriter;
+    writer.source = std::filesystem::path(
+        "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/"
+        "nd_reshard_copy_pages_writer.cpp");
+    writer.compile_time_args = {{"page_size", aligned_page_size}};
+    writer.runtime_arg_schema.runtime_arg_names = {"start_page", "end_page"};
+    writer.dfb_bindings = {DFBBinding{
+        .dfb_spec_name = kCbIn0,
+        .accessor_name = "cb_in0",
+        .endpoint_type = DFBEndpointType::CONSUMER,
+    }};
+    writer.tensor_bindings = {TensorBinding{.tensor_parameter_name = kOutput, .accessor_name = "output"}};
+    writer.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER};
+
+    spec.kernels.push_back(std::move(reader));
+    spec.kernels.push_back(std::move(writer));
+
+    // Single WorkUnitSpec hosting both kernels on the full grid: the DFB's producer (reader)
+    // and consumer (writer) share the same nodes (local-DFB invariant).
+    spec.work_units.push_back(WorkUnitSpec{
+        .name = "wu",
+        .kernels = {kReader, kWriter},
+        .target_nodes = grid,
+    });
+
+    // Run args.
+    ProgramRunArgs run_args;
+
+    KernelRunArgs reader_run;
+    reader_run.kernel = kReader;
+    KernelRunArgs writer_run;
+    writer_run.kernel = kWriter;
 
     // Per-core unique runtime args: [start_page, end_page]
     uint32_t start_page = 0;
@@ -110,15 +118,25 @@ ProgramDescriptor NdReshardCopyPagesFactory::create_descriptor(
             num_pages_for_core++;
             remainder--;
         }
-        reader_desc.emplace_runtime_args(core, {start_page, start_page + num_pages_for_core});
-        writer_desc.emplace_runtime_args(core, {start_page, start_page + num_pages_for_core});
+        uint32_t end_page = start_page + num_pages_for_core;
+        reader_run.runtime_arg_values.push_back(
+            KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"start_page", start_page}, {"end_page", end_page}}});
+        writer_run.runtime_arg_values.push_back(
+            KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"start_page", start_page}, {"end_page", end_page}}});
         start_page += num_pages_for_core;
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    run_args.kernel_run_args.push_back(std::move(reader_run));
+    run_args.kernel_run_args.push_back(std::move(writer_run));
 
-    return desc;
+    // Tensor arguments: reference the MeshTensors reachable from the factory io tensors
+    // (matched back by pointer identity by the framework adapter).
+    run_args.tensor_args = {
+        {kInput, input.mesh_tensor()},
+        {kOutput, output.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/nd_reshard_program_factory_copy_pages.hpp
@@ -4,16 +4,15 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "reshard_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
 // Factory for DRAM->DRAM nd reshard (simple page by page copy)
 struct NdReshardCopyPagesFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
@@ -695,18 +695,21 @@ ttnn::device_operation::ProgramArtifacts ReshardGenericFactory::create_program_s
         .borrowed_from = kOutput,
     });
 
-    // Self-loop the borrowed DFB on both kernels (base-pointer access only; no real FIFO).
-    auto bind_self_loop = [&](KernelSpec& k) {
+    // Borrowed-memory DFB binding. The borrowed output shard is a pure address source (both kernel
+    // instances only ever call get_write_ptr() on it; neither reads it through the DFB). It is accessed
+    // by BOTH kernels, so it cannot be a self-loop on either (the local-DFB invariant forbids two
+    // PRODUCERs — or a multi-kernel self-loop — sharing one WorkUnitSpec). Model it as a single
+    // producer/consumer pair across the two kernels in the shared WorkUnitSpec: reader=PRODUCER,
+    // writer=CONSUMER. For a borrowed DFB the role is only a placement label (no real FIFO sync); both
+    // get_write_ptr()/get_read_ptr() resolve to the same borrowed base, so behaviour is unchanged.
+    auto bind_endpoint = [&](KernelSpec& k, DFBEndpointType endpoint_type) {
         k.dfb_bindings = {
-            DFBBinding{
-                .dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = DFBEndpointType::PRODUCER},
-            DFBBinding{
-                .dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = DFBEndpointType::CONSUMER},
+            DFBBinding{.dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = endpoint_type},
         };
     };
 
     // CTAs: the legacy slot 0 (dst CB index) is now dfb::shard_cb; the remaining four stay CTAs.
-    auto make_kernel = [&](const KernelSpecName& unique_id, DataMovementRoleHint role) {
+    auto make_kernel = [&](const KernelSpecName& unique_id, DataMovementRoleHint role, DFBEndpointType endpoint_type) {
         KernelSpec k;
         k.unique_id = unique_id;
         k.source = kKernelSource;
@@ -716,14 +719,14 @@ ttnn::device_operation::ProgramArtifacts ReshardGenericFactory::create_program_s
             {"page_size", page_size},
             {"unit_size", unit_size},
         };
-        bind_self_loop(k);
+        bind_endpoint(k, endpoint_type);
         k.tensor_bindings = {TensorBinding{.tensor_parameter_name = kInput, .accessor_name = "input"}};
         k.hw_config = DataMovementHardwareConfig{.role = role};
         return k;
     };
 
-    KernelSpec reader = make_kernel(kReader, DataMovementRoleHint::READER);
-    KernelSpec writer = make_kernel(kWriter, DataMovementRoleHint::WRITER);
+    KernelSpec reader = make_kernel(kReader, DataMovementRoleHint::READER, DFBEndpointType::PRODUCER);
+    KernelSpec writer = make_kernel(kWriter, DataMovementRoleHint::WRITER, DFBEndpointType::CONSUMER);
 
     std::vector<uint32_t> physical_core_coords;
     physical_core_coords.reserve(grid.x * grid.y);

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.cpp
@@ -6,38 +6,15 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/tensor/tensor_utils.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
-
-namespace {
-
-// Anonymous-namespace helper unique to reshard generic to avoid unity-build collisions.
-void push_reshard_generic_cb_pair(
-    ProgramDescriptor& desc,
-    uint32_t cb_index,
-    tt::DataFormat data_format,
-    uint32_t total_size,
-    uint32_t page_size,
-    const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
-    CBDescriptor cb;
-    cb.total_size = total_size;
-    cb.core_ranges = core_ranges;
-    cb.format_descriptors.push_back(CBFormatDescriptor{
-        .buffer_index = static_cast<uint8_t>(cb_index),
-        .data_format = data_format,
-        .page_size = page_size,
-    });
-    cb.buffer = bound_buffer;
-    desc.cbs.push_back(std::move(cb));
-}
-
-}  // namespace
 
 namespace detail {
 // start is inclusive, end is exclusive
@@ -649,7 +626,7 @@ std::vector<uint32_t> get_runtime_args_for_given_ranges(
 
 }  // namespace detail
 
-ProgramDescriptor ReshardGenericFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts ReshardGenericFactory::create_program_spec(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
     const auto& input = tensor_args.input;
     auto& output = output_tensor;
@@ -661,7 +638,6 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
     auto grid = input_buffer->buffer_type() == BufferType::DRAM ? device->dram_grid_size()
                                                                 : device->compute_with_storage_grid_size();
     auto input_core_type = input_buffer->core_type();
-    uint32_t dst_cb_index = 16;
     auto cores = get_optimal_worker_cores_for_sharded_tensor(output);
     auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(cores));
 
@@ -686,40 +662,68 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
         total_size = static_cast<uint32_t>(output_shard_shape[0] * output_shard_shape[1] * output.element_size());
     }
 
-    ProgramDescriptor desc;
+    // Names. The output sharded buffer backs a borrowed-memory DFB; the input tensor flows through the
+    // typed TensorAccessor channel (Case-2 bridge: base address pulled kernel-side via get_bank_base_address).
+    const TensorParamName kInput{"input"};
+    const TensorParamName kOutput{"output"};
+    const DFBSpecName kShardCb{"shard_cb"};
+    const KernelSpecName kReader{"reader"};
+    const KernelSpecName kWriter{"writer"};
 
-    // Output sharded CB. Bind to output buffer for dynamic-CB rebinding on cache hits via cb.buffer.
-    push_reshard_generic_cb_pair(
-        desc,
-        dst_cb_index,
-        data_format,
-        total_size,
-        output_buffer->page_size(),
-        all_cores,
-        /*bound_buffer=*/output_buffer);
+    // Both KernelDescriptors used the SAME source (selected by input/output page-size equality).
+    const std::filesystem::path kKernelSource =
+        input_buffer->page_size() != output_buffer->page_size()
+            ? std::filesystem::path(
+                  "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/"
+                  "reshard_reader_diff_width_m2.cpp")
+            : std::filesystem::path(
+                  "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/reshard_reader_m2.cpp");
 
-    const std::string kernel_source = input_buffer->page_size() != output_buffer->page_size()
-                                          ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-                                            "reshard_reader_diff_width.cpp"
-                                          : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/"
-                                            "reshard_reader.cpp";
+    ProgramSpec spec;
+    spec.name = "reshard_generic";
 
-    std::vector<uint32_t> compile_args = {
-        dst_cb_index, static_cast<uint32_t>(grid.x), static_cast<uint32_t>(grid.y), page_size, unit_size};
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = kInput, .spec = input.tensor_spec()});
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = kOutput, .spec = output.tensor_spec()});
 
-    KernelDescriptor kernel_desc_0;
-    kernel_desc_0.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    kernel_desc_0.kernel_source = kernel_source;
-    kernel_desc_0.core_ranges = all_cores;
-    kernel_desc_0.config = ReaderConfigDescriptor{};
-    kernel_desc_0.compile_time_args = compile_args;
+    // Output sharded CB bound to the output buffer: borrowed-memory DFB. The backing L1 address resolves
+    // at runtime from the output TensorArgument (legacy set CBDescriptor.buffer + dynamic-CB rebinding).
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = kShardCb,
+        .entry_size = output_buffer->page_size(),
+        .num_entries = total_size / std::max<uint32_t>(output_buffer->page_size(), 1u),
+        .data_format_metadata = data_format,
+        .borrowed_from = kOutput,
+    });
 
-    KernelDescriptor kernel_desc_1;
-    kernel_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    kernel_desc_1.kernel_source = kernel_source;
-    kernel_desc_1.core_ranges = all_cores;
-    kernel_desc_1.config = WriterConfigDescriptor{};
-    kernel_desc_1.compile_time_args = std::move(compile_args);
+    // Self-loop the borrowed DFB on both kernels (base-pointer access only; no real FIFO).
+    auto bind_self_loop = [&](KernelSpec& k) {
+        k.dfb_bindings = {
+            DFBBinding{
+                .dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = DFBEndpointType::PRODUCER},
+            DFBBinding{
+                .dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = DFBEndpointType::CONSUMER},
+        };
+    };
+
+    // CTAs: the legacy slot 0 (dst CB index) is now dfb::shard_cb; the remaining four stay CTAs.
+    auto make_kernel = [&](const KernelSpecName& unique_id, DataMovementRoleHint role) {
+        KernelSpec k;
+        k.unique_id = unique_id;
+        k.source = kKernelSource;
+        k.compile_time_args = {
+            {"num_x_cores", static_cast<uint32_t>(grid.x)},
+            {"num_y_cores", static_cast<uint32_t>(grid.y)},
+            {"page_size", page_size},
+            {"unit_size", unit_size},
+        };
+        bind_self_loop(k);
+        k.tensor_bindings = {TensorBinding{.tensor_parameter_name = kInput, .accessor_name = "input"}};
+        k.hw_config = DataMovementHardwareConfig{.role = role};
+        return k;
+    };
+
+    KernelSpec reader = make_kernel(kReader, DataMovementRoleHint::READER);
+    KernelSpec writer = make_kernel(kWriter, DataMovementRoleHint::WRITER);
 
     std::vector<uint32_t> physical_core_coords;
     physical_core_coords.reserve(grid.x * grid.y);
@@ -732,6 +736,22 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
         physical_core_coords.push_back(physical_input_core.y);
     }
 
+    // The detail helpers emit a vector laid out as
+    //   [physical_core_coords (grid.x+grid.y)] [input_addr] [num_output_pages] [num_ranges] [output_page_offset] ...
+    // The input_addr element (legacy buffer base address, formerly back-patched to a Buffer*) is dropped:
+    // the kernel now reads the base address from the Case-2 TensorAccessor binding. Everything else rides
+    // VERBATIM as a runtime vararg block, preserving the legacy packed layout the kernel indexes positionally.
+    const size_t addr_slot = static_cast<size_t>(grid.x) + static_cast<size_t>(grid.y);
+    auto strip_addr = [&](std::vector<uint32_t> v) {
+        if (addr_slot < v.size()) {
+            v.erase(v.begin() + addr_slot);
+        }
+        return v;
+    };
+
+    std::vector<std::vector<uint32_t>> reader_tails(cores.size());
+    std::vector<std::vector<uint32_t>> writer_tails(cores.size());
+    size_t core_pos = 0;
     for (const auto& core : cores) {
         std::vector<uint32_t> runtime_args_0;
         std::vector<uint32_t> runtime_args_1;
@@ -776,35 +796,52 @@ ProgramDescriptor ReshardGenericFactory::create_descriptor(
                 page_stride_vector.size());
         }
 
-        // Patch arg index (grid.x + grid.y) to bind the input-buffer base address.
-        // The detail helpers already pre-compute physical_core_coords (size grid.x+grid.y) followed by input addr.
-        KernelDescriptor::RTArgList rt_args_0;
-        rt_args_0.reserve(runtime_args_0.size());
-        for (size_t i = 0; i < runtime_args_0.size(); ++i) {
-            if (i == grid.x + grid.y) {
-                rt_args_0.push_back(input_buffer);
-            } else {
-                rt_args_0.push_back(runtime_args_0[i]);
-            }
-        }
-        KernelDescriptor::RTArgList rt_args_1;
-        rt_args_1.reserve(runtime_args_1.size());
-        for (size_t i = 0; i < runtime_args_1.size(); ++i) {
-            if (i == grid.x + grid.y) {
-                rt_args_1.push_back(input_buffer);
-            } else {
-                rt_args_1.push_back(runtime_args_1[i]);
-            }
-        }
-
-        kernel_desc_0.emplace_runtime_args(core, rt_args_0);
-        kernel_desc_1.emplace_runtime_args(core, rt_args_1);
+        reader_tails[core_pos] = strip_addr(std::move(runtime_args_0));
+        writer_tails[core_pos] = strip_addr(std::move(runtime_args_1));
+        ++core_pos;
     }
 
-    desc.kernels.push_back(std::move(kernel_desc_0));
-    desc.kernels.push_back(std::move(kernel_desc_1));
+    uint32_t max_tail = 0;
+    for (size_t i = 0; i < cores.size(); ++i) {
+        max_tail = std::max<uint32_t>(max_tail, static_cast<uint32_t>(reader_tails[i].size()));
+        max_tail = std::max<uint32_t>(max_tail, static_cast<uint32_t>(writer_tails[i].size()));
+    }
+    reader.advanced_options.num_runtime_varargs = max_tail;
+    writer.advanced_options.num_runtime_varargs = max_tail;
 
-    return desc;
+    spec.kernels.push_back(reader);
+    spec.kernels.push_back(writer);
+
+    spec.work_units.push_back(WorkUnitSpec{
+        .name = "wu",
+        .kernels = {kReader, kWriter},
+        .target_nodes = all_cores,
+    });
+
+    // Run args.
+    ProgramRunArgs run_args;
+    KernelRunArgs reader_run;
+    reader_run.kernel = kReader;
+    KernelRunArgs writer_run;
+    writer_run.kernel = kWriter;
+
+    for (size_t i = 0; i < cores.size(); ++i) {
+        const NodeCoord node{cores[i]};
+        reader_tails[i].resize(max_tail, 0u);
+        writer_tails[i].resize(max_tail, 0u);
+        reader_run.advanced_options.runtime_varargs[node] = std::move(reader_tails[i]);
+        writer_run.advanced_options.runtime_varargs[node] = std::move(writer_tails[i]);
+    }
+
+    run_args.kernel_run_args.push_back(std::move(reader_run));
+    run_args.kernel_run_args.push_back(std::move(writer_run));
+
+    run_args.tensor_args = {
+        {kInput, input.mesh_tensor()},
+        {kOutput, output.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_generic.hpp
@@ -4,15 +4,14 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct ReshardGenericFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.cpp
@@ -8,43 +8,20 @@
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-namespace {
-
-// Anonymous-namespace helper unique to reshard same-height to avoid unity-build collisions.
-void push_reshard_same_height_cb_pair(
-    ProgramDescriptor& desc,
-    uint32_t cb_index,
-    tt::DataFormat data_format,
-    uint32_t total_size,
-    uint32_t page_size,
-    const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
-    CBDescriptor cb;
-    cb.total_size = total_size;
-    cb.core_ranges = core_ranges;
-    cb.format_descriptors.push_back(CBFormatDescriptor{
-        .buffer_index = static_cast<uint8_t>(cb_index),
-        .data_format = data_format,
-        .page_size = page_size,
-    });
-    cb.buffer = bound_buffer;
-    desc.cbs.push_back(std::move(cb));
-}
-
-}  // namespace
-
 template <bool local_is_output>
-ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
+ttnn::device_operation::ProgramArtifacts ReshardSameHeightFactory<local_is_output>::create_program_spec(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
     const auto& input = tensor_args.input;
-    const auto& output = output_tensor;
+    auto& output = output_tensor;
     const auto& local_tensor = local_is_output ? output : input;
     const auto& remote_tensor = local_is_output ? input : output;
     const auto local_shard_spec = local_tensor.shard_spec().value();
@@ -65,41 +42,51 @@ ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
     const uint32_t unit_size =
         static_cast<uint32_t>(local_shard_spec.shape[1] * local_tensor.element_size());  // width * element size
     const uint32_t remote_units_per_shard = remote_shard_spec.shape[0];                  // height
-    const uint32_t total_size = remote_units_per_shard * unit_size;
 
-    constexpr uint32_t cb_index = tt::CBIndex::c_0;
-
-    auto* local_buffer = local_tensor.buffer();
     auto* remote_buffer = remote_tensor.buffer();
 
-    ProgramDescriptor desc;
+    // Names. The local sharded buffer backs a borrowed-memory DFB; the remote tensor flows through the
+    // typed TensorAccessor channel (Case-2 bridge: base address pulled kernel-side via get_bank_base_address).
+    const TensorParamName kLocal{"local"};
+    const TensorParamName kRemote{"remote"};
+    const DFBSpecName kShardCb{"shard_cb"};
+    const KernelSpecName kReader{"reader"};
+    const KernelSpecName kWriter{"writer"};
 
-    // Local sharded CB. Bind to local buffer for dynamic-CB rebinding on cache hits via cb.buffer.
-    push_reshard_same_height_cb_pair(
-        desc, cb_index, data_format, total_size, unit_size, all_cores, /*bound_buffer=*/local_buffer);
+    // Both KernelDescriptors use the SAME source (selected by local_is_output); the CT define for the
+    // bank type differs by name across the two source files. The reader/writer roles split work along
+    // tensor height (each kernel handles half the sticks) and each reads/writes the shared local shard CB
+    // purely by base pointer, so the borrowed DFB is bound as a self-loop on both kernels.
+    const std::filesystem::path kKernelSource =
+        local_is_output ? std::filesystem::path(
+                              "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/"
+                              "reshard_same_height_reader_m2.cpp")
+                        : std::filesystem::path(
+                              "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/"
+                              "reshard_same_height_writer_m2.cpp");
+    // The legacy CTA slot 1 (interface_with_dram) becomes a named CTA whose name matches the source file's
+    // read_from_dram / write_to_dram constexpr.
+    const std::string kDramCtaName = local_is_output ? "read_from_dram" : "write_to_dram";
 
-    const std::string kernel_name =
-        local_is_output
-            ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_height_reader.cpp"
-            : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_height_writer.cpp";
+    ProgramSpec spec;
+    spec.name = "reshard_same_height";
 
-    KernelDescriptor reader_desc;
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.kernel_source = kernel_name;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.config = ReaderConfigDescriptor{};
-    reader_desc.compile_time_args = {cb_index, static_cast<uint32_t>(interface_with_dram)};
+    // Tensor parameters: the local (borrowed-memory) shard and the remote tensor (Case-2 binding).
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = kLocal, .spec = local_tensor.tensor_spec()});
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = kRemote, .spec = remote_tensor.tensor_spec()});
 
-    KernelDescriptor writer_desc;
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.kernel_source = kernel_name;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.compile_time_args = {cb_index, static_cast<uint32_t>(interface_with_dram)};
-
-    auto remote_buffer_type = remote_buffer->buffer_type();
+    // Local sharded CB bound to the local buffer: borrowed-memory DFB. The backing L1 address resolves at
+    // runtime from the local TensorArgument (legacy set CBDescriptor.buffer + UpdateDynamicCircularBufferAddress).
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = kShardCb,
+        .entry_size = unit_size,
+        .num_entries = remote_units_per_shard,
+        .data_format_metadata = data_format,
+        .borrowed_from = kLocal,
+    });
 
     // Generate all read/write offsets for each core
+    auto remote_buffer_type = remote_buffer->buffer_type();
     auto [runtime_args_for_each_core, total_num_sticks, local_stride_bytes, remote_stride_bytes] =
         ttnn::operations::data_movement::detail::compute_width_sharding_reshard_segments(
             local_shard_spec.shape,
@@ -115,49 +102,116 @@ ProgramDescriptor ReshardSameHeightFactory<local_is_output>::create_descriptor(
     const uint32_t total_num_sticks_kernel_0 = total_num_sticks / 2;
     const uint32_t total_num_sticks_kernel_1 = total_num_sticks - total_num_sticks_kernel_0;
 
+    // Self-loop the borrowed DFB on both kernels (base-pointer access only; no real FIFO).
+    auto bind_self_loop = [&](KernelSpec& k) {
+        k.dfb_bindings = {
+            DFBBinding{
+                .dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = DFBEndpointType::PRODUCER},
+            DFBBinding{
+                .dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = DFBEndpointType::CONSUMER},
+        };
+    };
+
+    auto make_kernel = [&](const KernelSpecName& unique_id, DataMovementRoleHint role) {
+        KernelSpec k;
+        k.unique_id = unique_id;
+        k.source = kKernelSource;
+        k.compile_time_args = {{kDramCtaName, static_cast<uint32_t>(interface_with_dram)}};
+        k.runtime_arg_schema.runtime_arg_names = {
+            "total_num_sticks", "local_stride_bytes", "remote_stride_bytes", "num_segments"};
+        bind_self_loop(k);
+        k.tensor_bindings = {TensorBinding{.tensor_parameter_name = kRemote, .accessor_name = "remote"}};
+        k.hw_config = DataMovementHardwareConfig{.role = role};
+        return k;
+    };
+
+    KernelSpec reader = make_kernel(kReader, DataMovementRoleHint::READER);
+    KernelSpec writer = make_kernel(kWriter, DataMovementRoleHint::WRITER);
+
+    // Determine the max per-core vararg tail length (4 values per segment).
+    uint32_t max_tail = 0;
+    for (uint32_t core_idx = 0; core_idx < local_cores.size(); core_idx++) {
+        max_tail = std::max<uint32_t>(max_tail, 4u * runtime_args_for_each_core[core_idx].size());
+    }
+    reader.advanced_options.num_runtime_varargs = max_tail;
+    writer.advanced_options.num_runtime_varargs = max_tail;
+
+    spec.kernels.push_back(reader);
+    spec.kernels.push_back(writer);
+
+    // Both kernels run on all_cores and self-loop the borrowed DFB: one WorkUnitSpec (Local-DFB rule).
+    spec.work_units.push_back(WorkUnitSpec{
+        .name = "wu",
+        .kernels = {kReader, kWriter},
+        .target_nodes = all_cores,
+    });
+
+    // Run args.
+    ProgramRunArgs run_args;
+    KernelRunArgs reader_run;
+    reader_run.kernel = kReader;
+    KernelRunArgs writer_run;
+    writer_run.kernel = kWriter;
+    reader_run.runtime_arg_values.reserve(local_cores.size());
+    writer_run.runtime_arg_values.reserve(local_cores.size());
+
     // Here all we do is convert pre-computed offsets into vectors so they can be passed as runtime arguments
     for (uint32_t core_idx = 0; core_idx < local_cores.size(); core_idx++) {
         const auto& args_for_all_segments = runtime_args_for_each_core[core_idx];
+        const NodeCoord node{local_cores[core_idx]};
 
-        // arg 3 is remote-buffer base address (binding via Buffer*).
-        KernelDescriptor::RTArgList runtime_args_0;
-        runtime_args_0.push_back(total_num_sticks_kernel_0);
-        runtime_args_0.push_back(local_stride_bytes);
-        runtime_args_0.push_back(remote_stride_bytes);
-        runtime_args_0.push_back(remote_buffer);
-        runtime_args_0.push_back(static_cast<uint32_t>(args_for_all_segments.size()));
+        // Named scalars (the legacy buffer-address RTA slot 3 is dropped — Case-2 binding supplies it).
+        reader_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = node,
+            .args = {
+                {"total_num_sticks", total_num_sticks_kernel_0},
+                {"local_stride_bytes", local_stride_bytes},
+                {"remote_stride_bytes", remote_stride_bytes},
+                {"num_segments", static_cast<uint32_t>(args_for_all_segments.size())}}});
+        writer_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = node,
+            .args = {
+                {"total_num_sticks", total_num_sticks_kernel_1},
+                {"local_stride_bytes", local_stride_bytes},
+                {"remote_stride_bytes", remote_stride_bytes},
+                {"num_segments", static_cast<uint32_t>(args_for_all_segments.size())}}});
 
-        KernelDescriptor::RTArgList runtime_args_1;
-        runtime_args_1.push_back(total_num_sticks_kernel_1);
-        runtime_args_1.push_back(local_stride_bytes);
-        runtime_args_1.push_back(remote_stride_bytes);
-        runtime_args_1.push_back(remote_buffer);
-        runtime_args_1.push_back(static_cast<uint32_t>(args_for_all_segments.size()));
-
+        // Per-segment packed vararg tail: [read/write_size, offset, bank_id, remote_offset].
+        AdvancedKernelRunArgs::Varargs reader_tail;
+        AdvancedKernelRunArgs::Varargs writer_tail;
+        reader_tail.reserve(max_tail);
+        writer_tail.reserve(max_tail);
         for (const auto& args : args_for_all_segments) {
-            runtime_args_0.push_back(args.write_size);
-            runtime_args_0.push_back(args.read_offset);
-            runtime_args_0.push_back(args.bank_id);
-            runtime_args_0.push_back(args.write_offset);
+            reader_tail.push_back(args.write_size);
+            reader_tail.push_back(args.read_offset);
+            reader_tail.push_back(args.bank_id);
+            reader_tail.push_back(args.write_offset);
 
             // Adjust read and write offsets to the correct stick address because we are splitting work across 2 kernels
             const uint32_t adjusted_read_offset = args.read_offset + (total_num_sticks_kernel_0 * local_stride_bytes);
             const uint32_t adjusted_write_offset =
                 args.write_offset + (total_num_sticks_kernel_0 * remote_stride_bytes);
 
-            runtime_args_1.push_back(args.write_size);
-            runtime_args_1.push_back(adjusted_read_offset);
-            runtime_args_1.push_back(args.bank_id);
-            runtime_args_1.push_back(adjusted_write_offset);
+            writer_tail.push_back(args.write_size);
+            writer_tail.push_back(adjusted_read_offset);
+            writer_tail.push_back(args.bank_id);
+            writer_tail.push_back(adjusted_write_offset);
         }
-        reader_desc.emplace_runtime_args(local_cores[core_idx], runtime_args_0);
-        writer_desc.emplace_runtime_args(local_cores[core_idx], runtime_args_1);
+        reader_tail.resize(max_tail, 0u);
+        writer_tail.resize(max_tail, 0u);
+        reader_run.advanced_options.runtime_varargs[node] = std::move(reader_tail);
+        writer_run.advanced_options.runtime_varargs[node] = std::move(writer_tail);
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    run_args.kernel_run_args.push_back(std::move(reader_run));
+    run_args.kernel_run_args.push_back(std::move(writer_run));
 
-    return desc;
+    run_args.tensor_args = {
+        {kLocal, local_tensor.mesh_tensor()},
+        {kRemote, remote_tensor.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 // Explicit template instantiations

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.cpp
@@ -56,7 +56,7 @@ ttnn::device_operation::ProgramArtifacts ReshardSameHeightFactory<local_is_outpu
     // Both KernelDescriptors use the SAME source (selected by local_is_output); the CT define for the
     // bank type differs by name across the two source files. The reader/writer roles split work along
     // tensor height (each kernel handles half the sticks) and each reads/writes the shared local shard CB
-    // purely by base pointer, so the borrowed DFB is bound as a self-loop on both kernels.
+    // purely by base pointer, so the borrowed DFB is bound as a producer/consumer pair across the kernels.
     const std::filesystem::path kKernelSource =
         local_is_output ? std::filesystem::path(
                               "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/"
@@ -102,31 +102,36 @@ ttnn::device_operation::ProgramArtifacts ReshardSameHeightFactory<local_is_outpu
     const uint32_t total_num_sticks_kernel_0 = total_num_sticks / 2;
     const uint32_t total_num_sticks_kernel_1 = total_num_sticks - total_num_sticks_kernel_0;
 
-    // Self-loop the borrowed DFB on both kernels (base-pointer access only; no real FIFO).
-    auto bind_self_loop = [&](KernelSpec& k) {
+    // Borrowed-memory DFB binding. The borrowed local shard is a pure address source: both kernel
+    // instances run the SAME source (selected by local_is_output) and access shard_cb only by base
+    // pointer (both get_write_ptr() when local is the output; both get_read_ptr() when local is the
+    // input). It is accessed by BOTH kernels, so it cannot be a self-loop on either (the local-DFB
+    // invariant forbids two same-role bindings — or a multi-kernel self-loop — sharing one
+    // WorkUnitSpec). Model it as a single producer/consumer pair across the two kernels in the shared
+    // WorkUnitSpec: reader=PRODUCER, writer=CONSUMER. For a borrowed DFB the role is only a placement
+    // label (no real FIFO sync); read and write pointers resolve to the same borrowed base, so
+    // behaviour is unchanged.
+    auto bind_endpoint = [&](KernelSpec& k, DFBEndpointType endpoint_type) {
         k.dfb_bindings = {
-            DFBBinding{
-                .dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = DFBEndpointType::PRODUCER},
-            DFBBinding{
-                .dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = DFBEndpointType::CONSUMER},
+            DFBBinding{.dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = endpoint_type},
         };
     };
 
-    auto make_kernel = [&](const KernelSpecName& unique_id, DataMovementRoleHint role) {
+    auto make_kernel = [&](const KernelSpecName& unique_id, DataMovementRoleHint role, DFBEndpointType endpoint_type) {
         KernelSpec k;
         k.unique_id = unique_id;
         k.source = kKernelSource;
         k.compile_time_args = {{kDramCtaName, static_cast<uint32_t>(interface_with_dram)}};
         k.runtime_arg_schema.runtime_arg_names = {
             "total_num_sticks", "local_stride_bytes", "remote_stride_bytes", "num_segments"};
-        bind_self_loop(k);
+        bind_endpoint(k, endpoint_type);
         k.tensor_bindings = {TensorBinding{.tensor_parameter_name = kRemote, .accessor_name = "remote"}};
         k.hw_config = DataMovementHardwareConfig{.role = role};
         return k;
     };
 
-    KernelSpec reader = make_kernel(kReader, DataMovementRoleHint::READER);
-    KernelSpec writer = make_kernel(kWriter, DataMovementRoleHint::WRITER);
+    KernelSpec reader = make_kernel(kReader, DataMovementRoleHint::READER, DFBEndpointType::PRODUCER);
+    KernelSpec writer = make_kernel(kWriter, DataMovementRoleHint::WRITER, DFBEndpointType::CONSUMER);
 
     // Determine the max per-core vararg tail length (4 values per segment).
     uint32_t max_tail = 0;
@@ -139,7 +144,8 @@ ttnn::device_operation::ProgramArtifacts ReshardSameHeightFactory<local_is_outpu
     spec.kernels.push_back(reader);
     spec.kernels.push_back(writer);
 
-    // Both kernels run on all_cores and self-loop the borrowed DFB: one WorkUnitSpec (Local-DFB rule).
+    // Both kernels run on all_cores and form the producer/consumer pair of the borrowed DFB: one
+    // WorkUnitSpec hosts both endpoints (Local-DFB rule).
     spec.work_units.push_back(WorkUnitSpec{
         .name = "wu",
         .kernels = {kReader, kWriter},

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_height.hpp
@@ -4,17 +4,16 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 // WIDTH_SHARDED -> WIDTH_SHARDED reshard
 template <bool local_is_output>
 struct ReshardSameHeightFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
@@ -109,27 +109,28 @@ ttnn::device_operation::ProgramArtifacts ReshardSameWidthFactory<local_is_output
         });
     }
 
-    // Self-loop the borrowed shard DFB (and scratch, if present) on both kernels (base-pointer access only).
-    auto bind_self_loops = [&](KernelSpec& k) {
+    // Both DFBs are accessed by BOTH kernels (the two kernel instances run the SAME source selected by
+    // local_is_output), so neither can be a self-loop (the local-DFB invariant forbids two same-role
+    // bindings — or a multi-kernel self-loop — sharing one WorkUnitSpec). Each DFB is modelled as a
+    // single producer/consumer pair across the two kernels: reader=PRODUCER, writer=CONSUMER.
+    //  - shard_cb is borrowed memory and a pure address source (both instances access it only by base
+    //    pointer; for a borrowed DFB the role is just a placement label, no real FIFO sync, and read
+    //    and write pointers resolve to the same borrowed base).
+    //  - scratch_cb (unaligned path only) is a single shared local scratch region used by both
+    //    instances (each writes then reads it by base pointer) — exactly the legacy single shared c_1
+    //    scratch CB. Binding it as one producer/consumer pair keeps that single shared region.
+    // For both, behaviour is unchanged.
+    auto bind_endpoints = [&](KernelSpec& k, DFBEndpointType endpoint_type) {
         k.dfb_bindings = {
-            DFBBinding{
-                .dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = DFBEndpointType::PRODUCER},
-            DFBBinding{
-                .dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = DFBEndpointType::CONSUMER},
+            DFBBinding{.dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = endpoint_type},
         };
         if (use_scratch) {
-            k.dfb_bindings.push_back(DFBBinding{
-                .dfb_spec_name = kScratchCb,
-                .accessor_name = "scratch_cb",
-                .endpoint_type = DFBEndpointType::PRODUCER});
-            k.dfb_bindings.push_back(DFBBinding{
-                .dfb_spec_name = kScratchCb,
-                .accessor_name = "scratch_cb",
-                .endpoint_type = DFBEndpointType::CONSUMER});
+            k.dfb_bindings.push_back(
+                DFBBinding{.dfb_spec_name = kScratchCb, .accessor_name = "scratch_cb", .endpoint_type = endpoint_type});
         }
     };
 
-    auto make_kernel = [&](const KernelSpecName& unique_id, DataMovementRoleHint role) {
+    auto make_kernel = [&](const KernelSpecName& unique_id, DataMovementRoleHint role, DFBEndpointType endpoint_type) {
         KernelSpec k;
         k.unique_id = unique_id;
         k.source = kKernelSource;
@@ -144,14 +145,14 @@ ttnn::device_operation::ProgramArtifacts ReshardSameWidthFactory<local_is_output
             k.compiler_options.defines = {{"UNALIGNED", "1"}};
         }
         k.runtime_arg_schema.runtime_arg_names = {kOffsetName, kNumName};
-        bind_self_loops(k);
+        bind_endpoints(k, endpoint_type);
         k.tensor_bindings = {TensorBinding{.tensor_parameter_name = kRemote, .accessor_name = "remote"}};
         k.hw_config = DataMovementHardwareConfig{.role = role};
         return k;
     };
 
-    KernelSpec reader = make_kernel(kReader, DataMovementRoleHint::READER);
-    KernelSpec writer = make_kernel(kWriter, DataMovementRoleHint::WRITER);
+    KernelSpec reader = make_kernel(kReader, DataMovementRoleHint::READER, DFBEndpointType::PRODUCER);
+    KernelSpec writer = make_kernel(kWriter, DataMovementRoleHint::WRITER, DFBEndpointType::CONSUMER);
 
     // ---- Build per-core, per-kernel runtime args (legacy work split, verbatim). ----
     // Legacy packed RTA layout per kernel: [remote_addr(dropped), start_offset, num_transfers, then

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.cpp
@@ -8,44 +8,21 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
 #include <tt-metalium/tt_align.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/tensor/tensor_utils.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-namespace {
-
-// Anonymous-namespace helper unique to reshard same-width to avoid unity-build collisions.
-void push_reshard_same_width_cb_pair(
-    ProgramDescriptor& desc,
-    uint32_t cb_index,
-    tt::DataFormat data_format,
-    uint32_t total_size,
-    uint32_t page_size,
-    const CoreRangeSet& core_ranges,
-    Buffer* bound_buffer) {
-    CBDescriptor cb;
-    cb.total_size = total_size;
-    cb.core_ranges = core_ranges;
-    cb.format_descriptors.push_back(CBFormatDescriptor{
-        .buffer_index = static_cast<uint8_t>(cb_index),
-        .data_format = data_format,
-        .page_size = page_size,
-    });
-    cb.buffer = bound_buffer;
-    desc.cbs.push_back(std::move(cb));
-}
-
-}  // namespace
-
 template <bool local_is_output>
-ProgramDescriptor ReshardSameWidthFactory<local_is_output>::create_descriptor(
+ttnn::device_operation::ProgramArtifacts ReshardSameWidthFactory<local_is_output>::create_program_spec(
     const ReshardParams& /*operation_attributes*/, const ReshardInputs& tensor_args, Tensor& output_tensor) {
     const auto& input = tensor_args.input;
-    const auto& output = output_tensor;
+    auto& output = output_tensor;
     const auto& local_tensor = local_is_output ? output : input;
     const auto& remote_tensor = local_is_output ? input : output;
 
@@ -55,8 +32,6 @@ ProgramDescriptor ReshardSameWidthFactory<local_is_output>::create_descriptor(
     const auto remote_shard_spec = remote_tensor.shard_spec().value();
 
     auto remote_core_type = remote_tensor.buffer()->core_type();
-    constexpr uint32_t cb_index = tt::CBIndex::c_0;
-    constexpr uint32_t cb_scratch_index = tt::CBIndex::c_1;
     auto local_cores = get_optimal_worker_cores_for_sharded_tensor(local_tensor);
     auto all_cores = CoreRangeSet(ttsl::Span<const CoreCoord>(local_cores));
     auto remote_cores = remote_tensor.buffer()->buffer_distribution_spec().value().cores_with_data();
@@ -82,114 +57,206 @@ ProgramDescriptor ReshardSameWidthFactory<local_is_output>::create_descriptor(
     if (remote_unit_size_padded != unit_size || local_unit_size_padded != unit_size) {
         unaligned = true;
     }
-    const uint32_t total_size = local_units_per_shard * unit_size;
-    const std::string kernel_name =
-        local_is_output
-            ? "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_reader.cpp"
-            : "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reshard_same_width_writer.cpp";
-
     bool interface_with_dram = (remote_core_type == tt::CoreType::DRAM);
-    auto* local_buffer = local_tensor.buffer();
     auto* remote_buffer = remote_tensor.buffer();
     auto remote_buffer_type = remote_buffer->buffer_type();
 
-    ProgramDescriptor desc;
+    // Names. The local sharded buffer backs a borrowed-memory DFB; the remote tensor flows through the
+    // typed TensorAccessor channel (Case-2 bridge). The unaligned reader path uses a local scratch DFB.
+    const TensorParamName kLocal{"local"};
+    const TensorParamName kRemote{"remote"};
+    const DFBSpecName kShardCb{"shard_cb"};
+    const DFBSpecName kScratchCb{"scratch_cb"};
+    const KernelSpecName kReader{"reader"};
+    const KernelSpecName kWriter{"writer"};
 
-    // Local sharded CB. Bind to local buffer for dynamic-CB rebinding on cache hits via cb.buffer.
-    push_reshard_same_width_cb_pair(
-        desc, cb_index, data_format, total_size, unit_size, all_cores, /*bound_buffer=*/local_buffer);
+    // Both KernelDescriptors use the SAME source (selected by local_is_output). Only the reader source has
+    // the unaligned scratch path. The CT define for the bank type differs by name across the two sources.
+    const std::filesystem::path kKernelSource =
+        local_is_output ? std::filesystem::path(
+                              "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/"
+                              "reshard_same_width_reader_m2.cpp")
+                        : std::filesystem::path(
+                              "ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/kernels/"
+                              "reshard_same_width_writer_m2.cpp");
+    const std::string kDramCtaName = local_is_output ? "read_from_dram" : "write_to_dram";
+    const std::string kNumName = local_is_output ? "num_reads" : "num_writes";
+    const std::string kOffsetName = local_is_output ? "write_offset" : "read_offset";
+    // The scratch DFB only exists on the (reader) unaligned path.
+    const bool use_scratch = local_is_output && unaligned;
 
-    if (unaligned) {
-        // Scratch CB used by kernels when local/remote alignments differ.
-        push_reshard_same_width_cb_pair(
-            desc,
-            cb_scratch_index,
-            data_format,
-            remote_units_per_shard * remote_unit_size_padded,
-            unit_size,
-            all_cores,
-            /*bound_buffer=*/nullptr);
+    ProgramSpec spec;
+    spec.name = "reshard_same_width";
+
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = kLocal, .spec = local_tensor.tensor_spec()});
+    spec.tensor_parameters.push_back(TensorParameter{.unique_id = kRemote, .spec = remote_tensor.tensor_spec()});
+
+    // Local sharded CB bound to the local buffer: borrowed-memory DFB.
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = kShardCb,
+        .entry_size = unit_size,
+        .num_entries = local_units_per_shard,
+        .data_format_metadata = data_format,
+        .borrowed_from = kLocal,
+    });
+    if (use_scratch) {
+        // Local (non-borrowed) scratch DFB used by the unaligned read path. Base-pointer access only.
+        spec.dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = kScratchCb,
+            .entry_size = unit_size,
+            .num_entries = remote_units_per_shard * remote_unit_size_padded / unit_size,
+            .data_format_metadata = data_format,
+        });
     }
 
-    // Reader/writer kernels share the same source and compile-time args.
-    std::vector<uint32_t> compile_args = {
-        cb_index,
-        static_cast<uint32_t>(interface_with_dram),
-        static_cast<uint32_t>(unaligned),
-        unit_size,
-        local_unit_size_padded,
-        remote_unit_size_padded,
-        cb_scratch_index};
+    // Self-loop the borrowed shard DFB (and scratch, if present) on both kernels (base-pointer access only).
+    auto bind_self_loops = [&](KernelSpec& k) {
+        k.dfb_bindings = {
+            DFBBinding{
+                .dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = DFBEndpointType::PRODUCER},
+            DFBBinding{
+                .dfb_spec_name = kShardCb, .accessor_name = "shard_cb", .endpoint_type = DFBEndpointType::CONSUMER},
+        };
+        if (use_scratch) {
+            k.dfb_bindings.push_back(DFBBinding{
+                .dfb_spec_name = kScratchCb,
+                .accessor_name = "scratch_cb",
+                .endpoint_type = DFBEndpointType::PRODUCER});
+            k.dfb_bindings.push_back(DFBBinding{
+                .dfb_spec_name = kScratchCb,
+                .accessor_name = "scratch_cb",
+                .endpoint_type = DFBEndpointType::CONSUMER});
+        }
+    };
 
-    KernelDescriptor reader_desc;
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.kernel_source = kernel_name;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.config = ReaderConfigDescriptor{};
-    reader_desc.compile_time_args = compile_args;
+    auto make_kernel = [&](const KernelSpecName& unique_id, DataMovementRoleHint role) {
+        KernelSpec k;
+        k.unique_id = unique_id;
+        k.source = kKernelSource;
+        k.compile_time_args = {
+            {kDramCtaName, static_cast<uint32_t>(interface_with_dram)},
+            {"unaligned", static_cast<uint32_t>(unaligned)},
+            {"unit_size", unit_size},
+            {"local_unit_size_padded", local_unit_size_padded},
+            {"remote_unit_size_padded", remote_unit_size_padded},
+        };
+        if (use_scratch) {
+            k.compiler_options.defines = {{"UNALIGNED", "1"}};
+        }
+        k.runtime_arg_schema.runtime_arg_names = {kOffsetName, kNumName};
+        bind_self_loops(k);
+        k.tensor_bindings = {TensorBinding{.tensor_parameter_name = kRemote, .accessor_name = "remote"}};
+        k.hw_config = DataMovementHardwareConfig{.role = role};
+        return k;
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.kernel_source = kernel_name;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.compile_time_args = std::move(compile_args);
+    KernelSpec reader = make_kernel(kReader, DataMovementRoleHint::READER);
+    KernelSpec writer = make_kernel(kWriter, DataMovementRoleHint::WRITER);
+
+    // ---- Build per-core, per-kernel runtime args (legacy work split, verbatim). ----
+    // Legacy packed RTA layout per kernel: [remote_addr(dropped), start_offset, num_transfers, then
+    // 3*num_transfers tail]. The remote base address is now supplied by the Case-2 TensorBinding.
+    // We collect, per core, the (start_offset, tail) for kernel_0 (reader) and kernel_1 (writer).
+    struct PerKernelArgs {
+        uint32_t start_offset = 0;
+        uint32_t num_transfers = 0;
+        std::vector<uint32_t> tail;  // [bank_id, offset, units] * num_transfers
+    };
+    std::vector<std::array<PerKernelArgs, 2>> per_core_args(local_cores.size());
 
     uint32_t remote_core_idx = 0;
     uint32_t remote_core_units_rem = remote_units_per_shard;
-    auto bank_id =
-        device->allocator()->get_bank_ids_from_logical_core(remote_buffer_type, remote_cores[remote_core_idx])[0];
-
-    std::array<KernelDescriptor*, 2> kernels = {&reader_desc, &writer_desc};
     uint32_t local_units_left = num_units;
+    uint32_t core_pos = 0;
     for (const auto& core : local_cores) {
+        (void)core;
         uint32_t local_units_per_core = std::min(local_units_left, local_units_per_shard);
         local_units_left -= local_units_per_core;
-        uint32_t local_units_per_kernel = tt::div_up(local_units_per_core, static_cast<uint32_t>(kernels.size()));
+        uint32_t local_units_per_kernel = tt::div_up(local_units_per_core, 2u);
         uint32_t local_start_offset = 0;
-        for (auto* kernel : kernels) {
-            // arg 0 is remote-buffer base address (binding via Buffer*).
-            // RTArgList doesn't expose operator[] for back-patching, so we build
-            // a std::vector<variant> here and pass via the vector overload of
-            // emplace_runtime_args.
-            std::vector<std::variant<uint32_t, Buffer*>> kernel_args;
-            kernel_args.emplace_back(remote_buffer);
-            kernel_args.emplace_back(uint32_t{0});
-            kernel_args.emplace_back(uint32_t{0});
+        for (uint32_t kidx = 0; kidx < 2; ++kidx) {
+            PerKernelArgs& ka = per_core_args[core_pos][kidx];
             uint32_t local_units_to_transfer = std::min(local_units_per_core, local_units_per_kernel);
             if (local_units_to_transfer != 0) {
                 uint32_t num_transfers = 0;
-                kernel_args[1] = local_start_offset;
+                ka.start_offset = local_start_offset;
                 local_start_offset += local_units_to_transfer * unit_size;
                 while (local_units_to_transfer > 0) {
                     if (remote_core_units_rem == 0) {
                         remote_core_idx++;
                         remote_core_units_rem = remote_units_per_shard;
-                        bank_id = device->allocator()->get_bank_ids_from_logical_core(
-                            remote_buffer_type, remote_cores[remote_core_idx])[0];
                     }
                     uint32_t units_to_transfer = std::min(remote_core_units_rem, local_units_to_transfer);
-                    bank_id = device->allocator()->get_bank_ids_from_logical_core(
+                    auto bank_id = device->allocator()->get_bank_ids_from_logical_core(
                         remote_buffer_type, remote_cores[remote_core_idx])[0];
-                    kernel_args.emplace_back(bank_id);
-                    kernel_args.emplace_back(
-                        (remote_units_per_shard - remote_core_units_rem) * remote_unit_size_padded);
-                    kernel_args.emplace_back(units_to_transfer);
+                    ka.tail.push_back(static_cast<uint32_t>(bank_id));
+                    ka.tail.push_back((remote_units_per_shard - remote_core_units_rem) * remote_unit_size_padded);
+                    ka.tail.push_back(units_to_transfer);
                     local_units_per_core -= units_to_transfer;
                     local_units_to_transfer -= units_to_transfer;
                     remote_core_units_rem -= units_to_transfer;
                     num_transfers++;
                 }
-                kernel_args[2] = num_transfers;
+                ka.num_transfers = num_transfers;
             }
-            kernel->emplace_runtime_args(core, kernel_args);
         }
+        ++core_pos;
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    // Max vararg tail length across cores (per kernel index).
+    uint32_t max_tail = 0;
+    for (const auto& pk : per_core_args) {
+        max_tail = std::max<uint32_t>(max_tail, static_cast<uint32_t>(pk[0].tail.size()));
+        max_tail = std::max<uint32_t>(max_tail, static_cast<uint32_t>(pk[1].tail.size()));
+    }
+    reader.advanced_options.num_runtime_varargs = max_tail;
+    writer.advanced_options.num_runtime_varargs = max_tail;
 
-    return desc;
+    spec.kernels.push_back(reader);
+    spec.kernels.push_back(writer);
+
+    spec.work_units.push_back(WorkUnitSpec{
+        .name = "wu",
+        .kernels = {kReader, kWriter},
+        .target_nodes = all_cores,
+    });
+
+    // ---- Run args. ----
+    ProgramRunArgs run_args;
+    KernelRunArgs reader_run;
+    reader_run.kernel = kReader;
+    KernelRunArgs writer_run;
+    writer_run.kernel = kWriter;
+    reader_run.runtime_arg_values.reserve(local_cores.size());
+    writer_run.runtime_arg_values.reserve(local_cores.size());
+
+    for (uint32_t i = 0; i < local_cores.size(); ++i) {
+        const NodeCoord node{local_cores[i]};
+        const PerKernelArgs& r = per_core_args[i][0];
+        const PerKernelArgs& w = per_core_args[i][1];
+
+        reader_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = node, .args = {{kOffsetName, r.start_offset}, {kNumName, r.num_transfers}}});
+        writer_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = node, .args = {{kOffsetName, w.start_offset}, {kNumName, w.num_transfers}}});
+
+        AdvancedKernelRunArgs::Varargs reader_tail = r.tail;
+        AdvancedKernelRunArgs::Varargs writer_tail = w.tail;
+        reader_tail.resize(max_tail, 0u);
+        writer_tail.resize(max_tail, 0u);
+        reader_run.advanced_options.runtime_varargs[node] = std::move(reader_tail);
+        writer_run.advanced_options.runtime_varargs[node] = std::move(writer_tail);
+    }
+
+    run_args.kernel_run_args.push_back(std::move(reader_run));
+    run_args.kernel_run_args.push_back(std::move(writer_run));
+
+    run_args.tensor_args = {
+        {kLocal, local_tensor.mesh_tensor()},
+        {kRemote, remote_tensor.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 // Explicit template instantiations

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/reshard/device/reshard_program_factory_same_width.hpp
@@ -4,17 +4,16 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
-
 #include "ttnn/operations/data_movement/sharded/reshard/device/reshard_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 // HEIGHT_SHARDED -> HEIGHT_SHARDED reshard
 template <bool local_is_output>
 struct ReshardSameWidthFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const ReshardParams& operation_attributes, const ReshardInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/METAL2_PORT_REPORT.md
@@ -1,0 +1,89 @@
+# Metal 2.0 port — slice (SliceTileProgramFactory → create_program_spec)
+
+STATUS: PORTED
+
+## Factory chosen
+The simplest single-program factory: the non-strided TILE path (`SliceTileProgramFactory`,
+`slice_program_factory_tile.{hpp,cpp}`). Two kernels (reader + writer), one CB, one work-split
+into up to two core groups. No semaphores, no op-owned tensors, no per-mesh-coord variation.
+
+## The two-concept conflict and how it was resolved
+`ccl/mesh_partition` builds its own `MeshWorkload` by calling
+`SliceTileProgramFactory::create_descriptor(...)` directly, per mesh coordinate, inside its
+own `create_at` / `override_runtime_arguments` (mesh_partition_program_factory.cpp lines ~127
+and ~157). It needs a `ProgramDescriptor` to stamp into a `Program` and to feed
+`apply_descriptor_runtime_args`.
+
+A single factory struct cannot satisfy BOTH `ProgramDescriptorFactoryConcept` (has
+`create_descriptor`) and `ProgramSpecFactoryConcept` (has `create_program_spec`) — the
+`AllFactoriesValid` check (operation_concepts.hpp) requires each `program_factory_t` variant
+alternative to satisfy EXACTLY one concept.
+
+Resolution (the recommended split):
+- **Kept** `SliceTileProgramFactory::create_descriptor` unchanged → mesh_partition keeps building.
+- **Added** a separate struct `SliceTileSpecProgramFactory::create_program_spec` (Metal 2.0)
+  in the same .hpp/.cpp. slice's own `select_program_factory` now routes the TILE path to it,
+  and the `program_factory_t` variant lists `SliceTileSpecProgramFactory` in place of the old
+  descriptor factory.
+- mesh_partition still `std::visit`s slice's variant; its two lambdas were given a one-line
+  `if constexpr (std::is_same_v<Factory, SliceTileSpecProgramFactory>)` branch that calls
+  `SliceTileProgramFactory::create_descriptor` (the descriptor variant of the identical TILE
+  work) for that alternative, and `Factory::create_descriptor` for the rest. This is the only
+  edit outside the slice op dir, and it is minimal + documented.
+
+## Kernels
+Both slice-local kernels are used ONLY by the TILE factory, but the legacy descriptor path
+(kept for mesh_partition) still consumes the originals via `get_named_compile_time_arg_val` /
+positional `get_arg_val` / `get_common_arg_addr`. The Metal 2.0 path needs the
+`experimental/kernel_args.h` named mechanism. So both were **forked** (not edited in place):
+
+- `kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_m2.cpp` (fork of the legacy reader)
+- `kernels/dataflow/writer_unary_interleaved_start_id_m2.cpp` (fork of the legacy writer)
+
+Port is access-mechanism-only (logic, #ifdefs, loop bounds, numeric paths UNCHANGED):
+- src/dst addresses: raw `src_addr`/`dst_addr` runtime args → `TensorAccessor(ta::src)` /
+  `TensorAccessor(ta::dst)` (address flows through TensorBinding; the appended
+  `TensorAccessorArgs` CTAs are gone).
+- CB ids: `get_named_compile_time_arg_val("cb_in"/"cb_out")` → `dfb::cb_in` / `dfb::cb_out`
+  (one DataflowBufferSpec `cb_in_out`, reader=PRODUCER, writer=CONSUMER, both on `all_cores`,
+  same WorkUnitSpec — local-DFB rule satisfied).
+- `num_dims`: positional CTA → named CTA `args::num_dims`.
+- reader `start_id`/`num_tiles`, writer `num_pages`/`start_id`: positional RTAs → named RTAs.
+- reader per-dim `id_per_dim[]` array → runtime **varargs** (`get_vararg`); the common
+  `[num_unpadded.., num_padded..]` arrays → common **varargs** (`get_common_vararg`). The
+  m2 vararg API exposes value getters only (no writable pointer into the vararg region), so
+  the per-dim running counters are copied into a local stack array (`uint32_t
+  id_per_dim[num_dims]`, sized by the `num_dims` CTA) and mutated there — identical arithmetic.
+
+## Files changed
+- `device/slice_program_factory_tile.hpp` — added `SliceTileSpecProgramFactory` struct (kept
+  `SliceTileProgramFactory`).
+- `device/slice_program_factory_tile.cpp` — added `SliceTileSpecProgramFactory::create_program_spec`
+  (legacy `create_descriptor` untouched).
+- `device/slice_device_operation.hpp` — `program_factory_t` variant: `SliceTileProgramFactory`
+  → `SliceTileSpecProgramFactory`.
+- `device/slice_device_operation.cpp` — `select_program_factory` TILE path returns
+  `SliceTileSpecProgramFactory{}`.
+- `device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_m2.cpp` — NEW (forked).
+- `device/kernels/dataflow/writer_unary_interleaved_start_id_m2.cpp` — NEW (forked).
+- `ccl/mesh_partition/device/mesh_partition_program_factory.cpp` — two `if constexpr` branches
+  mapping the spec factory alternative back to `SliceTileProgramFactory::create_descriptor`.
+  (Minimal, documented; the only change outside the slice op dir.)
+
+The `SliceTileProgramFactory::create_descriptor` pybind hook (slice_nanobind.cpp) was LEFT in
+place — it is not dangling (the descriptor factory still exists). No new pybind hook was added
+for the spec factory (matches rand; the spec path is dispatched by the framework adapter).
+
+## Blockers
+None. Both slice and ccl/mesh_partition retain everything they need to build.
+
+## Not built / not measured / not committed
+Per instructions. (This worktree has no build dir; cannot compile or measure here.)
+
+## Note on this worktree's base
+This worktree is checked out on a base commit that has the Metal 2.0 host API
+(`tt-metalium/experimental/metal2_host_api/*`) and adapter (`ProgramSpecMeshWorkloadFactoryAdapter`,
+`ttnn/metal2_artifacts.hpp`) merged, but does NOT contain the worked-example op ports (rand /
+matmul on this base are still legacy `create_descriptor`). The port was written against the
+in-tree framework API, using the `dgomez/rand-metal2` rand factory as the structural template
+for `create_program_spec` and the forked-kernel named-arg conventions.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/METAL2_PORT_REPORT.md
@@ -96,10 +96,21 @@ STATUS: PORTED
 
 ## Per-factory STATUS summary (all five slice factories)
 - `slice_program_factory_tile.cpp` (TILE, non-strided) — **PORTED** (prior pass; see top of file).
-- `slice_program_factory_tile_tensor_args.cpp` (TILE, tensor-args / `use_tensor_args`) — **PORTED** (this pass).
-- `slice_program_factory_rm.cpp` (ROW_MAJOR interleaved/sharded) — **BLOCKED** (see Blockers below).
-- `slice_program_factory_rm_sharded.cpp` (ROW_MAJOR HEIGHT-sharded in/out) — **BLOCKED**.
-- `slice_program_factory_rm_stride.cpp` (ROW_MAJOR strided 4D/ND) — **BLOCKED**.
+- `slice_program_factory_tile_tensor_args.cpp` (TILE, tensor-args / `use_tensor_args`) — **PORTED** (prior pass).
+- `slice_program_factory_rm.cpp` (ROW_MAJOR interleaved/W&B-sharded) — **BLOCKED** (per-shard
+  page-size override on a `ta::`-bound accessor + per-dispatch host-composed base offset; see RM
+  Case-2 re-examination below).
+- `slice_program_factory_rm_sharded.cpp` (ROW_MAJOR HEIGHT-sharded in/out) — **PORTED** (this pass,
+  Case-2 bridge: borrowed DFBs + raw NoC-map walk).
+- `slice_program_factory_rm_stride.cpp` (ROW_MAJOR strided 4D/ND) — **PORTED** (this pass, Case-1:
+  clean Buffer* address bindings, default page size).
+
+> NOTE: the prior pass marked the three RM factories METAL-BLOCKED. The Case-2 bridge re-examination
+> (this pass) flips two of them: rm_sharded does a raw NoC walk (no `TensorAccessor` fed to
+> `noc_async_*_sharded` at all), and rm_stride builds its accessor with the *default* page size (no
+> override) on a *clean* base address. Only rm.cpp genuinely hits the per-shard page-size-override
+> gap. The blocker sections further down (written by the prior pass) are superseded for rm_sharded /
+> rm_stride by the RM Case-2 re-examination section at the very bottom of this file.
 
 ## Factory chosen
 The TILE tensor-args path (`SliceTileTensorArgsProgramFactory`,
@@ -221,3 +232,138 @@ carry. Precise sites:
 
 ## Not built / not measured / not committed
 Per instructions. (This worktree has no build dir; cannot compile or measure here.)
+
+---
+
+# RM Case-2 re-examination — rm_sharded + rm_stride PORTED, rm.cpp BLOCKED (this pass)
+
+This pass re-examined the three ROW_MAJOR factories with the Case-2 bridge in mind (a data-movement
+kernel that consumes a tensor's raw base address is PORTABLE: bind the tensor as a normal
+`TensorParameter`/`TensorBinding`, pull the base kernel-side, keep the raw NoC arithmetic). The prior
+pass had marked all three METAL-BLOCKED; two of them are in fact portable.
+
+## `slice_program_factory_rm_sharded.cpp` — STATUS: PORTED (Case-2 bridge)
+
+The legacy factory has a SINGLE reader kernel (`slice_reader_unary_unpad_dims_rm_sharded.cpp`) that:
+- borrows two CBs onto the input/output shard buffers (`CBDescriptor::buffer = in/out.buffer()`) and
+  reads their L1 base via `get_write_ptr()`, and
+- reads peer shards by a hand-rolled NoC walk over a host-computed physical core-coordinate map
+  (`device->worker_core_from_logical_core(...)` → noc-x/noc-y RTAs) plus per-shard stick-chunk
+  descriptors (`noc.async_read(UnicastEndpoint{}, dst, ..., {.noc_x, .noc_y, .addr=...}, ...)`).
+
+It does NOT hand a `TensorAccessor` to `noc_async_*_sharded` and has NO host-composed base offset and
+NO per-shard page-size override — it is a pure raw-NoC-walk kernel. That is exactly the Case-2 shape.
+
+Port:
+- The two borrowed CBs become two `DataflowBufferSpec`s with `borrowed_from = src / dst` (sharded
+  tensors are L1-backed; the borrowed DFB resolves its backing L1 base from the matching
+  `TensorArgument`, refreshing on cache hits — replacing the legacy `CBDescriptor::buffer`). The
+  kernel reads `get_write_ptr()` exactly as before. The src/dst base addresses thus flow through the
+  typed tensor channel.
+- Both DFBs are bound on the single reader as **self-loops** (PRODUCER + CONSUMER): `cb_in` is a pure
+  address source (no real FIFO), `cb_out` is produced into but has no consumer kernel in this
+  single-reader factory. Self-loop satisfies the DFB ≥1-producer-and-≥1-consumer invariant. (Fake-CB
+  → self-loop pattern.)
+- `stick_size_padded` / `stick_size_unpadded` / `num_sticks_unpadded`: positional CTAs → named CTAs.
+- The per-core reader arg vector (`num_cores_read`, NoC x/y map, num-chunks, chunk descriptors) is
+  variable-length, so it travels as **per-core runtime varargs** with identical contents and layout.
+  Per-node vararg counts differ; the API's per-node-count override (`num_runtime_varargs_per_node`)
+  is **deprecated** ("truly bizarre, will be removed"), so instead a single uniform
+  `num_runtime_varargs` (= the longest per-core vector) is declared and each node's vararg vector is
+  zero-padded up to it. The kernel derives every index from `get_vararg(0)` (num_cores_read) and
+  never touches the padding tail, so padding is inert. Friction note: the deprecated per-node-count
+  field is the "natural" fit here and its removal will force exactly this zero-pad workaround on any
+  jagged-vararg op — flagging for the framework owners.
+
+Kernel forked: `kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded_m2.cpp` (the legacy file
+stays for the descriptor path that ccl/mesh_partition reuses).
+
+## `slice_program_factory_rm_stride.cpp` — STATUS: PORTED (Case-1, no bridge needed)
+
+The legacy strided factory selects between 4D and ND reader/writer kernels at runtime by rank. All
+four kernels build their accessor as `TensorAccessor(args, addr)` with **no third (page-size) ctor
+argument** — i.e. the default `AlignedPageSize`, which is exactly what the `ta::`-binding-token ctor
+supplies. The base address is a **clean `Buffer*` RTA** (no host-composed offset). So this is an
+ordinary **Case-1** binding, not even a Case-2 bridge: src/dst re-express as plain `TensorBinding`s
+(`TensorAccessor(ta::src)` / `(ta::dst)`), and `noc_async_*_sharded` receives an accessor with the
+same DSpec and same page size as the legacy path → identical behavior.
+
+Port (one factory, runtime-selected kernels convert together so all four are forked):
+- Single in CB (index 0) → one `DataflowBufferSpec` (`cb_in_out`), reader=PRODUCER / writer=CONSUMER,
+  one `WorkUnitSpec` on `all_cores`.
+- `element_size` leading CTA → named CTA `compile_time_element_size`.
+- 4D kernels: the fixed positional RTAs → named RTAs. ND kernels: leading scalar RTAs → named RTAs,
+  the five per-dim arrays (input/output dims, slice start/end/step — reader) and the output-dims
+  array (writer) → **runtime varargs**, same concatenated layout. The ND kernels copy them once into
+  local fixed-size stack arrays (the legacy kernel already caps rank at 16 via `coords[16]`) since
+  the vararg API exposes value getters only; the indexing arithmetic is unchanged.
+- The 4D vs ND branch is selected inside `create_program_spec` (multi-variant-factory pattern).
+
+Kernels forked: `reader_multicore_slice_4d_m2.cpp`, `writer_multicore_slice_4d_m2.cpp`,
+`reader_multicore_slice_nd_m2.cpp`, `writer_multicore_slice_nd_m2.cpp`.
+
+## `slice_program_factory_rm.cpp` — STATUS: BLOCKED (the remaining genuine metal gap)
+
+This one is genuinely blocked, for the precise reason the instructions named: the reader hands a
+`TensorAccessor` constructed with a **per-shard page-size override** to `noc_async_read_sharded`, and
+that override is not expressible on a `ta::`-bound accessor. Two distinct issues:
+
+1. **Per-shard page-size override on a `ta::`-bound accessor (dispositive).**
+   `slice_reader_unary_unpad_dims_rm_interleaved_start_id.cpp:34`:
+   `TensorAccessor(src_args, src_addr, padded_stick_size)` — the THIRD ctor argument is the per-shard
+   page size (`shard_W * element_size` for B/W-sharded; full row otherwise; host-computed at
+   `slice_program_factory_rm.cpp:76-85`). It feeds `noc_async_read_sharded`'s multi-shard row split
+   via `get_aligned_page_size()` (`common.hpp:235`). The writer is identical
+   (`slice_writer_unary_stick_layout_interleaved_start_id.cpp:22,27`, host
+   `slice_program_factory_rm.cpp:143-152`). The Metal 2.0 binding-token ctor
+   (`tt_metal/hw/inc/api/tensor/tensor_accessor.h:99`) delegates with NO page-size argument — it
+   hardcodes `page_size_in = TensorAccessorArgs<...>::AlignedPageSize`, the accessor's *natural*
+   aligned page size from the `TensorSpec`. There is no field on `TensorParameter` / `TensorBinding`
+   / the binding token to override `aligned_page_size`. So a `ta::`-bound accessor handed to
+   `noc_async_*_sharded` cannot carry the host-computed per-shard page size. **This is precisely the
+   "per-shard page-size override on a `ta::`-bound accessor passed to `noc_async_*_sharded`" gap.**
+
+2. **Per-dispatch host-composed base offset (also blocking, independent of #1).**
+   `slice_program_factory_rm.cpp:88`: the reader's common arg 0 is
+   `start_addr + begins_bytes - misalignment` — the input buffer base (`input.buffer()->address()`,
+   varies per dispatch) pre-composed with a host-computed misalignment-adjusted byte offset. The
+   sanctioned "host-computed base-pointer offset → CTA offset + kernel-side addition" pattern is
+   **CTA-only**; here the base is per-dispatch (an RTA), so that pattern explicitly does not apply.
+   Even if #1 were solved, the offset would still need a non-CTA path. (The kernel then re-aligns the
+   read with `tt_memmove` by `misalignment` — the offset and the page size are coupled.)
+
+Recommended framework fix to unblock rm.cpp: expose an `aligned_page_size` override on the
+`TensorParameter` / binding token (a per-binding constant — it does not vary per dispatch for a given
+cache entry), plus a sanctioned way to carry a per-dispatch base offset (e.g. an offset CRTA that the
+kernel adds after `get_bank_base_address()`, the RTA analogue of the existing CTA-offset pattern).
+Flagging for the framework / TensorAccessor owners.
+
+## Files changed (this pass)
+- `device/slice_program_factory_rm_sharded.hpp` — added `SliceRmShardedSpecProgramFactory` (kept
+  `SliceRmShardedProgramFactory`).
+- `device/slice_program_factory_rm_sharded.cpp` — added `create_program_spec` (legacy
+  `create_descriptor` untouched).
+- `device/slice_program_factory_rm_stride.hpp` — added `SliceRmStrideSpecProgramFactory` (kept
+  `SliceRmStrideProgramFactory`).
+- `device/slice_program_factory_rm_stride.cpp` — added `create_program_spec` (legacy untouched).
+- `device/slice_device_operation.hpp` — `program_factory_t`: `SliceRmShardedProgramFactory` →
+  `SliceRmShardedSpecProgramFactory`, `SliceRmStrideProgramFactory` → `SliceRmStrideSpecProgramFactory`.
+- `device/slice_device_operation.cpp` — `select_program_factory` HEIGHT-sharded path returns
+  `SliceRmShardedSpecProgramFactory{}`; strided path returns `SliceRmStrideSpecProgramFactory{}`.
+- `device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded_m2.cpp` — NEW (forked).
+- `device/kernels/dataflow/reader_multicore_slice_4d_m2.cpp` — NEW (forked).
+- `device/kernels/dataflow/writer_multicore_slice_4d_m2.cpp` — NEW (forked).
+- `device/kernels/dataflow/reader_multicore_slice_nd_m2.cpp` — NEW (forked).
+- `device/kernels/dataflow/writer_multicore_slice_nd_m2.cpp` — NEW (forked).
+- `ccl/mesh_partition/device/mesh_partition_program_factory.cpp` — two parallel `else if constexpr`
+  branches (one per new spec factory) in both `std::visit` lambdas, mapping each spec-factory
+  alternative back to the corresponding legacy `create_descriptor` for mesh_partition's MeshWorkload
+  build / per-coord rebuild. Only change outside the slice op dir; identical in shape to the TILE
+  branches the prior passes added.
+
+No custom `compute_program_hash` exists on `SliceDeviceOperation` (the report comments referencing
+"compute_program_hash() folds padded_shape" describe the DEFAULT reflection hash, which includes
+`padded_shape` — there is nothing to delete). No slice pybind hook references the rm_sharded or
+rm_stride `create_descriptor` (the only slice pybind hook points at the non-strided TILE factory).
+CMakeLists globs `slice/device/kernels/*`; the new *_m2 kernels are runtime-loaded sources, not
+compiled TUs, and the factory `.cpp` edits are in already-compiled files — no CMake change.

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/METAL2_PORT_REPORT.md
@@ -87,3 +87,137 @@ This worktree is checked out on a base commit that has the Metal 2.0 host API
 matmul on this base are still legacy `create_descriptor`). The port was written against the
 in-tree framework API, using the `dgomez/rand-metal2` rand factory as the structural template
 for `create_program_spec` and the forked-kernel named-arg conventions.
+
+---
+
+# Metal 2.0 port — slice TILE tensor-args path (SliceTileTensorArgsSpecProgramFactory)
+
+STATUS: PORTED
+
+## Per-factory STATUS summary (all five slice factories)
+- `slice_program_factory_tile.cpp` (TILE, non-strided) — **PORTED** (prior pass; see top of file).
+- `slice_program_factory_tile_tensor_args.cpp` (TILE, tensor-args / `use_tensor_args`) — **PORTED** (this pass).
+- `slice_program_factory_rm.cpp` (ROW_MAJOR interleaved/sharded) — **BLOCKED** (see Blockers below).
+- `slice_program_factory_rm_sharded.cpp` (ROW_MAJOR HEIGHT-sharded in/out) — **BLOCKED**.
+- `slice_program_factory_rm_stride.cpp` (ROW_MAJOR strided 4D/ND) — **BLOCKED**.
+
+## Factory chosen
+The TILE tensor-args path (`SliceTileTensorArgsProgramFactory`,
+`slice_program_factory_tile_tensor_args.{hpp,cpp}`), selected by `select_program_factory` when
+`args.use_tensor_args` is set. It is the same structural shape as the already-ported non-strided
+TILE factory (reader + writer, work-split into up to two core groups) but reads the slice
+`start`/`end` bounds from two extra device tensors at runtime, via a second single-tile staging CB.
+
+## Two-concept conflict — resolved exactly as the non-strided TILE path
+`ccl/mesh_partition`'s `std::visit` over slice's `program_factory_t` instantiates
+`Factory::create_descriptor(...)` for EVERY variant alternative (mesh_partition_program_factory.cpp,
+the generic `else` branches). So removing `create_descriptor` from the tensor-args factory would
+break mesh_partition's build, regardless of whether mesh_partition ever selects it at runtime.
+Same constraint, same resolution as the non-strided TILE path:
+- **Kept** `SliceTileTensorArgsProgramFactory::create_descriptor` unchanged.
+- **Added** a separate struct `SliceTileTensorArgsSpecProgramFactory::create_program_spec` (Metal 2.0)
+  in the same .hpp/.cpp. `select_program_factory`'s `use_tensor_args` path now routes to it, and the
+  `program_factory_t` variant lists `SliceTileTensorArgsSpecProgramFactory` in place of the descriptor factory.
+- mesh_partition's two `std::visit` lambdas were given a parallel
+  `else if constexpr (std::is_same_v<Factory, SliceTileTensorArgsSpecProgramFactory>)` branch that
+  calls `SliceTileTensorArgsProgramFactory::create_descriptor` (the descriptor variant of the
+  identical work). Minimal, documented; the only edit outside the slice op dir, and identical in
+  shape to the branch the prior TILE port already added.
+
+## Kernels (one forked, one reused)
+- **Reader — forked**: `kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args_m2.cpp`
+  (NEW; fork of `reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp`, which the kept legacy
+  descriptor path still consumes verbatim). Access-mechanism-only port:
+  - src/start/end addresses: `get_common_arg_val<uint32_t>(0..2)` → `TensorAccessor(ta::src/ta::start/ta::end)`.
+  - CB ids: `get_compile_time_arg_val(0)`/`(1)` → `dfb::cb_in` / `dfb::cb_tensor`.
+  - `num_dims`/`tile_width`/`tile_height`: positional CTAs → named CTAs (`args::...`).
+  - `start_id`/`num_tiles`: positional per-core RTAs → named RTAs.
+  - per-dim `id_per_dim[]`: per-core RTA tail → runtime **varargs** (copied into a local stack array
+    `uint32_t id_per_dim[num_dims]`, mutated locally — the m2 vararg API has value getters only;
+    identical arithmetic).
+  - common `[num_unpadded.., num_padded.., input_shape..]`: `get_common_arg_addr(3..)` → common
+    **varargs**. Layout preserved exactly: `get_common_vararg(j)` = num_unpadded[j],
+    `get_common_vararg(num_dims+j)` = num_padded[j], `get_common_vararg(2*num_dims+i)` = input_shape[i]
+    (the legacy `get_common_arg_addr(3 + 2*num_dims)` base shifts to common-vararg index `2*num_dims`
+    once the 3 buffer addresses leave the common-arg region).
+- **Writer — reused**: `kernels/dataflow/writer_unary_interleaved_start_id_m2.cpp` (the existing fork
+  added by the non-strided TILE port). The legacy tensor-args factory used the **shared eltwise**
+  `eltwise/unary/.../writer_unary_interleaved_start_id.cpp` (read CB id positionally, `TensorAccessorArgs<1>`),
+  whose Metal-2.0 shape — `dfb::cb_out` + `ta::dst`, named `num_pages`/`start_id` RTAs — is byte-for-byte
+  what that existing m2 fork already provides, so no second writer fork was created (avoids editing the
+  shared eltwise kernel in place, per the shared-kernel caution).
+
+## Spec shape
+- DFBs: `cb_in` (idx 0, double-buffered single-tile FIFO; reader=PRODUCER `cb_in`, writer=CONSUMER `cb_out`)
+  and `cb_tensor` (idx 1, single-tile staging for the start/end reads; reader **self-loop** —
+  PRODUCER + CONSUMER on the reader, since the reader is its only user: it writes start/end into it then
+  reads them back). The `cb_in` producer/consumer share the one WorkUnitSpec on `all_cores` (local-DFB rule).
+- TensorParameters: `src`, `start`, `end` (reader), `dst` (writer), each from `<tensor>.tensor_spec()`.
+- Per-core / common runtime-arg computation copied verbatim from `create_descriptor`, including the
+  zero-filled no-op-core path and the `constexpr start_offset = 0` (the tensor-args reader computes the
+  real per-region offset kernel-side from the start/end tensors).
+
+## Files changed (this pass)
+- `device/slice_program_factory_tile_tensor_args.hpp` — added `SliceTileTensorArgsSpecProgramFactory`
+  (kept `SliceTileTensorArgsProgramFactory`).
+- `device/slice_program_factory_tile_tensor_args.cpp` — added
+  `SliceTileTensorArgsSpecProgramFactory::create_program_spec` (legacy `create_descriptor` untouched).
+- `device/slice_device_operation.hpp` — `program_factory_t` variant: `SliceTileTensorArgsProgramFactory`
+  → `SliceTileTensorArgsSpecProgramFactory`.
+- `device/slice_device_operation.cpp` — `select_program_factory` `use_tensor_args` path returns
+  `SliceTileTensorArgsSpecProgramFactory{}`.
+- `device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args_m2.cpp` — NEW (forked).
+- `ccl/mesh_partition/device/mesh_partition_program_factory.cpp` — parallel `else if constexpr` branch in
+  both lambdas. (Only change outside the slice op dir.)
+
+No pybind hook references the tensor-args `create_descriptor` (the only slice pybind hook,
+slice_nanobind.cpp:167, points at `SliceTileProgramFactory::create_descriptor` — the non-strided
+factory — and is untouched). CMakeLists lists factory .hpp files only and already includes this one;
+no CMake change (the new kernel is a runtime-loaded source, not a compiled TU).
+
+## Blockers — the three ROW_MAJOR factories (re-confirmed METAL-BLOCKED, not ported)
+
+All three route per-row NOC traffic through the shared kernel-lib helpers
+`tt::data_movement::common::noc_async_read_sharded` / `noc_async_write_sharded`
+(`ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp:230` / `:200`), and/or smuggle a
+host-computed base offset / per-shard NOC layout through runtime args that a `ta::` TensorBinding cannot
+carry. Precise sites:
+
+- **`slice_program_factory_rm.cpp`** — BLOCKED.
+  - `slice_program_factory_rm.cpp:88`: the reader's CRTA slot 0 is
+    `start_addr + begins_bytes - misalignment` — the input buffer base address **pre-composed with a
+    host-computed misalignment-adjusted byte offset**, threaded through a runtime arg. `start_addr =
+    input.buffer()->address()` (`:72`) varies per dispatch, so this is a per-dispatch RTA, not a CTA.
+    The sanctioned "Host-computed base-pointer offset → CTA offset + kernel-side addition" pattern is
+    explicitly CTA-ONLY (its Constraint: "If your offset would need to be per-dispatch-varying (RTA),
+    this pattern doesn't apply; capitulate"). No `TensorBinding` mechanism reproduces this.
+  - `slice_program_factory_rm.cpp:85-89` and `:143-152`: `reader_page_size` / `writer_page_size` =
+    host-computed per-shard page size (`shard_spec.shape[1] * element_size`) threaded as a runtime arg
+    into the sharded NOC path. Not carried by a tensor identity binding.
+
+- **`slice_program_factory_rm_sharded.cpp`** — BLOCKED.
+  - `slice_program_factory_rm_sharded.cpp:153-178`: the reader runtime args carry, per core, a
+    host-computed **physical NOC core-coordinate map** (`worker_core_from_logical_core` walk at `:142-147`,
+    emitted as noc-x/noc-y pairs at `:158-162`) plus per-shard in-shard stick ids and contiguous-chunk
+    descriptors. The kernel reads peer shards directly from these RTA-supplied NOC coordinates. A `ta::`
+    binding carries a tensor identity, not a host-computed shard-grid NOC layout; there is no
+    `TensorAccessor` path that reproduces the host-side shard-grid walk.
+  - `slice_program_factory_rm_sharded.cpp:265` and `:277`: both CBs set `.buffer = input.buffer()` /
+    `.buffer = output.buffer()` (borrowed-memory CBs onto the sharded tensors). Borrowed DFBs alone are
+    expressible, but the NOC-coordinate-map blocker above is dispositive.
+
+- **`slice_program_factory_rm_stride.cpp`** — BLOCKED.
+  - The base address itself is a clean `Buffer*` RTA (`:126`, `:145` reader; `:134`, `:158` writer), which
+    in isolation would be a Case-1 `TensorBinding`. The blocker is the **sharded read/write path**: the
+    reader (`kernels/dataflow/reader_multicore_slice_4d.cpp:157-158`, and the ND variant) and writer
+    (`writer_multicore_slice_4d.cpp:89`) pass the constructed `TensorAccessor` into the out-of-op
+    kernel-lib helper `noc_async_read_sharded` / `noc_async_write_sharded`, which drive sharded address
+    generation through the accessor's `dspec()` / `get_aligned_page_size()` / `get_noc_addr()`
+    (`common.hpp:235-249`). This is the same per-shard sharded family flagged as not reproducible through
+    a host-injected-metadata `ta::` accessor; consistent with the prior METAL-BLOCKED finding, it was not
+    forced. (If the framework later confirms the m2 `TensorAccessor` exposes the same sharded `dspec`
+    interface to out-of-op helpers, rm_stride is the most likely of the three to become portable — its
+    address is not pre-offset. Flagging for the framework/kernel-lib owners.)
+
+## Not built / not measured / not committed
+Per instructions. (This worktree has no build dir; cannot compile or measure here.)

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d_m2.cpp
@@ -1,0 +1,205 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+/*
+ * Metal 2.0 (ProgramSpec) port of reader_multicore_slice_4d.cpp. Used only by
+ * SliceRmStrideSpecProgramFactory; the legacy file is still consumed unchanged by
+ * SliceRmStrideProgramFactory::create_descriptor (reused by ccl/mesh_partition).
+ * Logic, loop bounds and numeric paths are UNCHANGED; only the access mechanism moves to
+ * named bindings:
+ *   src address (clean Buffer* RTA) -> ta::src (TensorAccessor, Case-1 binding)
+ *   CB id                           -> dfb::cb_in_out
+ *   all positional RTAs / CTAs      -> named args (get_arg(args::...))
+ *
+ * TTNN Slice Operation - Multi-Core Reader Kernel (4D Support)
+ *
+ * This kernel handles the input data reading phase of the slice operation for multi-core
+ * execution, implementing slice logic for 1D, 2D, 3D, and 4D tensors with work distribution
+ * across multiple cores for improved performance.
+ *
+ * Key Responsibilities:
+ * - Read assigned portion of input tensor data from DRAM using TensorAccessor
+ * - Apply slice logic (start, end, step) for all dimensions (N, D, H, W)
+ * - Handle different data types with proper element size calculations
+ * - Process assigned rows for this core based on work distribution
+ * - Output sliced rows to circular buffer for writer kernel consumption
+ *
+ * Architecture:
+ * - Uses TensorAccessor for efficient DRAM address generation
+ * - Processes data row-by-row for optimal memory access patterns
+ * - Supports slicing with configurable start, end, and step parameters for all dimensions
+ * - Handles 1D (W), 2D (H,W), 3D (D,H,W), and 4D (N,D,H,W) tensors
+ * - Multi-core work distribution: each core processes a subset of output rows
+ *
+ * Memory Management:
+ * - DRAM alignment: 32-byte boundaries for memory controller optimization
+ * - L1 alignment: 16-byte boundaries for L1 cache efficiency
+ * - Circular buffer: Double buffering for continuous data flow
+ *
+ * Data Type Support:
+ * - Element size determined at compile time for performance
+ * - Dynamic element size passed as runtime argument for flexibility
+ *
+ * Performance Optimizations:
+ * - Minimal branching in inner loops for consistent execution
+ * - Efficient memory copy operations using NOC async transfers
+ * - Cache-friendly access patterns aligned to memory hierarchy
+ * - Parallel processing with load balancing across multiple cores
+ *
+ * Compatible with: TTNN framework, ROW_MAJOR_LAYOUT tensors, 1D-4D dimensions, multi-core execution
+ */
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    // Runtime arguments for 4D slice support with multi-core work distribution
+    uint32_t tensor_rank = get_arg(args::tensor_rank);
+    uint32_t input_w = get_arg(args::input_w);
+    uint32_t input_h = get_arg(args::input_h);
+    uint32_t input_d = get_arg(args::input_d);
+    uint32_t input_n = get_arg(args::input_n);
+    uint32_t output_w = get_arg(args::output_w);
+    uint32_t output_h = get_arg(args::output_h);
+    uint32_t output_d = get_arg(args::output_d);
+    uint32_t output_n = get_arg(args::output_n);
+    uint32_t slice_start_w = get_arg(args::slice_start_w);
+    uint32_t slice_end_w = get_arg(args::slice_end_w);
+    uint32_t slice_step_w = get_arg(args::slice_step_w);
+    uint32_t slice_start_h = get_arg(args::slice_start_h);
+    uint32_t slice_end_h = get_arg(args::slice_end_h);
+    uint32_t slice_step_h = get_arg(args::slice_step_h);
+    uint32_t slice_start_d = get_arg(args::slice_start_d);
+    uint32_t slice_end_d = get_arg(args::slice_end_d);
+    uint32_t slice_step_d = get_arg(args::slice_step_d);
+    uint32_t slice_start_n = get_arg(args::slice_start_n);
+    uint32_t slice_end_n = get_arg(args::slice_end_n);
+    uint32_t slice_step_n = get_arg(args::slice_step_n);
+    uint32_t element_size = get_arg(args::element_size);
+    uint32_t num_rows_for_this_core = get_arg(args::num_rows_for_this_core);
+    uint32_t start_row_for_this_core = get_arg(args::start_row_for_this_core);
+
+    // Compile-time arguments
+    constexpr uint32_t cb_id_out = dfb::cb_in_out;
+    constexpr uint32_t compile_time_element_size = get_arg(args::compile_time_element_size);
+
+    // Calculate sizes - working with rows, not tiles
+    uint32_t input_bytes_per_row = input_w * element_size;  // Dynamic element size
+    uint32_t output_bytes_per_row = output_w * element_size;
+
+    // Set up TensorAccessor for input data - use row size as page size
+    const auto s0 = TensorAccessor(ta::src);
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_out(cb_id_out);
+
+    // Multi-core work distribution: this core processes rows [start_row_for_this_core, start_row_for_this_core +
+    // num_rows_for_this_core) We need to map these logical output row indices back to the corresponding (n,d,h)
+    // coordinates
+
+    uint32_t rows_processed = 0;
+    uint32_t current_logical_row = 0;
+    bool found_start = false;
+
+    // Set loop bounds based on tensor rank
+    uint32_t n_start = (tensor_rank >= 4) ? slice_start_n : 0;
+    uint32_t n_end = (tensor_rank >= 4) ? slice_end_n : 1;
+    uint32_t n_step = (tensor_rank >= 4) ? slice_step_n : 1;
+
+    uint32_t d_start = (tensor_rank >= 3) ? slice_start_d : 0;
+    uint32_t d_end = (tensor_rank >= 3) ? slice_end_d : 1;
+    uint32_t d_step = (tensor_rank >= 3) ? slice_step_d : 1;
+
+    uint32_t h_start = (tensor_rank >= 2) ? slice_start_h : 0;
+    uint32_t h_end = (tensor_rank >= 2) ? slice_end_h : 1;
+    uint32_t h_step = (tensor_rank >= 2) ? slice_step_h : 1;
+
+    // Multi-dimensional slicing with nested loops
+    // 4D: Batch dimension loop
+    for (uint32_t n = n_start; n < n_end && rows_processed < num_rows_for_this_core; n += n_step) {
+        // 3D: Depth dimension loop
+        for (uint32_t d = d_start; d < d_end && rows_processed < num_rows_for_this_core; d += d_step) {
+            // 2D: Height dimension loop
+            for (uint32_t h = h_start; h < h_end && rows_processed < num_rows_for_this_core; h += h_step) {
+                // Check if this logical row should be processed by this core
+                if (!found_start) {
+                    if (current_logical_row == start_row_for_this_core) {
+                        found_start = true;
+                    } else {
+                        current_logical_row++;
+                        if (tensor_rank == 1) {
+                            break;  // For 1D, exit after checking once
+                        }
+                        continue;
+                    }
+                }
+
+                if (rows_processed >= num_rows_for_this_core) {
+                    break;
+                }
+
+                // Calculate input row index based on tensor rank
+                uint32_t input_row_idx;
+                if (tensor_rank == 1) {
+                    input_row_idx = 0;  // Single row for 1D
+                } else if (tensor_rank == 2) {
+                    input_row_idx = h;
+                } else if (tensor_rank == 3) {
+                    input_row_idx = d * input_h + h;
+                } else {  // 4D
+                    input_row_idx = n * input_d * input_h + d * input_h + h;
+                }
+
+                cb_out.reserve_back(1);
+                uint32_t l1_write_addr = cb_out.get_write_ptr();
+
+                // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
+                // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.
+                tt::data_movement::common::noc_async_read_sharded(
+                    l1_write_addr, s0, input_row_idx, /*offset=*/0, /*size=*/input_bytes_per_row);
+                noc.async_read_barrier();
+
+                // Now slice the row according to width slice parameters
+                // Copy sliced elements to the beginning of the buffer
+                if (slice_start_w != 0 || slice_step_w != 1 || slice_end_w != input_w) {
+                    // Need to reorganize the data in the buffer
+                    volatile tt_l1_ptr uint8_t* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+                    volatile tt_l1_ptr uint8_t* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+
+                    uint32_t out_col = 0;
+                    for (uint32_t input_col = slice_start_w; input_col < slice_end_w && out_col < output_w;
+                         input_col += slice_step_w) {
+                        // Copy element by element for the slice
+                        for (uint32_t byte_idx = 0; byte_idx < element_size; ++byte_idx) {
+                            dst_ptr[out_col * element_size + byte_idx] = src_ptr[input_col * element_size + byte_idx];
+                        }
+                        out_col++;
+                    }
+                }
+
+                cb_out.push_back(1);
+                rows_processed++;
+                current_logical_row++;
+
+                // Early exit for 1D tensors
+                if (tensor_rank == 1) {
+                    break;
+                }
+            }
+            // Early exit for 2D tensors
+            if (tensor_rank <= 2) {
+                break;
+            }
+        }
+        // Early exit for 3D tensors
+        if (tensor_rank <= 3) {
+            break;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd_m2.cpp
@@ -1,0 +1,201 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Metal 2.0 (ProgramSpec) port of reader_multicore_slice_nd.cpp. Used only by
+ * SliceRmStrideSpecProgramFactory; the legacy file is still consumed unchanged by
+ * SliceRmStrideProgramFactory::create_descriptor (reused by ccl/mesh_partition).
+ * Logic, loop bounds and numeric paths are UNCHANGED; only the access mechanism moves to
+ * named bindings:
+ *   src address (clean Buffer* RTA) -> ta::src (TensorAccessor, Case-1 binding)
+ *   CB id                           -> dfb::cb_in_out
+ *   leading scalar RTAs / CTAs      -> named args (get_arg(args::...))
+ *   the five per-dim arrays (input_dims/output_dims/slice_starts/ends/steps, each `tensor_rank`
+ *     long) -> runtime varargs, same concatenated layout. The legacy kernel indexed these via
+ *     tt_l1_ptr pointers into the RTA region; the m2 vararg API exposes value getters only, so
+ *     the arrays are copied once into local fixed-size stack arrays (the legacy kernel already
+ *     caps rank at 16 via coords[16]) and indexed there. Arithmetic is identical.
+ *
+ * TTNN Slice Operation - Multi-Core Reader Kernel (N-Dimensional Support)
+ *
+ * This kernel handles the input data reading phase of the slice operation for multi-core
+ * execution, implementing slice logic for N-dimensional tensors (1D, 2D, 3D, 4D, 5D, etc.)
+ * with work distribution across multiple cores for improved performance.
+ *
+ * Key Responsibilities:
+ * - Read assigned portion of input tensor data from DRAM using TensorAccessor
+ * - Apply slice logic (start, end, step) for all dimensions dynamically
+ * - Handle different data types with proper element size calculations
+ * - Process assigned rows for this core based on work distribution
+ * - Output sliced rows to circular buffer for writer kernel consumption
+ *
+ * Architecture:
+ * - Uses TensorAccessor for efficient DRAM address generation
+ * - Processes data row-by-row for optimal memory access patterns
+ * - Supports slicing with configurable start, end, and step parameters for all dimensions
+ * - Handles 1D, 2D, 3D, 4D, 5D+ tensors with dynamic nested loops
+ * - Multi-core work distribution: each core processes a subset of output rows
+ *
+ * Memory Management:
+ * - DRAM alignment: 32-byte boundaries for memory controller optimization
+ * - L1 alignment: 16-byte boundaries for L1 cache efficiency
+ * - Circular buffer: Double buffering for continuous data flow
+ *
+ * Data Type Support:
+ * - Element size determined at compile time for performance
+ * - Dynamic element size passed as runtime argument for flexibility
+ *
+ * Performance Optimizations:
+ * - Minimal branching in inner loops for consistent execution
+ * - Efficient memory copy operations using NOC async transfers
+ * - Cache-friendly access patterns aligned to memory hierarchy
+ * - Parallel processing with load balancing across multiple cores
+ *
+ * N-Dimensional Processing:
+ * - Dynamic nested loops based on tensor rank
+ * - Generic address calculation using stride-based indexing
+ * - Row concept: for rank R, rows = product(dims[0:R-1]), width = dims[R-1]
+ *
+ * Compatible with: TTNN framework, ROW_MAJOR_LAYOUT tensors, 1D-ND dimensions, multi-core execution
+ */
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    // Runtime arguments - first get basic parameters
+    uint32_t tensor_rank = get_arg(args::tensor_rank);
+    uint32_t element_size = get_arg(args::element_size);
+    uint32_t num_rows_for_this_core = get_arg(args::num_rows_for_this_core);
+    uint32_t start_row_for_this_core = get_arg(args::start_row_for_this_core);
+
+    // Compile-time arguments
+    constexpr uint32_t cb_id_out = dfb::cb_in_out;
+    constexpr uint32_t compile_time_element_size = get_arg(args::compile_time_element_size);
+
+    // Per-dim arrays from runtime varargs.
+    // Layout: input_dims[rank], output_dims[rank], slice_starts[rank], slice_ends[rank], slice_steps[rank]
+    // (Same order as the legacy RTA layout; copied into local stack arrays — the legacy kernel
+    // already caps rank at 16 via coords[16].)
+    uint32_t input_dims[16];
+    uint32_t output_dims[16];
+    uint32_t slice_starts[16];
+    uint32_t slice_ends[16];
+    uint32_t slice_steps[16];
+    for (uint32_t i = 0; i < tensor_rank; ++i) {
+        input_dims[i] = get_vararg(i);
+        output_dims[i] = get_vararg(tensor_rank + i);
+        slice_starts[i] = get_vararg(2 * tensor_rank + i);
+        slice_ends[i] = get_vararg(3 * tensor_rank + i);
+        slice_steps[i] = get_vararg(4 * tensor_rank + i);
+    }
+
+    // Calculate sizes - working with rows, not tiles
+    uint32_t input_bytes_per_row = input_dims[tensor_rank - 1] * element_size;
+    uint32_t output_bytes_per_row = output_dims[tensor_rank - 1] * element_size;
+
+    // Set up TensorAccessor for input data - use row size as page size
+    const auto s0 = TensorAccessor(ta::src);
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_out(cb_id_out);
+
+    // Multi-core work distribution using iterative approach with explicit coordinate tracking
+    // Track current position in N-dimensional space
+    uint32_t coords[16];  // Support up to 16 dimensions (reasonable limit)
+    for (uint32_t i = 0; i < tensor_rank; ++i) {
+        coords[i] = slice_starts[i];
+    }
+
+    uint32_t rows_processed = 0;
+    uint32_t current_logical_row = 0;
+    bool found_start = false;
+    bool more_iterations = true;
+
+    while (more_iterations && rows_processed < num_rows_for_this_core) {
+        // Check if this logical row should be processed by this core
+        bool should_process_row = false;
+        if (!found_start) {
+            if (current_logical_row == start_row_for_this_core) {
+                found_start = true;
+                should_process_row = true;
+            }
+        } else {
+            should_process_row = true;
+        }
+
+        if (should_process_row && rows_processed < num_rows_for_this_core) {
+            // Calculate input row index from coordinates (exclude last dimension)
+            uint32_t input_row_idx = 0;
+            if (tensor_rank > 1) {
+                for (int32_t dim = 0; dim < (int32_t)(tensor_rank - 1); ++dim) {
+                    uint32_t stride = 1;
+                    for (int32_t d = dim + 1; d < (int32_t)(tensor_rank - 1); ++d) {
+                        stride *= input_dims[d];
+                    }
+                    input_row_idx += coords[dim] * stride;
+                }
+            }
+
+            cb_out.reserve_back(1);
+            uint32_t l1_write_addr = cb_out.get_write_ptr();
+
+            // noc_async_read_sharded splits the read across shards for B/W-sharded inputs;
+            // falls through to a single noc_async_read for interleaved / HEIGHT-sharded.
+            tt::data_movement::common::noc_async_read_sharded(
+                l1_write_addr, s0, input_row_idx, /*offset=*/0, /*size=*/input_bytes_per_row);
+            noc.async_read_barrier();
+
+            // Now slice the row according to width slice parameters (last dimension)
+            uint32_t last_dim = tensor_rank - 1;
+            if (slice_starts[last_dim] != 0 || slice_steps[last_dim] != 1 ||
+                slice_ends[last_dim] != input_dims[last_dim]) {
+                // Need to reorganize the data in the buffer
+                volatile tt_l1_ptr uint8_t* src_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+                volatile tt_l1_ptr uint8_t* dst_ptr = reinterpret_cast<volatile tt_l1_ptr uint8_t*>(l1_write_addr);
+
+                uint32_t out_col = 0;
+                for (uint32_t input_col = slice_starts[last_dim];
+                     input_col < slice_ends[last_dim] && out_col < output_dims[last_dim];
+                     input_col += slice_steps[last_dim]) {
+                    // Copy element by element for the slice
+                    for (uint32_t byte_idx = 0; byte_idx < element_size; ++byte_idx) {
+                        dst_ptr[out_col * element_size + byte_idx] = src_ptr[input_col * element_size + byte_idx];
+                    }
+                    out_col++;
+                }
+            }
+
+            cb_out.push_back(1);
+            rows_processed++;
+        }
+
+        current_logical_row++;
+
+        // Advance to next coordinate combination (skip last dimension)
+        bool carry = true;
+        for (int32_t dim = (int32_t)(tensor_rank - 2); dim >= 0 && carry; --dim) {
+            coords[dim] += slice_steps[dim];
+            if (coords[dim] < slice_ends[dim]) {
+                carry = false;
+            } else {
+                coords[dim] = slice_starts[dim];
+            }
+        }
+        if (carry) {
+            more_iterations = false;
+        }
+
+        // Early exit for 1D tensors
+        if (tensor_rank == 1) {
+            break;
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_m2.cpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 (ProgramSpec) port of reader_unary_unpad_dims_interleaved_start_id.cpp.
+// Used only by SliceTileSpecProgramFactory, so it is a local fork of the legacy reader
+// (the legacy file is still consumed unchanged by SliceTileProgramFactory::create_descriptor,
+// which ccl/mesh_partition reuses). Logic, loop bounds and numeric paths are UNCHANGED;
+// only the access mechanism moves to named bindings:
+//   src address    -> ta::src (TensorAccessor)
+//   CB id          -> dfb::cb_in
+//   start_id/num_tiles named RTAs -> get_arg(args::...)
+//   per-dim id_per_dim          -> runtime varargs (get_vararg)
+//   src_addr/num_unpadded/num_padded common section -> common varargs (get_common_vararg)
+//
+// Vararg note: the legacy kernel mutated the id_per_dim slots in the RTA buffer in place.
+// The m2 vararg API exposes value getters only (no writable pointer into the vararg
+// region), so the per-dim running counters are copied into a local stack array and mutated
+// there. This is purely an access-mechanism change; the counter arithmetic is identical.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_in0 = dfb::cb_in;
+    constexpr uint32_t num_dims = get_arg(args::num_dims);
+
+    // Common varargs layout (after the single TensorBinding section for ta::src):
+    //   [num_unpadded_tiles_per_dim[0..num_dims-1], num_padded_tiles_per_dim[0..num_dims-1]]
+    // num_unpadded starts at common vararg index 0, num_padded at index num_dims.
+
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t num_tiles = get_arg(args::num_tiles);
+
+    // Local copy of the per-dim running indices (runtime varargs 0..num_dims-1).
+    uint32_t id_per_dim[num_dims];
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        id_per_dim[j] = get_vararg(j);
+    }
+
+    // In and out are assumed to be same dataformat
+    const auto s0 = TensorAccessor(ta::src);
+
+    // Create objects for Device 2.0 API
+    CircularBuffer cb_in0(cb_id_in0);
+    Noc noc;
+
+    // Get tile size from CB interface
+    const uint32_t tile_size = cb_in0.get_tile_size();
+
+    uint32_t src_tile_id = start_id;
+
+    for (uint32_t i = 0; i < num_tiles; ++i) {
+        // Copy Input
+        cb_in0.reserve_back(1);
+        noc.async_read(s0, cb_in0, tile_size, {.page_id = src_tile_id}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in0.push_back(1);
+        src_tile_id++;
+        for (uint32_t j = 0; j < num_dims; ++j) {
+            id_per_dim[j]++;
+            if (id_per_dim[j] == get_common_vararg(j)) {
+                id_per_dim[j] = 0;
+                src_tile_id += get_common_vararg(num_dims + j);
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_unary_unpad_dims_interleaved_start_id_tensor_args_m2.cpp
@@ -1,0 +1,141 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 (ProgramSpec) port of reader_unary_unpad_dims_interleaved_start_id_tensor_args.cpp.
+// Used only by SliceTileTensorArgsSpecProgramFactory, so it is a local fork of the legacy reader
+// (the legacy file remains in place for the legacy descriptor path). Logic, loop bounds and
+// numeric paths are UNCHANGED; only the access mechanism moves to named bindings:
+//   src / start / end addresses -> ta::src / ta::start / ta::end (TensorAccessor)
+//   CB ids                      -> dfb::cb_in / dfb::cb_tensor
+//   num_dims/tile_width/tile_height CTAs -> get_arg(args::...)
+//   start_id/num_tiles named per-core RTAs -> get_arg(args::...)
+//   per-dim id_per_dim                   -> runtime varargs (get_vararg)
+//   num_unpadded/num_padded/input_shape common section -> common varargs (get_common_vararg)
+//
+// Vararg note: the legacy kernel mutated the id_per_dim slots in the RTA buffer in place.
+// The m2 vararg API exposes value getters only (no writable pointer into the vararg region),
+// so the per-dim running counters are copied into a local stack array and mutated there. This
+// is purely an access-mechanism change; the counter arithmetic is identical.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr uint32_t cb_id_in0 = dfb::cb_in;
+    constexpr uint32_t cb_id_tensor = dfb::cb_tensor;
+    constexpr uint32_t num_dims = get_arg(args::num_dims);
+    const uint32_t tile_width = get_arg(args::tile_width);
+    const uint32_t tile_height = get_arg(args::tile_height);
+
+    // Common varargs layout (after the src/start/end TensorBinding sections):
+    //   [num_unpadded_tiles_per_dim[0..num_dims-1],
+    //    num_padded_tiles_per_dim[0..num_dims-1],
+    //    input_shape[0..num_dims-1]]
+    // num_unpadded starts at common vararg index 0, num_padded at num_dims, input_shape at 2*num_dims.
+
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t num_tiles = get_arg(args::num_tiles);
+
+    const auto s0 = TensorAccessor(ta::src);
+
+    // Create objects for Device 2.0 API
+    CircularBuffer cb_in0(cb_id_in0);
+    CircularBuffer cb_tensor(cb_id_tensor);
+    Noc noc;
+
+    // Get tile size from CB interface
+    const uint32_t tile_size = cb_in0.get_tile_size();
+
+    // Create TensorAccessors for start and end tensors
+    const auto start_tensor_accessor = TensorAccessor(ta::start);
+    const auto end_tensor_accessor = TensorAccessor(ta::end);
+
+    // Read start and end indices from tensors using TensorAccessor
+    uint32_t start_indices[num_dims];
+    uint32_t end_indices[num_dims];
+
+    // Read start tensor data using separate circular buffer
+    cb_tensor.reserve_back(1);
+    uint32_t start_buffer_l1_addr = cb_tensor.get_write_ptr();
+    noc.async_read(start_tensor_accessor, cb_tensor, tile_size, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+
+    volatile tt_l1_ptr uint32_t* start_data = (volatile tt_l1_ptr uint32_t*)start_buffer_l1_addr;
+
+    for (uint32_t i = 0; i < num_dims; i++) {
+        start_indices[i] = start_data[i];
+    }
+    cb_tensor.pop_front(1);
+
+    // Read end tensor data using separate circular buffer
+    cb_tensor.reserve_back(1);
+    uint32_t end_buffer_l1_addr = cb_tensor.get_write_ptr();
+    noc.async_read(end_tensor_accessor, cb_tensor, tile_size, {.page_id = 0}, {.offset_bytes = 0});
+    noc.async_read_barrier();
+
+    volatile tt_l1_ptr uint32_t* end_data = (volatile tt_l1_ptr uint32_t*)end_buffer_l1_addr;
+
+    for (uint32_t i = 0; i < num_dims; i++) {
+        end_indices[i] = end_data[i];
+    }
+    cb_tensor.pop_front(1);
+
+    uint32_t start_offset = 0;
+
+    if (num_dims >= 2) {
+        uint32_t start_h_tiles = start_indices[num_dims - 2] / tile_height;
+        uint32_t start_w_tiles = start_indices[num_dims - 1] / tile_width;
+
+        // input_shape lives in the common varargs starting at index 2 * num_dims.
+        uint32_t input_width = get_common_vararg(2 * num_dims + (num_dims - 1));
+        uint32_t input_height = get_common_vararg(2 * num_dims + (num_dims - 2));
+        uint32_t num_pages_width = input_width / tile_width;
+
+        start_offset += start_h_tiles * num_pages_width + start_w_tiles;
+
+        if (num_dims > 2) {
+            uint32_t upper_dims_offset = 0;
+            uint32_t multiplier = (input_height / tile_height) * num_pages_width;
+
+            for (int32_t i = num_dims - 3; i >= 0; i--) {
+                upper_dims_offset = upper_dims_offset * get_common_vararg(2 * num_dims + i) + start_indices[i];
+            }
+            start_offset += upper_dims_offset * multiplier;
+        }
+    }
+
+    // Add the calculated offset to the base start_id
+    uint32_t src_tile_id = start_id + start_offset;
+
+    // Local copy of the per-dim running indices (runtime varargs 0..num_dims-1).
+    uint32_t id_per_dim[num_dims];
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        id_per_dim[j] = get_vararg(j);
+    }
+
+    for (uint32_t i = 0; i < num_tiles; ++i) {
+        uint32_t old_src_tile_id = src_tile_id;
+
+        cb_in0.reserve_back(1);
+        noc.async_read(s0, cb_in0, tile_size, {.page_id = src_tile_id}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb_in0.push_back(1);
+
+        src_tile_id++;
+        for (uint32_t j = 0; j < num_dims; ++j) {
+            id_per_dim[j]++;
+            if (id_per_dim[j] == get_common_vararg(j)) {
+                id_per_dim[j] = 0;
+                src_tile_id += get_common_vararg(num_dims + j);
+
+            } else {
+                break;
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/slice_reader_unary_unpad_dims_rm_sharded_m2.cpp
@@ -1,0 +1,93 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 (ProgramSpec) port of slice_reader_unary_unpad_dims_rm_sharded.cpp.
+// Used only by SliceRmShardedSpecProgramFactory, so it is a local fork of the legacy reader
+// (the legacy file is still consumed unchanged by SliceRmShardedProgramFactory::create_descriptor,
+// which ccl/mesh_partition reuses). Logic, loop bounds and numeric paths are UNCHANGED; only the
+// access mechanism moves to named bindings.
+//
+// This is a Case-2 (bridge) port: the kernel performs a hand-rolled NoC walk over a
+// host-computed physical core-coordinate map (read_noc_x/read_noc_y) and reads peer shards by
+// raw {noc_x, noc_y, addr}. The input/output shard L1 base addresses are obtained from the two
+// borrowed-memory DFBs (cb_in / cb_out, .borrowed_from src / dst), exactly as the legacy kernel
+// obtained them from the borrowed CBs via get_write_ptr(). The raw NoC arithmetic is kept
+// verbatim; only the resource construction and arg retrieval change:
+//   CB ids               -> dfb::cb_in / dfb::cb_out (borrowed onto the src/dst tensors)
+//   stick_size CTAs      -> named CTAs (get_arg(args::...))
+//   per-core NoC map / chunk descriptors -> runtime varargs (get_vararg), identical layout
+//
+// Vararg note: the legacy kernel indexed the per-core RTA region directly through tt_l1_ptr
+// pointers computed from num_cores_read. The m2 vararg API exposes value getters only, so the
+// same indices are read with get_vararg(i); the arithmetic that derives each offset is unchanged.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr uint32_t stick_size_padded = get_arg(args::stick_size_padded);
+    constexpr uint32_t stick_size_unpadded = get_arg(args::stick_size_unpadded);
+    constexpr uint32_t num_sticks_unpadded = get_arg(args::num_sticks_unpadded);
+
+    // Per-core runtime varargs layout (identical to the legacy RTA layout):
+    //   [0]                          : num_cores_read
+    //   [1 + i*2 .. ], i in [0,num_cores_read) : read_noc_x[i], read_noc_y[i]
+    //   [1 + num_cores_read*2 + i]   : num_stick_chunks[i]
+    //   [1 + num_cores_read*3 ..]    : (chunk_start_id, chunk_num_sticks) pairs
+    const uint32_t num_cores_read = get_vararg(0);
+    const uint32_t noc_xy_base = 1;
+    const uint32_t num_chunks_base = 1 + num_cores_read * 2;
+    const uint32_t chunk_base = 1 + num_cores_read * 3;
+
+    constexpr uint32_t cb_id_in0 = dfb::cb_in;
+    constexpr uint32_t cb_id_out0 = dfb::cb_out;
+
+    Noc noc;
+    // Create CircularBuffers for Device 2.0 API
+    CircularBuffer cb_in(cb_id_in0);
+    CircularBuffer cb_out(cb_id_out0);
+
+    cb_out.reserve_back(num_sticks_unpadded);
+    uint32_t l1_read_addr = cb_in.get_write_ptr();
+    uint32_t l1_write_addr = cb_out.get_write_ptr();
+
+    uint32_t chunk_ptr_offset = 0;
+    uint32_t read_noc_xy_ptr_offset = 0;
+
+    for (uint32_t curr_core = 0; curr_core < num_cores_read; ++curr_core) {
+        const uint32_t src_noc_x = get_vararg(noc_xy_base + read_noc_xy_ptr_offset);
+        const uint32_t src_noc_y = get_vararg(noc_xy_base + read_noc_xy_ptr_offset + 1);
+
+        uint32_t curr_core_num_chunks = get_vararg(num_chunks_base + curr_core);
+
+        for (uint32_t curr_chunk = 0; curr_chunk < curr_core_num_chunks; ++curr_chunk) {
+            uint32_t curr_start_id = get_vararg(chunk_base + chunk_ptr_offset);
+            uint32_t curr_num_sticks = get_vararg(chunk_base + chunk_ptr_offset + 1);
+
+            uint32_t l1_read_offset = curr_start_id * stick_size_unpadded;
+            uint32_t read_data_size_bytes = curr_num_sticks * stick_size_unpadded;
+
+            CoreLocalMem<uint32_t> dst(l1_write_addr);
+            noc.async_read(
+                UnicastEndpoint{},
+                dst,
+                read_data_size_bytes,
+                {.noc_x = src_noc_x, .noc_y = src_noc_y, .addr = l1_read_addr + l1_read_offset},
+                {.offset_bytes = 0});
+            l1_write_addr += read_data_size_bytes;
+            chunk_ptr_offset += 2;
+        }
+
+        read_noc_xy_ptr_offset += 2;
+    }
+
+    noc.async_read_barrier();
+    cb_out.push_back(num_sticks_unpadded);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d_m2.cpp
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Metal 2.0 (ProgramSpec) port of writer_multicore_slice_4d.cpp. Used only by
+ * SliceRmStrideSpecProgramFactory; the legacy file is still consumed unchanged by
+ * SliceRmStrideProgramFactory::create_descriptor (reused by ccl/mesh_partition).
+ * Logic, loop bounds and numeric paths are UNCHANGED; only the access mechanism moves to
+ * named bindings:
+ *   dst address (clean Buffer* RTA) -> ta::dst (TensorAccessor, Case-1 binding)
+ *   CB id                           -> dfb::cb_in_out
+ *   all positional RTAs / CTAs      -> named args (get_arg(args::...))
+ *
+ * TTNN Slice Operation - Multi-Core Writer Kernel (4D Support)
+ *
+ * This kernel handles the output data writing phase of the slice operation for multi-core
+ * execution, writing sliced tensor data from circular buffer to output tensor memory.
+ * Supports 1D, 2D, 3D, and 4D tensors with work distribution across cores.
+ *
+ * Key Responsibilities:
+ * - Read sliced data from circular buffer (produced by reader kernel)
+ * - Write assigned portion of output data to DRAM using TensorAccessor
+ * - Handle different tensor dimensions with proper address calculations
+ * - Support different data types with proper element size handling
+ * - Process assigned rows for this core based on work distribution
+ *
+ * Architecture:
+ * - Uses TensorAccessor for efficient DRAM address generation
+ * - Processes data row-by-row to match reader kernel output
+ * - Simple sequential write pattern for optimal memory controller utilization
+ * - Multi-core work distribution: each core writes a subset of output rows
+ *
+ * Memory Management:
+ * - DRAM alignment: 32-byte boundaries for memory controller optimization
+ * - L1 alignment: 16-byte boundaries for L1 cache efficiency
+ * - Circular buffer: Double buffering synchronized with reader kernel
+ *
+ * Data Type Support:
+ * - Element size determined at compile time for performance
+ * - Dynamic element size passed as runtime argument for flexibility
+ *
+ * Performance Optimizations:
+ * - Minimal synchronization overhead with reader kernel
+ * - Efficient memory write operations using NOC async transfers
+ * - Sequential access patterns optimized for DRAM controllers
+ * - Parallel processing with load balancing across multiple cores
+ *
+ * Compatible with: TTNN framework, ROW_MAJOR_LAYOUT tensors, 1D-4D dimensions, multi-core execution
+ */
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    // Runtime arguments for 4D slice support with multi-core work distribution
+    uint32_t tensor_rank = get_arg(args::tensor_rank);
+    uint32_t output_w = get_arg(args::output_w);
+    uint32_t output_h = get_arg(args::output_h);
+    uint32_t output_d = get_arg(args::output_d);
+    uint32_t output_n = get_arg(args::output_n);
+    uint32_t element_size = get_arg(args::element_size);
+    uint32_t num_rows_for_this_core = get_arg(args::num_rows_for_this_core);
+    uint32_t start_row_for_this_core = get_arg(args::start_row_for_this_core);
+
+    // Compile-time arguments
+    constexpr uint32_t cb_id_in = dfb::cb_in_out;
+    constexpr uint32_t compile_time_element_size = get_arg(args::compile_time_element_size);
+
+    // Calculate sizes - working with rows, not tiles
+    uint32_t output_bytes_per_row = output_w * element_size;  // Dynamic element size
+
+    // Set up TensorAccessor for output data - use row size as page size
+    const auto s0 = TensorAccessor(ta::dst);
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_in(cb_id_in);
+
+    // Multi-core work distribution: this core writes rows starting from start_row_for_this_core
+    // Write each row from circular buffer to output tensor at the correct logical position
+    for (uint32_t local_row = 0; local_row < num_rows_for_this_core; ++local_row) {
+        cb_in.wait_front(1);
+        uint32_t l1_read_addr = cb_in.get_read_ptr();
+
+        // Calculate global output row index for this local row
+        uint32_t global_output_row = start_row_for_this_core + local_row;
+
+        // noc_async_write_sharded splits the write across shards for B/W-sharded outputs;
+        // falls through to a single noc_async_write for interleaved / HEIGHT-sharded.
+        tt::data_movement::common::noc_async_write_sharded(
+            l1_read_addr, s0, global_output_row, /*offset=*/0, /*size=*/output_bytes_per_row);
+        noc.async_writes_flushed();
+
+        cb_in.pop_front(1);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd_m2.cpp
@@ -1,0 +1,113 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+/*
+ * Metal 2.0 (ProgramSpec) port of writer_multicore_slice_nd.cpp. Used only by
+ * SliceRmStrideSpecProgramFactory; the legacy file is still consumed unchanged by
+ * SliceRmStrideProgramFactory::create_descriptor (reused by ccl/mesh_partition).
+ * Logic, loop bounds and numeric paths are UNCHANGED; only the access mechanism moves to
+ * named bindings:
+ *   dst address (clean Buffer* RTA) -> ta::dst (TensorAccessor, Case-1 binding)
+ *   CB id                           -> dfb::cb_in_out
+ *   leading scalar RTAs / CTAs      -> named args (get_arg(args::...))
+ *   the output_dims[tensor_rank] array -> runtime varargs (only output_dims[tensor_rank-1] is
+ *     read; copied to a local stack array to preserve the legacy index, identical arithmetic).
+ *
+ * TTNN Slice Operation - Multi-Core Writer Kernel (N-Dimensional Support)
+ *
+ * This kernel handles the output data writing phase of the slice operation for multi-core
+ * execution, writing sliced tensor data from circular buffer to output tensor memory.
+ * Supports 1D, 2D, 3D, 4D, 5D, etc. tensors with work distribution across cores.
+ *
+ * Key Responsibilities:
+ * - Read sliced data from circular buffer (produced by reader kernel)
+ * - Write assigned portion of output data to DRAM using TensorAccessor
+ * - Handle different tensor dimensions with proper address calculations
+ * - Support different data types with proper element size handling
+ * - Process assigned rows for this core based on work distribution
+ *
+ * Architecture:
+ * - Uses TensorAccessor for efficient DRAM address generation
+ * - Processes data row-by-row to match reader kernel output
+ * - Simple sequential write pattern for optimal memory controller utilization
+ * - Multi-core work distribution: each core writes a subset of output rows
+ *
+ * Memory Management:
+ * - DRAM alignment: 32-byte boundaries for memory controller optimization
+ * - L1 alignment: 16-byte boundaries for L1 cache efficiency
+ * - Circular buffer: Double buffering synchronized with reader kernel
+ *
+ * Data Type Support:
+ * - Element size determined at compile time for performance
+ * - Dynamic element size passed as runtime argument for flexibility
+ *
+ * Performance Optimizations:
+ * - Minimal synchronization overhead with reader kernel
+ * - Efficient memory write operations using NOC async transfers
+ * - Sequential access patterns optimized for DRAM controllers
+ * - Parallel processing with load balancing across multiple cores
+ *
+ * N-Dimensional Processing:
+ * - Row concept: for rank R, rows = product(dims[0:R-1]), width = dims[R-1]
+ * - Each core writes a contiguous range of logical output rows
+ * - Simple linear mapping from logical row index to physical address
+ *
+ * Compatible with: TTNN framework, ROW_MAJOR_LAYOUT tensors, 1D-ND dimensions, multi-core execution
+ */
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    // Runtime arguments - first get basic parameters
+    uint32_t tensor_rank = get_arg(args::tensor_rank);
+    uint32_t element_size = get_arg(args::element_size);
+    uint32_t num_rows_for_this_core = get_arg(args::num_rows_for_this_core);
+    uint32_t start_row_for_this_core = get_arg(args::start_row_for_this_core);
+
+    // Compile-time arguments
+    constexpr uint32_t cb_id_in = dfb::cb_in_out;
+    constexpr uint32_t compile_time_element_size = get_arg(args::compile_time_element_size);
+
+    // Get dimension array from runtime varargs.
+    // Layout: output_dims[rank] (copied into a local stack array; legacy caps rank at 16).
+    uint32_t output_dims[16];
+    for (uint32_t i = 0; i < tensor_rank; ++i) {
+        output_dims[i] = get_vararg(i);
+    }
+
+    // Calculate sizes - working with rows, not tiles
+    uint32_t output_bytes_per_row = output_dims[tensor_rank - 1] * element_size;
+
+    // Set up TensorAccessor for output data - use row size as page size
+    const auto s0 = TensorAccessor(ta::dst);
+
+    Noc noc;
+    // Create CircularBuffer for Device 2.0 API
+    CircularBuffer cb_in(cb_id_in);
+
+    // Multi-core work distribution: this core writes rows starting from start_row_for_this_core
+    // Write each row from circular buffer to output tensor at the correct logical position
+    for (uint32_t local_row = 0; local_row < num_rows_for_this_core; ++local_row) {
+        cb_in.wait_front(1);
+        uint32_t l1_read_addr = cb_in.get_read_ptr();
+
+        // Calculate global output row index for this local row
+        uint32_t global_output_row = start_row_for_this_core + local_row;
+
+        // noc_async_write_sharded splits the write across shards for B/W-sharded outputs;
+        // falls through to a single noc_async_write for interleaved / HEIGHT-sharded.
+        tt::data_movement::common::noc_async_write_sharded(
+            l1_read_addr, s0, global_output_row, /*offset=*/0, /*size=*/output_bytes_per_row);
+        noc.async_writes_flushed();
+
+        cb_in.pop_front(1);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_unary_interleaved_start_id_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_unary_interleaved_start_id_m2.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 (ProgramSpec) port of writer_unary_interleaved_start_id.cpp.
+// Used only by SliceTileSpecProgramFactory, so it is a local fork of the legacy writer
+// (the legacy file is still consumed unchanged by SliceTileProgramFactory::create_descriptor,
+// which ccl/mesh_partition reuses). Logic, #ifdefs, loop bounds and numeric paths are
+// UNCHANGED; only the access mechanism moves to named bindings:
+//   dst address  -> ta::dst (TensorAccessor)
+//   CB id        -> dfb::cb_out
+//   num_pages/start_id positional RTAs -> get_arg(args::...)
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t num_pages = get_arg(args::num_pages);
+    const uint32_t start_id = get_arg(args::start_id);
+
+    constexpr uint32_t cb_id_out = dfb::cb_out;
+
+    // Create objects for Device 2.0 API
+    CircularBuffer cb_out(cb_id_out);
+
+    // Get page size from CB interface (works for both TILE and ROW_MAJOR layouts)
+    const uint32_t page_bytes = cb_out.get_tile_size();
+    Noc noc;
+
+#ifdef OUT_SHARDED
+    cb_out.wait_front(num_pages);
+#else
+
+    // single-page ublocks (works for both TILE and ROW_MAJOR layouts)
+    constexpr uint32_t onepage = 1;
+
+    const auto s = TensorAccessor(ta::dst);
+
+#ifdef BACKWARDS
+    uint32_t end_id = start_id - num_pages;
+    for (uint32_t i = start_id; i != end_id; --i) {
+#else
+    uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+#endif
+        cb_out.wait_front(onepage);
+        noc.async_write(cb_out, s, page_bytes, {.offset_bytes = 0}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb_out.pop_front(onepage);
+    }
+    noc.async_write_barrier();
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -268,7 +268,10 @@ SliceDeviceOperation::program_factory_t SliceDeviceOperation::select_program_fac
     const auto& input = tensor_args.input;
 
     if (args.use_tensor_args) {
-        return SliceTileTensorArgsProgramFactory{};
+        // slice's own dispatch uses the Metal 2.0 (ProgramSpec) factory; ccl/mesh_partition still
+        // reuses the legacy SliceTileTensorArgsProgramFactory::create_descriptor directly (see
+        // mesh_partition_program_factory.cpp), so both factory structs are retained.
+        return SliceTileTensorArgsSpecProgramFactory{};
     }
 
     // Check if we have step != 1

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -291,7 +291,10 @@ SliceDeviceOperation::program_factory_t SliceDeviceOperation::select_program_fac
         return SliceRmProgramFactory{};
     }
     // Layout::TILE — TensorAccessor at tile granularity handles all sharded buffer types natively.
-    return SliceTileProgramFactory{};
+    // slice's own dispatch uses the Metal 2.0 (ProgramSpec) factory; ccl/mesh_partition still
+    // reuses the legacy SliceTileProgramFactory::create_descriptor directly (see
+    // mesh_partition_program_factory.cpp), so both factory structs are retained.
+    return SliceTileSpecProgramFactory{};
 }
 
 tt::tt_metal::operation::OpPerformanceModelGeneral<SliceDeviceOperation::tensor_return_value_t>

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.cpp
@@ -286,10 +286,16 @@ SliceDeviceOperation::program_factory_t SliceDeviceOperation::select_program_fac
             args.output_mem_config.is_sharded() &&
             args.output_mem_config.memory_layout() == tt::tt_metal::TensorMemoryLayout::HEIGHT_SHARDED && !has_step;
         if (height_sharded_in_out_no_step) {
-            return SliceRmShardedProgramFactory{};
+            // slice's own dispatch uses the Metal 2.0 (ProgramSpec) factory; ccl/mesh_partition still
+            // reuses the legacy SliceRmShardedProgramFactory::create_descriptor directly (see
+            // mesh_partition_program_factory.cpp), so both factory structs are retained.
+            return SliceRmShardedSpecProgramFactory{};
         }
         if (has_step) {
-            return SliceRmStrideProgramFactory{};
+            // slice's own dispatch uses the Metal 2.0 (ProgramSpec) factory; ccl/mesh_partition still
+            // reuses the legacy SliceRmStrideProgramFactory::create_descriptor directly (see
+            // mesh_partition_program_factory.cpp), so both factory structs are retained.
+            return SliceRmStrideSpecProgramFactory{};
         }
         return SliceRmProgramFactory{};
     }

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
@@ -38,7 +38,7 @@ struct SliceDeviceOperation {
         SliceRmShardedProgramFactory,
         SliceRmStrideProgramFactory,
         SliceTileSpecProgramFactory,
-        SliceTileTensorArgsProgramFactory>;
+        SliceTileTensorArgsSpecProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
@@ -37,7 +37,7 @@ struct SliceDeviceOperation {
         SliceRmProgramFactory,
         SliceRmShardedProgramFactory,
         SliceRmStrideProgramFactory,
-        SliceTileProgramFactory,
+        SliceTileSpecProgramFactory,
         SliceTileTensorArgsProgramFactory>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_device_operation.hpp
@@ -35,8 +35,8 @@ struct SliceDeviceOperation {
     using tensor_return_value_t = Tensor;
     using program_factory_t = std::variant<
         SliceRmProgramFactory,
-        SliceRmShardedProgramFactory,
-        SliceRmStrideProgramFactory,
+        SliceRmShardedSpecProgramFactory,
+        SliceRmStrideSpecProgramFactory,
         SliceTileSpecProgramFactory,
         SliceTileTensorArgsSpecProgramFactory>;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -383,8 +383,16 @@ ttnn::device_operation::ProgramArtifacts SliceRmShardedSpecProgramFactory::creat
     uint32_t num_cores_x_unpadded = grid_size_unpadded.x;
     uint32_t num_cores_y_unpadded = grid_size_unpadded.y;
 
-    // Data formats are not needed in the spec path: the borrowed DFBs are DM-only (no compute
-    // kernel binds them), so no data_format_metadata is required.
+    // Data formats: the borrowed DFBs are DM-only (no compute kernel binds them), but the framework
+    // still lowers each DFB to a CB and calls get_tile_size(data_format) when computing the CB tile
+    // size. A nullopt data_format_metadata lowers to tt::DataFormat::Invalid, which makes that
+    // conversion throw "Invalid data format" at program build. Mirror the legacy descriptor, which set
+    // each borrowed CB's data_format from the corresponding tensor's dtype (cb_data_format from the
+    // input dtype, dst_cb_data_format from the output dtype). The per-stick entry_size is still the
+    // row-major stick byte size below; data_format only supplies the element width for tile sizing.
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    tt::DataFormat dst_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+
     TT_FATAL(output.buffer() != nullptr, "Output buffer should be allocated on device!");
 
     m2::ProgramSpec spec;
@@ -398,12 +406,14 @@ ttnn::device_operation::ProgramArtifacts SliceRmShardedSpecProgramFactory::creat
             .unique_id = m2::DFBSpecName{"cb_in"},
             .entry_size = static_cast<uint32_t>(stick_size_padded),
             .num_entries = shard_height_padded,
+            .data_format_metadata = cb_data_format,
             .borrowed_from = m2::TensorParamName{"src"},
         },
         m2::DataflowBufferSpec{
             .unique_id = m2::DFBSpecName{"cb_out"},
             .entry_size = static_cast<uint32_t>(stick_size_unpadded),
             .num_entries = shard_height_unpadded,
+            .data_format_metadata = dst_cb_data_format,
             .borrowed_from = m2::TensorParamName{"dst"},
         },
     };

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.cpp
@@ -5,14 +5,22 @@
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp"
 
+#include <algorithm>
 #include <map>
 #include <optional>
+#include <filesystem>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
 using namespace tt::constants;
 using namespace tt::tt_metal;
+
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::operations::data_movement {
 
@@ -318,6 +326,191 @@ tt::tt_metal::ProgramDescriptor SliceRmShardedProgramFactory::create_descriptor(
     desc.kernels.push_back(std::move(reader_desc));
 
     return desc;
+}
+
+// Metal 2.0 (ProgramSpec) port of the ROW_MAJOR HEIGHT-sharded in/out factory. Mirrors
+// create_descriptor's sizing and per-core runtime-arg computation exactly, but expresses it with
+// the Metal 2.0 host API and points at the forked *_m2 reader kernel.
+//
+// Case-2 (bridge) port. The legacy factory had a SINGLE reader kernel that:
+//   - borrows two CBs onto the input/output shard buffers (CBDescriptor::buffer = in/out buffer)
+//     purely as L1 base-address sources (get_write_ptr()), and
+//   - reads peer shards by a hand-rolled NoC walk over a host-computed physical core-coordinate
+//     map plus per-shard stick-chunk descriptors threaded through runtime args.
+// Arg mapping vs the legacy descriptor:
+//   - The two borrowed CBs become two DataflowBufferSpecs with borrowed_from = src / dst. Each is
+//     bound on the single reader as a self-loop (PRODUCER + CONSUMER) so the DFB endpoint invariant
+//     is satisfied; the kernel reads their borrowed L1 base via get_write_ptr() exactly as before.
+//     (cb_in is a pure address source; cb_out is produced into but has no consumer kernel in this
+//     single-kernel factory — both are honored as self-loops.)
+//   - The src/dst buffer addresses move from CBDescriptor::buffer into TensorParameter/TensorBinding
+//     (the borrowed DFBs resolve their backing L1 address from the matching TensorArgument).
+//   - stick_size_padded / stick_size_unpadded / num_sticks_unpadded: positional CTAs -> named CTAs.
+//   - The per-core reader arg vector (num_cores_read, NoC x/y map, chunk descriptors) becomes
+//     per-core runtime varargs (identical contents and layout).
+ttnn::device_operation::ProgramArtifacts SliceRmShardedSpecProgramFactory::create_program_spec(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input;
+
+    // stick sizes
+    uint32_t W_padded = input.logical_shape()[-1];
+    uint32_t W_unpadded = output.logical_shape()[-1];
+    auto stick_size_padded = W_padded * input.element_size();
+    auto stick_size_unpadded = W_unpadded * output.element_size();
+
+    // input shard spec
+    auto shard_spec_padded = input.shard_spec().value();
+    uint32_t shard_height_padded = shard_spec_padded.shape[0];
+
+    auto bbox_padded = shard_spec_padded.grid.bounding_box();
+    CoreCoord grid_size_padded = {bbox_padded.end_coord.x + 1, bbox_padded.end_coord.y + 1};
+    uint32_t num_cores_x_padded = grid_size_padded.x;
+    uint32_t num_cores_y_padded = grid_size_padded.y;
+
+    if (args.sub_core_grids.has_value()) {
+        log_warning(tt::LogOp, "sub_core_grids is not used when input tensor is sharded");
+    }
+
+    // output shard spec
+    auto shard_spec_unpadded = output.shard_spec().value();
+    uint32_t shard_height_unpadded = shard_spec_unpadded.shape[0];
+    bool row_major = shard_spec_unpadded.orientation == ShardOrientation::ROW_MAJOR;
+
+    auto& all_cores_unpadded = shard_spec_unpadded.grid;
+    uint32_t num_cores_unpadded = shard_spec_unpadded.num_cores();
+    auto bbox_unpadded = all_cores_unpadded.bounding_box();
+    CoreCoord grid_size_unpadded = {bbox_unpadded.end_coord.x + 1, bbox_unpadded.end_coord.y + 1};
+    uint32_t num_cores_x_unpadded = grid_size_unpadded.x;
+    uint32_t num_cores_y_unpadded = grid_size_unpadded.y;
+
+    // Data formats are not needed in the spec path: the borrowed DFBs are DM-only (no compute
+    // kernel binds them), so no data_format_metadata is required.
+    TT_FATAL(output.buffer() != nullptr, "Output buffer should be allocated on device!");
+
+    m2::ProgramSpec spec;
+    spec.name = "slice_rm_sharded";
+
+    // --- DFBs (borrowed onto the src / dst shard buffers; sizing carried in the spec) ---
+    // cb_in: borrowed onto src, used as an L1 base-address source for the peer-shard NoC reads.
+    // cb_out: borrowed onto dst, produced into by the reader.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"cb_in"},
+            .entry_size = static_cast<uint32_t>(stick_size_padded),
+            .num_entries = shard_height_padded,
+            .borrowed_from = m2::TensorParamName{"src"},
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"cb_out"},
+            .entry_size = static_cast<uint32_t>(stick_size_unpadded),
+            .num_entries = shard_height_unpadded,
+            .borrowed_from = m2::TensorParamName{"dst"},
+        },
+    };
+
+    // --- Reader kernel spec ---
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+                                        "slice_reader_unary_unpad_dims_rm_sharded_m2.cpp"},
+        .compiler_options = {},
+        .dfb_bindings =
+            {
+                // cb_in self-loop (pure address source onto src).
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"cb_in"},
+                    .accessor_name = "cb_in",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"cb_in"},
+                    .accessor_name = "cb_in",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+                // cb_out self-loop (produced into by the reader; no separate consumer kernel).
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"cb_out"},
+                    .accessor_name = "cb_out",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"cb_out"},
+                    .accessor_name = "cb_out",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .compile_time_args =
+            {
+                {"stick_size_padded", static_cast<uint32_t>(stick_size_padded)},
+                {"stick_size_unpadded", static_cast<uint32_t>(stick_size_unpadded)},
+                {"num_sticks_unpadded", shard_height_unpadded},
+            },
+        .runtime_arg_schema = {},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+
+    auto all_runtime_args = ttnn::operations::data_movement::get_slice_runtime_args_rm_sharded(
+        input,
+        output,
+        args.slice_start,
+        num_cores_unpadded,
+        row_major,
+        num_cores_x_unpadded,
+        num_cores_y_unpadded,
+        shard_height_unpadded,
+        shard_height_padded,
+        num_cores_x_padded,
+        num_cores_y_padded);
+
+    // The per-core reader arg vector is variable-length (num_cores_read header + NoC x/y map +
+    // chunk descriptors), so it is carried as per-core runtime varargs with identical contents and
+    // layout. Per-node vararg counts differ, but the API's per-node count override is deprecated, so
+    // a single uniform num_runtime_varargs (= the longest per-core vector) is declared and each
+    // node's vector is zero-padded up to it. The kernel derives every index it reads from
+    // get_vararg(0) (num_cores_read) and never touches the padding tail, so padding is inert.
+    // --- ProgramRunArgs (computed first so the uniform vararg count is known for the KernelSpec) ---
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+
+    uint32_t max_varargs = 0;
+    for (uint32_t i = 0; i < num_cores_unpadded; ++i) {
+        max_varargs = std::max<uint32_t>(max_varargs, static_cast<uint32_t>(all_runtime_args[i].first.size()));
+    }
+    for (uint32_t i = 0; i < num_cores_unpadded; ++i) {
+        CoreCoord core;
+        if (row_major) {
+            core = {i % num_cores_x_unpadded, i / num_cores_x_unpadded};
+        } else {
+            core = {i / num_cores_y_unpadded, i % num_cores_y_unpadded};
+        }
+        const m2::NodeCoord node{core};
+        m2::AdvancedKernelRunArgs::Varargs varargs(max_varargs, 0u);
+        const auto& reader_args = all_runtime_args[i].first;
+        std::copy(reader_args.begin(), reader_args.end(), varargs.begin());
+        reader_run.advanced_options.runtime_varargs[node] = std::move(varargs);
+    }
+    reader.advanced_options.num_runtime_varargs = max_varargs;
+
+    spec.kernels = {reader};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = input.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()},
+    };
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "slice_rm_sharded",
+            .kernels = {m2::KernelSpecName{"reader"}},
+            .target_nodes = all_cores_unpadded,
+        },
+    };
+
+    run.kernel_run_args = {reader_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"src"}, input.mesh_tensor()},
+        {m2::TensorParamName{"dst"}, output.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_sharded.hpp
@@ -6,10 +6,23 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
+// Legacy ProgramDescriptor factory for the ROW_MAJOR HEIGHT-sharded in/out path.
+//
+// Retained (NOT deleted) because ccl/mesh_partition's std::visit over slice's
+// program_factory_t instantiates Factory::create_descriptor(...) for EVERY variant
+// alternative (mesh_partition_program_factory.cpp), so removing create_descriptor would
+// break mesh_partition's build regardless of whether it ever selects this factory.
+//
+// A single factory struct cannot satisfy BOTH ProgramDescriptorFactoryConcept (has
+// create_descriptor) and ProgramSpecFactoryConcept (has create_program_spec) — the
+// AllFactoriesValid check requires each program_factory_t alternative to satisfy EXACTLY
+// one. So slice's own Metal 2.0 path lives on the separate SliceRmShardedSpecProgramFactory
+// below; this struct stays descriptor-only for mesh_partition's reuse.
 struct SliceRmShardedProgramFactory {
     // Contract (1): per-coord ProgramDescriptor.  Both CBs are sharded
     // (CBDescriptor::buffer bound to input/output buffers); the framework
@@ -18,6 +31,16 @@ struct SliceRmShardedProgramFactory {
     // — padded_shape is folded into compute_program_hash() so each unique
     // sizing gets its own cache entry.
     static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+};
+
+// Metal 2.0 (ProgramSpec) factory for the ROW_MAJOR HEIGHT-sharded in/out path. This is the
+// factory slice's own SliceDeviceOperation dispatches through. Case-2 (bridge) port: the reader
+// keeps its hand-rolled NoC walk over a host-computed physical core-coordinate map; the input /
+// output shard L1 base addresses flow through two borrowed-memory DFBs (borrowed_from src / dst),
+// matching the legacy borrowed CBs. Points at the forked *_m2 reader kernel.
+struct SliceRmShardedSpecProgramFactory {
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.cpp
@@ -5,15 +5,23 @@
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp"
 
+#include <algorithm>
 #include <optional>
+#include <filesystem>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
 using namespace tt::constants;
 using namespace tt::tt_metal;
+
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
@@ -171,6 +179,286 @@ tt::tt_metal::ProgramDescriptor SliceRmStrideProgramFactory::create_descriptor(
     desc.kernels.push_back(std::move(writer_desc));
 
     return desc;
+}
+
+// Metal 2.0 (ProgramSpec) port of the ROW_MAJOR strided factory. Mirrors create_descriptor's work
+// split, kernel selection, and per-core runtime-arg computation exactly, expressed with the Metal
+// 2.0 host API and pointing at the forked *_m2 kernels.
+//
+// Case-1 port (no Case-2 bridge needed):
+//   - src/dst addresses move from clean Buffer* RTAs into TensorParameter/TensorBinding (ta::src /
+//     ta::dst). The legacy kernels built TensorAccessor(args, addr) with no page-size override, so
+//     the binding-token accessor's default aligned page size matches exactly; both feed
+//     noc_async_*_sharded with identical behavior.
+//   - The single in CB (index 0) becomes one DataflowBufferSpec, reader=PRODUCER / writer=CONSUMER,
+//     sharing one WorkUnitSpec on all_cores (local-DFB rule).
+//   - element_size leading CTA -> named CTA compile_time_element_size.
+//   - 4D kernels: fixed positional RTAs -> named RTAs. ND kernels: leading scalar RTAs -> named
+//     RTAs, the per-dim arrays -> runtime varargs (same concatenated layout).
+ttnn::device_operation::ProgramArtifacts SliceRmStrideSpecProgramFactory::create_program_spec(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input_tensor = tensor_args.input;
+    tt::tt_metal::IDevice* device = input_tensor.device();
+
+    const auto& input_shape = input_tensor.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    uint32_t element_size = input_tensor.element_size();
+
+    // Calculate total output rows based on tensor rank
+    uint32_t total_output_rows = output_shape.volume() / output_shape[-1];
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_rows_per_core_group_1, num_rows_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), total_output_rows)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, total_output_rows);
+    (void)core_group_1;
+    (void)core_group_2;
+    (void)num_rows_per_core_group_1;
+    (void)num_rows_per_core_group_2;
+
+    const bool using_4d_kernels = input_shape.rank() <= 4;
+
+    // Select kernels based on tensor rank (forked *_m2 kernels).
+    std::string reader_kernel_path;
+    std::string writer_kernel_path;
+    if (using_4d_kernels) {
+        reader_kernel_path =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_4d_m2.cpp";
+        writer_kernel_path =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_4d_m2.cpp";
+    } else {
+        reader_kernel_path =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/reader_multicore_slice_nd_m2.cpp";
+        writer_kernel_path =
+            "ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/writer_multicore_slice_nd_m2.cpp";
+    }
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t actual_input_w = input_shape[-1];
+    uint32_t input_bytes_per_row = actual_input_w * element_size;
+    uint32_t cb_page_size = input_bytes_per_row;
+
+    auto src_buffer_alignment = input_tensor.buffer()->alignment();
+    auto dst_buffer_alignment = output.buffer()->alignment();
+    auto alignment = std::max(src_buffer_alignment, dst_buffer_alignment);
+
+    uint32_t cb_page_size_aligned = tt::round_up(cb_page_size, alignment);
+    uint32_t cb_total_size = 2 * cb_page_size_aligned;
+
+    m2::ProgramSpec spec;
+    spec.name = "slice_rm_stride";
+
+    // --- DFB (was: in CB index 0, double-buffered single-row FIFO) ---
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"cb_in_out"},
+            .entry_size = cb_page_size_aligned,
+            .num_entries = cb_total_size / cb_page_size_aligned,
+            .data_format_metadata = cb_data_format,
+        },
+    };
+
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{reader_kernel_path},
+        .compiler_options = {},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"cb_in_out"},
+                    .accessor_name = "cb_in_out",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"},
+            },
+        .compile_time_args = {{"compile_time_element_size", element_size}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{writer_kernel_path},
+        .compiler_options = {},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"cb_in_out"},
+                    .accessor_name = "cb_in_out",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"},
+            },
+        .compile_time_args = {{"compile_time_element_size", element_size}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+
+    if (using_4d_kernels) {
+        reader.runtime_arg_schema = {
+            .runtime_arg_names = {
+                "tensor_rank",
+                "input_w",
+                "input_h",
+                "input_d",
+                "input_n",
+                "output_w",
+                "output_h",
+                "output_d",
+                "output_n",
+                "slice_start_w",
+                "slice_end_w",
+                "slice_step_w",
+                "slice_start_h",
+                "slice_end_h",
+                "slice_step_h",
+                "slice_start_d",
+                "slice_end_d",
+                "slice_step_d",
+                "slice_start_n",
+                "slice_end_n",
+                "slice_step_n",
+                "element_size",
+                "num_rows_for_this_core",
+                "start_row_for_this_core"}};
+        writer.runtime_arg_schema = {
+            .runtime_arg_names = {
+                "tensor_rank",
+                "output_w",
+                "output_h",
+                "output_d",
+                "output_n",
+                "element_size",
+                "num_rows_for_this_core",
+                "start_row_for_this_core"}};
+    } else {
+        // ND: leading scalar RTAs are named; the per-dim arrays travel as varargs.
+        reader.runtime_arg_schema = {
+            .runtime_arg_names = {"tensor_rank", "element_size", "num_rows_for_this_core", "start_row_for_this_core"}};
+        // 5 arrays of length input_shape.rank() (input/output dims, slice start/end/step).
+        reader.advanced_options.num_runtime_varargs = 5 * input_shape.rank();
+        writer.runtime_arg_schema = {
+            .runtime_arg_names = {"tensor_rank", "element_size", "num_rows_for_this_core", "start_row_for_this_core"}};
+        // 1 array of length output_shape.rank() (output dims).
+        writer.advanced_options.num_runtime_varargs = output_shape.rank();
+    }
+
+    spec.kernels = {reader, writer};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = input_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()},
+    };
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "slice_rm_stride",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = all_cores,
+        },
+    };
+
+    // --- ProgramRunArgs (per-core; mirrors create_descriptor's base+extra row distribution) ---
+    uint32_t tensor_rank = input_shape.rank();
+    uint32_t base_rows_per_core = total_output_rows / num_cores;
+    uint32_t extra_rows = total_output_rows % num_cores;
+
+    const auto& slice_start = args.slice_start;
+    const auto& slice_end = args.slice_end;
+    const auto& slice_step = args.step;
+
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+
+    uint32_t row_start_id = 0;
+    uint32_t extra_rows_remaining = extra_rows;
+
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        const m2::NodeCoord node{core};
+        uint32_t rows_for_this_core = base_rows_per_core;
+        if (extra_rows_remaining > 0) {
+            rows_for_this_core += 1;
+            extra_rows_remaining -= 1;
+        }
+
+        if (using_4d_kernels) {
+            reader_run.runtime_arg_values.push_back(
+                {node,
+                 {{"tensor_rank", tensor_rank},
+                  {"input_w", input_shape[-1]},
+                  {"input_h", input_shape[-2]},
+                  {"input_d", input_shape[-3]},
+                  {"input_n", input_shape[-4]},
+                  {"output_w", output_shape[-1]},
+                  {"output_h", output_shape[-2]},
+                  {"output_d", output_shape[-3]},
+                  {"output_n", output_shape[-4]},
+                  {"slice_start_w", slice_start[-1]},
+                  {"slice_end_w", slice_end[-1]},
+                  {"slice_step_w", slice_step[-1]},
+                  {"slice_start_h", slice_start[-2]},
+                  {"slice_end_h", slice_end[-2]},
+                  {"slice_step_h", slice_step[-2]},
+                  {"slice_start_d", slice_start[-3]},
+                  {"slice_end_d", slice_end[-3]},
+                  {"slice_step_d", slice_step[-3]},
+                  {"slice_start_n", slice_start[-4]},
+                  {"slice_end_n", slice_end[-4]},
+                  {"slice_step_n", slice_step[-4]},
+                  {"element_size", element_size},
+                  {"num_rows_for_this_core", rows_for_this_core},
+                  {"start_row_for_this_core", row_start_id}}});
+
+            writer_run.runtime_arg_values.push_back(
+                {node,
+                 {{"tensor_rank", tensor_rank},
+                  {"output_w", output_shape[-1]},
+                  {"output_h", output_shape[-2]},
+                  {"output_d", output_shape[-3]},
+                  {"output_n", output_shape[-4]},
+                  {"element_size", element_size},
+                  {"num_rows_for_this_core", rows_for_this_core},
+                  {"start_row_for_this_core", row_start_id}}});
+        } else {
+            reader_run.runtime_arg_values.push_back(
+                {node,
+                 {{"tensor_rank", tensor_rank},
+                  {"element_size", element_size},
+                  {"num_rows_for_this_core", rows_for_this_core},
+                  {"start_row_for_this_core", row_start_id}}});
+            m2::AdvancedKernelRunArgs::Varargs reader_varargs;
+            reader_varargs.reserve(5 * tensor_rank);
+            reader_varargs.insert(reader_varargs.end(), input_shape.cbegin(), input_shape.cend());
+            reader_varargs.insert(reader_varargs.end(), output_shape.cbegin(), output_shape.cend());
+            reader_varargs.insert(reader_varargs.end(), slice_start.cbegin(), slice_start.cend());
+            reader_varargs.insert(reader_varargs.end(), slice_end.cbegin(), slice_end.cend());
+            reader_varargs.insert(reader_varargs.end(), slice_step.cbegin(), slice_step.cend());
+            reader_run.advanced_options.runtime_varargs[node] = std::move(reader_varargs);
+
+            writer_run.runtime_arg_values.push_back(
+                {node,
+                 {{"tensor_rank", tensor_rank},
+                  {"element_size", element_size},
+                  {"num_rows_for_this_core", rows_for_this_core},
+                  {"start_row_for_this_core", row_start_id}}});
+            m2::AdvancedKernelRunArgs::Varargs writer_varargs(output_shape.cbegin(), output_shape.cend());
+            writer_run.advanced_options.runtime_varargs[node] = std::move(writer_varargs);
+        }
+
+        row_start_id += rows_for_this_core;
+    }
+
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"src"}, input_tensor.mesh_tensor()},
+        {m2::TensorParamName{"dst"}, output.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_rm_stride.hpp
@@ -6,12 +6,31 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
+// Legacy ProgramDescriptor factory for the ROW_MAJOR strided (step != 1) path.
+//
+// Retained (NOT deleted) because ccl/mesh_partition's std::visit over slice's
+// program_factory_t instantiates Factory::create_descriptor(...) for EVERY variant alternative
+// (mesh_partition_program_factory.cpp). A single struct cannot satisfy both the descriptor and
+// the ProgramSpec factory concepts, so slice's Metal 2.0 path lives on the separate
+// SliceRmStrideSpecProgramFactory below; this struct stays descriptor-only for mesh_partition.
 struct SliceRmStrideProgramFactory {
     static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+};
+
+// Metal 2.0 (ProgramSpec) factory for the ROW_MAJOR strided path. This is the factory slice's own
+// SliceDeviceOperation dispatches through. Case-1 port: src/dst are clean Buffer* address RTAs
+// (no host-composed offset, no per-shard page-size override — the legacy kernels build their
+// TensorAccessor with the binding's default aligned page size), so they re-express as ordinary
+// TensorBindings. Selects between the 4D and ND forked *_m2 kernels at runtime by rank, exactly
+// like create_descriptor.
+struct SliceRmStrideSpecProgramFactory {
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.cpp
@@ -6,14 +6,21 @@
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp"
 
 #include <optional>
+#include <filesystem>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
 using namespace tt::constants;
 using namespace tt::tt_metal;
+
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
@@ -176,6 +183,219 @@ tt::tt_metal::ProgramDescriptor SliceTileProgramFactory::create_descriptor(
     program_descriptor.kernels.push_back(std::move(writer_kernel_desc));
 
     return program_descriptor;
+}
+
+// Metal 2.0 (ProgramSpec) port of the TILE non-strided factory. Mirrors create_descriptor's
+// work split and per-core / common runtime-arg computation exactly, but expresses it with the
+// Metal 2.0 host API (ProgramSpec + ProgramRunArgs) and points at the forked *_m2 kernels.
+//
+// Arg mapping vs the legacy descriptor:
+//   - The single src0 CB (index 0) becomes one DataflowBufferSpec, bound reader=PRODUCER
+//     (accessor "cb_in") and writer=CONSUMER (accessor "cb_out"). Reader and writer share the
+//     one WorkUnitSpec on all_cores (local-DFB rule).
+//   - src/dst buffer addresses move from raw runtime args (src_addr/dst_addr) into
+//     TensorParameter/TensorBinding (ta::src / ta::dst); their TensorAccessor config is supplied
+//     by the binding rather than appended TensorAccessorArgs CTAs.
+//   - Reader: num_dims is a named CTA; start_id/num_tiles are named per-core RTAs; the per-dim
+//     id_per_dim[] array becomes runtime varargs; the common [num_unpadded.., num_padded..]
+//     arrays become common varargs.
+//   - Writer: num_pages/start_id are named per-core RTAs.
+ttnn::device_operation::ProgramArtifacts SliceTileSpecProgramFactory::create_program_spec(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input = tensor_args.input;
+    tt::tt_metal::IDevice* device = input.device();
+
+    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+
+    // Buffer addresses are no longer threaded through runtime args (they flow via the
+    // src/dst TensorParameter bindings), so we only need the output buffer for the assert.
+    TT_ASSERT(output.buffer() != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    const auto& input_shape = input.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_shape.rank());
+
+    // --- DFB (was: CB index 0, double-buffered single-tile FIFO) ---
+    uint32_t src0_cb_index = 0;
+    uint32_t num_input_tiles = 2;
+
+    m2::ProgramSpec spec;
+    spec.name = "slice_tile";
+
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"cb_in_out"},
+            .entry_size = single_tile_size,
+            .num_entries = num_input_tiles,
+            .data_format_metadata = cb_data_format,
+        },
+    };
+    (void)src0_cb_index;  // index is now implied by the DFB binding
+
+    // --- Common (broadcast) reader args: [num_unpadded_per_dim..., num_padded_per_dim...] ---
+    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
+    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
+    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
+    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    accumulated_total_per_dim[0] = num_total_Xt;
+    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+
+    std::vector<uint32_t> num_unpadded_tiles_per_dim(num_dims);
+    std::vector<uint32_t> num_padded_tiles_per_dim(num_dims);
+    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
+    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
+    num_padded_tiles_per_dim[0] = num_padded_Xt;
+    num_padded_tiles_per_dim[1] = num_padded_Yt;
+    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
+        num_padded_tiles_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+
+    uint32_t start_offset = ttnn::operations::data_movement::get_tiled_start_offset(input, args.slice_start);
+
+    // --- Kernel specs ---
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+                                        "reader_unary_unpad_dims_interleaved_start_id_m2.cpp"},
+        .compiler_options = {},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"cb_in_out"},
+                    .accessor_name = "cb_in",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"},
+            },
+        .compile_time_args = {{"num_dims", num_dims}},
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"start_id", "num_tiles"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+    // Per-dim id_per_dim[] running indices are passed as runtime varargs.
+    reader.advanced_options.num_runtime_varargs = num_dims;
+    // [num_unpadded_per_dim..., num_padded_per_dim...] are passed as common varargs.
+    reader.advanced_options.num_common_runtime_varargs = num_dims * 2;
+
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+                                        "writer_unary_interleaved_start_id_m2.cpp"},
+        .compiler_options = {},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"cb_in_out"},
+                    .accessor_name = "cb_out",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"},
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_pages", "start_id"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+
+    spec.kernels = {reader, writer};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = input.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()},
+    };
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "slice_tile",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = all_cores,
+        },
+    };
+
+    // --- ProgramRunArgs ---
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+
+    // Common reader varargs: [num_unpadded_per_dim..., num_padded_per_dim...]
+    m2::AdvancedKernelRunArgs::Varargs common_varargs;
+    common_varargs.reserve(num_dims * 2);
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        common_varargs.push_back(num_unpadded_tiles_per_dim[j]);
+    }
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        common_varargs.push_back(num_padded_tiles_per_dim[j]);
+    }
+    reader_run.advanced_options.common_runtime_varargs = std::move(common_varargs);
+
+    uint32_t num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        const m2::NodeCoord node{core};
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core: zero-filled args (matches legacy descriptor).
+            reader_run.runtime_arg_values.push_back({node, {{"start_id", 0u}, {"num_tiles", 0u}}});
+            reader_run.advanced_options.runtime_varargs[node] = m2::AdvancedKernelRunArgs::Varargs(num_dims, 0u);
+            writer_run.runtime_arg_values.push_back({node, {{"num_pages", 0u}, {"start_id", 0u}}});
+            continue;
+        }
+
+        // Per-dim starting indices for this core (the legacy reader_args[2..] / id_per_dim varargs).
+        m2::AdvancedKernelRunArgs::Varargs id_per_dim(num_dims);
+        id_per_dim[0] = num_tiles_written % num_unpadded_tiles_per_dim[0];
+        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
+        uint32_t start_id = id_per_dim[0] + start_offset;
+        for (uint32_t j = 1; j < num_dims; ++j) {
+            id_per_dim[j] = unpadded_written % num_unpadded_tiles_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
+            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+        }
+
+        reader_run.runtime_arg_values.push_back({node, {{"start_id", start_id}, {"num_tiles", num_tiles_per_core}}});
+        reader_run.advanced_options.runtime_varargs[node] = std::move(id_per_dim);
+
+        writer_run.runtime_arg_values.push_back(
+            {node, {{"num_pages", num_tiles_per_core}, {"start_id", num_tiles_written}}});
+
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"src"}, input.mesh_tensor()},
+        {m2::TensorParamName{"dst"}, output.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile.hpp
@@ -6,12 +6,35 @@
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 
 namespace ttnn::prim {
 
+// Legacy ProgramDescriptor factory for the non-strided TILE path.
+//
+// Retained (NOT deleted) because ccl/mesh_partition builds its own MeshWorkload by
+// directly calling SliceTileProgramFactory::create_descriptor() per mesh coordinate
+// (see mesh_partition_program_factory.cpp). mesh_partition needs a ProgramDescriptor it
+// can stamp into a Program and re-apply runtime args onto, so this descriptor entry point
+// must keep existing.
+//
+// A single factory struct cannot satisfy BOTH ProgramDescriptorFactoryConcept (has
+// create_descriptor) and ProgramSpecFactoryConcept (has create_program_spec) — the
+// AllFactoriesValid check requires each program_factory_t alternative to satisfy EXACTLY
+// one. So slice's own Metal 2.0 path lives on the separate SliceTileSpecProgramFactory
+// below; this struct stays descriptor-only for mesh_partition's reuse.
 struct SliceTileProgramFactory {
     static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+};
+
+// Metal 2.0 (ProgramSpec) factory for the non-strided TILE path. This is the factory
+// slice's own SliceDeviceOperation dispatches through (select_program_factory routes the
+// TILE path here). It produces the immutable ProgramSpec + mutable ProgramRunArgs and
+// points at the forked *_m2 kernels (which use the experimental named-arg mechanism).
+struct SliceTileSpecProgramFactory {
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.cpp
@@ -6,14 +6,21 @@
 #include "ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp"
 
 #include <optional>
+#include <filesystem>
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
 using namespace tt::constants;
 using namespace tt::tt_metal;
+
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
@@ -183,6 +190,257 @@ tt::tt_metal::ProgramDescriptor SliceTileTensorArgsProgramFactory::create_descri
     desc.kernels.push_back(std::move(writer_desc));
 
     return desc;
+}
+
+// Metal 2.0 (ProgramSpec) port of the TILE tensor-args factory. Mirrors create_descriptor's
+// work split and per-core / common runtime-arg computation exactly, but expresses it with the
+// Metal 2.0 host API (ProgramSpec + ProgramRunArgs) and points at the forked *_m2 kernels.
+//
+// Arg mapping vs the legacy descriptor:
+//   - The src0 CB (index 0, double-buffered) becomes DataflowBufferSpec "cb_in", bound
+//     reader=PRODUCER ("cb_in") and writer=CONSUMER ("cb_out").
+//   - The tensor CB (index 1, single-tile staging for start/end reads) becomes
+//     DataflowBufferSpec "cb_tensor", bound as a reader self-loop (PRODUCER + CONSUMER on the
+//     reader) — the reader is its only user (it reads start/end into it, then reads them back).
+//   - Reader and writer share the one WorkUnitSpec on all_cores (local-DFB rule for cb_in).
+//   - src/start/end/dst buffer addresses move from raw runtime args into
+//     TensorParameter/TensorBinding (ta::src / ta::start / ta::end / ta::dst); their
+//     TensorAccessor config is supplied by the binding rather than appended TensorAccessorArgs CTAs.
+//   - Reader: num_dims/tile_width/tile_height are named CTAs; start_id/num_tiles are named
+//     per-core RTAs; the per-dim id_per_dim[] array becomes runtime varargs; the common
+//     [num_unpadded.., num_padded.., input_shape..] arrays become common varargs.
+//   - Writer: num_pages/start_id are named per-core RTAs (reuses the shared *_m2 writer fork).
+ttnn::device_operation::ProgramArtifacts SliceTileTensorArgsSpecProgramFactory::create_program_spec(
+    const SliceParams& args, const SliceInputs& tensor_args, Tensor& output) {
+    const auto& input_tensor = tensor_args.input;
+    const auto& start_tensor = tensor_args.start_tensor.value();
+    const auto& end_tensor = tensor_args.end_tensor.value();
+    tt::tt_metal::IDevice* device = input_tensor.device();
+
+    uint32_t num_unpadded_tiles = output.physical_volume() / TILE_HW;
+
+    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        args.sub_core_grids.has_value()
+            ? tt::tt_metal::split_work_to_cores(args.sub_core_grids.value(), num_unpadded_tiles)
+            : tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_unpadded_tiles);
+
+    // Buffer addresses are no longer threaded through runtime args (they flow via the
+    // src/start/end/dst TensorParameter bindings), so we only assert the output is allocated.
+    TT_FATAL(output.buffer() != nullptr, "Output buffer should be allocated on device!");
+
+    tt::DataFormat cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input_tensor.dtype());
+    uint32_t single_tile_size = tt::tile_size(cb_data_format);
+
+    constexpr uint32_t num_input_tiles = 2;
+
+    m2::ProgramSpec spec;
+    spec.name = "slice_tile_tensor_args";
+
+    // --- DFBs (was: CB index 0 double-buffered FIFO, CB index 1 single-tile staging) ---
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"cb_in"},
+            .entry_size = single_tile_size,
+            .num_entries = num_input_tiles,
+            .data_format_metadata = cb_data_format,
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"cb_tensor"},
+            .entry_size = single_tile_size,
+            .num_entries = 1,
+            .data_format_metadata = cb_data_format,
+        },
+    };
+
+    std::uint32_t num_dims = static_cast<std::uint32_t>(input_tensor.padded_shape().rank());
+    auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
+    uint32_t tile_width = tile_shape[1];
+    uint32_t tile_height = tile_shape[0];
+
+    // --- Common (broadcast) reader args (matches kernel):
+    //   [num_unpadded_per_dim..., num_padded_per_dim..., input_shape...] ---
+    const auto& input_shape = input_tensor.padded_shape();
+    const auto& output_shape = output.padded_shape();
+    uint32_t num_unpadded_Xt = output_shape[-1] / TILE_WIDTH;
+    uint32_t num_total_Xt = input_shape[-1] / TILE_WIDTH;
+    uint32_t num_padded_Xt = num_total_Xt - num_unpadded_Xt;
+    uint32_t num_unpadded_Yt = output_shape[-2] / TILE_HEIGHT;
+    uint32_t num_total_Yt = input_shape[-2] / TILE_HEIGHT;
+    uint32_t num_padded_Yt = (num_total_Yt - num_unpadded_Yt) * num_total_Xt;
+
+    std::vector<uint32_t> accumulated_total_per_dim(num_dims);
+    accumulated_total_per_dim[0] = num_total_Xt;
+    accumulated_total_per_dim[1] = num_total_Yt * num_total_Xt;
+
+    std::vector<uint32_t> num_unpadded_tiles_per_dim(num_dims);
+    std::vector<uint32_t> num_padded_tiles_per_dim(num_dims);
+    std::vector<uint32_t> input_shape_args(num_dims);
+    num_unpadded_tiles_per_dim[0] = num_unpadded_Xt;
+    num_unpadded_tiles_per_dim[1] = num_unpadded_Yt;
+    num_padded_tiles_per_dim[0] = num_padded_Xt;
+    num_padded_tiles_per_dim[1] = num_padded_Yt;
+    for (int32_t i = 2; i < static_cast<int32_t>(num_dims); ++i) {
+        uint32_t num_unpadded_dim = output_shape[-(i + 1)];
+        uint32_t num_total_dim = input_shape[-(i + 1)];
+        uint32_t num_padded_dim = (num_total_dim - num_unpadded_dim) * accumulated_total_per_dim[i - 1];
+        num_unpadded_tiles_per_dim[i] = num_unpadded_dim;
+        num_padded_tiles_per_dim[i] = num_padded_dim;
+        accumulated_total_per_dim[i] = num_total_dim * accumulated_total_per_dim[i - 1];
+    }
+    for (int32_t i = 0; i < static_cast<int32_t>(num_dims); ++i) {
+        input_shape_args[i] = input_shape[i];
+    }
+
+    // --- Kernel specs ---
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+                                        "reader_unary_unpad_dims_interleaved_start_id_tensor_args_m2.cpp"},
+        .compiler_options = {},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"cb_in"},
+                    .accessor_name = "cb_in",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+                // cb_tensor self-loop: the reader is its only user (writes start/end in, reads back).
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"cb_tensor"},
+                    .accessor_name = "cb_tensor",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"cb_tensor"},
+                    .accessor_name = "cb_tensor",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"src"}, .accessor_name = "src"},
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"start"}, .accessor_name = "start"},
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"end"}, .accessor_name = "end"},
+            },
+        .compile_time_args = {{"num_dims", num_dims}, {"tile_width", tile_width}, {"tile_height", tile_height}},
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"start_id", "num_tiles"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+    // Per-dim id_per_dim[] running indices are passed as runtime varargs.
+    reader.advanced_options.num_runtime_varargs = num_dims;
+    // [num_unpadded_per_dim..., num_padded_per_dim..., input_shape...] are passed as common varargs.
+    reader.advanced_options.num_common_runtime_varargs = num_dims * 3;
+
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/slice/device/kernels/dataflow/"
+                                        "writer_unary_interleaved_start_id_m2.cpp"},
+        .compiler_options = {},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"cb_in"},
+                    .accessor_name = "cb_out",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"dst"}, .accessor_name = "dst"},
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_pages", "start_id"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+
+    spec.kernels = {reader, writer};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"src"}, .spec = input_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"start"}, .spec = start_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"end"}, .spec = end_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"dst"}, .spec = output.tensor_spec()},
+    };
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "slice_tile_tensor_args",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = all_cores,
+        },
+    };
+
+    // --- ProgramRunArgs ---
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+
+    // Common reader varargs: [num_unpadded_per_dim..., num_padded_per_dim..., input_shape...]
+    m2::AdvancedKernelRunArgs::Varargs common_varargs;
+    common_varargs.reserve(num_dims * 3);
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        common_varargs.push_back(num_unpadded_tiles_per_dim[j]);
+    }
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        common_varargs.push_back(num_padded_tiles_per_dim[j]);
+    }
+    for (uint32_t j = 0; j < num_dims; ++j) {
+        common_varargs.push_back(input_shape_args[j]);
+    }
+    reader_run.advanced_options.common_runtime_varargs = std::move(common_varargs);
+
+    // The legacy tensor-args reader uses a fixed base start_id of 0 (start_offset is constexpr 0
+    // there); the per-region offset is computed kernel-side from the start/end tensors.
+    constexpr uint32_t start_offset = 0;
+    uint32_t num_tiles_written = 0;
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        const m2::NodeCoord node{core};
+        uint32_t num_tiles_per_core;
+        if (core_group_1.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            num_tiles_per_core = num_tiles_per_core_group_2;
+        } else {
+            // no-op core: zero-filled args (matches legacy descriptor).
+            reader_run.runtime_arg_values.push_back({node, {{"start_id", 0u}, {"num_tiles", 0u}}});
+            reader_run.advanced_options.runtime_varargs[node] = m2::AdvancedKernelRunArgs::Varargs(num_dims, 0u);
+            writer_run.runtime_arg_values.push_back({node, {{"num_pages", 0u}, {"start_id", 0u}}});
+            continue;
+        }
+
+        // Per-dim starting indices for this core (the legacy reader_args[2..] / id_per_dim varargs).
+        m2::AdvancedKernelRunArgs::Varargs id_per_dim(num_dims);
+        id_per_dim[0] = num_tiles_written % num_unpadded_tiles_per_dim[0];
+        uint32_t unpadded_written = num_tiles_written / num_unpadded_tiles_per_dim[0];
+        uint32_t start_id = id_per_dim[0] + start_offset;
+        for (uint32_t j = 1; j < num_dims; ++j) {
+            id_per_dim[j] = unpadded_written % num_unpadded_tiles_per_dim[j];
+            unpadded_written = unpadded_written / num_unpadded_tiles_per_dim[j];
+            start_id += id_per_dim[j] * accumulated_total_per_dim[j - 1];
+        }
+
+        reader_run.runtime_arg_values.push_back({node, {{"start_id", start_id}, {"num_tiles", num_tiles_per_core}}});
+        reader_run.advanced_options.runtime_varargs[node] = std::move(id_per_dim);
+
+        writer_run.runtime_arg_values.push_back(
+            {node, {{"num_pages", num_tiles_per_core}, {"start_id", num_tiles_written}}});
+
+        num_tiles_written += num_tiles_per_core;
+    }
+
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"src"}, input_tensor.mesh_tensor()},
+        {m2::TensorParamName{"start"}, start_tensor.mesh_tensor()},
+        {m2::TensorParamName{"end"}, end_tensor.mesh_tensor()},
+        {m2::TensorParamName{"dst"}, output.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/slice/device/slice_program_factory_tile_tensor_args.hpp
@@ -5,13 +5,32 @@
 
 #include "ttnn/operations/data_movement/slice/device/slice_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
+// Legacy ProgramDescriptor factory for the TILE tensor-args (use_tensor_args) path.
+//
+// Retained (NOT deleted) because ccl/mesh_partition's std::visit over slice's program_factory_t
+// instantiates `Factory::create_descriptor(...)` for every variant alternative (see
+// mesh_partition_program_factory.cpp), so this descriptor entry point must keep existing to keep
+// mesh_partition building. As with the non-strided TILE path, a single factory struct cannot
+// satisfy BOTH ProgramDescriptorFactoryConcept and ProgramSpecFactoryConcept, so slice's own
+// Metal 2.0 path lives on the separate SliceTileTensorArgsSpecProgramFactory below; this struct
+// stays descriptor-only for mesh_partition's reuse.
 struct SliceTileTensorArgsProgramFactory {
     static tt::tt_metal::ProgramDescriptor create_descriptor(
+        const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
+};
+
+// Metal 2.0 (ProgramSpec) factory for the TILE tensor-args path. This is the factory slice's own
+// SliceDeviceOperation dispatches through (select_program_factory routes the use_tensor_args path
+// here). It produces the immutable ProgramSpec + mutable ProgramRunArgs and points at the forked
+// *_m2 reader kernel (the writer reuses the shared writer_unary_interleaved_start_id_m2.cpp fork).
+struct SliceTileTensorArgsSpecProgramFactory {
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const SliceParams& args, const SliceInputs& tensor_args, Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/METAL2_PORT_REPORT.md
@@ -1,0 +1,102 @@
+# Metal 2.0 Port Report — tilize (single-core factory)
+
+## Status: PORTED
+
+## Factory chosen
+`TilizeSingleCoreProgramFactory` — the simplest single-program factory in the op
+(one core, three kernels, two CBs, no work-split). The other four factories
+(`TilizeMultiCoreDefaultProgramFactory`, `TilizeMultiCoreBlockProgramFactory`,
+`TilizeMultiCoreShardedProgramFactory`, `TilizeMultiCoreWidthShardedProgramFactory`)
+remain on the legacy `ProgramDescriptor` concept. The framework's
+`program_factory_t` variant supports a mix of `ProgramSpecFactoryConcept` and
+`ProgramDescriptorFactoryConcept` alternatives (per `ttnn/api/ttnn/operation_concepts.hpp`),
+and dispatches per-factory at runtime, so the op continues to build and run with one
+factory ported.
+
+## Legacy inventory (ported factory)
+- Concept: `ProgramDescriptorFactoryConcept` (`create_descriptor` → `ProgramDescriptor`).
+- Custom `compute_program_hash`: none on `TilizeDeviceOperation`. Nothing to delete.
+- CBs: c_0 (`src0`, input format, `num_tiles_per_block` entries) and c_16 (`output`,
+  output format, `num_tiles_per_block` entries).
+- Kernels:
+  - reader `reader_unary_stick_layout_split_rows_singlecore.cpp` (op-local, used only by
+    this factory) — `ReaderConfigDescriptor`. RTAs: src_addr(0), num_sticks(1),
+    stick_size(2, UNUSED by kernel), num_tiles_per_block(3), block_width_size(4),
+    num_full_blocks_in_row(5), num_leftover_tiles(6, UNUSED), leftover_width_in_row(7, UNUSED),
+    row_start_id(8). CTA: stick_size + TensorAccessorArgs(src).
+  - writer `eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp`
+    (SHARED across ~dozens of ops) — `WriterConfigDescriptor`. RTAs: dst_addr(0),
+    num_tiles(1), start_id(2). CTA: output_cb_index(0) + TensorAccessorArgs(dst).
+  - compute `ttnn/cpp/ttnn/kernel/compute/tilize.cpp` (SHARED across many tilize/
+    tilize_with_val_padding factories) — `ComputeConfigDescriptor` with `fp32_dest_acc_en`
+    and `unpack_to_dest_mode[c_0]=UnpackToDestFp32` when fp32. CTAs: per_core_block_cnt(0),
+    per_core_block_tile_cnt(1).
+- Work split: none (single core, fixed at `(0,0)` or the first core of `sub_core_grids`).
+
+## Spec shape (post-port)
+- 2 DataflowBufferSpecs: `src0`, `output` (1:1 with legacy CBs).
+- 3 KernelSpecs: `reader`, `writer`, `compute`.
+- 2 TensorParameters: `input`, `output`; matching TensorArguments via `mesh_tensor()`.
+- 1 WorkUnitSpec hosting all three kernels on `core_ranges` (Local-DFB rule:
+  reader produces `src0`, compute consumes `src0` + produces `output`, writer consumes
+  `output` — all three share the one WorkUnitSpec, so every DFB's producer and consumer
+  are co-located).
+
+## Kernels: ported vs forked
+- **reader** `reader_unary_stick_layout_split_rows_singlecore.cpp` — **ported in place**
+  (op-local, single user). CircularBuffer→DataflowBuffer; CB id `c_0`→`dfb::src0`;
+  `TensorAccessorArgs<1>`+addr RTA→`TensorAccessor(ta::input)`; positional RTAs→named
+  (`args::num_sticks`, `args::num_tiles_per_block`, `args::block_width_size`,
+  `args::num_full_blocks_in_row`, `args::row_start_id`).
+- **writer** — **FORKED** to op-local
+  `device/kernels/dataflow/writer_unary_interleaved_start_id_m2.cpp` (the eltwise source is
+  shared by many other ops; not editable in place). Same mechanical conversion;
+  `OUT_SHARDED`/`BACKWARDS` `#ifdef`s preserved (neither is defined for tilize single-core,
+  so only the default interleaved path is active — behavior unchanged).
+- **compute** — **FORKED** to op-local `device/kernels/compute/tilize_m2.cpp` (the
+  `ttnn/cpp/ttnn/kernel/compute/tilize.cpp` source is shared by many factories). CB ids
+  `c_0`/`c_16`→`dfb::src0`/`dfb::output` (assigned to `constexpr uint32_t` locals first,
+  matching the matmul `bmm_m2` idiom, so they flow as non-type template args to
+  `is_fp32_input_format<>` and `tilize<>`); CTAs→`args::per_core_block_cnt` /
+  `args::per_core_block_tile_cnt`. `tilize_helpers.hpp` (kernel_lib) left untouched —
+  it takes CB ids as `uint32_t`, which `dfb::` converts to implicitly.
+
+## Dropped plumbing
+- Reader `src_addr` RTA(0) → `TensorBinding{input}`.
+- Reader unused RTAs `stick_size`(2), `num_leftover_tiles`(6), `leftover_width_in_row`(7):
+  dropped — the kernel never read them. The host stops emitting them.
+- Writer `dst_addr` RTA(0) → `TensorBinding{output}`; `output_cb_index` CTA(0) → `dfb::output`.
+- Compute magic CB ids `c_0`/`c_16` → DFB bindings.
+- All positional CTAs/RTAs → named args. All `TensorAccessorArgs` host plumbing removed.
+
+## Applied patterns
+- Single WorkUnitSpec with all three kernels (Local-DFB rule).
+- `unpack_to_dest_mode` carried via `ComputeHardwareConfig::unpack_to_dest_mode`
+  (`Table<DFBSpecName, UnpackToDestMode>`), keyed on `src0` (the fp32 compute-consumer DFB),
+  only when `fp32_llk_acc` — preserving the legacy `unpack_to_dest_mode[c_0]` behavior.
+
+## Device-op-class edits
+- `tilize_single_core_program_factory.hpp`: `create_descriptor`→`create_program_spec`,
+  return type `ProgramDescriptor`→`ttnn::device_operation::ProgramArtifacts`; include
+  `ttnn/metal2_artifacts.hpp` instead of `program_descriptors.hpp`.
+- No change needed to `tilize_device_operation.hpp/.cpp` — the variant already lists
+  `TilizeSingleCoreProgramFactory`, and `select_program_factory` already routes to it.
+- nanobind (`tilize_nanobind.cpp`): no `create_descriptor` hook for this factory; nothing to remove.
+
+## Findings / open items (routed, not changed)
+- The legacy reader emitted three RTAs the kernel never reads (slots 2/6/7). Left the
+  device-op/other-factory code untouched; only this factory's emission was trimmed as part
+  of the named-arg conversion.
+- `validate_on_program_cache_miss` comment "Assuming bfloat16 dataformat" on `stick_size`
+  predates the multi-dtype support now present — flagging for owner review (not touched).
+
+## Build / test
+NOT built, NOT committed (per instructions — this worktree has no build dir and the
+deliverable is a patch + report).
+
+## Assumptions to verify at build time
+- `dfb::name` usable as a `constexpr uint32_t` non-type template argument: confirmed by the
+  `dgomez/rand-metal2` matmul `bmm_m2.cpp` exemplar (`constexpr uint32_t cb_in0 = dfb::in0;`).
+- `get_local_cb_interface(dfb::output)` in the forked writer: `dfb::output` converts to
+  `uint32_t`, matching the legacy `get_local_cb_interface(cb_id_out)` call. Verify the DFB
+  interface is populated identically to the legacy local-CB interface.

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/METAL2_PORT_REPORT.md
@@ -1,4 +1,86 @@
-# Metal 2.0 Port Report — tilize (single-core factory)
+# Metal 2.0 Port Report — tilize (single-core + multi-core default factories)
+
+## Status: PORTED
+
+---
+
+# Multi-core default factory (added port)
+
+## Status: PORTED
+
+## Factory chosen
+`TilizeMultiCoreDefaultProgramFactory` — the default-selected factory for normal
+(interleaved, non-sharded) inputs (`select_program_factory` returns it as the fall-through
+case; `TilizeMultiCoreBlockProgramFactory` is the only alternative for tall/wide blocks).
+Interleaved multi-core, three kernel roles, two DFBs, work-split across the compute grid
+with a full core group + optional cliff core.
+
+## Legacy inventory (this factory)
+- Concept: `ProgramDescriptorFactoryConcept` (`create_descriptor` → `ProgramDescriptor`).
+- Custom `compute_program_hash`: none on `TilizeDeviceOperation`. Nothing to delete/keep.
+- CBs: c_0 (`src0`, input format, `ntiles_per_block` entries) and c_16 (`output`, output
+  format, `ntiles_per_block` entries), both on `all_cores`.
+- Work-split: `split_blocks_for_tilize(available_grid, nblocks)` → `core_range` (full cores,
+  `nblocks_per_core` each) + `core_range_cliff` (≤1 cliff core, `nblocks_per_core_cliff`).
+  Reader/writer placed on `all_cores`; compute on `core_range`, compute_cliff on
+  `core_range_cliff`.
+- Kernels:
+  - reader `reader_unary_stick_layout_split_rows_multicore.cpp` (op-local, used only by this
+    factory) — CTs `{aligned_page_size(0, UNUSED), num_pages_in_row(1), size_of_valid_data(2)}`
+    + `TensorAccessorArgs<3>`. RTAs: src_addr(0), num_rows(1), page_size(2, UNUSED),
+    ntiles_per_block(3), block_width_size(4), num_full_blocks_in_row(5), num_leftover_tiles(6,
+    UNUSED), leftover_width_in_row(7, UNUSED), start_page_id(8).
+  - writer `eltwise/unary/.../writer_unary_interleaved_start_id.cpp` (SHARED) — CT
+    `output_cb_index` + TensorAccessorArgs(dst). RTAs dst_addr(0), num_tiles(1), start_id(2).
+  - compute `ttnn/cpp/ttnn/kernel/compute/tilize.cpp` (SHARED) — `fp32_dest_acc_en` +
+    `unpack_to_dest_mode[c_0]=UnpackToDestFp32` when fp32. CTAs per_core_block_cnt(0),
+    per_core_block_tile_cnt(1). Full vs cliff differ only in per_core_block_cnt.
+
+## Spec shape (post-port)
+- 2 DataflowBufferSpecs: `src0`, `output`.
+- KernelSpecs: `reader`, `writer`, plus `compute` (full group) and/or `compute_cliff`.
+- 2 TensorParameters: `input`, `output`.
+- WorkUnitSpecs (Local-DFB rule, matmul-multicore pattern): one per core group, each hosting
+  reader + writer + that group's compute. `full` = {reader, writer, compute} on `core_range`;
+  `cliff` = {reader, writer, compute_cliff} on `core_range_cliff`. Reader/writer are shared
+  across both WorkUnitSpecs (per-core RTAs routed by core coord); the per-group compute differs
+  only in its `per_core_block_cnt` CTA (per-group-CTA pattern — NOT demoted to RTA). Groups
+  guarded by `has_full`/`has_cliff` so an all-cliff or no-cliff split emits only the needed units.
+
+## Kernels: ported vs forked (this factory)
+- **reader** `reader_unary_stick_layout_split_rows_multicore.cpp` — **ported in place**
+  (op-local, single user; same treatment as the single-core reader). CircularBuffer→
+  DataflowBuffer; `c_0`→`dfb::src0`; `TensorAccessorArgs<3>`+addr RTA→`TensorAccessor(ta::input)`;
+  CTs→named (`args::num_pages_in_row`, `args::size_of_valid_data_in_last_page_in_row`); RTAs→named
+  (`args::num_rows`, `args::num_tiles_per_block`, `args::block_width_size`,
+  `args::num_full_blocks_in_row`, `args::start_page_id`). Unused CT slot 0 (aligned_page_size)
+  and RTA slots 2/6/7 dropped — the kernel never read them.
+- **writer** — **REUSED** the single-core port's fork
+  `device/kernels/dataflow/writer_unary_interleaved_start_id_m2.cpp` (identical logic; legacy
+  multi-core writer RTAs `{num_tiles, start_id}` map 1:1 to the fork's `{num_pages, start_id}`).
+- **compute** — **REUSED** the single-core port's fork `device/kernels/compute/tilize_m2.cpp`
+  (identical CTAs `per_core_block_cnt`/`per_core_block_tile_cnt`; the multi-core legacy used the
+  same shared `ttnn/cpp/ttnn/kernel/compute/tilize.cpp` source).
+
+## Dropped plumbing (this factory)
+- Reader `src_addr` RTA(0)→`TensorBinding{input}`; unused RTAs 2/6/7 and CT0 dropped.
+- Writer `dst_addr` RTA(0)→`TensorBinding{output}`; `output_cb_index` CT→`dfb::output`.
+- All positional CTAs/RTAs→named args; all `TensorAccessorArgs` host plumbing removed.
+
+## Device-op-class edits (this factory)
+- `tilize_multi_core_default_program_factory.hpp`: `create_descriptor`→`create_program_spec`,
+  return type `ProgramDescriptor`→`ttnn::device_operation::ProgramArtifacts`; include
+  `ttnn/metal2_artifacts.hpp` + metal2 host-api headers instead of `program_descriptors.hpp`.
+- No change to `tilize_device_operation.hpp/.cpp` — variant already lists the factory and
+  `select_program_factory` already routes to it. nanobind: no hook for this factory.
+
+## Blockers
+- None. No op-owned tensors, no GlobalSemaphore, no per-mesh-coord variation, no live-allocator
+  introspection, no raw `buffer->address()` threaded to a kernel. Clean port.
+
+---
+
+# Single-core factory (original port)
 
 ## Status: PORTED
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/METAL2_PORT_REPORT.md
@@ -1,6 +1,144 @@
-# Metal 2.0 Port Report — tilize (single-core + multi-core default factories)
+# Metal 2.0 Port Report — tilize (ALL factories)
+
+## Status: PORTED (all 5 factories)
+
+All five `TilizeDeviceOperation` factories are now on `MetalV2FactoryConcept`
+(`create_program_spec` → `ProgramArtifacts`): single-core, multi-core default, multi-core
+block, multi-core sharded, multi-core width-sharded. The first two are documented at the
+bottom of this report; the three added in this pass are documented immediately below.
+
+---
+
+# Multi-core block factory (added port)
 
 ## Status: PORTED
+
+## Factory chosen
+`TilizeMultiCoreBlockProgramFactory` — selected for tall/wide tensors (`select_program_factory`
+returns it when `!enough_space_height`, or when the WH work-split yields fewer cores than the
+block split). Interleaved multi-core, three kernel roles, WH (both-dims) block split into up to
+four core groups (full + cliff-row + cliff-col + cliff-col-row).
+
+## Legacy inventory (this factory)
+- Concept: `ProgramDescriptorFactoryConcept`. No custom `compute_program_hash` on the op.
+- CBs (per core group, via `push_cb_pair`): c_1 (temp staging, 1 entry of `temp_cb_size`), c_0
+  (`src0`, `num_tiles` entries), c_16 (`output`, `num_tiles` entries). **`num_tiles` DIFFERS per
+  group** (`single_sub_block_size` for full/cliff-col vs `single_block_size_cliff_row` for
+  cliff-row/cliff-col-row).
+- Work-split: `split_blocks_for_tilize_wh(...)` → core_range (full) + cliff_row + cliff_col +
+  cliff_col_row, each with its own block dims. Reader/writer on `all_cores`; compute per group.
+- Kernels:
+  - reader `tilize_with_val_padding/.../reader_unary_pad_multicore_both_dims.cpp` (CROSS-OP —
+    lives in sibling op dir, shared with tilize_with_val_padding). Uses c_0 (real, push) and c_1
+    (scratch staging, used purely as an address source via `get_write_ptr()`). CTs
+    {total_num_rows, third_dim, tile_height, element_size, row_size_bytes, dram_alignment} +
+    `TensorAccessorArgs<6>`. RTAs src_addr(0), pad_value(1), width_size(2), then per-third_dim
+    re-reads start_row_id(3), start_column_id(4), single_block_size_row(5), single_block_size_col(6),
+    sub_block_width_size(7), single_sub_block_size_row(8) — all constant-index reads.
+  - writer `eltwise/unary/.../writer_unary_interleaved_start_id_wh.cpp` (SHARED with
+    tilize_with_val_padding). CTs {output_cb_index, num_tiles_2d, third_dim, total_tiles_per_row} +
+    `TensorAccessorArgs<4>`. RTAs dst_addr(0), start_id(1), single_block_size_row(2),
+    single_block_size_col(3).
+  - compute `tilize/device/kernels/compute/tilize_wh.cpp` (op-local but SHARED with
+    tilize_with_val_padding block factory). c_0/c_16 hardcoded. CTAs block_size_col(0),
+    block_size_row(1), third_dim(2).
+
+## Spec shape (post-port)
+- **Per-core-group DFB triples + KernelSpecs + WorkUnitSpec.** Because the legacy CB entry count
+  varies per group and a Metal 2.0 `DataflowBufferSpec::num_entries` is a single per-node template
+  value, each group gets its OWN `temp_<g>` / `src0_<g>` / `output_<g>` DFBs, its own
+  `reader_<g>`/`writer_<g>`/`compute_<g>` KernelSpecs, and its own WorkUnitSpec on the group's
+  cores. This mirrors the legacy per-range CBDescriptor structure exactly and satisfies the
+  Local-DFB rule (each group's reader+writer+compute are co-located in that group's WorkUnitSpec).
+- 2 TensorParameters: `input`, `output` (shared across groups; addresses patched on cache hits).
+- Per-core RTAs computed identically to legacy; each core routed to its group's reader/writer
+  KernelRunArgs by `CoreRangeSet::contains(core)` (membership matches the legacy block-dim branch).
+
+## Applied patterns
+- **Fake CB → self-loop DFB** (`temp_<g>` / legacy c_1): the temp staging buffer has no real FIFO
+  producer/consumer — the reader only grabs its base address via `get_write_ptr()`. Bound as a
+  self-loop (PRODUCER + CONSUMER, same `accessor_name="temp"`, both on the reader) to satisfy the
+  validator. **This is an interim validator-satisfying device, not a real FIFO** — flagged for the
+  eventual kernel-scratchpad migration (see Open items).
+- **Per-group multiplicity** (NOT CTA→RTA demotion): per-group compute CTAs (block_size_col/row)
+  and per-group DFB sizes preserved as separate KernelSpecs/DFBs in separate WorkUnitSpecs.
+
+## Kernels: ported vs forked (this factory)
+- **reader** — **FORKED** to op-local
+  `device/kernels/dataflow/reader_unary_pad_multicore_both_dims_m2.cpp` (legacy lives in the
+  sibling `tilize_with_val_padding/` op dir; cross-op → fork). c_0→`dfb::src0`, c_1→`dfb::temp`
+  (self-loop); `TensorAccessorArgs<6>`+addr RTA→`TensorAccessor(ta::input)`; all CTs/RTAs→named.
+  `fill_with_val` helper, alignment logic, `tt_memmove`, `CoreLocalMem`, `UnicastEndpoint` paths
+  all UNCHANGED.
+- **writer** — **FORKED** to op-local
+  `device/kernels/dataflow/writer_unary_interleaved_start_id_wh_m2.cpp` (legacy shared with
+  tilize_with_val_padding). c_16→`dfb::output`; addr RTA + `TensorAccessorArgs<4>`→`ta::output`;
+  CTs/RTAs→named. `BACKWARDS` `#ifdef` preserved (not defined for tilize block — default path only).
+- **compute** — **FORKED** to op-local `device/kernels/compute/tilize_wh_m2.cpp` (legacy shared
+  with tilize_with_val_padding). c_0/c_16→`dfb::src0`/`dfb::output` (assigned to constexpr uint32_t
+  locals, matching the tilize_m2 / bmm_m2 idiom for non-type template args); CTAs→named.
+
+## Dropped plumbing (this factory)
+- Reader src_addr RTA(0)→`TensorBinding{input}`; writer dst_addr RTA(0)→`TensorBinding{output}`;
+  writer output_cb_index CT→`dfb::output`. All `TensorAccessorArgs` host plumbing removed; all
+  positional CTAs/RTAs→named.
+
+## Blockers (this factory)
+- None — but note the per-group DFB-size workaround was necessary because Metal 2.0 has no
+  per-node-varying DFB size within one spec, and `dfb_run_overrides` is documented as unsupported.
+  The per-group fan-out is the sanctioned alternative (same as the default factory's full/cliff
+  split, extended to four groups with differing sizes). No GlobalSemaphore, no per-mesh-coord
+  variation, no live-allocator introspection, no raw buffer->address() through an RTA.
+
+---
+
+# Multi-core sharded + width-sharded factories (added port)
+
+## Status: PORTED (both)
+
+## Factories chosen
+`TilizeMultiCoreShardedProgramFactory` (HEIGHT_SHARDED) and
+`TilizeMultiCoreWidthShardedProgramFactory` (WIDTH_SHARDED) — selected by
+`select_program_factory` for sharded inputs when `can_use_sharded_optimized_factories(...)`. The
+two are structurally identical (same kernels, same DFB shape); they differ only in spec name and
+selection criteria, so they were ported in lockstep.
+
+## Legacy inventory (these factories)
+- Concept: `ProgramDescriptorFactoryConcept`. No custom hash.
+- CBs: c_0 (`src0`) and c_16 (`output`), each `num_tiles_per_shard` entries, **borrowed-memory**
+  (`cb.buffer = src_buffer` / `dst_buffer`) — io is L1-resident sharded.
+- Kernels (all on `all_cores` = shard grid):
+  - reader `eltwise/unary/.../reader_unary_sharded.cpp` (SHARED ~12 ops) — CT src0_cb_index;
+    RTA num_tiles_per_shard. Just `cb.push_back(n)`.
+  - writer `data_movement/sharded/.../writer_unary_sharded.cpp` (SHARED ~12 ops) — CT
+    output_cb_index; RTA num_tiles_per_shard. Just `cb.wait_front(n)`.
+  - compute `ttnn/cpp/ttnn/kernel/compute/tilize.cpp` (kernel_lib, SHARED) — CTs {cb_in0, cb_out,
+    per_core_block_cnt, per_core_block_tile_cnt}.
+
+## Spec shape (post-port)
+- 2 **borrowed-memory** DataflowBufferSpecs: `src0` (`borrowed_from = input`), `output`
+  (`borrowed_from = output`); backing L1 address resolves at runtime from the TensorArguments.
+- 3 KernelSpecs reader/writer/compute; 2 TensorParameters input/output.
+- 1 WorkUnitSpec hosting all three on `all_cores` (Local-DFB rule — borrowed DFBs still need
+  producer+consumer co-located).
+
+## Kernels: ported vs forked (these factories)
+- **reader** — **FORKED** to op-local `device/kernels/dataflow/reader_unary_sharded_m2.cpp` (legacy
+  shared by ~a dozen ops). CircularBuffer→DataflowBuffer; c_0→`dfb::src0`; RTA→`args::num_tiles_per_core`.
+- **writer** — **FORKED** to op-local `device/kernels/dataflow/writer_unary_sharded_m2.cpp` (legacy
+  shared by ~a dozen ops). c_16→`dfb::output`; RTA→`args::num_units`.
+- **compute** — **REUSED** the single-core port's existing fork `device/kernels/compute/tilize_m2.cpp`
+  (legacy used the same shared `kernel/compute/tilize.cpp`; the `_m2` fork already collapses the two
+  CB-index CTs to `dfb::src0`/`dfb::output` and keeps `per_core_block_cnt`/`per_core_block_tile_cnt`
+  CTAs — an exact match). Legacy compute_args `{num_tiles_per_shard/num_tiles_per_row, num_tiles_per_row}`
+  map 1:1 to `{per_core_block_cnt, per_core_block_tile_cnt}`.
+
+## Applied patterns
+- **Borrowed-memory DFB** (`borrowed_from`): src0←input, output←output (pool exemplar shape).
+- `unpack_to_dest_mode[c_0]` → `ComputeHardwareConfig::unpack_to_dest_mode` keyed on `src0` when fp32.
+
+## Blockers (these factories)
+- None. Clean borrowed-memory port.
 
 ---
 
@@ -164,6 +302,29 @@ factory ported.
 - No change needed to `tilize_device_operation.hpp/.cpp` — the variant already lists
   `TilizeSingleCoreProgramFactory`, and `select_program_factory` already routes to it.
 - nanobind (`tilize_nanobind.cpp`): no `create_descriptor` hook for this factory; nothing to remove.
+
+## Open items for downstream (added-port pass)
+- **Block temp DFB self-loop is interim.** `temp_<g>` (legacy c_1) is bound as a self-loop DFB
+  purely to satisfy the validator's producer-and-consumer rule — it is NOT a real FIFO; the reader
+  only reads its base pointer via `get_write_ptr()`. It is scratchpad-shaped; replace with the
+  forthcoming Metal 2.0 kernel-scratchpad resource when it lands.
+- **Cross-op / shared kernel forks (fork-vs-in-place coordination signal).** Five kernels were
+  forked rather than edited in place because their legacy sources are shared with sibling ops
+  (notably `tilize_with_val_padding`) or ~a dozen ops:
+  - `reader_unary_pad_multicore_both_dims.cpp` (lives in `tilize_with_val_padding/`) →
+    `reader_unary_pad_multicore_both_dims_m2.cpp`
+  - `eltwise/unary/.../writer_unary_interleaved_start_id_wh.cpp` →
+    `writer_unary_interleaved_start_id_wh_m2.cpp`
+  - `tilize/device/kernels/compute/tilize_wh.cpp` (shared with tilize_with_val_padding) →
+    `tilize_wh_m2.cpp`
+  - `eltwise/unary/.../reader_unary_sharded.cpp` → `reader_unary_sharded_m2.cpp`
+  - `data_movement/sharded/.../writer_unary_sharded.cpp` → `writer_unary_sharded_m2.cpp`
+  Until the last unmigrated consumer ports, keep bug fixes to the legacy copies in sync with these
+  `_m2` forks; delete the forks when the legacy copies are retired.
+- **Per-node-varying DFB size gap.** The block factory needed a per-core-group DFB fan-out because
+  Metal 2.0 has no way to give one `DataflowBufferSpec` per-node-varying `num_entries` within a
+  program, and `dfb_run_overrides` is documented unsupported. The fan-out is correct but verbose;
+  a per-WorkUnit DFB size override would collapse it.
 
 ## Findings / open items (routed, not changed)
 - The legacy reader emitted three RTAs the kernel never reads (slots 2/6/7). Left the

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_m2.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of ttnn/cpp/ttnn/kernel/compute/tilize.cpp, for the single-core tilize compute kernel.
+
+#include <cstdint>
+
+#include "api/compute/tilize.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "experimental/kernel_args.h"
+
+// #include "api/debug/dprint.h"
+
+void kernel_main() {
+    constexpr uint32_t per_core_block_cnt = get_arg(args::per_core_block_cnt);
+    constexpr uint32_t per_core_block_tile_cnt = get_arg(args::per_core_block_tile_cnt);
+
+    constexpr uint32_t cb_in0 = dfb::src0;
+    constexpr uint32_t cb_out = dfb::output;
+
+    compute_kernel_hw_startup(cb_in0, cb_out);
+
+    // Use lossless tilize for fp32 inputs to preserve exact values (fast tilize truncates fp32 → tf32)
+    constexpr auto fp32_mode = compute_kernel_lib::is_fp32_input_format<cb_in0>()
+                                   ? compute_kernel_lib::tilize_config::Fp32Mode::Lossless
+                                   : compute_kernel_lib::tilize_config::Fp32Mode::Fast;
+
+    compute_kernel_lib::tilize<
+        per_core_block_tile_cnt,
+        cb_in0,
+        cb_out,
+        compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+        compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+        compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure,
+        fp32_mode>(per_core_block_cnt);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh_m2.cpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp,
+// for the multi-core block tilize compute kernel. The legacy source is shared with the sibling
+// tilize_with_val_padding block factory, so it is forked rather than edited in place.
+
+#include <cstdint>
+
+#include "api/compute/tilize.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+// #include "api/debug/dprint.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr uint32_t block_size_col = get_arg(args::block_size_col);
+    constexpr uint32_t block_size_row = get_arg(args::block_size_row);
+    constexpr uint32_t third_dim = get_arg(args::third_dim);
+
+    constexpr uint32_t cb_in0 = dfb::src0;
+    constexpr uint32_t cb_out = dfb::output;
+
+    compute_kernel_hw_startup(cb_in0, cb_out);
+
+    constexpr auto fp32_mode = compute_kernel_lib::is_fp32_input_format<cb_in0>()
+                                   ? compute_kernel_lib::tilize_config::Fp32Mode::Lossless
+                                   : compute_kernel_lib::tilize_config::Fp32Mode::Fast;
+
+    compute_kernel_lib::tilize<
+        block_size_row,
+        cb_in0,
+        cb_out,
+        compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+        compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+        compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure,
+        fp32_mode>(block_size_col * third_dim);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/reader_unary_pad_multicore_both_dims_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/reader_unary_pad_multicore_both_dims_m2.cpp
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of
+// tilize_with_val_padding/device/kernels/dataflow/reader_unary_pad_multicore_both_dims.cpp,
+// for the multi-core block tilize reader. The legacy source lives in the sibling
+// tilize_with_val_padding op directory and is shared with it, so it is forked rather than
+// edited in place.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "cpp/ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "experimental/kernel_args.h"
+
+using tt::data_movement::common::tt_memmove;
+
+// Alignment-aware fill: writes 4 bytes at a time for the aligned middle,
+// and uses element-sized writes for unaligned start/end to avoid rv32 unaligned faults.
+// Supports 1-byte (FP8), 2-byte (BF16), and 4-byte (FP32) element sizes.
+// For val_size < 4, the value is replicated to fill a uint32_t for efficient aligned writes.
+template <uint32_t val_size>
+FORCE_INLINE void fill_with_val(uint32_t start_addr, uint32_t n_bytes, uint32_t val) {
+    static_assert(
+        val_size == sizeof(uint8_t) || val_size == sizeof(uint16_t) || val_size == sizeof(uint32_t),
+        "Unsupported val_size");
+    using IntType = std::conditional_t<
+        (val_size == sizeof(uint8_t)),
+        uint8_t,
+        std::conditional_t<(val_size == sizeof(uint16_t)), uint16_t, uint32_t>>;
+
+    const uint32_t end_addr = start_addr + n_bytes;
+    const uint32_t start_addr_4B = (start_addr + 0x3) & 0xFFFFFFFC;
+    const uint32_t end_addr_4B = end_addr & 0xFFFFFFFC;
+
+    // Prepare the 4-byte value for aligned writes
+    uint32_t val_4B = val;
+    if constexpr (val_size == sizeof(uint8_t)) {
+        // For 1-byte elements, replicate the byte 4 times
+        uint8_t byte_val = static_cast<uint8_t>(val);
+        val_4B =
+            (uint32_t(byte_val) << 24) | (uint32_t(byte_val) << 16) | (uint32_t(byte_val) << 8) | uint32_t(byte_val);
+    } else if constexpr (val_size == sizeof(uint16_t)) {
+        // For 2-byte elements, replicate the value 2 times
+        uint16_t short_val = static_cast<uint16_t>(val);
+        val_4B = (uint32_t(short_val) << 16) | uint32_t(short_val);
+    }
+
+    // Write 4 bytes at a time for the aligned region
+    {
+        auto* start_ptr_4B = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(start_addr_4B);
+        auto* end_ptr_4B = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(end_addr_4B);
+        for (auto* ptr = start_ptr_4B; ptr < end_ptr_4B; ++ptr) {
+            *ptr = val_4B;
+        }
+    }
+
+    // For data-types smaller than 4 bytes, handle unaligned start/end
+    if constexpr (val_size < sizeof(uint32_t)) {
+        auto* start_ptr = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr);
+        auto* end_ptr = reinterpret_cast<volatile tt_l1_ptr IntType*>(end_addr);
+        auto* start_ptr_4B = reinterpret_cast<volatile tt_l1_ptr IntType*>(start_addr_4B);
+        auto* end_ptr_4B = reinterpret_cast<volatile tt_l1_ptr IntType*>(end_addr_4B);
+        const IntType val_ = static_cast<IntType>(val);
+
+        for (auto* ptr = start_ptr; ptr < start_ptr_4B; ++ptr) {
+            *ptr = val_;
+        }
+        for (auto* ptr = end_ptr_4B; ptr < end_ptr; ++ptr) {
+            *ptr = val_;
+        }
+    }
+}
+
+void kernel_main() {
+    constexpr uint32_t total_num_rows = get_arg(args::total_num_rows);
+    constexpr uint32_t third_dim = get_arg(args::third_dim);
+    constexpr uint32_t tile_height = get_arg(args::tile_height);
+    constexpr uint32_t element_size = get_arg(args::element_size);
+    constexpr uint32_t unpadded_X_size = get_arg(args::unpadded_X_size);
+    constexpr uint32_t dram_alignment = get_arg(args::dram_alignment);
+    constexpr uint64_t dram_align_mask = ~static_cast<uint64_t>(dram_alignment - 1);
+    constexpr uint64_t dram_align_offset = static_cast<uint64_t>(dram_alignment - 1);
+
+    const uint32_t pad_value = get_arg(args::pad_value);
+
+    const auto s = TensorAccessor(ta::input);
+    Noc noc;
+    DataflowBuffer cb_in0(dfb::src0);
+    DataflowBuffer cb_in1(dfb::temp);
+
+    cb_in1.reserve_back(1);
+    uint32_t temp_addr_raw = cb_in1.get_write_ptr();
+    uint32_t temp_addr = (temp_addr_raw + dram_alignment - 1) & ~(dram_alignment - 1);
+    cb_in1.push_back(1);
+
+    auto read_block = [&](uint32_t num_rows,
+                          uint32_t start_row_id,
+                          uint32_t start_column_id,
+                          uint32_t width_size,
+                          uint32_t size_2d,
+                          uint32_t single_block_size) {
+        uint32_t padding_rows = num_rows == 32 ? 0 : 32 - num_rows;
+        bool has_rows = (num_rows + padding_rows) > 0;
+
+        cb_in0.reserve_back(single_block_size * has_rows);
+        uint32_t l1_write_addr = cb_in0.get_write_ptr();
+
+        for (uint32_t k = start_row_id; k < start_row_id + num_rows; k++) {
+            uint64_t src_noc_addr = s.get_noc_addr(size_2d + k);
+            if (((src_noc_addr + (uint64_t)start_column_id) & dram_align_offset) ==
+                ((uint64_t)l1_write_addr & dram_align_offset)) {
+                // Read from DRAM to tmp buffer
+                CoreLocalMem<uint32_t> dst(l1_write_addr);
+                noc.async_read(
+                    s, dst, width_size, {.page_id = size_2d + k, .offset_bytes = start_column_id}, {.offset_bytes = 0});
+
+                // Block before copying data from tmp to cb buffer
+                noc.async_read_barrier();
+
+                uint32_t prev_size = start_column_id;
+                uint32_t this_block_size = unpadded_X_size - prev_size;
+                if (this_block_size < width_size) {
+                    uint32_t to_pad = width_size - this_block_size;
+                    fill_with_val<element_size>(l1_write_addr + this_block_size, to_pad, pad_value);
+                }
+            } else {
+                // If there is a mis-alignment, we first load the data to a middle L1 cb, then copy to the final cb
+                // buffer. The aligned-down source is a full NoC address, so it is supplied directly via
+                // UnicastEndpoint (decomposed into x/y/local addr; NOC_XY_ADDR repacks it unchanged).
+                const uint64_t aligned_src_noc_addr = (src_noc_addr + (uint64_t)start_column_id) & dram_align_mask;
+                CoreLocalMem<uint32_t> temp_dst(temp_addr);
+                noc.async_read(
+                    UnicastEndpoint{},
+                    temp_dst,
+                    width_size + dram_alignment,
+                    {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(aligned_src_noc_addr),
+                     .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(aligned_src_noc_addr),
+                     .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(aligned_src_noc_addr)},
+                    {.offset_bytes = 0});
+
+                // Block before copying data from tmp to cb buffer
+                noc.async_read_barrier();
+
+                uint32_t prev_size = start_column_id;
+                uint32_t this_block_size = unpadded_X_size - prev_size;
+                if (this_block_size < width_size) {
+                    uint32_t to_pad = width_size - this_block_size;
+                    fill_with_val<element_size>(
+                        temp_addr + ((src_noc_addr + (uint64_t)start_column_id) & dram_align_offset) + this_block_size,
+                        to_pad,
+                        pad_value);
+                }
+
+                tt_memmove<false, false, true, 0>(
+                    l1_write_addr,
+                    temp_addr + ((src_noc_addr + (uint64_t)start_column_id) & dram_align_offset),
+                    width_size);
+            }
+
+            l1_write_addr += width_size;
+        }
+
+        for (uint32_t pad_row = 0; pad_row < padding_rows; pad_row++) {
+            fill_with_val<element_size>(l1_write_addr, width_size, pad_value);
+            l1_write_addr += width_size;
+        }
+
+        cb_in0.push_back(single_block_size * has_rows);
+    };
+
+    const uint32_t width_size = get_arg(args::width_size);
+
+    uint32_t size_2d = 0;
+    for (uint32_t dim3 = 0; dim3 < third_dim; dim3++) {
+        uint32_t start_row_id = get_arg(args::start_row_id);
+        uint32_t start_column_id = get_arg(args::start_column_id);
+        uint32_t single_block_size_row_arg = get_arg(args::single_block_size_row_arg);
+        uint32_t single_block_size_col_arg = get_arg(args::single_block_size_col_arg);
+        uint32_t sub_block_width_size = get_arg(args::sub_block_width_size);
+        uint32_t single_sub_block_size_row_arg = get_arg(args::single_sub_block_size_row_arg);
+
+        for (uint32_t b = 0; b < single_block_size_col_arg; b++) {
+            uint32_t this_block_num_rows = tile_height;
+            if (start_row_id + tile_height > total_num_rows) {
+                this_block_num_rows = total_num_rows - start_row_id;
+            }
+            if (this_block_num_rows > 0) {
+                for (uint32_t m = 0; m < width_size; m += sub_block_width_size) {
+                    uint32_t start_column_id_u = start_column_id + m;
+                    read_block(
+                        this_block_num_rows,
+                        start_row_id,
+                        start_column_id_u,
+                        sub_block_width_size,
+                        size_2d,
+                        single_sub_block_size_row_arg);
+                }
+            }
+            start_row_id += tile_height;
+        }
+        size_2d += total_num_rows;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/reader_unary_sharded_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/reader_unary_sharded_m2.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp,
+// for the sharded tilize reader (the legacy source is shared by ~a dozen ops; not
+// editable in place). Behavior unchanged: push the borrowed input DFB by num_tiles_per_core.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "experimental/kernel_args.h"
+
+#include "api/debug/dprint.h"
+
+void kernel_main() {
+    uint32_t num_tiles_per_core = get_arg(args::num_tiles_per_core);
+    constexpr uint32_t cb_id_in0 = dfb::src0;
+
+    DataflowBuffer cb(cb_id_in0);
+    cb.push_back(num_tiles_per_core);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/reader_unary_stick_layout_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/reader_unary_stick_layout_split_rows_multicore.cpp
@@ -2,6 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port. Used only by the TilizeMultiCoreDefault factory, so ported in place.
+// Logic unchanged from the legacy reader; only the access mechanism moves to named bindings:
+// source tensor address -> ta::input, CB id -> dfb::src0, positional compile-time / runtime args ->
+// get_arg(args::...). The legacy unused runtime-arg slots 2/6/7 (stick_size, num_leftover_tiles,
+// leftover_width_in_row) and compile-time slot 0 (aligned_page_size) are dropped — never read here.
+
 #include <stdint.h>
 #include <tt-metalium/constants.hpp>
 #include "api/dataflow/dataflow_api.h"
@@ -9,30 +15,29 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_id_in0 = dfb::src0;
     constexpr uint32_t tile_height = tt::constants::TILE_HEIGHT;
 
-    const uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const uint32_t num_rows = get_arg_val<uint32_t>(1);
-    const uint32_t num_tiles_per_block = get_arg_val<uint32_t>(3);
-    const uint32_t block_width_size = get_arg_val<uint32_t>(4);
-    const uint32_t num_full_blocks_in_row = get_arg_val<uint32_t>(5);
-    const uint32_t start_page_id = get_arg_val<uint32_t>(8);
+    const uint32_t num_rows = get_arg(args::num_rows);
+    const uint32_t num_tiles_per_block = get_arg(args::num_tiles_per_block);
+    const uint32_t block_width_size = get_arg(args::block_width_size);
+    const uint32_t num_full_blocks_in_row = get_arg(args::num_full_blocks_in_row);
+    const uint32_t start_page_id = get_arg(args::start_page_id);
 
     constexpr uint32_t num_pages_in_row =
-        get_compile_time_arg_val(1);  // For ND-sharded tensors, each row can have multiple pages.
+        get_arg(args::num_pages_in_row);  // For ND-sharded tensors, each row can have multiple pages.
     constexpr uint32_t size_of_valid_data_in_last_page_in_row =
-        get_compile_time_arg_val(2);  // For uneven sharding along the width, the last page could contain padding data,
-                                      // so we need to specify the size of valid data we want to read in.
+        get_arg(args::size_of_valid_data_in_last_page_in_row);  // For uneven sharding along the width, the last page
+                                                                // could contain padding data, so we need to specify the
+                                                                // size of valid data we want to read in.
 
-    constexpr auto src_tensor_args = TensorAccessorArgs<3>();
-
-    const auto s = TensorAccessor(src_tensor_args, src_addr);
+    const auto s = TensorAccessor(ta::input);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
+    DataflowBuffer cb_in0(cb_id_in0);
 
     auto read_tiles = [&](const uint32_t& num_tiles, uint32_t page_id) {
         cb_in0.reserve_back(num_tiles);

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/reader_unary_stick_layout_split_rows_singlecore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/reader_unary_stick_layout_split_rows_singlecore.cpp
@@ -8,25 +8,23 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // Constexpr
-    constexpr uint32_t cb_id_in0 = tt::CBIndex::c_0;
+    constexpr uint32_t cb_id_in0 = dfb::src0;
     constexpr uint32_t tile_height = 32;
 
-    const uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const uint32_t num_sticks = get_arg_val<uint32_t>(1);
-    const uint32_t num_tiles_per_block = get_arg_val<uint32_t>(3);
-    const uint32_t block_width_size = get_arg_val<uint32_t>(4);
-    const uint32_t num_full_blocks_in_row = get_arg_val<uint32_t>(5);
-    const uint32_t start_stick_id = get_arg_val<uint32_t>(8);
+    const uint32_t num_sticks = get_arg(args::num_sticks);
+    const uint32_t num_tiles_per_block = get_arg(args::num_tiles_per_block);
+    const uint32_t block_width_size = get_arg(args::block_width_size);
+    const uint32_t num_full_blocks_in_row = get_arg(args::num_full_blocks_in_row);
+    const uint32_t start_stick_id = get_arg(args::row_start_id);
 
-    constexpr auto src_tensor_args = TensorAccessorArgs<1>();
-
-    const auto s = TensorAccessor(src_tensor_args, src_addr);
+    const auto s = TensorAccessor(ta::input);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
+    DataflowBuffer cb_in0(cb_id_in0);
 
     uint32_t stick_ids[tile_height];
     uint32_t stick_offset = 0;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/writer_unary_interleaved_start_id_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/writer_unary_interleaved_start_id_m2.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp,
+// specialized for the single-core tilize writer (no OUT_SHARDED / BACKWARDS paths are taken there).
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t num_pages = get_arg(args::num_pages);
+    const uint32_t start_id = get_arg(args::start_id);
+
+    constexpr uint32_t cb_id_out = dfb::output;
+
+    // Get page size from DFB interface (works for both TILE and ROW_MAJOR layouts)
+    const uint32_t page_bytes = get_local_cb_interface(cb_id_out).fifo_page_size;
+
+    Noc noc;
+    DataflowBuffer cb(cb_id_out);
+
+#ifdef OUT_SHARDED
+    cb.wait_front(num_pages);
+#else
+
+    // single-page ublocks (works for both TILE and ROW_MAJOR layouts)
+    constexpr uint32_t onepage = 1;
+
+    const auto s = TensorAccessor(ta::output);
+
+#ifdef BACKWARDS
+    uint32_t end_id = start_id - num_pages;
+    for (uint32_t i = start_id; i != end_id; --i) {
+#else
+    uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+#endif
+        cb.wait_front(onepage);
+        noc.async_write(cb, s, page_bytes, {}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb.pop_front(onepage);
+    }
+    noc.async_write_barrier();
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/writer_unary_interleaved_start_id_wh_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/writer_unary_interleaved_start_id_wh_m2.cpp
@@ -1,0 +1,53 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp,
+// for the multi-core block tilize writer. The legacy source is shared with the sibling
+// tilize_with_val_padding block factory, so it is forked rather than edited in place.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    uint32_t start_id = get_arg(args::start_id);
+    uint32_t single_block_size_row_arg = get_arg(args::single_block_size_row_arg);
+    uint32_t single_block_size_col_arg = get_arg(args::single_block_size_col_arg);
+
+    constexpr uint32_t cb_id_out = dfb::output;
+    constexpr uint32_t num_tiles_per_2d = get_arg(args::num_tiles_per_2d);
+    constexpr uint32_t third_dim = get_arg(args::third_dim);
+    constexpr uint32_t total_tiles_per_row = get_arg(args::total_tiles_per_row);
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_tile_size(cb_id_out);
+
+    const auto s = TensorAccessor(ta::output);
+
+    Noc noc;
+    DataflowBuffer cb(cb_id_out);
+
+#ifdef BACKWARDS
+    for (uint32_t dim = 0; dim > -third_dim; dim--) {
+        for (uint32_t c = 0; c > -single_block_size_col_arg; c--) {
+            for (uint32_t r = 0; r > -single_block_size_row_arg; r--) {
+                uint32_t tile = -start_id + dim * num_tiles_per_2d + c * total_tiles_per_row + r;
+#else
+    for (uint32_t dim = 0; dim < third_dim; dim++) {
+        for (uint32_t c = 0; c < single_block_size_col_arg; c++) {
+            for (uint32_t r = 0; r < single_block_size_row_arg; r++) {
+                uint32_t tile = start_id + dim * num_tiles_per_2d + c * total_tiles_per_row + r;
+#endif
+                cb.wait_front(onetile);
+                noc.async_write(cb, s, tile_bytes, {}, {.page_id = tile});
+                noc.async_writes_flushed();
+                cb.pop_front(onetile);
+            }
+        }
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/writer_unary_sharded_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/writer_unary_sharded_m2.cpp
@@ -1,0 +1,22 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp,
+// for the sharded tilize writer (the legacy source is shared by ~a dozen ops; not editable
+// in place). Behavior unchanged: wait on the borrowed output DFB for num_units entries.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t num_units = get_arg(args::num_units);
+
+    constexpr uint32_t cb_id_out = dfb::output;
+
+    DataflowBuffer cb_out(cb_id_out);
+
+    cb_out.wait_front(num_units);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -4,6 +4,10 @@
 
 #include "tilize_multi_core_block_program_factory.hpp"
 
+#include <filesystem>
+#include <string>
+#include <vector>
+
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
@@ -11,69 +15,39 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
 namespace {
 
-// Helper: append a paired (input, output) CBDescriptor for a given core range.
-void push_cb_pair(
-    ProgramDescriptor& desc,
-    const CoreRangeSet& core_ranges,
-    uint32_t input_single_tile_size,
-    uint32_t output_single_tile_size,
-    uint32_t num_tiles,
-    tt::DataFormat input_cb_data_format,
-    tt::DataFormat output_cb_data_format,
-    uint32_t dram_alignment) {
-    // c_1 is a per-row staging buffer used by the reader when the DRAM source row and the
-    // L1 destination have different alignment offsets: the reader rounds the source address
-    // down to a dram_alignment boundary, issues one noc_async_read of (row_bytes + dram_alignment)
-    // into this buffer, then copies the correctly-offset slice into c_0.
-    //   row_bytes  = TILE_WIDTH * elt_size * num_tiles  (one row of a sub-block)
-    //              = input_single_tile_size / TILE_HEIGHT * num_tiles
-    //   + dram_alignment    : tail bytes from rounding the DRAM read down to alignment
-    //   + dram_alignment    : headroom for aligning the L1 write pointer up to dram_alignment
-    //                         (get_write_ptr only guarantees L1 alignment, not DRAM alignment)
-    uint32_t input_row_bytes = input_single_tile_size / TILE_HEIGHT;
-    uint32_t temp_cb_size = input_row_bytes * num_tiles + 2 * dram_alignment;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = temp_cb_size,
-        .core_ranges = core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_1),
-            .data_format = input_cb_data_format,
-            .page_size = temp_cb_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_tiles * input_single_tile_size,
-        .core_ranges = core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_tiles * output_single_tile_size,
-        .core_ranges = core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_16),
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
-}
+// One per-core-group bundle of DFBs + kernels + WorkUnitSpec. The legacy factory created a
+// separate (c_1, c_0, c_16) CBDescriptor triple per core range — and crucially the entry counts
+// differ between groups (single_sub_block_size vs single_block_size_cliff_row). A Metal 2.0
+// DataflowBufferSpec's num_entries is a single per-node template value, so each group needs its
+// OWN DFB triple, its own reader/writer/compute KernelSpecs (binding that group's DFBs), and its
+// own WorkUnitSpec — the Local-DFB rule (producer+consumer co-located) is satisfied because all
+// three kernels of a group share that group's WorkUnitSpec on the group's cores.
+struct BlockGroup {
+    std::string suffix;       // unique-id suffix (e.g. "full", "cliff_row")
+    CoreRangeSet cores;       // this group's core ranges
+    uint32_t num_tiles;       // CB/DFB entry count for c_0/c_16 (legacy push_cb_pair num_tiles)
+    uint32_t block_size_col;  // compute CTA 0
+    uint32_t block_size_row;  // compute CTA 1
+};
 
 }  // namespace
 
-ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
+// Metal 2.0 program factory: builds the immutable ProgramSpec and its mutable ProgramRunArgs.
+// Behavior-preserving port of the legacy ProgramDescriptor multi-core block (WH) tilize factory.
+ttnn::device_operation::ProgramArtifacts TilizeMultiCoreBlockProgramFactory::create_program_spec(
     const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input_tensor;
     const Tensor& output = tensor_return_value;
@@ -128,60 +102,12 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
 
     uint32_t row_size_bytes = a.padded_shape()[-1] * a.element_size();  // Assuming bfloat16 dataformat
 
-    Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
 
-    ProgramDescriptor desc;
-
-    if (!core_range.empty()) {
-        push_cb_pair(
-            desc,
-            core_range,
-            input_single_tile_size,
-            output_single_tile_size,
-            single_sub_block_size,
-            input_cb_data_format,
-            output_cb_data_format,
-            dram_alignment);
-    }
-    if (has_cliff_col && has_cliff_row) {
-        push_cb_pair(
-            desc,
-            cliff_col_row_core_range,
-            input_single_tile_size,
-            output_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format,
-            output_cb_data_format,
-            dram_alignment);
-    }
-    if (has_cliff_row) {
-        push_cb_pair(
-            desc,
-            cliff_row_core_range,
-            input_single_tile_size,
-            output_single_tile_size,
-            single_block_size_cliff_row,
-            input_cb_data_format,
-            output_cb_data_format,
-            dram_alignment);
-    }
-    if (has_cliff_col) {
-        push_cb_pair(
-            desc,
-            cliff_col_core_range,
-            input_single_tile_size,
-            output_single_tile_size,
-            single_sub_block_size,
-            input_cb_data_format,
-            output_cb_data_format,
-            dram_alignment);
-    }
-
-    // reader
+    // reader CT derivations (identical to legacy)
     uint32_t num_tiles_2d = output.padded_shape()[-1] * output.padded_shape()[-2] / TILE_HW;
 
     auto log_shape = output.logical_shape();
@@ -200,75 +126,261 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
         total_num_rows = output.padded_shape()[-2];
     }
 
-    std::vector<uint32_t> reader_compile_time_args = {
-        total_num_rows, third_dim, tile_height, a.element_size(), row_size_bytes, dram_alignment};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/"
-        "reader_unary_pad_multicore_both_dims.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    // writer
-    std::vector<uint32_t> writer_compile_time_args = {tt::CBIndex::c_16, num_tiles_2d, third_dim, total_tiles_per_row};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    // compute
+    // compute CT derivations (identical to legacy)
     uint32_t single_sub_block_wh = single_block_size * single_block_size / single_sub_block_size;
     uint32_t single_sub_block_cliff_col_wh = single_block_size_cliff_col * single_block_size / single_sub_block_size;
 
-    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
-    }
-
-    const std::string compute_kernel_path =
-        "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp";
-
-    auto make_compute_kernel = [&](const CoreRangeSet& cores, std::vector<uint32_t> compile_args) {
-        KernelDescriptor cd;
-        cd.kernel_source = compute_kernel_path;
-        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        cd.core_ranges = cores;
-        cd.compile_time_args = std::move(compile_args);
-        cd.config = ComputeConfigDescriptor{
-            .fp32_dest_acc_en = fp32_llk_acc,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-        };
-        return cd;
-    };
-
-    std::vector<KernelDescriptor> compute_kernels;
+    // ---- Per-core-group bundles ----
+    // Mirrors the legacy push_cb_pair / make_compute_kernel calls one-for-one. Each group carries
+    // the CB entry count (num_tiles) and the compute CTAs (block_size_col/row) it used legacy-side.
+    std::vector<BlockGroup> groups;
     if (!core_range.empty()) {
-        compute_kernels.push_back(
-            make_compute_kernel(core_range, {single_sub_block_wh, single_sub_block_size, third_dim}));
+        groups.push_back({"full", core_range, single_sub_block_size, single_sub_block_wh, single_sub_block_size});
     }
     if (has_cliff_col && has_cliff_row) {
-        compute_kernels.push_back(make_compute_kernel(
-            cliff_col_row_core_range, {single_block_size_cliff_col, single_block_size_cliff_row, third_dim}));
+        groups.push_back(
+            {"cliff_col_row",
+             cliff_col_row_core_range,
+             single_block_size_cliff_row,
+             single_block_size_cliff_col,
+             single_block_size_cliff_row});
     }
     if (has_cliff_row) {
-        compute_kernels.push_back(
-            make_compute_kernel(cliff_row_core_range, {single_block_size, single_block_size_cliff_row, third_dim}));
+        groups.push_back(
+            {"cliff_row",
+             cliff_row_core_range,
+             single_block_size_cliff_row,
+             single_block_size,
+             single_block_size_cliff_row});
     }
     if (has_cliff_col) {
-        compute_kernels.push_back(make_compute_kernel(
-            cliff_col_core_range, {single_sub_block_cliff_col_wh, single_sub_block_size, third_dim}));
+        groups.push_back(
+            {"cliff_col",
+             cliff_col_core_range,
+             single_sub_block_size,
+             single_sub_block_cliff_col_wh,
+             single_sub_block_size});
     }
 
-    // RUNTIME ARGS
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "tilize_multi_core_block";
+
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output.tensor_spec()},
+    };
+
+    const std::filesystem::path reader_src{
+        "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
+        "reader_unary_pad_multicore_both_dims_m2.cpp"};
+    const std::filesystem::path writer_src{
+        "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
+        "writer_unary_interleaved_start_id_wh_m2.cpp"};
+    const std::filesystem::path compute_src{
+        "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh_m2.cpp"};
+
+    std::vector<m2::WorkUnitSpec> work_units;
+    work_units.reserve(groups.size());
+
+    for (const auto& g : groups) {
+        const std::string src0_id = "src0_" + g.suffix;
+        const std::string temp_id = "temp_" + g.suffix;
+        const std::string output_id = "output_" + g.suffix;
+        const std::string reader_id = "reader_" + g.suffix;
+        const std::string writer_id = "writer_" + g.suffix;
+        const std::string compute_id = "compute_" + g.suffix;
+
+        // c_1 temp staging buffer (one entry of temp_cb_size bytes): the reader rounds the DRAM
+        // source down to a dram_alignment boundary, reads (row_bytes + dram_alignment) here, then
+        // copies the correctly-offset slice into src0. It is used purely as an address source
+        // (get_write_ptr) — there is no real FIFO producer/consumer pair — so it is bound as a
+        // self-loop DFB on the reader (PRODUCER + CONSUMER, same kernel) to satisfy the validator.
+        uint32_t input_row_bytes = input_single_tile_size / TILE_HEIGHT;
+        uint32_t temp_cb_size = input_row_bytes * g.num_tiles + 2 * dram_alignment;
+
+        // c_0 src0: row-major sticks the reader fills, the compute tilizes.
+        // c_16 output: tilized output the compute produces, the writer drains.
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{temp_id},
+            .entry_size = temp_cb_size,
+            .num_entries = 1,
+            .data_format_metadata = input_cb_data_format,
+        });
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{src0_id},
+            .entry_size = input_single_tile_size,
+            .num_entries = g.num_tiles,
+            .data_format_metadata = input_cb_data_format,
+        });
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{output_id},
+            .entry_size = output_single_tile_size,
+            .num_entries = g.num_tiles,
+            .data_format_metadata = output_cb_data_format,
+        });
+
+        // Reader: produces src0 + self-loops temp. Reads the input tensor (binding).
+        // Legacy CTs {total_num_rows, third_dim, tile_height, element_size, row_size_bytes(unpadded_X_size),
+        // dram_alignment} + TensorAccessorArgs<6> → named CTAs + ta::input.
+        m2::KernelSpec reader{
+            .unique_id = m2::KernelSpecName{reader_id},
+            .source = reader_src,
+            .dfb_bindings =
+                {
+                    m2::DFBBinding{
+                        .dfb_spec_name = m2::DFBSpecName{src0_id},
+                        .accessor_name = "src0",
+                        .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                    },
+                    m2::DFBBinding{
+                        .dfb_spec_name = m2::DFBSpecName{temp_id},
+                        .accessor_name = "temp",
+                        .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                    },
+                    m2::DFBBinding{
+                        .dfb_spec_name = m2::DFBSpecName{temp_id},
+                        .accessor_name = "temp",
+                        .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                    },
+                },
+            .tensor_bindings =
+                {
+                    m2::TensorBinding{
+                        .tensor_parameter_name = m2::TensorParamName{"input"},
+                        .accessor_name = "input",
+                    },
+                },
+            .compile_time_args =
+                {
+                    {"total_num_rows", total_num_rows},
+                    {"third_dim", third_dim},
+                    {"tile_height", tile_height},
+                    {"element_size", a.element_size()},
+                    {"unpadded_X_size", row_size_bytes},
+                    {"dram_alignment", dram_alignment},
+                },
+            .runtime_arg_schema =
+                {
+                    .runtime_arg_names =
+                        {"pad_value",
+                         "width_size",
+                         "start_row_id",
+                         "start_column_id",
+                         "single_block_size_row_arg",
+                         "single_block_size_col_arg",
+                         "sub_block_width_size",
+                         "single_sub_block_size_row_arg"},
+                },
+            .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+        };
+
+        // Writer: consumes output. Drains the output DFB into the output tensor (binding).
+        // Legacy CTs {output_cb_index, num_tiles_2d, third_dim, total_tiles_per_row} + TensorAccessorArgs<4>
+        // → dfb::output binding + named CTAs + ta::output.
+        m2::KernelSpec writer{
+            .unique_id = m2::KernelSpecName{writer_id},
+            .source = writer_src,
+            .dfb_bindings =
+                {
+                    m2::DFBBinding{
+                        .dfb_spec_name = m2::DFBSpecName{output_id},
+                        .accessor_name = "output",
+                        .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                    },
+                },
+            .tensor_bindings =
+                {
+                    m2::TensorBinding{
+                        .tensor_parameter_name = m2::TensorParamName{"output"},
+                        .accessor_name = "output",
+                    },
+                },
+            .compile_time_args =
+                {
+                    {"num_tiles_per_2d", num_tiles_2d},
+                    {"third_dim", third_dim},
+                    {"total_tiles_per_row", total_tiles_per_row},
+                },
+            .runtime_arg_schema =
+                {
+                    .runtime_arg_names = {"start_id", "single_block_size_row_arg", "single_block_size_col_arg"},
+                },
+            .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+        };
+
+        // Compute: consumes src0, produces output. Legacy CTAs {block_size_col, block_size_row, third_dim}.
+        m2::KernelSpec compute{
+            .unique_id = m2::KernelSpecName{compute_id},
+            .source = compute_src,
+            .dfb_bindings =
+                {
+                    m2::DFBBinding{
+                        .dfb_spec_name = m2::DFBSpecName{src0_id},
+                        .accessor_name = "src0",
+                        .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                    },
+                    m2::DFBBinding{
+                        .dfb_spec_name = m2::DFBSpecName{output_id},
+                        .accessor_name = "output",
+                        .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                    },
+                },
+            .compile_time_args =
+                {
+                    {"block_size_col", g.block_size_col},
+                    {"block_size_row", g.block_size_row},
+                    {"third_dim", third_dim},
+                },
+            .hw_config =
+                m2::ComputeHardwareConfig{
+                    .fp32_dest_acc_en = fp32_llk_acc,
+                },
+        };
+        // Legacy set unpack_to_dest_mode[c_0]=UnpackToDestFp32 when fp32_llk_acc; preserve that for
+        // this group's src0 DFB (the compute consumer of the fp32 input).
+        if (fp32_llk_acc) {
+            std::get<m2::ComputeHardwareConfig>(compute.hw_config).unpack_to_dest_mode = {
+                {m2::DFBSpecName{src0_id}, UnpackToDestMode::UnpackToDestFp32}};
+        }
+
+        spec.kernels.push_back(std::move(reader));
+        spec.kernels.push_back(std::move(writer));
+        spec.kernels.push_back(std::move(compute));
+
+        work_units.push_back(m2::WorkUnitSpec{
+            .name = "wu_" + g.suffix,
+            .kernels = {m2::KernelSpecName{reader_id}, m2::KernelSpecName{writer_id}, m2::KernelSpecName{compute_id}},
+            .target_nodes = g.cores,
+        });
+    }
+
+    spec.work_units = std::move(work_units);
+
+    // ---- ProgramRunArgs (mutable) ----
+    // Per-core RTAs computed exactly as legacy. Each core is routed to its group's reader/writer
+    // KernelRunArgs by checking which group's core set contains it (membership matches the legacy
+    // branch that picked the per-core block dimensions).
+    m2::ProgramRunArgs run;
+    // One reader/writer KernelRunArgs per group, keyed by suffix.
+    std::vector<m2::KernelRunArgs> reader_runs;
+    std::vector<m2::KernelRunArgs> writer_runs;
+    reader_runs.reserve(groups.size());
+    writer_runs.reserve(groups.size());
+    for (const auto& g : groups) {
+        reader_runs.push_back(m2::KernelRunArgs{.kernel = m2::KernelSpecName{"reader_" + g.suffix}});
+        writer_runs.push_back(m2::KernelRunArgs{.kernel = m2::KernelSpecName{"writer_" + g.suffix}});
+    }
+    auto group_index_for = [&](const CoreCoord& core) -> size_t {
+        for (size_t gi = 0; gi < groups.size(); ++gi) {
+            if (groups[gi].cores.contains(core)) {
+                return gi;
+            }
+        }
+        TT_FATAL(false, "tilize block: core not found in any work-split group");
+        return 0;
+    };
+
     const auto& cores = corerange_to_cores(available_grid);
     uint32_t start_row_id = 0;
     uint32_t start_column_id = 0;
@@ -305,23 +417,27 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
             single_sub_block_size_row_arg = single_sub_block_size;
         }
 
-        // reader runtime args — Buffer* slot auto-registers as a BufferBinding so the
-        // framework patches addresses on cache hits.
-        reader_desc.emplace_runtime_args(
-            core,
-            {src0_buffer,
-             std::uint32_t{0},
-             TILE_WIDTH * a.element_size() * single_block_size_row_arg,
-             start_row_id,
-             start_column_id,
-             single_block_size_row_arg,
-             single_block_size_col_arg,
-             TILE_WIDTH * a.element_size() * single_sub_block_size_row_arg,
-             single_sub_block_size_row_arg});
+        const size_t gi = group_index_for(core);
 
-        // writer runtime args
-        writer_desc.emplace_runtime_args(
-            core, {dst_buffer, tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
+        // reader runtime args — src addr is now a TensorBinding; the unused legacy slot 1 was the
+        // pad_value (0 for tilize, which has no padding value to apply).
+        reader_runs[gi].runtime_arg_values.push_back(
+            {core,
+             {{"pad_value", std::uint32_t{0}},
+              {"width_size", TILE_WIDTH * a.element_size() * single_block_size_row_arg},
+              {"start_row_id", start_row_id},
+              {"start_column_id", start_column_id},
+              {"single_block_size_row_arg", single_block_size_row_arg},
+              {"single_block_size_col_arg", single_block_size_col_arg},
+              {"sub_block_width_size", TILE_WIDTH * a.element_size() * single_sub_block_size_row_arg},
+              {"single_sub_block_size_row_arg", single_sub_block_size_row_arg}}});
+
+        // writer runtime args — dst addr is now a TensorBinding.
+        writer_runs[gi].runtime_arg_values.push_back(
+            {core,
+             {{"start_id", tile_start_id},
+              {"single_block_size_row_arg", single_block_size_row_arg},
+              {"single_block_size_col_arg", single_block_size_col_arg}}});
 
         uint32_t end_column_id = start_column_id + (single_block_size_row_arg * TILE_WIDTH * a.element_size());
         start_column_id = end_column_id % row_size_bytes;
@@ -337,12 +453,18 @@ ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
         }
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    for (auto& cd : compute_kernels) {
-        desc.kernels.push_back(std::move(cd));
+    run.kernel_run_args.reserve(reader_runs.size() + writer_runs.size());
+    for (auto& r : reader_runs) {
+        run.kernel_run_args.push_back(std::move(r));
     }
+    for (auto& w : writer_runs) {
+        run.kernel_run_args.push_back(std::move(w));
+    }
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, a.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output.mesh_tensor()},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.cpp
@@ -4,10 +4,6 @@
 
 #include "tilize_multi_core_block_program_factory.hpp"
 
-#include <filesystem>
-#include <string>
-#include <vector>
-
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
@@ -15,39 +11,69 @@
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
-
-#include "ttnn/metal2_artifacts.hpp"
-#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
-#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
-namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
 namespace {
 
-// One per-core-group bundle of DFBs + kernels + WorkUnitSpec. The legacy factory created a
-// separate (c_1, c_0, c_16) CBDescriptor triple per core range — and crucially the entry counts
-// differ between groups (single_sub_block_size vs single_block_size_cliff_row). A Metal 2.0
-// DataflowBufferSpec's num_entries is a single per-node template value, so each group needs its
-// OWN DFB triple, its own reader/writer/compute KernelSpecs (binding that group's DFBs), and its
-// own WorkUnitSpec — the Local-DFB rule (producer+consumer co-located) is satisfied because all
-// three kernels of a group share that group's WorkUnitSpec on the group's cores.
-struct BlockGroup {
-    std::string suffix;       // unique-id suffix (e.g. "full", "cliff_row")
-    CoreRangeSet cores;       // this group's core ranges
-    uint32_t num_tiles;       // CB/DFB entry count for c_0/c_16 (legacy push_cb_pair num_tiles)
-    uint32_t block_size_col;  // compute CTA 0
-    uint32_t block_size_row;  // compute CTA 1
-};
+// Helper: append a paired (input, output) CBDescriptor for a given core range.
+void push_cb_pair(
+    ProgramDescriptor& desc,
+    const CoreRangeSet& core_ranges,
+    uint32_t input_single_tile_size,
+    uint32_t output_single_tile_size,
+    uint32_t num_tiles,
+    tt::DataFormat input_cb_data_format,
+    tt::DataFormat output_cb_data_format,
+    uint32_t dram_alignment) {
+    // c_1 is a per-row staging buffer used by the reader when the DRAM source row and the
+    // L1 destination have different alignment offsets: the reader rounds the source address
+    // down to a dram_alignment boundary, issues one noc_async_read of (row_bytes + dram_alignment)
+    // into this buffer, then copies the correctly-offset slice into c_0.
+    //   row_bytes  = TILE_WIDTH * elt_size * num_tiles  (one row of a sub-block)
+    //              = input_single_tile_size / TILE_HEIGHT * num_tiles
+    //   + dram_alignment    : tail bytes from rounding the DRAM read down to alignment
+    //   + dram_alignment    : headroom for aligning the L1 write pointer up to dram_alignment
+    //                         (get_write_ptr only guarantees L1 alignment, not DRAM alignment)
+    uint32_t input_row_bytes = input_single_tile_size / TILE_HEIGHT;
+    uint32_t temp_cb_size = input_row_bytes * num_tiles + 2 * dram_alignment;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = temp_cb_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_1),
+            .data_format = input_cb_data_format,
+            .page_size = temp_cb_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * input_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
+            .data_format = input_cb_data_format,
+            .page_size = input_single_tile_size,
+        }}},
+    });
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = num_tiles * output_single_tile_size,
+        .core_ranges = core_ranges,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_16),
+            .data_format = output_cb_data_format,
+            .page_size = output_single_tile_size,
+        }}},
+    });
+}
 
 }  // namespace
 
-// Metal 2.0 program factory: builds the immutable ProgramSpec and its mutable ProgramRunArgs.
-// Behavior-preserving port of the legacy ProgramDescriptor multi-core block (WH) tilize factory.
-ttnn::device_operation::ProgramArtifacts TilizeMultiCoreBlockProgramFactory::create_program_spec(
+ProgramDescriptor TilizeMultiCoreBlockProgramFactory::create_descriptor(
     const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input_tensor;
     const Tensor& output = tensor_return_value;
@@ -102,12 +128,60 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreBlockProgramFactory::cre
 
     uint32_t row_size_bytes = a.padded_shape()[-1] * a.element_size();  // Assuming bfloat16 dataformat
 
+    Buffer* src0_buffer = a.buffer();
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     const uint32_t dram_alignment = tt::tt_metal::hal::get_dram_alignment();
 
-    // reader CT derivations (identical to legacy)
+    ProgramDescriptor desc;
+
+    if (!core_range.empty()) {
+        push_cb_pair(
+            desc,
+            core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_sub_block_size,
+            input_cb_data_format,
+            output_cb_data_format,
+            dram_alignment);
+    }
+    if (has_cliff_col && has_cliff_row) {
+        push_cb_pair(
+            desc,
+            cliff_col_row_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_block_size_cliff_row,
+            input_cb_data_format,
+            output_cb_data_format,
+            dram_alignment);
+    }
+    if (has_cliff_row) {
+        push_cb_pair(
+            desc,
+            cliff_row_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_block_size_cliff_row,
+            input_cb_data_format,
+            output_cb_data_format,
+            dram_alignment);
+    }
+    if (has_cliff_col) {
+        push_cb_pair(
+            desc,
+            cliff_col_core_range,
+            input_single_tile_size,
+            output_single_tile_size,
+            single_sub_block_size,
+            input_cb_data_format,
+            output_cb_data_format,
+            dram_alignment);
+    }
+
+    // reader
     uint32_t num_tiles_2d = output.padded_shape()[-1] * output.padded_shape()[-2] / TILE_HW;
 
     auto log_shape = output.logical_shape();
@@ -126,261 +200,75 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreBlockProgramFactory::cre
         total_num_rows = output.padded_shape()[-2];
     }
 
-    // compute CT derivations (identical to legacy)
+    std::vector<uint32_t> reader_compile_time_args = {
+        total_num_rows, third_dim, tile_height, a.element_size(), row_size_bytes, dram_alignment};
+    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/device/kernels/dataflow/"
+        "reader_unary_pad_multicore_both_dims.cpp";
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = all_cores;
+    reader_desc.compile_time_args = std::move(reader_compile_time_args);
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    // writer
+    std::vector<uint32_t> writer_compile_time_args = {tt::CBIndex::c_16, num_tiles_2d, third_dim, total_tiles_per_row};
+    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source =
+        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id_wh.cpp";
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = all_cores;
+    writer_desc.compile_time_args = std::move(writer_compile_time_args);
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // compute
     uint32_t single_sub_block_wh = single_block_size * single_block_size / single_sub_block_size;
     uint32_t single_sub_block_cliff_col_wh = single_block_size_cliff_col * single_block_size / single_sub_block_size;
 
-    // ---- Per-core-group bundles ----
-    // Mirrors the legacy push_cb_pair / make_compute_kernel calls one-for-one. Each group carries
-    // the CB entry count (num_tiles) and the compute CTAs (block_size_col/row) it used legacy-side.
-    std::vector<BlockGroup> groups;
+    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    if (fp32_llk_acc) {
+        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
+    }
+
+    const std::string compute_kernel_path =
+        "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh.cpp";
+
+    auto make_compute_kernel = [&](const CoreRangeSet& cores, std::vector<uint32_t> compile_args) {
+        KernelDescriptor cd;
+        cd.kernel_source = compute_kernel_path;
+        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
+        cd.core_ranges = cores;
+        cd.compile_time_args = std::move(compile_args);
+        cd.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_llk_acc,
+            .unpack_to_dest_mode = unpack_to_dest_mode,
+        };
+        return cd;
+    };
+
+    std::vector<KernelDescriptor> compute_kernels;
     if (!core_range.empty()) {
-        groups.push_back({"full", core_range, single_sub_block_size, single_sub_block_wh, single_sub_block_size});
+        compute_kernels.push_back(
+            make_compute_kernel(core_range, {single_sub_block_wh, single_sub_block_size, third_dim}));
     }
     if (has_cliff_col && has_cliff_row) {
-        groups.push_back(
-            {"cliff_col_row",
-             cliff_col_row_core_range,
-             single_block_size_cliff_row,
-             single_block_size_cliff_col,
-             single_block_size_cliff_row});
+        compute_kernels.push_back(make_compute_kernel(
+            cliff_col_row_core_range, {single_block_size_cliff_col, single_block_size_cliff_row, third_dim}));
     }
     if (has_cliff_row) {
-        groups.push_back(
-            {"cliff_row",
-             cliff_row_core_range,
-             single_block_size_cliff_row,
-             single_block_size,
-             single_block_size_cliff_row});
+        compute_kernels.push_back(
+            make_compute_kernel(cliff_row_core_range, {single_block_size, single_block_size_cliff_row, third_dim}));
     }
     if (has_cliff_col) {
-        groups.push_back(
-            {"cliff_col",
-             cliff_col_core_range,
-             single_sub_block_size,
-             single_sub_block_cliff_col_wh,
-             single_sub_block_size});
+        compute_kernels.push_back(make_compute_kernel(
+            cliff_col_core_range, {single_sub_block_cliff_col_wh, single_sub_block_size, third_dim}));
     }
 
-    // ---- ProgramSpec (immutable) ----
-    m2::ProgramSpec spec;
-    spec.name = "tilize_multi_core_block";
-
-    spec.tensor_parameters = {
-        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = a.tensor_spec()},
-        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output.tensor_spec()},
-    };
-
-    const std::filesystem::path reader_src{
-        "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
-        "reader_unary_pad_multicore_both_dims_m2.cpp"};
-    const std::filesystem::path writer_src{
-        "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
-        "writer_unary_interleaved_start_id_wh_m2.cpp"};
-    const std::filesystem::path compute_src{
-        "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_wh_m2.cpp"};
-
-    std::vector<m2::WorkUnitSpec> work_units;
-    work_units.reserve(groups.size());
-
-    for (const auto& g : groups) {
-        const std::string src0_id = "src0_" + g.suffix;
-        const std::string temp_id = "temp_" + g.suffix;
-        const std::string output_id = "output_" + g.suffix;
-        const std::string reader_id = "reader_" + g.suffix;
-        const std::string writer_id = "writer_" + g.suffix;
-        const std::string compute_id = "compute_" + g.suffix;
-
-        // c_1 temp staging buffer (one entry of temp_cb_size bytes): the reader rounds the DRAM
-        // source down to a dram_alignment boundary, reads (row_bytes + dram_alignment) here, then
-        // copies the correctly-offset slice into src0. It is used purely as an address source
-        // (get_write_ptr) — there is no real FIFO producer/consumer pair — so it is bound as a
-        // self-loop DFB on the reader (PRODUCER + CONSUMER, same kernel) to satisfy the validator.
-        uint32_t input_row_bytes = input_single_tile_size / TILE_HEIGHT;
-        uint32_t temp_cb_size = input_row_bytes * g.num_tiles + 2 * dram_alignment;
-
-        // c_0 src0: row-major sticks the reader fills, the compute tilizes.
-        // c_16 output: tilized output the compute produces, the writer drains.
-        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
-            .unique_id = m2::DFBSpecName{temp_id},
-            .entry_size = temp_cb_size,
-            .num_entries = 1,
-            .data_format_metadata = input_cb_data_format,
-        });
-        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
-            .unique_id = m2::DFBSpecName{src0_id},
-            .entry_size = input_single_tile_size,
-            .num_entries = g.num_tiles,
-            .data_format_metadata = input_cb_data_format,
-        });
-        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
-            .unique_id = m2::DFBSpecName{output_id},
-            .entry_size = output_single_tile_size,
-            .num_entries = g.num_tiles,
-            .data_format_metadata = output_cb_data_format,
-        });
-
-        // Reader: produces src0 + self-loops temp. Reads the input tensor (binding).
-        // Legacy CTs {total_num_rows, third_dim, tile_height, element_size, row_size_bytes(unpadded_X_size),
-        // dram_alignment} + TensorAccessorArgs<6> → named CTAs + ta::input.
-        m2::KernelSpec reader{
-            .unique_id = m2::KernelSpecName{reader_id},
-            .source = reader_src,
-            .dfb_bindings =
-                {
-                    m2::DFBBinding{
-                        .dfb_spec_name = m2::DFBSpecName{src0_id},
-                        .accessor_name = "src0",
-                        .endpoint_type = m2::DFBEndpointType::PRODUCER,
-                    },
-                    m2::DFBBinding{
-                        .dfb_spec_name = m2::DFBSpecName{temp_id},
-                        .accessor_name = "temp",
-                        .endpoint_type = m2::DFBEndpointType::PRODUCER,
-                    },
-                    m2::DFBBinding{
-                        .dfb_spec_name = m2::DFBSpecName{temp_id},
-                        .accessor_name = "temp",
-                        .endpoint_type = m2::DFBEndpointType::CONSUMER,
-                    },
-                },
-            .tensor_bindings =
-                {
-                    m2::TensorBinding{
-                        .tensor_parameter_name = m2::TensorParamName{"input"},
-                        .accessor_name = "input",
-                    },
-                },
-            .compile_time_args =
-                {
-                    {"total_num_rows", total_num_rows},
-                    {"third_dim", third_dim},
-                    {"tile_height", tile_height},
-                    {"element_size", a.element_size()},
-                    {"unpadded_X_size", row_size_bytes},
-                    {"dram_alignment", dram_alignment},
-                },
-            .runtime_arg_schema =
-                {
-                    .runtime_arg_names =
-                        {"pad_value",
-                         "width_size",
-                         "start_row_id",
-                         "start_column_id",
-                         "single_block_size_row_arg",
-                         "single_block_size_col_arg",
-                         "sub_block_width_size",
-                         "single_sub_block_size_row_arg"},
-                },
-            .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
-        };
-
-        // Writer: consumes output. Drains the output DFB into the output tensor (binding).
-        // Legacy CTs {output_cb_index, num_tiles_2d, third_dim, total_tiles_per_row} + TensorAccessorArgs<4>
-        // → dfb::output binding + named CTAs + ta::output.
-        m2::KernelSpec writer{
-            .unique_id = m2::KernelSpecName{writer_id},
-            .source = writer_src,
-            .dfb_bindings =
-                {
-                    m2::DFBBinding{
-                        .dfb_spec_name = m2::DFBSpecName{output_id},
-                        .accessor_name = "output",
-                        .endpoint_type = m2::DFBEndpointType::CONSUMER,
-                    },
-                },
-            .tensor_bindings =
-                {
-                    m2::TensorBinding{
-                        .tensor_parameter_name = m2::TensorParamName{"output"},
-                        .accessor_name = "output",
-                    },
-                },
-            .compile_time_args =
-                {
-                    {"num_tiles_per_2d", num_tiles_2d},
-                    {"third_dim", third_dim},
-                    {"total_tiles_per_row", total_tiles_per_row},
-                },
-            .runtime_arg_schema =
-                {
-                    .runtime_arg_names = {"start_id", "single_block_size_row_arg", "single_block_size_col_arg"},
-                },
-            .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
-        };
-
-        // Compute: consumes src0, produces output. Legacy CTAs {block_size_col, block_size_row, third_dim}.
-        m2::KernelSpec compute{
-            .unique_id = m2::KernelSpecName{compute_id},
-            .source = compute_src,
-            .dfb_bindings =
-                {
-                    m2::DFBBinding{
-                        .dfb_spec_name = m2::DFBSpecName{src0_id},
-                        .accessor_name = "src0",
-                        .endpoint_type = m2::DFBEndpointType::CONSUMER,
-                    },
-                    m2::DFBBinding{
-                        .dfb_spec_name = m2::DFBSpecName{output_id},
-                        .accessor_name = "output",
-                        .endpoint_type = m2::DFBEndpointType::PRODUCER,
-                    },
-                },
-            .compile_time_args =
-                {
-                    {"block_size_col", g.block_size_col},
-                    {"block_size_row", g.block_size_row},
-                    {"third_dim", third_dim},
-                },
-            .hw_config =
-                m2::ComputeHardwareConfig{
-                    .fp32_dest_acc_en = fp32_llk_acc,
-                },
-        };
-        // Legacy set unpack_to_dest_mode[c_0]=UnpackToDestFp32 when fp32_llk_acc; preserve that for
-        // this group's src0 DFB (the compute consumer of the fp32 input).
-        if (fp32_llk_acc) {
-            std::get<m2::ComputeHardwareConfig>(compute.hw_config).unpack_to_dest_mode = {
-                {m2::DFBSpecName{src0_id}, UnpackToDestMode::UnpackToDestFp32}};
-        }
-
-        spec.kernels.push_back(std::move(reader));
-        spec.kernels.push_back(std::move(writer));
-        spec.kernels.push_back(std::move(compute));
-
-        work_units.push_back(m2::WorkUnitSpec{
-            .name = "wu_" + g.suffix,
-            .kernels = {m2::KernelSpecName{reader_id}, m2::KernelSpecName{writer_id}, m2::KernelSpecName{compute_id}},
-            .target_nodes = g.cores,
-        });
-    }
-
-    spec.work_units = std::move(work_units);
-
-    // ---- ProgramRunArgs (mutable) ----
-    // Per-core RTAs computed exactly as legacy. Each core is routed to its group's reader/writer
-    // KernelRunArgs by checking which group's core set contains it (membership matches the legacy
-    // branch that picked the per-core block dimensions).
-    m2::ProgramRunArgs run;
-    // One reader/writer KernelRunArgs per group, keyed by suffix.
-    std::vector<m2::KernelRunArgs> reader_runs;
-    std::vector<m2::KernelRunArgs> writer_runs;
-    reader_runs.reserve(groups.size());
-    writer_runs.reserve(groups.size());
-    for (const auto& g : groups) {
-        reader_runs.push_back(m2::KernelRunArgs{.kernel = m2::KernelSpecName{"reader_" + g.suffix}});
-        writer_runs.push_back(m2::KernelRunArgs{.kernel = m2::KernelSpecName{"writer_" + g.suffix}});
-    }
-    auto group_index_for = [&](const CoreCoord& core) -> size_t {
-        for (size_t gi = 0; gi < groups.size(); ++gi) {
-            if (groups[gi].cores.contains(core)) {
-                return gi;
-            }
-        }
-        TT_FATAL(false, "tilize block: core not found in any work-split group");
-        return 0;
-    };
-
+    // RUNTIME ARGS
     const auto& cores = corerange_to_cores(available_grid);
     uint32_t start_row_id = 0;
     uint32_t start_column_id = 0;
@@ -417,27 +305,23 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreBlockProgramFactory::cre
             single_sub_block_size_row_arg = single_sub_block_size;
         }
 
-        const size_t gi = group_index_for(core);
+        // reader runtime args — Buffer* slot auto-registers as a BufferBinding so the
+        // framework patches addresses on cache hits.
+        reader_desc.emplace_runtime_args(
+            core,
+            {src0_buffer,
+             std::uint32_t{0},
+             TILE_WIDTH * a.element_size() * single_block_size_row_arg,
+             start_row_id,
+             start_column_id,
+             single_block_size_row_arg,
+             single_block_size_col_arg,
+             TILE_WIDTH * a.element_size() * single_sub_block_size_row_arg,
+             single_sub_block_size_row_arg});
 
-        // reader runtime args — src addr is now a TensorBinding; the unused legacy slot 1 was the
-        // pad_value (0 for tilize, which has no padding value to apply).
-        reader_runs[gi].runtime_arg_values.push_back(
-            {core,
-             {{"pad_value", std::uint32_t{0}},
-              {"width_size", TILE_WIDTH * a.element_size() * single_block_size_row_arg},
-              {"start_row_id", start_row_id},
-              {"start_column_id", start_column_id},
-              {"single_block_size_row_arg", single_block_size_row_arg},
-              {"single_block_size_col_arg", single_block_size_col_arg},
-              {"sub_block_width_size", TILE_WIDTH * a.element_size() * single_sub_block_size_row_arg},
-              {"single_sub_block_size_row_arg", single_sub_block_size_row_arg}}});
-
-        // writer runtime args — dst addr is now a TensorBinding.
-        writer_runs[gi].runtime_arg_values.push_back(
-            {core,
-             {{"start_id", tile_start_id},
-              {"single_block_size_row_arg", single_block_size_row_arg},
-              {"single_block_size_col_arg", single_block_size_col_arg}}});
+        // writer runtime args
+        writer_desc.emplace_runtime_args(
+            core, {dst_buffer, tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
 
         uint32_t end_column_id = start_column_id + (single_block_size_row_arg * TILE_WIDTH * a.element_size());
         start_column_id = end_column_id % row_size_bytes;
@@ -453,18 +337,12 @@ ttnn::device_operation::ProgramArtifacts TilizeMultiCoreBlockProgramFactory::cre
         }
     }
 
-    run.kernel_run_args.reserve(reader_runs.size() + writer_runs.size());
-    for (auto& r : reader_runs) {
-        run.kernel_run_args.push_back(std::move(r));
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    for (auto& cd : compute_kernels) {
+        desc.kernels.push_back(std::move(cd));
     }
-    for (auto& w : writer_runs) {
-        run.kernel_run_args.push_back(std::move(w));
-    }
-    run.tensor_args = {
-        {m2::TensorParamName{"input"}, a.mesh_tensor()},
-        {m2::TensorParamName{"output"}, output.mesh_tensor()},
-    };
 
-    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
+    return desc;
 }
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.hpp
@@ -4,14 +4,16 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 #include "tilize_device_operation_types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
-
+// Metal 2.0 program factory: returns a ProgramSpec + ProgramRunArgs artifact
+// (ProgramSpecFactoryConcept). The remaining tilize factories stay on the legacy
+// ProgramDescriptor concept; the framework adapter dispatches per-factory.
 struct TilizeMultiCoreBlockProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_block_program_factory.hpp
@@ -4,16 +4,14 @@
 
 #pragma once
 
-#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/program_descriptors.hpp>
 #include "tilize_device_operation_types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
-// Metal 2.0 program factory: returns a ProgramSpec + ProgramRunArgs artifact
-// (ProgramSpecFactoryConcept). The remaining tilize factories stay on the legacy
-// ProgramDescriptor concept; the framework adapter dispatches per-factory.
+
 struct TilizeMultiCoreBlockProgramFactory {
-    static ttnn::device_operation::ProgramArtifacts create_program_spec(
+    static tt::tt_metal::ProgramDescriptor create_descriptor(
         const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_default_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_default_program_factory.cpp
@@ -4,20 +4,28 @@
 
 #include "tilize_multi_core_default_program_factory.hpp"
 
+#include <filesystem>
+
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-ProgramDescriptor TilizeMultiCoreDefaultProgramFactory::create_descriptor(
+// Metal 2.0 program factory: builds the immutable ProgramSpec and its mutable ProgramRunArgs.
+// Behavior-preserving port of the legacy ProgramDescriptor multi-core (interleaved, default-selected)
+// tilize factory.
+ttnn::device_operation::ProgramArtifacts TilizeMultiCoreDefaultProgramFactory::create_program_spec(
     const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input_tensor;
     const Tensor& output = tensor_return_value;
@@ -48,35 +56,8 @@ ProgramDescriptor TilizeMultiCoreDefaultProgramFactory::create_descriptor(
     auto [ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff] =
         ttnn::split_blocks_for_tilize(available_grid, nblocks);
 
-    const uint32_t src0_cb_index = tt::CBIndex::c_0;
-    const uint32_t output_cb_index = tt::CBIndex::c_16;
-
-    ProgramDescriptor desc;
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = ntiles_per_block * input_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-    });
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = ntiles_per_block * output_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
-
-    /** reader
-     */
+    // ---- reader CT/RTA derivations (identical to legacy) ----
     uint32_t page_size = src0_buffer->page_size();
-    uint32_t aligned_page_size = src0_buffer->aligned_page_size();
     uint32_t num_pages_in_row = 1;
     uint32_t size_of_valid_data_in_last_page_in_row = page_size;
     if (a.is_sharded()) {
@@ -89,100 +70,193 @@ ProgramDescriptor TilizeMultiCoreDefaultProgramFactory::create_descriptor(
             (a.logical_shape()[-1] * a.element_size());  // Compute padding size for the last page in the row.
         size_of_valid_data_in_last_page_in_row = page_size - padding_size;
     }
-    std::vector<uint32_t> reader_ct_args = {
-        aligned_page_size, num_pages_in_row, size_of_valid_data_in_last_page_in_row};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_ct_args);
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
-        "reader_unary_stick_layout_split_rows_multicore.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "tilize_multi_core";
 
-    /** writer
-     */
-    std::vector<uint32_t> writer_ct_args = {output_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+    // "src0" (legacy CB c_0): input row-major sticks the reader fills and the compute tilizes.
+    // "output" (legacy CB c_16): tilized output the compute produces and the writer drains.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"src0"},
+            .entry_size = input_single_tile_size,
+            .num_entries = ntiles_per_block,
+            .data_format_metadata = input_cb_data_format,
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"output"},
+            .entry_size = output_single_tile_size,
+            .num_entries = ntiles_per_block,
+            .data_format_metadata = output_cb_data_format,
+        },
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    // Reader (multicore stick-layout split-rows). Reads the input tensor (binding) into the src0 DFB.
+    // Legacy positional CTs were {aligned_page_size, num_pages_in_row, size_of_valid_data_in_last_page_in_row}
+    // followed by TensorAccessorArgs<3>; the kernel only reads CT slots 1 and 2 (aligned_page_size is
+    // unused), and the accessor moves to the ta::input binding.
+    // Legacy positional RTAs were slots 0(src addr -> binding),1,3,4,5,8; the unused slots 2/6/7
+    // (stick_size, num_leftover_tiles, leftover_width_in_row) are dropped — the kernel never read them.
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
+                                        "reader_unary_stick_layout_split_rows_multicore.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{
+                    .tensor_parameter_name = m2::TensorParamName{"input"},
+                    .accessor_name = "input",
+                },
+            },
+        .compile_time_args =
+            {
+                {"num_pages_in_row", num_pages_in_row},
+                {"size_of_valid_data_in_last_page_in_row", size_of_valid_data_in_last_page_in_row},
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"num_rows", "num_tiles_per_block", "block_width_size", "num_full_blocks_in_row", "start_page_id"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
 
-    /** compute
-     */
-    std::vector<uint32_t> compute_args = {nblocks_per_core, ntiles_per_block};
-    std::vector<uint32_t> compute_args_cliff = {nblocks_per_core_cliff, ntiles_per_block};
+    // Writer (forked from eltwise/unary writer_unary_interleaved_start_id.cpp).
+    // Drains the output DFB into the output tensor (binding). Legacy CT was {output_cb_index} +
+    // TensorAccessorArgs; both become bindings (dfb::output / ta::output).
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
+                                        "writer_unary_interleaved_start_id_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"output"},
+                    .accessor_name = "output",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{
+                    .tensor_parameter_name = m2::TensorParamName{"output"},
+                    .accessor_name = "output",
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_pages", "start_id"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
 
-    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
-    }
-
-    std::optional<KernelDescriptor> compute_desc;
-    if (!core_range.ranges().empty()) {
-        KernelDescriptor cd;
-        cd.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
-        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        cd.core_ranges = core_range;
-        cd.compile_time_args = std::move(compute_args);
-        cd.config = ComputeConfigDescriptor{
-            .fp32_dest_acc_en = fp32_llk_acc,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
+    // Compute (forked from ttnn/cpp/ttnn/kernel/compute/tilize.cpp).
+    // Consumes src0, produces output. per_core_block_cnt / per_core_block_tile_cnt stay CTAs; the full
+    // and cliff core groups differ only in per_core_block_cnt (nblocks_per_core vs nblocks_per_core_cliff).
+    auto make_compute = [&](const std::string& id, uint32_t per_core_block_cnt) {
+        m2::KernelSpec cd{
+            .unique_id = m2::KernelSpecName{id},
+            .source =
+                std::filesystem::path{
+                    "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_m2.cpp"},
+            .dfb_bindings =
+                {
+                    m2::DFBBinding{
+                        .dfb_spec_name = m2::DFBSpecName{"src0"},
+                        .accessor_name = "src0",
+                        .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                    },
+                    m2::DFBBinding{
+                        .dfb_spec_name = m2::DFBSpecName{"output"},
+                        .accessor_name = "output",
+                        .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                    },
+                },
+            .compile_time_args =
+                {
+                    {"per_core_block_cnt", per_core_block_cnt},
+                    {"per_core_block_tile_cnt", ntiles_per_block},
+                },
+            .hw_config =
+                m2::ComputeHardwareConfig{
+                    .fp32_dest_acc_en = fp32_llk_acc,
+                },
         };
-        compute_desc = std::move(cd);
+        // Legacy set unpack_to_dest_mode[c_0]=UnpackToDestFp32 when fp32_llk_acc; preserve that for
+        // the src0 DFB (the compute consumer of the fp32 input).
+        if (fp32_llk_acc) {
+            std::get<m2::ComputeHardwareConfig>(cd.hw_config).unpack_to_dest_mode = {
+                {m2::DFBSpecName{"src0"}, UnpackToDestMode::UnpackToDestFp32}};
+        }
+        return cd;
+    };
+
+    const bool has_full = !core_range.ranges().empty();
+    const bool has_cliff = !core_range_cliff.ranges().empty();
+
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output.tensor_spec()},
+    };
+
+    // Local DFBs (src0/output) require their producer and consumer KernelSpecs to share the SAME
+    // WorkUnitSpec(s) — every node hosting the DFB must host both endpoints. So each core group gets
+    // one WorkUnitSpec containing reader + compute_<group> + writer (reader/writer are shared across
+    // both groups; the per-group compute differs only in its per_core_block_cnt CTA).
+    spec.kernels = {reader, writer};
+    std::vector<m2::WorkUnitSpec> work_units;
+    if (has_full) {
+        spec.kernels.push_back(make_compute("compute", nblocks_per_core));
+        work_units.push_back(m2::WorkUnitSpec{
+            .name = "full",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}, m2::KernelSpecName{"compute"}},
+            .target_nodes = core_range,
+        });
     }
-
-    std::optional<KernelDescriptor> compute_cliff_desc;
-    if (!core_range_cliff.empty()) {
-        KernelDescriptor cd;
-        cd.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
-        cd.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        cd.core_ranges = core_range_cliff;
-        cd.compile_time_args = std::move(compute_args_cliff);
-        cd.config = ComputeConfigDescriptor{
-            .fp32_dest_acc_en = fp32_llk_acc,
-            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
-        };
-        compute_cliff_desc = std::move(cd);
+    if (has_cliff) {
+        spec.kernels.push_back(make_compute("compute_cliff", nblocks_per_core_cliff));
+        work_units.push_back(m2::WorkUnitSpec{
+            .name = "cliff",
+            .kernels =
+                {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}, m2::KernelSpecName{"compute_cliff"}},
+            .target_nodes = core_range_cliff,
+        });
     }
+    spec.work_units = std::move(work_units);
 
-    // 1D distribution of blocks across cores
-    bool has_cliff = !core_range_cliff.empty();
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
 
-    uint32_t ncores_full = ncores - has_cliff;
+    // 1D distribution of blocks across cores (identical to legacy): first ncores_full cores are full,
+    // the last core (when present) is the cliff core.
+    uint32_t ncores_full = ncores - (has_cliff ? 1 : 0);
     uint32_t tile_start_id = 0;
     uint32_t page_start_id = 0;
     const auto& cores = corerange_to_cores(available_grid);
     for (uint32_t i = 0; i < ncores_full; ++i) {
         const CoreCoord& core = cores[i];
 
-        // reader runtime args — Buffer* slots auto-register as BufferBindings so the
-        // framework patches addresses on cache hits.
-        reader_desc.emplace_runtime_args(
-            core,
-            {src0_buffer,
-             nblocks_per_core * TILE_HEIGHT,
-             page_size,
-             ntiles_per_block,
-             page_size,
-             std::uint32_t{1},  // full blocks in row
-             std::uint32_t{0},  // num leftover tiles
-             std::uint32_t{0},  // leftover width in row
-             page_start_id});
+        reader_run.runtime_arg_values.push_back(
+            {core,
+             {{"num_rows", nblocks_per_core * TILE_HEIGHT},
+              {"num_tiles_per_block", ntiles_per_block},
+              {"block_width_size", page_size},
+              {"num_full_blocks_in_row", std::uint32_t{1}},
+              {"start_page_id", page_start_id}}});
 
-        // writer runtime args
-        writer_desc.emplace_runtime_args(
-            core,
-            {dst_buffer,
-             ntiles_per_block * nblocks_per_core,  // ntiles per core
-             tile_start_id});                      // start id
+        writer_run.runtime_arg_values.push_back(
+            {core, {{"num_pages", ntiles_per_block * nblocks_per_core}, {"start_id", tile_start_id}}});
 
         tile_start_id += ntiles_per_block * nblocks_per_core;
         page_start_id += TILE_HEIGHT * nblocks_per_core * num_pages_in_row;
@@ -191,37 +265,25 @@ ProgramDescriptor TilizeMultiCoreDefaultProgramFactory::create_descriptor(
         // the last core is a cliff core with nblocks_per_core_cliff blocks
         const CoreCoord& core = cores[ncores_full];
 
-        // reader runtime args
-        reader_desc.emplace_runtime_args(
-            core,
-            {src0_buffer,
-             nblocks_per_core_cliff * TILE_HEIGHT,
-             page_size,
-             ntiles_per_block,
-             page_size,
-             std::uint32_t{1},  // full blocks in row
-             std::uint32_t{0},  // num leftover tiles
-             std::uint32_t{0},  // leftover width in row
-             page_start_id});
+        reader_run.runtime_arg_values.push_back(
+            {core,
+             {{"num_rows", nblocks_per_core_cliff * TILE_HEIGHT},
+              {"num_tiles_per_block", ntiles_per_block},
+              {"block_width_size", page_size},
+              {"num_full_blocks_in_row", std::uint32_t{1}},
+              {"start_page_id", page_start_id}}});
 
-        // writer runtime args
-        writer_desc.emplace_runtime_args(
-            core,
-            {dst_buffer,
-             ntiles_per_block * nblocks_per_core_cliff,  // ntiles per core
-             tile_start_id});                            // start id
+        writer_run.runtime_arg_values.push_back(
+            {core, {{"num_pages", ntiles_per_block * nblocks_per_core_cliff}, {"start_id", tile_start_id}}});
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    if (compute_desc.has_value()) {
-        desc.kernels.push_back(std::move(*compute_desc));
-    }
-    if (compute_cliff_desc.has_value()) {
-        desc.kernels.push_back(std::move(*compute_cliff_desc));
-    }
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, a.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output.mesh_tensor()},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_default_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_default_program_factory.hpp
@@ -4,14 +4,16 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 #include "tilize_device_operation_types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
-
+// Metal 2.0 program factory: returns a ProgramSpec + ProgramRunArgs artifact
+// (ProgramSpecFactoryConcept). The remaining tilize factories stay on the legacy
+// ProgramDescriptor concept; the framework adapter dispatches per-factory.
 struct TilizeMultiCoreDefaultProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_sharded_program_factory.cpp
@@ -4,18 +4,25 @@
 
 #include "tilize_multi_core_sharded_program_factory.hpp"
 
+#include <filesystem>
+
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-ProgramDescriptor TilizeMultiCoreShardedProgramFactory::create_descriptor(
+// Metal 2.0 program factory: builds the immutable ProgramSpec and its mutable ProgramRunArgs.
+// Behavior-preserving port of the legacy ProgramDescriptor multi-core (height-)sharded tilize factory.
+ttnn::device_operation::ProgramArtifacts TilizeMultiCoreShardedProgramFactory::create_program_spec(
     const TilizeParams& /*operation_attributes*/, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input_tensor;
     const Tensor& output = tensor_return_value;
@@ -31,92 +38,147 @@ ProgramDescriptor TilizeMultiCoreShardedProgramFactory::create_descriptor(
     uint32_t num_tiles_per_row = shard_spec.shape[1] / TILE_WIDTH;
     const CoreRangeSet& all_cores = shard_spec.grid;
 
-    const uint32_t src0_cb_index = tt::CBIndex::c_0;
-    const uint32_t output_cb_index = tt::CBIndex::c_16;
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "tilize_multi_core_sharded";
 
-    Buffer* src_buffer = input.buffer();
-    Buffer* dst_buffer = output.buffer();
-
-    ProgramDescriptor desc;
-
-    // Sharded input CB — globally allocated to the input buffer; framework patches
-    // the CB address on cache hits via cb.buffer.
-    {
-        CBDescriptor cb_src0;
-        cb_src0.total_size = num_tiles_per_shard * input_single_tile_size;
-        cb_src0.core_ranges = all_cores;
-        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        });
-        cb_src0.buffer = src_buffer;
-        desc.cbs.push_back(std::move(cb_src0));
-    }
-
-    // Sharded output CB — globally allocated to the output buffer.
-    {
-        CBDescriptor cb_output;
-        cb_output.total_size = num_tiles_per_shard * output_single_tile_size;
-        cb_output.core_ranges = all_cores;
-        cb_output.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        });
-        cb_output.buffer = dst_buffer;
-        desc.cbs.push_back(std::move(cb_output));
-    }
-
-    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    // Sharded readers/writers consume only the (constant per-launch) num_tiles_per_shard
-    // count; no Buffer* slot is needed because the CB itself carries the buffer binding.
-    for (const auto& core : corerange_to_cores(all_cores)) {
-        reader_desc.emplace_runtime_args(core, {num_tiles_per_shard});
-        writer_desc.emplace_runtime_args(core, {num_tiles_per_shard});
-    }
-
-    std::vector<uint32_t> compute_args = {
-        uint32_t(num_tiles_per_shard / num_tiles_per_row), uint32_t(num_tiles_per_row)};
-
-    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
-    }
-
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = std::move(compute_args);
-    compute_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = fp32_llk_acc,
-        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    // "src0" (legacy CB c_0): borrowed-memory DFB on the sharded input buffer (io is L1) —
+    // backing address resolves at runtime from the "input" TensorArgument.
+    // "output" (legacy CB c_16): borrowed-memory DFB on the sharded output buffer.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"src0"},
+            .entry_size = input_single_tile_size,
+            .num_entries = num_tiles_per_shard,
+            .data_format_metadata = input_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"input"},
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"output"},
+            .entry_size = output_single_tile_size,
+            .num_entries = num_tiles_per_shard,
+            .data_format_metadata = output_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"output"},
+        },
     };
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    // Reader (forked from eltwise/unary reader_unary_sharded.cpp). Just pushes the borrowed
+    // src0 DFB by num_tiles_per_core; the legacy CT was the src0 CB index (now dfb::src0).
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
+                                        "reader_unary_sharded_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_tiles_per_core"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
 
-    return desc;
+    // Writer (forked from data_movement/sharded writer_unary_sharded.cpp). Waits on the borrowed
+    // output DFB for num_units entries; the legacy CT was the output CB index (now dfb::output).
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
+                                        "writer_unary_sharded_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"output"},
+                    .accessor_name = "output",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_units"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+
+    // Compute (reuses the single-core port's fork of ttnn/cpp/ttnn/kernel/compute/tilize.cpp).
+    // The legacy sharded compute used the same shared source with CTs
+    // {cb_in0, cb_out, per_core_block_cnt, per_core_block_tile_cnt}; the first two collapse to
+    // dfb::src0 / dfb::output bindings, the latter two stay CTAs.
+    //   per_core_block_cnt      = num_tiles_per_shard / num_tiles_per_row
+    //   per_core_block_tile_cnt = num_tiles_per_row
+    m2::KernelSpec compute{
+        .unique_id = m2::KernelSpecName{"compute"},
+        .source =
+            std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"output"},
+                    .accessor_name = "output",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .compile_time_args =
+            {
+                {"per_core_block_cnt", num_tiles_per_shard / num_tiles_per_row},
+                {"per_core_block_tile_cnt", num_tiles_per_row},
+            },
+        .hw_config =
+            m2::ComputeHardwareConfig{
+                .fp32_dest_acc_en = fp32_llk_acc,
+            },
+    };
+    // Legacy set unpack_to_dest_mode[c_0]=UnpackToDestFp32 when fp32_llk_acc; preserve that for
+    // the src0 DFB (the compute consumer of the fp32 input).
+    if (fp32_llk_acc) {
+        std::get<m2::ComputeHardwareConfig>(compute.hw_config).unpack_to_dest_mode = {
+            {m2::DFBSpecName{"src0"}, UnpackToDestMode::UnpackToDestFp32}};
+    }
+
+    spec.kernels = {reader, writer, compute};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = input.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output.tensor_spec()},
+    };
+
+    // All three kernels run on every shard core. Both DFBs are borrowed onto io tensors and
+    // produced/consumed across reader/compute/writer — they share the single WorkUnitSpec on
+    // all_cores so every node hosting a DFB hosts both its producer and consumer (Local-DFB rule).
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "tilize_multi_core_sharded",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}, m2::KernelSpecName{"compute"}},
+            .target_nodes = all_cores,
+        },
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+
+    // Sharded readers/writers consume only the (constant per-launch) num_tiles_per_shard count.
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        reader_run.runtime_arg_values.push_back({core, {{"num_tiles_per_core", num_tiles_per_shard}}});
+        writer_run.runtime_arg_values.push_back({core, {{"num_units", num_tiles_per_shard}}});
+    }
+
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, input.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_sharded_program_factory.hpp
@@ -4,14 +4,16 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 #include "tilize_device_operation_types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
-
+// Metal 2.0 program factory: returns a ProgramSpec + ProgramRunArgs artifact
+// (ProgramSpecFactoryConcept). The remaining tilize factories stay on the legacy
+// ProgramDescriptor concept; the framework adapter dispatches per-factory.
 struct TilizeMultiCoreShardedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_width_sharded_program_factory.cpp
@@ -4,18 +4,26 @@
 
 #include "tilize_multi_core_width_sharded_program_factory.hpp"
 
+#include <filesystem>
+
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-ProgramDescriptor TilizeMultiCoreWidthShardedProgramFactory::create_descriptor(
+// Metal 2.0 program factory: builds the immutable ProgramSpec and its mutable ProgramRunArgs.
+// Behavior-preserving port of the legacy ProgramDescriptor multi-core width-sharded tilize factory.
+// (Identical structure to the height-sharded factory; selected for WIDTH_SHARDED inputs.)
+ttnn::device_operation::ProgramArtifacts TilizeMultiCoreWidthShardedProgramFactory::create_program_spec(
     const TilizeParams& /*operation_attributes*/, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& input = tensor_args.input_tensor;
     const Tensor& output = tensor_return_value;
@@ -32,92 +40,147 @@ ProgramDescriptor TilizeMultiCoreWidthShardedProgramFactory::create_descriptor(
     uint32_t num_tiles_per_row = shard_spec.shape[1] / TILE_WIDTH;
     const CoreRangeSet& all_cores = shard_spec.grid;
 
-    const uint32_t src0_cb_index = tt::CBIndex::c_0;
-    const uint32_t output_cb_index = tt::CBIndex::c_16;
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "tilize_multi_core_width_sharded";
 
-    Buffer* src_buffer = input.buffer();
-    Buffer* dst_buffer = output.buffer();
-
-    ProgramDescriptor desc;
-
-    // Sharded input CB — globally allocated to the input buffer; framework patches
-    // the CB address on cache hits via cb.buffer.
-    {
-        CBDescriptor cb_src0;
-        cb_src0.total_size = num_tiles_per_shard * input_single_tile_size;
-        cb_src0.core_ranges = all_cores;
-        cb_src0.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        });
-        cb_src0.buffer = src_buffer;
-        desc.cbs.push_back(std::move(cb_src0));
-    }
-
-    // Sharded output CB — globally allocated to the output buffer.
-    {
-        CBDescriptor cb_output;
-        cb_output.total_size = num_tiles_per_shard * output_single_tile_size;
-        cb_output.core_ranges = all_cores;
-        cb_output.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        });
-        cb_output.buffer = dst_buffer;
-        desc.cbs.push_back(std::move(cb_output));
-    }
-
-    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    // Sharded readers/writers consume only num_tiles_per_shard (constant per launch);
-    // the CB itself carries the buffer binding.
-    for (const auto& core : corerange_to_cores(all_cores)) {
-        reader_desc.emplace_runtime_args(core, {num_tiles_per_shard});
-        writer_desc.emplace_runtime_args(core, {num_tiles_per_shard});
-    }
-
-    std::vector<uint32_t> compute_args = {
-        uint32_t(num_tiles_per_shard / num_tiles_per_row), uint32_t(num_tiles_per_row)};
-
-    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
-    if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
-    }
-
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = std::move(compute_args);
-    compute_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = fp32_llk_acc,
-        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    // "src0" (legacy CB c_0): borrowed-memory DFB on the sharded input buffer (io is L1) —
+    // backing address resolves at runtime from the "input" TensorArgument.
+    // "output" (legacy CB c_16): borrowed-memory DFB on the sharded output buffer.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"src0"},
+            .entry_size = input_single_tile_size,
+            .num_entries = num_tiles_per_shard,
+            .data_format_metadata = input_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"input"},
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"output"},
+            .entry_size = output_single_tile_size,
+            .num_entries = num_tiles_per_shard,
+            .data_format_metadata = output_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"output"},
+        },
     };
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    // Reader (forked from eltwise/unary reader_unary_sharded.cpp). Just pushes the borrowed
+    // src0 DFB by num_tiles_per_core; the legacy CT was the src0 CB index (now dfb::src0).
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
+                                        "reader_unary_sharded_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_tiles_per_core"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
 
-    return desc;
+    // Writer (forked from data_movement/sharded writer_unary_sharded.cpp). Waits on the borrowed
+    // output DFB for num_units entries; the legacy CT was the output CB index (now dfb::output).
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
+                                        "writer_unary_sharded_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"output"},
+                    .accessor_name = "output",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_units"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+
+    // Compute (reuses the single-core port's fork of ttnn/cpp/ttnn/kernel/compute/tilize.cpp).
+    // The legacy width-sharded compute used the same shared source with CTs
+    // {cb_in0, cb_out, per_core_block_cnt, per_core_block_tile_cnt}; the first two collapse to
+    // dfb::src0 / dfb::output bindings, the latter two stay CTAs.
+    //   per_core_block_cnt      = num_tiles_per_shard / num_tiles_per_row
+    //   per_core_block_tile_cnt = num_tiles_per_row
+    m2::KernelSpec compute{
+        .unique_id = m2::KernelSpecName{"compute"},
+        .source =
+            std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"output"},
+                    .accessor_name = "output",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .compile_time_args =
+            {
+                {"per_core_block_cnt", num_tiles_per_shard / num_tiles_per_row},
+                {"per_core_block_tile_cnt", num_tiles_per_row},
+            },
+        .hw_config =
+            m2::ComputeHardwareConfig{
+                .fp32_dest_acc_en = fp32_llk_acc,
+            },
+    };
+    // Legacy set unpack_to_dest_mode[c_0]=UnpackToDestFp32 when fp32_llk_acc; preserve that for
+    // the src0 DFB (the compute consumer of the fp32 input).
+    if (fp32_llk_acc) {
+        std::get<m2::ComputeHardwareConfig>(compute.hw_config).unpack_to_dest_mode = {
+            {m2::DFBSpecName{"src0"}, UnpackToDestMode::UnpackToDestFp32}};
+    }
+
+    spec.kernels = {reader, writer, compute};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = input.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output.tensor_spec()},
+    };
+
+    // All three kernels run on every shard core. Both DFBs are borrowed onto io tensors and
+    // produced/consumed across reader/compute/writer — they share the single WorkUnitSpec on
+    // all_cores so every node hosting a DFB hosts both its producer and consumer (Local-DFB rule).
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "tilize_multi_core_width_sharded",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}, m2::KernelSpecName{"compute"}},
+            .target_nodes = all_cores,
+        },
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+
+    // Sharded readers/writers consume only the (constant per-launch) num_tiles_per_shard count.
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        reader_run.runtime_arg_values.push_back({core, {{"num_tiles_per_core", num_tiles_per_shard}}});
+        writer_run.runtime_arg_values.push_back({core, {{"num_units", num_tiles_per_shard}}});
+    }
+
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, input.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_width_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_multi_core_width_sharded_program_factory.hpp
@@ -4,14 +4,16 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 #include "tilize_device_operation_types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
-
+// Metal 2.0 program factory: returns a ProgramSpec + ProgramRunArgs artifact
+// (ProgramSpecFactoryConcept). The remaining tilize factories stay on the legacy
+// ProgramDescriptor concept; the framework adapter dispatches per-factory.
 struct TilizeMultiCoreWidthShardedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_single_core_program_factory.cpp
@@ -4,18 +4,25 @@
 
 #include "tilize_single_core_program_factory.hpp"
 
+#include <filesystem>
+
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-ProgramDescriptor TilizeSingleCoreProgramFactory::create_descriptor(
+// Metal 2.0 program factory: builds the immutable ProgramSpec and its mutable ProgramRunArgs.
+// Behavior-preserving port of the legacy ProgramDescriptor single-core tilize factory.
+ttnn::device_operation::ProgramArtifacts TilizeSingleCoreProgramFactory::create_program_spec(
     const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value) {
     const auto& a = tensor_args.input_tensor;
     const Tensor& output = tensor_return_value;
@@ -24,10 +31,6 @@ ProgramDescriptor TilizeSingleCoreProgramFactory::create_descriptor(
     CoreRange default_core({0, 0}, {0, 0});
     CoreRange core = sub_core_grids.has_value() ? corerange_to_cores(sub_core_grids.value()).at(0) : default_core;
     CoreRangeSet core_ranges{core};
-
-    Buffer* src0_buffer = a.buffer();
-
-    // This should allocate a DRAM buffer on the device
 
     Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
@@ -46,7 +49,6 @@ ProgramDescriptor TilizeSingleCoreProgramFactory::create_descriptor(
     auto width = a.padded_shape()[-1];
     uint32_t stick_s = width;
     uint32_t num_sticks = a.physical_volume() / width;
-    uint32_t stick_size = stick_s * a.element_size();  // Assuming bfloat16 dataformat
 
     uint32_t num_tiles_in_row = stick_s / TILE_WIDTH;
     uint32_t num_tiles_per_block = 1;
@@ -71,101 +73,161 @@ ProgramDescriptor TilizeSingleCoreProgramFactory::create_descriptor(
 
     uint32_t block_width_size = num_tiles_per_block * TILE_WIDTH * a.element_size();
     uint32_t num_full_blocks_in_row = num_tiles_in_row / num_tiles_per_block;
-    uint32_t num_leftover_tiles = num_tiles_in_row % num_tiles_per_block;
-    uint32_t leftover_width_in_row = num_leftover_tiles * a.element_size();
 
-    const uint32_t src0_cb_index = 0;
-    const uint32_t output_cb_index = tt::CBIndex::c_16;
     const uint32_t num_input_tiles = num_tiles_per_block;
     const uint32_t num_output_tiles = num_tiles_per_block;
 
-    ProgramDescriptor desc;
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "tilize_single_core";
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * input_single_tile_size,
-        .core_ranges = core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-    });
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_output_tiles * output_single_tile_size,
-        .core_ranges = core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
-
-    // Reader compile-time args
-    std::vector<uint32_t> reader_compile_time_args = {stick_size};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
-    // Tilized reader
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
-        "reader_unary_stick_layout_split_rows_singlecore.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = core_ranges;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    // Buffer* slots register BufferBindings so the framework patches addresses on cache hits.
-    reader_desc.emplace_runtime_args(
-        core.start_coord,
-        {src0_buffer,
-         num_sticks,
-         stick_size,
-         num_tiles_per_block,
-         block_width_size,
-         num_full_blocks_in_row,
-         num_leftover_tiles,
-         leftover_width_in_row,
-         std::uint32_t{0}});  // row_start_id
-
-    // Tilized writer
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = core_ranges;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.emplace_runtime_args(core.start_coord, {dst_buffer, num_tiles, std::uint32_t{0}});
-
-    std::vector<uint32_t> compute_args = {
-        num_tiles / num_tiles_per_block,  // per_core_block_cnt
-        num_tiles_per_block               // per_core_block_tile_cnt
+    // "src0" (legacy CB c_0): input row-major sticks the reader fills and the compute tilizes.
+    // "output" (legacy CB c_16): tilized output the compute produces and the writer drains.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"src0"},
+            .entry_size = input_single_tile_size,
+            .num_entries = num_input_tiles,
+            .data_format_metadata = input_cb_data_format,
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"output"},
+            .entry_size = output_single_tile_size,
+            .num_entries = num_output_tiles,
+            .data_format_metadata = output_cb_data_format,
+        },
     };
 
-    std::vector<UnpackToDestMode> unpack_to_dest_mode(NUM_CIRCULAR_BUFFERS, UnpackToDestMode::Default);
+    // Tilized reader. Reads the input tensor (binding) into the src0 DFB.
+    // The legacy reader read positional RTA slots 0 (src addr -> TensorBinding), 1, 3, 4, 5, 8;
+    // the unused legacy slots 2/6/7 (stick_size, num_leftover_tiles, leftover_width_in_row) are
+    // dropped — the kernel never read them.
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
+                                        "reader_unary_stick_layout_split_rows_singlecore.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{
+                    .tensor_parameter_name = m2::TensorParamName{"input"},
+                    .accessor_name = "input",
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"num_sticks", "num_tiles_per_block", "block_width_size", "num_full_blocks_in_row", "row_start_id"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+
+    // Tilized writer (forked from eltwise/unary writer_unary_interleaved_start_id.cpp).
+    // Drains the output DFB into the output tensor (binding).
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/dataflow/"
+                                        "writer_unary_interleaved_start_id_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"output"},
+                    .accessor_name = "output",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{
+                    .tensor_parameter_name = m2::TensorParamName{"output"},
+                    .accessor_name = "output",
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_pages", "start_id"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+
+    // Compute (forked from ttnn/cpp/ttnn/kernel/compute/tilize.cpp).
+    // Consumes src0, produces output. per_core_block_cnt / per_core_block_tile_cnt stay CTAs.
+    m2::KernelSpec compute{
+        .unique_id = m2::KernelSpecName{"compute"},
+        .source =
+            std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/tilize/device/kernels/compute/tilize_m2.cpp"},
+        .compiler_options = {},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"output"},
+                    .accessor_name = "output",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .compile_time_args =
+            {
+                {"per_core_block_cnt", num_tiles / num_tiles_per_block},
+                {"per_core_block_tile_cnt", num_tiles_per_block},
+            },
+        .hw_config =
+            m2::ComputeHardwareConfig{
+                .fp32_dest_acc_en = fp32_llk_acc,
+            },
+    };
+    // Legacy set unpack_to_dest_mode[c_0]=UnpackToDestFp32 when fp32_llk_acc; preserve that
+    // for the src0 DFB (the compute consumer of the fp32 input).
     if (fp32_llk_acc) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = UnpackToDestMode::UnpackToDestFp32;
+        std::get<m2::ComputeHardwareConfig>(compute.hw_config).unpack_to_dest_mode = {
+            {m2::DFBSpecName{"src0"}, UnpackToDestMode::UnpackToDestFp32}};
     }
 
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source = "ttnn/cpp/ttnn/kernel/compute/tilize.cpp";
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = core_ranges;
-    compute_desc.compile_time_args = std::move(compute_args);
-    compute_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = fp32_llk_acc,
-        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    spec.kernels = {reader, writer, compute};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output.tensor_spec()},
+    };
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "tilize_single_core",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}, m2::KernelSpecName{"compute"}},
+            .target_nodes = core_ranges,
+        },
     };
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    reader_run.runtime_arg_values.push_back(
+        {core.start_coord,
+         {{"num_sticks", num_sticks},
+          {"num_tiles_per_block", num_tiles_per_block},
+          {"block_width_size", block_width_size},
+          {"num_full_blocks_in_row", num_full_blocks_in_row},
+          {"row_start_id", 0u}}});
 
-    return desc;
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+    writer_run.runtime_arg_values.push_back({core.start_coord, {{"num_pages", num_tiles}, {"start_id", 0u}}});
+
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, a.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_single_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/device/tilize_single_core_program_factory.hpp
@@ -4,13 +4,16 @@
 
 #pragma once
 
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 #include "tilize_device_operation_types.hpp"
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::prim {
+// Metal 2.0 program factory: returns a ProgramSpec + ProgramRunArgs artifact
+// (ProgramSpecFactoryConcept). The other tilize factories remain on the legacy
+// ProgramDescriptor concept; the framework adapter dispatches per-factory.
 struct TilizeSingleCoreProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TilizeParams& operation_attributes, const TilizeInputs& tensor_args, Tensor& tensor_return_value);
 };
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/METAL2_PORT_REPORT.md
@@ -1,0 +1,131 @@
+# Metal 2.0 Port Report — transpose (CN factory)
+
+## Summary
+
+- **Status:** PORTED (one factory of eight).
+- **Factory chosen:** `TransposeCNProgramFactory` — the simplest single-program factory in the
+  transpose device-op (147-line legacy `.cpp`, two data-movement kernels, no compute kernel).
+- **Concept:** legacy `ProgramDescriptorFactoryConcept` (`create_descriptor` → `ProgramDescriptor`)
+  → Metal 2.0 `ProgramSpecFactoryConcept` (`create_program_spec` → `ProgramArtifacts`).
+
+## Why CN
+
+Factory `.cpp` line counts (all under `transpose/device/`):
+
+| factory | lines |
+|---|---|
+| transpose_cn | 147 |
+| transpose_wh_sharded | 167 |
+| transpose_hc_rm | 202 |
+| transpose_hc_tiled | 208 |
+| transpose_hc_tiled_interleaved | 240 |
+| transpose_wh_sharded_rm | 253 |
+| transpose_wh | 343 |
+| transpose_hc_sharded | 429 |
+
+CN is the smallest and structurally the cleanest: one DFB, a reader + writer (no compute),
+two tensor parameters, a single work-split with one WorkUnitSpec.
+
+## Legacy inventory
+
+- **Legacy factory shape:** `ProgramDescriptorFactoryConcept` (returned `tt::tt_metal::ProgramDescriptor`).
+- **Custom `compute_program_hash`:** none on `TransposeDeviceOperation` — nothing to delete.
+- **CBs:** 1 — `src0` (legacy index 0), `entry_size = stick_size`, `num_entries = 2`,
+  `data_format = datatype_to_dataformat_converter(input.dtype())`.
+- **Kernels:**
+  - reader `kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp`,
+    `core_ranges = total_cores` (full grid), CTAs `{src0_cb_index, aligned_page_size, stick_size}`
+    + `TensorAccessorArgs(src0_buffer, RuntimeTensorShape)`, define `CN_RM` when row-major,
+    `ReaderConfigDescriptor`.
+  - writer `kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp`,
+    `core_ranges = total_cores`, CTAs `{src0_cb_index, aligned_page_size, stick_size}`
+    + `TensorAccessorArgs(dst_buffer, RuntimeTensorShape)`, define `CN_RM` when row-major,
+    `WriterConfigDescriptor`.
+- **Tensor accessors:** input `src0_buffer` (reader), output `dst_buffer` (writer) — both with
+  `tensor_accessor::ArgConfig::RuntimeTensorShape`.
+- **Work split:** `split_work_to_cores(compute_with_storage_grid_size, num_tensor_pages)`.
+  Kernels launch on the full grid; no-op cores get `num_pages = 0`.
+- **Cross-op kernels:** none. Both kernels are referenced ONLY by this factory
+  (`grep -rl <kernel> ttnn/cpp/ttnn/operations` returns just this file), so they were ported in
+  place (no fork needed).
+
+## Spec shape (ported)
+
+- **DataflowBufferSpec:** `src0` (entry_size = stick_size, num_entries = 2, format = input dtype).
+- **KernelSpecs:** `reader` (PRODUCER of src0; tensor binding `input`) and `writer` (CONSUMER of
+  src0; tensor binding `output`).
+- **TensorParameters:** `input` (= `input_tensor.tensor_spec()`), `output` (= `output_tensor.tensor_spec()`).
+- **WorkUnitSpec:** one, `{reader, writer}` on `total_cores` (the full grid) — the src0 DFB's
+  producer and consumer must share the same WorkUnitSpec.
+
+## Dropped plumbing
+
+- **Buffer-address RTAs:** legacy reader RTA slot 0 (`src0_buffer`) and writer RTA slot 0
+  (`dst_buffer`) → replaced by `TensorBinding`s (`input`, `output`). Kernel-side
+  `TensorAccessor(src_args, src_addr)` → `TensorAccessor(ta::input)` / `(ta::output)`.
+- **`TensorAccessorArgs` plumbing:** host `TensorAccessorArgs(...).append_to(cta, common_rta)` and
+  kernel `TensorAccessorArgs<3>()` removed — the binding mechanism owns accessor config end-to-end.
+- **Magic CB index in CTA:** `src0_cb_index` CTA → `dfb::src0` binding.
+- **Positional CTAs/RTAs → named:** `page_size`, `read_size`/`write_size` (CTAs); reader RTAs
+  `num_pages`, `start_id`, `hw`, `n` and CRTAs `N`, `C`, `HtWt`, `batch_step`, `channel_step`;
+  writer RTAs `num_pages`, `start_id`.
+
+## Faithful-mapping note (constant-per-core args → CRTA)
+
+The legacy factory emitted `N`, `C`, `HtWt`, `batch_step`, `channel_step` as per-core runtime args
+even though they are identical on every core. The port expresses them as **common** runtime args
+(broadcast), matching the matmul exemplar's treatment of its uniform args. Values are identical;
+only the dispatch channel (CRTA vs per-core RTA) changed. The kernel reads them via
+`get_arg(args::N)` etc. regardless, so this is invisible to the kernel.
+
+## Kernel edits (whitelist only)
+
+Both kernels were already on Device 2.0 APIs (`Noc`, `CircularBuffer`, `TensorAccessor`). Edits:
+
+1. Added `#include "experimental/kernel_args.h"`.
+2. `CircularBuffer cb(cb_id_*)` → `DataflowBuffer cb(dfb::src0)`.
+3. `TensorAccessor(src_args, addr)` → `TensorAccessor(ta::input)` / `(ta::output)`;
+   removed the `TensorAccessorArgs<3>()` line and the buffer-address `get_arg_val` reads.
+4. All positional `get_compile_time_arg_val` / `get_arg_val` → `get_arg(args::<name>)`.
+5. `#ifdef CN_RM` blocks, loop bounds, and the `noc_async_read_sharded` / `noc_async_write_sharded`
+   calls are **unchanged**; comments preserved verbatim.
+
+## Open items / friction for downstream
+
+1. **`RuntimeTensorShape` accessor config (the only real semantic question).** The legacy factory
+   built both TensorAccessors with `tensor_accessor::ArgConfig::RuntimeTensorShape` — the tensor's
+   shape is supplied as a runtime arg so one cached program serves inputs of varying shape. The
+   Metal 2.0 `TensorParameter` binding bakes the shape into the accessor's compile-time args by
+   default. `TensorParameterAdvancedOptions::dynamic_tensor_shape` exists and, per its header doc,
+   makes "shape an implicit runtime argument" — but **only for sharded tensors** ("for an
+   interleaved tensor, TensorAccessor configuration is unchanged"). CN is reached both for
+   interleaved and (via the `CN_RM` sharded path) for sharded buffers. Two consequences to confirm
+   on hardware:
+   - For interleaved inputs this is behavior-neutral (shape doesn't affect the interleaved
+     accessor's addressing), but it changes the **program-cache key**: the legacy cached program
+     was shape-agnostic; the default Metal 2.0 binding will key on shape and rebuild for each new
+     shape. This may regress cache-hit rate for callers that previously shared one entry across
+     shapes. If that matters, set `dynamic_tensor_shape = true` on both TensorParameters.
+   - For the `CN_RM` sharded path, `dynamic_tensor_shape = true` is likely **required** to
+     reproduce the legacy runtime-shape accessor; left at the default the sharded accessor would be
+     statically shaped. I left both TensorParameters at the default (no advanced option) to keep
+     the port minimal and behavior-preserving for the common interleaved case, and flag the sharded
+     case here rather than guessing. **Recommend the op/kernel owner confirm the intended
+     accessor-shape semantics before relying on the CN sharded path under Metal 2.0.**
+2. **No-op cores in the WorkUnitSpec.** The legacy factory launches both kernels on the full grid
+   (`total_cores`) and gives no-op cores `num_pages = 0`. The port preserves this by targeting the
+   WorkUnitSpec at `total_cores` and emitting RTAs for every core (including zero-page cores). If
+   the framework prefers WorkUnitSpecs scoped to only the working cores (`all_cores`), that would
+   be a behavior-equivalent simplification — left as-is to preserve exact legacy placement.
+
+## Remaining factories (not ported this pass)
+
+`TransposeWHProgramFactory`, `TransposeWHShardedProgramFactory`, `TransposeWHShardedRMProgramFactory`,
+`TransposeHCTiledInterleavedProgramFactory`, `TransposeHCTiledProgramFactory`,
+`TransposeHCRMProgramFactory`, `TransposeHCShardedProgramFactory` remain on
+`ProgramDescriptorFactoryConcept`. The op builds and runs with the variant mixed (per-factory
+dispatch).
+
+## Build / test
+
+Not built, not run (worktree has no build dir, per instructions).

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/METAL2_PORT_REPORT_REMAINING.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/METAL2_PORT_REPORT_REMAINING.md
@@ -1,0 +1,125 @@
+# Metal 2.0 Port Report — transpose (remaining 6 factories)
+
+This pass ports the remaining six `transpose` factories to `create_program_spec`
+(`ttnn::device_operation::ProgramArtifacts`), completing the device-op (CN and WH interleaved were
+ported earlier — see `METAL2_PORT_REPORT.md` / `METAL2_PORT_REPORT_WH.md`). All ports are faithful,
+behavior-preserving translations: legacy logic, `#ifdef`s, loop bounds, and comments are unchanged;
+only the host API and the kernel-side access mechanism move to Metal 2.0 named bindings.
+
+`select_program_factory` already routes to every factory by value (it returns the factory structs
+directly), and the `program_factory_t` variant already lists all eight; no device-op wiring change
+was needed. No legacy `create_descriptor` pybind hooks existed for any of these factories
+(`transpose_nanobind.cpp` exposes only the user-facing op). The custom hash question does not apply —
+`TransposeDeviceOperation` has no custom `compute_program_hash`.
+
+## Per-factory STATUS
+
+### 1. transpose_hc_rm — PORTED (interleaved RM)
+- One DFB `src0` (legacy c_0); reader produces sticks, writer consumes.
+- Kernels (both op-local, ported **in place**): `reader_unary_transpose_hc_interleaved_partitioned_rm.cpp`,
+  `writer_unary_transpose_hc_interleaved_start_id_rm.cpp`.
+- Buffer-address RTA (legacy slot 0) → `ta::input` / `ta::output` TensorBindings. The legacy
+  `aligned_page_size` CTA was consumed only by the `TensorAccessorArgs` plumbing (never read by the
+  kernel) and disappears with it. Per-core RTAs named.
+
+### 2. transpose_hc_tiled — PORTED (interleaved tiled; misaligned scratch fake-CB self-loop)
+- DFB `src0` (c_0, reader→writer). When `misaligned`, an extra DFB `scratch` (legacy c_1) is a **fake
+  CB** — used purely as an address source (`get_write_ptr` + manual copy), bound as a **self-loop**
+  (PRODUCER+CONSUMER) on the reader to satisfy the validator. The legacy `MISALIGNED` constexpr is
+  promoted to the `MISALIGNED` define so `dfb::scratch` is name-looked-up only on the misaligned build.
+- Reader ported **in place** (`reader_unary_transpose_hc_interleaved_partitioned.cpp`). Writer
+  **reuses** the existing transpose-local fork `writer_unary_interleaved_start_id_m2.cpp` (the legacy
+  writer was the shared `eltwise/unary/.../writer_unary_interleaved_start_id.cpp`); its magic c_0 CTA →
+  `dfb::out` consuming the shared `src0` DFB.
+
+### 3. transpose_hc_tiled_interleaved — PORTED (padding-aware; conditional padding FIFO DFB via #ifdef)
+- DFB `src0` (c_0, reader→writer). When `needs_padding`, an extra real FIFO DFB `padding` (legacy c_1)
+  is produced by the reader and consumed by the writer; conditionally bound on both kernels and gated
+  kernel-side by the **promoted `NEEDS_PADDING` define** (legacy gated via `if constexpr (needs_padding)`).
+- Reader is shared with the unmigrated `permute_tiled` factory → **forked** to
+  `reader_unary_transpose_hc_interleaved_tiled_padding_aware_m2.cpp`. Writer ported **in place**
+  (`writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp`); its magic c_0 CTA → `dfb::out`.
+- `swap_hw`/`H`/`W`/… reader CTAs preserved verbatim (transpose always passes `swap_hw = 0` and the
+  `1u` placeholders), since the forked kernel still reads them.
+
+### 4. transpose_hc_sharded — PORTED (borrowed-memory DFBs; array-tail RTAs → runtime varargs)
+- Two **borrowed** DFBs: `src0`←input, `out`←output (legacy c_0 / c_16 with `.buffer` set). Both are
+  accessed by base pointer only (`get_read_ptr`/`get_write_ptr` + NOC), with no real FIFO, so each is
+  bound as a **self-loop** on every kernel that touches it.
+- The legacy variable-length per-core RTA tails (read via `get_arg_addr` pointer arithmetic — per-core
+  stick offsets + NOC x/y in the special case; shard-grid x/y maps in the generic case) → **runtime
+  varargs** (`advanced_options.num_runtime_varargs`, zero-padded to the per-launch max), with the
+  leading scalars kept as named RTAs. The packed layout is preserved exactly.
+- Multi-variant within one factory: generic vs `USE_SPECIAL_CASE`. The writer kernel exists **only** in
+  the special case (the generic path runs everything through the reader, matching the legacy empty
+  writer). Both kernels ported **in place** (`reader_/writer_unary_transpose_hc_sharded_rm.cpp`); the
+  two legacy `get_runtime_args_*` host helpers are reproduced verbatim.
+
+### 5. transpose_wh_sharded — PORTED (borrowed DFBs; 3 kernel forks)
+- Two borrowed DFBs `src0`/`out` (c_0/c_16). reader pushes `src0`, writer waits on `out`, compute
+  consumes `src0` and produces `out`.
+- Three shared kernels **forked** into transpose's dir: `reader_unary_sharded_m2.cpp` (from
+  eltwise/unary), `writer_unary_sharded_m2.cpp` (from data_movement/sharded), `transpose_wh_sharded_m2.cpp`
+  (compute, from transpose; legacy source also used by the unmigrated create_qkv_heads* / split_qkv ops).
+  Magic CB-index CTAs → `dfb::src0`/`dfb::out`. fp32 `unpack_to_dest_mode` preserved on `src0`.
+- Targets the active shard cores (`all_cores`), like the tilize sharded exemplar. The legacy factory
+  additionally launched the kernels on the full grid with zeroed args on the trailing no-op cores;
+  those cores did no work, so this is behavior-preserving (noted inline).
+
+### 6. transpose_wh_sharded_rm — PORTED (borrowed + scratch DFBs; ht>8 conditional; reuses transpose_wh_rm_m2 SHARDED branch)
+- DFBs: `src0`←input (borrowed, reader self-loop base-ptr), `out`←output (borrowed),
+  `in_scratch` (c_24, reader→compute), `tilize` (c_25, compute self-loop). When `ht > 8`, an extra
+  `out_stage` (c_27) DFB: compute produces, writer consumes; `out` is then written by the writer via
+  base pointer (writer self-loop). When `ht <= 8`, compute pack-untilizes directly into `out`
+  (compute self-loop) and there is **no writer kernel**.
+- The legacy c_26 ("im2") DFB is dead (no kernel reads/writes it) → omitted (a Metal 2.0 DFB requires
+  ≥1 producer and ≥1 consumer), mirroring the WH-interleaved port's handling of its dead c_25.
+- Compute **reuses the existing `transpose_wh_rm_m2.cpp` SHARDED branch**, which this pass finished
+  porting: its raw `tt::CBIndex::c_24/c_25/c_27/c_16` constants → `dfb::in_scratch`/`dfb::tilize`/
+  `dfb::out_stage`/`dfb::out`, its positional SHARDED CTAs (slots 3–8) → named CTAs, and its
+  `(Ht > 8) ? c_27 : c_16` compile-time ternary → the **promoted `OUT_STAGE` define** so the unbound
+  output token never enters name lookup. (The non-SHARDED interleaved path of that kernel is unchanged.)
+  Reader/writer ported **in place** (`reader_/writer_unary_transpose_wh_sharded_rm.cpp`).
+
+## Kernels: ported vs forked
+
+- **Ported in place** (op-local): `reader_unary_transpose_hc_interleaved_partitioned_rm.cpp`,
+  `writer_unary_transpose_hc_interleaved_start_id_rm.cpp`,
+  `reader_unary_transpose_hc_interleaved_partitioned.cpp`,
+  `writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp`,
+  `reader_unary_transpose_hc_sharded_rm.cpp`, `writer_unary_transpose_hc_sharded_rm.cpp`,
+  `reader_unary_transpose_wh_sharded_rm.cpp`, `writer_unary_transpose_wh_sharded_rm.cpp`.
+- **Forked** (legacy shared by unmigrated consumers):
+  `reader_unary_transpose_hc_interleaved_tiled_padding_aware_m2.cpp` (← permute_tiled),
+  `reader_unary_sharded_m2.cpp` (← eltwise/unary, ~dozen ops),
+  `writer_unary_sharded_m2.cpp` (← data_movement/sharded, ~dozen ops),
+  `transpose_wh_sharded_m2.cpp` (← create_qkv_heads* / split_qkv).
+- **Reused** (existing forks on this branch): `writer_unary_interleaved_start_id_m2.cpp` (hc_tiled
+  writer), `transpose_wh_rm_m2.cpp` (wh_sharded_rm compute — SHARDED branch finished this pass).
+
+## Open items / Friction (for downstream)
+
+- **Fake-CB self-loops** (interim workarounds, not real FIFOs): hc_tiled `scratch` (misaligned address
+  source); hc_sharded `src0`/`out` (borrowed base-pointer access); wh_sharded_rm `src0` (reader) and
+  `out` (writer, ht>8). Each is bound PRODUCER+CONSUMER purely to satisfy the validator. These map to
+  the forthcoming Metal 2.0 kernel-scratchpad / local-TensorAccessor resources.
+- **hc_sharded special-case double self-loop (verify at build/validation):** in the special case both
+  the reader and the writer touch the borrowed `src0` and `out` DFBs purely by base pointer, so each is
+  self-looped on **both** kernels (yielding 2 producers + 2 consumers per DFB). The single-kernel
+  borrowed self-loop is precedented (pad sharded `in0`), but the two-kernel form here is not yet
+  exercised elsewhere; if the spec validator enforces a single-producer rule for these DFBs, this is
+  the spot to revisit (e.g. designate one kernel PRODUCER and the other CONSUMER). Could not be
+  build-verified in this worktree (no build dir).
+- **Runtime varargs** retained in hc_sharded reader (+ writer in the special case): the per-core packed
+  tails are genuinely variable-length and read via runtime indexing, so varargs are the right fit today
+  (slated to migrate to typed `std::array` args when available).
+- **`RuntimeTensorShape` accessors dropped**: like CN/WH interleaved, the legacy
+  `TensorAccessorArgs(ArgConfig::RuntimeTensorShape)` (shape passed as a runtime arg so one cached
+  program serves varying shapes) is replaced by the default `TensorParameter` binding, which bakes the
+  shape into the accessor's CTAs. See the CN report's `dynamic_tensor_shape` note.
+- **wh_sharded no-op cores dropped**: the legacy full-grid launch with zeroed no-op rows is replaced by
+  targeting only the active shard cores; behavior-preserving (the no-op cores did nothing).
+- **wh_sharded_rm dead c_26 ("im2") DFB omitted** (no kernel touches it).
+- `transpose_wh_sharded_m2.cpp` (compute) and `transpose_wh_rm_m2.cpp` (SHARDED branch now live) carry
+  the standard fork drift-discipline note: keep in sync with the legacy copies until their last
+  unmigrated consumer ports.

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/METAL2_PORT_REPORT_WH.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/METAL2_PORT_REPORT_WH.md
@@ -1,0 +1,128 @@
+# Metal 2.0 Port Report — transpose (WH interleaved factory)
+
+## Summary
+
+- **Status:** PORTED (one factory of eight; second after CN).
+- **Factory chosen:** `TransposeWHProgramFactory` — the WH (height/width) interleaved factory, the
+  common/default WH path. The two *sharded* WH factories (`TransposeWHShardedProgramFactory`,
+  `TransposeWHShardedRMProgramFactory`) were NOT ported this pass.
+- **Concept:** legacy `ProgramDescriptorFactoryConcept` (`create_descriptor` → `ProgramDescriptor`)
+  → Metal 2.0 `ProgramSpecFactoryConcept` (`create_program_spec` → `ProgramArtifacts`).
+
+## Scope note — one factory, two layout sub-paths
+
+`TransposeWHProgramFactory` is a *single* factory / single program that selects its kernel **sources**
+at runtime on `row_major` (input layout TILE vs ROW_MAJOR). Per the recipe's atomic-unit rule (a
+factory and ALL the kernel entry points it can bind convert together), both sub-paths were ported in
+one pass:
+
+| role | TILE (tiled) source | ROW_MAJOR (RM) source |
+|---|---|---|
+| reader | `reader_unary_transpose_wh_interleaved_start_id.cpp` (in place) | `reader_unary_transpose_wh_interleaved_start_id_rm.cpp` (in place) |
+| writer | `writer_unary_interleaved_start_id_m2.cpp` (FORK) | `writer_unary_transpose_wh_interleaved_start_id_rm.cpp` (in place) |
+| compute | `transpose_wh_m2.cpp` (FORK) | `transpose_wh_rm_m2.cpp` (FORK) |
+
+## Kernels — ported in place vs forked
+
+`grep -rl <kernel> ttnn/cpp/ttnn/operations` results drove the fork decision:
+
+- **In place (op-local, only this factory uses them):**
+  - `reader_unary_transpose_wh_interleaved_start_id.cpp`
+  - `reader_unary_transpose_wh_interleaved_start_id_rm.cpp`
+  - `writer_unary_transpose_wh_interleaved_start_id_rm.cpp`
+- **Forked to `*_m2.cpp` (shared with unmigrated ops):**
+  - `writer_unary_interleaved_start_id.cpp` (lives in `eltwise/unary/`, used by ~30 ops) →
+    `writer_unary_interleaved_start_id_m2.cpp` placed in this op's `kernels/dataflow/`.
+  - `transpose_wh.cpp` (compute; shared with nlp_create_qkv_heads*, split_qkv, permute_tiled) →
+    `transpose_wh_m2.cpp`.
+  - `transpose_wh_rm.cpp` (compute; shared with the unmigrated `transpose_wh_sharded_rm` factory) →
+    `transpose_wh_rm_m2.cpp`.
+
+  All forks must stay in sync with their legacy originals until the last unmigrated consumer ports.
+
+## Spec shape (ported)
+
+- **DataflowBufferSpecs:** `src0` (legacy c_0; entry=src0 tile size, num_entries = `2` tiled / `wt*2`
+  RM), `out` (legacy c_16; num_entries = `2` tiled / `ht*2` RM). RM adds `tilize` (legacy c_24;
+  num_entries = `ht*wt`).
+- **KernelSpecs:** `reader` (PRODUCER src0; tensor `input`), `writer` (CONSUMER out; tensor
+  `output`), `compute`. RM compute binds src0 (CONSUMER), `tilize` (self-loop PRODUCER+CONSUMER), out
+  (PRODUCER); tiled compute binds src0 (CONSUMER) + out (PRODUCER).
+- **TensorParameters:** `input`, `output`.
+- **WorkUnitSpec:** one, `{reader, writer, compute}` on `total_cores` (full grid) — all three share
+  the src0/tilize/out DFBs so they must share one WorkUnitSpec. No-op cores get count = 0.
+- **ComputeHardwareConfig:** `fp32_dest_acc_en` = Float32/Int32/UInt32 (verbatim from legacy);
+  `unpack_to_dest_mode` = UnpackToDestFp32 for `src0` (+ `tilize` on RM) when src dtype is Float32.
+- **Compute defines:** `DST_ACCUM_MODE=1` emitted to the RM compute kernel when input dtype is
+  UINT32/INT32 (verbatim from legacy `compute_defines`).
+
+## Dropped plumbing
+
+- **Buffer-address RTAs:** reader `input_tensor.buffer()` (legacy reader RTA slot 0) and writer
+  `output_tensor.buffer()` (writer RTA slot 0) → replaced by `TensorBinding`s (`input`, `output`).
+  Kernel-side `TensorAccessor(args, addr)` → `TensorAccessor(ta::input)` / `(ta::output)`.
+- **`TensorAccessorArgs` plumbing:** host `TensorAccessorArgs(buffer, RuntimeTensorShape).append_to(
+  cta, common_rta)` and kernel `TensorAccessorArgs<N>()` removed end-to-end.
+- **Magic CB indices in CTAs:** tiled writer CTA slot 0 (`output_cb_index`) and RM writer CTA slot 0
+  (`cb_out0`) → `dfb::out` binding. Compute kernels' `tt::CBIndex::c_0/c_16/c_24` raw constants →
+  `dfb::src0` / `dfb::out` / `dfb::tilize`.
+- **Positional CTAs/RTAs → named:** all reader/writer/compute CTAs and RTAs renamed (see kernels).
+
+## Faithful-mapping note (compute count → per-core RTA preserved)
+
+The compute kernel's single per-core count (`NHtWt` tiled / `num_hw_blocks_per_core` RM) varies per
+core (work split), so it stays a per-core RTA (NOT a CRTA). The tiled reader's `Ht/Wt/HtWt` are
+uniform but the legacy emitted them as per-core RTAs; the port preserves them as per-core RTAs (no
+CRTA promotion) to stay maximally behavior-preserving for this multi-path factory. (CN promoted its
+uniform args to CRTA; here they were left as RTAs because the tiled reader interleaves them with the
+genuinely per-core `start_id`/`start_ht`/`start_wt` in one slot block.)
+
+## Kernel edits (whitelist only)
+
+All six kernels were already on Device 2.0 APIs (`Noc`, `CircularBuffer`, `TensorAccessor`). Edits:
+1. Added `#include "experimental/kernel_args.h"`.
+2. `CircularBuffer cb(c_NN)` → `DataflowBuffer cb(dfb::name)`; the RM compute helper templates'
+   `CircularBuffer&` param → `DataflowBuffer&`.
+3. `TensorAccessor(args, addr)` → `TensorAccessor(ta::input)` / `(ta::output)`; removed
+   `TensorAccessorArgs<N>()` and buffer-address `get_arg_val` reads.
+4. All positional `get_compile_time_arg_val` / `get_arg_val` → `get_arg(args::<name>)`.
+5. `dfb::name` passed directly to LLKs (`transpose_wh_init`, `transpose_wh_tile`, `pack_tile`,
+   `unary_op_init_common`, `get_local_cb_interface`) and to kernel-lib `compute_kernel_lib::tilize<>`
+   (template-arg position) via the implicit `DFBAccessor → uint32_t` conversion. No `.id` extraction.
+6. The RM compute kernel's `#ifdef SHARDED` blocks are preserved verbatim and stay #ifdef-gated; the
+   SHARDED branch's `tt::CBIndex::c_24/c_25/c_27` references are never name-looked-up in this build
+   (SHARDED is never defined by this factory). The non-SHARDED CB indices became DFB handles.
+   Comments preserved verbatim.
+
+## Open items / friction for downstream
+
+1. **Legacy CB c_25 ("im2", `TODO REMOVE`) is dropped.** The RM path's legacy factory allocated a
+   second intermediate CB at index 25 (`num_im2_tiles = ht`), but **no kernel on the interleaved RM
+   path reads or writes it** (the non-SHARDED `transpose_wh_rm` compute uses only c_0/c_24/c_16). A
+   Metal 2.0 DFB requires >=1 producer and >=1 consumer binding, so a never-touched buffer cannot be
+   expressed. It was omitted. Net effect: slightly less L1 reserved on the RM path; numerically
+   inert. (It is already flagged `// TODO REMOVE` in the legacy source.) **Confirm on hardware that
+   c_25 is genuinely dead on the interleaved RM path** (it IS used on the sharded RM path, which is a
+   separate, unported factory).
+2. **`RuntimeTensorShape` accessor config → program-cache key (same as CN).** The legacy factory
+   built both TensorAccessors with `tensor_accessor::ArgConfig::RuntimeTensorShape` (shape supplied
+   as a runtime arg so one cached program serves varying shapes). The Metal 2.0 `TensorParameter`
+   binding bakes the shape into the accessor's compile-time args by default → keys the program cache
+   on shape and rebuilds per new shape. For interleaved tensors this is numerically inert but may
+   regress cache-hit rate vs the legacy shape-agnostic program. If that matters, set
+   `dynamic_tensor_shape = true` on the `input`/`output` TensorParameters. Left at default to keep
+   the port minimal/behavior-preserving for the common case.
+3. **No-op cores in the WorkUnitSpec (same as CN).** All three kernels launch on the full grid;
+   no-op cores receive count = 0. Preserved by targeting the WorkUnitSpec at `total_cores` and
+   emitting RTAs for every core. A WorkUnitSpec scoped to `all_cores` would be a behavior-equivalent
+   simplification — left as-is to preserve exact legacy placement.
+
+## Device-op-class edits
+
+None. `TransposeDeviceOperation` has no custom `compute_program_hash` (nothing to delete); the
+`program_factory_t` variant already lists `TransposeWHProgramFactory` and `select_program_factory`
+already routes WH to it. No pybind `create_descriptor` hook for this factory existed.
+
+## Build / test
+
+Not built, not run (worktree has no build dir, per instructions).

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_m2.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of transpose/device/kernels/compute/transpose_wh.cpp. The legacy source is also
+// used by nlp_create_qkv_heads* / split_query_key_value_and_split_heads / permute_tiled, which have
+// not yet migrated; this copy is named-binding ported for the transpose WH (tiled) compute kernel
+// only. Keep the two in sync until the legacy copy's last consumer ports.
+
+#include <cstdint>
+
+#include "api/compute/transpose_wh.h"
+#include "api/dataflow/circular_buffer.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    auto NHtWt = get_arg(args::NHtWt);
+
+    transpose_wh_init(dfb::src0, dfb::out);
+
+    DataflowBuffer cb_in(dfb::src0);
+    DataflowBuffer cb_out(dfb::out);
+
+    // transpose a row-major block:
+    // - assumes the tiles come in in column major order from reader
+    // - uses reader_unary_transpose_wh
+    // - transpose_wh each tile
+    for (uint32_t n = 0; n < NHtWt; n++) {
+        cb_in.wait_front(1);
+        cb_out.reserve_back(1);
+
+        tile_regs_acquire();
+        transpose_wh_tile(dfb::src0, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, dfb::out);
+        tile_regs_release();
+
+        cb_out.push_back(1);
+        cb_in.pop_front(1);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm_m2.cpp
@@ -2,12 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Metal 2.0 fork of transpose/device/kernels/compute/transpose_wh_rm.cpp. The legacy source is also
-// used by the (unmigrated) transpose_wh_sharded_rm factory; this copy is named-binding ported for
-// the transpose WH (RM, interleaved) compute kernel only. Keep the two in sync until the legacy copy's
-// last consumer ports. The SHARDED path below is dead for this factory (never defines SHARDED) and is
-// preserved verbatim, #ifdef-gated, so its CB tokens (c_24/c_25/c_27) are never name-looked-up in this
-// build — the non-SHARDED path's CB indices are bound as DFBs (dfb::src0 / dfb::tilize / dfb::out).
+// Metal 2.0 fork of transpose/device/kernels/compute/transpose_wh_rm.cpp, serving BOTH the transpose WH
+// (RM, interleaved) compute kernel (non-SHARDED) and the transpose WH (RM, sharded) compute kernel
+// (SHARDED). The legacy source remained shared by other consumers when this fork was created; keep the
+// two in sync until the legacy copy's last consumer ports.
+//   non-SHARDED: dfb::src0 (input), dfb::tilize (intermediate self-loop), dfb::out (output).
+//   SHARDED:     dfb::in_scratch (c_24), dfb::tilize (c_25); output is dfb::out_stage (c_27) when Ht > 8
+//                else dfb::out (c_16). The legacy "(Ht > 8) ? c_27 : c_16" compile-time ternary is
+//                promoted to the OUT_STAGE preprocessor define so the unbound token never enters name
+//                lookup. All SHARDED CB indices are now framework-assigned DFBs (no raw tt::CBIndex).
 #include <cstdint>
 
 #include "api/compute/eltwise_unary/eltwise_unary.h"
@@ -108,12 +111,12 @@ void kernel_main() {
     constexpr auto Wt = get_arg(args::Wt);
     constexpr auto HtWt = get_arg(args::HtWt);
 #ifdef SHARDED
-    constexpr uint32_t num_hw_blocks_per_core = get_compile_time_arg_val(3);
-    constexpr uint32_t last_output_row_num_datums = get_compile_time_arg_val(4);
-    constexpr uint32_t pack_num_pages = get_compile_time_arg_val(5);
-    constexpr uint32_t pack_num_pages_last_col = get_compile_time_arg_val(6);
-    constexpr uint32_t pack_num_pages_last_row = get_compile_time_arg_val(7);
-    constexpr uint32_t pack_num_pages_last_row_col = get_compile_time_arg_val(8);
+    constexpr uint32_t num_hw_blocks_per_core = get_arg(args::num_hw_blocks_per_core);
+    constexpr uint32_t last_output_row_num_datums = get_arg(args::last_output_row_num_datums);
+    [[maybe_unused]] constexpr uint32_t pack_num_pages = get_arg(args::pack_num_pages);
+    constexpr uint32_t pack_num_pages_last_col = get_arg(args::pack_num_pages_last_col);
+    [[maybe_unused]] constexpr uint32_t pack_num_pages_last_row = get_arg(args::pack_num_pages_last_row);
+    constexpr uint32_t pack_num_pages_last_row_col = get_arg(args::pack_num_pages_last_row_col);
     // In order to support full_ct_dim > block_ct_dim, we would need to change use_narrow_row and row_size conditions to
     // be:
     //
@@ -131,10 +134,13 @@ void kernel_main() {
 #endif
 
 #ifdef SHARDED
-    constexpr auto cb_in = tt::CBIndex::c_24;
-    constexpr auto cb_tilize = tt::CBIndex::c_25;
-    constexpr auto cb_out_idx =
-        (Ht > 8) ? tt::CBIndex::c_27 : tt::CBIndex::c_16;  // temporary fix until pack_untilize is fully fixed
+    constexpr auto cb_in = dfb::in_scratch;
+    constexpr auto cb_tilize = dfb::tilize;
+#ifdef OUT_STAGE
+    constexpr auto cb_out_idx = dfb::out_stage;  // temporary fix until pack_untilize is fully fixed (Ht > 8)
+#else
+    constexpr auto cb_out_idx = dfb::out;
+#endif
 #else
     constexpr auto cb_in = dfb::src0;
     constexpr auto cb_tilize = dfb::tilize;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm_m2.cpp
@@ -1,0 +1,185 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of transpose/device/kernels/compute/transpose_wh_rm.cpp. The legacy source is also
+// used by the (unmigrated) transpose_wh_sharded_rm factory; this copy is named-binding ported for
+// the transpose WH (RM, interleaved) compute kernel only. Keep the two in sync until the legacy copy's
+// last consumer ports. The SHARDED path below is dead for this factory (never defines SHARDED) and is
+// preserved verbatim, #ifdef-gated, so its CB tokens (c_24/c_25/c_27) are never name-looked-up in this
+// build — the non-SHARDED path's CB indices are bound as DFBs (dfb::src0 / dfb::tilize / dfb::out).
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/transpose_wh.h"
+#include "api/compute/tilize.h"
+#include "api/compute/pack_untilize.h"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "api/dataflow/circular_buffer.h"
+#include "experimental/kernel_args.h"
+
+template <
+    uint32_t Wt,
+    uint32_t Ht,
+    uint32_t HtWt,
+    bool use_narrow_row,
+    uint32_t row_size,
+    uint32_t pack_num_pages_last_col,
+    uint32_t pack_num_pages_last_row_col,
+    uint32_t cb_out>
+ALWI void transpose_with_pack_untilize_narrow_row(uint32_t cb_tilize, DataflowBuffer& cb_out_buf) {
+    uint32_t tile_idx = 0;
+
+    transpose_wh_init_short(cb_tilize);
+    pack_untilize_dest_init<Ht, Ht, use_narrow_row, row_size>(cb_out);
+    for (uint32_t w = 0; w < Wt; ++w) {
+        tile_regs_acquire();
+        for (uint32_t h = 0; h < Ht; ++h) {
+            transpose_wh_tile(cb_tilize, tile_idx, h);
+            tile_idx += Wt;
+        }
+
+        tile_regs_commit();
+
+        if (w == Wt - 1) {  // last row
+            cb_out_buf.reserve_back(pack_num_pages_last_row_col);
+            tile_regs_wait();
+            pack_untilize_dest<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
+            tile_regs_release();
+            cb_out_buf.push_back(pack_num_pages_last_row_col);
+        } else {
+            cb_out_buf.reserve_back(pack_num_pages_last_col);
+            tile_regs_wait();
+            pack_untilize_dest<Ht, Ht, false, use_narrow_row, row_size>(cb_out);
+            tile_regs_release();
+            cb_out_buf.push_back(pack_num_pages_last_col);
+        }
+        tile_idx = tile_idx - HtWt + 1;
+    }
+    pack_untilize_uninit(cb_out);
+}
+
+// Helper constexpr function to compute num_blocks_per_col
+constexpr uint32_t compute_num_blocks_per_col(uint32_t per_core_block_tile_cnt) {
+    const uint32_t max_bct = DST_ACCUM_MODE ? 4 : 8;
+
+    for (uint32_t bct = max_bct; bct >= 1; --bct) {
+        if (per_core_block_tile_cnt % bct == 0) {
+            return per_core_block_tile_cnt / bct;
+        }
+    }
+
+    return 1;
+}
+
+template <uint32_t Wt, uint32_t Ht, uint32_t HtWt, uint32_t cb_out>
+ALWI void transpose_with_pack_untilize(uint32_t cb_tilize, DataflowBuffer& cb_out_buf) {
+    uint32_t tile_idx = 0;
+
+    transpose_wh_init_short(cb_tilize);
+    constexpr uint32_t num_blocks_per_col = compute_num_blocks_per_col(Ht);
+    constexpr uint32_t block_ct_dim = Ht / num_blocks_per_col;
+    constexpr uint32_t full_ct_dim = Ht;
+    pack_untilize_dest_init<block_ct_dim, full_ct_dim>(cb_out);
+    for (uint32_t w = 0; w < Wt; ++w) {
+        cb_out_buf.reserve_back(Ht);
+        for (uint32_t b = 0; b < num_blocks_per_col; ++b) {
+            tile_regs_acquire();
+            for (uint32_t h = 0; h < block_ct_dim; ++h) {
+                transpose_wh_tile(cb_tilize, tile_idx, h);
+                tile_idx += Wt;
+            }
+            tile_regs_commit();
+
+            tile_regs_wait();
+            pack_untilize_dest<block_ct_dim, full_ct_dim>(cb_out, 1, b);
+            tile_regs_release();
+        }
+        cb_out_buf.push_back(Ht);
+
+        cb_out_buf.wait_front(Ht);
+        tile_idx = tile_idx - HtWt + 1;
+    }
+    pack_untilize_uninit(cb_out);
+}
+
+void kernel_main() {
+    constexpr auto Ht = get_arg(args::Ht);
+    constexpr auto Wt = get_arg(args::Wt);
+    constexpr auto HtWt = get_arg(args::HtWt);
+#ifdef SHARDED
+    constexpr uint32_t num_hw_blocks_per_core = get_compile_time_arg_val(3);
+    constexpr uint32_t last_output_row_num_datums = get_compile_time_arg_val(4);
+    constexpr uint32_t pack_num_pages = get_compile_time_arg_val(5);
+    constexpr uint32_t pack_num_pages_last_col = get_compile_time_arg_val(6);
+    constexpr uint32_t pack_num_pages_last_row = get_compile_time_arg_val(7);
+    constexpr uint32_t pack_num_pages_last_row_col = get_compile_time_arg_val(8);
+    // In order to support full_ct_dim > block_ct_dim, we would need to change use_narrow_row and row_size conditions to
+    // be:
+    //
+    //     constexpr bool use_narrow_row = last_output_row_num_datums < FACE_WIDTH ? true : false;
+    //     constexpr uint32_t row_size = last_output_row_num_datums < FACE_WIDTH ? last_output_row_num_datums :
+    //     TILE_WIDTH;
+    //
+    // However, changing these conditions makes yolov4 and transpose tests fail with a PCC error. For the error to be
+    // present in BH, it needs to be run in the full model sweep, but for WH_B0 it can be seen in isolation.
+    constexpr bool use_narrow_row = last_output_row_num_datums < TILE_WIDTH ? true : false;
+    constexpr uint32_t row_size = last_output_row_num_datums < TILE_WIDTH ? last_output_row_num_datums : TILE_WIDTH;
+
+#else
+    auto num_hw_blocks_per_core = get_arg(args::num_hw_blocks_per_core);
+#endif
+
+#ifdef SHARDED
+    constexpr auto cb_in = tt::CBIndex::c_24;
+    constexpr auto cb_tilize = tt::CBIndex::c_25;
+    constexpr auto cb_out_idx =
+        (Ht > 8) ? tt::CBIndex::c_27 : tt::CBIndex::c_16;  // temporary fix until pack_untilize is fully fixed
+#else
+    constexpr auto cb_in = dfb::src0;
+    constexpr auto cb_tilize = dfb::tilize;
+    constexpr auto cb_out_idx = dfb::out;
+#endif
+
+    DataflowBuffer cb_tilize_buf(cb_tilize);
+    DataflowBuffer cb_out(cb_out_idx);
+
+    unary_op_init_common(cb_in, cb_out_idx);
+
+    for (uint32_t n = 0; n < num_hw_blocks_per_core; n++) {
+        // Tilize input (Ht rows × Wt tiles). Fp32Mode::Lossless keeps the full
+        // Float32 mantissa through tilization; the default Fast mode would
+        // collapse it to tf32 precision before the transpose ever runs.
+        compute_kernel_lib::tilize<
+            Wt,
+            cb_in,
+            cb_tilize,
+            compute_kernel_lib::tilize_config::InitUninitMode::InitAndUninit,
+            compute_kernel_lib::tilize_config::WaitMode::WaitBlock,
+            compute_kernel_lib::tilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure,
+            compute_kernel_lib::tilize_config::Fp32Mode::Lossless>(Ht);
+
+        // transpose
+        cb_tilize_buf.wait_front(HtWt);
+        uint32_t tile_idx = 0;
+#ifdef SHARDED
+        if constexpr (use_narrow_row) {
+            transpose_with_pack_untilize_narrow_row<
+                Wt,
+                Ht,
+                HtWt,
+                use_narrow_row,
+                row_size,
+                pack_num_pages_last_col,
+                pack_num_pages_last_row_col,
+                cb_out_idx>(cb_tilize, cb_out);
+        } else {
+            transpose_with_pack_untilize<Wt, Ht, HtWt, cb_out_idx>(cb_tilize, cb_out);
+        }
+#else
+        transpose_with_pack_untilize<Wt, Ht, HtWt, cb_out_idx>(cb_tilize, cb_out);
+#endif
+
+        cb_tilize_buf.pop_front(HtWt);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded_m2.cpp
@@ -1,0 +1,62 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of transpose/device/kernels/compute/transpose_wh_sharded.cpp. The legacy source is
+// also used by the (unmigrated) experimental transformer create_qkv_heads* / split_qkv ops; this copy
+// is named-binding ported for the transpose WH sharded compute kernel only. Keep the two in sync until
+// the legacy copy's last consumer ports (see METAL2_PORT_REPORT.md). Logic UNCHANGED; only the access
+// mechanism moves to named bindings:
+//   - input CB c_0  -> dfb::src0 (borrowed input shard; compute consumes)
+//   - output CB c_16 -> dfb::out  (borrowed output shard; compute produces)
+//   - positional RTAs -> get_arg(args::...)
+
+#include <cstdint>
+
+#include "api/compute/transpose_wh.h"
+#include "api/dataflow/circular_buffer.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    uint32_t NHtWt = get_arg(args::NHtWt);
+    uint32_t HtWt = get_arg(args::HtWt);
+    uint32_t N = get_arg(args::N);
+    uint32_t Ht = get_arg(args::Ht);
+    uint32_t Wt = get_arg(args::Wt);
+
+    constexpr auto cb_id_in = dfb::src0;
+    constexpr auto cb_id_out = dfb::out;
+
+    transpose_wh_init(cb_id_in, cb_id_out);
+
+    DataflowBuffer cb_in(cb_id_in);
+    DataflowBuffer cb_out(cb_id_out);
+
+    // transpose a row-major block:
+    // - uses reader_unary_transpose_wh
+    // - transpose_wh each tile
+
+    uint32_t tile_idx = 0;
+    uint32_t tile_idx_N = 0;
+
+    cb_in.wait_front(NHtWt);
+    cb_out.reserve_back(NHtWt);
+    for (uint32_t n = 0; n < N; ++n) {
+        tile_idx = tile_idx_N;
+        for (uint32_t w = 0; w < Wt; ++w) {
+            for (uint32_t h = 0; h < Ht; ++h) {
+                tile_regs_acquire();
+                transpose_wh_tile(cb_id_in, tile_idx, 0);
+                tile_regs_commit();
+                tile_regs_wait();
+                pack_tile(0, cb_id_out);
+                tile_regs_release();
+                tile_idx += Wt;
+            }
+            tile_idx = tile_idx - HtWt + 1;
+        }
+        tile_idx_N += HtWt;
+    }
+    cb_out.push_back(NHtWt);
+    cb_in.pop_front(NHtWt);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_sharded_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_sharded_m2.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp, for the sharded
+// transpose WH reader (the legacy source is shared by ~a dozen ops; not editable in place). Behavior
+// unchanged: push the borrowed input DFB by num_tiles_per_core. The legacy CT (src0 CB index) is now
+// the dfb::src0 binding.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "experimental/kernel_args.h"
+
+#include "api/debug/dprint.h"
+
+void kernel_main() {
+    uint32_t num_tiles_per_core = get_arg(args::num_tiles_per_core);
+    constexpr uint32_t cb_id_in0 = dfb::src0;
+
+    DataflowBuffer cb(cb_id_in0);
+    cb.push_back(num_tiles_per_core);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_cn_interleaved_start_id.cpp
@@ -2,37 +2,39 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port. Used only by the TransposeCNProgramFactory, so ported in place.
+// Logic unchanged from the legacy reader; only the access mechanism moves to named
+// bindings: source address -> ta::input, CB id -> dfb::src0, positional args -> get_arg(args::...).
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    const uint32_t src_addr = get_arg_val<uint32_t>(0);
-    const uint32_t N = get_arg_val<uint32_t>(1);
-    const uint32_t C = get_arg_val<uint32_t>(2);
-    const uint32_t HtWt = get_arg_val<uint32_t>(3);
-    const uint32_t batch_step = get_arg_val<uint32_t>(4);    // CHtWt - HtWt
-    const uint32_t channel_step = get_arg_val<uint32_t>(5);  // NCHtWt - HtWt
-    const uint32_t num_pages = get_arg_val<uint32_t>(6);
-    const uint32_t start_id = get_arg_val<uint32_t>(7);
-    uint32_t hw = get_arg_val<uint32_t>(8);
-    uint32_t n = get_arg_val<uint32_t>(9);
+    const uint32_t N = get_arg(args::N);
+    const uint32_t C = get_arg(args::C);
+    const uint32_t HtWt = get_arg(args::HtWt);
+    const uint32_t batch_step = get_arg(args::batch_step);      // CHtWt - HtWt
+    const uint32_t channel_step = get_arg(args::channel_step);  // NCHtWt - HtWt
+    const uint32_t num_pages = get_arg(args::num_pages);
+    const uint32_t start_id = get_arg(args::start_id);
+    uint32_t hw = get_arg(args::hw);
+    uint32_t n = get_arg(args::n);
 
-    constexpr uint32_t cb_id_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
-    constexpr uint32_t read_size = get_compile_time_arg_val(2);
-    constexpr auto src_args = TensorAccessorArgs<3>();
+    constexpr uint32_t page_size = get_arg(args::page_size);
+    constexpr uint32_t read_size = get_arg(args::read_size);
 
     // ublocks size defined in tiles
     constexpr uint32_t onepage = 1;
 
-    const auto s = TensorAccessor(src_args, src_addr);
+    const auto s = TensorAccessor(ta::input);
 
     Noc noc;
-    CircularBuffer cb(cb_id_in0);
+    DataflowBuffer cb(dfb::src0);
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     uint32_t page_idx = start_id;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned.cpp
@@ -2,12 +2,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the TransposeHCTiled factory). Logic UNCHANGED; only the
+// access mechanism moves to named bindings:
+//   - output CB c_0       -> dfb::src0  (reader produces output tiles; writer consumes)
+//   - misaligned scratch CB c_1 -> dfb::scratch (fake CB: address source only, self-loop DFB)
+//   - input buffer addr   -> ta::input (TensorAccessor binding; legacy RTA slot 0 + TensorAccessorArgs)
+//   - positional CTAs / RTAs -> get_arg(args::...)
+// The legacy MISALIGNED was a constexpr derived from CTAs; because the scratch DFB is conditionally
+// bound on the host, the gate is promoted to the #ifdef MISALIGNED preprocessor define so dfb::scratch
+// never enters name lookup in the aligned build.
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 using uint32_t = std::uint32_t;
 
@@ -16,41 +27,41 @@ inline uint32_t TADDR_FLOAT32(uint32_t ti) { return ti << 12; }
 inline uint32_t TADDR_BFLOAT16(uint32_t ti) { return ti << 11; }
 
 void kernel_main() {
-    uint32_t src0_addr = get_arg_val<uint32_t>(0);
-    uint32_t WT = get_arg_val<uint32_t>(1);
-    uint32_t H = get_arg_val<uint32_t>(2);
-    uint32_t CT = get_arg_val<uint32_t>(3);
-    uint32_t HW_bytes = get_arg_val<uint32_t>(4);
-    uint32_t CHW_bytes = get_arg_val<uint32_t>(5);
-    uint32_t start_id = get_arg_val<uint32_t>(6);
-    uint32_t num_tiles = get_arg_val<uint32_t>(7);
-    uint32_t batch_addr = get_arg_val<uint32_t>(8);
-    uint32_t h = get_arg_val<uint32_t>(9);
-    uint32_t htWT = get_arg_val<uint32_t>(10);
-    uint32_t ct = get_arg_val<uint32_t>(11);
-    uint32_t ctoffs = get_arg_val<uint32_t>(12);
-    uint32_t wt = get_arg_val<uint32_t>(13);
+    uint32_t WT = get_arg(args::WT);
+    uint32_t H = get_arg(args::H);
+    uint32_t CT = get_arg(args::CT);
+    uint32_t HW_bytes = get_arg(args::HW_bytes);
+    uint32_t CHW_bytes = get_arg(args::CHW_bytes);
+    uint32_t start_id = get_arg(args::start_id);
+    uint32_t num_tiles = get_arg(args::num_tiles);
+    uint32_t batch_addr = get_arg(args::batch_addr);
+    uint32_t h = get_arg(args::h);
+    uint32_t htWT = get_arg(args::htWT);
+    uint32_t ct = get_arg(args::ct);
+    uint32_t ctoffs = get_arg(args::ctoffs);
+    uint32_t wt = get_arg(args::wt);
 
-    constexpr uint32_t SUBTILE_LINE_BYTES = get_compile_time_arg_val(0);
-    constexpr uint32_t FLOAT32_DTYPE = get_compile_time_arg_val(1);
-    constexpr uint32_t ALIGNMENT = get_compile_time_arg_val(2);
-    constexpr auto src_args = TensorAccessorArgs<3>();
+    constexpr uint32_t SUBTILE_LINE_BYTES = get_arg(args::SUBTILE_LINE_BYTES);
+    constexpr uint32_t FLOAT32_DTYPE = get_arg(args::FLOAT32_DTYPE);
+    constexpr uint32_t ALIGNMENT = get_arg(args::ALIGNMENT);
     constexpr bool MISALIGNED = ALIGNMENT > SUBTILE_LINE_BYTES;
 
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t cb_id_in0 = 0;
 
     // The basic idea here is to iterate over output tiles (that will be over CT,WT) and H
     // this will generate a linearly incremented output address in the inner loop
     // we then reverse map this linear dest address to src address
 
-    const auto s0 = TensorAccessor(src_args, src0_addr);
+    const auto s0 = TensorAccessor(ta::input);
 
     Noc noc;
-    CircularBuffer cb(cb_id_in0);
-    CircularBuffer cb_scratch(1);
-
-    uint32_t intermed_l1_scratch = MISALIGNED ? cb_scratch.get_write_ptr() : 0;
+    DataflowBuffer cb(dfb::src0);
+#ifdef MISALIGNED
+    DataflowBuffer cb_scratch(dfb::scratch);
+    uint32_t intermed_l1_scratch = cb_scratch.get_write_ptr();
+#else
+    uint32_t intermed_l1_scratch = 0;
+#endif
     volatile tt_l1_ptr uint8_t* intermed_l1_scratch_ptr = (volatile uint8_t*)intermed_l1_scratch;
     for (uint32_t t = 0; t < num_tiles; t++) {
         auto h32 = (h & 31);

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_partitioned_rm.cpp
@@ -2,38 +2,41 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the TransposeHCRM factory). Logic UNCHANGED; only the
+// access mechanism moves to named bindings:
+//   - input CB c_0      -> dfb::src0  (reader produces; writer consumes)
+//   - input buffer addr -> ta::input  (TensorAccessor binding; legacy RTA slot 0 + TensorAccessorArgs)
+//   - positional CTAs / RTAs -> get_arg(args::...)
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(1);
-    uint32_t num_read_per_barrier = get_arg_val<uint32_t>(2);
-    uint32_t start_id = get_arg_val<uint32_t>(3);
-    uint32_t curr_c = get_arg_val<uint32_t>(4);
-    uint32_t curr_h = get_arg_val<uint32_t>(5);
-    uint32_t curr_n = get_arg_val<uint32_t>(6);
+    uint32_t num_sticks_per_core_read = get_arg(args::num_sticks_per_core_read);
+    uint32_t num_read_per_barrier = get_arg(args::num_read_per_barrier);
+    uint32_t start_id = get_arg(args::start_id);
+    uint32_t curr_c = get_arg(args::curr_c);
+    uint32_t curr_h = get_arg(args::curr_h);
+    uint32_t curr_n = get_arg(args::curr_n);
 
-    constexpr uint32_t N = get_compile_time_arg_val(0);
-    constexpr uint32_t H = get_compile_time_arg_val(1);
-    constexpr uint32_t C = get_compile_time_arg_val(2);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(3);
+    constexpr uint32_t N = get_arg(args::N);
+    constexpr uint32_t H = get_arg(args::H);
+    constexpr uint32_t C = get_arg(args::C);
+    constexpr uint32_t W_size_bytes = get_arg(args::W_size_bytes);
 
     constexpr uint32_t CH = C * H;
 
-    constexpr auto cb_in0 = tt::CBIndex::c_0;
-
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    constexpr auto src_args = TensorAccessorArgs<5>();
-    const auto s = TensorAccessor(src_args, src_addr);
+    const auto s = TensorAccessor(ta::input);
 
     Noc noc;
-    CircularBuffer cb(cb_in0);
+    DataflowBuffer cb(dfb::src0);
 
     uint32_t i_stick = start_id;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read; ++iter) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware_m2.cpp
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of transpose/device/kernels/dataflow/reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp.
+// The legacy source is also used by the (unmigrated) permute_tiled factory; this copy is named-binding
+// ported for the transpose HC (tiled, interleaved) reader only. Keep the two in sync until the legacy
+// copy's last consumer ports (see METAL2_PORT_REPORT.md). Logic UNCHANGED; only the access mechanism
+// moves to named bindings:
+//   - input CB c_0       -> dfb::src0    (reader produces tiles; writer consumes)
+//   - padding CB c_1     -> dfb::padding (conditional; reader produces, writer consumes; #ifdef NEEDS_PADDING)
+//   - input buffer addr  -> ta::input    (TensorAccessor binding; legacy RTA slot 0 + TensorAccessorArgs)
+//   - positional CTAs / named CTAs / RTAs -> get_arg(args::...)
+// The legacy `needs_padding` named CTA gated the padding CB use via `if constexpr`; because the padding
+// DFB is conditionally bound on the host, the gate is promoted to #ifdef NEEDS_PADDING so dfb::padding
+// never enters name lookup in the no-padding build.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg(args::num_tiles);
+    uint32_t start_id = get_arg(args::start_id);
+
+    constexpr uint32_t num_writes = get_arg(args::num_writes);
+    constexpr uint32_t padding_val_packed = get_arg(args::padding_val_packed);
+    constexpr uint32_t swap_hw = get_arg(args::swap_hw) == 1;
+    constexpr uint32_t H = get_arg(args::H);
+    constexpr uint32_t W = get_arg(args::W);
+    constexpr uint32_t accumulated_outer_dims = get_arg(args::accumulated_outer_dims);
+    constexpr uint32_t TILE_HEIGHT = get_arg(args::tile_height);
+    constexpr uint32_t TILE_WIDTH = get_arg(args::tile_width);
+
+    constexpr uint32_t H_p = tt::data_movement::common::round_up<H, TILE_HEIGHT>();
+    constexpr uint32_t W_p = tt::data_movement::common::round_up<W, TILE_WIDTH>();
+
+    constexpr uint32_t Wt = W_p / TILE_WIDTH;
+    constexpr uint32_t Ht = H_p / TILE_HEIGHT;
+
+    constexpr uint32_t HtWt = Ht * Wt;
+
+    // ublocks size defined in tiles
+    constexpr uint32_t onetile = 1;
+    const auto s = TensorAccessor(ta::input);
+
+    Noc noc;
+    DataflowBuffer cb(dfb::src0);
+#ifdef NEEDS_PADDING
+    DataflowBuffer cb_padding(dfb::padding);
+#endif
+    const uint32_t tile_bytes = cb.get_tile_size();
+
+// read a ublock of tiles from src to CB, and then push the ublock to unpacker
+#ifdef BACKWARDS
+    uint32_t end_id = start_id - num_tiles;
+    for (uint32_t i = start_id; i != end_id; --i) {
+#else
+    uint32_t end_id = start_id + num_tiles;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+#endif
+        uint32_t linear_tile_index = 0;
+        if constexpr (swap_hw) {
+            uint32_t rem = i;
+            uint32_t ht = rem % Ht;
+            rem /= Ht;
+            uint32_t wt = rem % Wt;
+            rem /= Wt;
+            uint32_t offset = rem % accumulated_outer_dims;
+            linear_tile_index = offset * HtWt + ht * Wt + wt;
+        } else {
+            linear_tile_index = i;
+        }
+        cb.reserve_back(onetile);
+        noc.async_read(s, cb, tile_bytes, {.page_id = linear_tile_index}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        cb.push_back(onetile);
+    }
+#ifdef NEEDS_PADDING
+    // Add padding
+    cb_padding.reserve_back(1);
+    uint32_t l1_write_addr = cb_padding.get_write_ptr();
+    // Fill with padding value
+    // if bfloat16 num_writes = FACE_WIDTH / (sizeof(uint32_t))/(element_size)
+    tt::data_movement::common::fill_with_val(l1_write_addr, num_writes, padding_val_packed);
+    cb_padding.push_back(1);
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_hc_sharded_rm.cpp
@@ -2,6 +2,16 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the TransposeHCSharded factory). Logic UNCHANGED; only the
+// access mechanism moves to named bindings:
+//   - input shard CB c_0  -> dfb::src0 (borrowed input shard; read by base pointer only -> self-loop)
+//   - output shard CB c_16 -> dfb::out  (borrowed output shard; written by base pointer only -> self-loop)
+//   - positional CTAs      -> get_arg(args::...)
+//   - the packed variable-length RTA tails (per-core stick offsets + noc x/y, or shard-grid maps) ->
+//     runtime varargs. The legacy reader read these tails via get_arg_addr pointer arithmetic; the same
+//     packed layout is preserved, now sourced from varargs.
+// USE_SPECIAL_CASE selects the special-case shard mapping; otherwise the generic mapping runs.
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -9,39 +19,42 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
 #ifdef USE_SPECIAL_CASE
 
-    bool read_single_h_block_per_core = get_arg_val<uint32_t>(0) == 1;
-    uint32_t num_C_blocks_per_core = get_arg_val<uint32_t>(1);
-    uint32_t num_sticks_per_shard_core = get_arg_val<uint32_t>(2);
-    uint32_t num_cores_read = get_arg_val<uint32_t>(3);
-    uint32_t read_stick_stride = get_arg_val<uint32_t>(4);
-    tt_l1_ptr uint32_t* read_stick_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(5));
-    tt_l1_ptr uint32_t* noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(5 + num_cores_read));
-    tt_l1_ptr uint32_t* noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(5 + num_cores_read * 2));
+    bool read_single_h_block_per_core = get_arg(args::read_single_h_block_per_core) == 1;
+    uint32_t num_C_blocks_per_core = get_arg(args::num_C_blocks_per_core);
+    uint32_t num_sticks_per_shard_core = get_arg(args::num_sticks_per_shard_core);
+    uint32_t num_cores_read = get_arg(args::num_cores_read);
+    uint32_t read_stick_stride = get_arg(args::read_stick_stride);
+    // Packed vararg tail, preserving the legacy get_arg_addr layout:
+    //   [0 .. num_cores_read)              : read_stick_offset
+    //   [num_cores_read .. 2*num_cores_read) : noc_coord_x
+    //   [2*num_cores_read .. 3*num_cores_read) : noc_coord_y
+    const uint32_t read_stick_offset_base = 0;
+    const uint32_t noc_coord_x_base = num_cores_read;
+    const uint32_t noc_coord_y_base = num_cores_read * 2;
 
-    constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
-    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t stick_size_bytes = get_arg(args::stick_size_bytes);
 
     Noc noc;
-    CircularBuffer cb_in(cb_in0);
-    CircularBuffer cb_out(cb_out0);
+    DataflowBuffer cb_in(dfb::src0);
+    DataflowBuffer cb_out(dfb::out);
 
     if (read_single_h_block_per_core) {
         uint32_t write_stick_stride = stick_size_bytes * num_cores_read;
         uint32_t l1_write_offset = 0;
 
         for (uint32_t core = 0; core < num_cores_read; ++core) {
-            uint32_t src_addr = cb_in.get_read_ptr() + read_stick_offset[core];
+            uint32_t src_addr = cb_in.get_read_ptr() + get_vararg(read_stick_offset_base + core);
             uint32_t l1_write_addr = cb_out.get_write_ptr() + l1_write_offset;
+            uint32_t noc_x = get_vararg(noc_coord_x_base + core);
+            uint32_t noc_y = get_vararg(noc_coord_y_base + core);
 
             noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
-                UnicastEndpoint{},
-                stick_size_bytes,
-                {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr});
+                UnicastEndpoint{}, stick_size_bytes, {.noc_x = noc_x, .noc_y = noc_y, .addr = src_addr});
 
             for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
                 CoreLocalMem<uint32_t> dst(l1_write_addr);
@@ -49,7 +62,7 @@ void kernel_main() {
                     UnicastEndpoint{},
                     dst,
                     stick_size_bytes,
-                    {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr},
+                    {.noc_x = noc_x, .noc_y = noc_y, .addr = src_addr},
                     {.offset_bytes = 0});
                 src_addr += read_stick_stride;
                 l1_write_addr += write_stick_stride;
@@ -63,12 +76,12 @@ void kernel_main() {
 
         for (uint32_t c = 0; c < num_C_blocks_per_core; ++c) {
             for (uint32_t core = 0; core < num_cores_read; ++core) {
-                uint32_t src_addr = l1_read_addr + read_stick_offset[core];
+                uint32_t src_addr = l1_read_addr + get_vararg(read_stick_offset_base + core);
+                uint32_t noc_x = get_vararg(noc_coord_x_base + core);
+                uint32_t noc_y = get_vararg(noc_coord_y_base + core);
 
                 noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
-                    UnicastEndpoint{},
-                    stick_size_bytes,
-                    {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr});
+                    UnicastEndpoint{}, stick_size_bytes, {.noc_x = noc_x, .noc_y = noc_y, .addr = src_addr});
 
                 for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
                     CoreLocalMem<uint32_t> dst(l1_write_addr);
@@ -76,7 +89,7 @@ void kernel_main() {
                         UnicastEndpoint{},
                         dst,
                         stick_size_bytes,
-                        {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr},
+                        {.noc_x = noc_x, .noc_y = noc_y, .addr = src_addr},
                         {.offset_bytes = 0});
                     src_addr += read_stick_stride;
                     l1_write_addr += stick_size_bytes;
@@ -90,35 +103,33 @@ void kernel_main() {
 
 #else
 
-    constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
-    constexpr uint32_t N = get_compile_time_arg_val(2);
-    constexpr uint32_t H = get_compile_time_arg_val(3);
-    constexpr uint32_t C = get_compile_time_arg_val(4);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(5);
-    constexpr bool row_major = get_compile_time_arg_val(6) == 1;
-    constexpr uint32_t num_cores_x = get_compile_time_arg_val(7);
-    constexpr uint32_t num_cores_y = get_compile_time_arg_val(8);
+    constexpr uint32_t N = get_arg(args::N);
+    constexpr uint32_t H = get_arg(args::H);
+    constexpr uint32_t C = get_arg(args::C);
+    constexpr uint32_t W_size_bytes = get_arg(args::W_size_bytes);
+    constexpr bool row_major = get_arg(args::row_major) == 1;
+    constexpr uint32_t num_cores_x = get_arg(args::num_cores_x);
+    constexpr uint32_t num_cores_y = get_arg(args::num_cores_y);
 
-    uint32_t arg_idx = 0;
-    uint32_t num_sticks_per_core = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t start_id = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t curr_c = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t curr_h = get_arg_val<uint32_t>(arg_idx++);
-    uint32_t curr_n = get_arg_val<uint32_t>(arg_idx++);
+    uint32_t num_sticks_per_core = get_arg(args::num_sticks_per_core);
+    uint32_t start_id = get_arg(args::start_id);
+    uint32_t curr_c = get_arg(args::curr_c);
+    uint32_t curr_h = get_arg(args::curr_h);
+    uint32_t curr_n = get_arg(args::curr_n);
 
-    const uint32_t* const shard_grid_x_map = reinterpret_cast<const uint32_t* const>(get_arg_addr(arg_idx));
-    arg_idx += num_cores_x;
-    const uint32_t* const shard_grid_y_map = reinterpret_cast<const uint32_t* const>(get_arg_addr(arg_idx));
-    arg_idx += num_cores_y;
+    // Packed vararg tail, preserving the legacy get_arg_addr layout:
+    //   [0 .. num_cores_x)              : shard_grid_x_map
+    //   [num_cores_x .. num_cores_x+num_cores_y) : shard_grid_y_map
+    const uint32_t shard_grid_x_map_base = 0;
+    const uint32_t shard_grid_y_map_base = num_cores_x;
 
     constexpr uint32_t CH = C * H;
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
     Noc noc;
-    CircularBuffer cb_in(cb_in0);
-    CircularBuffer cb_out(cb_out0);
+    DataflowBuffer cb_in(dfb::src0);
+    DataflowBuffer cb_out(dfb::out);
 
     cb_out.reserve_back(num_sticks_per_core);
     uint32_t l1_write_addr = cb_out.get_write_ptr();
@@ -139,11 +150,11 @@ void kernel_main() {
 
         uint32_t worker_x_physical, worker_y_physical;
         if constexpr (row_major) {
-            worker_x_physical = shard_grid_x_map[shard_grid_inner_dim_id];
-            worker_y_physical = shard_grid_y_map[shard_grid_outer_dim_id];
+            worker_x_physical = get_vararg(shard_grid_x_map_base + shard_grid_inner_dim_id);
+            worker_y_physical = get_vararg(shard_grid_y_map_base + shard_grid_outer_dim_id);
         } else {
-            worker_x_physical = shard_grid_x_map[shard_grid_outer_dim_id];
-            worker_y_physical = shard_grid_y_map[shard_grid_inner_dim_id];
+            worker_x_physical = get_vararg(shard_grid_x_map_base + shard_grid_outer_dim_id);
+            worker_y_physical = get_vararg(shard_grid_y_map_base + shard_grid_inner_dim_id);
         }
 
         uint32_t l1_read_addr = cb_in.get_read_ptr() + stick_id_in_shard * stick_size_bytes;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id.cpp
@@ -7,27 +7,23 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_tiles = get_arg_val<uint32_t>(1);
-    uint32_t start_id = get_arg_val<uint32_t>(2);
-    uint32_t start_ht = get_arg_val<uint32_t>(3);
-    uint32_t start_wt = get_arg_val<uint32_t>(4);
+    auto num_tiles = get_arg(args::num_tiles);
+    auto start_id = get_arg(args::start_id);
+    auto start_ht = get_arg(args::start_ht);
+    auto start_wt = get_arg(args::start_wt);
 
-    uint32_t Ht = get_arg_val<uint32_t>(5);
-    uint32_t Wt = get_arg_val<uint32_t>(6);
-    uint32_t HtWt = get_arg_val<uint32_t>(7);
-
-    constexpr auto src_args = TensorAccessorArgs<0>();
-
-    constexpr uint32_t cb_id_in0 = 0;
+    auto Ht = get_arg(args::Ht);
+    auto Wt = get_arg(args::Wt);
+    auto HtWt = get_arg(args::HtWt);
 
     // ublocks size defined in tiles
     constexpr uint32_t onetile = 1;
-    CircularBuffer cb(cb_id_in0);
+    DataflowBuffer cb(dfb::src0);
     const uint32_t tile_bytes = cb.get_tile_size();
-    const auto s = TensorAccessor(src_args, src_addr);
+    const auto s = TensorAccessor(ta::input);
 
     Noc noc;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -8,30 +8,27 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t src_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_id = get_arg_val<uint32_t>(1);
-    uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(2);
+    auto start_id = get_arg(args::start_id);
+    auto num_hw_blocks_per_core = get_arg(args::num_hw_blocks_per_core);
 
-    constexpr uint32_t Ht = get_compile_time_arg_val(0);
-    constexpr uint32_t H_per_tile = get_compile_time_arg_val(1);
-    constexpr uint32_t H_per_tile_last = get_compile_time_arg_val(2);
-    constexpr uint32_t Wt = get_compile_time_arg_val(3);
-    constexpr uint32_t W = get_compile_time_arg_val(4);
-    constexpr uint32_t HtWt = get_compile_time_arg_val(5);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(6);
-    constexpr uint32_t l1_write_offset_bytes = get_compile_time_arg_val(7);
-    constexpr auto src_args = TensorAccessorArgs<9>();
-
-    constexpr auto cb_in0 = tt::CBIndex::c_0;
+    constexpr auto Ht = get_arg(args::Ht);
+    constexpr auto H_per_tile = get_arg(args::H_per_tile);
+    constexpr auto H_per_tile_last = get_arg(args::H_per_tile_last);
+    constexpr auto Wt = get_arg(args::Wt);
+    constexpr auto W = get_arg(args::W);
+    constexpr auto HtWt = get_arg(args::HtWt);
+    constexpr auto W_size_bytes = get_arg(args::W_size_bytes);
+    constexpr auto l1_write_offset_bytes = get_arg(args::l1_write_offset_bytes);
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    const auto s = TensorAccessor(src_args, src_addr);
+    const auto s = TensorAccessor(ta::input);
 
     Noc noc;
-    CircularBuffer cb(cb_in0);
+    DataflowBuffer cb(dfb::src0);
 
     uint32_t i_stick = start_id;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/reader_unary_transpose_wh_sharded_rm.cpp
@@ -2,6 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the TransposeWHShardedRM factory). Logic UNCHANGED; only the
+// access mechanism moves to named bindings:
+//   - input shard CB c_0  -> dfb::src0       (borrowed input shard; read by base pointer only -> self-loop)
+//   - intermediate CB c_24 -> dfb::in_scratch (scratch; written by base pointer; producer for compute)
+//   - positional CTAs      -> get_arg(args::...)
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -9,24 +15,25 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t num_hw_blocks_per_core = get_compile_time_arg_val(0);
-    constexpr uint32_t Ht = get_compile_time_arg_val(1);
-    constexpr uint32_t H_per_tile = get_compile_time_arg_val(2);
-    constexpr uint32_t H_per_tile_last = get_compile_time_arg_val(3);
-    constexpr uint32_t Wt = get_compile_time_arg_val(4);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(5);
-    constexpr uint32_t l1_write_offset_bytes = get_compile_time_arg_val(6);
+    constexpr uint32_t num_hw_blocks_per_core = get_arg(args::num_hw_blocks_per_core);
+    constexpr uint32_t Ht = get_arg(args::Ht);
+    constexpr uint32_t H_per_tile = get_arg(args::H_per_tile);
+    constexpr uint32_t H_per_tile_last = get_arg(args::H_per_tile_last);
+    constexpr uint32_t Wt = get_arg(args::Wt);
+    constexpr uint32_t W_size_bytes = get_arg(args::W_size_bytes);
+    constexpr uint32_t l1_write_offset_bytes = get_arg(args::l1_write_offset_bytes);
 
-    constexpr auto cb_in0 = tt::CBIndex::c_0;
-    constexpr auto cb_in = tt::CBIndex::c_24;
+    constexpr auto cb_in0 = dfb::src0;
+    constexpr auto cb_in = dfb::in_scratch;
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
     Noc noc;
-    CircularBuffer cb_src(cb_in0);
-    CircularBuffer cb_dst(cb_in);
+    DataflowBuffer cb_src(cb_in0);
+    DataflowBuffer cb_dst(cb_in);
 
     uint32_t src_addr = cb_src.get_read_ptr();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_interleaved_start_id_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_interleaved_start_id_m2.cpp
@@ -1,0 +1,49 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp.
+// The legacy source is shared by ~30 ops that have not yet migrated; this copy is named-binding
+// ported for the transpose WH (tiled) writer only. Keep the two in sync until the legacy copy's
+// last consumer ports (see METAL2_PORT_REPORT.md).
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const auto num_pages = get_arg(args::num_pages);
+    const auto start_id = get_arg(args::start_id);
+
+    // Get page size from CB interface (works for both TILE and ROW_MAJOR layouts)
+    const uint32_t page_bytes = get_local_cb_interface(dfb::out).fifo_page_size;
+
+    Noc noc;
+    DataflowBuffer cb(dfb::out);
+
+#ifdef OUT_SHARDED
+    cb.wait_front(num_pages);
+#else
+
+    // single-page ublocks (works for both TILE and ROW_MAJOR layouts)
+    constexpr uint32_t onepage = 1;
+
+    const auto s = TensorAccessor(ta::output);
+
+#ifdef BACKWARDS
+    uint32_t end_id = start_id - num_pages;
+    for (uint32_t i = start_id; i != end_id; --i) {
+#else
+    uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+#endif
+        cb.wait_front(onepage);
+        noc.async_write(cb, s, page_bytes, {}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb.pop_front(onepage);
+    }
+    noc.async_write_barrier();
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_sharded_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_sharded_m2.cpp
@@ -1,0 +1,23 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp, for the
+// sharded transpose WH writer (the legacy source is shared by ~a dozen ops; not editable in place).
+// Behavior unchanged: wait on the borrowed output DFB for num_units entries. The legacy CT (output CB
+// index) is now the dfb::out binding.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/circular_buffer.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t num_units = get_arg(args::num_units);
+
+    constexpr uint32_t cb_id_out = dfb::out;
+
+    DataflowBuffer cb_out(cb_id_out);
+
+    cb_out.wait_front(num_units);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_cn_interleaved_start_id.cpp
@@ -1,28 +1,30 @@
 // SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port. Used only by the TransposeCNProgramFactory, so ported in place.
+// Logic unchanged from the legacy writer; only the access mechanism moves to named
+// bindings: dest address -> ta::output, CB id -> dfb::src0, positional args -> get_arg(args::...).
+
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_pages = get_arg_val<uint32_t>(1);
-    uint32_t start_id = get_arg_val<uint32_t>(2);
+    uint32_t num_pages = get_arg(args::num_pages);
+    uint32_t start_id = get_arg(args::start_id);
 
-    constexpr uint32_t cb_id_out = get_compile_time_arg_val(0);
-    constexpr uint32_t page_size = get_compile_time_arg_val(1);
-    constexpr uint32_t write_size = get_compile_time_arg_val(2);
-    constexpr auto dst_args = TensorAccessorArgs<3>();
+    constexpr uint32_t page_size = get_arg(args::page_size);
+    constexpr uint32_t write_size = get_arg(args::write_size);
 
     constexpr uint32_t onepage = 1;
 
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(ta::output);
 
     Noc noc;
-    CircularBuffer cb(cb_id_out);
+    DataflowBuffer cb(dfb::src0);
 
     uint32_t end_id = start_id + num_pages;
     for (uint32_t i = start_id; i < end_id; ++i) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_start_id_rm.cpp
@@ -2,28 +2,32 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the TransposeHCRM factory). Logic UNCHANGED; only the
+// access mechanism moves to named bindings:
+//   - output CB c_0       -> dfb::src0  (the single shared DFB; reader produces, writer consumes)
+//   - output buffer addr  -> ta::output (TensorAccessor binding; legacy RTA slot 0 + TensorAccessorArgs)
+//   - positional CTAs / RTAs -> get_arg(args::...)
+
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t num_sticks_per_core_read = get_arg_val<uint32_t>(1);
-    uint32_t num_read_per_barrier = get_arg_val<uint32_t>(2);
-    uint32_t start_id = get_arg_val<uint32_t>(3);
+    uint32_t num_sticks_per_core_read = get_arg(args::num_sticks_per_core_read);
+    uint32_t num_read_per_barrier = get_arg(args::num_read_per_barrier);
+    uint32_t start_id = get_arg(args::start_id);
 
-    constexpr uint32_t cb_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t W_size_bytes = get_compile_time_arg_val(1);
+    constexpr uint32_t W_size_bytes = get_arg(args::W_size_bytes);
 
     const uint32_t stick_size_bytes = W_size_bytes;
 
-    constexpr auto dst_args = TensorAccessorArgs<3>();
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(ta::output);
 
     Noc noc;
-    CircularBuffer cb(cb_out0);
+    DataflowBuffer cb(dfb::src0);
 
     uint32_t i_stick = start_id;
     for (uint32_t iter = 0; iter < num_sticks_per_core_read; ++iter) {

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp
@@ -2,33 +2,40 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the TransposeHCTiledInterleaved factory). Logic UNCHANGED;
+// only the access mechanism moves to named bindings:
+//   - output CB c_0       -> dfb::out     (the shared src0 DFB; reader produces, writer consumes)
+//   - padding CB c_1      -> dfb::padding (conditional; reader produces, writer consumes; #ifdef NEEDS_PADDING)
+//   - output buffer addr  -> ta::output   (TensorAccessor binding; legacy RTA slot 0 + TensorAccessorArgs)
+//   - positional CTAs / RTAs -> get_arg(args::...)
+// The legacy `needs_padding` CTA gated the padding CB use via `if constexpr`; because the padding DFB is
+// conditionally bound on the host, the gate is promoted to #ifdef NEEDS_PADDING so dfb::padding never
+// enters name lookup in the no-padding build.
+
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "ttnn/operations/data_movement/common/kernels/common.hpp"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // Retrieve arguments
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_tile_idx = get_arg_val<uint32_t>(1);
-    uint32_t end_tile_idx = get_arg_val<uint32_t>(2);
-    uint32_t start_padding_tile_idx = get_arg_val<uint32_t>(3);
-    uint32_t end_padding_tile_idx = get_arg_val<uint32_t>(4);
+    uint32_t start_tile_idx = get_arg(args::start_tile_idx);
+    uint32_t end_tile_idx = get_arg(args::end_tile_idx);
+    uint32_t start_padding_tile_idx = get_arg(args::start_padding_tile_idx);
+    uint32_t end_padding_tile_idx = get_arg(args::end_padding_tile_idx);
 
     // Compile-time constants
-    constexpr uint32_t element_size = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(1);
-    constexpr uint32_t C = get_compile_time_arg_val(2);
-    constexpr uint32_t H = get_compile_time_arg_val(3);
-    constexpr uint32_t W = get_compile_time_arg_val(4);
-    constexpr uint32_t TILE_HEIGHT = get_compile_time_arg_val(5);
-    constexpr uint32_t TILE_WIDTH = get_compile_time_arg_val(6);
-    constexpr uint32_t FACE_HEIGHT = get_compile_time_arg_val(7);
-    constexpr uint32_t FACE_WIDTH = get_compile_time_arg_val(8);
-    constexpr bool needs_padding = get_compile_time_arg_val(9) == 1;
-    constexpr auto dst_args = TensorAccessorArgs<10>();
+    constexpr uint32_t element_size = get_arg(args::element_size);
+    constexpr uint32_t C = get_arg(args::C);
+    constexpr uint32_t H = get_arg(args::H);
+    constexpr uint32_t W = get_arg(args::W);
+    constexpr uint32_t TILE_HEIGHT = get_arg(args::tile_height);
+    constexpr uint32_t TILE_WIDTH = get_arg(args::tile_width);
+    constexpr uint32_t FACE_HEIGHT = get_arg(args::face_height);
+    constexpr uint32_t FACE_WIDTH = get_arg(args::face_width);
 
     // Derived compile-time constants
     constexpr uint32_t TILE_HW = TILE_HEIGHT * TILE_WIDTH;
@@ -46,11 +53,13 @@ void kernel_main() {
     constexpr uint32_t SUBTILE_LINE_BYTES = FACE_WIDTH * element_size;
 
     // Initialize address generator
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(ta::output);
 
     Noc noc;
-    CircularBuffer cb(cb_id_out0);
-    CircularBuffer cb_padding(tt::CBIndex::c_1);
+    DataflowBuffer cb(dfb::out);
+#ifdef NEEDS_PADDING
+    DataflowBuffer cb_padding(dfb::padding);
+#endif
 
     // Calculate actual data height in the last tile
     constexpr uint32_t H_last_tile = H - (H_t - 1) * TILE_HEIGHT;
@@ -162,44 +171,44 @@ void kernel_main() {
     }
 
     // add padding
-    if constexpr (needs_padding) {
-        cb_padding.wait_front(1);
+#ifdef NEEDS_PADDING
+    cb_padding.wait_front(1);
 
-        uint32_t l1_read_ptr = cb_padding.get_read_ptr();
+    uint32_t l1_read_ptr = cb_padding.get_read_ptr();
 
-        constexpr uint32_t c_t = C_t - 1;
-        constexpr uint8_t C_in_tile = C % TILE_HEIGHT;
-        constexpr uint8_t face_c_start = C_in_tile / FACE_HEIGHT;
+    constexpr uint32_t c_t = C_t - 1;
+    constexpr uint8_t C_in_tile = C % TILE_HEIGHT;
+    constexpr uint8_t face_c_start = C_in_tile / FACE_HEIGHT;
 
-        for (uint32_t tile_idx = start_padding_tile_idx; tile_idx < end_padding_tile_idx; ++tile_idx) {
-            // Map tile_idx to (n, h, w_t)
-            uint32_t n = tile_idx / (H * W_t);
-            uint32_t remainder1 = tile_idx % (H * W_t);
-            uint32_t h = remainder1 / W_t;
-            uint32_t w_t = remainder1 % W_t;
+    for (uint32_t tile_idx = start_padding_tile_idx; tile_idx < end_padding_tile_idx; ++tile_idx) {
+        // Map tile_idx to (n, h, w_t)
+        uint32_t n = tile_idx / (H * W_t);
+        uint32_t remainder1 = tile_idx % (H * W_t);
+        uint32_t h = remainder1 / W_t;
+        uint32_t w_t = remainder1 % W_t;
 
-            // Calculate linear_idx of padded tile inside output tensor buffer
-            uint32_t linear_idx = n * H * C_t * W_t + h * C_t * W_t + c_t * W_t + w_t;
+        // Calculate linear_idx of padded tile inside output tensor buffer
+        uint32_t linear_idx = n * H * C_t * W_t + h * C_t * W_t + c_t * W_t + w_t;
 
-            for (uint8_t face_c = face_c_start; face_c < NUM_FACES_H; ++face_c) {
-                // Offset to the start of the current face along the channel dimension/height of the tile
-                uint32_t face_c_offset = face_c * NUM_FACES_W * face_height_width;
+        for (uint8_t face_c = face_c_start; face_c < NUM_FACES_H; ++face_c) {
+            // Offset to the start of the current face along the channel dimension/height of the tile
+            uint32_t face_c_offset = face_c * NUM_FACES_W * face_height_width;
 
-                // Sub-tile/face line where our padded data starts
-                uint8_t sub_tile_line_start = face_c == face_c_start ? C_in_tile % FACE_HEIGHT : 0;
+            // Sub-tile/face line where our padded data starts
+            uint8_t sub_tile_line_start = face_c == face_c_start ? C_in_tile % FACE_HEIGHT : 0;
 
-                for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
-                    // Offset to the start of the current face along the width of the tile
-                    uint32_t face_w_offset = face_w * face_height_width;
-                    uint32_t offset = (face_c_offset + face_w_offset + sub_tile_line_start * FACE_WIDTH) * element_size;
-                    uint32_t write_size = SUBTILE_LINE_BYTES * (FACE_HEIGHT - sub_tile_line_start);
-                    CoreLocalMem<uint32_t> pad_src(l1_read_ptr);
-                    noc.async_write(
-                        pad_src, s, write_size, {.offset_bytes = 0}, {.page_id = linear_idx, .offset_bytes = offset});
-                }
+            for (uint8_t face_w = 0; face_w < NUM_FACES_W; ++face_w) {
+                // Offset to the start of the current face along the width of the tile
+                uint32_t face_w_offset = face_w * face_height_width;
+                uint32_t offset = (face_c_offset + face_w_offset + sub_tile_line_start * FACE_WIDTH) * element_size;
+                uint32_t write_size = SUBTILE_LINE_BYTES * (FACE_HEIGHT - sub_tile_line_start);
+                CoreLocalMem<uint32_t> pad_src(l1_read_ptr);
+                noc.async_write(
+                    pad_src, s, write_size, {.offset_bytes = 0}, {.page_id = linear_idx, .offset_bytes = offset});
             }
         }
-        noc.async_write_barrier();
-        cb_padding.pop_front(1);
     }
+    noc.async_write_barrier();
+    cb_padding.pop_front(1);
+#endif
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_hc_sharded_rm.cpp
@@ -2,6 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the TransposeHCSharded factory, special-case path). Logic
+// UNCHANGED; only the access mechanism moves to named bindings:
+//   - input shard CB c_0  -> dfb::src0 (borrowed input shard; read by base pointer only -> self-loop)
+//   - output shard CB c_16 -> dfb::out  (borrowed output shard; written by base pointer only -> self-loop)
+//   - positional CTAs      -> get_arg(args::...)
+//   - the packed variable-length RTA tail (per-core stick offsets + noc x/y) -> runtime varargs. The
+//     legacy writer read this tail via get_arg_addr pointer arithmetic; the same packed layout is
+//     preserved, now sourced from varargs.
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
@@ -9,41 +18,47 @@
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    bool read_single_h_block_per_core = get_arg_val<uint32_t>(0) == 1;
-    uint32_t num_C_blocks_per_core = get_arg_val<uint32_t>(1);
-    uint32_t num_sticks_per_shard_core = get_arg_val<uint32_t>(2);
-    uint32_t num_cores_read = get_arg_val<uint32_t>(3);
-    uint32_t read_stick_stride = get_arg_val<uint32_t>(4);
-    uint32_t src_read_stick_offset = get_arg_val<uint32_t>(5);
-    uint32_t dst_write_stick_offset = get_arg_val<uint32_t>(6);
-    tt_l1_ptr uint32_t* read_stick_offset = (tt_l1_ptr uint32_t*)(get_arg_addr(7));
-    tt_l1_ptr uint32_t* noc_coord_x = (tt_l1_ptr uint32_t*)(get_arg_addr(7 + num_cores_read));
-    tt_l1_ptr uint32_t* noc_coord_y = (tt_l1_ptr uint32_t*)(get_arg_addr(7 + num_cores_read * 2));
+    bool read_single_h_block_per_core = get_arg(args::read_single_h_block_per_core) == 1;
+    uint32_t num_C_blocks_per_core = get_arg(args::num_C_blocks_per_core);
+    uint32_t num_sticks_per_shard_core = get_arg(args::num_sticks_per_shard_core);
+    uint32_t num_cores_read = get_arg(args::num_cores_read);
+    uint32_t read_stick_stride = get_arg(args::read_stick_stride);
+    uint32_t src_read_stick_offset = get_arg(args::src_read_stick_offset);
+    uint32_t dst_write_stick_offset = get_arg(args::dst_write_stick_offset);
+    // Packed vararg tail, preserving the legacy get_arg_addr layout:
+    //   [0 .. num_cores_read)              : read_stick_offset
+    //   [num_cores_read .. 2*num_cores_read) : noc_coord_x
+    //   [2*num_cores_read .. 3*num_cores_read) : noc_coord_y
+    const uint32_t read_stick_offset_base = 0;
+    const uint32_t noc_coord_x_base = num_cores_read;
+    const uint32_t noc_coord_y_base = num_cores_read * 2;
 
-    constexpr uint32_t cb_in0 = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_out0 = get_compile_time_arg_val(1);
-    constexpr uint32_t stick_size_bytes = get_compile_time_arg_val(2);
+    constexpr uint32_t stick_size_bytes = get_arg(args::stick_size_bytes);
 
     Noc noc;
-    CircularBuffer cb_in(cb_in0);
-    CircularBuffer cb_out(cb_out0);
+    DataflowBuffer cb_in(dfb::src0);
+    DataflowBuffer cb_out(dfb::out);
 
     if (read_single_h_block_per_core) {
         uint32_t write_stick_stride = stick_size_bytes * num_cores_read;
 
         uint32_t l1_write_offset = 0;
         for (uint32_t core = 0; core < num_cores_read; ++core) {
-            uint32_t src_addr = cb_in.get_read_ptr() + read_stick_offset[core] + src_read_stick_offset;
+            uint32_t src_addr =
+                cb_in.get_read_ptr() + get_vararg(read_stick_offset_base + core) + src_read_stick_offset;
             uint32_t l1_write_addr = cb_out.get_write_ptr() + l1_write_offset + dst_write_stick_offset;
+            uint32_t noc_x = get_vararg(noc_coord_x_base + core);
+            uint32_t noc_y = get_vararg(noc_coord_y_base + core);
             for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
                 CoreLocalMem<uint32_t> dst(l1_write_addr);
                 noc.async_read<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
                     UnicastEndpoint{},
                     dst,
                     stick_size_bytes,
-                    {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr},
+                    {.noc_x = noc_x, .noc_y = noc_y, .addr = src_addr},
                     {.offset_bytes = 0});
                 src_addr += read_stick_stride;
                 l1_write_addr += write_stick_stride;
@@ -57,12 +72,12 @@ void kernel_main() {
 
         for (uint32_t c = 0; c < num_C_blocks_per_core; ++c) {
             for (uint32_t core = 0; core < num_cores_read; ++core) {
-                uint32_t src_addr = l1_read_addr + read_stick_offset[core];
+                uint32_t src_addr = l1_read_addr + get_vararg(read_stick_offset_base + core);
+                uint32_t noc_x = get_vararg(noc_coord_x_base + core);
+                uint32_t noc_y = get_vararg(noc_coord_y_base + core);
 
                 noc.set_async_read_state<NocOptions::DEFAULT, NOC_MAX_BURST_SIZE>(
-                    UnicastEndpoint{},
-                    stick_size_bytes,
-                    {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr});
+                    UnicastEndpoint{}, stick_size_bytes, {.noc_x = noc_x, .noc_y = noc_y, .addr = src_addr});
 
                 for (uint32_t i = 0; i < num_sticks_per_shard_core; ++i) {
                     CoreLocalMem<uint32_t> dst(l1_write_addr);
@@ -70,7 +85,7 @@ void kernel_main() {
                         UnicastEndpoint{},
                         dst,
                         stick_size_bytes,
-                        {.noc_x = noc_coord_x[core], .noc_y = noc_coord_y[core], .addr = src_addr},
+                        {.noc_x = noc_x, .noc_y = noc_y, .addr = src_addr},
                         {.offset_bytes = 0});
                     src_addr += read_stick_stride;
                     l1_write_addr += stick_size_bytes;

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_interleaved_start_id_rm.cpp
@@ -7,30 +7,28 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_id = get_arg_val<uint32_t>(1);
-    uint32_t num_hw_blocks_per_core = get_arg_val<uint32_t>(2);
+    auto start_id = get_arg(args::start_id);
+    auto num_hw_blocks_per_core = get_arg(args::num_hw_blocks_per_core);
 
-    constexpr uint32_t cb_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t Ht = get_compile_time_arg_val(1);
-    constexpr uint32_t H = get_compile_time_arg_val(2);
-    constexpr uint32_t Wt = get_compile_time_arg_val(3);
-    constexpr uint32_t W_per_tile = get_compile_time_arg_val(4);
-    constexpr uint32_t W_per_tile_last = get_compile_time_arg_val(5);
-    constexpr uint32_t HtWt = get_compile_time_arg_val(6);
-    constexpr uint32_t H_size_bytes = get_compile_time_arg_val(7);
-    constexpr uint32_t l1_read_offset_bytes = get_compile_time_arg_val(8);
+    constexpr auto Ht = get_arg(args::Ht);
+    constexpr auto H = get_arg(args::H);
+    constexpr auto Wt = get_arg(args::Wt);
+    constexpr auto W_per_tile = get_arg(args::W_per_tile);
+    constexpr auto W_per_tile_last = get_arg(args::W_per_tile_last);
+    constexpr auto HtWt = get_arg(args::HtWt);
+    constexpr auto H_size_bytes = get_arg(args::H_size_bytes);
+    constexpr auto l1_read_offset_bytes = get_arg(args::l1_read_offset_bytes);
 
     // single-tile ublocks
     const uint32_t stick_size_bytes = H_size_bytes;
 
-    constexpr auto dst_args = TensorAccessorArgs<10>();
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(ta::output);
 
     Noc noc;
-    CircularBuffer cb(cb_out0);
+    DataflowBuffer cb(dfb::out);
 
     uint32_t i_stick = start_id;
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_sharded_rm.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/writer_unary_transpose_wh_sharded_rm.cpp
@@ -2,30 +2,39 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port (in place — used only by the TransposeWHShardedRM factory, and only launched when
+// Ht > 8). Logic UNCHANGED; only the access mechanism moves to named bindings:
+//   - compute-output staging CB c_27 -> dfb::out_stage (scratch; read by base pointer; consumer)
+//   - output shard CB c_16           -> dfb::out       (borrowed output shard; written by base pointer)
+//   - positional CTAs                -> get_arg(args::...)
+// The writer is bound (and this source compiled) only on the Ht > 8 path, where both DFBs exist; the
+// `if constexpr (Ht > 8)` guard is preserved verbatim.
+
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t num_hw_blocks_per_core = get_compile_time_arg_val(0);
-    constexpr uint32_t Ht = get_compile_time_arg_val(1);
-    constexpr uint32_t Wt = get_compile_time_arg_val(2);
-    constexpr uint32_t W_per_tile = get_compile_time_arg_val(3);
-    constexpr uint32_t W_per_tile_last = get_compile_time_arg_val(4);
-    constexpr uint32_t H_size_bytes = get_compile_time_arg_val(5);
-    constexpr uint32_t l1_read_offset_bytes = get_compile_time_arg_val(6);
+    constexpr uint32_t num_hw_blocks_per_core = get_arg(args::num_hw_blocks_per_core);
+    constexpr uint32_t Ht = get_arg(args::Ht);
+    constexpr uint32_t Wt = get_arg(args::Wt);
+    constexpr uint32_t W_per_tile = get_arg(args::W_per_tile);
+    constexpr uint32_t W_per_tile_last = get_arg(args::W_per_tile_last);
+    constexpr uint32_t H_size_bytes = get_arg(args::H_size_bytes);
+    constexpr uint32_t l1_read_offset_bytes = get_arg(args::l1_read_offset_bytes);
 
-    constexpr auto cb_out = tt::CBIndex::c_27;
-    constexpr auto cb_out0 = tt::CBIndex::c_16;
+    constexpr auto cb_out = dfb::out_stage;
+    constexpr auto cb_out0 = dfb::out;
 
     const uint32_t stick_size_bytes = H_size_bytes;
 
     Noc noc;
-    CircularBuffer cb_src(cb_out);
-    CircularBuffer cb_dst(cb_out0);
+    DataflowBuffer cb_src(cb_out);
+    DataflowBuffer cb_dst(cb_out0);
 
     uint32_t dst_addr = cb_dst.get_write_ptr();
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.cpp
@@ -7,16 +7,19 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeCNProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
     auto input_shape = input_tensor.padded_shape();
@@ -24,8 +27,6 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_cn needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_cn needs to be allocated in a buffer on device!");
-
-    ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t page_shape[2] = {TILE_WIDTH, TILE_HEIGHT};
@@ -53,59 +54,100 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     Buffer* dst_buffer = output_tensor.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    uint32_t src0_cb_index = 0;
     uint32_t num_input_pages = 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_pages * stick_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = stick_size,
-        }}},
-    });
 
-    KernelDescriptor::Defines reader_defines;
-    std::vector<uint32_t> reader_compile_time_args = {
-        static_cast<uint32_t>(src0_cb_index), src0_buffer->aligned_page_size(), stick_size};
-    std::vector<uint32_t> reader_common_runtime_args;
-    TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(reader_compile_time_args, reader_common_runtime_args);
-    KernelDescriptor::Defines writer_defines;
-    std::vector<uint32_t> writer_compile_time_args = {
-        static_cast<uint32_t>(src0_cb_index), dst_buffer->aligned_page_size(), stick_size};
-    std::vector<uint32_t> writer_common_runtime_args;
-    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(writer_compile_time_args, writer_common_runtime_args);
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "transpose_cn";
+
+    // src0 DFB (legacy CB c_0): one page is read from src by the reader and consumed by the writer.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"src0"},
+            .entry_size = stick_size,
+            .num_entries = num_input_pages,
+            .data_format_metadata = cb_data_format,
+        },
+    };
+
+    // src0_buffer / dst_buffer addresses are no longer plumbed through a CTA + RTA; the legacy
+    // TensorAccessorArgs(...).append_to(cta, common_rta) host plumbing and the kernel-side
+    // TensorAccessorArgs<3>() / buffer-address RTA reads collapse to a TensorBinding end-to-end.
+    // NOTE: the legacy factory built these accessors with ArgConfig::RuntimeTensorShape (tensor
+    // shape passed as a runtime arg so one cached program serves varying shapes). The Metal 2.0
+    // TensorParameter binding bakes the shape into the accessor's compile-time args by default;
+    // see METAL2_PORT_REPORT.md "Open items" for the dynamic_tensor_shape consideration.
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                        "reader_unary_transpose_cn_interleaved_start_id.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"input"}, .accessor_name = "input"},
+            },
+        .compile_time_args = {{"page_size", src0_buffer->aligned_page_size()}, {"read_size", stick_size}},
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_pages", "start_id", "hw", "n"},
+                .common_runtime_arg_names = {"N", "C", "HtWt", "batch_step", "channel_step"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                        "writer_unary_transpose_cn_interleaved_start_id.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"output"}, .accessor_name = "output"},
+            },
+        .compile_time_args = {{"page_size", dst_buffer->aligned_page_size()}, {"write_size", stick_size}},
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_pages", "start_id"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
 
     if (row_major) {
-        reader_defines.emplace_back("CN_RM", "1");
-        writer_defines.emplace_back("CN_RM", "1");
+        reader.compiler_options.defines = {{"CN_RM", "1"}};
+        writer.compiler_options.defines = {{"CN_RM", "1"}};
     }
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_cn_interleaved_start_id.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = total_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.defines = std::move(reader_defines);
-    reader_desc.config = ReaderConfigDescriptor{};
-    reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
+    spec.kernels = {reader, writer};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = input_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output_tensor.tensor_spec()},
+    };
+    // The src0 DFB's producer (reader) and consumer (writer) must share the same WorkUnitSpec —
+    // every node hosting the DFB must host both endpoints. The legacy factory launches both kernels
+    // on the full grid (total_cores); no-op cores receive num_pages = 0.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "transpose_cn",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = total_cores,
+        },
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "writer_unary_transpose_cn_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = total_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.defines = std::move(writer_defines);
-    writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
-
-    // Set runtime arguments for each core
+    // ---- ProgramRunArgs (mutable) ----
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1], N = input_shape[0];
     uint32_t Wt = W / page_shape[1];
     uint32_t Ht = H / page_shape[0];
@@ -115,8 +157,13 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
     uint32_t batch_step = CHtWt - HtWt;
     uint32_t channel_step = NCHtWt - HtWt;
 
-    reader_desc.runtime_args.reserve(num_cores_total);
-    writer_desc.runtime_args.reserve(num_cores_total);
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    // N/C/HtWt/batch_step/channel_step are uniform across cores → common runtime args.
+    reader_run.common_runtime_arg_values = {
+        {"N", N}, {"C", C}, {"HtWt", HtWt}, {"batch_step", batch_step}, {"channel_step", channel_step}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+
     for (uint32_t i = 0, num_pages_read = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
         uint32_t num_pages_per_core = 0;
@@ -131,17 +178,21 @@ tt::tt_metal::ProgramDescriptor TransposeCNProgramFactory::create_descriptor(
         uint32_t n = curr_c % N;
         uint32_t start_tile = num_pages_read + (curr_c * batch_step) - (curr_c / N * channel_step);
 
-        reader_desc.emplace_runtime_args(
-            core, {src0_buffer, N, C, HtWt, batch_step, channel_step, num_pages_per_core, start_tile, hw, n});
-        writer_desc.emplace_runtime_args(core, {dst_buffer, num_pages_per_core, num_pages_read});
+        reader_run.runtime_arg_values.push_back(
+            {core, {{"num_pages", num_pages_per_core}, {"start_id", start_tile}, {"hw", hw}, {"n", n}}});
+        writer_run.runtime_arg_values.push_back(
+            {core, {{"num_pages", num_pages_per_core}, {"start_id", num_pages_read}}});
 
         num_pages_read += num_pages_per_core;
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, input_tensor.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output_tensor.mesh_tensor()},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_cn_program_factory.hpp
@@ -6,14 +6,14 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct TransposeCNProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.cpp
@@ -7,34 +7,38 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-logger/tt-logger.hpp>
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+#include <algorithm>
+
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
 namespace {
 
 // Compute per-core runtime args (reader+writer) for HC RM transpose and append them to the
-// supplied KernelDescriptors. The traversal logic that advances (curr_c, curr_h, curr_n) was
+// supplied KernelRunArgs. The traversal logic that advances (curr_c, curr_h, curr_n) was
 // previously shared between `create` and `override_runtime_arguments`; now it has a single home.
+// Only the dispatch channel changes (named RTAs); the buffer-address RTA (legacy slot 0) is
+// replaced by the input/output TensorBindings, so it is dropped here.
 void emit_runtime_args_hc_rm(
-    KernelDescriptor& reader_desc,
-    KernelDescriptor& writer_desc,
+    m2::KernelRunArgs& reader_run,
+    m2::KernelRunArgs& writer_run,
     const Tensor& input_tensor,
-    Tensor& output_tensor,
     uint32_t num_cores_total,
     uint32_t num_cores_y,
     const CoreRangeSet& core_group_1,
     uint32_t num_sticks_per_core_group_1,
     const CoreRangeSet& core_group_2,
     uint32_t num_sticks_per_core_group_2) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
     auto input_shape = input_tensor.padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
@@ -43,8 +47,8 @@ void emit_runtime_args_hc_rm(
     uint32_t max_read_size = 2048;
     uint32_t curr_c = 0, curr_h = 0, curr_n = 0;
 
-    reader_desc.runtime_args.reserve(num_cores_total);
-    writer_desc.runtime_args.reserve(num_cores_total);
+    reader_run.runtime_arg_values.reserve(num_cores_total);
+    writer_run.runtime_arg_values.reserve(num_cores_total);
 
     for (uint32_t i = 0, curr_sticks_read = 0, curr_sticks_write = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -64,12 +68,20 @@ void emit_runtime_args_hc_rm(
             num_read_per_barrier = num_sticks_per_core / num_sticks_per_core_read;
         }
 
-        reader_desc.emplace_runtime_args(
-            core,
-            {input_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_read, curr_c, curr_h, curr_n});
+        reader_run.runtime_arg_values.push_back(
+            {core,
+             {{"num_sticks_per_core_read", num_sticks_per_core_read},
+              {"num_read_per_barrier", num_read_per_barrier},
+              {"start_id", curr_sticks_read},
+              {"curr_c", curr_c},
+              {"curr_h", curr_h},
+              {"curr_n", curr_n}}});
 
-        writer_desc.emplace_runtime_args(
-            core, {output_buffer, num_sticks_per_core_read, num_read_per_barrier, curr_sticks_write});
+        writer_run.runtime_arg_values.push_back(
+            {core,
+             {{"num_sticks_per_core_read", num_sticks_per_core_read},
+              {"num_read_per_barrier", num_read_per_barrier},
+              {"start_id", curr_sticks_write}}});
 
         curr_sticks_write += num_sticks_per_core;
 
@@ -94,7 +106,7 @@ void emit_runtime_args_hc_rm(
 
 }  // namespace
 
-tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeHCRMProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
 
@@ -104,8 +116,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     const auto& a_shape = input_tensor.logical_shape();
     uint32_t W = a_shape[3], H = a_shape[2], C = a_shape[1], N = a_shape[0];
     uint32_t NCH = N * C * H;
-
-    ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
 
@@ -125,8 +135,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     Buffer* dst_buffer = output_tensor.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    uint32_t src0_cb_index = 0;
-
     auto num_sticks = num_sticks_per_core_group_1 > num_sticks_per_core_group_2 ? num_sticks_per_core_group_1
                                                                                 : num_sticks_per_core_group_2;
 
@@ -134,58 +142,102 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
     uint32_t aligned_page = std::max(src0_buffer->aligned_page_size(), dst_buffer->aligned_page_size());
     auto stick_size = std::max(W * input_tensor.element_size(), aligned_page);
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_sticks * stick_size,
-        .core_ranges = total_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = stick_size,
-        }}},
-    });
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "transpose_hc_rm";
 
-    std::vector<uint32_t> reader_compile_time_args;
-    std::vector<uint32_t> reader_common_runtime_args;
-    reader_compile_time_args.push_back(N);
-    reader_compile_time_args.push_back(H);
-    reader_compile_time_args.push_back(C);
-    reader_compile_time_args.push_back(stick_size);
-    reader_compile_time_args.push_back(src0_buffer->aligned_page_size());
-    TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(reader_compile_time_args, reader_common_runtime_args);
+    // src0 DFB (legacy CB c_0): the reader produces sticks into it, the writer consumes them.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"src0"},
+            .entry_size = stick_size,
+            .num_entries = num_sticks,
+            .data_format_metadata = cb_data_format,
+        },
+    };
 
-    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
-    std::vector<uint32_t> writer_common_runtime_args;
-    writer_compile_time_args.push_back(stick_size);
-    writer_compile_time_args.push_back(dst_buffer->aligned_page_size());
-    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(writer_compile_time_args, writer_common_runtime_args);
+    // The legacy factory built the input/output accessors with TensorAccessorArgs(RuntimeTensorShape)
+    // and plumbed the buffer addresses through RTA slot 0; both collapse to the TensorBindings below.
+    // See METAL2_PORT_REPORT.md "Open items" for the dynamic_tensor_shape consideration. The legacy
+    // CTA `src0_buffer->aligned_page_size()` was consumed only by the TensorAccessorArgs plumbing
+    // (never read by the kernel) and disappears with it.
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                        "reader_unary_transpose_hc_interleaved_partitioned_rm.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"input"}, .accessor_name = "input"},
+            },
+        .compile_time_args = {{"N", N}, {"H", H}, {"C", C}, {"W_size_bytes", stick_size}},
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"num_sticks_per_core_read", "num_read_per_barrier", "start_id", "curr_c", "curr_h", "curr_n"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_hc_interleaved_partitioned_rm.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = total_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-    reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
+    // Legacy writer carried the src0 CB index as CTA slot 0; that magic index is replaced by the
+    // dfb::src0 binding. The `dst_buffer->aligned_page_size()` CTA was consumed only by the
+    // TensorAccessorArgs plumbing and disappears with the TensorBinding.
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                        "writer_unary_transpose_hc_interleaved_start_id_rm.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"output"}, .accessor_name = "output"},
+            },
+        .compile_time_args = {{"W_size_bytes", stick_size}},
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_sticks_per_core_read", "num_read_per_barrier", "start_id"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "writer_unary_transpose_hc_interleaved_start_id_rm.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = total_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
+    spec.kernels = {reader, writer};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = input_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output_tensor.tensor_spec()},
+    };
+    // The src0 DFB's producer (reader) and consumer (writer) must share the same WorkUnitSpec —
+    // every node hosting the DFB must host both endpoints. The legacy factory launches both kernels
+    // on the full grid (total_cores); no-op cores receive num_sticks_per_core_read = 0.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "transpose_hc_rm",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = total_cores,
+        },
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
 
     emit_runtime_args_hc_rm(
-        reader_desc,
-        writer_desc,
+        reader_run,
+        writer_run,
         input_tensor,
-        output_tensor,
         num_cores_total,
         num_cores_y,
         core_group_1,
@@ -193,10 +245,13 @@ tt::tt_metal::ProgramDescriptor TransposeHCRMProgramFactory::create_descriptor(
         core_group_2,
         num_sticks_per_core_group_2);
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, input_tensor.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output_tensor.mesh_tensor()},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_rm_program_factory.hpp
@@ -6,14 +6,14 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct TransposeHCRMProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.cpp
@@ -6,19 +6,28 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <tt-logger/tt-logger.hpp>
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+#include <algorithm>
 #include <map>
 #include <set>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
 namespace {
 
+// Legacy per-core arg builder for the generic shard mapping. Produces {reader_args, writer_args};
+// writer_args is empty in the generic case (the generic path puts everything through the reader).
+// The reader_args layout is: [5 scalars] + [shard_grid_x_map (num_cores_x)] + [shard_grid_y_map
+// (num_cores_y)]. Reproduced verbatim from the legacy factory.
 std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime_args_hc_rm_sharded(
     const Tensor& input_tensor, uint32_t num_cores, uint32_t num_cores_x, uint32_t num_cores_y) {
     auto input_shape = input_tensor.padded_shape();
@@ -83,6 +92,9 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
     return ret_val;
 }
 
+// Legacy per-core arg builder for the special-case shard mapping. Produces {reader_args, writer_args}.
+// reader_args layout: [5 scalars] + [stick_offset, noc_x, noc_y] tails (each num_non_repeat_cores).
+// writer_args layout: [7 scalars] + the same three tails. Reproduced verbatim from the legacy factory.
 std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime_args_hc_rm_sharded_special_case(
     const Tensor& input_tensor, uint32_t num_cores, uint32_t num_cores_x, uint32_t num_cores_y) {
     auto input_shape = input_tensor.padded_shape();
@@ -282,14 +294,12 @@ std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> get_runtime
 
 }  // namespace
 
-tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeHCShardedProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
-
-    ProgramDescriptor desc;
 
     tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
@@ -320,66 +330,85 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
     uint32_t num_cores_x = grid_size.x;
     uint32_t num_cores_y = grid_size.y;
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    // Sharded CBs bound to the input/output buffers: the framework re-applies
-    // UpdateDynamicCircularBufferAddress on cache hit via the .buffer member.
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = shard_height * stick_size_bytes,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = src0_cb_data_format,
-            .page_size = stick_size_bytes,
-        }}},
-        .buffer = input_tensor.buffer(),
-    });
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "transpose_hc_sharded";
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = shard_height * stick_size_bytes,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = dst_cb_data_format,
-            .page_size = stick_size_bytes,
-        }}},
-        .buffer = output_tensor.buffer(),
-    });
+    // Sharded CBs bound to the input/output buffers: borrowed-memory DFBs. The backing L1 address
+    // resolves at runtime from the input/output TensorArguments (the legacy factory set CBDescriptor
+    // .buffer + relied on UpdateDynamicCircularBufferAddress on cache hit). Both DFBs are accessed by
+    // base pointer only (get_read_ptr / get_write_ptr + NOC), with no real FIFO producer/consumer, so
+    // each is bound as a self-loop on every kernel that touches it. See METAL2_PORT_REPORT.md.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"src0"},
+            .entry_size = stick_size_bytes,
+            .num_entries = shard_height,
+            .data_format_metadata = src0_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"input"},
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"out"},
+            .entry_size = stick_size_bytes,
+            .num_entries = shard_height,
+            .data_format_metadata = dst_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"output"},
+        },
+    };
 
-    std::vector<uint32_t> reader_compile_time_args;
+    // Reader. The legacy CT slots 0/1 were the src0/output CB indices (now dfb::src0 / dfb::out, bound
+    // as self-loops). The remaining scalars stay CTAs; the variable-length per-core tail rides as
+    // runtime varargs.
+    auto self_loop = [](m2::KernelSpec& k) {
+        k.dfb_bindings = {
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"src0"},
+                .accessor_name = "src0",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER},
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"src0"},
+                .accessor_name = "src0",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER},
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"out"},
+                .accessor_name = "out",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER},
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"out"},
+                .accessor_name = "out",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        };
+    };
+
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                        "reader_unary_transpose_hc_sharded_rm.cpp"},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+    self_loop(reader);
     if (is_special_case) {
-        reader_compile_time_args = {src0_cb_index, output_cb_index, stick_size_bytes};
+        reader.compile_time_args = {{"stick_size_bytes", stick_size_bytes}};
+        reader.runtime_arg_schema.runtime_arg_names = {
+            "read_single_h_block_per_core",
+            "num_C_blocks_per_core",
+            "num_sticks_per_shard_core",
+            "num_cores_read",
+            "read_stick_stride"};
+        reader.compiler_options.defines = {{"USE_SPECIAL_CASE", "1"}};
     } else {
-        reader_compile_time_args = {
-            src0_cb_index,
-            output_cb_index,
-            N,
-            H,
-            C,
-            stick_size_bytes,
-            static_cast<uint32_t>(row_major_orientation),
-            num_cores_x,
-            num_cores_y};
+        reader.compile_time_args = {
+            {"N", N},
+            {"H", H},
+            {"C", C},
+            {"W_size_bytes", stick_size_bytes},
+            {"row_major", static_cast<uint32_t>(row_major_orientation)},
+            {"num_cores_x", num_cores_x},
+            {"num_cores_y", num_cores_y}};
+        reader.runtime_arg_schema.runtime_arg_names = {"num_sticks_per_core", "start_id", "curr_c", "curr_h", "curr_n"};
     }
 
-    KernelDescriptor::Defines reader_defines;
-    if (is_special_case) {
-        reader_defines.emplace_back("USE_SPECIAL_CASE", "1");
-    }
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_hc_sharded_rm.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.defines = std::move(reader_defines);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    // Writer kernel only exists in the special case path; the generic path puts
-    // everything through the reader (writer args returned by the generic helper
-    // are empty, matching the legacy `KernelHandle writer_kernel_id{}` behavior).
+    // Build the per-core runtime args (legacy helpers, verbatim).
     std::vector<std::pair<std::vector<uint32_t>, std::vector<uint32_t>>> all_runtime_args;
     if (is_special_case) {
         all_runtime_args =
@@ -388,7 +417,75 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
         all_runtime_args = get_runtime_args_hc_rm_sharded(input_tensor, num_cores, num_cores_x, num_cores_y);
     }
 
-    reader_desc.runtime_args.reserve(num_cores);
+    // Reader: scalars (5) named + the rest as a vararg tail (zero-padded to the per-launch max).
+    constexpr uint32_t kReaderScalars = 5;
+    uint32_t max_reader_tail = 0;
+    for (uint32_t i = 0; i < num_cores; i++) {
+        max_reader_tail = std::max<uint32_t>(max_reader_tail, all_runtime_args[i].first.size() - kReaderScalars);
+    }
+    reader.advanced_options.num_runtime_varargs = max_reader_tail;
+
+    m2::KernelSpec writer;
+    constexpr uint32_t kWriterScalars = 7;
+    uint32_t max_writer_tail = 0;
+    if (is_special_case) {
+        for (uint32_t i = 0; i < num_cores; i++) {
+            max_writer_tail = std::max<uint32_t>(max_writer_tail, all_runtime_args[i].second.size() - kWriterScalars);
+        }
+        writer = m2::KernelSpec{
+            .unique_id = m2::KernelSpecName{"writer"},
+            .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                            "writer_unary_transpose_hc_sharded_rm.cpp"},
+            .compile_time_args = {{"stick_size_bytes", stick_size_bytes}},
+            .runtime_arg_schema =
+                {
+                    .runtime_arg_names =
+                        {"read_single_h_block_per_core",
+                         "num_C_blocks_per_core",
+                         "num_sticks_per_shard_core",
+                         "num_cores_read",
+                         "read_stick_stride",
+                         "src_read_stick_offset",
+                         "dst_write_stick_offset"},
+                },
+            .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+        };
+        self_loop(writer);
+        writer.advanced_options.num_runtime_varargs = max_writer_tail;
+    }
+
+    if (is_special_case) {
+        spec.kernels = {reader, writer};
+    } else {
+        spec.kernels = {reader};
+    }
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = input_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output_tensor.tensor_spec()},
+    };
+    // Both borrowed DFBs are self-looped on every kernel; all kernels run on all_cores, sharing the one
+    // WorkUnitSpec (Local-DFB rule).
+    std::vector<m2::KernelSpecName> wu_kernels = {m2::KernelSpecName{"reader"}};
+    if (is_special_case) {
+        wu_kernels.push_back(m2::KernelSpecName{"writer"});
+    }
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "transpose_hc_sharded",
+            .kernels = std::move(wu_kernels),
+            .target_nodes = all_cores,
+        },
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+
+    reader_run.runtime_arg_values.reserve(num_cores);
+    if (is_special_case) {
+        writer_run.runtime_arg_values.reserve(num_cores);
+    }
     for (uint32_t i = 0; i < num_cores; i++) {
         CoreCoord core;
         if (row_major_orientation) {
@@ -396,34 +493,66 @@ tt::tt_metal::ProgramDescriptor TransposeHCShardedProgramFactory::create_descrip
         } else {
             core = {i / num_cores_y, i % num_cores_y};
         }
-        reader_desc.runtime_args.emplace_back(core, all_runtime_args[i].first);
-    }
+        const m2::NodeCoord node{core};
 
-    desc.kernels.push_back(std::move(reader_desc));
+        const auto& reader_args = all_runtime_args[i].first;
+        if (is_special_case) {
+            reader_run.runtime_arg_values.push_back(
+                {node,
+                 {{"read_single_h_block_per_core", reader_args[0]},
+                  {"num_C_blocks_per_core", reader_args[1]},
+                  {"num_sticks_per_shard_core", reader_args[2]},
+                  {"num_cores_read", reader_args[3]},
+                  {"read_stick_stride", reader_args[4]}}});
+        } else {
+            reader_run.runtime_arg_values.push_back(
+                {node,
+                 {{"num_sticks_per_core", reader_args[0]},
+                  {"start_id", reader_args[1]},
+                  {"curr_c", reader_args[2]},
+                  {"curr_h", reader_args[3]},
+                  {"curr_n", reader_args[4]}}});
+        }
+        m2::AdvancedKernelRunArgs::Varargs reader_tail;
+        reader_tail.reserve(max_reader_tail);
+        for (size_t k = kReaderScalars; k < reader_args.size(); ++k) {
+            reader_tail.push_back(reader_args[k]);
+        }
+        reader_tail.resize(max_reader_tail, 0u);
+        reader_run.advanced_options.runtime_varargs[node] = std::move(reader_tail);
+
+        if (is_special_case) {
+            const auto& writer_args = all_runtime_args[i].second;
+            writer_run.runtime_arg_values.push_back(
+                {node,
+                 {{"read_single_h_block_per_core", writer_args[0]},
+                  {"num_C_blocks_per_core", writer_args[1]},
+                  {"num_sticks_per_shard_core", writer_args[2]},
+                  {"num_cores_read", writer_args[3]},
+                  {"read_stick_stride", writer_args[4]},
+                  {"src_read_stick_offset", writer_args[5]},
+                  {"dst_write_stick_offset", writer_args[6]}}});
+            m2::AdvancedKernelRunArgs::Varargs writer_tail;
+            writer_tail.reserve(max_writer_tail);
+            for (size_t k = kWriterScalars; k < writer_args.size(); ++k) {
+                writer_tail.push_back(writer_args[k]);
+            }
+            writer_tail.resize(max_writer_tail, 0u);
+            writer_run.advanced_options.runtime_varargs[node] = std::move(writer_tail);
+        }
+    }
 
     if (is_special_case) {
-        KernelDescriptor writer_desc;
-        writer_desc.kernel_source =
-            "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-            "writer_unary_transpose_hc_sharded_rm.cpp";
-        writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        writer_desc.core_ranges = all_cores;
-        writer_desc.compile_time_args = {src0_cb_index, output_cb_index, stick_size_bytes};
-        writer_desc.config = WriterConfigDescriptor{};
-        writer_desc.runtime_args.reserve(num_cores);
-        for (uint32_t i = 0; i < num_cores; i++) {
-            CoreCoord core;
-            if (row_major_orientation) {
-                core = {i % num_cores_x, i / num_cores_x};
-            } else {
-                core = {i / num_cores_y, i % num_cores_y};
-            }
-            writer_desc.runtime_args.emplace_back(core, all_runtime_args[i].second);
-        }
-        desc.kernels.push_back(std::move(writer_desc));
+        run.kernel_run_args = {reader_run, writer_run};
+    } else {
+        run.kernel_run_args = {reader_run};
     }
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, input_tensor.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output_tensor.mesh_tensor()},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_sharded_program_factory.hpp
@@ -6,14 +6,14 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct TransposeHCShardedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.cpp
@@ -9,15 +9,18 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/operations/data_movement/common/common.hpp"
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
 using ttnn::operations::data_movement::float_to_uint16;
 using ttnn::operations::data_movement::pack_two_uint16_into_uint32;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
@@ -26,16 +29,14 @@ namespace {
 // Per-core runtime args for the reader + writer kernels. The work split uses
 // two parallel partitions (unpadded vs padded tile counts) so each core needs a
 // (start, end) pair from both. Writer also tracks the padded range; reader only
-// the unpadded count.
+// the unpadded count. Only the dispatch channel changes (named RTAs); the legacy
+// buffer-address RTA (reader/writer slot 0) is replaced by the TensorBindings.
 void emit_runtime_args_hc_tiled_interleaved(
-    KernelDescriptor& reader_desc,
-    KernelDescriptor& writer_desc,
+    m2::KernelRunArgs& reader_run,
+    m2::KernelRunArgs& writer_run,
     const Tensor& input_tensor,
     Tensor& output_tensor,
     const CoreRange& total_cores) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
-
     auto tile_shape = input_tensor.tensor_spec().tile().get_tile_shape();
     auto tile_hw = tile_shape[0] * tile_shape[1];
     uint32_t num_tensor_tiles = input_tensor.physical_volume() / tile_hw;
@@ -84,11 +85,13 @@ void emit_runtime_args_hc_tiled_interleaved(
         uint32_t end_idx = start_idx + num_tiles_per_core;
         uint32_t padded_end_idx = padded_start_idx + padded_tiles_per_core;
 
-        reader_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{input_buffer->address(), num_tiles_per_core, start_idx});
-        writer_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{output_buffer->address(), start_idx, end_idx, padded_start_idx, padded_end_idx});
+        reader_run.runtime_arg_values.push_back({core, {{"num_tiles", num_tiles_per_core}, {"start_id", start_idx}}});
+        writer_run.runtime_arg_values.push_back(
+            {core,
+             {{"start_tile_idx", start_idx},
+              {"end_tile_idx", end_idx},
+              {"start_padding_tile_idx", padded_start_idx},
+              {"end_padding_tile_idx", padded_end_idx}}});
 
         start_idx = end_idx;
         padded_start_idx = padded_end_idx;
@@ -97,7 +100,7 @@ void emit_runtime_args_hc_tiled_interleaved(
 
 }  // namespace
 
-tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeHCTiledInterleavedProgramFactory::create_program_spec(
     const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
     // pad_value is always defined at API level; padding is decided purely by shape
@@ -106,7 +109,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_hc needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_hc needs to be allocated in a buffer on device!");
 
-    ProgramDescriptor desc;
     auto tile = input_tensor.tensor_spec().tile();
     auto tile_shape = tile.get_tile_shape();
     auto face_shape = tile.get_face_shape();
@@ -121,33 +123,33 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
     uint32_t num_cores_y = compute_with_storage_grid_size.y;
     CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t padding_cb_index = tt::CBIndex::c_1;
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "transpose_hc_tiled_interleaved";
 
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = 2 * single_tile_size,
-        .core_ranges = total_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
+    // src0 DFB (legacy CB c_0): the reader produces tiles into it, the writer consumes them.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"src0"},
+            .entry_size = single_tile_size,
+            .num_entries = 2,
+            .data_format_metadata = cb_data_format,
+        },
+    };
 
     auto max_padding_write = face_shape[0] * face_shape[1];
+    // padding DFB (legacy CB c_1): only present when needs_padding. The reader produces one padding
+    // entry, the writer consumes it. The conditional binding is honored kernel-side via #ifdef
+    // NEEDS_PADDING. See METAL2_PORT_REPORT.md.
     if (needs_padding) {
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = max_padding_write * input_tensor.element_size(),
-            .core_ranges = total_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(padding_cb_index),
-                .data_format = cb_data_format,
-                .page_size = max_padding_write * input_tensor.element_size(),
-            }}},
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"padding"},
+            .entry_size = max_padding_write * input_tensor.element_size(),
+            .num_entries = 1,
+            .data_format_metadata = cb_data_format,
         });
     }
 
-    Buffer* src_buffer = input_tensor.buffer();
     uint32_t element_size = input_tensor.element_size();
     uint32_t padding_val_packed = 0;
     uint32_t num_writes = 0;
@@ -176,65 +178,131 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledInterleavedProgramFactory::creat
         }
     }
 
-    std::vector<uint32_t> reader_compile_time_args = {};
-    std::vector<uint32_t> reader_common_runtime_args;
-    KernelDescriptor::NamedCompileTimeArgs reader_named_compile_time_args = {
-        {"num_writes", num_writes},
-        {"padding_val_packed", padding_val_packed},
-        {"needs_padding", needs_padding},
-        {"swap_hw", 0u},
-        {"H", 1u},
-        {"W", 1u},
-        {"accumulated_outer_dims", 1u},
-        {"tile_height", 1u},
-        {"tile_width", 1u},
+    // Reader: forked from reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp (shared with
+    // the unmigrated permute_tiled factory) to reader_unary_transpose_hc_interleaved_tiled_padding_aware_m2.cpp.
+    // The legacy factory built the input accessor with TensorAccessorArgs(RuntimeTensorShape) and
+    // plumbed the buffer address through RTA slot 0; both collapse to the TensorBinding below. The
+    // legacy named CTA `needs_padding` is promoted to the NEEDS_PADDING define (gates dfb::padding).
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                        "reader_unary_transpose_hc_interleaved_tiled_padding_aware_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"input"}, .accessor_name = "input"},
+            },
+        .compile_time_args =
+            {
+                {"num_writes", num_writes},
+                {"padding_val_packed", padding_val_packed},
+                {"swap_hw", 0u},
+                {"H", 1u},
+                {"W", 1u},
+                {"accumulated_outer_dims", 1u},
+                {"tile_height", 1u},
+                {"tile_width", 1u},
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_tiles", "start_id"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
     };
-    TensorAccessorArgs(*src_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(reader_compile_time_args, reader_common_runtime_args);
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_hc_interleaved_tiled_padding_aware.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = total_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.named_compile_time_args = std::move(reader_named_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-    reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
+    // Writer (in place — used only by this factory). The legacy writer carried the output CB index
+    // (= c_0, the shared src0 DFB) as CTA slot 1; that magic index is replaced by the dfb::out binding
+    // (accessor_name "out", consuming the src0 DFB). The legacy `needs_padding` CTA is promoted to the
+    // NEEDS_PADDING define (gates dfb::padding).
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                        "writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "out",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"output"}, .accessor_name = "output"},
+            },
+        .compile_time_args =
+            {
+                {"element_size", element_size},
+                {"C", C},
+                {"H", H},
+                {"W", W},
+                {"tile_height", tile_shape[0]},
+                {"tile_width", tile_shape[1]},
+                {"face_height", face_shape[0]},
+                {"face_width", face_shape[1]},
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"start_tile_idx", "end_tile_idx", "start_padding_tile_idx", "end_padding_tile_idx"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
 
-    Buffer* dst_buffer = output_tensor.buffer();
-    std::vector<uint32_t> writer_compile_time_args = {
-        element_size,
-        tt::CBIndex::c_0,
-        C,
-        H,
-        W,
-        tile_shape[0],
-        tile_shape[1],
-        face_shape[0],
-        face_shape[1],
-        static_cast<uint32_t>(needs_padding)};
-    std::vector<uint32_t> writer_common_runtime_args;
-    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(writer_compile_time_args, writer_common_runtime_args);
+    if (needs_padding) {
+        // The padding DFB is bound on both kernels; emit the matching define to both so the kernel-side
+        // dfb::padding references compile.
+        reader.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"padding"},
+            .accessor_name = "padding",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER,
+        });
+        reader.compiler_options.defines = {{"NEEDS_PADDING", "1"}};
+        writer.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"padding"},
+            .accessor_name = "padding",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER,
+        });
+        writer.compiler_options.defines = {{"NEEDS_PADDING", "1"}};
+    }
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "writer_unary_transpose_hc_interleaved_tiled_padding_aware.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = total_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
+    spec.kernels = {reader, writer};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = input_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output_tensor.tensor_spec()},
+    };
+    // reader (produces src0/padding) and writer (consumes src0/padding) share one WorkUnitSpec — every
+    // node hosting a DFB hosts both its endpoints. The legacy factory launches both on the full grid
+    // (total_cores); cores outside the work split get num_tiles = 0.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "transpose_hc_tiled_interleaved",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = total_cores,
+        },
+    };
 
-    emit_runtime_args_hc_tiled_interleaved(reader_desc, writer_desc, input_tensor, output_tensor, total_cores);
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    emit_runtime_args_hc_tiled_interleaved(reader_run, writer_run, input_tensor, output_tensor, total_cores);
 
-    return desc;
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, input_tensor.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output_tensor.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_interleaved_program_factory.hpp
@@ -6,14 +6,14 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct TransposeHCTiledInterleavedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.cpp
@@ -7,31 +7,34 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
 #include <tt-logger/tt-logger.hpp>
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
 namespace {
 
+// Per-core runtime args for the reader + writer kernels. Reproduces the legacy
+// emit_runtime_args_hc_tiled loop verbatim; only the dispatch channel changes (named RTAs). The
+// legacy buffer-address RTA (reader/writer slot 0) is replaced by the TensorBindings and dropped.
 void emit_runtime_args_hc_tiled(
-    KernelDescriptor& reader_desc,
-    KernelDescriptor& writer_desc,
+    m2::KernelRunArgs& reader_run,
+    m2::KernelRunArgs& writer_run,
     const Tensor& input_tensor,
-    Tensor& output_tensor,
     uint32_t num_cores_total,
     uint32_t num_cores_y,
     const CoreRangeSet& core_group_1,
     uint32_t num_tiles_per_core_group_1,
     const CoreRangeSet& core_group_2,
     uint32_t num_tiles_per_core_group_2) {
-    auto* input_buffer = input_tensor.buffer();
-    auto* output_buffer = output_tensor.buffer();
     auto input_shape = input_tensor.padded_shape();
 
     uint32_t W = input_shape[3], H = input_shape[2], C = input_shape[1];
@@ -44,8 +47,8 @@ void emit_runtime_args_hc_tiled(
     uint32_t CtHWt = Ct * H * Wt;
     uint32_t CtWt = Ct * Wt;
 
-    reader_desc.runtime_args.reserve(num_cores_total);
-    writer_desc.runtime_args.reserve(num_cores_total);
+    reader_run.runtime_arg_values.reserve(num_cores_total);
+    writer_run.runtime_arg_values.reserve(num_cores_total);
 
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -62,26 +65,24 @@ void emit_runtime_args_hc_tiled(
         uint32_t h = num_tiles_read / CtWt % H;
         uint32_t ct = num_tiles_read / Wt % Ct;
 
-        reader_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{
-                input_buffer->address(),
-                Wt,
-                H,
-                Ct,
-                HW_bytes,
-                CHW_bytes,
-                num_tiles_read,
-                num_tiles_per_core,
-                num_tiles_read / CtHWt * CHW_bytes,
-                h,
-                h / TILE_HEIGHT * Wt,
-                ct,
-                ct * TILE_HEIGHT * HW_bytes,
-                num_tiles_read % Wt});
+        reader_run.runtime_arg_values.push_back(
+            {core,
+             {{"WT", Wt},
+              {"H", H},
+              {"CT", Ct},
+              {"HW_bytes", HW_bytes},
+              {"CHW_bytes", CHW_bytes},
+              {"start_id", num_tiles_read},
+              {"num_tiles", num_tiles_per_core},
+              {"batch_addr", num_tiles_read / CtHWt * CHW_bytes},
+              {"h", h},
+              {"htWT", h / TILE_HEIGHT * Wt},
+              {"ct", ct},
+              {"ctoffs", ct * TILE_HEIGHT * HW_bytes},
+              {"wt", num_tiles_read % Wt}}});
 
-        writer_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{output_buffer->address(), num_tiles_per_core, num_tiles_read});
+        writer_run.runtime_arg_values.push_back(
+            {core, {{"num_pages", num_tiles_per_core}, {"start_id", num_tiles_read}}});
 
         num_tiles_read += num_tiles_per_core;
     }
@@ -89,7 +90,7 @@ void emit_runtime_args_hc_tiled(
 
 }  // namespace
 
-tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeHCTiledProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
 
@@ -98,8 +99,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
 
     uint32_t sub_tile_line_bytes = 16 * input_tensor.element_size();
     uint32_t num_tensor_tiles = input_tensor.physical_volume() / TILE_HW;
-
-    ProgramDescriptor desc;
 
     tt::DataFormat cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t single_tile_size = tt::tile_size(cb_data_format);
@@ -122,7 +121,6 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
     Buffer* dst_buffer = output_tensor.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    uint32_t src0_cb_index = 0;
     // check if we need to allocate a scratch buffer
     // The kernel reads several 16 element face lines (32B for BFLOAT16) from different input tiles to form a single
     // output tile, one output tile at a time Each face line is 32 bytes, so if our minimum read alignment is greater
@@ -134,64 +132,149 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
     uint32_t alignment = dst_buffer->alignment();
     bool misaligned = alignment > sub_tile_line_bytes;
 
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "transpose_hc_tiled";
+
+    // src0 DFB (legacy CB c_0): the reader produces output tiles into it, the writer consumes them.
     uint32_t num_input_tiles = 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * single_tile_size,
-        .core_ranges = total_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"src0"},
+            .entry_size = single_tile_size,
+            .num_entries = num_input_tiles,
+            .data_format_metadata = cb_data_format,
+        },
+    };
 
     // need some scratch memory here - if we need data from a misaligned address then we need to read from the
-    // nearest aligned address and then copy the data to the correct location
+    // nearest aligned address and then copy the data to the correct location.
+    // This is a "fake CB" (legacy c_1) — the kernel uses it purely as an address source (get_write_ptr,
+    // then direct memory copy), with no real FIFO producer/consumer. It is bound as a self-loop DFB on
+    // the reading kernel (PRODUCER + CONSUMER) to satisfy the validator's producer-and-consumer rule.
+    // See METAL2_PORT_REPORT.md "Open items". Only present (and only referenced kernel-side) when
+    // MISALIGNED.
     if (misaligned) {
-        uint32_t src1_cb_index = 1;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = alignment,
-            .core_ranges = total_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(src1_cb_index),
-                .data_format = cb_data_format,
-                .page_size = alignment,
-            }}},
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"scratch"},
+            .entry_size = alignment,
+            .num_entries = 1,
+            .data_format_metadata = cb_data_format,
         });
     }
 
-    Buffer* src0_buffer = input_tensor.buffer();
-    std::vector<uint32_t> reader_compile_time_args;
-    reader_compile_time_args.push_back(sub_tile_line_bytes);
-    reader_compile_time_args.push_back(cb_data_format == tt::DataFormat::Float32 ? 1 : 0);
-    reader_compile_time_args.push_back(alignment);
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
+    // The legacy factory built the input accessor with TensorAccessorArgs and plumbed the buffer
+    // address through RTA slot 0; both collapse to the TensorBinding below. The reader's CB index
+    // (c_0) is bound as dfb::src0; the misaligned scratch (c_1) as a self-loop dfb::scratch.
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                        "reader_unary_transpose_hc_interleaved_partitioned.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"input"}, .accessor_name = "input"},
+            },
+        .compile_time_args =
+            {
+                {"SUBTILE_LINE_BYTES", sub_tile_line_bytes},
+                {"FLOAT32_DTYPE", cb_data_format == tt::DataFormat::Float32 ? 1u : 0u},
+                {"ALIGNMENT", alignment},
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names =
+                    {"WT",
+                     "H",
+                     "CT",
+                     "HW_bytes",
+                     "CHW_bytes",
+                     "start_id",
+                     "num_tiles",
+                     "batch_addr",
+                     "h",
+                     "htWT",
+                     "ct",
+                     "ctoffs",
+                     "wt"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+    if (misaligned) {
+        // Self-loop the fake scratch CB on the single reading kernel so the validator is satisfied
+        // (nothing is actually produced/consumed as a FIFO — it is an address-source borrow).
+        reader.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"scratch"},
+            .accessor_name = "scratch",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER,
+        });
+        reader.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"scratch"},
+            .accessor_name = "scratch",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER,
+        });
+        reader.compiler_options.defines = {{"MISALIGNED", "1"}};
+    }
 
-    std::vector<uint32_t> writer_compile_time_args = {src0_cb_index};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    // Writer: forked from eltwise/unary/.../writer_unary_interleaved_start_id.cpp (shared, unmigrated);
+    // reuses the existing transpose-local writer_unary_interleaved_start_id_m2.cpp. The legacy writer
+    // carried the output CB index (= c_0, the shared src0 DFB) as CTA slot 0; that magic index is
+    // replaced by the dfb::out binding (accessor_name "out", consuming the src0 DFB).
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                        "writer_unary_interleaved_start_id_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "out",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"output"}, .accessor_name = "output"},
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_pages", "start_id"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_hc_interleaved_partitioned.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = total_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    spec.kernels = {reader, writer};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = input_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output_tensor.tensor_spec()},
+    };
+    // reader (produces src0) and writer (consumes src0) share one WorkUnitSpec — every node hosting
+    // the DFB hosts both endpoints. The legacy factory launches both on the full grid (total_cores);
+    // no-op cores get num_tiles = 0.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "transpose_hc_tiled",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = total_cores,
+        },
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = total_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
 
     emit_runtime_args_hc_tiled(
-        reader_desc,
-        writer_desc,
+        reader_run,
+        writer_run,
         input_tensor,
-        output_tensor,
         num_cores_total,
         num_cores_y,
         core_group_1,
@@ -199,10 +282,13 @@ tt::tt_metal::ProgramDescriptor TransposeHCTiledProgramFactory::create_descripto
         core_group_2,
         num_tiles_per_core_group_2);
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, input_tensor.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output_tensor.mesh_tensor()},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_hc_tiled_program_factory.hpp
@@ -6,14 +6,14 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct TransposeHCTiledProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.cpp
@@ -7,23 +7,27 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
 namespace {
 
+// Emit per-core runtime args for the tiled (TILE-layout) WH path. Reproduces the legacy
+// emit_runtime_args_wh_tiled loop verbatim; only the dispatch channel changes (named RTAs).
 void emit_runtime_args_wh_tiled(
-    KernelDescriptor& reader_desc,
-    KernelDescriptor& compute_desc,
-    KernelDescriptor& writer_desc,
+    m2::KernelRunArgs& reader_run,
+    m2::KernelRunArgs& compute_run,
+    m2::KernelRunArgs& writer_run,
     const Tensor& input_tensor,
-    Tensor& output_tensor,
     uint32_t num_cores_total,
     uint32_t num_cores_y,
     const CoreRangeSet& core_group_1,
@@ -39,9 +43,9 @@ void emit_runtime_args_wh_tiled(
 
     auto HtWt = Ht * Wt;
 
-    reader_desc.runtime_args.reserve(num_cores_total);
-    compute_desc.runtime_args.reserve(num_cores_total);
-    writer_desc.runtime_args.reserve(num_cores_total);
+    reader_run.runtime_arg_values.reserve(num_cores_total);
+    compute_run.runtime_arg_values.reserve(num_cores_total);
+    writer_run.runtime_arg_values.reserve(num_cores_total);
 
     for (uint32_t i = 0, num_tiles_read = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -58,31 +62,32 @@ void emit_runtime_args_wh_tiled(
         uint32_t h = num_tiles_read % Ht;
         uint32_t w = num_tiles_read / Ht % Wt;
 
-        reader_desc.emplace_runtime_args(
-            core,
-            {input_tensor.buffer(),
-             num_tiles_per_core,
-             tt::round_down(num_tiles_read, HtWt) + (h * Wt) + w,
-             h,
-             w,
-             Ht,
-             Wt,
-             HtWt});
+        reader_run.runtime_arg_values.push_back(
+            {core,
+             {{"num_tiles", num_tiles_per_core},
+              {"start_id", tt::round_down(num_tiles_read, HtWt) + (h * Wt) + w},
+              {"start_ht", h},
+              {"start_wt", w},
+              {"Ht", Ht},
+              {"Wt", Wt},
+              {"HtWt", HtWt}}});
 
-        compute_desc.emplace_runtime_args(core, {num_tiles_per_core});
+        compute_run.runtime_arg_values.push_back({core, {{"NHtWt", num_tiles_per_core}}});
 
-        writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_tiles_per_core, num_tiles_read});
+        writer_run.runtime_arg_values.push_back(
+            {core, {{"num_pages", num_tiles_per_core}, {"start_id", num_tiles_read}}});
 
         num_tiles_read += num_tiles_per_core;
     }
 }
 
+// Emit per-core runtime args for the row-major (RM) WH path. Reproduces the legacy
+// emit_runtime_args_wh_rm loop verbatim; only the dispatch channel changes (named RTAs).
 void emit_runtime_args_wh_rm(
-    KernelDescriptor& reader_desc,
-    KernelDescriptor& compute_desc,
-    KernelDescriptor& writer_desc,
+    m2::KernelRunArgs& reader_run,
+    m2::KernelRunArgs& compute_run,
+    m2::KernelRunArgs& writer_run,
     const Tensor& input_tensor,
-    Tensor& output_tensor,
     uint32_t num_cores_total,
     uint32_t num_cores_y,
     const CoreRangeSet& core_group_1,
@@ -93,9 +98,9 @@ void emit_runtime_args_wh_rm(
 
     uint32_t W = input_shape[3], H = input_shape[2];
 
-    reader_desc.runtime_args.reserve(num_cores_total);
-    compute_desc.runtime_args.reserve(num_cores_total);
-    writer_desc.runtime_args.reserve(num_cores_total);
+    reader_run.runtime_arg_values.reserve(num_cores_total);
+    compute_run.runtime_arg_values.reserve(num_cores_total);
+    writer_run.runtime_arg_values.reserve(num_cores_total);
 
     for (uint32_t i = 0, num_sticks_read = 0, num_sticks_write = 0; i < num_cores_total; i++) {
         CoreCoord core = {i / num_cores_y, i % num_cores_y};
@@ -109,11 +114,13 @@ void emit_runtime_args_wh_rm(
             num_hw_blocks_per_core = 0;
         }
 
-        reader_desc.emplace_runtime_args(core, {input_tensor.buffer(), num_sticks_read, num_hw_blocks_per_core});
+        reader_run.runtime_arg_values.push_back(
+            {core, {{"start_id", num_sticks_read}, {"num_hw_blocks_per_core", num_hw_blocks_per_core}}});
 
-        compute_desc.emplace_runtime_args(core, {num_hw_blocks_per_core});
+        compute_run.runtime_arg_values.push_back({core, {{"num_hw_blocks_per_core", num_hw_blocks_per_core}}});
 
-        writer_desc.emplace_runtime_args(core, {output_tensor.buffer(), num_sticks_write, num_hw_blocks_per_core});
+        writer_run.runtime_arg_values.push_back(
+            {core, {{"start_id", num_sticks_write}, {"num_hw_blocks_per_core", num_hw_blocks_per_core}}});
 
         num_sticks_read += num_hw_blocks_per_core * H;
         num_sticks_write += num_hw_blocks_per_core * W;
@@ -122,7 +129,7 @@ void emit_runtime_args_wh_rm(
 
 }  // namespace
 
-tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeWHProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
 
@@ -137,14 +144,11 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     uint32_t ht = (H + TILE_HEIGHT - 1) / TILE_HEIGHT;
     uint32_t wt = (W + TILE_WIDTH - 1) / TILE_WIDTH;
 
-    ProgramDescriptor desc;
-
     tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
     tt::DataFormat dst_cb_data_format = datatype_to_dataformat_converter(output_tensor.dtype());
     uint32_t dst_single_tile_size = tt::tile_size(dst_cb_data_format);
 
-    Buffer* src0_buffer = input_tensor.buffer();
     IDevice* device = input_tensor.device();
 
     bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32 ||
@@ -163,155 +167,227 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
     Buffer* dst_buffer = output_tensor.buffer();
     TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
-    uint32_t src0_cb_index = 0;
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "transpose_wh";
+
+    // src0 DFB (legacy CB c_0) and output DFB (legacy CB c_16). The RM path adds a "tilize"
+    // intermediate DFB (legacy CB c_24). The legacy c_25 ("im2", marked TODO REMOVE) is dead — no
+    // kernel reads or writes it on the interleaved RM path — so it is omitted (a Metal 2.0 DFB
+    // requires >=1 producer and >=1 consumer; binding a never-touched buffer is impossible). See
+    // METAL2_PORT_REPORT.md "Open items".
     uint32_t num_input_tiles = row_major ? wt * 2 : 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * src0_single_tile_size,
-        .core_ranges = total_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = src0_cb_data_format,
-            .page_size = src0_single_tile_size,
-        }}},
-    });
-
-    uint32_t output_cb_index = tt::CBIndex::c_16;
     uint32_t num_output_tiles = row_major ? ht * 2 : 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_output_tiles * dst_single_tile_size,
-        .core_ranges = total_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = dst_cb_data_format,
-            .page_size = dst_single_tile_size,
-        }}},
-    });
 
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"src0"},
+            .entry_size = src0_single_tile_size,
+            .num_entries = num_input_tiles,
+            .data_format_metadata = src0_cb_data_format,
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"out"},
+            .entry_size = dst_single_tile_size,
+            .num_entries = num_output_tiles,
+            .data_format_metadata = dst_cb_data_format,
+        },
+    };
     if (row_major) {
-        uint32_t im_cb_index = 24;
         uint32_t num_im_tiles = ht * wt;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = num_im_tiles * src0_single_tile_size,
-            .core_ranges = total_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(im_cb_index),
-                .data_format = src0_cb_data_format,
-                .page_size = src0_single_tile_size,
-            }}},
-        });
-        // TODO REMOVE
-        uint32_t im2_cb_index = 25;
-        uint32_t num_im2_tiles = ht;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = num_im2_tiles * dst_single_tile_size,
-            .core_ranges = total_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(im2_cb_index),
-                .data_format = dst_cb_data_format,
-                .page_size = dst_single_tile_size,
-            }}},
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"tilize"},
+            .entry_size = src0_single_tile_size,
+            .num_entries = num_im_tiles,
+            .data_format_metadata = src0_cb_data_format,
         });
     }
 
-    std::vector<uint32_t> reader_compile_time_args;
-    std::vector<uint32_t> reader_common_runtime_args;
+    // ---- Kernel sources (selected by layout) ----
+    const std::filesystem::path reader_source =
+        row_major ? std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                           "reader_unary_transpose_wh_interleaved_start_id_rm.cpp"}
+                  : std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                          "reader_unary_transpose_wh_interleaved_start_id.cpp"};
+    const std::filesystem::path writer_source =
+        row_major ? std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                           "writer_unary_transpose_wh_interleaved_start_id_rm.cpp"}
+                  // Forked from eltwise/unary/.../writer_unary_interleaved_start_id.cpp (shared, unmigrated).
+                  : std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                          "writer_unary_interleaved_start_id_m2.cpp"};
+    const std::filesystem::path compute_source =
+        row_major ? std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/"
+                                          "transpose_wh_rm_m2.cpp"}
+                  : std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/"
+                                          "transpose_wh_m2.cpp"};
+
+    // ---- Reader ----
+    // The legacy factory built the input accessor with TensorAccessorArgs(RuntimeTensorShape) and
+    // plumbed the buffer address through an RTA; both collapse to the TensorBinding below. See
+    // METAL2_PORT_REPORT.md "Open items" for the dynamic_tensor_shape consideration.
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = reader_source,
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"input"}, .accessor_name = "input"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
     if (row_major) {
-        reader_compile_time_args.push_back(ht);
-        reader_compile_time_args.push_back(H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT);
-        reader_compile_time_args.push_back(H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT);
-        reader_compile_time_args.push_back(wt);
-        reader_compile_time_args.push_back(W);
-        reader_compile_time_args.push_back(ht * wt);
-        reader_compile_time_args.push_back(W * input_tensor.element_size());
-        reader_compile_time_args.push_back(wt * input_tensor.element_size() * TILE_WIDTH);
-        reader_compile_time_args.push_back(src0_buffer->aligned_page_size());
+        reader.compile_time_args = {
+            {"Ht", ht},
+            {"H_per_tile", H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT},
+            {"H_per_tile_last", H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT},
+            {"Wt", wt},
+            {"W", W},
+            {"HtWt", ht * wt},
+            {"W_size_bytes", W * input_tensor.element_size()},
+            {"l1_write_offset_bytes", wt * input_tensor.element_size() * TILE_WIDTH},
+        };
+        reader.runtime_arg_schema.runtime_arg_names = {"start_id", "num_hw_blocks_per_core"};
+    } else {
+        reader.runtime_arg_schema.runtime_arg_names = {
+            "num_tiles", "start_id", "start_ht", "start_wt", "Ht", "Wt", "HtWt"};
     }
-    TensorAccessorArgs(*src0_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(reader_compile_time_args, reader_common_runtime_args);
 
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
-    std::vector<uint32_t> writer_common_runtime_args;
+    // ---- Writer ----
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = writer_source,
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"out"},
+                    .accessor_name = "out",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"output"}, .accessor_name = "output"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
     if (row_major) {
-        writer_compile_time_args.push_back(ht);
-        writer_compile_time_args.push_back(H);
-        writer_compile_time_args.push_back(wt);
-        writer_compile_time_args.push_back(W > TILE_WIDTH ? TILE_WIDTH : W % TILE_WIDTH);
-        writer_compile_time_args.push_back(W % TILE_WIDTH == 0 ? TILE_WIDTH : W % TILE_WIDTH);
-        writer_compile_time_args.push_back(ht * wt);
-        writer_compile_time_args.push_back(H * output_tensor.element_size());
-        writer_compile_time_args.push_back(ht * output_tensor.element_size() * TILE_HEIGHT);
-        writer_compile_time_args.push_back(dst_buffer->aligned_page_size());
-    }
-    TensorAccessorArgs(*dst_buffer, tensor_accessor::ArgConfig::RuntimeTensorShape)
-        .append_to(writer_compile_time_args, writer_common_runtime_args);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source = row_major ? "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-                                            "reader_unary_transpose_wh_interleaved_start_id_rm.cpp"
-                                          : "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-                                            "reader_unary_transpose_wh_interleaved_start_id.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = total_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-    reader_desc.common_runtime_args = std::move(reader_common_runtime_args);
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        row_major
-            ? "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-              "writer_unary_transpose_wh_interleaved_start_id_rm.cpp"
-            : "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = total_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
-
-    std::vector<uint32_t> compute_kernel_args = {};
-    if (row_major) {
-        compute_kernel_args.push_back(ht);
-        compute_kernel_args.push_back(wt);
-        compute_kernel_args.push_back(ht * wt);
+        writer.compile_time_args = {
+            {"Ht", ht},
+            {"H", H},
+            {"Wt", wt},
+            {"W_per_tile", W > TILE_WIDTH ? TILE_WIDTH : W % TILE_WIDTH},
+            {"W_per_tile_last", W % TILE_WIDTH == 0 ? TILE_WIDTH : W % TILE_WIDTH},
+            {"HtWt", ht * wt},
+            {"H_size_bytes", H * output_tensor.element_size()},
+            {"l1_read_offset_bytes", ht * output_tensor.element_size() * TILE_HEIGHT},
+        };
+        writer.runtime_arg_schema.runtime_arg_names = {"start_id", "num_hw_blocks_per_core"};
+    } else {
+        // Legacy writer_unary_interleaved_start_id carried the output CB index as CTA slot 0;
+        // that magic index is replaced by the dfb::out binding.
+        writer.runtime_arg_schema.runtime_arg_names = {"num_pages", "start_id"};
     }
 
-    KernelDescriptor::Defines compute_defines;
-    if (row_major && (input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::INT32)) {
-        compute_defines.emplace_back("DST_ACCUM_MODE", "1");
-    }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
-        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    // ---- Compute ----
+    m2::ComputeHardwareConfig compute_hw{.fp32_dest_acc_en = fp32_dest_acc_en};
     if (src0_cb_data_format == tt::DataFormat::Float32) {
-        // Keep the source CB in full Float32 on the unpack-to-dest path. In
-        // the row-major kernel, the tile-formatted intermediate (c_24) also
-        // feeds the transpose, so it needs the same treatment.
-        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        // Keep the source DFB in full Float32 on the unpack-to-dest path. In the row-major kernel,
+        // the tile-formatted intermediate ("tilize", legacy c_24) also feeds the transpose, so it
+        // needs the same treatment.
+        compute_hw.unpack_to_dest_mode.insert(
+            {m2::DFBSpecName{"src0"}, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
         if (row_major) {
-            unpack_to_dest_mode[static_cast<std::size_t>(tt::CBIndex::c_24)] =
-                tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+            compute_hw.unpack_to_dest_mode.insert(
+                {m2::DFBSpecName{"tilize"}, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
         }
     }
 
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source =
-        row_major ? "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp"
-                  : "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh.cpp";
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = total_cores;
-    compute_desc.compile_time_args = std::move(compute_kernel_args);
-    compute_desc.defines = std::move(compute_defines);
-    compute_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    m2::KernelSpec compute{
+        .unique_id = m2::KernelSpecName{"compute"},
+        .source = compute_source,
+        .hw_config = compute_hw,
     };
+    if (row_major) {
+        compute.dfb_bindings = {
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"src0"},
+                .accessor_name = "src0",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER,
+            },
+            // "tilize" is a producer-and-consumer intermediate within the compute kernel
+            // (tilize writes it, the transpose reads it back) → self-loop binding.
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"tilize"},
+                .accessor_name = "tilize",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER,
+            },
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"tilize"},
+                .accessor_name = "tilize",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER,
+            },
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"out"},
+                .accessor_name = "out",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER,
+            },
+        };
+        compute.compile_time_args = {{"Ht", ht}, {"Wt", wt}, {"HtWt", ht * wt}};
+        compute.runtime_arg_schema.runtime_arg_names = {"num_hw_blocks_per_core"};
+        if (input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::INT32) {
+            compute.compiler_options.defines = {{"DST_ACCUM_MODE", "1"}};
+        }
+    } else {
+        compute.dfb_bindings = {
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"src0"},
+                .accessor_name = "src0",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER,
+            },
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"out"},
+                .accessor_name = "out",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER,
+            },
+        };
+        compute.runtime_arg_schema.runtime_arg_names = {"NHtWt"};
+    }
+
+    spec.kernels = {reader, writer, compute};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = input_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output_tensor.tensor_spec()},
+    };
+    // reader/compute/writer share the src0/tilize/out DFBs, so they must share one WorkUnitSpec.
+    // The legacy factory launches all three kernels on the full grid (total_cores); no-op cores get
+    // num_tiles/num_hw_blocks = 0.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "transpose_wh",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}, m2::KernelSpecName{"compute"}},
+            .target_nodes = total_cores,
+        },
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs compute_run{.kernel = m2::KernelSpecName{"compute"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
 
     if (row_major) {
         emit_runtime_args_wh_rm(
-            reader_desc,
-            compute_desc,
-            writer_desc,
+            reader_run,
+            compute_run,
+            writer_run,
             input_tensor,
-            output_tensor,
             num_cores_total,
             num_cores_y,
             core_group_1,
@@ -320,11 +396,10 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
             num_tiles_per_core_group_2);
     } else {
         emit_runtime_args_wh_tiled(
-            reader_desc,
-            compute_desc,
-            writer_desc,
+            reader_run,
+            compute_run,
+            writer_run,
             input_tensor,
-            output_tensor,
             num_cores_total,
             num_cores_y,
             core_group_1,
@@ -333,11 +408,13 @@ tt::tt_metal::ProgramDescriptor TransposeWHProgramFactory::create_descriptor(
             num_tiles_per_core_group_2);
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    run.kernel_run_args = {reader_run, compute_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, input_tensor.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output_tensor.mesh_tensor()},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_program_factory.hpp
@@ -6,14 +6,14 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct TransposeWHProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.cpp
@@ -6,23 +6,25 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 #include <algorithm>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeWHShardedProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
-
-    ProgramDescriptor desc;
 
     tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
@@ -32,87 +34,133 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
     const auto tile = input_tensor.tensor_spec().tile();
     const uint32_t tile_hw = tile.get_tile_hw();
 
-    IDevice* device = input_tensor.device();
-
     bool fp32_dest_acc_en = src0_cb_data_format == tt::DataFormat::Float32;
-    auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
-    uint32_t num_cores_x = compute_with_storage_grid_size.x;
-    uint32_t num_cores_y = compute_with_storage_grid_size.y;
-    CoreRange total_cores({0, 0}, {num_cores_x - 1, num_cores_y - 1});
 
     auto shard_spec = input_tensor.shard_spec().value();
-    bool row_major = shard_spec.orientation == ShardOrientation::ROW_MAJOR;
 
     auto& all_cores = shard_spec.grid;
     uint32_t num_tiles_per_shard = shard_spec.numel() / tile_hw;
 
-    // Sharded CBs: total_size depends on num_tiles_per_shard which can vary across
-    // cache hits; .buffer triggers UpdateDynamicCircularBufferAddress. total_size
-    // is not in the program hash so the framework re-applies the combined update
-    // via apply_descriptor_runtime_args.
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    uint32_t num_input_tiles = num_tiles_per_shard;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * src0_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = src0_cb_data_format,
-            .page_size = src0_single_tile_size,
-        }}},
-        .buffer = input_tensor.buffer(),
-    });
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "transpose_wh_sharded";
 
-    uint32_t output_cb_index = tt::CBIndex::c_16;
-    uint32_t num_output_tiles = num_tiles_per_shard;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_output_tiles * dst_single_tile_size,
-        .core_ranges = total_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = dst_cb_data_format,
-            .page_size = dst_single_tile_size,
-        }}},
-        .buffer = output_tensor.buffer(),
-    });
-
-    std::vector<uint32_t> reader_compile_time_args = {src0_cb_index};
-    std::vector<uint32_t> writer_compile_time_args = {output_cb_index};
-    std::vector<uint32_t> compute_compile_time_args = {src0_cb_index, output_cb_index};
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = total_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/writer_unary_sharded.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = total_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
-        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (src0_cb_data_format == tt::DataFormat::Float32) {
-        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-    }
-
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_sharded.cpp";
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = total_cores;
-    compute_desc.compile_time_args = std::move(compute_compile_time_args);
-    compute_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    // Sharded CBs (legacy c_0 / c_16): borrowed-memory DFBs on the sharded input/output buffers. The
+    // backing L1 address resolves at runtime from the input/output TensorArguments (the legacy factory
+    // set CBDescriptor .buffer + relied on UpdateDynamicCircularBufferAddress on cache hit). total_size
+    // tracked num_tiles_per_shard (which can vary across cache hits); the DFB's num_entries plays the
+    // same role.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"src0"},
+            .entry_size = src0_single_tile_size,
+            .num_entries = num_tiles_per_shard,
+            .data_format_metadata = src0_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"input"},
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"out"},
+            .entry_size = dst_single_tile_size,
+            .num_entries = num_tiles_per_shard,
+            .data_format_metadata = dst_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"output"},
+        },
     };
 
+    // Reader (forked from eltwise/unary reader_unary_sharded.cpp): pushes the borrowed src0 DFB by
+    // num_tiles_per_core; the legacy CT was the src0 CB index (now dfb::src0).
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                        "reader_unary_sharded_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_tiles_per_core"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
+
+    // Writer (forked from data_movement/sharded writer_unary_sharded.cpp): waits on the borrowed out
+    // DFB for num_units entries; the legacy CT was the output CB index (now dfb::out).
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                        "writer_unary_sharded_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"out"},
+                    .accessor_name = "out",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"num_units"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+
+    // Compute (forked from transpose_wh_sharded.cpp). The legacy CTs {cb_in, cb_out} collapse to the
+    // dfb::src0 / dfb::out bindings; the work counts stay RTAs.
+    m2::ComputeHardwareConfig compute_hw{.fp32_dest_acc_en = fp32_dest_acc_en};
+    if (src0_cb_data_format == tt::DataFormat::Float32) {
+        // Legacy set unpack_to_dest_mode[c_0]=UnpackToDestFp32 when fp32; preserve for the src0 DFB.
+        compute_hw.unpack_to_dest_mode.insert(
+            {m2::DFBSpecName{"src0"}, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
+    }
+
+    m2::KernelSpec compute{
+        .unique_id = m2::KernelSpecName{"compute"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/"
+                                        "transpose_wh_sharded_m2.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"out"},
+                    .accessor_name = "out",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"NHtWt", "HtWt", "N", "Ht", "Wt"},
+            },
+        .hw_config = compute_hw,
+    };
+
+    spec.kernels = {reader, writer, compute};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = input_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output_tensor.tensor_spec()},
+    };
+    // All three kernels run on every shard core. Both DFBs are borrowed onto io tensors and
+    // produced/consumed across reader/compute/writer — they share the single WorkUnitSpec on all_cores
+    // (Local-DFB rule). The legacy factory additionally launched the kernels on the full grid with
+    // zeroed args on the trailing no-op cores; those cores did no work, so targeting the active shard
+    // cores is behavior-preserving.
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "transpose_wh_sharded",
+            .kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"writer"}, m2::KernelSpecName{"compute"}},
+            .target_nodes = all_cores,
+        },
+    };
+
+    // ---- ProgramRunArgs (mutable) ----
     auto padded_shape = input_tensor.padded_shape();
     auto shard_shape = shard_spec.shape;
 
@@ -130,38 +178,32 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedProgramFactory::create_descrip
     uint32_t HtWt_tile_size = Ht_per_shard * Wts;
     uint32_t num_blocks = num_hw_blocks_per_shard * HtWt_tile_size;
 
-    auto bbox = all_cores.bounding_box();
-    std::vector<CoreCoord> cores =
-        grid_to_cores_with_noop(bbox.end_coord.x, bbox.end_coord.y, num_cores_x, num_cores_y, row_major);
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+    m2::KernelRunArgs compute_run{.kernel = m2::KernelSpecName{"compute"}};
 
-    // Active shard cores get the real arg values; the trailing no-op cores keep the
-    // default-constructed slots (matching legacy std::fill behavior on cores.size()).
-    const std::vector<uint32_t> reader_rt = {num_blocks};
-    const std::vector<uint32_t> compute_rt = {num_blocks, HtWt_tile_size, num_hw_blocks_per_shard, Ht_per_shard, Wts};
-    const std::vector<uint32_t> writer_rt = {num_blocks};
-
-    const uint32_t num_active = all_cores.num_cores();
-    reader_desc.runtime_args.reserve(cores.size());
-    compute_desc.runtime_args.reserve(cores.size());
-    writer_desc.runtime_args.reserve(cores.size());
-    for (uint32_t i = 0; i < cores.size(); ++i) {
-        if (i < num_active) {
-            reader_desc.runtime_args.emplace_back(cores[i], reader_rt);
-            compute_desc.runtime_args.emplace_back(cores[i], compute_rt);
-            writer_desc.runtime_args.emplace_back(cores[i], writer_rt);
-        } else {
-            // No-op core: matches legacy std::vector<uint32_t>(1)/(5) zero-initialized rows.
-            reader_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(1));
-            compute_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(5));
-            writer_desc.runtime_args.emplace_back(cores[i], std::vector<uint32_t>(1));
-        }
+    // Active shard cores get the real arg values (matching the legacy per-active-core args; the legacy
+    // no-op tail cores are not part of this work unit).
+    for (const auto& core : corerange_to_cores(all_cores)) {
+        reader_run.runtime_arg_values.push_back({core, {{"num_tiles_per_core", num_blocks}}});
+        writer_run.runtime_arg_values.push_back({core, {{"num_units", num_blocks}}});
+        compute_run.runtime_arg_values.push_back(
+            {core,
+             {{"NHtWt", num_blocks},
+              {"HtWt", HtWt_tile_size},
+              {"N", num_hw_blocks_per_shard},
+              {"Ht", Ht_per_shard},
+              {"Wt", Wts}}});
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    run.kernel_run_args = {reader_run, writer_run, compute_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, input_tensor.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output_tensor.mesh_tensor()},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_program_factory.hpp
@@ -6,14 +6,14 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct TransposeWHShardedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.cpp
@@ -6,24 +6,26 @@
 #include <tt_stl/assert.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <tt-logger/tt-logger.hpp>
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 #include <algorithm>
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts TransposeWHShardedRMProgramFactory::create_program_spec(
     const TransposeParams& /*operation_attributes*/, const TransposeInputs& tensor_args, Tensor& output_tensor) {
     const auto& input_tensor = tensor_args.input;
 
     TT_ASSERT(input_tensor.storage_type() == StorageType::DEVICE, "Operand to transpose_wh needs to be on device!");
     TT_ASSERT(input_tensor.buffer() != nullptr, "Operand to transpose_wh needs to be allocated in a buffer on device!");
-
-    ProgramDescriptor desc;
 
     tt::DataFormat src0_cb_data_format = datatype_to_dataformat_converter(input_tensor.dtype());
     uint32_t src0_single_tile_size = tt::tile_size(src0_cb_data_format);
@@ -86,168 +88,236 @@ tt::tt_metal::ProgramDescriptor TransposeWHShardedRMProgramFactory::create_descr
     log_debug(tt::LogOp, "all_cores: {}", all_cores);
     log_debug(tt::LogOp, "num_cores: {}", num_cores);
 
-    // sharded cb (input): .buffer triggers UpdateDynamicCircularBufferAddress on cache hit.
-    uint32_t src0_cb_index = tt::CBIndex::c_0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = shard_height * stick_size_bytes,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(src0_cb_index),
-            .data_format = src0_cb_data_format,
-            .page_size = stick_size_bytes,
-        }}},
-        .buffer = input_tensor.buffer(),
-    });
+    const bool out_stage = ht > 8;
 
-    // sharded cb (output): .buffer triggers UpdateDynamicCircularBufferAddress on cache hit.
-    uint32_t output_cb_index = tt::CBIndex::c_16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = stick_size_bytes * shard_height,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = dst_cb_data_format,
-            .page_size = output_page_size,
-        }}},
-        .buffer = output_tensor.buffer(),
-    });
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "transpose_wh_sharded_rm";
 
-    // cb_in (double-buffered intermediate)
-    uint32_t in_cb_index = tt::CBIndex::c_24;
+    // src0 (legacy c_0): borrowed input shard, read by base pointer only (reader self-loop).
+    // out (legacy c_16): borrowed output shard. When Ht <= 8 the compute pack-untilizes directly into
+    //   it (compute self-loop FIFO); when Ht > 8 the writer drains the staging DFB into it by base
+    //   pointer (writer self-loop).
+    // in_scratch (legacy c_24): allocated double-buffered intermediate; reader produces, compute
+    //   consumes (tilize input).
+    // tilize (legacy c_25): allocated; compute self-loop (tilize writes, transpose reads back).
+    // out_stage (legacy c_27, only Ht > 8): allocated; compute produces (pack-untilize), writer consumes.
+    // The legacy c_26 ("im2") DFB is dead — no kernel reads or writes it — so it is omitted (a Metal 2.0
+    //   DFB requires >=1 producer and >=1 consumer). See METAL2_PORT_REPORT.md "Open items".
     uint32_t num_in_tiles = wt * 2;  // double buffer
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_in_tiles * src0_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(in_cb_index),
-            .data_format = src0_cb_data_format,
-            .page_size = src0_single_tile_size,
-        }}},
-    });
-
-    // tilize cb
-    uint32_t im_cb_index = tt::CBIndex::c_25;
     uint32_t num_im_tiles = ht * wt;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_im_tiles * src0_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(im_cb_index),
-            .data_format = src0_cb_data_format,
-            .page_size = src0_single_tile_size,
-        }}},
-    });
-
-    // untilize cb (only when ht > 8) + matching output staging CB
-    if (ht > 8) {
-        uint32_t im2_cb_index = tt::CBIndex::c_26;
-        uint32_t num_im2_tiles = ht;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = num_im2_tiles * dst_single_tile_size,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(im2_cb_index),
-                .data_format = dst_cb_data_format,
-                .page_size = dst_single_tile_size,
-            }}},
-        });
-
-        // compute_output_cb
-        uint32_t out_cb_index = tt::CBIndex::c_27;
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"src0"},
+            .entry_size = stick_size_bytes,
+            .num_entries = shard_height,
+            .data_format_metadata = src0_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"input"},
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"out"},
+            .entry_size = output_page_size,
+            .num_entries = shard_height,
+            .data_format_metadata = dst_cb_data_format,
+            .borrowed_from = m2::TensorParamName{"output"},
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"in_scratch"},
+            .entry_size = src0_single_tile_size,
+            .num_entries = num_in_tiles,
+            .data_format_metadata = src0_cb_data_format,
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"tilize"},
+            .entry_size = src0_single_tile_size,
+            .num_entries = num_im_tiles,
+            .data_format_metadata = src0_cb_data_format,
+        },
+    };
+    if (out_stage) {
         uint32_t num_out_tiles = ht * 2;  // double buffer
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = num_out_tiles * dst_single_tile_size,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(out_cb_index),
-                .data_format = dst_cb_data_format,
-                .page_size = dst_single_tile_size,
-            }}},
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"out_stage"},
+            .entry_size = dst_single_tile_size,
+            .num_entries = num_out_tiles,
+            .data_format_metadata = dst_cb_data_format,
         });
     }
 
-    std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)num_hw_blocks_per_core,
-        (std::uint32_t)ht,
-        (std::uint32_t)H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT,
-        (std::uint32_t)H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT,
-        (std::uint32_t)wt,
-        (std::uint32_t)stick_size_bytes,
-        (std::uint32_t)wt * input_tensor.element_size() * TILE_WIDTH,
-    };
-    reader_compile_time_args.push_back(H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT);
-    reader_compile_time_args.push_back(H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "reader_unary_transpose_wh_sharded_rm.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)num_hw_blocks_per_core,
-        (std::uint32_t)ht,
-        (std::uint32_t)wt,
-        (std::uint32_t)W > TILE_WIDTH ? TILE_WIDTH : W % TILE_WIDTH,
-        (std::uint32_t)W % TILE_WIDTH == 0 ? TILE_WIDTH : W % TILE_WIDTH,
-        (std::uint32_t)H * output_tensor.element_size(),
-        (std::uint32_t)ht * output_tensor.element_size() * TILE_HEIGHT,
-    };
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
-        "writer_unary_transpose_wh_sharded_rm.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    std::vector<uint32_t> compute_compile_time_args = {
-        (std::uint32_t)ht,
-        (std::uint32_t)wt,
-        (std::uint32_t)ht * wt,
-        (std::uint32_t)num_hw_blocks_per_core,
-        (std::uint32_t)H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT,  // last_output_row_num_datums
-        (std::uint32_t)pack_num_pages,
-        (std::uint32_t)pack_num_pages_last_col,
-        (std::uint32_t)pack_num_pages_last_row,
-        (std::uint32_t)pack_num_pages_last_row_col,
+    // ---- Reader (in place) ----
+    // src0 read by base pointer only -> self-loop. in_scratch produced for the compute.
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                        "reader_unary_transpose_wh_sharded_rm.cpp"},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER},
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"src0"},
+                    .accessor_name = "src0",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER},
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"in_scratch"},
+                    .accessor_name = "in_scratch",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER},
+            },
+        .compile_time_args =
+            {
+                {"num_hw_blocks_per_core", num_hw_blocks_per_core},
+                {"Ht", ht},
+                {"H_per_tile", H > TILE_HEIGHT ? TILE_HEIGHT : H % TILE_HEIGHT},
+                {"H_per_tile_last", H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT},
+                {"Wt", wt},
+                {"W_size_bytes", stick_size_bytes},
+                {"l1_write_offset_bytes", wt * input_tensor.element_size() * TILE_WIDTH},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
     };
 
-    KernelDescriptor::Defines compute_defines;
-    compute_defines.emplace_back("SHARDED", "1");
-
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
-        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    // ---- Compute (reuses transpose_wh_rm_m2.cpp SHARDED branch) ----
+    m2::ComputeHardwareConfig compute_hw{.fp32_dest_acc_en = fp32_dest_acc_en};
     if (src0_cb_data_format == tt::DataFormat::Float32) {
-        // Keep both the tilize input (c_24) and its output (c_25, which feeds
-        // the transpose) in full Float32 on the unpack-to-dest path; otherwise
-        // the unpacker falls back to tf32 and drops the low mantissa bits.
-        unpack_to_dest_mode[in_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-        unpack_to_dest_mode[im_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        // Keep both the tilize input (in_scratch / c_24) and its output (tilize / c_25, which feeds the
+        // transpose) in full Float32 on the unpack-to-dest path; otherwise the unpacker falls back to
+        // tf32 and drops the low mantissa bits.
+        compute_hw.unpack_to_dest_mode.insert(
+            {m2::DFBSpecName{"in_scratch"}, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
+        compute_hw.unpack_to_dest_mode.insert(
+            {m2::DFBSpecName{"tilize"}, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
     }
 
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/transpose_wh_rm.cpp";
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = std::move(compute_compile_time_args);
-    compute_desc.defines = std::move(compute_defines);
-    compute_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    m2::KernelSpec compute{
+        .unique_id = m2::KernelSpecName{"compute"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/compute/"
+                                        "transpose_wh_rm_m2.cpp"},
+        .compile_time_args =
+            {
+                {"Ht", ht},
+                {"Wt", wt},
+                {"HtWt", ht * wt},
+                {"num_hw_blocks_per_core", num_hw_blocks_per_core},
+                {"last_output_row_num_datums", H % TILE_HEIGHT == 0 ? TILE_HEIGHT : H % TILE_HEIGHT},
+                {"pack_num_pages", pack_num_pages},
+                {"pack_num_pages_last_col", pack_num_pages_last_col},
+                {"pack_num_pages_last_row", pack_num_pages_last_row},
+                {"pack_num_pages_last_row_col", pack_num_pages_last_row_col},
+            },
+        .hw_config = compute_hw,
+    };
+    // in_scratch consumer (tilize input), tilize self-loop, and output PRODUCER+CONSUMER (pack-untilize
+    // both reserves/pushes and — on the non-narrow path — waits on the output FIFO).
+    compute.dfb_bindings = {
+        m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in_scratch"},
+            .accessor_name = "in_scratch",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"tilize"},
+            .accessor_name = "tilize",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER},
+        m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"tilize"},
+            .accessor_name = "tilize",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER},
+    };
+    compute.compiler_options.defines = {{"SHARDED", "1"}};
+    if (input_tensor.dtype() == DataType::UINT32 || input_tensor.dtype() == DataType::INT32) {
+        compute.compiler_options.defines.insert({"DST_ACCUM_MODE", "1"});
+    }
+    if (out_stage) {
+        // compute pack-untilizes into the staging DFB (producer; consumer too on the non-narrow path).
+        compute.compiler_options.defines.insert({"OUT_STAGE", "1"});
+        compute.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"out_stage"},
+            .accessor_name = "out_stage",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER});
+        compute.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"out_stage"},
+            .accessor_name = "out_stage",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    } else {
+        // compute pack-untilizes directly into the borrowed output (producer + self-consumer).
+        compute.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"out"},
+            .accessor_name = "out",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER});
+        compute.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"out"},
+            .accessor_name = "out",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    }
+
+    // ---- Writer (in place, only when Ht > 8) ----
+    m2::KernelSpec writer;
+    if (out_stage) {
+        writer = m2::KernelSpec{
+            .unique_id = m2::KernelSpecName{"writer"},
+            .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/data_movement/transpose/device/kernels/dataflow/"
+                                            "writer_unary_transpose_wh_sharded_rm.cpp"},
+            .compile_time_args =
+                {
+                    {"num_hw_blocks_per_core", num_hw_blocks_per_core},
+                    {"Ht", ht},
+                    {"Wt", wt},
+                    {"W_per_tile", W > TILE_WIDTH ? TILE_WIDTH : W % TILE_WIDTH},
+                    {"W_per_tile_last", W % TILE_WIDTH == 0 ? TILE_WIDTH : W % TILE_WIDTH},
+                    {"H_size_bytes", H * output_tensor.element_size()},
+                    {"l1_read_offset_bytes", ht * output_tensor.element_size() * TILE_HEIGHT},
+                },
+            .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+        };
+        // writer drains out_stage (consumer) and writes the borrowed output by base pointer (self-loop).
+        writer.dfb_bindings = {
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"out_stage"},
+                .accessor_name = "out_stage",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER},
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"out"},
+                .accessor_name = "out",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER},
+            m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"out"},
+                .accessor_name = "out",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER},
+        };
+    }
+
+    std::vector<m2::KernelSpecName> wu_kernels = {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"compute"}};
+    if (out_stage) {
+        spec.kernels = {reader, compute, writer};
+        wu_kernels.push_back(m2::KernelSpecName{"writer"});
+    } else {
+        spec.kernels = {reader, compute};
+    }
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"input"}, .spec = input_tensor.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output_tensor.tensor_spec()},
+    };
+    // The DFBs link reader->compute (in_scratch) and compute->writer (out_stage), so all kernels share
+    // one WorkUnitSpec on all_cores (Local-DFB rule).
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "transpose_wh_sharded_rm",
+            .kernels = std::move(wu_kernels),
+            .target_nodes = all_cores,
+        },
     };
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    // ---- ProgramRunArgs (mutable) ----
+    // No per-kernel runtime args: every count is a compile-time arg in this factory (the legacy factory
+    // emitted no runtime_args at all).
+    m2::ProgramRunArgs run;
+    run.tensor_args = {
+        {m2::TensorParamName{"input"}, input_tensor.mesh_tensor()},
+        {m2::TensorParamName{"output"}, output_tensor.mesh_tensor()},
+    };
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/transpose/device/transpose_wh_sharded_rm_program_factory.hpp
@@ -6,14 +6,14 @@
 #include "transpose_device_operation_types.hpp"
 
 #include "ttnn/device_operation.hpp"
+#include "ttnn/metal2_artifacts.hpp"
 
 #include <tt-metalium/core_coord.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 
 namespace ttnn::prim {
 
 struct TransposeWHShardedRMProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const TransposeParams& operation_attributes, const TransposeInputs& tensor_args, Tensor& output_tensor);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/METAL2_PORT_PLAN.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/METAL2_PORT_PLAN.md
@@ -1,0 +1,90 @@
+# Port Plan — untilize_with_unpadding (single-core factory)
+
+Port plan for the `UntilizeWithUnpaddingSingleCoreProgramFactory`, ported from the
+`ProgramDescriptorFactoryConcept` (`create_descriptor`) API to Metal 2.0
+(`ProgramSpecFactoryConcept` / `create_program_spec`).
+
+Only the **single-core** factory is ported. The device-operation's other five
+factories (multi-core interleaved / sharded / col-interleaved / block-interleaved /
+nd-sharded) remain on the legacy `ProgramDescriptorFactoryConcept` and continue to
+build and run; the framework dispatches per-factory.
+
+## Legacy Inventory
+
+### Legacy factory shape
+- Concept: `ProgramDescriptorFactoryConcept` (`create_descriptor(params, const Tensor&, Tensor&)`).
+- Variants: single (this factory). The device-op `program_factory_t` variant holds 6 factories total.
+- Custom `compute_program_hash`: none — device-op uses the default reflection-based hash.
+
+### Kernels
+| unique_id | source | core_ranges | CTAs (positional) | RTAs | defines | config |
+|---|---|---|---|---|---|---|
+| reader | eltwise/unary/.../reader_unary_interleaved_start_id.cpp | single core | TensorAccessorArgs(src0) | src_addr, num_tiles, start_id(=0) | — | ReaderConfigDescriptor |
+| writer | untilize_with_unpadding/.../writer_unary_unpad_dims_split_rows.cpp | single core | [0]=FLOAT32_DTYPE, [1]=unpadded_stick_size (UNUSED by kernel), TensorAccessorArgs(dst) | dst_addr + 14 dims | — | WriterConfigDescriptor |
+| compute | untilize/.../compute/untilize.cpp | single core | per_core_block_cnt, per_core_block_tile_cnt, src_cb_id(0), out_cb_id(16) | — | DST_ACCUM_MODE (int32/uint32/fp32) | ComputeConfigDescriptor{fp32_dest_acc_en, unpack_to_dest_mode} |
+
+### CBs
+| index | total_size | core_ranges | data_format | page_size |
+|---|---|---|---|---|
+| 0 (src0) | num_tiles_per_block * input_single_tile_size | core | input fmt | input_single_tile_size |
+| 16 (c_16, out) | num_tiles_per_block * output_single_tile_size | core | output fmt | output_single_tile_size |
+
+### Semaphores
+none
+
+### Tensor accessors
+| host site | originating Tensor | RTA slot (host) |
+|---|---|---|
+| reader_compile_time_args TensorAccessorArgs(*src0_buffer) | input | reader RTA 0 (src_addr) |
+| writer_compile_time_args TensorAccessorArgs(*dst_buffer) | output | writer RTA 0 (dst_addr) |
+
+### Work split
+n/a — single core (core 0,0 or first core of sub_core_grids).
+
+### Cross-op kernels
+- `eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp` — shared by ~12 op directories. **FORKED** (see report).
+- `data_movement/untilize/device/kernels/compute/untilize.cpp` — shared by ~9 op directories. **FORKED** (see report).
+- Writer (`writer_unary_unpad_dims_split_rows.cpp`) lives in this op's dir and is used only by this factory — ported **in place**.
+
+### Flags
+- Writer host CTA slot 1 (`unpadded_stick_size`) is emitted by the legacy host but never read by the kernel (it reads only CTA slot 0 and `TensorAccessorArgs<2>()`). It is dropped in the port (no named CTA), which is behavior-preserving.
+- Writer reads `num_unpadded_X` / `padded_X_size` RTAs but does not use them in the loop body; preserved as named RTAs to match legacy emission.
+
+## TTNN ProgramFactory
+- **Concept**: `MetalV2FactoryConcept` (`ProgramSpecFactoryConcept`), returning `ttnn::device_operation::ProgramArtifacts`.
+- **Custom `compute_program_hash`**: none.
+- **Implementation notes**: `tensor_args_t = Tensor` (the single input), `tensor_return_value_t = Tensor` (the output). `create_program_spec(params, const Tensor& input, Tensor& output)`.
+
+## Planned Spec Shape
+- KernelSpecs: reader (DM READER), writer (DM WRITER), compute. 1:1 with legacy.
+- DataflowBufferSpecs: IN (legacy CB 0), OUT (legacy CB 16). `data_format_metadata` set on both (consumed/produced by compute).
+- SemaphoreSpecs: none.
+- TensorParameters: SRC (input), DST (output).
+- WorkUnitSpecs: one — {reader, writer, compute} on the single core. Satisfies the local-DFB rule (IN: reader PRODUCER → compute CONSUMER; OUT: compute PRODUCER → writer CONSUMER; all on the same WU/node).
+
+## Preserved Multiplicity
+none — no work-split multiplicity in legacy (single core).
+
+## Dropped Plumbing
+| legacy location | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| reader RTA 0 | `src0_buffer` address | `TensorBinding(SRC)` → `TensorAccessor(ta::src)` |
+| reader CTA (TensorAccessorArgs) | `TensorAccessorArgs(*src0_buffer)` | binding mechanism |
+| reader CTA implicit cb id 0 | `cb_id_in0 = 0` | `DFBBinding(IN, "in", PRODUCER)` → `dfb::in` |
+| reader RTA 1,2 | num_tiles, start_id | named RTAs `num_pages`, `start_id` |
+| writer RTA 0 | `dst_buffer` address | `TensorBinding(DST)` → `TensorAccessor(ta::dst)` |
+| writer CTA (TensorAccessorArgs) | `TensorAccessorArgs(*dst_buffer)` | binding mechanism |
+| writer CTA slot 0 | FLOAT32_DTYPE (a flag, not a CB id) | named CTA `float32_dtype` |
+| writer CTA slot 1 | unpadded_stick_size | DROPPED (kernel never reads it) |
+| writer magic cb id 16 | `cb_id_out0 = 16` | `DFBBinding(OUT, "out", CONSUMER)` → `dfb::out` |
+| writer RTA 1..14 | positional dims | named RTAs |
+| compute CTA 2,3 | src_cb_id(0), out_cb_id(16) | `DFBBinding(IN CONSUMER)`, `DFBBinding(OUT PRODUCER)` → `dfb::in`, `dfb::out` |
+| compute CTA 0,1 | positional | named CTAs `per_core_block_cnt`, `per_core_block_tile_cnt` |
+
+## Applied Patterns
+- Pass DFB handles directly to LLKs / kernel-lib helpers: compute kernel passes `dfb::in` / `dfb::out` into `compute_kernel_hw_startup` and `compute_kernel_lib::untilize<...>` (template-parameter position via the constexpr implicit conversion).
+- Caution: Modifying a shared dataflow kernel — reader and compute FORKED to `_m2` copies (see report).
+
+## Deferred / Flagged
+- New finding: writer's unused `unpadded_stick_size` CTA dropped; writer's unused `num_unpadded_X`/`padded_X_size` RTAs preserved (behavior-preserving). Flagged to op owner.
+- The other 5 factories of this device-op remain on the legacy concept (out of scope for this single-factory port).

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/METAL2_PORT_PLAN.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/METAL2_PORT_PLAN.md
@@ -88,3 +88,95 @@ none — no work-split multiplicity in legacy (single core).
 ## Deferred / Flagged
 - New finding: writer's unused `unpadded_stick_size` CTA dropped; writer's unused `num_unpadded_X`/`padded_X_size` RTAs preserved (behavior-preserving). Flagged to op owner.
 - The other 5 factories of this device-op remain on the legacy concept (out of scope for this single-factory port).
+
+---
+
+# Port Plan — untilize_with_unpadding (multi-core interleaved factory)
+
+Port plan for `UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory`, ported from
+`ProgramDescriptorFactoryConcept` (`create_descriptor`) to Metal 2.0
+(`create_program_spec` → `ttnn::device_operation::ProgramArtifacts`). This is the
+**default-selected** factory for non-sharded multicore untilize_with_unpadding.
+
+## Legacy Inventory (multi-core)
+### Kernels
+| unique_id | source | core_ranges | CTAs (positional) | RTAs | defines | config |
+|---|---|---|---|---|---|---|
+| reader | eltwise/unary/.../reader_unary_interleaved_start_id.cpp | all_cores | TensorAccessorArgs(src0) | src_addr, num_tiles_per_core, tile_start_id | — | ReaderConfigDescriptor |
+| writer | untilize_with_unpadding/.../writer_unary_stick_layout_split_rows_multicore.cpp | all_cores | [0]=FLOAT32_DTYPE, [1]=unpadded_row_size_bytes, TensorAccessorArgs(dst) | dst_addr, padded_X_size, start_stick_id, n_block_reps, + variable-length 5-tuples (n_data,n_mixed,n_pads,times,repeat_count) | — | WriterConfigDescriptor |
+| compute (full) | untilize/.../compute/untilize.cpp | core_range | nblocks_per_core, num_tiles_per_row, c_0, c_16 | — | DST_ACCUM_MODE (int32/uint32/fp32) | Compute{fp32_dest_acc_en, unpack_to_dest_mode} |
+| compute (cliff) | untilize/.../compute/untilize.cpp | core_range_cliff | nblocks_per_core_cliff, num_tiles_per_row, c_0, c_16 | — | DST_ACCUM_MODE | Compute{...} |
+
+### CBs
+| index | total_size | core_ranges | data_format | page_size |
+|---|---|---|---|---|
+| 0 (src0) | num_tiles_per_row * input_single_tile_size | all_cores | input fmt | input_single_tile_size |
+| 16 (out) | num_tiles_per_row * output_single_tile_size | all_cores | output fmt | output_single_tile_size |
+
+### Work split
+`split_blocks_for_tilize(available_grid, num_blocks)` →
+`(ncores, all_cores, core_range, core_range_cliff, nblocks_per_core, nblocks_per_core_cliff)`.
+Reader/writer placed on `all_cores`; compute split into a full group (`core_range`,
+`nblocks_per_core`) and a cliff group (`core_range_cliff`, `nblocks_per_core_cliff`).
+`distribute_work(...)` produces per-core BlockRep assignments driving the writer RTAs.
+
+### Cross-op / shared kernels
+- reader `reader_unary_interleaved_start_id.cpp` — cross-op (~12 consumers). REUSES the existing
+  `reader_unary_interleaved_start_id_m2.cpp` fork in this op dir (already created for single-core).
+- compute `untilize/.../compute/untilize.cpp` — cross-op (~9 consumers). REUSES the existing
+  `untilize_m2.cpp` fork in this op dir.
+- writer `writer_unary_stick_layout_split_rows_multicore.cpp` — op-local, single consumer (this
+  factory only). Ported **in place**.
+
+## Planned Spec Shape (multi-core)
+- KernelSpecs: reader (DM READER, all_cores), writer (DM WRITER, all_cores), compute_full,
+  compute_cliff (1 KernelSpec per work-split group — preserves multiplicity, no CTA→RTA demotion).
+- DataflowBufferSpecs: IN (legacy c_0), OUT (legacy c_16). num_entries = num_tiles_per_row.
+- TensorParameters: SRC (input), DST (output).
+- WorkUnitSpecs: uwu_full {reader, writer, compute_full} on core_range; uwu_cliff
+  {reader, writer, compute_cliff} on core_range_cliff. Reader/writer appear in BOTH WUs
+  (their target node set = core_range ∪ core_range_cliff = all_cores), satisfying the local-DFB
+  rule (IN: reader PRODUCER → compute CONSUMER; OUT: compute PRODUCER → writer CONSUMER, same WU).
+
+## Preserved Multiplicity (multi-core)
+```
+Legacy KernelDescriptors [compute(full), compute(cliff)] of source untilize.cpp
+  → KernelSpecs [compute_full, compute_cliff] of same source (untilize_m2.cpp)
+  → in WorkUnitSpecs [uwu_full, uwu_cliff]
+  → sharing IN (CONSUMER) / OUT (PRODUCER) DFBs; reader/writer shared across both WUs.
+```
+
+## Dropped Plumbing (multi-core)
+| legacy location | legacy form | Metal 2.0 replacement |
+|---|---|---|
+| reader RTA 0 | src0_buffer address | TensorBinding(SRC) → ta::src |
+| reader CTA TensorAccessorArgs | TensorAccessorArgs(*src0_buffer) | binding mechanism |
+| reader implicit cb id 0 | cb_id_in0=0 | DFBBinding(IN PRODUCER) → dfb::in |
+| reader RTA 1,2 | num_tiles_per_core, tile_start_id | named RTAs num_pages, start_id |
+| writer RTA 0 | dst_buffer address | TensorBinding(DST) → ta::dst |
+| writer CTA TensorAccessorArgs | TensorAccessorArgs(*dst_buffer) | binding mechanism |
+| writer CTA 0 | FLOAT32_DTYPE | named CTA float32_dtype |
+| writer CTA 1 | unpadded_row_size_bytes | named CTA unpadded_X_size (READ by kernel — unlike single-core writer) |
+| writer magic cb id 16 | cb_id_out0=16 | DFBBinding(OUT CONSUMER) → dfb::out |
+| writer RTA 1,2,3 | padded_X_size, start_stick_id, n_block_reps | named RTAs |
+| writer RTA 4+ (variable) | run-length-compressed BlockRep 5-tuples | runtime varargs (get_vararg), per-node count |
+| compute CTA 2,3 | c_0, c_16 | DFBBinding(IN CONSUMER), DFBBinding(OUT PRODUCER) → dfb::in, dfb::out |
+| compute CTA 0,1 | nblocks_per_core, num_tiles_per_row | named CTAs per_core_block_cnt, per_core_block_tile_cnt |
+
+## Applied Patterns (multi-core)
+- **Anti-pattern avoided — Demoting per-group CTA to RTA**: full/cliff compute kept as two
+  KernelSpecs in two WorkUnitSpecs (matmul-multicore exemplar shape), not one KernelSpec with the
+  per-group block count demoted to an RTA.
+- **Caution: shared dataflow kernel** — reader + compute REUSE the cross-op `_m2` forks created
+  for single-core; writer ported in place (op-local).
+- **Pass DFB handles directly** — compute feeds dfb::in/dfb::out into kernel-lib helpers.
+- **Varargs (Caution: avoid varargs unless necessary)** — writer's per-core block-rep tuples are
+  genuinely variable-length per node (kernel reads them in a loop bounded by the n_block_reps RTA),
+  so varargs are the correct fit. Count varies per core → uses KernelAdvancedOptions
+  `num_runtime_varargs_per_node` (see report Open items: this field is `[[deprecated]]`).
+
+## Deferred / Flagged (multi-core)
+- `num_runtime_varargs_per_node` is marked `[[deprecated]]` in advanced_options.hpp (slated for
+  removal). It is the only API supporting per-node-VARYING vararg counts; the non-deprecated scalar
+  `num_runtime_varargs` requires a uniform count across all nodes. Documented in the report.
+- Remaining 4 factories (sharded / col-interleaved / block-interleaved / nd-sharded) stay legacy.

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/METAL2_PORT_REPORT.md
@@ -29,3 +29,33 @@ Status: **PORTED** (single-core factory only; not built — this worktree has no
   - `untilize/device/kernels/compute/untilize.cpp` — FORKED to `untilize_with_unpadding/device/kernels/compute/untilize_m2.cpp`. Legacy original unchanged; ~8 other consumer op dirs remain unmigrated.
 - **Sibling factories (carry-over):** the 5 remaining factories in this device-op are candidates for the same treatment in a follow-up pass; several share these same reader/compute kernels, so the forks created here can be reused.
 - **Test coverage note:** not built or run (no build dir per instructions). Verification (gtests + pytests at `tests/ttnn/unit_tests/operations/data_movement/` and under the simulator) is required before merge.
+
+---
+
+# Metal 2.0 Port Report — untilize_with_unpadding (multi-core interleaved factory)
+
+Status: **PORTED** (multi-core interleaved factory — the default-selected non-sharded multicore
+path; not built — this worktree has no build dir).
+
+## TTNN ProgramFactory
+- **Concept realized**: `MetalV2FactoryConcept`. `UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create_descriptor` → `create_program_spec`, returning `ttnn::device_operation::ProgramArtifacts{.spec, .run_params}`. Header updated (`tt-metalium/program_descriptors.hpp` include → `ttnn/metal2_artifacts.hpp`; return type `ProgramDescriptor` → `ProgramArtifacts`).
+- **Device-op-class edits**: none. `select_program_factory` returns this factory by value (unchanged); the adapter dispatches per-factory on the concept. No custom `compute_program_hash` to delete.
+- **Pybind entry points removed**: none — grepped `untilize_with_unpadding_nanobind.{cpp,hpp}`; no `create_descriptor`/`create_program` exposure for any factory.
+
+## Kernels (multi-core)
+- **reader** — REUSES `reader_unary_interleaved_start_id_m2.cpp` (the cross-op `_m2` fork already created for single-core). The multicore reader emits `{src, num_tiles_per_core, tile_start_id}` → the m2 reader's `num_pages`/`start_id` named RTAs + `ta::src`. No new fork.
+- **compute** — REUSES `untilize_m2.cpp` (the cross-op `_m2` fork already created for single-core). Multicore CTAs `{nblocks_per_core, num_tiles_per_row}` map onto the m2 compute's `per_core_block_cnt`/`per_core_block_tile_cnt`; cb ids become `dfb::in`/`dfb::out`. No new fork.
+- **writer** — `writer_unary_stick_layout_split_rows_multicore.cpp` ported **in place** (op-local, single consumer = this factory). dst addr → `ta::dst`; cb 16 → `dfb::out`; FLOAT32_DTYPE/unpadded_X_size → named CTAs; padded_X_size/start_stick_id/n_block_reps → named RTAs; per-core block-rep 5-tuples → runtime varargs (`get_vararg`).
+
+## Successes
+- **Multi-group work split → multi-KernelSpec / multi-WorkUnitSpec** (matmul-multicore exemplar shape) applied cleanly: full + cliff compute are two KernelSpecs in two WUs (`uwu_full`, `uwu_cliff`); reader + writer are members of BOTH WUs (so their derived node set = all_cores). The per-group block count stays a CTA — no CTA→RTA demotion.
+- **Cross-op fork reuse**: the single-core port's `reader_*_m2.cpp` and `untilize_m2.cpp` forks were directly reusable by the multicore factory (same kernel sources, same named bindings). No additional cross-op kernels touched.
+- **Varargs** modeled the writer's variable-length per-core block-rep tuples faithfully (the kernel already bounds its read with the `n_block_reps` named RTA), reusing the `get_vararg` mechanism proven by slice's m2 reader.
+
+## Friction / Open items for downstream
+- **BLOCKER-adjacent — deprecated API is the only fit.** The writer needs a DIFFERENT number of runtime varargs per core. The non-deprecated scalar `KernelAdvancedOptions::num_runtime_varargs` only supports a UNIFORM count across all of a kernel's nodes; the per-node-varying case requires `num_runtime_varargs_per_node`, which is marked `[[deprecated]]` ("will be removed once existing uses are refactored"). This port is (per grep) the FIRST in-tree use of that field. It compiles clean because the repo sets `-Wno-deprecated-declarations`. Surfacing precisely so the API owners can decide: either (a) keep a supported per-node-varying-vararg mechanism, or (b) provide guidance to pad every core to the max count via the scalar (inert padding — the kernel reads only `n_block_reps*5` varargs). I chose the deprecated per-node field over padding because padding adds dispatch-buffer bloat and obscures the real per-core count. File: `untilize_with_unpadding_multi_core_interleaved_program_factory.cpp` (the `writer.advanced_options.num_runtime_varargs_per_node[...]` line).
+- **Vararg use (report-required)**: writer runtime varargs retained (genuinely variable-length, loop-indexed) — this is the sanctioned vararg case, not a positional-RTA carry-over.
+- **Cross-op kernel forks (sunset checklist)**: unchanged from single-core — `reader_unary_interleaved_start_id_m2.cpp` and `untilize_m2.cpp` remain forks; now used by BOTH the single-core and multi-core m2 factories. Delete only when this op no longer needs them AND the shared originals are themselves m2-ported.
+- **Compute-kernel pointer escape valve**: none. Writer's only base-pointer read is `cb_out0.get_read_ptr()` on its own DFB (framework-managed). No smuggled addresses.
+- **Remaining factories**: 4 of 6 (sharded / col-interleaved / block-interleaved / nd-sharded) stay on the legacy concept; the op keeps building/running (mixed-concept variant, per-factory dispatch).
+- **Test coverage**: not built or run (no build dir). gtests + pytests + simulator verification required before merge.

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/METAL2_PORT_REPORT.md
@@ -1,0 +1,31 @@
+# Metal 2.0 Port Report — untilize_with_unpadding (single-core factory)
+
+Status: **PORTED** (single-core factory only; not built — this worktree has no build dir).
+
+## TTNN ProgramFactory
+- **Concept realized**: `MetalV2FactoryConcept` (`ProgramSpecFactoryConcept`). `UntilizeWithUnpaddingSingleCoreProgramFactory::create_descriptor` → `create_program_spec`, returning `ttnn::device_operation::ProgramArtifacts{.spec, .run_params}`.
+- **Device-op-class edits**: none required.
+  - `select_program_factory` returns the factory by value; the variant routing in `mesh_device_operation_adapter` dispatches on the concept, so the only change to route to the new path is the factory itself swapping `create_descriptor` → `create_program_spec`. No edit to `untilize_with_unpadding_device_operation.cpp` / `.hpp`.
+  - Custom `compute_program_hash`: none (default reflection hash) — nothing to delete.
+- **Pybind entry points removed**: none. Grepped the op's pybind/nanobind surface for `create_descriptor` / `create_program` — no exposure of this factory's entry point.
+- **Open items (concept fit)**: the device-op's other 5 factories stay on the legacy `ProgramDescriptorFactoryConcept`. The `program_factory_t` variant is mixed-concept and the framework dispatches per-factory, so the op keeps building/running. Those are the remaining work for a future pass.
+
+## Handoff points
+- **No worked examples on this branch.** PORT_INSTRUCTIONS.md described worked `rand` / `matmul` Metal 2.0 ports on branch `dgomez/rand-metal2`, but this worktree is on `worktree-agent-...` off a commit where NO in-tree factory uses `create_program_spec` / `device_operation::ProgramArtifacts` (grep returned zero). The Metal 2.0 *framework* headers (`metal2_host_api/*`, `ttnn/metal2_artifacts.hpp`, adapter `ProgramSpecMeshWorkloadFactoryAdapter`, device-side `dataflow_buffer.h` / `tensor_accessor.h` / `kernel_args.h`) ARE all present and complete. The port was written directly against those headers + the recipe/patterns docs. Flagging the missing exemplars so the invoker can confirm the branch is the intended one before building.
+
+## Successes
+- **Caution: Modifying a shared dataflow kernel** (patterns catalog) fired correctly. The reader (`reader_unary_interleaved_start_id.cpp`, ~12 consumers) and compute (`untilize/.../compute/untilize.cpp`, ~9 consumers) are heavily shared; both were FORKED to `_m2` copies inside this op's `device/kernels/` tree rather than edited in place, so no sibling op breaks. The writer (`writer_unary_unpad_dims_split_rows.cpp`, this op's dir, single consumer) was ported in place.
+- **Pass DFB handles directly** pattern: the compute kernel feeds `dfb::in`/`dfb::out` straight into `compute_kernel_hw_startup(...)` and `compute_kernel_lib::untilize<per_core_block_tile_cnt, dfb::in, dfb::out, ...>(...)` (template-parameter position), relying on the constexpr `DFBAccessor::operator uint32_t()`. No `.id` extraction.
+
+## Friction
+- **Gap — fork location for cross-op kernels.** The patterns catalog says fork "alongside the original" (`*_metal2.cpp` next to the legacy file), but the recipe's hard scope fence is "stay within `ttnn/cpp/ttnn/operations/<op>/`". For cross-op shared kernels these conflict (the original lives in another op's dir). Resolved by placing the forks inside THIS op's `device/kernels/` tree with an `_m2` suffix and pointing the factory at them. The docs should state explicitly where a cross-op fork lands when the porter may not write outside the op dir.
+- **Confusion — writer CTA slot 1.** The legacy host emitted `unpadded_stick_size` as writer CTA slot 1, but the kernel reads only CTA slot 0 (`FLOAT32_DTYPE`) and `TensorAccessorArgs<2>()`. The slot-1 value is dead. Dropping it (no named CTA) is behavior-preserving; documented in the plan's Dropped Plumbing.
+
+## Open items for downstream
+- **Fake-CB self-loops**: none. Both DFBs (IN, OUT) have real producer/consumer pairs (reader→compute, compute→writer).
+- **Compute-kernel pointer escape valve**: none. The compute kernel needs no raw L1 base address; the writer's only base-pointer read is `cb_out0.get_read_ptr()` on its own DFB (`CoreLocalMem` over the DFB's L1) — framework-managed, refreshed per execution, no smuggled pointer.
+- **Cross-op kernel forks (sunset checklist):**
+  - `reader_unary_interleaved_start_id.cpp` — FORKED to `untilize_with_unpadding/device/kernels/dataflow/reader_unary_interleaved_start_id_m2.cpp`. Legacy original (`eltwise/unary/device/kernels/dataflow/`) unchanged; ~11 other consumer op dirs remain unmigrated. Delete the fork only when this op no longer needs it AND the shared original is itself Metal-2.0-ported.
+  - `untilize/device/kernels/compute/untilize.cpp` — FORKED to `untilize_with_unpadding/device/kernels/compute/untilize_m2.cpp`. Legacy original unchanged; ~8 other consumer op dirs remain unmigrated.
+- **Sibling factories (carry-over):** the 5 remaining factories in this device-op are candidates for the same treatment in a follow-up pass; several share these same reader/compute kernels, so the forks created here can be reused.
+- **Test coverage note:** not built or run (no build dir per instructions). Verification (gtests + pytests at `tests/ttnn/unit_tests/operations/data_movement/` and under the simulator) is required before merge.

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/METAL2_PORT_REPORT.md
@@ -59,3 +59,217 @@ path; not built — this worktree has no build dir).
 - **Compute-kernel pointer escape valve**: none. Writer's only base-pointer read is `cb_out0.get_read_ptr()` on its own DFB (framework-managed). No smuggled addresses.
 - **Remaining factories**: 4 of 6 (sharded / col-interleaved / block-interleaved / nd-sharded) stay on the legacy concept; the op keeps building/running (mixed-concept variant, per-factory dispatch).
 - **Test coverage**: not built or run (no build dir). gtests + pytests + simulator verification required before merge.
+
+---
+
+## Block-interleaved factory port
+
+Status: **PORTED** (multi-core block-interleaved factory; not built — no build dir in this worktree).
+
+### TTNN ProgramFactory
+- **Concept realized**: `MetalV2FactoryConcept`.
+  `UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create_descriptor` → `create_program_spec`,
+  returning `ttnn::device_operation::ProgramArtifacts{.spec, .run_params}`. Header updated
+  (`tt-metalium/program_descriptors.hpp` → `ttnn/metal2_artifacts.hpp`; return type `ProgramDescriptor` →
+  `ProgramArtifacts`).
+- **Device-op-class edits**: none. The factory is selected by value in `select_program_factory` and listed in
+  `program_factory_t`; the adapter dispatches per-factory on the concept, so swapping the entry point is the
+  only change. No custom `compute_program_hash`. No pybind exposure of this entry point.
+- All host scalar/shape arithmetic (the full `split_blocks_for_tilize_wh` destructuring,
+  `total_tiles_per_row`, `el_size`/`padded`/`unpadded` row bytes, `third_dim`, the per-core RTA loop with
+  `single_block_size_row_arg`/`col_arg`/`sub_block` selection and the `start_row_id`/`start_column_id`/
+  `tile_start_id` bookkeeping) is copied **verbatim**. Only resource declaration changed.
+
+### Kernels — ported vs forked (all three FORKED)
+| role | legacy source | fork (new path, all in this op's `device/kernels/`) | reason |
+|------|---------------|------|--------|
+| reader | `eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp` | `.../untilize_with_unpadding/device/kernels/dataflow/reader_unary_interleaved_wh_multicore_m2.cpp` | shared (lives outside op dir; also used by untilize) |
+| writer | `.../untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore.cpp` | `.../writer_unary_stick_layout_wh_multicore_m2.cpp` | op-local BUT also referenced by `untilize/.../untilize_multi_core_block_program_factory.cpp:196` (still legacy) → forked so untilize keeps its legacy copy untouched |
+| compute | `untilize/device/kernels/compute/untilize_wh.cpp` | `.../untilize_with_unpadding/device/kernels/compute/untilize_wh_m2.cpp` | shared (lives outside op dir) |
+
+Kernel port mechanics (logic/loops/`#ifdef`s unchanged, only access mechanism):
+- **reader**: `TensorAccessorArgs<3>()` + `src_addr` RTA → `TensorAccessor(ta::src)` (src_addr slot 0 dropped);
+  `cb_id_in0=0` → `dfb::in`; `get_tile_size` → `get_local_cb_interface(dfb::in).fifo_page_size`; CTAs
+  (num_tiles_per_2d, third_dim, total_tiles_per_row) and RTAs (start_id, single_block_size_row_arg,
+  single_block_size_col_arg) → named `get_arg(args::...)`. BACKWARDS `#ifdef` preserved.
+- **writer**: `TensorAccessorArgs<4>()` + `dst_addr` RTA → `TensorAccessor(ta::dst)` (dst_addr slot 0 dropped);
+  `cb_id_out0=16` → `dfb::out`; kept `api/core_local_mem.h` (`CoreLocalMem<uint32_t>`); CTAs (total_num_rows,
+  third_dim, tile_height, unpadded_X_size) and RTAs (width_size + the in-loop start_row_id, start_column_id,
+  single_block_size_row_arg, single_block_size_col_arg, sub_block_width_size, single_sub_block_size_row_arg)
+  → named args. The in-loop RTAs were the SAME positional slots re-read each `third_dim` iteration; with named
+  args they are read once per iteration via `get_arg(args::name)` returning the same value — identical behavior.
+- **compute**: `c_0/c_16` → `dfb::in/dfb::out` (fed straight into `compute_kernel_hw_startup` and the
+  `compute_kernel_lib::untilize<block_size_row, dfb::in, dfb::out, ...>` template params); CTAs
+  (block_size_col, block_size_row, third_dim) → named `constexpr` args (constexpr required because
+  `block_size_row` is a template argument). `DST_ACCUM_MODE` define + `unpack_to_dest_mode` handled host-side
+  per the interleaved exemplar.
+
+### CB-SIZE CONSOLIDATION DECISION (prominent)
+Legacy emitted a PAIR of (c_0 input, c_16 output) CBs on each non-empty core sub-region via `push_cb_pair`,
+and the per-region `num_tiles` differed:
+- `core_range` → `single_sub_block_size`
+- `cliff_col_row_core_range` → `single_block_size_cliff_row`
+- `cliff_row_core_range` → `single_block_size_cliff_row`
+- `cliff_col_core_range` → `single_sub_block_size`
+
+A Metal 2.0 `DataflowBufferSpec` fixes `entry_size`/`num_entries` ONCE per spec (the per-execution
+`dfb_run_overrides` does NOT support resizing — only addresses), so one DFB per logical buffer must pick a
+`num_entries` that is safe (>=) for ALL emitted regions. **Resolution**: `num_entries` = MAX over the
+emitted regions of `{single_sub_block_size, single_block_size_cliff_row}`, computed under the SAME emission
+guards (`!core_range.empty()`, `has_cliff_col && has_cliff_row`, `has_cliff_row`, `has_cliff_col`) so an
+unused region never inflates the reservation. IN uses `entry_size = input_single_tile_size`, OUT uses
+`output_single_tile_size`; both use this shared `max_cb_num_tiles`.
+
+**Footprint/correctness judgment (not a blocker)**: each per-region CB L1 reservation can only INCREASE to the
+max, never decrease, so no region under-reserves — correctness is preserved. The footprint increase is bounded
+by `(max - per_region) * (input_single_tile_size + output_single_tile_size)` per core on the smaller regions,
+and the host-side split itself sizes everything under `cb_block_size_limit = max_l1_size / (in+out tile size)`
+(so the max single block already fits L1). I judged this does NOT materially risk correctness or L1 overflow,
+hence proceeded with one max-sized DFB rather than treating it as a blocker. If a future requirement needs the
+exact per-region sizing back, that would require per-WorkUnit DFB sizing, which the current
+`DataflowBufferSpec`/`dfb_run_overrides` API does not provide.
+
+### Compute work-split multiplicity
+Preserved the up-to-4-group structure: one compute `KernelSpec` per region (full / cliff-col-row / cliff-row /
+cliff-col) with distinct `KernelSpecName`s and its own `{block_size_col, block_size_row, third_dim}` CTAs, each
+in its own `WorkUnitSpec` (`uwu_full`/`uwu_cliff_col_row`/`uwu_cliff_row`/`uwu_cliff_col`), guarded by the same
+conditions and CTA values as the legacy `push_compute` calls. Reader + writer run on `all_cores`, so they are
+members of EVERY `WorkUnitSpec` (Local-DFB rule). A `make_compute` lambda parameterized by unique_id, target
+CoreRangeSet, the two block-size CTAs, and the WU name builds the `KernelSpec` and pushes the `WorkUnitSpec`,
+generalizing the row exemplar's full/cliff pattern to up to 4 groups. No CTA→RTA demotion.
+
+### Buffer-address / TensorAccessor plumbing
+`src0_buffer->address()`/`dst_buffer->address()` RTAs and the `TensorAccessorArgs(...).append_to(...)` CTAs
+DISAPPEAR → `TensorParameter` SRC/DST + `TensorArgument{input.mesh_tensor()}` / `{output.mesh_tensor()}` +
+per-kernel `TensorBinding`s. The `Buffer* src0_buffer/dst_buffer` locals and the `TT_FATAL(dst_buffer != ...)`
+(framework-enforced now) are gone.
+
+### Blockers
+- **None.** No missing framework API was hit; the CB consolidation is a clean (and judged-safe) modeling
+  decision, not a gap. This factory does NOT use per-node-varying varargs (unlike the interleaved factory's
+  writer), so it does not touch the deprecated `num_runtime_varargs_per_node` field.
+
+### Deviations
+- CB sizes consolidated to one max-sized IN/OUT DFB pair (documented above) — the only behavioral modeling
+  deviation, judged footprint-safe.
+- Reader/writer RTA push order: reader pushed before writer (matching the exemplar's KernelRunArgs grouping);
+  legacy computed `writer_rt_args` first then pushed reader-then-writer. Net per-core arg sets are identical;
+  only the local construction order differs. Comments adjusted to match.
+
+### Cross-op kernel forks (sunset checklist)
+- `reader_unary_interleaved_wh_multicore_m2.cpp` — fork of `eltwise/unary/.../reader_unary_interleaved_wh_multicore.cpp`. Legacy original unchanged.
+- `writer_unary_stick_layout_wh_multicore_m2.cpp` — fork of this op's `writer_unary_stick_layout_wh_multicore.cpp`; legacy original retained because `untilize/.../untilize_multi_core_block_program_factory.cpp` still uses it. Delete the fork only once untilize's block factory is m2-ported (it can then share/own the kernel) AND this op no longer needs it.
+- `untilize_wh_m2.cpp` — fork of `untilize/.../compute/untilize_wh.cpp`. Legacy original unchanged.
+
+### Test coverage
+Not built or run (no build dir). gtests + pytests + simulator verification required before merge.
+
+## Col-interleaved factory port
+
+**STATUS: PORTED** (multi-core COL interleaved factory; not built — this worktree has no build dir).
+
+### Files changed
+- `device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.hpp` — swapped `program_descriptors.hpp` include for `ttnn/metal2_artifacts.hpp`; method now `static ttnn::device_operation::ProgramArtifacts create_program_spec(...)`.
+- `device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp` — rewritten `create_descriptor` → `create_program_spec`. All host scalar/shape arithmetic (`num_blocks`, `split_blocks_for_tilize`, `el_size`, `unpadded_row_size_bytes`, `num_tiles_2d`, `third_dim`, `total_num_rows`, per-core `size_per_row_per_block`/`number_blocks_per_core`) copied verbatim. Resource tail converted to DataflowBufferSpec / TensorParameter / KernelSpec / WorkUnitSpec / ProgramSpec / ProgramRunArgs, mirroring the row-interleaved exemplar.
+
+### Kernels: ported vs forked
+- READER — **forked** (shared, lives outside op dir): `device/kernels/dataflow/reader_unary_interleaved_col_multicore_m2.cpp` (NEW), forked from `eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp`. Ported to DFB `dfb::in` + `TensorAccessor(ta::src)` + named args; CTAs (num_tiles_per_2d/third_dim/number_blocks_per_core) and RTAs (core_number/tiles_per_row/num_blocks) named; loops/#ifdefs verbatim.
+- WRITER — **ported in place** (op-local): `device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp`. DFB `dfb::cb_id_out0`, `TensorAccessor(ta::dst)`, named CTAs (total_num_rows/ncores/third_dim/tile_width/unpadded_X_size) + named RTAs (core_number/size_per_row_per_block/blocks_per_core/width_size). `write_block` lambda/pad logic/loops verbatim. Kept `api/core_local_mem.h`.
+- COMPUTE — **forked** (shared with untilize): `device/kernels/compute/untilize_w_m2.cpp` (NEW), forked from `data_movement/untilize/device/kernels/compute/untilize_w.cpp`. CB ids → `dfb::in`/`dfb::out`; CTAs (per_core_block_cnt/per_core_block_tile_cnt/third_dim) named; `untilize<1,...>(per_core_block_cnt * per_core_block_tile_cnt * third_dim)` preserved verbatim. Two compute KernelSpecs (COMPUTE_FULL / COMPUTE_CLIFF) preserve the per-group CTA multiplicity; reader+writer are members of both WUs (uwu_full / uwu_cliff) per the Local-DFB rule.
+
+### Metal blocks
+None. No missing host/kernel API encountered.
+
+### Deviations / findings (must-read)
+1. **Pre-existing off-by-one RTA bug in the legacy descriptor writer (NOT introduced here).** The descriptor `create_descriptor` wrote writer RTAs `{dst_addr(0), i(1), size_per_row_per_block(2), number_blocks_per_core(3), TILE_WIDTH*el_size(4)}` (5 values), but `writer_unary_stick_layout_col_multicore.cpp` read `core_number=arg(1)`, `size_per_row_per_block=arg(3)`, `blocks_per_core=arg(4)`, `width_size=arg(5)`. After the `dst_addr` slot, that is an off-by-one: it read `number_blocks_per_core` as `size_per_row_per_block`, `width_size` as `blocks_per_core`, and `width_size` from an OUT-OF-BOUNDS index 5 (host never wrote it). The original pre-descriptor (PR #17538) `SetRuntimeArgs` layout `{dst_addr, unpadded_X_size, i, size_per_row_per_block, number_blocks_per_core, width_size}` matched the kernel correctly; the #45071 descriptor migration dropped `unpadded_X_size` from the RTAs (folded it into a CTA) without re-indexing the kernel reads. Since Metal 2.0 named bindings cannot reproduce an OOB positional read, this port wires each kernel variable to the host's **intended** value by name (the correct pre-descriptor mapping). This is a behavior *fix* relative to the buggy descriptor variant, surfaced and documented rather than silently propagated. A matching comment lives at the top of the writer kernel.
+2. **This factory is dead in dispatch.** `select_program_factory` (device/untilize_with_unpadding_device_operation.cpp:18-63) never returns `UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory` — it routes only to single-core / multi-core-interleaved / block-interleaved / sharded / nd-sharded. The col-interleaved variant is registered in the `program_factory_t` variant but unreachable, which is why finding (1) was never caught at runtime. The port is faithful and ready, but this path is not exercised by current dispatch or tests.
+3. **DFB num_entries.** Legacy CBs `c_0`/`c_16` used `total_size = num_tiles_per_col * single_tile_size`; ported to `entry_size = single_tile_size`, `num_entries = num_tiles_per_col` (per rule 4).
+
+### Test coverage
+Not built or run (no build dir in this worktree). gtests + pytests + simulator verification required before merge; note the dead-dispatch caveat (finding 2) — exercising this factory requires forcing its selection.
+
+## ND-sharded factory port
+
+**STATUS: PORTED** (multi-core ND-sharded factory; not built — this worktree has no build dir). Behavior-preserving; all host arithmetic copied verbatim.
+
+### TTNN ProgramFactory
+- `UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create_descriptor` (legacy `ProgramDescriptor`) → `create_program_spec` returning `ttnn::device_operation::ProgramArtifacts{.spec, .run_params}`. `.hpp` decl + include `ttnn/metal2_artifacts.hpp` updated (dropped `program_descriptors.hpp`).
+- No device-op-class edits (variant dispatch is per-factory concept, same as the already-ported single-core / interleaved factories).
+- `.cpp` includes: dropped `program_descriptors.hpp`, `tensor_accessor_args.hpp`, `cb_utils.hpp`, `host_api.hpp`, and the unused `untilize/device/untilize_device_operation.hpp`; added the metal2 `program_spec.hpp` / `program_run_args.hpp` + `using namespace tt::tt_metal::experimental;`. Kept `buffer_distribution_spec.hpp`, `ccl/sharding_addrgen_helper.hpp`, `work_split.hpp`, `work_split_tilize.hpp`.
+
+### Kernels — ported vs forked
+- **Reader — FORKED** (shared with `untilize/` factories, still legacy):
+  `.../untilize_with_unpadding/device/kernels/dataflow/reader_unary_nd_sharded_blocks_m2.cpp` (new), source of fork `data_movement/sharded/device/kernels/dataflow/reader_unary_nd_sharded_blocks.cpp` (untouched). `cb_id_in0` CTA → `dfb::in`; `TensorAccessorArgs<4>()+src_addr` → `TensorAccessor(ta::src)`; `src_addr` RTA dropped (TensorBinding); `start_shard_id` named RTA; `num_tiles_per_input_block`/`num_shards`/`num_cores` named CTAs. `get_tile_size(cb_id_in0)` → `get_local_cb_interface(dfb::in).fifo_page_size` (established m2 pattern; tile CB ⇒ identical value). Kept `ccl/kernel_common/sharding_addrgen.hpp` + `shard_pages` loop.
+- **Writer — PORTED IN PLACE** (op-local; only this factory references it):
+  `.../untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp` (rewritten). `cb_id_out0` → `dfb::out`; both `TensorAccessorArgs` → `ta::dst` then `ta::src`; `dst_addr`/`src0_addr` RTAs dropped (two TensorBindings); `start_shard_id` named RTA; scalar CTAs named; common-arg loop reads `get_common_vararg(i)`. Logic/loops/`div_up` helper unchanged.
+- **Compute — FORKED** (shared with `untilize/` factories, still legacy):
+  `.../untilize_with_unpadding/device/kernels/compute/untilize_variable_num_blocks_m2.cpp` (new), source of fork `data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp` (untouched). cb-id CTAs → `dfb::in`/`dfb::out`; `per_core_block_tile_cnt` named CTA; `num_input_blocks_to_process` named RTA. `DST_ACCUM_MODE` define preserved; early-return-on-0-blocks guard preserved.
+
+### Two TensorParameters on the writer (dst + src binding order)
+Two `TensorParameter`s declared: `SRC` (`input.tensor_spec()`), `DST` (`output.tensor_spec()`). Reader binds `SRC` only. Writer binds **both**, in order **DST then SRC** — matching the legacy append order (`TensorAccessorArgs(*dst_buffer)` THEN `TensorAccessorArgs(*src0_buffer)`, "for ND sharded input we need info on the input buffer distribution") and the kernel's accessor construction order (`accessor_dst` first, `accessor_src` second) so the auto-injected CTA layout aligns. `tensor_args` = `{SRC, input.mesh_tensor()}, {DST, output.mesh_tensor()}`. The two buffer-address RTAs (dst_buffer, src0_buffer) disappear into these bindings; only `start_shard_id` remains a per-node named RTA.
+
+### Common runtime args handling — VARARGS (rationale)
+The writer's legacy `common_runtime_args` (output padded-shape dims, then input padded-shape dims) is **rank-dependent** (count = `2 * tensor_rank`, ≤ 16 after ND→4D squeezing). The kernel reads them in a runtime loop (`for i in [0, tensor_rank): get_common_vararg(i)` / `(i + tensor_rank)`), with `i` a runtime variable — so by the named/vararg test in the patterns catalog this is the honest vararg case, not named args.
+- Schema: `writer.advanced_options.num_common_runtime_varargs = 2 * tensor_rank;`
+- Values: `writer_run_args.advanced_options.common_runtime_varargs = {out dims..., in dims...}` (broadcast to all nodes).
+- Kernel: `get_common_arg_val<uint32_t>(i)` → `get_common_vararg(i)`. The writer declares **no** named common RTAs, so the genfiles `get_common_vararg` base offset is 0 ⇒ index-for-index identical to legacy.
+- **Caution (per patterns doc):** varargs retained deliberately because the count is rank-dependent. If `tensor_rank` were fixed this could be fixed named common args, but the kernel's runtime-indexed loop makes varargs the faithful mapping.
+
+### has_compute / DFB producer-consumer edge case
+Legacy always pushes reader+writer and gates compute on `has_compute = !compute_core_range.ranges().empty()`. The port mirrors this exactly: one `WorkUnitSpec` (`target_nodes = compute_core_range`) lists `{READER, WRITER}` and appends `COMPUTE` only when `has_compute`. The local IN/OUT DFBs are PRODUCER reader→IN / CONSUMER compute←IN, PRODUCER compute→OUT / CONSUMER writer←OUT.
+- **Edge case noted:** if `has_compute` were false, IN would have a producer (reader) but no consumer, and OUT a consumer (writer) but no producer — violating the DFB producer-and-consumer invariant; the spec validator would reject it. In the ND-sharded path `compute_core_range` is exactly `cores_with_data()`, which is non-empty whenever the op runs, so `has_compute` is effectively always true and the degenerate case is unreachable (the legacy op would itself be a no-op). The DFBs and bindings are only assembled consistent with the present kernels (compute pushed iff `has_compute`), so the invariant holds for every reachable input. No structural blocker.
+
+### Deviations / notes
+- Unused legacy writer CTAs `output_stick_size` (legacy idx 1) and `input_single_tile_size` (legacy idx 8) are not read by the kernel; retained as named CTAs for fidelity (named-arg resolution is by name, so dead CTAs are harmless and shift no offsets).
+- No metal/framework blockers. The common-vararg path (`num_common_runtime_varargs` / `AdvancedKernelRunArgs::common_runtime_varargs` / device `get_common_vararg`) exists and is wired end-to-end (advanced_options.hpp, program_run_args.hpp/.cpp, genfiles.cpp).
+- Not built: this worktree has no build dir; not compiled or run.
+
+---
+
+## Sharded factory port
+
+### STATUS
+DONE (not built — this worktree has no build dir; not compiled or run). `UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create_descriptor` → `create_program_spec` returning `ttnn::device_operation::ProgramArtifacts{.spec, .run_params}`. Header swapped `tt-metalium/program_descriptors.hpp` → `ttnn/metal2_artifacts.hpp`. No edit to `untilize_with_unpadding_device_operation.{cpp,hpp}` (adapter dispatches on the concept). Pybind: none exposed for this factory.
+
+All host scalar/shape arithmetic (num_rows_block, block_row_size, last_block_row_size_unpadded, num_output_rows_unpadded, last_idx/end_core, ntiles_per_batch, aligned_page_size, and the full per-core `!out_sharded` writer-RTA loop with block_start_row_offset/block_start_row_id_offset) copied **verbatim**.
+
+### The 3 kernel-config branches (selected at runtime inside `create_program_spec`)
+- **Config A — `out_sharded && !unpad_tensor_w_16`**: compute = untilize; writer = `writer_unary_unpad_batch_rows_sharded.cpp`. DFBs: IN, OUT, SHARDED_OUT.
+- **Config B — `out_sharded && unpad_tensor_w_16`**: compute = eltwise_copy (data-type-convert only, skip untilize); writer = `writer_unary_unpad_width_16_sharded.cpp`. DFBs: IN, OUT, SHARDED_OUT.
+- **Config C — `!out_sharded`**: compute = untilize; writer = `writer_unary_stick_layout_interleaved_blocks_m2.cpp` (writes to interleaved DST via TensorAccessor). DFBs: IN, OUT (no SHARDED_OUT).
+
+Reader is the same in all three (`reader_unary_sharded_m2.cpp` — push_back resident input tiles into IN).
+
+### Kernels: ported / forked / reused (absolute paths)
+- **Reader — FORKED** (shared by ~12 ops): new `.../untilize_with_unpadding/device/kernels/dataflow/reader_unary_sharded_m2.cpp` from `eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp` (legacy untouched). `CircularBuffer cb(cb_id_in0); cb.push_back(...)` → `DataflowBuffer dfb_in(dfb::in); dfb_in.push_back(get_arg(args::num_tiles_per_core))`. cb-id CTA → `dfb::in`.
+- **Writer A — PORTED IN PLACE** (op-local; grep confirmed only this factory referenced it): `.../kernels/dataflow/writer_unary_unpad_batch_rows_sharded.cpp`. `cb_id_untilize_out`→`dfb::out`, `cb_id_out`→`dfb::sharded_out`; `aligned_page_size` named CTA; 6 named RTAs. CoreLocalMem/Noc/endpoints logic unchanged.
+- **Writer B — PORTED IN PLACE** (op-local): `.../kernels/dataflow/writer_unary_unpad_width_16_sharded.cpp`. Same dfb mapping; `get_tile_size(cb_id_out)` → `get_tile_size(dfb::sharded_out)` (constexpr free function + implicit `DFBAccessor::operator uint32_t`); 2 named RTAs; all face-copy logic unchanged.
+- **Writer C — FORKED** (generic, lives in `ttnn/cpp/ttnn/kernel/dataflow/`): new `.../untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_interleaved_blocks_m2.cpp` from `ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp` (legacy untouched). `TensorAccessorArgs<2>()+dst_addr` → `TensorAccessor(ta::dst)`; cb-id c_16 → `dfb::out`; `FLOAT32_DTYPE` named CTA; 9 named RTAs; the template helper `write_tiles_in_block` takes `dfb::out` (implicit conv). The `dst_addr` RTA disappears.
+- **Compute untilize — REUSED**: existing `.../kernels/compute/untilize_m2.cpp` (forked for single-/multi-core interleaved). Legacy `untilize.cpp` uses 4 CTAs (`per_core_block_cnt`, `per_block_ntiles`, `src_cb_id`, `out_cb_id`); `untilize_m2.cpp` uses named `per_core_block_cnt`/`per_core_block_tile_cnt` + `dfb::in`/`dfb::out` and the **identical** `compute_kernel_lib::untilize` template params. Reused as-is (configs A, C).
+- **Compute eltwise_copy — FORKED** (generic, `ttnn/cpp/ttnn/kernel/compute/`): new `.../kernels/compute/eltwise_copy_m2.cpp` from `ttnn/cpp/ttnn/kernel/compute/eltwise_copy.cpp` (legacy untouched). `tt::CBIndex::c_0`→`dfb::in`, `c_16`→`dfb::out`; `per_core_tile_cnt` named CTA (host sets it to `num_input_tiles`, matching legacy `compute_args[0] = num_input_tiles`). LLK calls take `dfb::` directly (config B).
+
+### Borrowed DFBs (sharded I/O in L1)
+- **IN** (`c_0`): `borrowed_from = SRC` **iff `src_sharded`** (branch preserved exactly — when not src_sharded it is a plain allocated DFB). PRODUCER on reader, CONSUMER on compute — a real producer/consumer pair.
+- **OUT** (`c_16`): plain DFB (no borrow). PRODUCER on compute, CONSUMER on writer.
+- **SHARDED_OUT** (`c_17`): present **only** when `out_sharded` (configs A, B). `borrowed_from = DST`, `entry_size = aligned_page_size` (NOT a tile size — the kernel advances the write ptr by aligned_page_size), `num_entries = num_output_rows_unpadded`.
+
+Backing L1 addresses for IN/SHARDED_OUT resolve at runtime from the matching `TensorArgument` (SRC/DST); no `dfb_run_overrides` needed.
+
+### SHARDED_OUT self-loop fake-CB workaround (PROMINENT — interim)
+**SHARDED_OUT is a one-ended FIFO.** In configs A/B the writer is the *only* kernel touching it: `reserve_back` / `get_write_ptr` (member) / `push_back`. Nothing consumes it — it **is** the sharded output buffer in L1. A Metal 2.0 DFB requires ≥1 PRODUCER and ≥1 CONSUMER binding, so to satisfy the validator SHARDED_OUT is bound as a **SELF-LOOP**: both a PRODUCER and a CONSUMER `DFBBinding` on the **writer**, sharing `accessor_name = "sharded_out"` (one device-side `dfb::sharded_out` handle). This is the [Fake CB → self-loop DFB] interim pattern — a deliberate validator-satisfying white lie, **not** a real FIFO. To be replaced by the forthcoming "local" TensorAccessor variant when it lands. (IN in sharded mode is *not* a fake CB — reader push_back / compute wait_front is a genuine producer/consumer pair.)
+
+### Per-node vs common RTA choice
+**Per-node for all kernels** (one `NodeRuntimeArgs` per core), matching the legacy `SetRuntimeArgs(program, kernel, all_cores, args)` / per-core enumeration exactly. The reader args and the `out_sharded` writer args are in fact identical across cores (could be `common_runtime_arg_values`), but per-node is always safe and is the faithful 1:1 of the legacy code; the `!out_sharded` (config C) writer args genuinely vary per core and must be per-node.
+
+### Work units / local-DFB rule
+One `WorkUnitSpec` (`uwu_sharded`, `target_nodes = all_cores = shard_spec.grid`) listing `{READER, WRITER, COMPUTE}`. All kernels run on all_cores, so every DFB's producer & consumer share the same WU — the local-DFB invariant holds trivially.
+
+### CTAs / hw_config
+Positional CTAs → named: `aligned_page_size` (config A), `float32_dtype` (config C), `per_core_block_cnt`/`per_core_block_tile_cnt` (untilize), `per_core_tile_cnt` (eltwise_copy). CB-index CTAs became `dfb::` handles (not named args). Reader/writer `hw_config = DataMovementHardwareConfig{.role = READER/WRITER}`; compute `ComputeHardwareConfig{.fp32_dest_acc_en}` + `unpack_to_dest_mode.insert({IN, UnpackToDestFp32})` iff fp32_dest_acc_en. `DST_ACCUM_MODE` define via `CompilerOptions::Defines` (Int32/UInt32/Float32), preserved verbatim.
+
+Unused-CTA note: config C's legacy writer_ct_args included `output_row_size` (slot 1) which the kernel never read — dropped (named-arg resolution is by name; behavior unchanged). Config B's legacy writer_ct_args included `aligned_page_size` (slot 2) which writer B never read — dropped.
+
+### Deviations / blockers
+- **No framework blockers.** All required APIs present: `DataflowBufferSpec.borrowed_from`, self-loop dual-binding (per-kernel accessor-name dedup), `get_tile_size(dfb::)` constexpr free function, `TensorAccessor(ta::dst)`, per-node RTAs.
+- Config C `dst_addr` RTA (legacy slot 0) folds into `ta::dst`; the three constant-`1` RTAs map to `batch`/`num_blocks_h`/`num_blocks_w` named RTAs.
+- Not built: no build dir in this worktree; not compiled, not run on hardware/sim.

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.cpp
@@ -4,61 +4,29 @@
 
 #include "untilize_with_unpadding_multi_core_block_interleaved_program_factory.hpp"
 
-#include "ttnn/operations/cb_utils.hpp"
+#include <algorithm>
+
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-namespace {
-
-inline void push_cb_pair(
-    ProgramDescriptor& desc,
-    const CoreRangeSet& core_ranges,
-    uint32_t num_tiles,
-    uint32_t input_single_tile_size,
-    uint32_t output_single_tile_size,
-    tt::DataFormat input_cb_data_format,
-    tt::DataFormat output_cb_data_format) {
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_tiles * input_single_tile_size,
-        .core_ranges = core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_tiles * output_single_tile_size,
-        .core_ranges = core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_16),
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
-}
-
-}  // namespace
-
-tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts
+UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory::create_program_spec(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
     const auto& a = input;
     bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
-
-    ProgramDescriptor desc;
 
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -121,53 +89,60 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedPr
         el_size = a.element_size();
     }
 
-    // CBs: emit a pair (input + output) per non-empty core sub-region. The legacy code
-    // created two CreateCircularBuffer calls on different core ranges — descriptors mirror
-    // this layout exactly.
+    // ---- Resource names ----
+    const DFBSpecName IN{"in"};
+    const DFBSpecName OUT{"out"};
+    const TensorParamName SRC{"src"};
+    const TensorParamName DST{"dst"};
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+    const KernelSpecName COMPUTE_FULL{"compute_full"};
+    const KernelSpecName COMPUTE_CLIFF_COL_ROW{"compute_cliff_col_row"};
+    const KernelSpecName COMPUTE_CLIFF_ROW{"compute_cliff_row"};
+    const KernelSpecName COMPUTE_CLIFF_COL{"compute_cliff_col"};
+
+    // ---- Dataflow buffers (legacy CBs c_0 / c_16) ----
+    // CB-SIZE CONSOLIDATION DECISION:
+    //   Legacy emitted a PAIR of (c_0 input, c_16 output) CBs on each non-empty core sub-region via
+    //   push_cb_pair, and the per-region num_tiles differed: core_range and cliff_col_core_range used
+    //   `single_sub_block_size`; cliff_col_row_core_range and cliff_row_core_range used
+    //   `single_block_size_cliff_row`. A Metal 2.0 DataflowBufferSpec fixes entry_size/num_entries
+    //   ONCE per spec (dfb_run_overrides cannot resize), so one DFB per logical buffer must pick a
+    //   num_entries that is safe (>=) for ALL emitted regions. We use the MAX of the per-region
+    //   num-tiles that the legacy push_cb_pair calls actually used, guarded by the SAME emission
+    //   conditions so an unused region never inflates the reservation. This collapses the legacy
+    //   per-region CB sizes to a single max-sized DFB; L1 footprint per core can only INCREASE (to
+    //   the max), never decrease, so no region under-reserves — correctness is preserved.
+    uint32_t max_cb_num_tiles = 0;
     if (!core_range.empty()) {
-        push_cb_pair(
-            desc,
-            core_range,
-            single_sub_block_size,
-            input_single_tile_size,
-            output_single_tile_size,
-            input_cb_data_format,
-            output_cb_data_format);
+        max_cb_num_tiles = std::max(max_cb_num_tiles, single_sub_block_size);
     }
     if (has_cliff_col && has_cliff_row) {
-        push_cb_pair(
-            desc,
-            cliff_col_row_core_range,
-            single_block_size_cliff_row,
-            input_single_tile_size,
-            output_single_tile_size,
-            input_cb_data_format,
-            output_cb_data_format);
+        max_cb_num_tiles = std::max(max_cb_num_tiles, single_block_size_cliff_row);
     }
     if (has_cliff_row) {
-        push_cb_pair(
-            desc,
-            cliff_row_core_range,
-            single_block_size_cliff_row,
-            input_single_tile_size,
-            output_single_tile_size,
-            input_cb_data_format,
-            output_cb_data_format);
+        max_cb_num_tiles = std::max(max_cb_num_tiles, single_block_size_cliff_row);
     }
     if (has_cliff_col) {
-        push_cb_pair(
-            desc,
-            cliff_col_core_range,
-            single_sub_block_size,
-            input_single_tile_size,
-            output_single_tile_size,
-            input_cb_data_format,
-            output_cb_data_format);
+        max_cb_num_tiles = std::max(max_cb_num_tiles, single_sub_block_size);
     }
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    DataflowBufferSpec in_dfb{
+        .unique_id = IN,
+        .entry_size = input_single_tile_size,
+        .num_entries = max_cb_num_tiles,
+        .data_format_metadata = input_cb_data_format,
+    };
+    DataflowBufferSpec out_dfb{
+        .unique_id = OUT,
+        .entry_size = output_single_tile_size,
+        .num_entries = max_cb_num_tiles,
+        .data_format_metadata = output_cb_data_format,
+    };
+
+    // ---- Tensor parameters ----
+    TensorParameter src_param{.unique_id = SRC, .spec = input.tensor_spec()};
+    TensorParameter dst_param{.unique_id = DST, .spec = output.tensor_spec()};
 
     // reader
 
@@ -181,72 +156,142 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedPr
         third_dim = log_shape[-3] * log_shape[-4];
     }
 
-    std::vector<uint32_t> reader_compile_time_args = {num_tiles_2d, third_dim, total_tiles_per_row};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    // ---- Reader kernel (tilized reader; forked m2 copy of the shared eltwise/unary wh reader) ----
+    KernelSpec reader{
+        .unique_id = READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "reader_unary_interleaved_wh_multicore_m2.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER},
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"},
+            },
+        .compile_time_args =
+            {
+                {"num_tiles_per_2d", num_tiles_2d},
+                {"third_dim", third_dim},
+                {"total_tiles_per_row", total_tiles_per_row},
+            },
+        .runtime_arg_schema =
+            {.runtime_arg_names = {"start_id", "single_block_size_row_arg", "single_block_size_col_arg"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+    };
 
     // writer
     uint32_t total_num_rows = output.logical_shape()[-2];
-    std::vector<uint32_t> writer_ct_args = {total_num_rows, third_dim, TILE_HEIGHT, unpadded_row_size_bytes};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-        "writer_unary_stick_layout_wh_multicore.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+
+    // ---- Writer kernel (untilized wh split-rows writer; forked m2 copy — the legacy original is
+    // ---- still used by untilize's block factory, so it is forked rather than edited in place) ----
+    KernelSpec writer{
+        .unique_id = WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "writer_unary_stick_layout_wh_multicore_m2.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER},
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"},
+            },
+        .compile_time_args =
+            {
+                {"total_num_rows", total_num_rows},
+                {"third_dim", third_dim},
+                {"tile_height", TILE_HEIGHT},
+                {"unpadded_X_size", unpadded_row_size_bytes},
+            },
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"width_size",
+                  "start_row_id",
+                  "start_column_id",
+                  "single_block_size_row_arg",
+                  "single_block_size_col_arg",
+                  "sub_block_width_size",
+                  "single_sub_block_size_row_arg"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
 
     // compute
     uint32_t single_sub_block_size_wh = single_block_size * single_block_size / single_sub_block_size;
     uint32_t single_sub_block_size_cliff_col_wh =
         single_block_size_cliff_col * single_block_size / single_sub_block_size;
-    KernelDescriptor::Defines compute_kernel_defines;
+    KernelSpec::CompilerOptions::Defines compute_kernel_defines;
     if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
         input_cb_data_format == tt::DataFormat::Float32) {
-        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
-    }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
-        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (fp32_dest_acc_en) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        compute_kernel_defines.insert({"DST_ACCUM_MODE", "1"});
     }
 
-    const std::string compute_kernel_path(
-        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_wh.cpp");
+    // One compute KernelSpec per work-split region (full / cliff-col-row / cliff-row / cliff-col),
+    // each with its own CTA values (block_size_col, block_size_row, third_dim) and its own WorkUnitSpec.
+    // Reader + writer run on all_cores, so they must be members of EVERY WorkUnitSpec (Local-DFB rule:
+    // IN/OUT producer & consumer share the same WUs). The per-region block sizes stay CTAs — no
+    // CTA->RTA demotion — preserving compile-time loop unrolling.
+    Group<KernelSpec> kernels;
+    std::vector<WorkUnitSpec> work_units;
+    kernels.push_back(std::move(reader));
+    kernels.push_back(std::move(writer));
 
-    auto push_compute = [&](const CoreRangeSet& cr, std::initializer_list<uint32_t> compile_args) {
-        KernelDescriptor compute_desc;
-        compute_desc.kernel_source = compute_kernel_path;
-        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_desc.core_ranges = cr;
-        compute_desc.compile_time_args = std::vector<uint32_t>(compile_args.begin(), compile_args.end());
-        compute_desc.defines = compute_kernel_defines;
-        compute_desc.config = ComputeConfigDescriptor{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
-        };
-        desc.kernels.push_back(std::move(compute_desc));
+    auto make_compute = [&](const KernelSpecName& unique_id,
+                            const CoreRangeSet& target,
+                            uint32_t block_size_col,
+                            uint32_t block_size_row,
+                            const char* wu_name) {
+        ComputeHardwareConfig compute_hw_config{.fp32_dest_acc_en = fp32_dest_acc_en};
+        if (fp32_dest_acc_en) {
+            compute_hw_config.unpack_to_dest_mode.insert({IN, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
+        }
+        kernels.push_back(KernelSpec{
+            .unique_id = unique_id,
+            .source = "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/"
+                      "untilize_wh_m2.cpp",
+            .compiler_options = {.defines = compute_kernel_defines},
+            .dfb_bindings =
+                {
+                    DFBBinding{.dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
+                    DFBBinding{
+                        .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER},
+                },
+            .compile_time_args =
+                {
+                    {"block_size_col", block_size_col},
+                    {"block_size_row", block_size_row},
+                    {"third_dim", third_dim},
+                },
+            .hw_config = std::move(compute_hw_config),
+        });
+        work_units.push_back(
+            WorkUnitSpec{.name = wu_name, .kernels = {READER, WRITER, unique_id}, .target_nodes = target});
     };
 
     if (!core_range.empty()) {
-        push_compute(core_range, {single_sub_block_size_wh, single_sub_block_size, third_dim});
+        make_compute(COMPUTE_FULL, core_range, single_sub_block_size_wh, single_sub_block_size, "uwu_full");
     }
     if (has_cliff_col && has_cliff_row) {
-        push_compute(cliff_col_row_core_range, {single_block_size_cliff_col, single_block_size_cliff_row, third_dim});
+        make_compute(
+            COMPUTE_CLIFF_COL_ROW,
+            cliff_col_row_core_range,
+            single_block_size_cliff_col,
+            single_block_size_cliff_row,
+            "uwu_cliff_col_row");
     }
     if (has_cliff_row) {
-        push_compute(cliff_row_core_range, {single_block_size, single_block_size_cliff_row, third_dim});
+        make_compute(
+            COMPUTE_CLIFF_ROW, cliff_row_core_range, single_block_size, single_block_size_cliff_row, "uwu_cliff_row");
     }
     if (has_cliff_col) {
-        push_compute(cliff_col_core_range, {single_sub_block_size_cliff_col_wh, single_sub_block_size, third_dim});
+        make_compute(
+            COMPUTE_CLIFF_COL,
+            cliff_col_core_range,
+            single_sub_block_size_cliff_col_wh,
+            single_sub_block_size,
+            "uwu_cliff_col");
     }
 
     // RUNTIME ARGS
@@ -264,8 +309,10 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedPr
     }
     uint32_t cores_col_count = 1;
 
-    reader_desc.runtime_args.reserve(ncores);
-    writer_desc.runtime_args.reserve(ncores);
+    KernelRunArgs reader_run_args{.kernel = READER};
+    KernelRunArgs writer_run_args{.kernel = WRITER};
+    reader_run_args.runtime_arg_values.reserve(ncores);
+    writer_run_args.runtime_arg_values.reserve(ncores);
     for (uint32_t i = 0; i < ncores; ++i) {
         const auto& core = cores[i];
 
@@ -290,23 +337,25 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedPr
             single_sub_block_size_row_arg = single_sub_block_size;
         }
 
-        //  writer runtime args
-        std::vector<uint32_t> writer_rt_args = {
-            dst_buffer->address(),
-            TILE_WIDTH * el_size * single_block_size_row_arg,
-            start_row_id,
-            start_column_id,
-            single_block_size_row_arg,
-            single_block_size_col_arg,
-            TILE_WIDTH * el_size * single_sub_block_size_row_arg,
-            single_sub_block_size_row_arg};
+        // reader runtime args (the legacy src0_buffer->address() slot is folded into ta::src)
+        reader_run_args.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = core,
+            .args = {
+                {"start_id", tile_start_id},
+                {"single_block_size_row_arg", single_block_size_row_arg},
+                {"single_block_size_col_arg", single_block_size_col_arg}}});
 
-        // reader runtime args
-        reader_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{
-                src0_buffer->address(), tile_start_id, single_block_size_row_arg, single_block_size_col_arg});
-        writer_desc.runtime_args.emplace_back(core, std::move(writer_rt_args));
+        // writer runtime args (the legacy dst_buffer->address() slot is folded into ta::dst)
+        writer_run_args.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = core,
+            .args = {
+                {"width_size", TILE_WIDTH * el_size * single_block_size_row_arg},
+                {"start_row_id", start_row_id},
+                {"start_column_id", start_column_id},
+                {"single_block_size_row_arg", single_block_size_row_arg},
+                {"single_block_size_col_arg", single_block_size_col_arg},
+                {"sub_block_width_size", TILE_WIDTH * el_size * single_sub_block_size_row_arg},
+                {"single_sub_block_size_row_arg", single_sub_block_size_row_arg}}});
 
         uint32_t end_column_id = start_column_id + (single_block_size_row_arg * TILE_WIDTH * el_size);
         start_column_id = end_column_id % padded_row_size_bytes;
@@ -322,12 +371,24 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreBlockInterleavedPr
         }
     }
 
-    // Insert reader+writer at the beginning so they occupy descriptor positions 0 and 1
-    // (compute kernels follow).
-    desc.kernels.insert(desc.kernels.begin(), std::move(writer_desc));
-    desc.kernels.insert(desc.kernels.begin(), std::move(reader_desc));
+    ProgramSpec spec{
+        .name = "untilize_with_unpadding_multi_core_block_interleaved",
+        .kernels = std::move(kernels),
+        .dataflow_buffers = {std::move(in_dfb), std::move(out_dfb)},
+        .tensor_parameters = {std::move(src_param), std::move(dst_param)},
+        .work_units = std::move(work_units),
+    };
 
-    return desc;
+    ProgramRunArgs run_args{
+        .kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)},
+        .tensor_args =
+            {
+                {SRC, TensorArgument{input.mesh_tensor()}},
+                {DST, TensorArgument{output.mesh_tensor()}},
+            },
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_block_interleaved_program_factory.hpp
@@ -6,12 +6,12 @@
 
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeWithUnpaddingMultiCoreBlockInterleavedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.cpp
@@ -4,29 +4,27 @@
 
 #include "untilize_with_unpadding_multi_core_col_interleaved_program_factory.hpp"
 
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operation.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts
+UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory::create_program_spec(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
     const auto& a = input;
     bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
     const auto& sub_core_grids = operation_attributes.sub_core_grids;
-
-    ProgramDescriptor desc;
 
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -62,31 +60,6 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreColInterleavedProg
         el_size = a.element_size();
     }
 
-    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_tiles_per_col * input_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src0_cb_index,
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-    });
-    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_tiles_per_col * output_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
-
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-
     // reader
     uint32_t num_tiles_2d = a.padded_shape()[-1] * a.padded_shape()[-2] / TILE_HW;
 
@@ -98,59 +71,123 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreColInterleavedProg
         third_dim = log_shape[-3] * log_shape[-4];
     }
 
-    std::vector<uint32_t> reader_compile_time_args = {num_tiles_2d, third_dim, nblocks_per_core};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
     // writer
     uint32_t total_num_rows = output.logical_shape()[-2];
 
-    std::vector<uint32_t> writer_ct_args = {total_num_rows, ncores, third_dim, TILE_WIDTH, unpadded_row_size_bytes};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
+    // ---- Resource names ----
+    const DFBSpecName IN{"in"};
+    const DFBSpecName OUT{"out"};
+    const TensorParamName SRC{"src"};
+    const TensorParamName DST{"dst"};
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+    const KernelSpecName COMPUTE_FULL{"compute_full"};
+    const KernelSpecName COMPUTE_CLIFF{"compute_cliff"};
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-        "writer_unary_stick_layout_col_multicore.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    // ---- Dataflow buffers (legacy CBs c_0 / c_16) ----
+    DataflowBufferSpec in_dfb{
+        .unique_id = IN,
+        .entry_size = input_single_tile_size,
+        .num_entries = num_tiles_per_col,
+        .data_format_metadata = input_cb_data_format,
+    };
+    DataflowBufferSpec out_dfb{
+        .unique_id = OUT,
+        .entry_size = output_single_tile_size,
+        .num_entries = num_tiles_per_col,
+        .data_format_metadata = output_cb_data_format,
+    };
 
-    // compute
-    const std::string compute_kernel(
-        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_w.cpp");
+    // ---- Tensor parameters ----
+    TensorParameter src_param{.unique_id = SRC, .spec = input.tensor_spec()};
+    TensorParameter dst_param{.unique_id = DST, .spec = output.tensor_spec()};
 
-    if (!core_range.empty()) {
-        KernelDescriptor compute_desc;
-        compute_desc.kernel_source = compute_kernel;
-        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_desc.core_ranges = core_range;
-        compute_desc.compile_time_args = {nblocks_per_core, num_tiles_per_col, third_dim};
-        compute_desc.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
-        desc.kernels.push_back(std::move(compute_desc));
-    }
-    if (has_cliff) {
-        KernelDescriptor cliff_desc;
-        cliff_desc.kernel_source = compute_kernel;
-        cliff_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        cliff_desc.core_ranges = core_range_cliff;
-        cliff_desc.compile_time_args = {nblocks_per_core_cliff, num_tiles_per_col, third_dim};
-        cliff_desc.config = ComputeConfigDescriptor{.fp32_dest_acc_en = fp32_dest_acc_en};
-        desc.kernels.push_back(std::move(cliff_desc));
-    }
+    // ---- Reader kernel (col-multicore tilized reader; forked m2 copy of the shared eltwise/unary reader) ----
+    KernelSpec reader{
+        .unique_id = READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "reader_unary_interleaved_col_multicore_m2.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER},
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"},
+            },
+        .compile_time_args =
+            {
+                {"num_tiles_per_2d", num_tiles_2d},
+                {"third_dim", third_dim},
+                {"number_blocks_per_core", nblocks_per_core},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"core_number", "tiles_per_row", "num_blocks"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+    };
 
-    // RUNTIME ARGS
+    // ---- Writer kernel (col-multicore untilized stick-layout writer; ported in place) ----
+    KernelSpec writer{
+        .unique_id = WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "writer_unary_stick_layout_col_multicore.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER},
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"},
+            },
+        .compile_time_args =
+            {
+                {"total_num_rows", total_num_rows},
+                {"ncores", ncores},
+                {"third_dim", third_dim},
+                {"tile_width", TILE_WIDTH},
+                {"unpadded_X_size", unpadded_row_size_bytes},
+            },
+        .runtime_arg_schema =
+            {.runtime_arg_names = {"core_number", "size_per_row_per_block", "blocks_per_core", "width_size"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
+
+    // ---- Compute kernel (forked m2 copy of the shared untilize_w compute) ----
+    auto make_compute = [&](const KernelSpecName& unique_id, uint32_t nblocks) {
+        ComputeHardwareConfig compute_hw_config{.fp32_dest_acc_en = fp32_dest_acc_en};
+        if (fp32_dest_acc_en) {
+            compute_hw_config.unpack_to_dest_mode.insert({IN, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
+        }
+        return KernelSpec{
+            .unique_id = unique_id,
+            .source =
+                "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/"
+                "untilize_w_m2.cpp",
+            .dfb_bindings =
+                {
+                    DFBBinding{.dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
+                    DFBBinding{
+                        .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER},
+                },
+            .compile_time_args =
+                {
+                    {"per_core_block_cnt", nblocks},
+                    {"per_core_block_tile_cnt", num_tiles_per_col},
+                    {"third_dim", third_dim},
+                },
+            .hw_config = std::move(compute_hw_config),
+        };
+    };
+
+    // ---- Per-core runtime args ----
     const auto& cores = corerange_to_cores(available_grid);
-    reader_desc.runtime_args.reserve(ncores);
-    writer_desc.runtime_args.reserve(ncores);
+
+    KernelRunArgs reader_run_args{.kernel = READER};
+    KernelRunArgs writer_run_args{.kernel = WRITER};
+    reader_run_args.runtime_arg_values.reserve(ncores);
+    writer_run_args.runtime_arg_values.reserve(ncores);
+
     uint32_t number_blocks_per_core;
     for (uint32_t i = 0; i < ncores; ++i) {
         const auto& core = cores[i];
@@ -163,27 +200,63 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreColInterleavedProg
         uint32_t size_per_row_per_block = nblocks_per_core * TILE_WIDTH * el_size;
 
         //  writer runtime args
-        writer_desc.runtime_args.emplace_back(
-            core,
-            std::vector<uint32_t>{
-                dst_buffer->address(),
-                i,
-                size_per_row_per_block,
-                number_blocks_per_core,
-                TILE_WIDTH * el_size,
-            });
+        writer_run_args.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = core,
+            .args = {
+                {"core_number", i},
+                {"size_per_row_per_block", size_per_row_per_block},
+                {"blocks_per_core", number_blocks_per_core},
+                {"width_size", TILE_WIDTH * el_size},
+            }});
 
         // reader runtime args
-        reader_desc.runtime_args.emplace_back(
-            core, std::vector<uint32_t>{src0_buffer->address(), i, num_tiles_per_row, number_blocks_per_core});
+        reader_run_args.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = core,
+            .args = {
+                {"core_number", i},
+                {"tiles_per_row", num_tiles_per_row},
+                {"num_blocks", number_blocks_per_core},
+            }});
     }
 
-    // Insert reader+writer at the start so kernel ordering matches the legacy program: reader is
-    // descriptor 0, writer is descriptor 1, compute kernels follow.
-    desc.kernels.insert(desc.kernels.begin(), std::move(writer_desc));
-    desc.kernels.insert(desc.kernels.begin(), std::move(reader_desc));
+    // ---- Work units ----
+    // Local DFBs (IN, OUT) require their producer/consumer KernelSpecs to share the SAME
+    // WorkUnitSpec(s). Reader/writer run on all_cores (so they are members of both groups' WUs);
+    // the compute differs per work-split group only in its per_core_block_cnt CTA (preserving
+    // compile-time loop unrolling — no CTA→RTA demotion).
+    Group<KernelSpec> kernels;
+    std::vector<WorkUnitSpec> work_units;
+    kernels.push_back(std::move(reader));
+    kernels.push_back(std::move(writer));
+    if (!core_range.empty()) {
+        kernels.push_back(make_compute(COMPUTE_FULL, nblocks_per_core));
+        work_units.push_back(
+            WorkUnitSpec{.name = "uwu_full", .kernels = {READER, WRITER, COMPUTE_FULL}, .target_nodes = core_range});
+    }
+    if (has_cliff) {
+        kernels.push_back(make_compute(COMPUTE_CLIFF, nblocks_per_core_cliff));
+        work_units.push_back(WorkUnitSpec{
+            .name = "uwu_cliff", .kernels = {READER, WRITER, COMPUTE_CLIFF}, .target_nodes = core_range_cliff});
+    }
 
-    return desc;
+    ProgramSpec spec{
+        .name = "untilize_with_unpadding_multi_core_col_interleaved",
+        .kernels = std::move(kernels),
+        .dataflow_buffers = {std::move(in_dfb), std::move(out_dfb)},
+        .tensor_parameters = {std::move(src_param), std::move(dst_param)},
+        .work_units = std::move(work_units),
+    };
+
+    ProgramRunArgs run_args{
+        .kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)},
+        .tensor_args =
+            {
+                {SRC, TensorArgument{input.mesh_tensor()}},
+                {DST, TensorArgument{output.mesh_tensor()}},
+            },
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_col_interleaved_program_factory.hpp
@@ -6,12 +6,12 @@
 
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeWithUnpaddingMultiCoreColInterleavedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
@@ -4,28 +4,25 @@
 
 #include "untilize_with_unpadding_multi_core_interleaved_program_factory.hpp"
 
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operation.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory::create_program_spec(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
     const auto& a = input;
     bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
-
-    ProgramDescriptor desc;
 
     tt::DataFormat input_cb_data_format = datatype_to_dataformat_converter(a.dtype());
     uint32_t input_single_tile_size = tt::tile_size(input_cb_data_format);
@@ -61,111 +58,112 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgram
         unpadded_row_size_bytes = output_shape[-1] * a.element_size();
     }
 
-    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_tiles_per_row * input_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src0_cb_index,
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-    });
-    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_tiles_per_row * output_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
+    // ---- Resource names ----
+    const DFBSpecName IN{"in"};
+    const DFBSpecName OUT{"out"};
+    const TensorParamName SRC{"src"};
+    const TensorParamName DST{"dst"};
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+    const KernelSpecName COMPUTE_FULL{"compute_full"};
+    const KernelSpecName COMPUTE_CLIFF{"compute_cliff"};
 
-    Buffer* src0_buffer = a.buffer();
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
+    // ---- Dataflow buffers (legacy CBs c_0 / c_16) ----
+    DataflowBufferSpec in_dfb{
+        .unique_id = IN,
+        .entry_size = input_single_tile_size,
+        .num_entries = num_tiles_per_row,
+        .data_format_metadata = input_cb_data_format,
+    };
+    DataflowBufferSpec out_dfb{
+        .unique_id = OUT,
+        .entry_size = output_single_tile_size,
+        .num_entries = num_tiles_per_row,
+        .data_format_metadata = output_cb_data_format,
+    };
 
-    /** reader
-     */
+    // ---- Tensor parameters ----
+    TensorParameter src_param{.unique_id = SRC, .spec = input.tensor_spec()};
+    TensorParameter dst_param{.unique_id = DST, .spec = output.tensor_spec()};
 
-    std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
+    // ---- Reader kernel (tilized reader; forked m2 copy of the shared eltwise/unary reader) ----
+    KernelSpec reader{
+        .unique_id = READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "reader_unary_interleaved_start_id_m2.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER},
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+    };
 
-    /** writer
-     */
-    std::vector<uint32_t> writer_ct_args = {
-        (input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32 or
-         input_cb_data_format == tt::DataFormat::Int32),
-        unpadded_row_size_bytes};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-        "writer_unary_stick_layout_split_rows_multicore.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
+    // ---- Writer kernel (untilized split-rows writer; ported in place) ----
+    // The per-core block-rep tuples are variable-length, so they are passed as runtime varargs.
+    KernelSpec writer{
+        .unique_id = WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "writer_unary_stick_layout_split_rows_multicore.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER},
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"},
+            },
+        .compile_time_args =
+            {
+                {"float32_dtype",
+                 (std::uint32_t)(input_cb_data_format == tt::DataFormat::Float32 or
+                                 input_cb_data_format == tt::DataFormat::UInt32 or
+                                 input_cb_data_format == tt::DataFormat::Int32)},
+                {"unpadded_X_size", unpadded_row_size_bytes},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"padded_X_size", "start_stick_id", "n_block_reps"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
 
-    /** compute
-     */
-    KernelDescriptor::Defines compute_kernel_defines;
+    // ---- Compute kernel (forked m2 copy of the shared untilize compute) ----
+    KernelSpec::CompilerOptions::Defines compute_kernel_defines;
     if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
         input_cb_data_format == tt::DataFormat::Float32) {
-        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
+        compute_kernel_defines.insert({"DST_ACCUM_MODE", "1"});
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
-        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (fp32_dest_acc_en) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-    }
-    const std::string compute_kernel(
-        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
 
-    // Track compute kernel indices in case both full and cliff exist; we push them after the
-    // dataflow kernels so reader stays at index 0 and writer at index 1.
-    int full_compute_idx = -1;
-    int cliff_compute_idx = -1;
-
-    if (!core_range.empty()) {
-        KernelDescriptor compute_desc;
-        compute_desc.kernel_source = compute_kernel;
-        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_desc.core_ranges = core_range;
-        compute_desc.compile_time_args = {nblocks_per_core, num_tiles_per_row, tt::CBIndex::c_0, tt::CBIndex::c_16};
-        compute_desc.defines = compute_kernel_defines;
-        compute_desc.config = ComputeConfigDescriptor{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = unpack_to_dest_mode,
+    auto make_compute = [&](const KernelSpecName& unique_id, uint32_t nblocks) {
+        ComputeHardwareConfig compute_hw_config{.fp32_dest_acc_en = fp32_dest_acc_en};
+        if (fp32_dest_acc_en) {
+            compute_hw_config.unpack_to_dest_mode.insert({IN, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
+        }
+        return KernelSpec{
+            .unique_id = unique_id,
+            .source =
+                "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/untilize_m2.cpp",
+            .compiler_options = {.defines = compute_kernel_defines},
+            .dfb_bindings =
+                {
+                    DFBBinding{.dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
+                    DFBBinding{
+                        .dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER},
+                },
+            .compile_time_args =
+                {
+                    {"per_core_block_cnt", nblocks},
+                    {"per_core_block_tile_cnt", num_tiles_per_row},
+                },
+            .hw_config = std::move(compute_hw_config),
         };
-        full_compute_idx = 2 + static_cast<int>(desc.kernels.size());  // reader at 0, writer at 1 once pushed
-        (void)full_compute_idx;
-        desc.kernels.push_back(std::move(compute_desc));
-    }
-    if (has_cliff) {
-        KernelDescriptor cliff_desc;
-        cliff_desc.kernel_source = compute_kernel;
-        cliff_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        cliff_desc.core_ranges = core_range_cliff;
-        cliff_desc.compile_time_args = {nblocks_per_core_cliff, num_tiles_per_row, tt::CBIndex::c_0, tt::CBIndex::c_16};
-        cliff_desc.defines = std::move(compute_kernel_defines);
-        cliff_desc.config = ComputeConfigDescriptor{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
-        };
-        cliff_compute_idx = 2 + static_cast<int>(desc.kernels.size());
-        (void)cliff_compute_idx;
-        desc.kernels.push_back(std::move(cliff_desc));
-    }
+    };
 
+    // ---- Per-core runtime args ----
     uint32_t tile_height = output.tensor_spec().tile().get_height();
     auto core_assignments = ttnn::distribute_work(
         output_shape, input_shape, ncores, nblocks_per_core, has_cliff, nblocks_per_core_cliff, tile_height);
@@ -174,18 +172,21 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgram
     uint32_t row_start_id = 0;
 
     const auto& cores = corerange_to_cores(available_grid);
-    reader_desc.runtime_args.reserve(ncores);
-    writer_desc.runtime_args.reserve(ncores);
+
+    KernelRunArgs reader_run_args{.kernel = READER};
+    KernelRunArgs writer_run_args{.kernel = WRITER};
+    reader_run_args.runtime_arg_values.reserve(ncores);
+    writer_run_args.runtime_arg_values.reserve(ncores);
+
+    // Per-core vararg counts (block-rep tuples vary in number per core). Declared via the
+    // per-node vararg override so the framework validates each core's exact vararg length.
     for (uint32_t i = 0; i < ncores; ++i) {
         const auto& core = cores[i];
         const std::vector<BlockRep>& assignment = core_assignments.at(i);
 
-        // writer runtime args
-        KernelDescriptor::RTArgList writer_rt_args;
-        writer_rt_args.push_back(dst_buffer);
-        writer_rt_args.push_back(padded_row_size_bytes);
-        writer_rt_args.push_back(row_start_id);
-        writer_rt_args.push_back(static_cast<uint32_t>(assignment.size()));
+        // writer block-rep varargs (run-length-compressed 5-tuples)
+        AdvancedKernelRunArgs::Varargs writer_varargs;
+        uint32_t row_start_id_core = row_start_id;
 
         uint32_t nblocks_per_core_core = 0;
 
@@ -198,36 +199,81 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgram
                 count_repeated++;
             } else {
                 // push back information for previous elements
-                writer_rt_args.push_back(ref_el.n_data);
-                writer_rt_args.push_back(ref_el.n_mixed);
-                writer_rt_args.push_back(ref_el.n_pads);
-                writer_rt_args.push_back(ref_el.times);
-                writer_rt_args.push_back(count_repeated);
+                writer_varargs.push_back(ref_el.n_data);
+                writer_varargs.push_back(ref_el.n_mixed);
+                writer_varargs.push_back(ref_el.n_pads);
+                writer_varargs.push_back(ref_el.times);
+                writer_varargs.push_back(count_repeated);
                 // Set up assignment for this element
                 ref_el = el;
                 count_repeated = 1;
             }
         }
-        writer_rt_args.push_back(ref_el.n_data);
-        writer_rt_args.push_back(ref_el.n_mixed);
-        writer_rt_args.push_back(ref_el.n_pads);
-        writer_rt_args.push_back(ref_el.times);
-        writer_rt_args.push_back(count_repeated);
+        writer_varargs.push_back(ref_el.n_data);
+        writer_varargs.push_back(ref_el.n_mixed);
+        writer_varargs.push_back(ref_el.n_pads);
+        writer_varargs.push_back(ref_el.times);
+        writer_varargs.push_back(count_repeated);
 
         uint32_t num_tiles_per_core = num_tiles_per_row * nblocks_per_core_core;
 
         // reader runtime args
-        reader_desc.emplace_runtime_args(core, {src0_buffer, num_tiles_per_core, tile_start_id});
-        writer_desc.emplace_runtime_args(core, writer_rt_args);
+        reader_run_args.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = core, .args = {{"num_pages", num_tiles_per_core}, {"start_id", tile_start_id}}});
+
+        // writer runtime args: fixed named RTAs + per-core vararg block-rep tuples
+        writer_run_args.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = core,
+            .args = {
+                {"padded_X_size", padded_row_size_bytes},
+                {"start_stick_id", row_start_id_core},
+                {"n_block_reps", static_cast<uint32_t>(assignment.size())}}});
+        writer.advanced_options.num_runtime_varargs_per_node[Nodes{NodeCoord{core}}] =
+            static_cast<uint32_t>(writer_varargs.size());
+        writer_run_args.advanced_options.runtime_varargs[core] = std::move(writer_varargs);
 
         tile_start_id += num_tiles_per_core;
     }
 
-    // Insert reader+writer at the beginning so they occupy descriptor positions 0 and 1.
-    desc.kernels.insert(desc.kernels.begin(), std::move(writer_desc));
-    desc.kernels.insert(desc.kernels.begin(), std::move(reader_desc));
+    // ---- Work units ----
+    // Local DFBs (IN, OUT) require their producer/consumer KernelSpecs to share the SAME
+    // WorkUnitSpec(s). Reader/writer run on all_cores (so they are members of both groups' WUs);
+    // the compute differs per work-split group only in its per_core_block_cnt CTA (preserving
+    // compile-time loop unrolling — no CTA→RTA demotion). Assembled after the RTA loop so the
+    // writer's per-node vararg-count schema (populated above) is included when it is moved in.
+    Group<KernelSpec> kernels;
+    std::vector<WorkUnitSpec> work_units;
+    kernels.push_back(std::move(reader));
+    kernels.push_back(std::move(writer));
+    if (!core_range.empty()) {
+        kernels.push_back(make_compute(COMPUTE_FULL, nblocks_per_core));
+        work_units.push_back(
+            WorkUnitSpec{.name = "uwu_full", .kernels = {READER, WRITER, COMPUTE_FULL}, .target_nodes = core_range});
+    }
+    if (has_cliff) {
+        kernels.push_back(make_compute(COMPUTE_CLIFF, nblocks_per_core_cliff));
+        work_units.push_back(WorkUnitSpec{
+            .name = "uwu_cliff", .kernels = {READER, WRITER, COMPUTE_CLIFF}, .target_nodes = core_range_cliff});
+    }
 
-    return desc;
+    ProgramSpec spec{
+        .name = "untilize_with_unpadding_multi_core_interleaved",
+        .kernels = std::move(kernels),
+        .dataflow_buffers = {std::move(in_dfb), std::move(out_dfb)},
+        .tensor_parameters = {std::move(src_param), std::move(dst_param)},
+        .work_units = std::move(work_units),
+    };
+
+    ProgramRunArgs run_args{
+        .kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)},
+        .tensor_args =
+            {
+                {SRC, TensorArgument{input.mesh_tensor()}},
+                {DST, TensorArgument{output.mesh_tensor()}},
+            },
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.hpp
@@ -6,12 +6,12 @@
 
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.cpp
@@ -2,31 +2,28 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include "ttnn/operation.hpp"
-#include "ttnn/operations/cb_utils.hpp"
+#include "untilize_with_unpadding_multi_core_nd_sharded_program_factory.hpp"
+
 #include "ttnn/operations/math.hpp"
-#include "ttnn/common/constants.hpp"
 #include "ttnn/operations/ccl/sharding_addrgen_helper.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/buffer_distribution_spec.hpp>
-#include "untilize_with_unpadding_multi_core_nd_sharded_program_factory.hpp"
-#include "ttnn/operations/data_movement/untilize/device/untilize_device_operation.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+#include "ttnn/common/constants.hpp"
+#include "ttnn/operation.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory::create_program_spec(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
-    ProgramDescriptor desc;
-
     // const auto& a = input;
     const auto& fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
     tt::DataFormat input_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(input.dtype());
@@ -34,7 +31,6 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    tt::tt_metal::Buffer* src0_buffer = input.buffer();
     tt::tt_metal::Buffer* dst_buffer = output.buffer();
     TT_FATAL(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
@@ -86,16 +82,6 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
         // Double buffer if the core is processing 2+ blocks
         input_cb_num_tiles = num_tiles_per_input_block * 2;
     }
-    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = input_cb_num_tiles * input_single_tile_size,
-        .core_ranges = compute_core_range,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src0_cb_index,
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-    });
 
     // Output CB
     uint32_t output_cb_num_tiles;
@@ -106,34 +92,8 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
         // Double buffer if the core is processing 2+ blocks
         output_cb_num_tiles = num_tiles_per_input_block * 2;
     }
-    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = output_cb_num_tiles * output_single_tile_size,
-        .core_ranges = compute_core_range,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
 
-    // Reader compile-time args and kernel (sharded input)
-    std::vector<uint32_t> reader_compile_time_args = {
-        (uint32_t)src0_cb_index,
-        (uint32_t)num_tiles_per_input_block,
-        (uint32_t)num_shards,
-        (uint32_t)num_compute_cores};
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_nd_sharded_blocks.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = compute_core_range;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    // Writer compile-time args
+    // Writer scalar arithmetic (output stick layout)
     uint32_t output_element_size = output.element_size();
     uint32_t output_page_width =
         output_tensor_width;  // In height-sharded and interleaved cases, the output page is the entire tensor row
@@ -152,85 +112,144 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
     uint32_t num_cols_per_input_block = num_tiles_per_input_block * tile_width;
     uint32_t num_cols_per_output_block = output_page_width;
     uint32_t output_stick_size = num_cols_per_output_block * output_element_size;
-    std::vector<uint32_t> writer_compile_time_args = {
-        (uint32_t)output_cb_index,
-        (uint32_t)output_stick_size,
-        (uint32_t)tile_height,
-        (uint32_t)num_tiles_per_input_block,
-        (uint32_t)output_num_blocks_across_width,
-        (uint32_t)output_element_size,
-        (uint32_t)num_cols_per_input_block,
-        (uint32_t)num_cols_per_output_block,
-        (uint32_t)input_single_tile_size,
-        (uint32_t)num_shards,
-        (uint32_t)num_compute_cores,
-        (uint32_t)num_tiles_per_input_row,
-        (uint32_t)num_tiles_per_output_row,
-        (uint32_t)tile_width,
-        (uint32_t)output_tensor_width,
-        (uint32_t)output_tensor_height,
-        (uint32_t)input.padded_shape().rank()
 
+    uint32_t tensor_rank = input.padded_shape().rank();
+
+    // ---- Resource names ----
+    const DFBSpecName IN{"in"};
+    const DFBSpecName OUT{"out"};
+    const TensorParamName SRC{"src"};
+    const TensorParamName DST{"dst"};
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+    const KernelSpecName COMPUTE{"compute"};
+
+    // ---- Dataflow buffers (legacy CBs c_0 / c_16) ----
+    DataflowBufferSpec in_dfb{
+        .unique_id = IN,
+        .entry_size = input_single_tile_size,
+        .num_entries = input_cb_num_tiles,
+        .data_format_metadata = input_cb_data_format,
     };
-    std::vector<uint32_t>
-        writer_common_runtime_args;  // Due to tensor squeezing from ND to 4D when the input tensor has rank > 4,
-                                     // writer_common_runtime_args will have at most 8 entries.
-    for (const auto dim : output.padded_shape()) {
-        writer_common_runtime_args.push_back(dim);
-    }
-    for (const auto dim : input.padded_shape()) {
-        writer_common_runtime_args.push_back(dim);
-    }
+    DataflowBufferSpec out_dfb{
+        .unique_id = OUT,
+        .entry_size = output_single_tile_size,
+        .num_entries = output_cb_num_tiles,
+        .data_format_metadata = output_cb_data_format,
+    };
 
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
+    // ---- Tensor parameters ----
+    TensorParameter src_param{.unique_id = SRC, .spec = input.tensor_spec()};
+    TensorParameter dst_param{.unique_id = DST, .spec = output.tensor_spec()};
 
-    TensorAccessorArgs(*src0_buffer)
-        .append_to(writer_compile_time_args);  // For ND sharded input, we need info on the input buffer distribution
+    // ---- Reader kernel (sharded input; forked m2 copy of the shared ND-sharded reader) ----
+    KernelSpec reader{
+        .unique_id = READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "reader_unary_nd_sharded_blocks_m2.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER},
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"},
+            },
+        .compile_time_args =
+            {
+                {"num_tiles_per_input_block", num_tiles_per_input_block},
+                {"num_shards", num_shards},
+                {"num_cores", num_compute_cores},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"start_shard_id"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+    };
 
-    // Writer kernel
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-        "writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = compute_core_range;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-    writer_desc.common_runtime_args = std::move(writer_common_runtime_args);
+    // ---- Writer kernel (ND-sharded split-rows writer; ported in place) ----
+    // The writer binds TWO TensorParameters: DST (the output buffer it writes to) AND SRC (the
+    // input buffer's distribution info — for ND sharded input we need its shard mapping). The
+    // legacy factory appended TensorAccessorArgs for dst THEN src; that order is preserved here
+    // (and in the kernel's TensorAccessor construction order) so the auto-injected CTA layout
+    // matches: accessor_dst is constructed first, accessor_src second.
+    //
+    // The output/input padded-shape dim lists are passed as COMMON runtime varargs: their count
+    // is 2 * tensor_rank (rank-dependent after ND->4D squeezing), and the kernel reads them in a
+    // runtime loop via get_common_vararg(i), so varargs is the honest mapping.
+    KernelSpec writer{
+        .unique_id = WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER},
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"},
+                TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"},
+            },
+        .compile_time_args =
+            {
+                {"output_stick_size", output_stick_size},
+                {"tile_height", tile_height},
+                {"num_tiles_per_input_block", num_tiles_per_input_block},
+                {"num_output_blocks_across_width", output_num_blocks_across_width},
+                {"output_element_size", output_element_size},
+                {"num_cols_per_input_block", num_cols_per_input_block},
+                {"num_cols_per_output_block", num_cols_per_output_block},
+                {"input_single_tile_size", input_single_tile_size},
+                {"num_shards", num_shards},
+                {"num_cores", num_compute_cores},
+                {"num_tiles_per_input_row", num_tiles_per_input_row},
+                {"num_tiles_per_output_row", num_tiles_per_output_row},
+                {"tile_width", tile_width},
+                {"output_tensor_width", output_tensor_width},
+                {"output_tensor_height", output_tensor_height},
+                {"tensor_rank", tensor_rank},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"start_shard_id"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
+    // Due to tensor squeezing from ND to 4D when the input tensor has rank > 4, the common
+    // runtime varargs (output padded-shape dims followed by input padded-shape dims) have at
+    // most 8 + 8 = 16 entries. Both shapes have the same rank.
+    writer.advanced_options.num_common_runtime_varargs = 2 * tensor_rank;
 
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
-        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (fp32_dest_acc_en) {
-        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-    }
-
-    // Compute kernel file
-    const std::string compute_kernel(
-        "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp");
-
-    // Compute compile-time args and kernel
+    // ---- Compute kernel (forked m2 copy of the shared variable-num-blocks untilize compute) ----
     // Note: This condition is always true for sharded input
-    KernelDescriptor::Defines compute_kernel_defines;
+    KernelSpec::CompilerOptions::Defines compute_kernel_defines;
     if (input.dtype() == DataType::INT32 || input.dtype() == DataType::UINT32 || input.dtype() == DataType::FLOAT32) {
-        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
-    }
-    KernelDescriptor compute_desc;
-    bool has_compute = !compute_core_range.ranges().empty();
-    if (has_compute) {
-        std::vector<uint32_t> compute_compile_time_args = {
-            (uint32_t)num_tiles_per_input_block, (uint32_t)src0_cb_index, (uint32_t)output_cb_index};
-        compute_desc.kernel_source = compute_kernel;
-        compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_desc.core_ranges = compute_core_range;
-        compute_desc.compile_time_args = std::move(compute_compile_time_args);
-        compute_desc.defines = std::move(compute_kernel_defines);
-        compute_desc.config = ComputeConfigDescriptor{
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
-        };
+        compute_kernel_defines.insert({"DST_ACCUM_MODE", "1"});
     }
 
-    // Run-time args
+    ComputeHardwareConfig compute_hw_config{.fp32_dest_acc_en = fp32_dest_acc_en};
+    if (fp32_dest_acc_en) {
+        compute_hw_config.unpack_to_dest_mode.insert({IN, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
+    }
+
+    bool has_compute = !compute_core_range.ranges().empty();
+    KernelSpec compute{
+        .unique_id = COMPUTE,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/"
+            "untilize_variable_num_blocks_m2.cpp",
+        .compiler_options = {.defines = std::move(compute_kernel_defines)},
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
+                DFBBinding{.dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER},
+            },
+        .compile_time_args =
+            {
+                {"per_core_block_tile_cnt", num_tiles_per_input_block},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"num_input_blocks_to_process"}},
+        .hw_config = std::move(compute_hw_config),
+    };
+
+    // ---- Run-time args ----
     // Logic for ND sharding makes as few assumptions about page locations as possible. Padded pages will be handled
     // in the writer kernel.
     const auto& mapped_cores = page_mapping.all_cores;
@@ -239,11 +258,16 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
     // page_mapping.core_host_page_indices[core_id] contains host page indices for all device pages on that core,
     // with UncompressedBufferPageMapping::PADDING indicating padding pages
     uint32_t start_shard_id = 0;
-    reader_desc.runtime_args.reserve(ordered_cores_with_data.size());
-    writer_desc.runtime_args.reserve(ordered_cores_with_data.size());
+
+    KernelRunArgs reader_run_args{.kernel = READER};
+    KernelRunArgs writer_run_args{.kernel = WRITER};
+    KernelRunArgs compute_run_args{.kernel = COMPUTE};
+    reader_run_args.runtime_arg_values.reserve(ordered_cores_with_data.size());
+    writer_run_args.runtime_arg_values.reserve(ordered_cores_with_data.size());
     if (has_compute) {
-        compute_desc.runtime_args.reserve(ordered_cores_with_data.size());
+        compute_run_args.runtime_arg_values.reserve(ordered_cores_with_data.size());
     }
+
     for (auto core : ordered_cores_with_data) {
         auto core_it = std::find(mapped_cores.begin(), mapped_cores.end(), core);
         uint32_t num_input_blocks_to_process = 0;
@@ -269,24 +293,75 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreNDShardedProgramFa
             }
         }
         // Reader run-time args
-        reader_desc.emplace_runtime_args(core, {src0_buffer, start_shard_id});
+        reader_run_args.runtime_arg_values.push_back(
+            KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"start_shard_id", start_shard_id}}});
 
         // Writer run-time args
-        writer_desc.emplace_runtime_args(core, {dst_buffer, src0_buffer, start_shard_id});
+        writer_run_args.runtime_arg_values.push_back(
+            KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"start_shard_id", start_shard_id}}});
         start_shard_id++;
 
         // Compute run-time args
         if (has_compute) {
-            compute_desc.emplace_runtime_args(core, {num_input_blocks_to_process});
+            compute_run_args.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+                .node = core, .args = {{"num_input_blocks_to_process", num_input_blocks_to_process}}});
         }
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    // Writer common runtime varargs (broadcast to all nodes): output padded-shape dims, then
+    // input padded-shape dims.
+    AdvancedKernelRunArgs::Varargs writer_common_varargs;
+    writer_common_varargs.reserve(2 * tensor_rank);
+    for (const auto dim : output.padded_shape()) {
+        writer_common_varargs.push_back(dim);
+    }
+    for (const auto dim : input.padded_shape()) {
+        writer_common_varargs.push_back(dim);
+    }
+    writer_run_args.advanced_options.common_runtime_varargs = std::move(writer_common_varargs);
+
+    // ---- Work unit (all data cores, reader + writer + (compute if present)) ----
+    // Local DFBs (IN, OUT) require their producer/consumer KernelSpecs to share the SAME
+    // WorkUnitSpec. In the ND-sharded path compute_core_range is exactly the set of cores with
+    // data, and the legacy guards the compute kernel on that same (non-empty) range, so the
+    // producer (reader->IN, compute->OUT) / consumer (compute<-IN, writer<-OUT) chain is intact.
+    Group<KernelSpec> kernels;
+    kernels.push_back(std::move(reader));
+    kernels.push_back(std::move(writer));
+    Group<KernelSpecName> wu_kernels = {READER, WRITER};
     if (has_compute) {
-        desc.kernels.push_back(std::move(compute_desc));
+        kernels.push_back(std::move(compute));
+        wu_kernels.push_back(COMPUTE);
     }
 
-    return desc;
+    WorkUnitSpec work_unit{
+        .name = "uwu_nd_sharded", .kernels = std::move(wu_kernels), .target_nodes = compute_core_range};
+
+    ProgramSpec spec{
+        .name = "untilize_with_unpadding_multi_core_nd_sharded",
+        .kernels = std::move(kernels),
+        .dataflow_buffers = {std::move(in_dfb), std::move(out_dfb)},
+        .tensor_parameters = {std::move(src_param), std::move(dst_param)},
+        .work_units = {std::move(work_unit)},
+    };
+
+    Group<KernelRunArgs> kernel_run_args;
+    kernel_run_args.push_back(std::move(reader_run_args));
+    kernel_run_args.push_back(std::move(writer_run_args));
+    if (has_compute) {
+        kernel_run_args.push_back(std::move(compute_run_args));
+    }
+
+    ProgramRunArgs run_args{
+        .kernel_run_args = std::move(kernel_run_args),
+        .tensor_args =
+            {
+                {SRC, TensorArgument{input.mesh_tensor()}},
+                {DST, TensorArgument{output.mesh_tensor()}},
+            },
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
+
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_nd_sharded_program_factory.hpp
@@ -6,12 +6,12 @@
 
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.cpp
@@ -6,28 +6,25 @@
 
 #include <cmath>
 
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operation.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingMultiCoreShardedProgramFactory::create_program_spec(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
     const auto& a = input;
     bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
-
-    ProgramDescriptor desc;
 
     bool src_sharded = a.memory_config().is_sharded();
     bool out_sharded = output.memory_config().is_sharded();
@@ -40,8 +37,10 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
     tt::DataFormat output_cb_data_format = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
     uint32_t output_single_tile_size = tt::tile_size(output_cb_data_format);
 
-    uint32_t num_rows_block = 0, block_row_size = 0, output_row_size = 0, last_block_row_size_unpadded = 0,
-             num_output_rows_unpadded = 0;
+    uint32_t num_rows_block = 0, block_row_size = 0, last_block_row_size_unpadded = 0, num_output_rows_unpadded = 0;
+    // output_row_size is only consumed by the (now-dropped) legacy config-C writer CTA; the Metal 2.0
+    // writer never reads it, so split it out of the multi-var decl and mark it unused to keep -Werror happy.
+    [[maybe_unused]] uint32_t output_row_size = 0;
     CoreCoord end_core;
     uint32_t last_idx = 0;
     auto shard_spec = a.shard_spec().value();
@@ -82,159 +81,226 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
         std::swap(end_core.x, end_core.y);
     }
 
-    constexpr uint8_t src0_cb_index = tt::CBIndex::c_0;
     uint32_t num_input_tiles = ntiles_per_block * nblocks_per_core;
-    // Input CB: sharded → bind .buffer to the input buffer; framework re-applies
-    // UpdateDynamicCircularBufferAddress on cache hit.
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * input_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src0_cb_index,
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-        .buffer = src_sharded ? a.buffer() : nullptr,
-    });
-
     uint32_t num_output_tiles = out_sharded ? (unpad_tensor_w_16 ? 16 : ntiles_per_batch * 2) : ntiles_per_block * 2;
     uint32_t aligned_page_size = static_cast<uint32_t>(output.buffer()->aligned_page_size());
-    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_output_tiles * output_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
 
-    constexpr uint8_t sharded_output_cb_index = tt::CBIndex::c_17;
-    if (out_sharded) {
-        // The kernel advances the write pointer by aligned_page_size (which may be
-        // larger than block_row_size due to buffer alignment padding), so the CB
-        // page size must match to avoid overflow.
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = num_output_rows_unpadded * aligned_page_size,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = sharded_output_cb_index,
-                .data_format = output_cb_data_format,
-                .page_size = aligned_page_size,
-            }}},
-            .buffer = output.buffer(),
-        });
-    }
+    // ---- Resource names ----
+    const DFBSpecName IN{"in"};
+    const DFBSpecName OUT{"out"};
+    const DFBSpecName SHARDED_OUT{"sharded_out"};
+    const TensorParamName SRC{"src"};
+    const TensorParamName DST{"dst"};
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+    const KernelSpecName COMPUTE{"compute"};
 
-    Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
-
-    /** reader
-     */
-    std::vector<uint32_t> reader_ct_args;
-    reader_ct_args.push_back(src0_cb_index);
-
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = std::move(reader_ct_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    /** writer
-     */
-    KernelDescriptor writer_desc;
-    if (out_sharded) {
-        std::vector<uint32_t> writer_ct_args{output_cb_index, sharded_output_cb_index, aligned_page_size};
-        writer_desc.kernel_source =
-            unpad_tensor_w_16
-                ? "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-                  "writer_unary_unpad_width_16_sharded.cpp"
-                : "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-                  "writer_unary_unpad_batch_rows_sharded.cpp";
-        writer_desc.compile_time_args = std::move(writer_ct_args);
-    } else {
-        std::vector<uint32_t> writer_ct_args = {
-            (input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32 or
-             input_cb_data_format == tt::DataFormat::Int32),
-            output_row_size};
-        TensorAccessorArgs(*dst_buffer).append_to(writer_ct_args);
-        writer_desc.kernel_source = "ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp";
-        writer_desc.compile_time_args = std::move(writer_ct_args);
-    }
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.config = WriterConfigDescriptor{};
-
-    /** compute
-     */
-    std::vector<uint32_t> compute_args = {
-        (uint32_t)nblocks_per_core,  // per_core_block_cnt
-        (uint32_t)ntiles_per_block,  // per_block_ntiles
-        (uint32_t)src0_cb_index,
-        (uint32_t)output_cb_index,
+    // ---- Dataflow buffers ----
+    // IN (legacy CB c_0): sharded input lives in L1, so borrow the input buffer iff src_sharded
+    // (the reader merely publishes the resident tiles via push_back — there is no NOC read). The
+    // borrowed backing L1 address resolves at runtime from the SRC TensorArgument.
+    DataflowBufferSpec in_dfb{
+        .unique_id = IN,
+        .entry_size = input_single_tile_size,
+        .num_entries = num_input_tiles,
+        .data_format_metadata = input_cb_data_format,
+        .borrowed_from = src_sharded ? std::optional<TensorParamName>{SRC} : std::nullopt,
+    };
+    // OUT (legacy CB c_16): plain compute-output DFB (produced by compute, consumed by writer).
+    DataflowBufferSpec out_dfb{
+        .unique_id = OUT,
+        .entry_size = output_single_tile_size,
+        .num_entries = num_output_tiles,
+        .data_format_metadata = output_cb_data_format,
+    };
+    // SHARDED_OUT (legacy CB c_17): present only when out_sharded. Borrowed onto the output buffer's
+    // L1 — the writer advances the write pointer by aligned_page_size (which may exceed block_row_size
+    // due to buffer alignment padding), so the DFB page size must match to avoid overflow. The backing
+    // L1 address resolves at runtime from the DST TensorArgument.
+    DataflowBufferSpec sharded_out_dfb{
+        .unique_id = SHARDED_OUT,
+        .entry_size = aligned_page_size,
+        .num_entries = num_output_rows_unpadded,
+        .data_format_metadata = output_cb_data_format,
+        .borrowed_from = DST,
     };
 
-    KernelDescriptor::Defines compute_kernel_defines;
+    // ---- Tensor parameters ----
+    TensorParameter src_param{.unique_id = SRC, .spec = input.tensor_spec()};
+    TensorParameter dst_param{.unique_id = DST, .spec = output.tensor_spec()};
+
+    // ---- Reader kernel (sharded input; forked m2 copy of the shared eltwise/unary reader) ----
+    // The sharded input lives in L1, so the reader just advances the IN write pointer (push_back) to
+    // publish the resident tiles to the compute consumer — IN PRODUCER / compute IN CONSUMER is a real pair.
+    KernelSpec reader{
+        .unique_id = READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "reader_unary_sharded_m2.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"num_tiles_per_core"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+    };
+
+    // ---- Writer kernel (one of three sources, selected at host time) ----
+    // Config A: out_sharded && !unpad_tensor_w_16 -> batch-rows sharded writer (untilize compute output)
+    // Config B: out_sharded &&  unpad_tensor_w_16 -> width-16 sharded writer (copy compute output)
+    // Config C: !out_sharded                      -> interleaved stick-layout writer (writes to interleaved DST)
+    KernelSpec writer{
+        .unique_id = WRITER,
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
+    if (out_sharded) {
+        // OUT consumed here; SHARDED_OUT is a one-ended fake CB (the writer is the only kernel touching
+        // it — reserve_back / get_write_ptr / push_back). It IS the sharded output buffer in L1; nothing
+        // produces or consumes it as a FIFO. To satisfy the DFB ">=1 PRODUCER and >=1 CONSUMER" validator
+        // rule, bind it as a SELF-LOOP on the writer (PRODUCER + CONSUMER, shared accessor_name). This is
+        // an INTERIM validator-satisfying device, NOT a real FIFO; to be replaced by the forthcoming
+        // "local" TensorAccessor variant.
+        writer.dfb_bindings = {
+            DFBBinding{.dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER},
+            DFBBinding{
+                .dfb_spec_name = SHARDED_OUT,
+                .accessor_name = "sharded_out",
+                .endpoint_type = DFBEndpointType::PRODUCER},
+            DFBBinding{
+                .dfb_spec_name = SHARDED_OUT,
+                .accessor_name = "sharded_out",
+                .endpoint_type = DFBEndpointType::CONSUMER},
+        };
+        if (unpad_tensor_w_16) {
+            // Config B: width-16 writer. No CTA (it reads get_tile_size(dfb::sharded_out)).
+            writer.source =
+                "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+                "writer_unary_unpad_width_16_sharded.cpp";
+            writer.runtime_arg_schema = {
+                .runtime_arg_names = {"num_unpadded_output_rows", "num_padded_tiles_per_core"}};
+        } else {
+            // Config A: batch-rows writer.
+            writer.source =
+                "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+                "writer_unary_unpad_batch_rows_sharded.cpp";
+            writer.compile_time_args = {
+                {"aligned_page_size", aligned_page_size},
+            };
+            writer.runtime_arg_schema = {
+                .runtime_arg_names = {
+                    "num_unpadded_output_rows",
+                    "num_padded_tiles_per_batch",
+                    "num_unpadded_rows_per_batch",
+                    "padded_block_row_size_bytes",
+                    "unpadded_block_row_size_bytes",
+                    "batch"}};
+        }
+    } else {
+        // Config C: interleaved stick-layout writer. dst addr -> ta::dst (the dst_addr RTA disappears).
+        writer.source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "writer_unary_stick_layout_interleaved_blocks_m2.cpp";
+        writer.dfb_bindings = {
+            DFBBinding{.dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER},
+        };
+        writer.tensor_bindings = {
+            TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"},
+        };
+        writer.compile_time_args = {
+            {"float32_dtype",
+             (std::uint32_t)(input_cb_data_format == tt::DataFormat::Float32 or
+                             input_cb_data_format == tt::DataFormat::UInt32 or
+                             input_cb_data_format == tt::DataFormat::Int32)},
+        };
+        writer.runtime_arg_schema = {
+            .runtime_arg_names = {
+                "num_rows_block",
+                "block_row_size",
+                "batch",
+                "num_blocks_h",
+                "num_blocks_w",
+                "last_block_row_size_unpadded",
+                "num_output_rows_unpadded",
+                "block_start_row_id",
+                "block_start_row_offset"}};
+    }
+
+    // ---- Compute kernel (untilize, or eltwise_copy for the unpad-width-16 path) ----
+    KernelSpec::CompilerOptions::Defines compute_kernel_defines;
     if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
         input_cb_data_format == tt::DataFormat::Float32) {
-        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
+        compute_kernel_defines.insert({"DST_ACCUM_MODE", "1"});
     }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
-        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    ComputeHardwareConfig compute_hw_config{.fp32_dest_acc_en = fp32_dest_acc_en};
     if (fp32_dest_acc_en) {
-        unpack_to_dest_mode[tt::CBIndex::c_0] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+        compute_hw_config.unpack_to_dest_mode.insert({IN, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
     }
-    std::string compute_kernel("ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp");
+
+    KernelSpec compute{
+        .unique_id = COMPUTE,
+        .compiler_options = {.defines = std::move(compute_kernel_defines)},
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
+                DFBBinding{.dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER},
+            },
+        .hw_config = std::move(compute_hw_config),
+    };
     if (unpad_tensor_w_16) {
         // Use copy compute kernel just for a potential data type conversion.
-        compute_kernel = "ttnn/cpp/ttnn/kernel/compute/eltwise_copy.cpp";
-        compute_args[0] = (uint32_t)num_input_tiles;  // per_core_tile_cnt
+        compute.source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/eltwise_copy_m2.cpp";
+        compute.compile_time_args = {
+            {"per_core_tile_cnt", num_input_tiles},
+        };
+    } else {
+        compute.source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/untilize_m2.cpp";
+        compute.compile_time_args = {
+            {"per_core_block_cnt", nblocks_per_core},
+            {"per_core_block_tile_cnt", ntiles_per_block},
+        };
     }
 
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source = compute_kernel;
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = std::move(compute_args);
-    compute_desc.defines = std::move(compute_kernel_defines);
-    compute_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
-    };
-
     // Runtime args: legacy code uses SetRuntimeArgs(program, kernel, all_cores, args) which broadcasts
-    // the same args to every core. The descriptor API needs per-core entries; enumerate cores and
-    // emit one runtime_args entry per core.
+    // the same args to every core. Enumerate cores and emit one per-node entry per core (the !out_sharded
+    // writer args genuinely vary per core).
     const std::vector<CoreCoord> all_core_coords = corerange_to_cores(all_cores, std::nullopt, row_major);
 
-    const std::vector<uint32_t> reader_rt_args = {ntiles_per_block * nblocks_per_core};
-    reader_desc.runtime_args.reserve(all_core_coords.size());
+    KernelRunArgs reader_run_args{.kernel = READER};
+    KernelRunArgs writer_run_args{.kernel = WRITER};
+    reader_run_args.runtime_arg_values.reserve(all_core_coords.size());
+    writer_run_args.runtime_arg_values.reserve(all_core_coords.size());
+
+    const uint32_t reader_num_tiles_per_core = ntiles_per_block * nblocks_per_core;
     for (const auto& core : all_core_coords) {
-        reader_desc.runtime_args.emplace_back(core, reader_rt_args);
+        reader_run_args.runtime_arg_values.push_back(
+            KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"num_tiles_per_core", reader_num_tiles_per_core}}});
     }
 
     if (out_sharded) {
-        std::vector<uint32_t> writer_rt_args;
-        if (unpad_tensor_w_16) {
-            writer_rt_args = {num_output_rows_unpadded, num_input_tiles};
-        } else {
-            writer_rt_args = {
-                num_output_rows_unpadded,
-                ntiles_per_batch,
-                out_shard_spec.shape[0] / batch,
-                shard_spec.shape[1] * output.element_size(),
-                block_row_size,
-                batch};
-        }
-        writer_desc.runtime_args.reserve(all_core_coords.size());
+        writer_run_args.runtime_arg_values.reserve(all_core_coords.size());
         for (const auto& core : all_core_coords) {
-            writer_desc.runtime_args.emplace_back(core, writer_rt_args);
+            if (unpad_tensor_w_16) {
+                writer_run_args.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+                    .node = core,
+                    .args = {
+                        {"num_unpadded_output_rows", num_output_rows_unpadded},
+                        {"num_padded_tiles_per_core", num_input_tiles}}});
+            } else {
+                writer_run_args.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+                    .node = core,
+                    .args = {
+                        {"num_unpadded_output_rows", num_output_rows_unpadded},
+                        {"num_padded_tiles_per_batch", ntiles_per_batch},
+                        {"num_unpadded_rows_per_batch", out_shard_spec.shape[0] / batch},
+                        {"padded_block_row_size_bytes", shard_spec.shape[1] * output.element_size()},
+                        {"unpadded_block_row_size_bytes", block_row_size},
+                        {"batch", batch}}});
+            }
         }
     } else {
-        writer_desc.runtime_args.reserve(all_core_coords.size());
+        writer_run_args.runtime_arg_values.reserve(all_core_coords.size());
         for (uint32_t i = 0; i < all_core_coords.size(); ++i) {
             CoreCoord core = all_core_coords[i];
 
@@ -293,26 +359,53 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreShardedProgramFact
                 }
             }
 
-            writer_desc.emplace_runtime_args(
-                core,
-                {dst_buffer,  // dst_addr
-                 num_rows_block,
-                 block_row_size,
-                 std::uint32_t{1},
-                 std::uint32_t{1},
-                 std::uint32_t{1},
-                 row_size_unpadded,
-                 num_rows_unpadded,
-                 block_start_row_id_offset,
-                 block_start_row_offset});
+            // The three constant-1 RTAs (legacy slots 3/4/5) map to batch / num_blocks_h / num_blocks_w.
+            writer_run_args.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+                .node = core,
+                .args = {
+                    {"num_rows_block", num_rows_block},
+                    {"block_row_size", block_row_size},
+                    {"batch", std::uint32_t{1}},
+                    {"num_blocks_h", std::uint32_t{1}},
+                    {"num_blocks_w", std::uint32_t{1}},
+                    {"last_block_row_size_unpadded", row_size_unpadded},
+                    {"num_output_rows_unpadded", num_rows_unpadded},
+                    {"block_start_row_id", block_start_row_id_offset},
+                    {"block_start_row_offset", block_start_row_offset}}});
         }
     }
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    // ---- Work unit ----
+    // All kernels run on all_cores, so every local DFB's producer and consumer share the SAME
+    // WorkUnitSpec — the local-DFB invariant holds trivially.
+    WorkUnitSpec work_unit{.name = "uwu_sharded", .kernels = {READER, WRITER, COMPUTE}, .target_nodes = all_cores};
 
-    return desc;
+    // Dataflow buffers: IN, OUT always; SHARDED_OUT only when out_sharded.
+    Group<DataflowBufferSpec> dataflow_buffers;
+    dataflow_buffers.push_back(std::move(in_dfb));
+    dataflow_buffers.push_back(std::move(out_dfb));
+    if (out_sharded) {
+        dataflow_buffers.push_back(std::move(sharded_out_dfb));
+    }
+
+    ProgramSpec spec{
+        .name = "untilize_with_unpadding_multi_core_sharded",
+        .kernels = {std::move(reader), std::move(writer), std::move(compute)},
+        .dataflow_buffers = std::move(dataflow_buffers),
+        .tensor_parameters = {std::move(src_param), std::move(dst_param)},
+        .work_units = {std::move(work_unit)},
+    };
+
+    ProgramRunArgs run_args{
+        .kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)},
+        .tensor_args =
+            {
+                {SRC, TensorArgument{input.mesh_tensor()}},
+                {DST, TensorArgument{output.mesh_tensor()}},
+            },
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_sharded_program_factory.hpp
@@ -6,12 +6,12 @@
 
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeWithUnpaddingMultiCoreShardedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.cpp
@@ -6,31 +6,28 @@
 
 #include <cmath>
 
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/math.hpp"
 #include "ttnn/operations/core/work_split/work_split_tilize.hpp"
 #include <tt-metalium/constants.hpp>
-#include <tt-metalium/host_api.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <tt-metalium/allocator.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 #include "ttnn/common/constants.hpp"
 #include "ttnn/operation.hpp"
 
 using namespace tt::constants;
 using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts UntilizeWithUnpaddingSingleCoreProgramFactory::create_program_spec(
     const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output) {
     const auto& a = input;
     bool fp32_dest_acc_en = operation_attributes.fp32_dest_acc_en;
     const auto& sub_core_grids = operation_attributes.sub_core_grids;
     const auto& input_shape = a.padded_shape();
     const auto& output_shape = output.padded_shape();
-
-    ProgramDescriptor desc;
 
     CoreRange default_core({0, 0}, {0, 0});
     CoreRange core = sub_core_grids.has_value() ? corerange_to_cores(sub_core_grids.value()).at(0) : default_core;
@@ -44,14 +41,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::c
     log_debug(tt::LogOp, "input_cb_data_format: {}", input_cb_data_format);
     log_debug(tt::LogOp, "output_cb_data_format: {}", output_cb_data_format);
 
-    tt::tt_metal::Buffer* src0_buffer = a.buffer();
-
     int32_t num_tiles = a.physical_volume() / TILE_HW;
-
-    // This should allocate a DRAM buffer on the device
-
-    tt::tt_metal::Buffer* dst_buffer = output.buffer();
-    TT_ASSERT(dst_buffer != nullptr, "Output buffer should be allocated on device!");
 
     auto input_w = input_shape.rank() >= 4 ? input_shape[-4] : 1;
     auto input_z = input_shape.rank() >= 3 ? input_shape[-3] : 1;
@@ -102,112 +92,175 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingSingleCoreProgramFactory::c
     const uint32_t padded_W_diff_blocks = (input_w - output_w) * input_z * input_y / TILE_HEIGHT * num_blocks_w_input;
     const uint32_t num_leftover_Y = output_y - (output_y / TILE_HEIGHT * TILE_HEIGHT);
 
-    constexpr uint8_t src0_cb_index = 0;
+    // ---- Resource names ----
+    const DFBSpecName IN{"in"};
+    const DFBSpecName OUT{"out"};
+    const TensorParamName SRC{"src"};
+    const TensorParamName DST{"dst"};
+    const KernelSpecName READER{"reader"};
+    const KernelSpecName WRITER{"writer"};
+    const KernelSpecName COMPUTE{"compute"};
+
+    // ---- Dataflow buffers (legacy CBs) ----
     uint32_t num_input_tiles = num_tiles_per_block;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * input_single_tile_size,
-        .core_ranges = core,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = src0_cb_index,
-            .data_format = input_cb_data_format,
-            .page_size = input_single_tile_size,
-        }}},
-    });
-
-    constexpr uint8_t output_cb_index = tt::CBIndex::c_16;
-    uint32_t num_output_tiles = num_tiles_per_block;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_output_tiles * output_single_tile_size,
-        .core_ranges = core,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = output_cb_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
-
-    std::vector<uint32_t> reader_compile_time_args;
-    TensorAccessorArgs(*src0_buffer).append_to(reader_compile_time_args);
-
-    std::vector<uint32_t> writer_compile_time_args = {
-        (std::uint32_t)((
-            input_cb_data_format == tt::DataFormat::Float32 or input_cb_data_format == tt::DataFormat::UInt32 or
-            input_cb_data_format == tt::DataFormat::Int32)),
-        unpadded_stick_size};
-    TensorAccessorArgs(*dst_buffer).append_to(writer_compile_time_args);
-
-    // Tilized reader
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = core;
-    reader_desc.compile_time_args = std::move(reader_compile_time_args);
-    reader_desc.config = ReaderConfigDescriptor{};
-
-    // Untilized writer
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
-        "writer_unary_unpad_dims_split_rows.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = core;
-    writer_desc.compile_time_args = std::move(writer_compile_time_args);
-    writer_desc.config = WriterConfigDescriptor{};
-
-    std::vector<uint32_t> compute_args = {
-        uint32_t(num_tiles / num_tiles_per_block),
-        uint32_t(num_tiles_per_block),
-        uint32_t(src0_cb_index),
-        uint32_t(output_cb_index)};
-
-    KernelDescriptor::Defines compute_kernel_defines;
-    if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
-        input_cb_data_format == tt::DataFormat::Float32) {
-        compute_kernel_defines.emplace_back("DST_ACCUM_MODE", "1");
-    }
-    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
-        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (fp32_dest_acc_en) {
-        unpack_to_dest_mode[src0_cb_index] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-    }
-
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/data_movement/untilize/device/kernels/compute/untilize.cpp";
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = core;
-    compute_desc.compile_time_args = std::move(compute_args);
-    compute_desc.defines = std::move(compute_kernel_defines);
-    compute_desc.config = ComputeConfigDescriptor{
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+    DataflowBufferSpec in_dfb{
+        .unique_id = IN,
+        .entry_size = input_single_tile_size,
+        .num_entries = num_input_tiles,
+        .data_format_metadata = input_cb_data_format,
     };
 
+    uint32_t num_output_tiles = num_tiles_per_block;
+    DataflowBufferSpec out_dfb{
+        .unique_id = OUT,
+        .entry_size = output_single_tile_size,
+        .num_entries = num_output_tiles,
+        .data_format_metadata = output_cb_data_format,
+    };
+
+    // ---- Tensor parameters ----
+    TensorParameter src_param{.unique_id = SRC, .spec = input.tensor_spec()};
+    TensorParameter dst_param{.unique_id = DST, .spec = output.tensor_spec()};
+
+    // ---- Reader kernel (tilized reader) ----
+    KernelSpec reader{
+        .unique_id = READER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "reader_unary_interleaved_start_id_m2.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::PRODUCER},
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = SRC, .accessor_name = "src"},
+            },
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER},
+    };
+
+    // ---- Writer kernel (untilized writer) ----
+    KernelSpec writer{
+        .unique_id = WRITER,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/"
+            "writer_unary_unpad_dims_split_rows.cpp",
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::CONSUMER},
+            },
+        .tensor_bindings =
+            {
+                TensorBinding{.tensor_parameter_name = DST, .accessor_name = "dst"},
+            },
+        .compile_time_args =
+            {
+                {"float32_dtype",
+                 (std::uint32_t)(input_cb_data_format == tt::DataFormat::Float32 or
+                                 input_cb_data_format == tt::DataFormat::UInt32 or
+                                 input_cb_data_format == tt::DataFormat::Int32)},
+            },
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"num_unpadded_W",
+                  "padded_W_diff_blocks",
+                  "num_unpadded_Z",
+                  "padded_Z_diff_blocks",
+                  "num_unpadded_Y",
+                  "padded_Y_diff_blocks",
+                  "num_leftover_Y",
+                  "num_unpadded_X",
+                  "padded_X_size",
+                  "num_blocks_w_input",
+                  "num_blocks_w_output",
+                  "num_blocks_w_diff",
+                  "block_row_size",
+                  "block_row_leftover_size"}},
+        .hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER},
+    };
+
+    // ---- Compute kernel ----
+    KernelSpec::CompilerOptions::Defines compute_kernel_defines;
+    if (input_cb_data_format == tt::DataFormat::Int32 || input_cb_data_format == tt::DataFormat::UInt32 ||
+        input_cb_data_format == tt::DataFormat::Float32) {
+        compute_kernel_defines.insert({"DST_ACCUM_MODE", "1"});
+    }
+
+    ComputeHardwareConfig compute_hw_config{.fp32_dest_acc_en = fp32_dest_acc_en};
+    if (fp32_dest_acc_en) {
+        compute_hw_config.unpack_to_dest_mode.insert({IN, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
+    }
+
+    KernelSpec compute{
+        .unique_id = COMPUTE,
+        .source =
+            "ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/untilize_m2.cpp",
+        .compiler_options = {.defines = std::move(compute_kernel_defines)},
+        .dfb_bindings =
+            {
+                DFBBinding{.dfb_spec_name = IN, .accessor_name = "in", .endpoint_type = DFBEndpointType::CONSUMER},
+                DFBBinding{.dfb_spec_name = OUT, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER},
+            },
+        .compile_time_args =
+            {
+                {"per_core_block_cnt", (uint32_t)(num_tiles / num_tiles_per_block)},
+                {"per_core_block_tile_cnt", (uint32_t)num_tiles_per_block},
+            },
+        .hw_config = std::move(compute_hw_config),
+    };
+
+    // ---- Work unit (single core, all three kernels) ----
+    WorkUnitSpec work_unit{.name = "uwu_single_core", .kernels = {READER, WRITER, COMPUTE}, .target_nodes = core};
+
+    ProgramSpec spec{
+        .name = "untilize_with_unpadding_single_core",
+        .kernels = {std::move(reader), std::move(writer), std::move(compute)},
+        .dataflow_buffers = {std::move(in_dfb), std::move(out_dfb)},
+        .tensor_parameters = {std::move(src_param), std::move(dst_param)},
+        .work_units = {std::move(work_unit)},
+    };
+
+    // ---- Run args (per-node RTAs + tensor args) ----
     CoreCoord core_0 = corerange_to_cores(core).at(0);
-    reader_desc.emplace_runtime_args(core_0, {src0_buffer, uint32_t(num_tiles), 0u});
-    writer_desc.emplace_runtime_args(
-        core_0,
-        {dst_buffer,
-         output_w,
-         padded_W_diff_blocks,
-         output_z,
-         padded_Z_diff_blocks,
-         output_y,
-         padded_Y_diff_blocks,
-         num_leftover_Y,
-         output_x,
-         padded_stick_size,
-         num_blocks_w_input,
-         num_blocks_w_output,
-         num_blocks_w_diff,
-         block_row_size,
-         block_row_leftover_size});
 
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
+    KernelRunArgs reader_run_args{
+        .kernel = READER,
+        .runtime_arg_values = {KernelRunArgs::NodeRuntimeArgs{
+            .node = core_0, .args = {{"num_pages", (uint32_t)num_tiles}, {"start_id", 0u}}}},
+    };
 
-    return desc;
+    KernelRunArgs writer_run_args{
+        .kernel = WRITER,
+        .runtime_arg_values = {KernelRunArgs::NodeRuntimeArgs{
+            .node = core_0,
+            .args =
+                {{"num_unpadded_W", output_w},
+                 {"padded_W_diff_blocks", padded_W_diff_blocks},
+                 {"num_unpadded_Z", output_z},
+                 {"padded_Z_diff_blocks", padded_Z_diff_blocks},
+                 {"num_unpadded_Y", output_y},
+                 {"padded_Y_diff_blocks", padded_Y_diff_blocks},
+                 {"num_leftover_Y", num_leftover_Y},
+                 {"num_unpadded_X", output_x},
+                 {"padded_X_size", padded_stick_size},
+                 {"num_blocks_w_input", num_blocks_w_input},
+                 {"num_blocks_w_output", num_blocks_w_output},
+                 {"num_blocks_w_diff", num_blocks_w_diff},
+                 {"block_row_size", block_row_size},
+                 {"block_row_leftover_size", block_row_leftover_size}}}},
+    };
+
+    ProgramRunArgs run_args{
+        .kernel_run_args = {std::move(reader_run_args), std::move(writer_run_args)},
+        .tensor_args =
+            {
+                {SRC, TensorArgument{input.mesh_tensor()}},
+                {DST, TensorArgument{output.mesh_tensor()}},
+            },
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_single_core_program_factory.hpp
@@ -6,12 +6,12 @@
 
 #include "ttnn/operations/data_movement/untilize_with_unpadding/device/untilize_with_unpadding_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct UntilizeWithUnpaddingSingleCoreProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const UntilizeWithUnpaddingParams& operation_attributes, const Tensor& input, Tensor& output);
 };
 

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/eltwise_copy_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/eltwise_copy_m2.cpp
@@ -1,0 +1,42 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of ttnn/cpp/ttnn/kernel/compute/eltwise_copy.cpp.
+// The legacy source is shared, so it is forked here (not edited in place) and ported to
+// Metal 2.0 named bindings for untilize_with_unpadding's multi-core sharded factory (the
+// unpad-width-16 path uses copy compute purely for a potential data type conversion).
+//   tt::CBIndex::c_0  -> dfb::in
+//   tt::CBIndex::c_16 -> dfb::out
+//   per_core_tile_cnt CTA -> named CTA
+
+#include <cstdint>
+
+#include "api/compute/common.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    uint32_t per_core_tile_cnt = get_arg(args::per_core_tile_cnt);
+
+    unary_op_init_common(dfb::in, dfb::out);
+    copy_tile_init(dfb::in);
+    for (uint32_t b = 0; b < per_core_tile_cnt; ++b) {
+        tile_regs_acquire();
+
+        // Pop tile after tile, copy to DST and pack
+        cb_wait_front(dfb::in, 1);
+        cb_reserve_back(dfb::out, 1);
+        copy_tile(dfb::in, 0, 0);
+
+        tile_regs_commit();
+        tile_regs_wait();
+        pack_tile(0, dfb::out);
+
+        cb_pop_front(dfb::in, 1);
+        cb_push_back(dfb::out, 1);
+
+        tile_regs_release();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/untilize_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/untilize_m2.cpp
@@ -1,0 +1,26 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of data_movement/untilize/device/kernels/compute/untilize.cpp.
+// The legacy source is shared by ~9 ops, so it is forked here (not edited in place) and
+// ported to Metal 2.0 named bindings for untilize_with_unpadding's single-core factory.
+
+#include <cstdint>
+
+#include "experimental/kernel_args.h"
+#include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+
+void kernel_main() {
+    constexpr uint32_t per_core_block_cnt = get_arg(args::per_core_block_cnt);
+    constexpr uint32_t per_core_block_tile_cnt = get_arg(args::per_core_block_tile_cnt);
+
+    compute_kernel_hw_startup(dfb::in, dfb::out);
+    compute_kernel_lib::untilize<
+        per_core_block_tile_cnt,
+        dfb::in,
+        dfb::out,
+        compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
+        compute_kernel_lib::untilize_config::WaitMode::WaitBlock,
+        compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_block_cnt);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/untilize_variable_num_blocks_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/untilize_variable_num_blocks_m2.cpp
@@ -1,0 +1,38 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// //
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of data_movement/untilize/device/kernels/compute/untilize_variable_num_blocks.cpp.
+// The legacy source is shared, so it is forked here (not edited in place) and ported to Metal 2.0
+// named bindings for untilize_with_unpadding's multi-core ND-sharded factory.
+// Logic, loops and numeric paths are UNCHANGED; only the access mechanism moves to named bindings:
+//   CB ids               -> dfb::in / dfb::out
+//   per_core_block_tile_cnt CTA -> named CTA (get_arg(args::...))
+//   num_input_blocks_to_process RTA -> named RTA (get_arg(args::num_input_blocks_to_process))
+
+#include <cstdint>
+
+#include "experimental/kernel_args.h"
+#include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+
+void kernel_main() {
+    const uint32_t per_core_block_cnt = get_arg(args::num_input_blocks_to_process);
+
+    // For uneven nd-sharding, the host assigns 0 blocks to cores that fall outside
+    // the populated shard set. The kernel_lib untilize asserts num_blocks > 0,
+    // so we early-return on those idle cores.
+    if (per_core_block_cnt == 0) {
+        return;
+    }
+
+    constexpr uint32_t per_core_block_tile_cnt = get_arg(args::per_core_block_tile_cnt);
+
+    compute_kernel_hw_startup(dfb::in, dfb::out);
+    compute_kernel_lib::untilize<
+        per_core_block_tile_cnt,
+        dfb::in,
+        dfb::out,
+        compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
+        compute_kernel_lib::untilize_config::WaitMode::WaitBlock,
+        compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(per_core_block_cnt);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/untilize_w_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/untilize_w_m2.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of data_movement/untilize/device/kernels/compute/untilize_w.cpp.
+// The legacy source is shared (also used by untilize), so it is forked here (not edited in place) and
+// ported to Metal 2.0 named bindings for untilize_with_unpadding's multi-core COL interleaved factory.
+// Only the access mechanism changed:
+//   - the input/output CB ids (legacy c_0 / c_16) come from the DFB tokens (dfb::in / dfb::out)
+//   - per_core_block_cnt / per_core_block_tile_cnt / third_dim become named compile-time args (args::)
+// The block-count arithmetic passed to the untilize helper is preserved verbatim.
+
+#include "experimental/kernel_args.h"
+#include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+
+void kernel_main() {
+    constexpr uint32_t per_core_block_cnt = get_arg(args::per_core_block_cnt);
+    constexpr uint32_t per_core_block_tile_cnt = get_arg(args::per_core_block_tile_cnt);
+    constexpr uint32_t third_dim = get_arg(args::third_dim);
+
+    compute_kernel_hw_startup(dfb::in, dfb::out);
+    compute_kernel_lib::untilize<
+        1,
+        dfb::in,
+        dfb::out,
+        compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
+        compute_kernel_lib::untilize_config::WaitMode::WaitBlock,
+        compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(
+        per_core_block_cnt * per_core_block_tile_cnt * third_dim);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/untilize_wh_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/compute/untilize_wh_m2.cpp
@@ -1,0 +1,30 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of data_movement/untilize/device/kernels/compute/untilize_wh.cpp.
+// The legacy source lives outside this op's directory (untilize) and is shared, so it is forked
+// here (not edited in place) and ported to Metal 2.0 named bindings for untilize_with_unpadding's
+// multi-core block-interleaved factory.
+// Logic is UNCHANGED; only the access mechanism moves to named bindings:
+//   block_size_col / block_size_row / third_dim CTAs -> named CTAs (get_arg(args::...))
+//   CB ids c_0 / c_16 -> dfb::in / dfb::out
+
+#include "experimental/kernel_args.h"
+#include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+
+void kernel_main() {
+    constexpr uint32_t block_size_col = get_arg(args::block_size_col);
+    constexpr uint32_t block_size_row = get_arg(args::block_size_row);
+    constexpr uint32_t third_dim = get_arg(args::third_dim);
+
+    compute_kernel_hw_startup(dfb::in, dfb::out);
+    compute_kernel_lib::untilize<
+        block_size_row,
+        dfb::in,
+        dfb::out,
+        compute_kernel_lib::untilize_config::InitUninitMode::InitAndUninit,
+        compute_kernel_lib::untilize_config::WaitMode::WaitBlock,
+        compute_kernel_lib::untilize_config::ReconfigureRegisterDatatypeMode::NoReconfigure>(
+        block_size_col * third_dim);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/reader_unary_interleaved_col_multicore_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/reader_unary_interleaved_col_multicore_m2.cpp
@@ -1,0 +1,68 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_col_multicore.cpp.
+// The legacy source lives outside the op directory and is shared, so it is forked here (not edited in
+// place) and ported to Metal 2.0 named bindings for untilize_with_unpadding's multi-core COL
+// interleaved factory. Only the access mechanism changed:
+//   - the source CB id (legacy c_0) comes from the DFB producer token (dfb::in)
+//   - the source address comes from the TensorAccessor binding (ta::src)
+//   - num_tiles_per_2d / third_dim / number_blocks_per_core become named compile-time args (args::)
+//   - core_number / tiles_per_row / num_blocks become named runtime args (args::)
+// The read loops / #ifdefs / numeric paths are preserved verbatim.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t core_number = get_arg(args::core_number);
+    const uint32_t tiles_per_row = get_arg(args::tiles_per_row);
+    const uint32_t num_blocks = get_arg(args::num_blocks);
+
+    constexpr uint32_t num_tiles_per_2d = get_arg(args::num_tiles_per_2d);
+    constexpr uint32_t third_dim = get_arg(args::third_dim);
+    constexpr uint32_t number_blocks_per_core = get_arg(args::number_blocks_per_core);
+
+    const auto s = TensorAccessor(ta::src);
+
+    constexpr uint32_t onetile = 1;
+
+    Noc noc;
+    DataflowBuffer dfb_in(dfb::in);
+
+#ifdef OUT_SHARDED
+    dfb_in.wait_front(onetile);
+#else
+
+    // single-tile ublocks
+    const uint32_t tile_bytes = get_local_cb_interface(dfb::in).fifo_page_size;
+
+#ifdef BACKWARDS
+    uint32_t end_id = -num_tiles_per_2d;
+    for (uint32_t dim = 0; dim > -third_dim; dim--) {
+        for (uint32_t k = 0; k > -num_blocks; k--) {
+            for (uint32_t i = num_tiles_per_2d * dim - number_blocks_per_core * core_number;
+                 i > end_id + num_tiles_per_2d * dim;
+                 i = i - tiles_per_row) {
+#else
+    uint32_t end_id = num_tiles_per_2d;
+    for (uint32_t dim = 0; dim < third_dim; dim++) {
+        for (uint32_t k = 0; k < num_blocks; k++) {
+            for (uint32_t i = num_tiles_per_2d * dim + number_blocks_per_core * core_number;
+                 i < end_id + num_tiles_per_2d * dim;
+                 i = i + tiles_per_row) {
+#endif
+                dfb_in.reserve_back(onetile);
+                noc.async_read(s, dfb_in, tile_bytes, {.page_id = static_cast<uint32_t>(i + k)}, {.offset_bytes = 0});
+
+                noc.async_read_barrier();
+                dfb_in.push_back(onetile);
+            }
+        }
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/reader_unary_interleaved_start_id_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/reader_unary_interleaved_start_id_m2.cpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_start_id.cpp.
+// The legacy source is shared by ~12 ops, so it is forked here (not edited in place) and
+// ported to Metal 2.0 named bindings for untilize_with_unpadding's single-core factory.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t num_pages = get_arg(args::num_pages);
+    const uint32_t start_id = get_arg(args::start_id);
+
+    const auto s = TensorAccessor(ta::src);
+
+    // Get page size from CB interface (works for both TILE and ROW_MAJOR layouts)
+    const uint32_t page_bytes = get_local_cb_interface(dfb::in).fifo_page_size;
+
+    // ublocks size defined in pages (works for both TILE and ROW_MAJOR layouts)
+    constexpr uint32_t onepage = 1;
+
+    Noc noc;
+    DataflowBuffer dfb_in(dfb::in);
+
+// read a ublock of pages from src to DFB, and then push the ublock to unpacker
+#ifdef BACKWARDS
+    uint32_t end_id = start_id - num_pages;
+    for (uint32_t i = start_id; i != end_id; --i) {
+#else
+    uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+#endif
+        dfb_in.reserve_back(onepage);
+        noc.async_read(s, dfb_in, page_bytes, {.page_id = i}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+        dfb_in.push_back(onepage);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/reader_unary_interleaved_wh_multicore_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/reader_unary_interleaved_wh_multicore_m2.cpp
@@ -1,0 +1,60 @@
+
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of eltwise/unary/device/kernels/dataflow/reader_unary_interleaved_wh_multicore.cpp.
+// The legacy source lives outside this op's directory (eltwise/unary) and is shared by untilize, so
+// it is forked here (not edited in place) and ported to Metal 2.0 named bindings for
+// untilize_with_unpadding's multi-core block-interleaved factory.
+// Logic, loop bounds and #ifdefs are UNCHANGED; only the access mechanism moves to named bindings:
+//   src address                -> ta::src (TensorAccessor)
+//   CB id 0                     -> dfb::in
+//   num_tiles_per_2d / third_dim / total_tiles_per_row CTAs -> named CTAs (get_arg(args::...))
+//   start_id / single_block_size_row_arg / single_block_size_col_arg RTAs -> named RTAs
+//   the src_addr RTA (slot 0) read disappears (folded into ta::src)
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t single_block_size_row_arg = get_arg(args::single_block_size_row_arg);
+    const uint32_t single_block_size_col_arg = get_arg(args::single_block_size_col_arg);
+
+    constexpr uint32_t num_tiles_per_2d = get_arg(args::num_tiles_per_2d);
+    constexpr uint32_t third_dim = get_arg(args::third_dim);
+    constexpr uint32_t total_tiles_per_row = get_arg(args::total_tiles_per_row);
+
+    // single-tile ublocks
+    constexpr uint32_t onetile = 1;
+    const uint32_t tile_bytes = get_local_cb_interface(dfb::in).fifo_page_size;
+
+    const auto s = TensorAccessor(ta::src);
+
+    Noc noc;
+    DataflowBuffer cb(dfb::in);
+
+#ifdef BACKWARDS
+    for (uint32_t dim = 0; dim > -third_dim; dim--) {
+        for (uint32_t c = 0; c > -single_block_size_col_arg; c--) {
+            for (uint32_t r = 0; r > -single_block_size_row_arg; r--) {
+                uint32_t tile = -start_id + dim * num_tiles_per_2d + c * total_tiles_per_row + r;
+#else
+    for (uint32_t dim = 0; dim < third_dim; dim++) {
+        for (uint32_t c = 0; c < single_block_size_col_arg; c++) {
+            for (uint32_t r = 0; r < single_block_size_row_arg; r++) {
+                uint32_t tile = start_id + dim * num_tiles_per_2d + c * total_tiles_per_row + r;
+#endif
+                cb.reserve_back(onetile);
+                noc.async_read(s, cb, tile_bytes, {.page_id = tile}, {.offset_bytes = 0});
+
+                noc.async_read_barrier();
+                cb.push_back(onetile);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/reader_unary_nd_sharded_blocks_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/reader_unary_nd_sharded_blocks_m2.cpp
@@ -1,0 +1,51 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of data_movement/sharded/device/kernels/dataflow/reader_unary_nd_sharded_blocks.cpp.
+// The legacy source is shared (also used by untilize), so it is forked here (not edited in place) and
+// ported to Metal 2.0 named bindings for untilize_with_unpadding's multi-core ND-sharded factory.
+// Logic, loops and numeric paths are UNCHANGED; only the access mechanism moves to named bindings:
+//   src address          -> ta::src (TensorAccessor)
+//   CB id 0              -> dfb::in
+//   num_tiles_per_input_block / num_shards / num_cores CTAs -> named CTAs (get_arg(args::...))
+//   start_shard_id RTA   -> named RTA (get_arg(args::start_shard_id))
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    // run-time args
+    const uint32_t start_shard_id = get_arg(args::start_shard_id);
+
+    // compile-time args
+    constexpr uint32_t num_tiles_per_input_block = get_arg(args::num_tiles_per_input_block);
+    constexpr uint32_t num_shards = get_arg(args::num_shards);
+    constexpr uint32_t num_cores = get_arg(args::num_cores);
+    const uint32_t tile_size_bytes = get_local_cb_interface(dfb::in).fifo_page_size;
+
+    Noc noc;
+    DataflowBuffer cb_in(dfb::in);
+
+    const auto accessor_src = TensorAccessor(ta::src);
+    for (uint32_t shard_id = start_shard_id; shard_id < num_shards; shard_id += num_cores) {
+        auto shard_pages = accessor_src.shard_pages(shard_id);
+        for (auto page_iter = shard_pages.begin(); page_iter != shard_pages.end();
+             page_iter += num_tiles_per_input_block) {
+            cb_in.reserve_back(num_tiles_per_input_block);
+            noc.async_read(
+                accessor_src,
+                cb_in,
+                tile_size_bytes * num_tiles_per_input_block,
+                {.page_id = page_iter->page_id(), .offset_bytes = 0},
+                {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb_in.push_back(num_tiles_per_input_block);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/reader_unary_sharded_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/reader_unary_sharded_m2.cpp
@@ -1,0 +1,21 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of eltwise/unary/device/kernels/dataflow/reader_unary_sharded.cpp.
+// The legacy source is shared by ~12 ops, so it is forked here (not edited in place) and
+// ported to Metal 2.0 named bindings for untilize_with_unpadding's multi-core sharded factory.
+// The sharded input lives in L1: the reader merely advances the DFB write pointer (push_back)
+// to publish the resident tiles to the compute consumer; there is no NOC read.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    uint32_t num_tiles_per_core = get_arg(args::num_tiles_per_core);
+
+    DataflowBuffer dfb_in(dfb::in);
+    dfb_in.push_back(num_tiles_per_core);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_col_multicore.cpp
@@ -1,6 +1,21 @@
+
 // SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port (in place — this kernel is op-local, used only by the untilize_with_unpadding
+// multi-core COL interleaved factory). Only the access mechanism changed:
+//   - the output CB id (legacy c_16) comes from the DFB consumer token (dfb::cb_id_out0)
+//   - the destination address comes from the TensorAccessor binding (ta::dst)
+//   - total_num_rows / ncores / third_dim / tile_width / unpadded_X_size are named compile-time args
+//   - core_number / size_per_row_per_block / blocks_per_core / width_size are named runtime args
+// The write_block lambda / pad logic / loop structure are preserved verbatim.
+//
+// NOTE: the legacy positional descriptor variant read these RTAs from indices {1,3,4,5} while the host
+// only wrote indices {0..4} — i.e. it had a latent off-by-one (index 5 was an out-of-bounds read and
+// index 2 was unread). The named bindings below restore the host's *intended* mapping (core_number ←
+// the per-core index, size_per_row_per_block, blocks_per_core, width_size), matching the original
+// pre-descriptor SetRuntimeArgs layout. See the factory's METAL2_PORT_REPORT.md for details.
 
 #include <stdint.h>
 
@@ -9,21 +24,20 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t cb_id_out0 = 16;
+    constexpr uint32_t cb_id_out0 = dfb::cb_id_out0;
 
-    constexpr uint32_t total_num_rows = get_compile_time_arg_val(0);
-    constexpr uint32_t ncores = get_compile_time_arg_val(1);
-    constexpr uint32_t third_dim = get_compile_time_arg_val(2);
-    constexpr uint32_t tile_width = get_compile_time_arg_val(3);
-    constexpr uint32_t unpadded_X_size = get_compile_time_arg_val(4);
-    constexpr auto dst_args = TensorAccessorArgs<5>();
+    constexpr uint32_t total_num_rows = get_arg(args::total_num_rows);
+    constexpr uint32_t ncores = get_arg(args::ncores);
+    constexpr uint32_t third_dim = get_arg(args::third_dim);
+    constexpr uint32_t tile_width = get_arg(args::tile_width);
+    constexpr uint32_t unpadded_X_size = get_arg(args::unpadded_X_size);
 
-    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const uint32_t core_number = get_arg_val<uint32_t>(1);
+    const uint32_t core_number = get_arg(args::core_number);
 
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(ta::dst);
 
     Noc noc;
     CircularBuffer cb_out0(cb_id_out0);
@@ -69,9 +83,9 @@ void kernel_main() {
         cb_out0.pop_front(onetile * has_rows);
     };
 
-    const uint32_t size_per_row_per_block = get_arg_val<uint32_t>(3);
-    const uint32_t blocks_per_core = get_arg_val<uint32_t>(4);
-    const uint32_t width_size = get_arg_val<uint32_t>(5);
+    const uint32_t size_per_row_per_block = get_arg(args::size_per_row_per_block);
+    const uint32_t blocks_per_core = get_arg(args::blocks_per_core);
+    const uint32_t width_size = get_arg(args::width_size);
 
     uint32_t size_2d = 0;
     for (uint32_t dim3 = 0; dim3 < third_dim; dim3++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_interleaved_blocks_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_interleaved_blocks_m2.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of ttnn/cpp/ttnn/kernel/dataflow/writer_unary_stick_layout_interleaved_blocks.cpp.
+// The legacy source lives in the generic ttnn/kernel tree and is shared, so it is forked here
+// (not edited in place) and ported to Metal 2.0 named bindings for untilize_with_unpadding's
+// multi-core sharded factory (the non-sharded-output path).
+//   CB id c_16                       -> dfb::out
+//   TensorAccessorArgs<2>() + dst_addr RTA -> TensorAccessor(ta::dst)  (the dst_addr RTA disappears)
+//   FLOAT32_DTYPE CTA                -> named CTA float32_dtype
+//   remaining RTAs                   -> named RTAs
+// Logic, loop bounds and numeric paths are UNCHANGED.
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "experimental/kernel_args.h"
+// #include "api/debug/dprint.h"
+
+template <typename DSpec>
+inline void write_tiles_in_block(
+    uint32_t cb_id_out0,
+    uint32_t block_height_ntiles,
+    uint32_t block_width_ntiles,
+    uint32_t block_start_row_id,
+    uint32_t block_row_offset,
+    uint32_t block_row_size,
+    uint32_t block_row_size_unpadded,  // to remove padding from the last block in the row
+    uint32_t num_rows_unpadded,
+    const TensorAccessor<DSpec>& s) {
+    constexpr uint32_t TILE_HEIGHT = 32;  // TODO: use common source of truth
+    uint32_t block_row_id = block_start_row_id;
+    for (uint32_t tile_row_id = 0; tile_row_id < block_height_ntiles; tile_row_id++) {
+        // We reserve back an entire row of tiles in a block and issue a bunch of reads
+        cb_wait_front(cb_id_out0, block_width_ntiles);
+        uint32_t l1_read_addr = get_read_ptr(cb_id_out0);
+        for (uint32_t j = 0; j < TILE_HEIGHT; j++) {
+            if (block_row_id >= num_rows_unpadded) {
+                break;
+            }
+            uint64_t dst_noc_addr = s.get_noc_addr(block_row_id, block_row_offset);
+            noc_async_write(l1_read_addr, dst_noc_addr, block_row_size_unpadded);
+            l1_read_addr += block_row_size;
+            block_row_id++;
+        }  // for tile_nrows
+        noc_async_write_barrier();
+        cb_pop_front(cb_id_out0, block_width_ntiles);
+    }  // for block_height_ntiles
+}
+void kernel_main() {
+    uint32_t num_rows_block = get_arg(args::num_rows_block);
+    uint32_t block_row_size = get_arg(args::block_row_size);  // in0_block_w * TILE_WIDTH * dtype_nbytes
+    uint32_t batch = get_arg(args::batch);
+    uint32_t num_blocks_h = get_arg(args::num_blocks_h);
+    uint32_t num_blocks_w = get_arg(args::num_blocks_w);
+    uint32_t last_block_row_size_unpadded = get_arg(args::last_block_row_size_unpadded);  // unpadded last block width
+    uint32_t num_output_rows_unpadded = get_arg(args::num_output_rows_unpadded);
+    uint32_t block_start_row_id = get_arg(args::block_start_row_id);
+    uint32_t block_start_row_offset = get_arg(args::block_start_row_offset);
+
+    constexpr bool FLOAT32_DTYPE = get_arg(args::float32_dtype) == 1;
+
+    // NOTE: Row major layout only supports bfp16
+    constexpr uint32_t cb_id_out0 = dfb::out;
+
+    constexpr uint32_t TILE_HEIGHT = 32;  // TODO: use common source of truth
+
+    const uint32_t block_width_ntiles =
+        FLOAT32_DTYPE ? block_row_size >> 7
+                      : block_row_size >> 6;  // Assuming 4/2 bytes per datum, there are 128/64 bytes per tile row
+    const uint32_t block_height_ntiles = num_rows_block / TILE_HEIGHT;
+
+    const auto s = TensorAccessor(ta::dst);
+    uint32_t num_rows_unpadded = num_output_rows_unpadded + block_start_row_id;
+    for (uint32_t b = 0; b < batch; ++b) {
+        for (uint32_t block_h = 0; block_h < num_blocks_h; block_h++) {
+            uint32_t block_row_offset = block_start_row_offset;
+            for (uint32_t block_w = 0; block_w < num_blocks_w; block_w++) {
+                uint32_t current_block_row_size_unpadded = block_row_size;
+                if (block_w == (num_blocks_w - 1)) {
+                    current_block_row_size_unpadded = last_block_row_size_unpadded;
+                }
+                write_tiles_in_block(
+                    cb_id_out0,
+                    block_height_ntiles,
+                    block_width_ntiles,
+                    block_start_row_id,
+                    block_row_offset,
+                    block_row_size,
+                    current_block_row_size_unpadded,  // padding is only in the last block
+                    num_rows_unpadded,
+                    s);
+                block_row_offset += block_row_size;
+            }  // for num_blocks_w
+            block_start_row_id += num_rows_block;
+        }  // for num_blocks_h
+    }  // for batch
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore.cpp
@@ -2,34 +2,42 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 (ProgramSpec) port. This kernel lives in this op's directory and is used only by
+// UntilizeWithUnpaddingMultiCoreInterleavedProgramFactory, so it is ported in place (not forked).
+// Logic, loop bounds and numeric paths are UNCHANGED; only the access mechanism moves to named
+// bindings:
+//   dst address          -> ta::dst (TensorAccessor)
+//   CB id 16             -> dfb::out
+//   FLOAT32_DTYPE / unpadded_X_size CTAs -> named CTAs (get_arg(args::...))
+//   padded_X_size / start_stick_id / n_block_reps fixed RTAs -> named RTAs
+//   per-core block-rep 5-tuples (variable length) -> runtime varargs (get_vararg)
+
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // Constexpr
-    constexpr uint32_t cb_id_out0 = 16;
     constexpr uint32_t tile_height = 32;
 
-    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const uint32_t padded_X_size = get_arg_val<uint32_t>(1);
-    const uint32_t start_stick_id = get_arg_val<uint32_t>(2);
-    const uint32_t n_block_reps = get_arg_val<uint32_t>(3);
+    const uint32_t padded_X_size = get_arg(args::padded_X_size);
+    const uint32_t start_stick_id = get_arg(args::start_stick_id);
+    const uint32_t n_block_reps = get_arg(args::n_block_reps);
 
-    constexpr bool FLOAT32_DTYPE = get_compile_time_arg_val(0) == 1;
-    constexpr uint32_t unpadded_X_size = get_compile_time_arg_val(1);
-    constexpr auto dst_args = TensorAccessorArgs<2>();
+    constexpr bool FLOAT32_DTYPE = get_arg(args::float32_dtype) == 1;
+    constexpr uint32_t unpadded_X_size = get_arg(args::unpadded_X_size);
 
     const uint32_t num_tiles_per_row = padded_X_size >> (FLOAT32_DTYPE ? 7 : 6);
 
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(ta::dst);
 
     Noc noc;
-    CircularBuffer cb_out0(cb_id_out0);
+    DataflowBuffer cb_out0(dfb::out);
 
     auto pop_blocks = [&](uint32_t num_blocks) {
         for (uint32_t i = 0; i < num_blocks; i++) {
@@ -56,7 +64,9 @@ void kernel_main() {
     };
 
     uint32_t stick_id = start_stick_id;
-    uint32_t rt_arg_idx = 4;
+    // The per-core block-rep tuples are positional runtime varargs (run-length-compressed).
+    // get_vararg(i) indexes from 0 (the named RTA section is invisibly skipped by the helper).
+    uint32_t vararg_idx = 0;
     uint32_t count = 1;
     constexpr int32_t n_mixed_idx = 1;
     constexpr int32_t n_pad_idx = 2;
@@ -65,15 +75,13 @@ void kernel_main() {
     constexpr int32_t num_rt_idx = 5;
 
     for (uint32_t block_rep_idx = 0; block_rep_idx < n_block_reps; ++block_rep_idx) {
-        const uint32_t repeat_count = get_arg_val<uint32_t>(rt_arg_idx + repeat_ct_idx);
-        const uint32_t n_data = get_arg_val<uint32_t>(rt_arg_idx);  // number of full tile-rows
-        const uint32_t n_mixed =
-            get_arg_val<uint32_t>(rt_arg_idx + n_mixed_idx);  // number of rows in a partially filled tile-row
-        const uint32_t n_pads = get_arg_val<uint32_t>(rt_arg_idx + n_pad_idx);  // number of padding tile-rows
-        const uint32_t times =
-            get_arg_val<uint32_t>(rt_arg_idx + times_idx);  // number of times the pattern of tile-rows repeats
+        const uint32_t repeat_count = get_vararg(vararg_idx + repeat_ct_idx);
+        const uint32_t n_data = get_vararg(vararg_idx);                 // number of full tile-rows
+        const uint32_t n_mixed = get_vararg(vararg_idx + n_mixed_idx);  // number of rows in a partially filled tile-row
+        const uint32_t n_pads = get_vararg(vararg_idx + n_pad_idx);     // number of padding tile-rows
+        const uint32_t times = get_vararg(vararg_idx + times_idx);  // number of times the pattern of tile-rows repeats
         if (count == repeat_count) {
-            rt_arg_idx = rt_arg_idx + num_rt_idx;
+            vararg_idx = vararg_idx + num_rt_idx;
             count = 1;
         } else {
             count++;

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp
@@ -2,15 +2,27 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 (ProgramSpec) port. This kernel lives in this op's directory and is used only by
+// UntilizeWithUnpaddingMultiCoreNDShardedProgramFactory, so it is ported in place (not forked).
+// Logic, loops and numeric paths are UNCHANGED; only the access mechanism moves to named bindings:
+//   dst address          -> ta::dst (TensorAccessor)
+//   src0 distribution     -> ta::src (TensorAccessor; ND sharded input distribution info)
+//   CB id 16             -> dfb::out
+//   scalar CTAs          -> named CTAs (get_arg(args::...))
+//   start_shard_id RTA   -> named RTA (get_arg(args::start_shard_id))
+//   output/input padded-shape dim lists (variable length, rank-dependent) -> common runtime
+//     varargs (get_common_vararg); 2 * tensor_rank entries broadcast to all nodes.
+
 #include <stdint.h>
 #include <array>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
 #include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 #include "api/debug/dprint.h"
+#include "experimental/kernel_args.h"
 
 namespace {
 FORCE_INLINE uint32_t div_up(uint32_t x, uint32_t y) { return (x + y - 1) / y; }
@@ -18,33 +30,28 @@ FORCE_INLINE uint32_t div_up(uint32_t x, uint32_t y) { return (x + y - 1) / y; }
 
 void kernel_main() {
     // run-time args
-    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const uint32_t src0_addr = get_arg_val<uint32_t>(1);
-    const uint32_t start_shard_id = get_arg_val<uint32_t>(2);
+    const uint32_t start_shard_id = get_arg(args::start_shard_id);
 
     // compile-time args
-    constexpr uint32_t cb_id_out0 = get_compile_time_arg_val(0);
-    constexpr uint32_t tile_height = get_compile_time_arg_val(2);
-    constexpr uint32_t num_tiles_per_input_block = get_compile_time_arg_val(3);
-    constexpr uint32_t num_output_blocks_across_width = get_compile_time_arg_val(4);
-    constexpr uint32_t output_element_size = get_compile_time_arg_val(5);
-    constexpr uint32_t num_cols_per_input_block = get_compile_time_arg_val(6);
-    constexpr uint32_t num_cols_per_output_block = get_compile_time_arg_val(7);
-    constexpr uint32_t num_shards = get_compile_time_arg_val(9);
-    constexpr uint32_t num_cores = get_compile_time_arg_val(10);
-    constexpr uint32_t num_tiles_per_input_row = get_compile_time_arg_val(11);
-    constexpr uint32_t num_tiles_per_output_row = get_compile_time_arg_val(12);
-    constexpr uint32_t tile_width = get_compile_time_arg_val(13);
-    constexpr uint32_t output_tensor_width = get_compile_time_arg_val(14);
-    constexpr uint32_t output_tensor_height = get_compile_time_arg_val(15);
-    constexpr uint32_t tensor_rank = get_compile_time_arg_val(16);
-    constexpr auto dst_args = TensorAccessorArgs<17>();
-    const auto accessor_dst = TensorAccessor(dst_args, dst_addr);
-    constexpr auto src0_args = TensorAccessorArgs<dst_args.next_compile_time_args_offset()>();
-    const auto accessor_src = TensorAccessor(src0_args, src0_addr);
+    constexpr uint32_t tile_height = get_arg(args::tile_height);
+    constexpr uint32_t num_tiles_per_input_block = get_arg(args::num_tiles_per_input_block);
+    constexpr uint32_t num_output_blocks_across_width = get_arg(args::num_output_blocks_across_width);
+    constexpr uint32_t output_element_size = get_arg(args::output_element_size);
+    constexpr uint32_t num_cols_per_input_block = get_arg(args::num_cols_per_input_block);
+    constexpr uint32_t num_cols_per_output_block = get_arg(args::num_cols_per_output_block);
+    constexpr uint32_t num_shards = get_arg(args::num_shards);
+    constexpr uint32_t num_cores = get_arg(args::num_cores);
+    constexpr uint32_t num_tiles_per_input_row = get_arg(args::num_tiles_per_input_row);
+    constexpr uint32_t num_tiles_per_output_row = get_arg(args::num_tiles_per_output_row);
+    constexpr uint32_t tile_width = get_arg(args::tile_width);
+    constexpr uint32_t output_tensor_width = get_arg(args::output_tensor_width);
+    constexpr uint32_t output_tensor_height = get_arg(args::output_tensor_height);
+    constexpr uint32_t tensor_rank = get_arg(args::tensor_rank);
+    const auto accessor_dst = TensorAccessor(ta::dst);
+    const auto accessor_src = TensorAccessor(ta::src);
 
     Noc noc;
-    CircularBuffer cb_out(cb_id_out0);
+    DataflowBuffer cb_out(dfb::out);
 
     auto write_tiles_in_current_block = [&](uint32_t start_row,
                                             uint32_t width_wise_output_block_start_index,
@@ -99,10 +106,10 @@ void kernel_main() {
     uint32_t output_tensor_shape[tensor_rank];
     uint32_t input_tensor_shape[tensor_rank];
     for (uint32_t i = 0; i < tensor_rank; ++i) {
-        output_tensor_shape[i] = get_common_arg_val<uint32_t>(i);
+        output_tensor_shape[i] = get_common_vararg(i);
     }
     for (uint32_t i = 0; i < tensor_rank; ++i) {
-        input_tensor_shape[i] = get_common_arg_val<uint32_t>(i + tensor_rank);
+        input_tensor_shape[i] = get_common_vararg(i + tensor_rank);
     }
 
     uint32_t global_coord[tensor_rank];

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore_m2.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of
+// data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_wh_multicore.cpp.
+// The legacy source is op-local but is ALSO referenced by untilize's block factory
+// (untilize/.../untilize_multi_core_block_program_factory.cpp), which is still on the legacy concept,
+// so it is forked here (not edited in place) and ported to Metal 2.0 named bindings for
+// untilize_with_unpadding's multi-core block-interleaved factory. The legacy original is left
+// untouched for untilize.
+// Logic, loop bounds and numeric paths are UNCHANGED; only the access mechanism moves to named
+// bindings:
+//   dst address                -> ta::dst (TensorAccessor)
+//   CB id 16                   -> dfb::out
+//   total_num_rows / third_dim / tile_height / unpadded_X_size CTAs -> named CTAs
+//   width_size / start_row_id / start_column_id / single_block_size_row_arg /
+//     single_block_size_col_arg / sub_block_width_size / single_sub_block_size_row_arg RTAs -> named RTAs
+//   the dst_addr RTA (slot 0) read disappears (folded into ta::dst)
+// Note: the in-loop RTAs (start_row_id .. single_sub_block_size_row_arg) were re-read each third_dim
+// iteration via fixed positional indices in the legacy kernel — they are the SAME slots re-read.
+// With named args they are read once per loop iteration via get_arg(args::name), which returns the
+// same value. Behavior is identical.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    constexpr uint32_t total_num_rows = get_arg(args::total_num_rows);
+    constexpr uint32_t third_dim = get_arg(args::third_dim);
+    constexpr uint32_t tile_height = get_arg(args::tile_height);
+    constexpr uint32_t unpadded_X_size = get_arg(args::unpadded_X_size);
+
+    const auto s = TensorAccessor(ta::dst);
+    Noc noc;
+    DataflowBuffer cb_out0(dfb::out);
+
+    auto write_block = [&](uint32_t num_rows,
+                           uint32_t start_row_id,
+                           uint32_t start_column_id,
+                           uint32_t width_size,
+                           uint32_t size_2d,
+                           uint32_t single_block_size) {
+        bool has_rows = (num_rows) > 0;
+
+        cb_out0.wait_front(single_block_size * has_rows);
+        uint32_t l1_read_addr = cb_out0.get_write_ptr();
+
+        for (uint32_t k = start_row_id; k < start_row_id + num_rows; k++) {
+            uint32_t total_size = start_column_id + width_size;
+            uint32_t write_size = width_size;
+
+            if (total_size > unpadded_X_size) {
+                uint32_t padded_size = total_size - unpadded_X_size;
+                write_size -= padded_size;
+            }
+
+            CoreLocalMem<uint32_t> src(l1_read_addr);
+            noc.async_write(
+                src, s, write_size, {.offset_bytes = 0}, {.page_id = size_2d + k, .offset_bytes = start_column_id});
+
+            noc.async_write_barrier();
+
+            l1_read_addr += width_size;
+        }
+
+        cb_out0.pop_front(single_block_size * has_rows);
+    };
+
+    const uint32_t width_size = get_arg(args::width_size);
+
+    uint32_t size_2d = 0;
+    for (uint32_t dim3 = 0; dim3 < third_dim; dim3++) {
+        uint32_t start_row_id = get_arg(args::start_row_id);
+        uint32_t start_column_id = get_arg(args::start_column_id);
+        uint32_t single_block_size_row_arg = get_arg(args::single_block_size_row_arg);
+        uint32_t single_block_size_col_arg = get_arg(args::single_block_size_col_arg);
+        uint32_t sub_block_width_size = get_arg(args::sub_block_width_size);
+        uint32_t single_sub_block_size_row_arg = get_arg(args::single_sub_block_size_row_arg);
+
+        for (uint32_t b = 0; b < single_block_size_col_arg; b++) {
+            uint32_t this_block_num_rows = tile_height;
+            if (start_row_id + tile_height > total_num_rows) {
+                this_block_num_rows = total_num_rows - start_row_id;
+            }
+            for (uint32_t m = 0; m < width_size; m += sub_block_width_size) {
+                uint32_t start_column_id_u = start_column_id + m;
+                if (this_block_num_rows > 0) {
+                    write_block(
+                        this_block_num_rows,
+                        start_row_id,
+                        start_column_id_u,
+                        sub_block_width_size,
+                        size_2d,
+                        single_sub_block_size_row_arg);
+                }
+            }
+            start_row_id += tile_height;
+        }
+        size_2d += total_num_rows;
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_batch_rows_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_batch_rows_sharded.cpp
@@ -2,29 +2,35 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Ported in place to Metal 2.0 named bindings for untilize_with_unpadding's multi-core sharded
+// factory (this writer is op-local — only untilize_with_unpadding uses it).
+//   cb_id_untilize_out (c_16) -> dfb::out          (untilize compute output, consumed here)
+//   cb_id_out          (c_17) -> dfb::sharded_out  (borrowed L1 sharded output, written here)
+//   aligned_page_size CTA     -> named CTA
+//   runtime args              -> named RTAs
+
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/endpoints.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    uint32_t num_unpadded_output_rows = get_arg_val<uint32_t>(0);
-    uint32_t num_padded_tiles_per_batch = get_arg_val<uint32_t>(1);
-    uint32_t num_unpadded_rows_per_batch = get_arg_val<uint32_t>(2);
-    uint32_t padded_block_row_size_bytes = get_arg_val<uint32_t>(3);
-    uint32_t unpadded_block_row_size_bytes = get_arg_val<uint32_t>(4);
-    uint32_t batch = get_arg_val<uint32_t>(5);
+    uint32_t num_unpadded_output_rows = get_arg(args::num_unpadded_output_rows);
+    uint32_t num_padded_tiles_per_batch = get_arg(args::num_padded_tiles_per_batch);
+    uint32_t num_unpadded_rows_per_batch = get_arg(args::num_unpadded_rows_per_batch);
+    uint32_t padded_block_row_size_bytes = get_arg(args::padded_block_row_size_bytes);
+    uint32_t unpadded_block_row_size_bytes = get_arg(args::unpadded_block_row_size_bytes);
+    uint32_t batch = get_arg(args::batch);
 
-    constexpr uint32_t cb_id_untilize_out = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_out = get_compile_time_arg_val(1);
-    constexpr uint32_t aligned_page_size = get_compile_time_arg_val(2);
+    constexpr uint32_t aligned_page_size = get_arg(args::aligned_page_size);
 
     Noc noc;
-    CircularBuffer cb_untilize_out(cb_id_untilize_out);
-    CircularBuffer cb_out(cb_id_out);
+    DataflowBuffer cb_untilize_out(dfb::out);
+    DataflowBuffer cb_out(dfb::sharded_out);
 
     cb_out.reserve_back(num_unpadded_output_rows);
     uint32_t l1_write_addr = cb_out.get_write_ptr();

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_dims_split_rows.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_dims_split_rows.cpp
@@ -5,45 +5,43 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/dataflow_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 inline uint64_t round_down_32(uint64_t a) { return (a >> 5) << 5; }
 
 void kernel_main() {
     // Constexpr
-    constexpr uint32_t cb_id_out0 = 16;
     constexpr uint32_t tile_height = 32;
 
-    const uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    const uint32_t num_unpadded_W = get_arg_val<uint32_t>(1);
-    const uint32_t padded_W_diff_blocks = get_arg_val<uint32_t>(2);
-    const uint32_t num_unpadded_Z = get_arg_val<uint32_t>(3);
-    const uint32_t padded_Z_diff_blocks = get_arg_val<uint32_t>(4);
-    const uint32_t num_unpadded_Y = get_arg_val<uint32_t>(5);
-    const uint32_t padded_Y_diff_blocks = get_arg_val<uint32_t>(6);
-    const uint32_t num_leftover_Y = get_arg_val<uint32_t>(7);
-    const uint32_t num_unpadded_X = get_arg_val<uint32_t>(8);
-    const uint32_t padded_X_size = get_arg_val<uint32_t>(9);
-    const uint32_t num_blocks_w_input = get_arg_val<uint32_t>(10);
-    const uint32_t num_blocks_w_output = get_arg_val<uint32_t>(11);
-    const uint32_t num_blocks_w_diff = get_arg_val<uint32_t>(12);
-    const uint32_t block_row_size = get_arg_val<uint32_t>(13);
-    const uint32_t block_row_leftover_size = get_arg_val<uint32_t>(14);
+    const uint32_t num_unpadded_W = get_arg(args::num_unpadded_W);
+    const uint32_t padded_W_diff_blocks = get_arg(args::padded_W_diff_blocks);
+    const uint32_t num_unpadded_Z = get_arg(args::num_unpadded_Z);
+    const uint32_t padded_Z_diff_blocks = get_arg(args::padded_Z_diff_blocks);
+    const uint32_t num_unpadded_Y = get_arg(args::num_unpadded_Y);
+    const uint32_t padded_Y_diff_blocks = get_arg(args::padded_Y_diff_blocks);
+    const uint32_t num_leftover_Y = get_arg(args::num_leftover_Y);
+    const uint32_t num_unpadded_X = get_arg(args::num_unpadded_X);
+    const uint32_t padded_X_size = get_arg(args::padded_X_size);
+    const uint32_t num_blocks_w_input = get_arg(args::num_blocks_w_input);
+    const uint32_t num_blocks_w_output = get_arg(args::num_blocks_w_output);
+    const uint32_t num_blocks_w_diff = get_arg(args::num_blocks_w_diff);
+    const uint32_t block_row_size = get_arg(args::block_row_size);
+    const uint32_t block_row_leftover_size = get_arg(args::block_row_leftover_size);
 
     uint32_t stick_id = 0;
 
-    constexpr bool FLOAT32_DTYPE = get_compile_time_arg_val(0) == 1;
-    constexpr auto dst_args = TensorAccessorArgs<2>();
+    constexpr bool FLOAT32_DTYPE = get_arg(args::float32_dtype) == 1;
 
     const uint32_t num_tiles_block_c =
         FLOAT32_DTYPE ? block_row_size / 128
                       : block_row_size / 64;  // Assuming 4 / 2 bytes per datum, there are 128 / 64 bytes per tile row
 
-    const auto s = TensorAccessor(dst_args, dst_addr);
+    const auto s = TensorAccessor(ta::dst);
     Noc noc;
-    CircularBuffer cb_out0(cb_id_out0);
+    DataflowBuffer cb_out0(dfb::out);
 
     auto pop_blocks = [&](uint32_t num_blocks) {
         for (uint32_t i = 0; i < num_blocks; i++) {

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_width_16_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_unpad_width_16_sharded.cpp
@@ -2,32 +2,37 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-#include <stdint.h>
-#include "api/dataflow/dataflow_api.h"
-#include "api/dataflow/noc.h"
-#include "api/dataflow/circular_buffer.h"
-#include "api/dataflow/endpoints.h"
-#include "api/core_local_mem.h"
-#include "api/tensor/noc_traits.h"
+// Ported in place to Metal 2.0 named bindings for untilize_with_unpadding's multi-core sharded
+// factory (this writer is op-local — only untilize_with_unpadding uses it).
+//   cb_id_untilize_out (c_16) -> dfb::out          (copy compute output, consumed here)
+//   cb_id_out          (c_17) -> dfb::sharded_out  (borrowed L1 sharded output, written here)
+//   runtime args              -> named RTAs
 
 // Special case writer for unpad width 16 tensors
 // Skip untilize and just copy f0 and f2 from input tiles to output tiles
+
+#include <stdint.h>
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/dataflow_buffer.h"
+#include "api/dataflow/endpoints.h"
+#include "api/core_local_mem.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
 void kernel_main() {
-    uint32_t num_unpadded_output_rows = get_arg_val<uint32_t>(0);
-    uint32_t num_padded_tiles_per_core = get_arg_val<uint32_t>(1);
+    uint32_t num_unpadded_output_rows = get_arg(args::num_unpadded_output_rows);
+    uint32_t num_padded_tiles_per_core = get_arg(args::num_padded_tiles_per_core);
 
-    constexpr uint32_t cb_id_untilize_out = get_compile_time_arg_val(0);
-    constexpr uint32_t cb_id_out = get_compile_time_arg_val(1);
-
-    constexpr uint32_t tile_size_in_bytes = get_tile_size(cb_id_out);
+    constexpr uint32_t tile_size_in_bytes = get_tile_size(dfb::sharded_out);
     constexpr uint32_t quarter_tile_size_in_bytes = tile_size_in_bytes / 4;
 
     const uint32_t batches_of_8 = num_padded_tiles_per_core / 8;
     const uint32_t remaining_tiles = num_padded_tiles_per_core % 8;
 
     Noc noc;
-    CircularBuffer cb_untilize_out(cb_id_untilize_out);
-    CircularBuffer cb_out(cb_id_out);
+    DataflowBuffer cb_untilize_out(dfb::out);
+    DataflowBuffer cb_out(dfb::sharded_out);
 
     cb_out.reserve_back(num_unpadded_output_rows);
     uint32_t l1_write_addr = cb_out.get_write_ptr();

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/METAL2_PORT_REPORT.md
@@ -1,129 +1,111 @@
 # binary_ng — Metal 2.0 Port Report
 
-**STATUS: PARTIAL** — the simplest path of the op is ported to a new Metal 2.0
-`ProgramSpecFactory`; every other path remains on the legacy `ProgramFactory::create_descriptor`.
-The op builds and runs as a mixed-concept device operation (`program_factory_t` holds one
-legacy `ProgramDescriptorFactoryConcept` factory and one Metal 2.0 `ProgramSpecFactoryConcept`
-factory), dispatched per-call by a new `select_program_factory`.
+**STATUS: PARTIAL (widened).** The Metal 2.0 spec factory
+(`BinaryNgDeviceOperation::ProgramSpecFactory`, in
+`device/binary_ng_program_factory_m2.cpp`) previously covered exactly ONE path
+(no-broadcast × tile × FPU × tensor-b × interleaved × no-activation × plain ADD/SUB/MUL).
+This pass widens Metal 2.0 coverage to **three** operand/compute axes on the same
+no-broadcast/tile/interleaved/no-activation/no-typecast/plain-op base:
 
-## Op / factory
+1. tensor-b present × **FPU**  (unchanged from before)
+2. tensor-b present × **SFPU** (new)
+3. **scalar-b** (no tensor b) × FPU (new)
 
-- Op dir: `ttnn/cpp/ttnn/operations/eltwise/binary_ng/`
-- Device op: `BinaryNgDeviceOperation` (`device/binary_ng_device_operation.hpp`)
-- Legacy factory: `ProgramFactory::create_descriptor` (`device/binary_ng_program_factory.cpp:384`),
-  a single `ProgramDescriptorFactoryConcept` factory that runtime-selects its kernel *source
-  files* across ~6 multiplying axes (layout × broadcast type × compute flavor × b-present ×
-  LLK-vs-software-bcast × sharded), binding ~24 op-local kernel sources.
+All remaining paths stay on the legacy `ProgramFactory::create_descriptor`
+(`device/binary_ng_program_factory.cpp`). `select_program_factory()` routes only the three
+modeled cases to the spec factory; the gate is conservative — anything not modeled falls through.
+The op builds/runs as a mixed-concept device op (`program_factory_t` holds one legacy
+`ProgramDescriptorFactoryConcept` factory and one Metal 2.0 `MetalV2FactoryConcept` factory),
+dispatched per-call.
 
-## Why PARTIAL (not full), and why this shape is buildable
+The custom `compute_program_hash` is **kept** (shared across both factories; not deleted).
 
-A Metal 2.0 factory's conversion is **atomic within the factory body**: `create_program_spec`
-emits Metal 2.0 bindings (`dfb::`/`ta::`/`args::`), so *every* kernel source it can select at
-runtime must read those bindings. The legacy `create_descriptor` selects among ~24 sources across
-multiplying axes inside one body — converting it in place would require converting all 24 kernels
-(each with `#ifdef`-driven sub-variants) plus the per-axis host logic (3 RTA layouts, borrowed-
-memory sharded CBs, software/LLK bcast forks, per-variant dummy-arg padding) as one unit. Not
-faithfully completable in one pass.
+## Factory chosen
+`BinaryNgDeviceOperation::ProgramSpecFactory` (`MetalV2FactoryConcept`), one
+`create_program_spec` that branches on `is_sfpu` and `b_present` to pick kernels, DFB sizing,
+and per-core RTA layout. The legacy `ProgramFactory` handles everything else; the
+`program_factory_t` variant dispatches per-factory at runtime.
 
-Instead, the framework supports a `program_factory_t` variant whose alternatives satisfy
-*different* concepts, dispatched per-call by `select_program_factory` (operation_concepts.hpp:90,
-129–145; recipe "atomic unit" note). So this port **adds a second, narrow Metal 2.0 factory** for
-one path and leaves the legacy factory untouched for all others. The three kernels the narrow
-factory binds are **forked** to `*_m2.cpp` copies (the legacy factory still binds the originals),
-so the originals are not disturbed.
+## Kernels — ported vs forked
+All edited kernels are FORKED to `*_m2.cpp` (the legacy copies are shared with the legacy factory
+and other broadcast/RM paths, so in-place editing would break them). Conversion is mechanical:
+CB id → `dfb::`, `TensorAccessorArgs`/addr → `ta::`, positional `get_arg_val` /
+`get_compile_time_arg_val` → `get_arg(args::)`. Logic, `#ifdef`s, loop bounds unchanged.
 
-## Path ported
+| Forked file (`device/...`) | Forked from | Bound by |
+|---|---|---|
+| `kernels_ng/dataflow/reader_interleaved_no_bcast_m2.cpp` | `kernels_ng/dataflow/reader_interleaved_no_bcast.cpp` | tensor-b reader (FPU+SFPU) — *pre-existing* |
+| `kernels_ng/dataflow/writer_interleaved_no_bcast_m2.cpp` | `kernels_ng/dataflow/writer_interleaved_no_bcast.cpp` | tensor-b writer (FPU+SFPU) — *pre-existing* |
+| `kernels/compute/eltwise_binary_no_bcast_m2.cpp` | `kernels/compute/eltwise_binary_no_bcast.cpp` | tensor-b FPU compute — *pre-existing* |
+| `kernels/compute/eltwise_binary_sfpu_no_bcast_m2.cpp` | `kernels/compute/eltwise_binary_sfpu_no_bcast.cpp` | tensor-b SFPU compute — **NEW** |
+| `kernels/dataflow/reader_interleaved_no_bcast_m2.cpp` | `kernels/dataflow/reader_interleaved_no_bcast.cpp` (single-tensor `ReaderNoBcast`) | scalar-b reader — **NEW** |
+| `kernels/dataflow/writer_interleaved_scalar_m2.cpp` | `kernels/dataflow/writer_interleaved_scalar.cpp` | scalar-b writer (fills scalar tile + writes dst) — **NEW** |
+| `kernels/compute/eltwise_binary_scalar_m2.cpp` | `kernels/compute/eltwise_binary_scalar.cpp` | scalar-b FPU compute — **NEW** |
 
-`SubtileBroadcastType::NONE × tile layout × FPU (not SFPU/where/quant) × tensor-b-present ×
-interleaved (not sharded) × no activations × no typecast × plain ADD/SUB/MUL.`
+Note: two distinct `reader_interleaved_no_bcast_m2.cpp` files exist — one under `kernels_ng/`
+(two-tensor reader) and one under `kernels/` (single-tensor `ReaderNoBcast`); they are different
+kernels with the same base name, mirroring the legacy layout.
 
-`select_program_factory` (`device/binary_ng_device_operation.cpp`) routes only that exact case to
-`ProgramSpecFactory`; the gate is deliberately conservative — anything the narrow factory does not
-model falls through to the legacy factory.
+## DFB / binding shape
+- `src` (c_0), `src_b` (c_1), `dst` (c_2). `src_b` is double-buffered (2 entries) on the
+  tensor-b path and single-entry (1) on the scalar-b path, matching legacy CB page counts.
+- tensor-b: reader PRODUCES src+src_b; compute CONSUMES src+src_b, PRODUCES dst; writer CONSUMES dst.
+- scalar-b: reader PRODUCES src; **writer PRODUCES src_b** (fills the scalar tile once) and
+  CONSUMES dst; compute CONSUMES src+src_b, PRODUCES dst. The src_b producer/consumer endpoints
+  (writer/compute) co-reside in each WorkUnitSpec — local-DFB rule satisfied.
+- Activation-intermediate DFBs c_3/c_4 (`post_lhs`/`post_rhs`) are `#ifdef HAS_ACTIVATIONS`-gated
+  in every compute kernel but **never bound** by this factory: the routed cases are all
+  no-activation/no-typecast/plain ADD-SUB-MUL, for which `OpConfig` injects no process activations
+  (verified in `binary_ng_utils.cpp`), so the conditional branches compile out cleanly.
 
-### Files added
+## Findings / notes for downstream
+- **SFPU `unpack_to_dest_mode`.** The legacy `ComputeConfigDescriptor` set `UnpackToDestFp32` on
+  the operand CBs unconditionally for non-POWER SFPU ops, regardless of `fp32_dest_acc_en`. The
+  Metal 2.0 `ComputeHardwareConfig` **rejects** `UnpackToDestFp32` unless `fp32_dest_acc_en == true`
+  (header contract). The mode is hardware-inert outside the Float32+consumer+fp32-dest triple, so
+  this port sets `UnpackToDestFp32` on `src`/`src_b` **only when `fp32_dest_acc_en` is true** and
+  `Default` otherwise — behavior-preserving (only plain ADD/SUB/MUL route here, never POWER, so the
+  per-operand-dtype POWER branch is irrelevant).
+- **`compute_program_hash` kept** (shared; deliberately not deleted).
+- **Per-core dummy/no-op RTA emission dropped.** Metal 2.0 derives the active node set from
+  WorkUnitSpec `target_nodes`; unused cores get no per-core args (legacy emitted zero-filled dummy
+  arg vectors to size the allocation). Behavior-equivalent.
 
-- `device/binary_ng_program_factory_m2.cpp` — `ProgramSpecFactory::create_program_spec`.
-- `device/kernels_ng/dataflow/reader_interleaved_no_bcast_m2.cpp` — fork+port of the reader.
-- `device/kernels_ng/dataflow/writer_interleaved_no_bcast_m2.cpp` — fork+port of the writer.
-- `device/kernels_ng/compute/eltwise_binary_no_bcast_m2.cpp` — fork+port of the compute kernel.
+## Remaining on legacy (NOT yet on Metal 2.0) — for a follow-up pass
+- **Row-major (RM) no-bcast** (priority #1). Entirely different RTA layout (26 reader / 14 writer
+  slots: page sizes, alignments, stride bytes, row blocks), a different reader/writer pair
+  (`reader_interleaved_rm_no_bcast.cpp`, `writer_interleaved_rm_no_bcast.cpp`,
+  `reader_interleaved_rm_scalar_op.cpp`), and DFB producer roles that differ from the tile path.
+  Larger and faithfulness-risky; deferred so the shipped subset stays correct.
+- **Simple broadcast (ROW / COL / SCALAR) on tile** (priority #4). Requires the extra CBs c_5/c_6
+  (`cb_llk_post`), the `BCAST_INPUT` define, `calculate_compute_kernel_args` (freq/counter RTAs),
+  same-FIFO aliasing (`cb_pre_lhs = cb_llk_post`), and — critically — the ~80-line `use_llk_bcast`
+  software-vs-LLK fallback decision (arch/dtype-specific hangs: BH COL bf16→fp32, BH MOVB2D fp32,
+  UInt16 SCALAR relational #36217, EXP/BFP rounding). Faithful reproduction is substantial;
+  deferred to keep the subset correct.
+- where-op, quant-op, scalar-b-on-SFPU, sharded (interleaved-only here), activations, typecast,
+  non-plain ops (DIV, comparisons, bitwise, etc.), `ROW_A_COL_B` / `ROW_B_COL_A` mixed broadcast,
+  ISCLOSE.
 
-### Files changed
+## Routed-cases matrix (broadcast × layout × compute × operand)
 
-- `device/binary_ng_device_operation.hpp` — added `ProgramSpecFactory` to `program_factory_t`,
-  declared `select_program_factory`, `#include "ttnn/metal2_artifacts.hpp"`.
-- `device/binary_ng_device_operation.cpp` — added `select_program_factory`.
-- `sources.cmake` — added the new factory `.cpp`.
+Legend: **M2** = on Metal 2.0 spec factory; legacy = on `ProgramFactory::create_descriptor`.
+All M2 cells additionally require: interleaved (not sharded), no activations, no typecast
+(a.dtype == out.dtype), and plain op (ADD/SUB/MUL). Any cell not meeting those → legacy.
 
-### Kernel conversion (logic unchanged; access mechanism only)
-
-- Reader/writer: CB ids → `dfb::src`/`dfb::src_b`/`dfb::dst`; `TensorAccessorArgs<N>()` +
-  address RTA → `TensorAccessor(ta::...)` (address auto-injected, so the `src_addr`/`dst_addr`
-  RTA slots drop); positional args → `get_arg(args::...)`; the trailing positional `has_sharding`
-  CTA → named CTA. `#if SRC_SHARDED`/`DST_SHARDED` branches preserved verbatim (compiled out on
-  this interleaved path, kept for faithfulness).
-- Compute: CB ids → `dfb::pre_lhs`/`dfb::pre_rhs`/`dfb::out`; the activation-intermediate CBs
-  (c_3/c_4) become conditionally-bound `dfb::post_lhs`/`dfb::post_rhs`, and the legacy
-  `HAS_ACTIVATIONS(LHS) ? c_3 : c_0` C++ ternary is rewritten as a preprocessor `#if` so the
-  conditionally-bound DFB name never enters name lookup when its activation is absent (recipe
-  kernel-side rule 6). `dfb::` handles flow into the `PREPROCESS`/`BINARY_OP`/`pack_tile`/`cb_*`
-  helpers via the accessor's implicit `uint32_t` conversion (no `.id` extraction). The op-local
-  helper headers `eltwise_utils*.hpp` are left untouched.
-
-## TensorParameter relaxation (mirrored, not invented)
-
-The legacy factory declares `ArgConfig::RuntimeTensorShape` on its I/O `TensorAccessorArgs`
-(eltwise family). Mirrored here as `TensorParameter::advanced_options.dynamic_tensor_shape = true`
-on a/b/c — faithful to the relaxation the legacy op already had. Interleaved ⇒ TensorAccessor
-config is unchanged by it (safe).
-
-## Custom compute_program_hash — KEPT (deliberate deviation from the recipe default)
-
-The recipe normally deletes a custom `compute_program_hash` on a Metal 2.0 port. Here it is
-**kept** (`device/binary_ng_device_operation.cpp:487`): the op is mixed-concept — the legacy
-`ProgramFactory` still serves every non-narrow path and depends on the custom hash (it folds in
-`shard_volumes`). Deleting it would change the legacy factory's caching behavior. The hash is
-shared across both factories. (Per the task instruction: keep the custom hash.) When the FULL
-port lands and the legacy factory is retired, the custom hash should be revisited per the recipe.
-
-## Remaining entry points (for the full port)
-
-The legacy factory still binds all of these; the full port must convert the factory body + all of
-them as one atomic unit (or peel further narrow paths off into the Metal 2.0 factory, each with
-its own forked kernels):
-
-- Readers (`device/kernels_ng/dataflow/`): `reader_interleaved_row_bcast.cpp`,
-  `reader_interleaved_col_bcast.cpp`, `reader_interleaved_row_col_mixed_bcast.cpp`,
-  `reader_interleaved_scalar_bcast.cpp`, and the `*_rm_*` row-major family
-  (`reader_interleaved_rm_no_bcast.cpp`, `_rm_row_bcast`, `_rm_col_bcast`,
-  `_rm_row_col_mixed_bcast`, `_rm_scalar_bcast`, `_rm_scalar_op`).
-- Writers: `device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp`; legacy scalar writer
-  `device/kernels/dataflow/writer_interleaved_scalar.cpp` (`WriterScalar`).
-- Compute (LLK-bcast tree, `device/kernels_ng/compute/`): `eltwise_binary_row_bcast.cpp`,
-  `eltwise_binary_col_bcast.cpp`, `eltwise_binary_scalar_bcast.cpp`,
-  `eltwise_binary_row_col_bcast.cpp` and their `*_sfpu_*` + `eltwise_where_sfpu_*` siblings.
-- Compute (software-bcast tree, `device/kernels/compute/`): `eltwise_binary.cpp`,
-  `eltwise_binary_scalar.cpp`, `eltwise_binary_sfpu*.cpp`, `eltwise_where_*.cpp`, plus the FPU
-  `eltwise_binary_no_bcast.cpp` for the scalar/SFPU sub-cases of the no-bcast axis.
-- Axes not yet modeled by the narrow factory: row-major layout; SCALAR/ROW/COL/mixed broadcasts;
-  SFPU and where-op compute flavors; scalar-b (no tensor b); sharded (borrowed-memory CBs +
-  shard work-split); activations / typecast / quant; ISCLOSE (5-arg compute RTA); the
-  software-vs-LLK bcast fork and its arch/dtype hang-workaround fallbacks.
-
-## Handoff points / open items
-
-- **Custom hash kept by design** (above) — revisit when the full port retires the legacy factory.
-- **Untested at runtime** — no build dir in this worktree; this is a static/faithful conversion.
-  Per recipe, the narrow path's pytests (`tests/ttnn/.../eltwise`, the binary-ng add/sub/mul tile
-  interleaved bf16/fp32 cases) should be run once built; exclude not-yet-converted paths are
-  unaffected since they stay on the legacy factory.
-- **No pybind hook removed** — the legacy `create_descriptor` is still live (the legacy factory
-  remains), so no pybind surface changed.
-
-## Anti-pattern self-audit
-
-- No `tensor.buffer()->address()` in the new factory (addresses via `TensorBinding`). ✓
-- No magic CB indices in CTAs (only `has_sharding`/`num_tiles_per_cycle` named CTAs). ✓
-- No `TensorAccessorArgs<N>()` in the `_m2` kernels (replaced by `TensorAccessor(ta::...)`). ✓
-- Conditional compute DFBs (`post_lhs`/`post_rhs`) follow the `#ifdef`-gated-alias pattern. ✓
-- All CTAs named; compute work-split multiplicity preserved (one KernelSpec per core group). ✓
+| Broadcast | Layout | Compute | Operand | Routed to |
+|---|---|---|---|---|
+| NONE | TILE | FPU  | tensor-b | **M2** |
+| NONE | TILE | SFPU | tensor-b | **M2** |
+| NONE | TILE | FPU  | scalar-b | **M2** |
+| NONE | TILE | SFPU | scalar-b | legacy |
+| NONE | TILE | where/quant | any | legacy |
+| NONE | TILE | any (activations / typecast / non-plain) | any | legacy |
+| NONE | TILE | any | sharded | legacy |
+| NONE | ROW_MAJOR | any | any | legacy |
+| ROW_A / ROW_B | TILE | any | any | legacy |
+| COL_A / COL_B | TILE | any | any | legacy |
+| SCALAR_A / SCALAR_B | TILE | any | any | legacy |
+| ROW_A_COL_B / ROW_B_COL_A | TILE | any | any | legacy |
+| any | ROW_MAJOR | any | any | legacy |
+| any | any | any | sharded | legacy |

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/METAL2_PORT_REPORT.md
@@ -1,0 +1,129 @@
+# binary_ng — Metal 2.0 Port Report
+
+**STATUS: PARTIAL** — the simplest path of the op is ported to a new Metal 2.0
+`ProgramSpecFactory`; every other path remains on the legacy `ProgramFactory::create_descriptor`.
+The op builds and runs as a mixed-concept device operation (`program_factory_t` holds one
+legacy `ProgramDescriptorFactoryConcept` factory and one Metal 2.0 `ProgramSpecFactoryConcept`
+factory), dispatched per-call by a new `select_program_factory`.
+
+## Op / factory
+
+- Op dir: `ttnn/cpp/ttnn/operations/eltwise/binary_ng/`
+- Device op: `BinaryNgDeviceOperation` (`device/binary_ng_device_operation.hpp`)
+- Legacy factory: `ProgramFactory::create_descriptor` (`device/binary_ng_program_factory.cpp:384`),
+  a single `ProgramDescriptorFactoryConcept` factory that runtime-selects its kernel *source
+  files* across ~6 multiplying axes (layout × broadcast type × compute flavor × b-present ×
+  LLK-vs-software-bcast × sharded), binding ~24 op-local kernel sources.
+
+## Why PARTIAL (not full), and why this shape is buildable
+
+A Metal 2.0 factory's conversion is **atomic within the factory body**: `create_program_spec`
+emits Metal 2.0 bindings (`dfb::`/`ta::`/`args::`), so *every* kernel source it can select at
+runtime must read those bindings. The legacy `create_descriptor` selects among ~24 sources across
+multiplying axes inside one body — converting it in place would require converting all 24 kernels
+(each with `#ifdef`-driven sub-variants) plus the per-axis host logic (3 RTA layouts, borrowed-
+memory sharded CBs, software/LLK bcast forks, per-variant dummy-arg padding) as one unit. Not
+faithfully completable in one pass.
+
+Instead, the framework supports a `program_factory_t` variant whose alternatives satisfy
+*different* concepts, dispatched per-call by `select_program_factory` (operation_concepts.hpp:90,
+129–145; recipe "atomic unit" note). So this port **adds a second, narrow Metal 2.0 factory** for
+one path and leaves the legacy factory untouched for all others. The three kernels the narrow
+factory binds are **forked** to `*_m2.cpp` copies (the legacy factory still binds the originals),
+so the originals are not disturbed.
+
+## Path ported
+
+`SubtileBroadcastType::NONE × tile layout × FPU (not SFPU/where/quant) × tensor-b-present ×
+interleaved (not sharded) × no activations × no typecast × plain ADD/SUB/MUL.`
+
+`select_program_factory` (`device/binary_ng_device_operation.cpp`) routes only that exact case to
+`ProgramSpecFactory`; the gate is deliberately conservative — anything the narrow factory does not
+model falls through to the legacy factory.
+
+### Files added
+
+- `device/binary_ng_program_factory_m2.cpp` — `ProgramSpecFactory::create_program_spec`.
+- `device/kernels_ng/dataflow/reader_interleaved_no_bcast_m2.cpp` — fork+port of the reader.
+- `device/kernels_ng/dataflow/writer_interleaved_no_bcast_m2.cpp` — fork+port of the writer.
+- `device/kernels_ng/compute/eltwise_binary_no_bcast_m2.cpp` — fork+port of the compute kernel.
+
+### Files changed
+
+- `device/binary_ng_device_operation.hpp` — added `ProgramSpecFactory` to `program_factory_t`,
+  declared `select_program_factory`, `#include "ttnn/metal2_artifacts.hpp"`.
+- `device/binary_ng_device_operation.cpp` — added `select_program_factory`.
+- `sources.cmake` — added the new factory `.cpp`.
+
+### Kernel conversion (logic unchanged; access mechanism only)
+
+- Reader/writer: CB ids → `dfb::src`/`dfb::src_b`/`dfb::dst`; `TensorAccessorArgs<N>()` +
+  address RTA → `TensorAccessor(ta::...)` (address auto-injected, so the `src_addr`/`dst_addr`
+  RTA slots drop); positional args → `get_arg(args::...)`; the trailing positional `has_sharding`
+  CTA → named CTA. `#if SRC_SHARDED`/`DST_SHARDED` branches preserved verbatim (compiled out on
+  this interleaved path, kept for faithfulness).
+- Compute: CB ids → `dfb::pre_lhs`/`dfb::pre_rhs`/`dfb::out`; the activation-intermediate CBs
+  (c_3/c_4) become conditionally-bound `dfb::post_lhs`/`dfb::post_rhs`, and the legacy
+  `HAS_ACTIVATIONS(LHS) ? c_3 : c_0` C++ ternary is rewritten as a preprocessor `#if` so the
+  conditionally-bound DFB name never enters name lookup when its activation is absent (recipe
+  kernel-side rule 6). `dfb::` handles flow into the `PREPROCESS`/`BINARY_OP`/`pack_tile`/`cb_*`
+  helpers via the accessor's implicit `uint32_t` conversion (no `.id` extraction). The op-local
+  helper headers `eltwise_utils*.hpp` are left untouched.
+
+## TensorParameter relaxation (mirrored, not invented)
+
+The legacy factory declares `ArgConfig::RuntimeTensorShape` on its I/O `TensorAccessorArgs`
+(eltwise family). Mirrored here as `TensorParameter::advanced_options.dynamic_tensor_shape = true`
+on a/b/c — faithful to the relaxation the legacy op already had. Interleaved ⇒ TensorAccessor
+config is unchanged by it (safe).
+
+## Custom compute_program_hash — KEPT (deliberate deviation from the recipe default)
+
+The recipe normally deletes a custom `compute_program_hash` on a Metal 2.0 port. Here it is
+**kept** (`device/binary_ng_device_operation.cpp:487`): the op is mixed-concept — the legacy
+`ProgramFactory` still serves every non-narrow path and depends on the custom hash (it folds in
+`shard_volumes`). Deleting it would change the legacy factory's caching behavior. The hash is
+shared across both factories. (Per the task instruction: keep the custom hash.) When the FULL
+port lands and the legacy factory is retired, the custom hash should be revisited per the recipe.
+
+## Remaining entry points (for the full port)
+
+The legacy factory still binds all of these; the full port must convert the factory body + all of
+them as one atomic unit (or peel further narrow paths off into the Metal 2.0 factory, each with
+its own forked kernels):
+
+- Readers (`device/kernels_ng/dataflow/`): `reader_interleaved_row_bcast.cpp`,
+  `reader_interleaved_col_bcast.cpp`, `reader_interleaved_row_col_mixed_bcast.cpp`,
+  `reader_interleaved_scalar_bcast.cpp`, and the `*_rm_*` row-major family
+  (`reader_interleaved_rm_no_bcast.cpp`, `_rm_row_bcast`, `_rm_col_bcast`,
+  `_rm_row_col_mixed_bcast`, `_rm_scalar_bcast`, `_rm_scalar_op`).
+- Writers: `device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast.cpp`; legacy scalar writer
+  `device/kernels/dataflow/writer_interleaved_scalar.cpp` (`WriterScalar`).
+- Compute (LLK-bcast tree, `device/kernels_ng/compute/`): `eltwise_binary_row_bcast.cpp`,
+  `eltwise_binary_col_bcast.cpp`, `eltwise_binary_scalar_bcast.cpp`,
+  `eltwise_binary_row_col_bcast.cpp` and their `*_sfpu_*` + `eltwise_where_sfpu_*` siblings.
+- Compute (software-bcast tree, `device/kernels/compute/`): `eltwise_binary.cpp`,
+  `eltwise_binary_scalar.cpp`, `eltwise_binary_sfpu*.cpp`, `eltwise_where_*.cpp`, plus the FPU
+  `eltwise_binary_no_bcast.cpp` for the scalar/SFPU sub-cases of the no-bcast axis.
+- Axes not yet modeled by the narrow factory: row-major layout; SCALAR/ROW/COL/mixed broadcasts;
+  SFPU and where-op compute flavors; scalar-b (no tensor b); sharded (borrowed-memory CBs +
+  shard work-split); activations / typecast / quant; ISCLOSE (5-arg compute RTA); the
+  software-vs-LLK bcast fork and its arch/dtype hang-workaround fallbacks.
+
+## Handoff points / open items
+
+- **Custom hash kept by design** (above) — revisit when the full port retires the legacy factory.
+- **Untested at runtime** — no build dir in this worktree; this is a static/faithful conversion.
+  Per recipe, the narrow path's pytests (`tests/ttnn/.../eltwise`, the binary-ng add/sub/mul tile
+  interleaved bf16/fp32 cases) should be run once built; exclude not-yet-converted paths are
+  unaffected since they stay on the legacy factory.
+- **No pybind hook removed** — the legacy `create_descriptor` is still live (the legacy factory
+  remains), so no pybind surface changed.
+
+## Anti-pattern self-audit
+
+- No `tensor.buffer()->address()` in the new factory (addresses via `TensorBinding`). ✓
+- No magic CB indices in CTAs (only `has_sharding`/`num_tiles_per_cycle` named CTAs). ✓
+- No `TensorAccessorArgs<N>()` in the `_m2` kernels (replaced by `TensorAccessor(ta::...)`). ✓
+- Conditional compute DFBs (`post_lhs`/`post_rhs`) follow the `#ifdef`-gated-alias pattern. ✓
+- All CTAs named; compute work-split multiplicity preserved (one KernelSpec per core group). ✓

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/METAL2_PORT_REPORT.md
@@ -1,6 +1,21 @@
 # binary_ng — Metal 2.0 port report
 
-## STATUS: PARTIAL (coverage widened; remaining cases deliberately on legacy)
+## STATUS: PARTIAL (NONE-broadcast only; simple-broadcast widening REVERTED — see fix note below)
+
+> ### Fix note (routing narrowed)
+> The earlier broadcast widening was unsound and has been reverted in `binary_ng_m2_routes_to_spec`:
+> - **bf4b/bf8b broadcast HANG**: the forked LLK-bcast compute/reader kernels deadlock for
+>   multi-tile broadcast operands (e.g. `test_bf4b_bf8b` add over `[5,3,128,64]+[1,3,128,1]`). All
+>   simple-broadcast tile paths (SCALAR/ROW/COL) are now routed to the **legacy** factory.
+> - **01-volume / sub-tile wrong values**: tensors whose logical shape does not fill a full tile
+>   (e.g. `[1]+[2]` -> `[2]` instead of `[3]`; `[1,2]+[3]` -> `[0,0]`) read back wrong data on the
+>   spec path because `dynamic_tensor_shape = true` rebuilds the interleaved TensorAccessor page
+>   geometry from the live sub-tile logical `TensorSpec`, so the per-tile NoC reads in the forked
+>   dataflow kernels no longer match the on-device padded-tile layout. A guard now keeps any tensor
+>   with `logical volume < tile_area` on the **legacy** factory.
+> Only NONE-broadcast (tile + RM), tile-aligned (>= 1 full tile) cases route to spec. The unused
+> simple-broadcast forked kernels + spec-construction code remain in the factory for a future debug
+> pass but are unreachable. (Original "widened" report text retained below for context.)
 
 `BinaryNgDeviceOperation::ProgramSpecFactory::create_program_spec` (in
 `binary_ng_program_factory_m2.cpp`) is the single Metal 2.0 factory for the op. It now models a
@@ -24,20 +39,20 @@ Common gate for any spec routing: interleaved (not sharded), no activations, no 
 (`a.dtype() == output dtype`), plain op ∈ {ADD, SUB, MUL}, not where-op, not quant-op, operand
 present (tensor-b or scalar value).
 
+Additional gate (applied to every routed case): all of `a`, `b` (if present), and `c` have logical
+volume >= one full tile (`tile_height * tile_width`). Sub-tile / 01-volume tensors -> legacy.
+
 | Broadcast | Layout | Compute | Operand | Routed to |
 |-----------|--------|---------|---------|-----------|
 | NONE | TILE | FPU | tensor-b | **SPEC** |
 | NONE | TILE | SFPU | tensor-b | **SPEC** |
 | NONE | TILE | FPU | scalar-b | **SPEC** |
-| NONE | TILE | SFPU | scalar-b | **SPEC** (new) |
-| NONE | ROW_MAJOR | FPU | tensor-b | **SPEC** (new) |
+| NONE | TILE | SFPU | scalar-b | **SPEC** |
+| NONE | ROW_MAJOR | FPU | tensor-b | **SPEC** |
 | NONE | ROW_MAJOR | SFPU | tensor-b | legacy |
 | NONE | ROW_MAJOR | any | scalar-b (RM scalar-op) | legacy |
-| SCALAR_A / SCALAR_B | TILE | FPU | tensor-b | **SPEC iff `use_llk_bcast`** (new); else legacy |
-| ROW_A / ROW_B | TILE | FPU | tensor-b | **SPEC iff `use_llk_bcast`** (new); else legacy |
-| COL_A / COL_B | TILE | FPU | tensor-b | **SPEC iff `use_llk_bcast`** (new); else legacy |
-| SCALAR / ROW / COL | TILE | SFPU | tensor-b | legacy |
-| SCALAR / ROW / COL | TILE | any | scalar-b | legacy |
+| NONE (any layout) | any | any | sub-tile / 01-volume tensor | legacy (new guard) |
+| SCALAR / ROW / COL (any *_A/*_B) | TILE | any | any | legacy (reverted — hang/wrong values) |
 | ROW_A_COL_B / ROW_B_COL_A (mixed) | any | any | any | legacy |
 | any broadcast | ROW_MAJOR | any | any | legacy |
 | any (sharded) | any | any | any | legacy |

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/METAL2_PORT_REPORT.md
@@ -1,0 +1,123 @@
+# binary_ng — Metal 2.0 port report
+
+## STATUS: PARTIAL (coverage widened; remaining cases deliberately on legacy)
+
+`BinaryNgDeviceOperation::ProgramSpecFactory::create_program_spec` (in
+`binary_ng_program_factory_m2.cpp`) is the single Metal 2.0 factory for the op. It now models a
+widened set of interleaved cases. `select_program_factory` routes ONLY the verified-ported cases to
+the spec factory (via the shared predicate `binary_ng_m2_routes_to_spec`); every other case stays on
+the legacy `ProgramFactory::create_descriptor`. The custom `compute_program_hash` is **kept**
+(unchanged) — it is shared by both factories.
+
+This pass extends the previously-routed 3 cases (NONE × tile × interleaved × {tensor-b FPU,
+tensor-b SFPU, scalar-b FPU}) with:
+1. **ROW_MAJOR × NONE-broadcast × tensor-b × FPU** — own reader/writer RM forks; reuses the FPU
+   no-bcast compute (RM forces freq=1/counter=0, so the no-bcast compute is correct).
+2. **scalar-b × SFPU (tile)** — adds the SFPU scalar compute fork.
+3. **Simple broadcast on tile (SCALAR / ROW / COL) × tensor-b × FPU** — adds bcast readers + the
+   LLK-bcast compute kernels, extra bcast DFBs (legacy c_5 / c_6), compute freq/counter RTAs, and
+   the `BCAST_INPUT` / `SRC_BCAST(_B)` defines. Routed **only on the LLK-bcast subset** (see below).
+
+## Routed-cases matrix (broadcast × layout × compute × operand → spec vs legacy)
+
+Common gate for any spec routing: interleaved (not sharded), no activations, no typecast
+(`a.dtype() == output dtype`), plain op ∈ {ADD, SUB, MUL}, not where-op, not quant-op, operand
+present (tensor-b or scalar value).
+
+| Broadcast | Layout | Compute | Operand | Routed to |
+|-----------|--------|---------|---------|-----------|
+| NONE | TILE | FPU | tensor-b | **SPEC** |
+| NONE | TILE | SFPU | tensor-b | **SPEC** |
+| NONE | TILE | FPU | scalar-b | **SPEC** |
+| NONE | TILE | SFPU | scalar-b | **SPEC** (new) |
+| NONE | ROW_MAJOR | FPU | tensor-b | **SPEC** (new) |
+| NONE | ROW_MAJOR | SFPU | tensor-b | legacy |
+| NONE | ROW_MAJOR | any | scalar-b (RM scalar-op) | legacy |
+| SCALAR_A / SCALAR_B | TILE | FPU | tensor-b | **SPEC iff `use_llk_bcast`** (new); else legacy |
+| ROW_A / ROW_B | TILE | FPU | tensor-b | **SPEC iff `use_llk_bcast`** (new); else legacy |
+| COL_A / COL_B | TILE | FPU | tensor-b | **SPEC iff `use_llk_bcast`** (new); else legacy |
+| SCALAR / ROW / COL | TILE | SFPU | tensor-b | legacy |
+| SCALAR / ROW / COL | TILE | any | scalar-b | legacy |
+| ROW_A_COL_B / ROW_B_COL_A (mixed) | any | any | any | legacy |
+| any broadcast | ROW_MAJOR | any | any | legacy |
+| any (sharded) | any | any | any | legacy |
+| activations / typecast / where / quant / non-plain op | any | any | any | legacy |
+
+`use_llk_bcast` is the legacy factory's decision (reproduced verbatim in
+`binary_ng_m2_use_llk_bcast`): true for {bf16, bf8, bf4} all-matching on any arch, and for
+{fp32, int32, uint32, uint16} all-matching only on Wormhole_B0; with the legacy fallbacks subtracted
+(BH col bf16→fp32 hang; BH MOVB2D fp32 for SCALAR/ROW; UInt16 scalar relational — inert for the
+routed plain-arithmetic subset). When `use_llk_bcast` is false, the software-fallback (`BCAST_LLK=0`)
+compute kernels would run — those are **not ported**, so those tuples stay on legacy. This honors the
+rule "never route a case whose kernels you didn't convert."
+
+## Kernels (ported vs forked)
+
+All kernels live inside the op directory and are referenced by path. None is shared by another op
+(`grep -rl` across `ttnn/cpp/ttnn/operations` confirmed), so each was **forked** to a `*_m2.cpp`
+copy (the legacy factory still binds the originals by `KernelName` path). Newly forked this pass:
+
+| New `*_m2` kernel | Forked from | Used by |
+|---|---|---|
+| `kernels/compute/eltwise_binary_sfpu_scalar_m2.cpp` | `eltwise_binary_sfpu_scalar.cpp` | scalar-b × SFPU |
+| `kernels_ng/dataflow/reader_interleaved_rm_no_bcast_m2.cpp` | `reader_interleaved_rm_no_bcast.cpp` | RM no-bcast |
+| `kernels_ng/dataflow/writer_interleaved_rm_no_bcast_m2.cpp` | `writer_interleaved_rm_no_bcast.cpp` | RM no-bcast |
+| `kernels_ng/dataflow/reader_interleaved_scalar_bcast_m2.cpp` | `reader_interleaved_scalar_bcast.cpp` | SCALAR bcast |
+| `kernels_ng/dataflow/reader_interleaved_row_bcast_m2.cpp` | `reader_interleaved_row_bcast.cpp` | ROW bcast |
+| `kernels_ng/dataflow/reader_interleaved_col_bcast_m2.cpp` | `reader_interleaved_col_bcast.cpp` | COL bcast |
+| `kernels_ng/compute/eltwise_binary_scalar_bcast_m2.cpp` | `eltwise_binary_scalar_bcast.cpp` | SCALAR bcast (LLK) |
+| `kernels_ng/compute/eltwise_binary_row_bcast_m2.cpp` | `eltwise_binary_row_bcast.cpp` | ROW bcast (LLK) |
+| `kernels_ng/compute/eltwise_binary_col_bcast_m2.cpp` | `eltwise_binary_col_bcast.cpp` | COL bcast (LLK) |
+
+Pre-existing forks (prior pass, reused): `reader_interleaved_no_bcast_m2.cpp` (both kernels/ and
+kernels_ng/), `writer_interleaved_no_bcast_m2.cpp`, `writer_interleaved_scalar_m2.cpp`,
+`eltwise_binary_no_bcast_m2.cpp`, `eltwise_binary_sfpu_no_bcast_m2.cpp`, `eltwise_binary_scalar_m2.cpp`.
+
+Per-kernel conversions were mechanical (CB id → `dfb::`, `TensorAccessorArgs`/addr → `ta::`,
+positional `get_arg_val`/`get_compile_time_arg_val` → `get_arg(args::)`); logic, `#ifdef`s, loop
+bounds, numeric paths and comments preserved. The `HAS_ACTIVATIONS(LHS/RHS) ? c_3/c_4 : …` ternaries
+were rewritten as `#if/#else` preprocessor gates so the conditionally-bound `dfb::post_lhs/post_rhs`
+tokens never enter name lookup when their activation is absent (Conditional-DFB-binding pattern).
+
+## Spec-construction notes
+
+- **DFB ← CB**: c_0=`src`, c_1=`src_b`, c_2=`dst`. The LLK-bcast tile path adds the legacy
+  intermediate c_5 (bcast operand = A → `llk_post_a`) or c_6 (bcast operand = B → `llk_post_b`),
+  bound on the compute kernel as a **self-loop** (PRODUCER+CONSUMER, shared accessor name) — a genuine
+  self-loop (the compute packs into it then consumes it), not a fake-CB workaround.
+- **Conditional activation DFBs** (c_3/c_4 = `post_lhs`/`post_rhs`) are NOT bound for the routed
+  cases (no activations route), and the kernels `#ifdef`-gate their tokens accordingly.
+- **RM page-size override removed**: the legacy RM reader/writer passed
+  `TensorAccessor(args, addr, page_size_override)` "to override TensorAccessorArgs::AlignedPageSize
+  which may be stale on program cache hits." The Metal 2.0 framework rebuilds the interleaved
+  TensorAccessor CTA payload (incl. `aligned_page_size = align(compute_page_size_bytes, alignment)`)
+  from the live `TensorSpec` on every cache miss (`program_spec.cpp` `ResolveTensorParameterStaticCTAs`),
+  so the staleness the override guarded against does not exist on the m2 path. The override (and the
+  `page_size_*` RTAs feeding it) were dropped; the `alignment_*` RTAs were KEPT (still used for
+  `align(current_chunk_bytes, alignment)` read/write-length rounding). This is the only behavioral
+  reasoning beyond pure mechanical translation; flagged here for reviewer confirmation.
+- **Work split**: tile path parallelizes across output tiles (`physical_volume/tile_hw`); RM path
+  across row blocks (`total_row_blocks`), reproducing the legacy RM geometry
+  (`num_rows_per_tile`, `tiles_per_row_width`, reader/writer stride bytes). Multiplicity preserved:
+  one compute `KernelSpec` + `WorkUnitSpec` per core group.
+- **Compute RTAs**: no-bcast/scalar/RM read `num_tiles` only. The simple-broadcast computes read
+  `num_tiles, tile_freq, tile_start` (`calculate_compute_kernel_args`); the legacy 4th compute arg
+  (`compute_scalar_value` = quant zero-point) is dead for plain ADD/SUB/MUL and dropped (a
+  superfluous named arg is an m2 validation error).
+- **dynamic_tensor_shape = true** on all tensor parameters mirrors the legacy
+  `RuntimeTensorShape` config; for interleaved tensors it is a pure host-side validation loosening.
+
+## Open items / findings (routed to owners, not changed here)
+
+- The software-fallback (`BCAST_LLK=0`) simple-broadcast compute kernels (`eltwise_binary.cpp`,
+  `eltwise_binary_no_bcast.cpp` software-bcast use) are not ported; porting them would let the
+  remaining SCALAR/ROW/COL tuples (and Blackhole fp32 / non-WH non-bf16) route to spec.
+- SFPU simple-broadcast, scalar-b simple-broadcast, mixed ROW+COL broadcast, RM broadcast, and RM
+  scalar-op remain on legacy (their kernels were not converted this pass).
+- Sharded paths remain on legacy (the m2 factory models interleaved only).
+- `binary_ng_m2_use_llk_bcast` duplicates the legacy `is_llk_bcast` gate (kept in sync by comment).
+  A future consolidation could hoist the single source of truth into `binary_ng_utils`.
+
+## Not built / not committed
+Per instructions: no build, no measurement, no commit. The patch is at
+`/tmp/port_binary_ng_more2.patch`.

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -486,17 +486,24 @@ BinaryNgDeviceOperation::tensor_return_value_t BinaryNgDeviceOperation::create_o
 
 BinaryNgDeviceOperation::program_factory_t BinaryNgDeviceOperation::select_program_factory(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    // Route ONLY the simplest path to the Metal 2.0 ProgramSpecFactory:
-    //   SubtileBroadcastType::NONE x tile layout x FPU (not SFPU, not where) x tensor-b-present x
-    //   interleaved (not sharded) x no activations x no typecast x plain ADD/SUB/MUL.
-    // Everything else stays on the legacy ProgramFactory::create_descriptor. The gate is
-    // deliberately conservative: any condition the narrow factory does not model falls through.
+    // Route to the Metal 2.0 ProgramSpecFactory the no-broadcast x tile x interleaved x
+    // no-activation x no-typecast x plain ADD/SUB/MUL cases across these operand/compute axes:
+    //   1. tensor-b present x FPU
+    //   2. tensor-b present x SFPU
+    //   3. scalar-b (no tensor b) x FPU
+    // Everything else (row-major, all broadcast types, where-op, quant-op, scalar-b-on-SFPU,
+    // sharded, activations, typecast, non-plain ops) stays on the legacy
+    // ProgramFactory::create_descriptor. The gate is deliberately conservative: any condition the
+    // factory does not model falls through. See binary_ng_program_factory_m2.cpp / the report.
     const auto& a = tensor_args.input_tensor_a;
     const auto& b = tensor_args.input_tensor_b;
 
     const bool b_present = b.has_value();
     const bool is_none_bcast = attributes.subtile_broadcast_type == SubtileBroadcastType::NONE;
-    const bool is_fpu = !attributes.is_sfpu && !attributes.is_where_op && !attributes.is_quant_op;
+    // where/quant ops are never modeled by the Metal 2.0 factory; SFPU is modeled only with a
+    // tensor b (the scalar-b path is FPU-only in the factory).
+    const bool compute_modeled =
+        !attributes.is_where_op && !attributes.is_quant_op && (!attributes.is_sfpu || b_present);
     const bool tile_layout = attributes.input_layout_a == Layout::TILE && attributes.input_layout_b == Layout::TILE &&
                              attributes.output_layout == Layout::TILE;
     const bool no_activations =
@@ -507,10 +514,13 @@ BinaryNgDeviceOperation::program_factory_t BinaryNgDeviceOperation::select_progr
 
     bool sharded = a.memory_config().is_sharded() || (b_present && b->memory_config().is_sharded()) ||
                    attributes.memory_config.is_sharded();
-    // No typecast (a and output share dtype) so the FPU compute kernel binds no POST activation.
-    const bool no_typecast = b_present && a.dtype() == attributes.get_dtype();
+    // No typecast (a and output share dtype) so the compute kernel binds no POST activation. The
+    // scalar-b path also requires a scalar value present.
+    const bool no_typecast = a.dtype() == attributes.get_dtype();
+    const bool operand_ok = b_present || attributes.scalar.has_value();
 
-    if (b_present && is_none_bcast && is_fpu && tile_layout && no_activations && plain_op && !sharded && no_typecast) {
+    if (is_none_bcast && compute_modeled && tile_layout && no_activations && plain_op && !sharded && no_typecast &&
+        operand_ok) {
         return ProgramSpecFactory{};
     }
     return ProgramFactory{};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -484,6 +484,38 @@ BinaryNgDeviceOperation::tensor_return_value_t BinaryNgDeviceOperation::create_o
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
 }
 
+BinaryNgDeviceOperation::program_factory_t BinaryNgDeviceOperation::select_program_factory(
+    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
+    // Route ONLY the simplest path to the Metal 2.0 ProgramSpecFactory:
+    //   SubtileBroadcastType::NONE x tile layout x FPU (not SFPU, not where) x tensor-b-present x
+    //   interleaved (not sharded) x no activations x no typecast x plain ADD/SUB/MUL.
+    // Everything else stays on the legacy ProgramFactory::create_descriptor. The gate is
+    // deliberately conservative: any condition the narrow factory does not model falls through.
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+
+    const bool b_present = b.has_value();
+    const bool is_none_bcast = attributes.subtile_broadcast_type == SubtileBroadcastType::NONE;
+    const bool is_fpu = !attributes.is_sfpu && !attributes.is_where_op && !attributes.is_quant_op;
+    const bool tile_layout = attributes.input_layout_a == Layout::TILE && attributes.input_layout_b == Layout::TILE &&
+                             attributes.output_layout == Layout::TILE;
+    const bool no_activations =
+        attributes.lhs_activations.empty() && attributes.rhs_activations.empty() && attributes.post_activations.empty();
+    const bool plain_op = attributes.binary_op_type == BinaryOpType::ADD ||
+                          attributes.binary_op_type == BinaryOpType::SUB ||
+                          attributes.binary_op_type == BinaryOpType::MUL;
+
+    bool sharded = a.memory_config().is_sharded() || (b_present && b->memory_config().is_sharded()) ||
+                   attributes.memory_config.is_sharded();
+    // No typecast (a and output share dtype) so the FPU compute kernel binds no POST activation.
+    const bool no_typecast = b_present && a.dtype() == attributes.get_dtype();
+
+    if (b_present && is_none_bcast && is_fpu && tile_layout && no_activations && plain_op && !sharded && no_typecast) {
+        return ProgramSpecFactory{};
+    }
+    return ProgramFactory{};
+}
+
 ttsl::hash::hash_t BinaryNgDeviceOperation::compute_program_hash(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
     const auto& input_tensor_a = tensor_args.input_tensor_a;

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -486,25 +486,24 @@ BinaryNgDeviceOperation::tensor_return_value_t BinaryNgDeviceOperation::create_o
 
 // Defined in binary_ng_program_factory_m2.cpp. Returns true for exactly the (broadcast x layout x
 // compute x operand) cases the Metal 2.0 ProgramSpecFactory faithfully models. Routing and the
-// factory share this single predicate so the two never drift -- in particular the simple-broadcast
-// cases route to spec ONLY on the LLK-bcast subset (the software-fallback compute kernels are not
-// ported), reproducing the legacy `use_llk_bcast` (arch/dtype/fp32) gating verbatim.
+// factory share this single predicate so the two never drift.
 bool binary_ng_m2_routes_to_spec(
     const BinaryNgDeviceOperation::operation_attributes_t& attributes,
     const BinaryNgDeviceOperation::tensor_args_t& tensor_args);
 
 BinaryNgDeviceOperation::program_factory_t BinaryNgDeviceOperation::select_program_factory(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    // Route to the Metal 2.0 ProgramSpecFactory the interleaved x no-activation x no-typecast x
-    // plain ADD/SUB/MUL x non-where x non-quant cases that the factory models:
-    //   TILE:  NONE bcast {tensor-b FPU, tensor-b SFPU, scalar-b FPU, scalar-b SFPU};
-    //          SCALAR/ROW/COL bcast {tensor-b FPU} -- LLK-bcast subset only.
+    // Route to the Metal 2.0 ProgramSpecFactory only the interleaved x no-activation x no-typecast x
+    // plain ADD/SUB/MUL x non-where x non-quant x NONE-broadcast cases that fully populate at least
+    // one tile (no sub-tile / 01-volume tensors):
+    //   TILE:      NONE bcast {tensor-b FPU, tensor-b SFPU, scalar-b FPU, scalar-b SFPU};
     //   ROW_MAJOR: NONE bcast {tensor-b FPU}.
-    // Everything else (sharded, activations, typecast, where-op, quant-op, scalar-b broadcast,
-    // software-fallback broadcast tuples, mixed row+col bcast, RM broadcast/scalar-op, SFPU bcast)
-    // stays on the legacy ProgramFactory::create_descriptor. The gate is deliberately conservative:
-    // any condition the factory does not model falls through. See binary_ng_program_factory_m2.cpp /
-    // the report.
+    // Everything else (sharded, activations, typecast, where-op, quant-op, ALL subtile broadcast
+    // (scalar/row/col/mixed), RM broadcast/scalar-op, and sub-tile / 01-volume tensors) stays on the
+    // legacy ProgramFactory::create_descriptor. The simple-broadcast spec path was reverted: its
+    // forked LLK-bcast kernels deadlock for multi-tile broadcast operands. The gate is deliberately
+    // conservative: any condition the factory does not model falls through. See
+    // binary_ng_program_factory_m2.cpp / the report.
     if (binary_ng_m2_routes_to_spec(attributes, tensor_args)) {
         return ProgramSpecFactory{};
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.cpp
@@ -484,43 +484,28 @@ BinaryNgDeviceOperation::tensor_return_value_t BinaryNgDeviceOperation::create_o
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
 }
 
+// Defined in binary_ng_program_factory_m2.cpp. Returns true for exactly the (broadcast x layout x
+// compute x operand) cases the Metal 2.0 ProgramSpecFactory faithfully models. Routing and the
+// factory share this single predicate so the two never drift -- in particular the simple-broadcast
+// cases route to spec ONLY on the LLK-bcast subset (the software-fallback compute kernels are not
+// ported), reproducing the legacy `use_llk_bcast` (arch/dtype/fp32) gating verbatim.
+bool binary_ng_m2_routes_to_spec(
+    const BinaryNgDeviceOperation::operation_attributes_t& attributes,
+    const BinaryNgDeviceOperation::tensor_args_t& tensor_args);
+
 BinaryNgDeviceOperation::program_factory_t BinaryNgDeviceOperation::select_program_factory(
     const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    // Route to the Metal 2.0 ProgramSpecFactory the no-broadcast x tile x interleaved x
-    // no-activation x no-typecast x plain ADD/SUB/MUL cases across these operand/compute axes:
-    //   1. tensor-b present x FPU
-    //   2. tensor-b present x SFPU
-    //   3. scalar-b (no tensor b) x FPU
-    // Everything else (row-major, all broadcast types, where-op, quant-op, scalar-b-on-SFPU,
-    // sharded, activations, typecast, non-plain ops) stays on the legacy
-    // ProgramFactory::create_descriptor. The gate is deliberately conservative: any condition the
-    // factory does not model falls through. See binary_ng_program_factory_m2.cpp / the report.
-    const auto& a = tensor_args.input_tensor_a;
-    const auto& b = tensor_args.input_tensor_b;
-
-    const bool b_present = b.has_value();
-    const bool is_none_bcast = attributes.subtile_broadcast_type == SubtileBroadcastType::NONE;
-    // where/quant ops are never modeled by the Metal 2.0 factory; SFPU is modeled only with a
-    // tensor b (the scalar-b path is FPU-only in the factory).
-    const bool compute_modeled =
-        !attributes.is_where_op && !attributes.is_quant_op && (!attributes.is_sfpu || b_present);
-    const bool tile_layout = attributes.input_layout_a == Layout::TILE && attributes.input_layout_b == Layout::TILE &&
-                             attributes.output_layout == Layout::TILE;
-    const bool no_activations =
-        attributes.lhs_activations.empty() && attributes.rhs_activations.empty() && attributes.post_activations.empty();
-    const bool plain_op = attributes.binary_op_type == BinaryOpType::ADD ||
-                          attributes.binary_op_type == BinaryOpType::SUB ||
-                          attributes.binary_op_type == BinaryOpType::MUL;
-
-    bool sharded = a.memory_config().is_sharded() || (b_present && b->memory_config().is_sharded()) ||
-                   attributes.memory_config.is_sharded();
-    // No typecast (a and output share dtype) so the compute kernel binds no POST activation. The
-    // scalar-b path also requires a scalar value present.
-    const bool no_typecast = a.dtype() == attributes.get_dtype();
-    const bool operand_ok = b_present || attributes.scalar.has_value();
-
-    if (is_none_bcast && compute_modeled && tile_layout && no_activations && plain_op && !sharded && no_typecast &&
-        operand_ok) {
+    // Route to the Metal 2.0 ProgramSpecFactory the interleaved x no-activation x no-typecast x
+    // plain ADD/SUB/MUL x non-where x non-quant cases that the factory models:
+    //   TILE:  NONE bcast {tensor-b FPU, tensor-b SFPU, scalar-b FPU, scalar-b SFPU};
+    //          SCALAR/ROW/COL bcast {tensor-b FPU} -- LLK-bcast subset only.
+    //   ROW_MAJOR: NONE bcast {tensor-b FPU}.
+    // Everything else (sharded, activations, typecast, where-op, quant-op, scalar-b broadcast,
+    // software-fallback broadcast tuples, mixed row+col bcast, RM broadcast/scalar-op, SFPU bcast)
+    // stays on the legacy ProgramFactory::create_descriptor. The gate is deliberately conservative:
+    // any condition the factory does not model falls through. See binary_ng_program_factory_m2.cpp /
+    // the report.
+    if (binary_ng_m2_routes_to_spec(attributes, tensor_args)) {
         return ProgramSpecFactory{};
     }
     return ProgramFactory{};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -10,6 +10,7 @@
 #include "ttnn/operations/eltwise/unary/common/unary_op_types.hpp"
 #include <tt-metalium/sub_device_types.hpp>
 #include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 namespace ttnn::operations::binary_ng {
 
 enum class SubtileBroadcastType {
@@ -71,7 +72,21 @@ struct BinaryNgDeviceOperation {
             tensor_return_value_t& c);
     };
 
-    using program_factory_t = std::variant<ProgramFactory>;
+    // Metal 2.0 factory. Currently handles ONLY the simplest path:
+    //   no-broadcast (SubtileBroadcastType::NONE) x tile layout x FPU x tensor-b-present x
+    //   interleaved x no activations. select_program_factory() routes only that exact case
+    //   here; every other path stays on the legacy ProgramFactory above. The remaining paths
+    //   (row-major, all broadcast types, SFPU, where-op, scalar-b, sharded) are enumerated in
+    //   METAL2_PORT_REPORT.md for a follow-up pass.
+    struct ProgramSpecFactory {
+        static ttnn::device_operation::ProgramArtifacts create_program_spec(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& c);
+    };
+
+    using program_factory_t = std::variant<ProgramFactory, ProgramSpecFactory>;
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_device_operation.hpp
@@ -72,12 +72,15 @@ struct BinaryNgDeviceOperation {
             tensor_return_value_t& c);
     };
 
-    // Metal 2.0 factory. Currently handles ONLY the simplest path:
-    //   no-broadcast (SubtileBroadcastType::NONE) x tile layout x FPU x tensor-b-present x
-    //   interleaved x no activations. select_program_factory() routes only that exact case
-    //   here; every other path stays on the legacy ProgramFactory above. The remaining paths
-    //   (row-major, all broadcast types, SFPU, where-op, scalar-b, sharded) are enumerated in
-    //   METAL2_PORT_REPORT.md for a follow-up pass.
+    // Metal 2.0 factory. Handles the interleaved x no-activation x no-typecast x plain ADD/SUB/MUL
+    // x non-where x non-quant cases across these axes (select_program_factory routes only these):
+    //   TILE:  NONE bcast {tensor-b FPU, tensor-b SFPU, scalar-b FPU, scalar-b SFPU};
+    //          SCALAR/ROW/COL bcast {tensor-b FPU}, LLK-bcast subset only (legacy use_llk_bcast).
+    //   ROW_MAJOR: NONE bcast {tensor-b FPU}.
+    // Every other path stays on the legacy ProgramFactory above. The remaining paths (sharded,
+    // activations, typecast, where-op, quant-op, scalar-b broadcast, software-fallback broadcast
+    // tuples, mixed row+col bcast, RM broadcast/scalar-op, SFPU broadcast) are enumerated in
+    // METAL2_PORT_REPORT.md for follow-up passes.
     struct ProgramSpecFactory {
         static ttnn::device_operation::ProgramArtifacts create_program_spec(
             const operation_attributes_t& operation_attributes,

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory_m2.cpp
@@ -4,17 +4,20 @@
 
 // Metal 2.0 program factory for binary_ng.
 //
-// SCOPE: this factory handles ONLY the simplest path of the op:
-//   SubtileBroadcastType::NONE x tile layout x FPU (not SFPU, not where) x tensor-b-present x
-//   interleaved (not sharded) x no activations.
-// BinaryNgDeviceOperation::select_program_factory() routes only that exact case here; every
-// other path (row-major, all broadcast types, SFPU, where-op, scalar-b, sharded, activations)
-// stays on the legacy ProgramFactory::create_descriptor in binary_ng_program_factory.cpp.
-// The full set of remaining kernel entry points is enumerated in METAL2_PORT_REPORT.md.
+// SCOPE: this factory handles the no-broadcast (SubtileBroadcastType::NONE) x tile layout x
+// interleaved (not sharded) x no-activation x plain ADD/SUB/MUL x no-typecast cases, across the
+// following operand/compute axes (all routed here by select_program_factory()):
+//   1. tensor-b present x FPU   (eltwise_binary_no_bcast_m2 compute)
+//   2. tensor-b present x SFPU  (eltwise_binary_sfpu_no_bcast_m2 compute)
+//   3. scalar-b (no tensor b) x FPU (eltwise_binary_scalar_m2 compute; writer fills the scalar tile)
+// Every OTHER path (row-major, all broadcast types, where-op, quant-op, scalar-b-on-SFPU, sharded,
+// activations, typecast, non-plain ops) stays on the legacy ProgramFactory::create_descriptor in
+// binary_ng_program_factory.cpp. The full set of remaining kernel entry points and the routed-vs-
+// legacy matrix are enumerated in METAL2_PORT_REPORT.md.
 //
-// The legacy factory's logic for this path is preserved exactly (work-split, per-core tile
-// strides, CB sizes); only the host API is converted to Metal 2.0 ProgramSpec / ProgramRunArgs,
-// and the three kernels it binds are the forked *_m2.cpp ports.
+// The legacy factory's logic for these paths is preserved exactly (work-split, per-core tile
+// strides, CB sizes, fp32_dest_acc_en, unpack-to-dest); only the host API is converted to
+// Metal 2.0 ProgramSpec / ProgramRunArgs, and the kernels it binds are the forked *_m2.cpp ports.
 
 #include "binary_ng_device_operation.hpp"
 #include "binary_ng_utils.hpp"
@@ -40,13 +43,23 @@ namespace ttnn::operations::binary_ng {
 
 namespace {
 
-// Forked Metal 2.0 kernel sources (no-broadcast tile FPU interleaved path).
-constexpr const char* READER_M2 =
+// Forked Metal 2.0 kernel sources.
+//   tensor-b path (reader reads both src & src_b; writer copies dst):
+constexpr const char* READER_AB_M2 =
     "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast_m2.cpp";
-constexpr const char* WRITER_M2 =
+constexpr const char* WRITER_AB_M2 =
     "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast_m2.cpp";
-constexpr const char* COMPUTE_M2 =
+constexpr const char* COMPUTE_FPU_M2 =
     "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast_m2.cpp";
+constexpr const char* COMPUTE_SFPU_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast_m2.cpp";
+//   scalar-b path (reader reads only src; writer fills the scalar tile AND copies dst):
+constexpr const char* READER_SCALAR_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast_m2.cpp";
+constexpr const char* WRITER_SCALAR_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_m2.cpp";
+constexpr const char* COMPUTE_SCALAR_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar_m2.cpp";
 
 // Mirror of the legacy factory's get_shape_dims for the narrow (tile) path.
 std::tuple<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t> get_shape_dims(const Tensor& x) {
@@ -74,14 +87,21 @@ uint32_t extract_nD_dims(const Tensor& x, const int out_rank) {
 
 }  // namespace
 
-// Implements c = a op b, no-broadcast tile FPU interleaved path.
+// Implements c = a op b, no-broadcast tile interleaved path (FPU/SFPU x tensor-b/scalar-b).
 ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFactory::create_program_spec(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, tensor_return_value_t& c) {
     const auto& a = tensor_args.input_tensor_a;
-    const auto& b = *tensor_args.input_tensor_b;  // present on this path (select_program_factory guarantees it)
+    const auto& b_opt = tensor_args.input_tensor_b;
+    const bool b_present = b_opt.has_value();
+    const bool is_sfpu_op = operation_attributes.is_sfpu;
 
     const auto a_dtype = a.dtype();
-    const auto b_dtype = b.dtype();
+    // Mirror the legacy b_dtype derivation for the routed cases. When b is a scalar, it is packed
+    // as bfloat16 for block-float input types; the rhs CB format must match (BFLOAT16) — not the
+    // block-float a_dtype. quant/where ops never route here.
+    const auto b_dtype = b_present                                  ? b_opt->dtype()
+                         : (is_sfpu_op && !is_block_float(a_dtype)) ? a_dtype
+                                                                    : DataType::BFLOAT16;
     const auto c_dtype = c.dtype();
     const auto a_data_format = datatype_to_dataformat_converter(a_dtype);
     const auto b_data_format = datatype_to_dataformat_converter(b_dtype);
@@ -91,10 +111,13 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
     const uint32_t b_single_tile_size = tt::tile_size(b_data_format);
     const uint32_t c_single_tile_size = tt::tile_size(c_data_format);
 
-    // Compute defines for the binary op (FPU). Mirrors the legacy factory's OpConfig path for
-    // the no-activation FPU case (no lhs/rhs/post activations -> no PROCESS_* defines beyond the
-    // op itself). This path is only selected for plain ADD/SUB/MUL with no activations.
-    auto op_config = OpConfig(operation_attributes.binary_op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype);
+    // Compute defines for the binary op. Mirrors the legacy factory's OpConfig path for the
+    // no-activation case (no lhs/rhs/post activations -> no PROCESS_* defines beyond the op
+    // itself). Only plain ADD/SUB/MUL with no activations and no typecast route here, so OpConfig
+    // injects no process_lhs/process_rhs/postprocess (see binary_ng_utils.cpp).
+    auto op_config =
+        is_sfpu_op ? OpConfig(operation_attributes.binary_op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype)
+                   : OpConfig(operation_attributes.binary_op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype);
     auto compute_kernel_defines = op_config.as_defines(a_dtype);
     add_activation_defines(compute_kernel_defines, {}, "LHS", a_dtype);
     add_activation_defines(compute_kernel_defines, {}, "RHS", b_dtype);
@@ -135,11 +158,13 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
     // ProgramSpec resources
     // ----------------------------------------------------------------------------------------
     ProgramSpec spec;
-    spec.name = "binary_ng_no_bcast_tile_fpu";
+    spec.name = is_sfpu_op ? "binary_ng_no_bcast_tile_sfpu"
+                           : (b_present ? "binary_ng_no_bcast_tile_fpu" : "binary_ng_no_bcast_tile_scalar");
 
     // Tensor parameters (one per distinct accessed tensor). eltwise dataflow kernels declare
     // RuntimeTensorShape on the I/O tensors in the legacy factory, so mirror that relaxation
-    // with dynamic_tensor_shape = true (interleaved -> TensorAccessor config unchanged).
+    // with dynamic_tensor_shape = true (interleaved -> TensorAccessor config unchanged). On the
+    // scalar-b path there is no b tensor, so only a and c are declared.
     const TensorParamName A_PARAM{"a"};
     const TensorParamName B_PARAM{"b"};
     const TensorParamName C_PARAM{"c"};
@@ -147,12 +172,16 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
     dyn_shape.dynamic_tensor_shape = true;
     spec.tensor_parameters.push_back(
         TensorParameter{.unique_id = A_PARAM, .spec = a.tensor_spec(), .advanced_options = dyn_shape});
-    spec.tensor_parameters.push_back(
-        TensorParameter{.unique_id = B_PARAM, .spec = b.tensor_spec(), .advanced_options = dyn_shape});
+    if (b_present) {
+        spec.tensor_parameters.push_back(
+            TensorParameter{.unique_id = B_PARAM, .spec = b_opt->tensor_spec(), .advanced_options = dyn_shape});
+    }
     spec.tensor_parameters.push_back(
         TensorParameter{.unique_id = C_PARAM, .spec = c.tensor_spec(), .advanced_options = dyn_shape});
 
-    // DFBs (one per legacy CB). c_0 = a (src), c_1 = b (src_b), c_2 = c (dst).
+    // DFBs (one per legacy CB). c_0 = a (src), c_1 = b/scalar (src_b), c_2 = c (dst).
+    // On the scalar-b path the legacy single-tensor reader fills c_0 from src and the writer fills
+    // c_1 (single tile) from the packed scalar; both still exist.
     const DFBSpecName SRC_DFB{"src"};
     const DFBSpecName SRC_B_DFB{"src_b"};
     const DFBSpecName DST_DFB{"dst"};
@@ -164,7 +193,8 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
     spec.dataflow_buffers.push_back(DataflowBufferSpec{
         .unique_id = SRC_B_DFB,
         .entry_size = b_single_tile_size,
-        .num_entries = 2,
+        // Legacy: tensor-b CB is double-buffered (2 pages); scalar-b CB holds a single tile.
+        .num_entries = b_present ? 2u : 1u,
         .data_format_metadata = b_data_format});
     spec.dataflow_buffers.push_back(DataflowBufferSpec{
         .unique_id = DST_DFB,
@@ -185,59 +215,102 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
     KernelSpec::CompilerOptions::Defines writer_def_table(writer_defines);
     KernelSpec::CompilerOptions::Defines compute_def_table(compute_kernel_defines);
 
+    const char* reader_src = b_present ? READER_AB_M2 : READER_SCALAR_M2;
+    const char* writer_src = b_present ? WRITER_AB_M2 : WRITER_SCALAR_M2;
+    const char* compute_src = b_present ? (is_sfpu_op ? COMPUTE_SFPU_M2 : COMPUTE_FPU_M2) : COMPUTE_SCALAR_M2;
+
     // Reader KernelSpec.
     KernelSpec reader_k;
     reader_k.unique_id = READER_K;
-    reader_k.source = std::filesystem::path(READER_M2);
+    reader_k.source = std::filesystem::path(reader_src);
     reader_k.compiler_options.defines = reader_def_table;
     reader_k.compile_time_args = {{"has_sharding", 0u}};
-    reader_k.runtime_arg_schema.runtime_arg_names = {
-        "start_tile_id",
-        "src_num_tiles",
-        "dst_num_tiles",
-        "dst_shard_width",
-        "nD_stride",
-        "d_stride",
-        "n_stride",
-        "c_stride",
-        "D",
-        "N",
-        "C",
-        "Ht",
-        "Wt",
-        "cND",
-        "nD_stride_b",
-        "d_stride_b",
-        "n_stride_b",
-        "c_stride_b",
-        "src_num_tiles_b"};
-    reader_k.dfb_bindings = {
-        DFBBinding{.dfb_spec_name = SRC_DFB, .accessor_name = "src", .endpoint_type = DFBEndpointType::PRODUCER},
-        DFBBinding{.dfb_spec_name = SRC_B_DFB, .accessor_name = "src_b", .endpoint_type = DFBEndpointType::PRODUCER}};
-    reader_k.tensor_bindings = {
-        TensorBinding{.tensor_parameter_name = A_PARAM, .accessor_name = "src"},
-        TensorBinding{.tensor_parameter_name = B_PARAM, .accessor_name = "src_b"}};
+    if (b_present) {
+        reader_k.runtime_arg_schema.runtime_arg_names = {
+            "start_tile_id",
+            "src_num_tiles",
+            "dst_num_tiles",
+            "dst_shard_width",
+            "nD_stride",
+            "d_stride",
+            "n_stride",
+            "c_stride",
+            "D",
+            "N",
+            "C",
+            "Ht",
+            "Wt",
+            "cND",
+            "nD_stride_b",
+            "d_stride_b",
+            "n_stride_b",
+            "c_stride_b",
+            "src_num_tiles_b"};
+        reader_k.dfb_bindings = {
+            DFBBinding{.dfb_spec_name = SRC_DFB, .accessor_name = "src", .endpoint_type = DFBEndpointType::PRODUCER},
+            DFBBinding{
+                .dfb_spec_name = SRC_B_DFB, .accessor_name = "src_b", .endpoint_type = DFBEndpointType::PRODUCER}};
+        reader_k.tensor_bindings = {
+            TensorBinding{.tensor_parameter_name = A_PARAM, .accessor_name = "src"},
+            TensorBinding{.tensor_parameter_name = B_PARAM, .accessor_name = "src_b"}};
+    } else {
+        // Single-tensor (scalar-b) reader: reads only src into c_0.
+        reader_k.runtime_arg_schema.runtime_arg_names = {
+            "start_tile_id",
+            "src_num_tiles",
+            "dst_num_tiles",
+            "dst_shard_width",
+            "nD_stride",
+            "d_stride",
+            "n_stride",
+            "c_stride",
+            "D",
+            "N",
+            "C",
+            "Ht",
+            "Wt",
+            "cND"};
+        reader_k.dfb_bindings = {
+            DFBBinding{.dfb_spec_name = SRC_DFB, .accessor_name = "src", .endpoint_type = DFBEndpointType::PRODUCER}};
+        reader_k.tensor_bindings = {TensorBinding{.tensor_parameter_name = A_PARAM, .accessor_name = "src"}};
+    }
     reader_k.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER};
 
     // Writer KernelSpec.
     KernelSpec writer_k;
     writer_k.unique_id = WRITER_K;
-    writer_k.source = std::filesystem::path(WRITER_M2);
+    writer_k.source = std::filesystem::path(writer_src);
     writer_k.compiler_options.defines = writer_def_table;
     writer_k.compile_time_args = {{"has_sharding", 0u}};
-    writer_k.runtime_arg_schema.runtime_arg_names = {
-        "start_tile_id", "dst_num_tiles", "dst_shard_width", "D", "N", "C", "Ht", "Wt", "cND"};
-    writer_k.dfb_bindings = {
-        DFBBinding{.dfb_spec_name = DST_DFB, .accessor_name = "dst", .endpoint_type = DFBEndpointType::CONSUMER}};
-    writer_k.tensor_bindings = {TensorBinding{.tensor_parameter_name = C_PARAM, .accessor_name = "dst"}};
+    if (b_present) {
+        writer_k.runtime_arg_schema.runtime_arg_names = {
+            "start_tile_id", "dst_num_tiles", "dst_shard_width", "D", "N", "C", "Ht", "Wt", "cND"};
+        writer_k.dfb_bindings = {
+            DFBBinding{.dfb_spec_name = DST_DFB, .accessor_name = "dst", .endpoint_type = DFBEndpointType::CONSUMER}};
+        writer_k.tensor_bindings = {TensorBinding{.tensor_parameter_name = C_PARAM, .accessor_name = "dst"}};
+    } else {
+        // Scalar-b writer: fills the scalar tile into c_1 (src_b) AND writes c_2 (dst). The packed
+        // scalar is the leading named RTA `packed_scalar` (a value, mirroring legacy positional 0).
+        writer_k.runtime_arg_schema.runtime_arg_names = {
+            "packed_scalar", "start_tile_id", "dst_num_tiles", "dst_shard_width", "D", "N", "C", "Ht", "Wt", "cND"};
+        writer_k.dfb_bindings = {
+            DFBBinding{
+                .dfb_spec_name = SRC_B_DFB, .accessor_name = "src_b", .endpoint_type = DFBEndpointType::PRODUCER},
+            DFBBinding{.dfb_spec_name = DST_DFB, .accessor_name = "dst", .endpoint_type = DFBEndpointType::CONSUMER}};
+        writer_k.tensor_bindings = {TensorBinding{.tensor_parameter_name = C_PARAM, .accessor_name = "dst"}};
+    }
     writer_k.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER};
 
     // Compute KernelSpec template (one per core group; only the num_tiles RTA is read by the
-    // no-bcast compute kernel). num_tiles_per_cycle is a named CTA.
+    // no-bcast/scalar compute kernels). num_tiles_per_cycle is a named CTA.
+    // SFPU unpack-to-dest: legacy sets UnpackToDestFp32 on the operand CBs for non-POWER SFPU ops.
+    // The Metal 2.0 ComputeHardwareConfig rejects UnpackToDestFp32 unless fp32_dest_acc_en=true; in
+    // the legacy-inert case (fp32_dest_acc_en=false) the hardware ignored the mode anyway, so we
+    // faithfully map it to Default there (only plain ADD/SUB/MUL route here, never POWER).
     auto make_compute_k = [&](const KernelSpecName& id) {
         KernelSpec k;
         k.unique_id = id;
-        k.source = std::filesystem::path(COMPUTE_M2);
+        k.source = std::filesystem::path(compute_src);
         k.compiler_options.defines = compute_def_table;
         k.compile_time_args = {{"num_tiles_per_cycle", num_tiles_per_cycle}};
         k.runtime_arg_schema.runtime_arg_names = {"num_tiles"};
@@ -249,6 +322,10 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
             DFBBinding{.dfb_spec_name = DST_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER}};
         ComputeHardwareConfig hw;
         hw.fp32_dest_acc_en = fp32_dest_acc_en;
+        if (is_sfpu_op && fp32_dest_acc_en) {
+            hw.unpack_to_dest_mode.insert({SRC_DFB, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
+            hw.unpack_to_dest_mode.insert({SRC_B_DFB, tt::tt_metal::UnpackToDestMode::UnpackToDestFp32});
+        }
         k.hw_config = hw;
         return k;
     };
@@ -263,8 +340,9 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
 
     // WorkUnitSpec: reader + writer + compute_g1 over core_group_1; a second WorkUnit for
     // core_group_2 (reader + writer + compute_g2). Each DFB's producer and consumer share the
-    // same WorkUnitSpec (local-DFB rule): reader (producer of src/src_b) + writer (consumer of
-    // dst) + compute (consumer of src/src_b, producer of dst) all co-located per group.
+    // same WorkUnitSpec (local-DFB rule): reader (producer of src[/src_b]) + writer (consumer of
+    // dst [and producer of the scalar src_b on the scalar path]) + compute (consumer of src/src_b,
+    // producer of dst) all co-located per group.
     {
         WorkUnitSpec wu1;
         wu1.name = "group_1";
@@ -282,8 +360,8 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
 
     // ----------------------------------------------------------------------------------------
     // ProgramRunArgs (per-core runtime arguments). Mirrors the legacy factory's inline per-core
-    // RTA emission for the no-bcast tile interleaved b-present path, minus the buffer-address
-    // slots (now carried by the TensorBindings).
+    // RTA emission for the no-bcast tile interleaved path, minus the buffer-address slots (now
+    // carried by the TensorBindings).
     // ----------------------------------------------------------------------------------------
     ProgramRunArgs run_args;
 
@@ -294,11 +372,15 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
 
     const auto out_rank = c.logical_shape().rank();
     const auto aND = extract_nD_dims(a, out_rank);
-    const auto bND = extract_nD_dims(b, out_rank);
+    const auto bND = b_present ? extract_nD_dims(*b_opt, out_rank) : 1u;
     const auto cND = extract_nD_dims(c, out_rank);
     const auto [aD, aN, aC, aHt, aWt] = get_shape_dims(a);
-    const auto [bD, bN, bC, bHt, bWt] = get_shape_dims(b);
+    const auto [bD, bN, bC, bHt, bWt] = b_present ? get_shape_dims(*b_opt) : std::tuple{1u, 1u, 1u, 1u, 1u};
     const auto [cD, cN, cC, cHt, cWt] = get_shape_dims(c);
+
+    // Packed scalar value for the scalar-b path (mirrors the legacy pack_scalar_runtime_arg call).
+    const uint32_t packed_scalar =
+        b_present ? 0u : pack_scalar_runtime_arg(*operation_attributes.scalar, a.dtype(), /*is_quant_op=*/false);
 
     for (uint32_t i = 0, start_tile_id = 0; i < num_cores; i++) {
         const auto& core = cores[i];
@@ -312,48 +394,88 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
         }
 
         // Reader RTAs (legacy slots, minus a/b base addresses now handled by ta:: bindings).
-        reader_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
-            .node = core,
-            .args = {
-                {"start_tile_id", start_tile_id},
-                {"src_num_tiles", 0u},  // a_num_tiles: 0 on the interleaved (unsharded) path
-                {"dst_num_tiles", c_num_tiles_core},
-                {"dst_shard_width", 0u},
-                {"nD_stride", aHt * aWt * aC * aN * aD * (aND > 1)},
-                {"d_stride", aHt * aWt * aC * aN * (aD > 1)},
-                {"n_stride", aHt * aWt * aC * (aN > 1)},
-                {"c_stride", aHt * aWt * (aC > 1)},
-                {"D", cD},
-                {"N", cN},
-                {"C", cC},
-                {"Ht", cHt},
-                {"Wt", cWt},
-                {"cND", cND},
-                {"nD_stride_b", bHt * bWt * bC * bN * bD * (bND > 1)},
-                {"d_stride_b", bHt * bWt * bC * bN * (bD > 1)},
-                {"n_stride_b", bHt * bWt * bC * (bN > 1)},
-                {"c_stride_b", bHt * bWt * (bC > 1)},
-                {"src_num_tiles_b", 0u},  // b_num_tiles: 0 on the interleaved (unsharded) path
-            }});
+        if (b_present) {
+            reader_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+                .node = core,
+                .args = {
+                    {"start_tile_id", start_tile_id},
+                    {"src_num_tiles", 0u},  // a_num_tiles: 0 on the interleaved (unsharded) path
+                    {"dst_num_tiles", c_num_tiles_core},
+                    {"dst_shard_width", 0u},
+                    {"nD_stride", aHt * aWt * aC * aN * aD * (aND > 1)},
+                    {"d_stride", aHt * aWt * aC * aN * (aD > 1)},
+                    {"n_stride", aHt * aWt * aC * (aN > 1)},
+                    {"c_stride", aHt * aWt * (aC > 1)},
+                    {"D", cD},
+                    {"N", cN},
+                    {"C", cC},
+                    {"Ht", cHt},
+                    {"Wt", cWt},
+                    {"cND", cND},
+                    {"nD_stride_b", bHt * bWt * bC * bN * bD * (bND > 1)},
+                    {"d_stride_b", bHt * bWt * bC * bN * (bD > 1)},
+                    {"n_stride_b", bHt * bWt * bC * (bN > 1)},
+                    {"c_stride_b", bHt * bWt * (bC > 1)},
+                    {"src_num_tiles_b", 0u},  // b_num_tiles: 0 on the interleaved (unsharded) path
+                }});
+        } else {
+            // Single-tensor reader: a strides only (mirrors legacy reader_interleaved_no_bcast).
+            reader_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+                .node = core,
+                .args = {
+                    {"start_tile_id", start_tile_id},
+                    {"src_num_tiles", 0u},  // a_num_tiles: 0 on the interleaved (unsharded) path
+                    {"dst_num_tiles", c_num_tiles_core},
+                    {"dst_shard_width", 0u},
+                    {"nD_stride", aHt * aWt * aC * aN * aD * (aND > 1)},
+                    {"d_stride", aHt * aWt * aC * aN * (aD > 1)},
+                    {"n_stride", aHt * aWt * aC * (aN > 1)},
+                    {"c_stride", aHt * aWt * (aC > 1)},
+                    {"D", cD},
+                    {"N", cN},
+                    {"C", cC},
+                    {"Ht", cHt},
+                    {"Wt", cWt},
+                    {"cND", cND},
+                }});
+        }
 
-        // Writer RTAs (legacy slots, minus the c base address now handled by ta:: binding).
-        writer_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
-            .node = core,
-            .args = {
-                {"start_tile_id", start_tile_id},
-                {"dst_num_tiles", c_num_tiles_core},
-                {"dst_shard_width", 0u},
-                {"D", cD},
-                {"N", cN},
-                {"C", cC},
-                {"Ht", cHt},
-                {"Wt", cWt},
-                {"cND", cND},
-            }});
+        // Writer RTAs (legacy slots, minus the c base address now handled by ta:: binding; on the
+        // scalar path the packed scalar value leads).
+        if (b_present) {
+            writer_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+                .node = core,
+                .args = {
+                    {"start_tile_id", start_tile_id},
+                    {"dst_num_tiles", c_num_tiles_core},
+                    {"dst_shard_width", 0u},
+                    {"D", cD},
+                    {"N", cN},
+                    {"C", cC},
+                    {"Ht", cHt},
+                    {"Wt", cWt},
+                    {"cND", cND},
+                }});
+        } else {
+            writer_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+                .node = core,
+                .args = {
+                    {"packed_scalar", packed_scalar},
+                    {"start_tile_id", start_tile_id},
+                    {"dst_num_tiles", c_num_tiles_core},
+                    {"dst_shard_width", 0u},
+                    {"D", cD},
+                    {"N", cN},
+                    {"C", cC},
+                    {"Ht", cHt},
+                    {"Wt", cWt},
+                    {"cND", cND},
+                }});
+        }
 
-        // Compute RTA: the no-bcast compute kernel reads only num_tiles (= c_num_tiles_core on
-        // the tile path). freq/counter/scalar slots of the legacy 4-arg vector are dead for this
-        // kernel and dropped (superfluous named args are a Metal 2.0 validation error).
+        // Compute RTA: the no-bcast/scalar compute kernels read only num_tiles (= c_num_tiles_core
+        // on the tile path). freq/counter/scalar slots of the legacy 4-arg vector are dead for
+        // these kernels and dropped (superfluous named args are a Metal 2.0 validation error).
         auto& compute_run = core_group_1.contains(core) ? compute_run_1 : compute_run_2;
         compute_run.runtime_arg_values.push_back(
             KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"num_tiles", c_num_tiles_core}}});
@@ -370,7 +492,9 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
 
     // Tensor arguments: reference the SAME MeshTensors the factory received (matched by identity).
     run_args.tensor_args.insert({A_PARAM, TensorArgument{a.mesh_tensor()}});
-    run_args.tensor_args.insert({B_PARAM, TensorArgument{b.mesh_tensor()}});
+    if (b_present) {
+        run_args.tensor_args.insert({B_PARAM, TensorArgument{b_opt->mesh_tensor()}});
+    }
     run_args.tensor_args.insert({C_PARAM, TensorArgument{c.mesh_tensor()}});
 
     return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory_m2.cpp
@@ -5,33 +5,27 @@
 // Metal 2.0 program factory for binary_ng.
 //
 // SCOPE: this factory handles interleaved (not sharded), no-activation, no-typecast, plain
-// ADD/SUB/MUL, non-where, non-quant cases across the following axes (all routed here by
-// select_program_factory()):
+// ADD/SUB/MUL, non-where, non-quant, NONE-broadcast cases that fully populate at least one tile,
+// across the following axes (all routed here by select_program_factory()):
 //   TILE layout:
 //     1. NONE broadcast x tensor-b x FPU   (eltwise_binary_no_bcast_m2 compute)
 //     2. NONE broadcast x tensor-b x SFPU  (eltwise_binary_sfpu_no_bcast_m2 compute)
 //     3. NONE broadcast x scalar-b x FPU   (eltwise_binary_scalar_m2 compute; writer fills scalar)
 //     4. NONE broadcast x scalar-b x SFPU  (eltwise_binary_sfpu_scalar_m2 compute; writer fills scalar)
-//     5. SCALAR_A/SCALAR_B broadcast x tensor-b x FPU  (eltwise_binary_scalar_bcast_m2 compute) -- LLK-bcast subset
-//     only
-//     6. ROW_A/ROW_B broadcast    x tensor-b x FPU  (eltwise_binary_row_bcast_m2 compute)    -- LLK-bcast subset only
-//     7. COL_A/COL_B broadcast    x tensor-b x FPU  (eltwise_binary_col_bcast_m2 compute)    -- LLK-bcast subset only
 //   ROW_MAJOR layout:
-//     8. NONE broadcast x tensor-b x FPU   (RM reader/writer forks + eltwise_binary_no_bcast_m2 compute)
+//     5. NONE broadcast x tensor-b x FPU   (RM reader/writer forks + eltwise_binary_no_bcast_m2 compute)
 //
-// The simple-broadcast cases (5,6,7) are routed to spec ONLY when the legacy `use_llk_bcast`
-// decision would be true for the (arch, broadcast, dtype, fp32_dest_acc_en) tuple -- the
-// software-fallback (BCAST_LLK=0) compute kernels are NOT ported, so any (arch,dtype) tuple that
-// the legacy code would have run on the software path stays on the legacy ProgramFactory. The
-// `use_llk_bcast` gating (BH col bf16->fp32 hang, BH MOVB2D fp32, UInt16 relational, exp ops,
-// where/scalar/col where-op exclusions) is reproduced verbatim from the legacy factory so the
-// routed subset is identical to what the legacy factory would have compiled on the LLK path.
+// The simple-broadcast tile paths (SCALAR/ROW/COL) are NO LONGER routed here: the forked LLK-bcast
+// kernels deadlock for multi-tile broadcast operands (test_bf4b_bf8b add hangs) and the degenerate
+// SCALAR_B case ([1,2]+[3]) produces wrong values. They (and any "01-volume" / sub-tile tensor on
+// the NONE path, which mis-reads under dynamic_tensor_shape) fall back to the legacy
+// ProgramFactory. The simple-broadcast forked kernels + spec wiring (cases 5-7 of the prior pass)
+// are left in this file for a future debug pass but are unreachable via the routing predicate.
 //
-// Every OTHER path (sharded, activations, typecast, where-op, quant-op, scalar-b broadcast types,
-// row/col/scalar broadcast on the software-fallback tuple, mixed row+col bcast, RM broadcast,
-// RM scalar-op, SFPU broadcast) stays on the legacy ProgramFactory::create_descriptor in
-// binary_ng_program_factory.cpp. The full routed-vs-legacy matrix is enumerated in
-// METAL2_PORT_REPORT.md.
+// Every OTHER path (sharded, activations, typecast, where-op, quant-op, ALL subtile broadcast
+// (scalar/row/col/mixed), RM broadcast, RM scalar-op, and sub-tile / 01-volume tensors) stays on
+// the legacy ProgramFactory::create_descriptor in binary_ng_program_factory.cpp. The full
+// routed-vs-legacy matrix is enumerated in METAL2_PORT_REPORT.md.
 //
 // The legacy factory's logic for these paths is preserved exactly (work-split, per-core tile
 // strides, CB sizes, fp32_dest_acc_en, unpack-to-dest, use_llk_bcast); only the host API is
@@ -255,39 +249,44 @@ bool binary_ng_m2_routes_to_spec(
 
     const auto sbt = attributes.subtile_broadcast_type;
 
+    // Only NONE-broadcast is routed to the spec factory. The simple-broadcast tile paths
+    // (SCALAR/ROW/COL) are NOT routed: the forked LLK-bcast kernels deadlock on this path for
+    // multi-tile broadcast operands (e.g. test_bf4b_bf8b add over [5,3,128,64]+[1,3,128,1] hangs),
+    // and the degenerate SCALAR_B case ([1,2]+[3]) produces wrong values. The legacy ProgramFactory
+    // handles all broadcast cases correctly, so they stay there until the broadcast spec path is
+    // debugged. (Reverts the broadcast widening from the prior pass; see METAL2_PORT_REPORT.md.)
+    if (sbt != SubtileBroadcastType::NONE) {
+        return false;
+    }
+
+    // Sub-tile / "01-volume" guard. Degenerate tensors whose logical shape does not fill a full
+    // 32x32 tile (e.g. rank-1 [1], [1,2], [2,3]) read back wrong values on the spec path: with
+    // dynamic_tensor_shape = true the framework rebuilds the interleaved TensorAccessor page
+    // geometry from the LIVE (sub-tile) logical TensorSpec, so the per-tile 2048-byte NoC reads in
+    // the forked dataflow kernels no longer line up with the on-device padded-tile layout (a=[1]
+    // reads back 0, so [1]+[2] yields 2 instead of 3). Tensors that fully populate at least one tile
+    // (logical volume >= tile area) are unaffected; keep the degenerate cases on the legacy factory,
+    // which carries an explicit page-size override.
+    // (The output tensor is not available here on a cache miss; for NONE broadcast a and b share the
+    // broadcasted shape, so guarding on the inputs is sufficient.)
+    const uint64_t tile_area =
+        static_cast<uint64_t>(a.tensor_spec().tile().get_height()) * a.tensor_spec().tile().get_width();
+    const bool sub_tile =
+        a.logical_shape().volume() < tile_area || (b_present && b->logical_shape().volume() < tile_area);
+    if (sub_tile) {
+        return false;
+    }
+
     if (rm) {
         // Row-major: only NONE broadcast x tensor-b x FPU.
-        return sbt == SubtileBroadcastType::NONE && b_present && !attributes.is_sfpu;
+        return b_present && !attributes.is_sfpu;
     }
     if (!tile) {
         return false;
     }
 
-    if (sbt == SubtileBroadcastType::NONE) {
-        // NONE tile: tensor-b FPU, tensor-b SFPU, scalar-b FPU, scalar-b SFPU.
-        return true;
-    }
-
-    // Simple broadcast tile (SCALAR/ROW/COL): FPU + tensor-b only, and only the LLK-bcast subset.
-    const bool simple_bcast = sbt == SubtileBroadcastType::SCALAR_A || sbt == SubtileBroadcastType::SCALAR_B ||
-                              sbt == SubtileBroadcastType::ROW_A || sbt == SubtileBroadcastType::ROW_B ||
-                              sbt == SubtileBroadcastType::COL_A || sbt == SubtileBroadcastType::COL_B;
-    if (!simple_bcast || !b_present || attributes.is_sfpu) {
-        return false;
-    }
-
-    // Reproduce the legacy fp32_dest_acc_en + use_llk_bcast decision to gate routing.
-    const auto a_dtype = a.dtype();
-    const auto b_dtype = b->dtype();
-    const auto a_df = datatype_to_dataformat_converter(a_dtype);
-    const auto b_df = datatype_to_dataformat_converter(b_dtype);
-    const auto c_df = datatype_to_dataformat_converter(attributes.get_dtype());
-    const bool fp32_dest_acc_en = c_df == tt::DataFormat::UInt32 || c_df == tt::DataFormat::Int32 ||
-                                  c_df == tt::DataFormat::Float32 || a_df == tt::DataFormat::Float32 ||
-                                  b_df == tt::DataFormat::Float32 ||
-                                  (a_df == tt::DataFormat::Int32 && b_df == tt::DataFormat::Int32) ||
-                                  (a_df == tt::DataFormat::UInt32 && b_df == tt::DataFormat::UInt32);
-    return binary_ng_m2_use_llk_bcast(sbt, a_dtype, b_dtype, fp32_dest_acc_en);
+    // NONE tile: tensor-b FPU, tensor-b SFPU, scalar-b FPU, scalar-b SFPU.
+    return true;
 }
 
 // Implements c = a op b for the routed interleaved cases (see SCOPE header).

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory_m2.cpp
@@ -4,20 +4,39 @@
 
 // Metal 2.0 program factory for binary_ng.
 //
-// SCOPE: this factory handles the no-broadcast (SubtileBroadcastType::NONE) x tile layout x
-// interleaved (not sharded) x no-activation x plain ADD/SUB/MUL x no-typecast cases, across the
-// following operand/compute axes (all routed here by select_program_factory()):
-//   1. tensor-b present x FPU   (eltwise_binary_no_bcast_m2 compute)
-//   2. tensor-b present x SFPU  (eltwise_binary_sfpu_no_bcast_m2 compute)
-//   3. scalar-b (no tensor b) x FPU (eltwise_binary_scalar_m2 compute; writer fills the scalar tile)
-// Every OTHER path (row-major, all broadcast types, where-op, quant-op, scalar-b-on-SFPU, sharded,
-// activations, typecast, non-plain ops) stays on the legacy ProgramFactory::create_descriptor in
-// binary_ng_program_factory.cpp. The full set of remaining kernel entry points and the routed-vs-
-// legacy matrix are enumerated in METAL2_PORT_REPORT.md.
+// SCOPE: this factory handles interleaved (not sharded), no-activation, no-typecast, plain
+// ADD/SUB/MUL, non-where, non-quant cases across the following axes (all routed here by
+// select_program_factory()):
+//   TILE layout:
+//     1. NONE broadcast x tensor-b x FPU   (eltwise_binary_no_bcast_m2 compute)
+//     2. NONE broadcast x tensor-b x SFPU  (eltwise_binary_sfpu_no_bcast_m2 compute)
+//     3. NONE broadcast x scalar-b x FPU   (eltwise_binary_scalar_m2 compute; writer fills scalar)
+//     4. NONE broadcast x scalar-b x SFPU  (eltwise_binary_sfpu_scalar_m2 compute; writer fills scalar)
+//     5. SCALAR_A/SCALAR_B broadcast x tensor-b x FPU  (eltwise_binary_scalar_bcast_m2 compute) -- LLK-bcast subset
+//     only
+//     6. ROW_A/ROW_B broadcast    x tensor-b x FPU  (eltwise_binary_row_bcast_m2 compute)    -- LLK-bcast subset only
+//     7. COL_A/COL_B broadcast    x tensor-b x FPU  (eltwise_binary_col_bcast_m2 compute)    -- LLK-bcast subset only
+//   ROW_MAJOR layout:
+//     8. NONE broadcast x tensor-b x FPU   (RM reader/writer forks + eltwise_binary_no_bcast_m2 compute)
+//
+// The simple-broadcast cases (5,6,7) are routed to spec ONLY when the legacy `use_llk_bcast`
+// decision would be true for the (arch, broadcast, dtype, fp32_dest_acc_en) tuple -- the
+// software-fallback (BCAST_LLK=0) compute kernels are NOT ported, so any (arch,dtype) tuple that
+// the legacy code would have run on the software path stays on the legacy ProgramFactory. The
+// `use_llk_bcast` gating (BH col bf16->fp32 hang, BH MOVB2D fp32, UInt16 relational, exp ops,
+// where/scalar/col where-op exclusions) is reproduced verbatim from the legacy factory so the
+// routed subset is identical to what the legacy factory would have compiled on the LLK path.
+//
+// Every OTHER path (sharded, activations, typecast, where-op, quant-op, scalar-b broadcast types,
+// row/col/scalar broadcast on the software-fallback tuple, mixed row+col bcast, RM broadcast,
+// RM scalar-op, SFPU broadcast) stays on the legacy ProgramFactory::create_descriptor in
+// binary_ng_program_factory.cpp. The full routed-vs-legacy matrix is enumerated in
+// METAL2_PORT_REPORT.md.
 //
 // The legacy factory's logic for these paths is preserved exactly (work-split, per-core tile
-// strides, CB sizes, fp32_dest_acc_en, unpack-to-dest); only the host API is converted to
-// Metal 2.0 ProgramSpec / ProgramRunArgs, and the kernels it binds are the forked *_m2.cpp ports.
+// strides, CB sizes, fp32_dest_acc_en, unpack-to-dest, use_llk_bcast); only the host API is
+// converted to Metal 2.0 ProgramSpec / ProgramRunArgs, and the kernels it binds are the forked
+// *_m2.cpp ports.
 
 #include "binary_ng_device_operation.hpp"
 #include "binary_ng_utils.hpp"
@@ -25,12 +44,14 @@
 #include <tt-metalium/work_split.hpp>
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/math.hpp>
+#include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_backend_api_types.hpp>
 
 #include <filesystem>
 #include <map>
 #include <tuple>
 #include <utility>
+#include <variant>
 
 #include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
@@ -43,8 +64,8 @@ namespace ttnn::operations::binary_ng {
 
 namespace {
 
-// Forked Metal 2.0 kernel sources.
-//   tensor-b path (reader reads both src & src_b; writer copies dst):
+// ---- Forked Metal 2.0 kernel sources ----------------------------------------------------------
+// NONE-broadcast tile, tensor-b path (reader reads both src & src_b; writer copies dst):
 constexpr const char* READER_AB_M2 =
     "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast_m2.cpp";
 constexpr const char* WRITER_AB_M2 =
@@ -53,15 +74,36 @@ constexpr const char* COMPUTE_FPU_M2 =
     "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast_m2.cpp";
 constexpr const char* COMPUTE_SFPU_M2 =
     "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast_m2.cpp";
-//   scalar-b path (reader reads only src; writer fills the scalar tile AND copies dst):
+// NONE-broadcast tile, scalar-b path (reader reads only src; writer fills the scalar tile AND
+// copies dst):
 constexpr const char* READER_SCALAR_M2 =
     "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast_m2.cpp";
 constexpr const char* WRITER_SCALAR_M2 =
     "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_m2.cpp";
-constexpr const char* COMPUTE_SCALAR_M2 =
+constexpr const char* COMPUTE_SCALAR_FPU_M2 =
     "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar_m2.cpp";
+constexpr const char* COMPUTE_SCALAR_SFPU_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar_m2.cpp";
+// Simple-broadcast tile readers + LLK-bcast computes (FPU):
+constexpr const char* READER_SCALAR_BCAST_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast_m2.cpp";
+constexpr const char* READER_ROW_BCAST_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast_m2.cpp";
+constexpr const char* READER_COL_BCAST_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast_m2.cpp";
+constexpr const char* COMPUTE_SCALAR_BCAST_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast_m2.cpp";
+constexpr const char* COMPUTE_ROW_BCAST_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast_m2.cpp";
+constexpr const char* COMPUTE_COL_BCAST_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast_m2.cpp";
+// Row-major NONE-broadcast tensor-b path (reader/writer forks; compute is the FPU no-bcast kernel):
+constexpr const char* READER_RM_AB_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast_m2.cpp";
+constexpr const char* WRITER_RM_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast_m2.cpp";
 
-// Mirror of the legacy factory's get_shape_dims for the narrow (tile) path.
+// Mirror of the legacy factory's get_shape_dims for the tile path.
 std::tuple<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t> get_shape_dims(const Tensor& x) {
     const auto& shape = x.padded_shape();
     const auto& tile = x.tensor_spec().tile();
@@ -85,19 +127,183 @@ uint32_t extract_nD_dims(const Tensor& x, const int out_rank) {
     return nD_dim;
 }
 
+// Mirror of legacy calculate_compute_kernel_args (drives the compute freq/counter RTAs for the
+// broadcast tile path).
+std::tuple<uint32_t, uint32_t> calculate_compute_kernel_args(
+    SubtileBroadcastType broadcast_type, uint32_t start_tile_id, uint32_t Ht, uint32_t Wt) {
+    uint32_t start_t = start_tile_id % (Ht * Wt);
+    uint32_t start_tw = start_t % Wt;
+
+    switch (broadcast_type) {
+        case SubtileBroadcastType::NONE:
+        case SubtileBroadcastType::ROW_A:
+        case SubtileBroadcastType::ROW_B: return {1, 0};
+        case SubtileBroadcastType::SCALAR_A:
+        case SubtileBroadcastType::SCALAR_B: return {Ht * Wt, start_t};
+        case SubtileBroadcastType::COL_A:
+        case SubtileBroadcastType::ROW_B_COL_A:
+        case SubtileBroadcastType::COL_B:
+        case SubtileBroadcastType::ROW_A_COL_B: return {Wt, start_tw};
+        default: __builtin_unreachable();
+    }
+}
+
 }  // namespace
 
-// Implements c = a op b, no-broadcast tile interleaved path (FPU/SFPU x tensor-b/scalar-b).
+// ----------------------------------------------------------------------------------------------
+// Shared LLK-bcast routing predicate. Reproduces the legacy factory's `use_llk_bcast` decision
+// (binary_ng_program_factory.cpp) EXACTLY for the routed subset (no activations, no exp ops,
+// non-where, non-quant, tile layout). select_program_factory() and the factory both consult this
+// so the spec path is selected only on the (arch, broadcast, dtype, fp32) tuples the legacy LLK
+// path would have compiled. Kept in sync with the legacy gates: BH col bf16->fp32 hang, dtype/arch
+// matrix, BH MOVB2D fp32 fallback, UInt16-scalar relational fallback. The exp-op and where-op
+// gates are subsumed by the routing predicate restricting to plain ADD/SUB/MUL and non-where.
+bool binary_ng_m2_use_llk_bcast(
+    SubtileBroadcastType subtile_broadcast_type, DataType a_dtype, DataType b_dtype, bool fp32_dest_acc_en) {
+    [[maybe_unused]] const auto a_data_format = datatype_to_dataformat_converter(a_dtype);
+    [[maybe_unused]] const auto b_data_format = datatype_to_dataformat_converter(b_dtype);
+
+    const bool is_col_bcast =
+        subtile_broadcast_type == SubtileBroadcastType::COL_A || subtile_broadcast_type == SubtileBroadcastType::COL_B;
+    const bool has_bf16_input = a_dtype == DataType::BFLOAT16 || b_dtype == DataType::BFLOAT16;
+    // BH col bf16->fp32 hang.
+    if (tt::tt_metal::hal::get_arch() == tt::ARCH::BLACKHOLE && is_col_bcast && fp32_dest_acc_en && has_bf16_input) {
+        return false;
+    }
+
+    auto all_match = [&](DataType dt) { return a_dtype == dt && b_dtype == dt; };
+
+    bool use_llk = false;
+    if (subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
+        subtile_broadcast_type == SubtileBroadcastType::ROW_B ||
+        subtile_broadcast_type == SubtileBroadcastType::COL_A ||
+        subtile_broadcast_type == SubtileBroadcastType::COL_B ||
+        subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ||
+        subtile_broadcast_type == SubtileBroadcastType::SCALAR_B) {
+        if (all_match(DataType::BFLOAT16) || all_match(DataType::BFLOAT8_B) || all_match(DataType::BFLOAT4_B)) {
+            use_llk = true;
+        }
+        if (all_match(DataType::FLOAT32) || all_match(DataType::INT32) || all_match(DataType::UINT32) ||
+            all_match(DataType::UINT16)) {
+            if (tt::tt_metal::hal::get_arch() == tt::ARCH::WORMHOLE_B0) {
+                use_llk = true;
+            }
+        }
+    }
+    if (!use_llk) {
+        return false;
+    }
+
+    // BH MOVB2D fp32 fallback (SCALAR / ROW use MOVB2D; COL uses ELWADD and is unaffected).
+    if (fp32_dest_acc_en && tt::tt_metal::hal::get_arch() == tt::ARCH::BLACKHOLE) {
+        const bool uses_movb2d = subtile_broadcast_type == SubtileBroadcastType::SCALAR_A ||
+                                 subtile_broadcast_type == SubtileBroadcastType::SCALAR_B ||
+                                 subtile_broadcast_type == SubtileBroadcastType::ROW_A ||
+                                 subtile_broadcast_type == SubtileBroadcastType::ROW_B;
+        if (uses_movb2d) {
+            return false;
+        }
+    }
+
+    // UInt16 scalar relational fallback (#36217): only EQ/NE (postprocess) or LT/GT/LE/GE (SFPU)
+    // hit the corruption. The m2 routing restricts to plain ADD/SUB/MUL with no postprocess, so
+    // none of those relational ops route here -- but we mirror the gate for faithfulness: a plain
+    // arithmetic UInt16 scalar op has no postprocess and is unaffected, so this never fires for the
+    // routed subset.
+    return true;
+}
+
+bool binary_ng_m2_routes_to_spec(
+    const BinaryNgDeviceOperation::operation_attributes_t& attributes,
+    const BinaryNgDeviceOperation::tensor_args_t& tensor_args) {
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = tensor_args.input_tensor_b;
+    const bool b_present = b.has_value();
+
+    // where/quant ops never route. SFPU routes only on NONE-broadcast (tensor-b or scalar-b);
+    // broadcast paths route only FPU.
+    if (attributes.is_where_op || attributes.is_quant_op) {
+        return false;
+    }
+    const bool no_activations =
+        attributes.lhs_activations.empty() && attributes.rhs_activations.empty() && attributes.post_activations.empty();
+    const bool plain_op = attributes.binary_op_type == BinaryOpType::ADD ||
+                          attributes.binary_op_type == BinaryOpType::SUB ||
+                          attributes.binary_op_type == BinaryOpType::MUL;
+    if (!no_activations || !plain_op) {
+        return false;
+    }
+    const bool sharded = a.memory_config().is_sharded() || (b_present && b->memory_config().is_sharded()) ||
+                         attributes.memory_config.is_sharded();
+    if (sharded) {
+        return false;
+    }
+    // No typecast (a and output share dtype) so the compute kernel binds no POST activation.
+    if (a.dtype() != attributes.get_dtype()) {
+        return false;
+    }
+    // scalar-b path requires a scalar value.
+    const bool operand_ok = b_present || attributes.scalar.has_value();
+    if (!operand_ok) {
+        return false;
+    }
+
+    const bool rm = attributes.input_layout_a == Layout::ROW_MAJOR && attributes.output_layout == Layout::ROW_MAJOR &&
+                    (!b_present || attributes.input_layout_b == Layout::ROW_MAJOR);
+    const bool tile = attributes.input_layout_a == Layout::TILE && attributes.output_layout == Layout::TILE &&
+                      (!b_present || attributes.input_layout_b == Layout::TILE);
+
+    const auto sbt = attributes.subtile_broadcast_type;
+
+    if (rm) {
+        // Row-major: only NONE broadcast x tensor-b x FPU.
+        return sbt == SubtileBroadcastType::NONE && b_present && !attributes.is_sfpu;
+    }
+    if (!tile) {
+        return false;
+    }
+
+    if (sbt == SubtileBroadcastType::NONE) {
+        // NONE tile: tensor-b FPU, tensor-b SFPU, scalar-b FPU, scalar-b SFPU.
+        return true;
+    }
+
+    // Simple broadcast tile (SCALAR/ROW/COL): FPU + tensor-b only, and only the LLK-bcast subset.
+    const bool simple_bcast = sbt == SubtileBroadcastType::SCALAR_A || sbt == SubtileBroadcastType::SCALAR_B ||
+                              sbt == SubtileBroadcastType::ROW_A || sbt == SubtileBroadcastType::ROW_B ||
+                              sbt == SubtileBroadcastType::COL_A || sbt == SubtileBroadcastType::COL_B;
+    if (!simple_bcast || !b_present || attributes.is_sfpu) {
+        return false;
+    }
+
+    // Reproduce the legacy fp32_dest_acc_en + use_llk_bcast decision to gate routing.
+    const auto a_dtype = a.dtype();
+    const auto b_dtype = b->dtype();
+    const auto a_df = datatype_to_dataformat_converter(a_dtype);
+    const auto b_df = datatype_to_dataformat_converter(b_dtype);
+    const auto c_df = datatype_to_dataformat_converter(attributes.get_dtype());
+    const bool fp32_dest_acc_en = c_df == tt::DataFormat::UInt32 || c_df == tt::DataFormat::Int32 ||
+                                  c_df == tt::DataFormat::Float32 || a_df == tt::DataFormat::Float32 ||
+                                  b_df == tt::DataFormat::Float32 ||
+                                  (a_df == tt::DataFormat::Int32 && b_df == tt::DataFormat::Int32) ||
+                                  (a_df == tt::DataFormat::UInt32 && b_df == tt::DataFormat::UInt32);
+    return binary_ng_m2_use_llk_bcast(sbt, a_dtype, b_dtype, fp32_dest_acc_en);
+}
+
+// Implements c = a op b for the routed interleaved cases (see SCOPE header).
 ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFactory::create_program_spec(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, tensor_return_value_t& c) {
     const auto& a = tensor_args.input_tensor_a;
     const auto& b_opt = tensor_args.input_tensor_b;
     const bool b_present = b_opt.has_value();
     const bool is_sfpu_op = operation_attributes.is_sfpu;
+    const auto sbt = operation_attributes.subtile_broadcast_type;
+    const bool is_none_bcast = sbt == SubtileBroadcastType::NONE;
+    const bool inputs_row_major = operation_attributes.input_layout_a == Layout::ROW_MAJOR;
 
     const auto a_dtype = a.dtype();
     // Mirror the legacy b_dtype derivation for the routed cases. When b is a scalar, it is packed
-    // as bfloat16 for block-float input types; the rhs CB format must match (BFLOAT16) — not the
+    // as bfloat16 for block-float input types; the rhs CB format must match (BFLOAT16) -- not the
     // block-float a_dtype. quant/where ops never route here.
     const auto b_dtype = b_present                                  ? b_opt->dtype()
                          : (is_sfpu_op && !is_block_float(a_dtype)) ? a_dtype
@@ -111,28 +317,6 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
     const uint32_t b_single_tile_size = tt::tile_size(b_data_format);
     const uint32_t c_single_tile_size = tt::tile_size(c_data_format);
 
-    // Compute defines for the binary op. Mirrors the legacy factory's OpConfig path for the
-    // no-activation case (no lhs/rhs/post activations -> no PROCESS_* defines beyond the op
-    // itself). Only plain ADD/SUB/MUL with no activations and no typecast route here, so OpConfig
-    // injects no process_lhs/process_rhs/postprocess (see binary_ng_utils.cpp).
-    auto op_config =
-        is_sfpu_op ? OpConfig(operation_attributes.binary_op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype)
-                   : OpConfig(operation_attributes.binary_op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype);
-    auto compute_kernel_defines = op_config.as_defines(a_dtype);
-    add_activation_defines(compute_kernel_defines, {}, "LHS", a_dtype);
-    add_activation_defines(compute_kernel_defines, {}, "RHS", b_dtype);
-    add_activation_defines(compute_kernel_defines, {}, "POST", operation_attributes.input_dtype);
-    compute_kernel_defines["BCAST_INPUT"] = "";  // NONE broadcast
-
-    // Dataflow defines (no broadcast, interleaved -> not sharded).
-    auto reader_defines = make_dataflow_defines(a_dtype, b_dtype);
-    reader_defines["SRC_SHARDED"] = "0";
-    reader_defines["SRC_SHARDED_B"] = "0";
-    reader_defines["BCAST_LLK"] = "0";
-    auto writer_defines = make_dataflow_defines(b_dtype);
-    writer_defines["SRC_SHARDED"] = "0";
-    writer_defines["DST_SHARDED"] = "0";
-
     // fp32 dest accumulation, mirroring the legacy factory rule.
     const bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
                                   c_data_format == tt::DataFormat::Float32 ||
@@ -141,33 +325,105 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
                                   (a_data_format == tt::DataFormat::Int32 && b_data_format == tt::DataFormat::Int32) ||
                                   (a_data_format == tt::DataFormat::UInt32 && b_data_format == tt::DataFormat::UInt32);
 
+    // For the simple-broadcast tile path the factory is reached only on the LLK-bcast subset
+    // (see binary_ng_m2_routes_to_spec); the software-fallback path is never routed here.
+    const bool use_llk_bcast = !is_none_bcast && !inputs_row_major;
+
+    // Compute defines. Mirrors the legacy OpConfig path for the no-activation case (no
+    // lhs/rhs/post activations -> no PROCESS_* defines beyond the op itself). Only plain
+    // ADD/SUB/MUL with no activations / no typecast route here.
+    auto op_config =
+        is_sfpu_op ? OpConfig(operation_attributes.binary_op_type, std::in_place_type<OpConfig::SfpuBinaryOp>, a_dtype)
+                   : OpConfig(operation_attributes.binary_op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype);
+    auto compute_kernel_defines = op_config.as_defines(a_dtype);
+    add_activation_defines(compute_kernel_defines, {}, "LHS", a_dtype);
+    add_activation_defines(compute_kernel_defines, {}, "RHS", b_dtype);
+    add_activation_defines(compute_kernel_defines, {}, "POST", operation_attributes.input_dtype);
+
+    // BCAST_INPUT: legacy kernel_config.bcast_input_str(). NONE -> "" ; *_A -> "0" ; *_B -> "1".
+    std::string bcast_input_str;
+    switch (sbt) {
+        case SubtileBroadcastType::NONE: bcast_input_str = ""; break;
+        case SubtileBroadcastType::SCALAR_A:
+        case SubtileBroadcastType::ROW_A:
+        case SubtileBroadcastType::COL_A: bcast_input_str = "0"; break;
+        case SubtileBroadcastType::SCALAR_B:
+        case SubtileBroadcastType::ROW_B:
+        case SubtileBroadcastType::COL_B: bcast_input_str = "1"; break;
+        default: bcast_input_str = ""; break;
+    }
+    compute_kernel_defines["BCAST_INPUT"] = bcast_input_str;
+    // SRC_BCAST / SRC_BCAST_B on the compute kernel (overwrite_compute_kernel_name_and_defines).
+    if (sbt == SubtileBroadcastType::ROW_A || sbt == SubtileBroadcastType::ROW_B ||
+        sbt == SubtileBroadcastType::COL_A || sbt == SubtileBroadcastType::COL_B ||
+        sbt == SubtileBroadcastType::SCALAR_A || sbt == SubtileBroadcastType::SCALAR_B) {
+        compute_kernel_defines["SRC_BCAST"] =
+            (sbt == SubtileBroadcastType::ROW_A || sbt == SubtileBroadcastType::COL_A ||
+             sbt == SubtileBroadcastType::SCALAR_A)
+                ? "1"
+                : "0";
+        compute_kernel_defines["SRC_BCAST_B"] =
+            (sbt == SubtileBroadcastType::ROW_B || sbt == SubtileBroadcastType::COL_B ||
+             sbt == SubtileBroadcastType::SCALAR_B)
+                ? "1"
+                : "0";
+    }
+
+    // Dataflow defines (interleaved -> not sharded).
+    auto reader_defines = make_dataflow_defines(a_dtype, b_dtype);
+    reader_defines["SRC_SHARDED"] = "0";
+    reader_defines["SRC_SHARDED_B"] = "0";
+    reader_defines["BCAST_LLK"] = use_llk_bcast ? "1" : "0";
+    // Reader SRC_BCAST / SRC_BCAST_B (get_reader_kernel_name_and_defines).
+    if (!is_none_bcast) {
+        reader_defines["SRC_BCAST"] = (sbt == SubtileBroadcastType::ROW_A || sbt == SubtileBroadcastType::COL_A ||
+                                       sbt == SubtileBroadcastType::SCALAR_A)
+                                          ? "1"
+                                          : "0";
+        reader_defines["SRC_BCAST_B"] = (sbt == SubtileBroadcastType::ROW_B || sbt == SubtileBroadcastType::COL_B ||
+                                         sbt == SubtileBroadcastType::SCALAR_B)
+                                            ? "1"
+                                            : "0";
+    }
+    auto writer_defines = make_dataflow_defines(b_dtype);
+    writer_defines["SRC_SHARDED"] = "0";
+    writer_defines["DST_SHARDED"] = "0";
+
     const auto& all_device_cores = operation_attributes.worker_grid;
 
-    // Work split: parallelize across output tiles (tile path, interleaved -> physical_volume).
-    const uint32_t tile_hw = c.tensor_spec().tile().get_tile_hw();
-    const uint32_t rt_c_num_tiles = c.physical_volume() / tile_hw;
-    const bool row_major = true;  // unsharded path uses row-major core ordering
-
-    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
-        tt::tt_metal::split_work_to_cores(all_device_cores, rt_c_num_tiles, row_major);
-    const auto cores = corerange_to_cores(all_device_cores, {}, row_major);
-
-    constexpr uint32_t num_tiles_per_cycle = 1;  // non-sharded default
-
     // ----------------------------------------------------------------------------------------
-    // ProgramSpec resources
+    // Resource names.
     // ----------------------------------------------------------------------------------------
-    ProgramSpec spec;
-    spec.name = is_sfpu_op ? "binary_ng_no_bcast_tile_sfpu"
-                           : (b_present ? "binary_ng_no_bcast_tile_fpu" : "binary_ng_no_bcast_tile_scalar");
-
-    // Tensor parameters (one per distinct accessed tensor). eltwise dataflow kernels declare
-    // RuntimeTensorShape on the I/O tensors in the legacy factory, so mirror that relaxation
-    // with dynamic_tensor_shape = true (interleaved -> TensorAccessor config unchanged). On the
-    // scalar-b path there is no b tensor, so only a and c are declared.
     const TensorParamName A_PARAM{"a"};
     const TensorParamName B_PARAM{"b"};
     const TensorParamName C_PARAM{"c"};
+    const DFBSpecName SRC_DFB{"src"};
+    const DFBSpecName SRC_B_DFB{"src_b"};
+    const DFBSpecName DST_DFB{"dst"};
+    const DFBSpecName LLK_POST_A_DFB{"llk_post_a"};  // legacy c_5 (bcast on A)
+    const DFBSpecName LLK_POST_B_DFB{"llk_post_b"};  // legacy c_6 (bcast on B)
+    const KernelSpecName READER_K{"reader"};
+    const KernelSpecName WRITER_K{"writer"};
+    const KernelSpecName COMPUTE_K1{"compute_g1"};
+    const KernelSpecName COMPUTE_K2{"compute_g2"};
+
+    // Which extra LLK-bcast CB does the broadcast operand use? legacy adds c_5 when the broadcast
+    // operand is A (SCALAR_A/ROW_A/COL_A) and c_6 when it is B.
+    const bool bcast_on_a = sbt == SubtileBroadcastType::SCALAR_A || sbt == SubtileBroadcastType::ROW_A ||
+                            sbt == SubtileBroadcastType::COL_A;
+    const bool bcast_on_b = sbt == SubtileBroadcastType::SCALAR_B || sbt == SubtileBroadcastType::ROW_B ||
+                            sbt == SubtileBroadcastType::COL_B;
+
+    ProgramSpec spec;
+    spec.name = inputs_row_major ? "binary_ng_rm_no_bcast_fpu"
+                : is_none_bcast
+                    ? (is_sfpu_op ? (b_present ? "binary_ng_no_bcast_tile_sfpu" : "binary_ng_no_bcast_tile_scalar_sfpu")
+                                  : (b_present ? "binary_ng_no_bcast_tile_fpu" : "binary_ng_no_bcast_tile_scalar"))
+                    : "binary_ng_simple_bcast_tile_fpu";
+
+    // Tensor parameters. eltwise dataflow kernels declare RuntimeTensorShape on the I/O tensors in
+    // the legacy factory, so mirror that relaxation with dynamic_tensor_shape = true (interleaved
+    // -> TensorAccessor config unchanged). On the scalar-b path there is no b tensor.
     TensorParameterAdvancedOptions dyn_shape;
     dyn_shape.dynamic_tensor_shape = true;
     spec.tensor_parameters.push_back(
@@ -179,12 +435,8 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
     spec.tensor_parameters.push_back(
         TensorParameter{.unique_id = C_PARAM, .spec = c.tensor_spec(), .advanced_options = dyn_shape});
 
-    // DFBs (one per legacy CB). c_0 = a (src), c_1 = b/scalar (src_b), c_2 = c (dst).
-    // On the scalar-b path the legacy single-tensor reader fills c_0 from src and the writer fills
-    // c_1 (single tile) from the packed scalar; both still exist.
-    const DFBSpecName SRC_DFB{"src"};
-    const DFBSpecName SRC_B_DFB{"src_b"};
-    const DFBSpecName DST_DFB{"dst"};
+    // DFBs (one per legacy CB). c_0 = a (src), c_1 = b/scalar (src_b), c_2 = c (dst). The
+    // simple-broadcast LLK path adds c_5 (bcast-on-A) or c_6 (bcast-on-B) as an intermediate.
     spec.dataflow_buffers.push_back(DataflowBufferSpec{
         .unique_id = SRC_DFB,
         .entry_size = a_single_tile_size,
@@ -201,51 +453,95 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
         .entry_size = c_single_tile_size,
         .num_entries = 2,
         .data_format_metadata = c_data_format});
+    if (use_llk_bcast && bcast_on_a) {
+        spec.dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = LLK_POST_A_DFB,
+            .entry_size = a_single_tile_size,
+            .num_entries = 2,
+            .data_format_metadata = a_data_format});
+    }
+    if (use_llk_bcast && bcast_on_b) {
+        spec.dataflow_buffers.push_back(DataflowBufferSpec{
+            .unique_id = LLK_POST_B_DFB,
+            .entry_size = b_single_tile_size,
+            .num_entries = 2,
+            .data_format_metadata = b_data_format});
+    }
 
-    // Kernel names.
-    const KernelSpecName READER_K{"reader"};
-    const KernelSpecName WRITER_K{"writer"};
-    // Per the recipe, preserve work-split multiplicity: one compute KernelSpec per core group.
-    const KernelSpecName COMPUTE_K1{"compute_g1"};
-    const KernelSpecName COMPUTE_K2{"compute_g2"};
-
-    // op_config.as_defines() / make_dataflow_defines() return std::map<string,string>; the
-    // Table range constructor copies them in directly.
+    // op_config.as_defines() / make_dataflow_defines() return std::map<string,string>; the Table
+    // range constructor copies them in directly.
     KernelSpec::CompilerOptions::Defines reader_def_table(reader_defines);
     KernelSpec::CompilerOptions::Defines writer_def_table(writer_defines);
     KernelSpec::CompilerOptions::Defines compute_def_table(compute_kernel_defines);
 
-    const char* reader_src = b_present ? READER_AB_M2 : READER_SCALAR_M2;
-    const char* writer_src = b_present ? WRITER_AB_M2 : WRITER_SCALAR_M2;
-    const char* compute_src = b_present ? (is_sfpu_op ? COMPUTE_SFPU_M2 : COMPUTE_FPU_M2) : COMPUTE_SCALAR_M2;
+    // Kernel source selection.
+    const char* reader_src = nullptr;
+    const char* writer_src = nullptr;
+    const char* compute_src = nullptr;
+    if (inputs_row_major) {
+        reader_src = READER_RM_AB_M2;
+        writer_src = WRITER_RM_M2;
+        compute_src = COMPUTE_FPU_M2;  // RM NONE-bcast uses the FPU no-bcast compute (freq=1,counter=0)
+    } else if (is_none_bcast) {
+        reader_src = b_present ? READER_AB_M2 : READER_SCALAR_M2;
+        writer_src = b_present ? WRITER_AB_M2 : WRITER_SCALAR_M2;
+        compute_src = b_present ? (is_sfpu_op ? COMPUTE_SFPU_M2 : COMPUTE_FPU_M2)
+                                : (is_sfpu_op ? COMPUTE_SCALAR_SFPU_M2 : COMPUTE_SCALAR_FPU_M2);
+    } else {
+        // Simple broadcast tile (LLK path), tensor-b FPU.
+        switch (sbt) {
+            case SubtileBroadcastType::SCALAR_A:
+            case SubtileBroadcastType::SCALAR_B:
+                reader_src = READER_SCALAR_BCAST_M2;
+                compute_src = COMPUTE_SCALAR_BCAST_M2;
+                break;
+            case SubtileBroadcastType::ROW_A:
+            case SubtileBroadcastType::ROW_B:
+                reader_src = READER_ROW_BCAST_M2;
+                compute_src = COMPUTE_ROW_BCAST_M2;
+                break;
+            case SubtileBroadcastType::COL_A:
+            case SubtileBroadcastType::COL_B:
+                reader_src = READER_COL_BCAST_M2;
+                compute_src = COMPUTE_COL_BCAST_M2;
+                break;
+            default: __builtin_unreachable();
+        }
+        writer_src = WRITER_AB_M2;  // tensor-b writer (no scalar fill)
+    }
 
+    // ----------------------------------------------------------------------------------------
     // Reader KernelSpec.
+    // ----------------------------------------------------------------------------------------
     KernelSpec reader_k;
     reader_k.unique_id = READER_K;
     reader_k.source = std::filesystem::path(reader_src);
     reader_k.compiler_options.defines = reader_def_table;
-    reader_k.compile_time_args = {{"has_sharding", 0u}};
-    if (b_present) {
+    if (inputs_row_major) {
+        // Row-major reader: addresses + page-size overrides dropped (ta::src/ta::src_b carry them).
+        reader_k.compile_time_args = {};
         reader_k.runtime_arg_schema.runtime_arg_names = {
-            "start_tile_id",
-            "src_num_tiles",
             "dst_num_tiles",
-            "dst_shard_width",
-            "nD_stride",
-            "d_stride",
-            "n_stride",
-            "c_stride",
-            "D",
-            "N",
-            "C",
-            "Ht",
-            "Wt",
+            "aD",
+            "aN",
+            "aC",
+            "aHt",
+            "aND",
+            "bD",
+            "bN",
+            "bC",
+            "bHt",
+            "bND",
+            "cHt",
+            "cC",
             "cND",
-            "nD_stride_b",
-            "d_stride_b",
-            "n_stride_b",
-            "c_stride_b",
-            "src_num_tiles_b"};
+            "current_block_start",
+            "rows_per_tile",
+            "row_width_elements",
+            "alignment_a",
+            "alignment_b",
+            "tiles_per_row",
+            "stride_size_bytes"};
         reader_k.dfb_bindings = {
             DFBBinding{.dfb_spec_name = SRC_DFB, .accessor_name = "src", .endpoint_type = DFBEndpointType::PRODUCER},
             DFBBinding{
@@ -254,72 +550,249 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
             TensorBinding{.tensor_parameter_name = A_PARAM, .accessor_name = "src"},
             TensorBinding{.tensor_parameter_name = B_PARAM, .accessor_name = "src_b"}};
     } else {
-        // Single-tensor (scalar-b) reader: reads only src into c_0.
-        reader_k.runtime_arg_schema.runtime_arg_names = {
-            "start_tile_id",
-            "src_num_tiles",
-            "dst_num_tiles",
-            "dst_shard_width",
-            "nD_stride",
-            "d_stride",
-            "n_stride",
-            "c_stride",
-            "D",
-            "N",
-            "C",
-            "Ht",
-            "Wt",
-            "cND"};
-        reader_k.dfb_bindings = {
-            DFBBinding{.dfb_spec_name = SRC_DFB, .accessor_name = "src", .endpoint_type = DFBEndpointType::PRODUCER}};
-        reader_k.tensor_bindings = {TensorBinding{.tensor_parameter_name = A_PARAM, .accessor_name = "src"}};
+        reader_k.compile_time_args = {{"has_sharding", 0u}};
+        if (b_present) {
+            reader_k.runtime_arg_schema.runtime_arg_names = {
+                "start_tile_id",
+                "src_num_tiles",
+                "dst_num_tiles",
+                "dst_shard_width",
+                "nD_stride",
+                "d_stride",
+                "n_stride",
+                "c_stride",
+                "D",
+                "N",
+                "C",
+                "Ht",
+                "Wt",
+                "cND",
+                "nD_stride_b",
+                "d_stride_b",
+                "n_stride_b",
+                "c_stride_b",
+                "src_num_tiles_b"};
+            reader_k.dfb_bindings = {
+                DFBBinding{
+                    .dfb_spec_name = SRC_DFB, .accessor_name = "src", .endpoint_type = DFBEndpointType::PRODUCER},
+                DFBBinding{
+                    .dfb_spec_name = SRC_B_DFB, .accessor_name = "src_b", .endpoint_type = DFBEndpointType::PRODUCER}};
+            reader_k.tensor_bindings = {
+                TensorBinding{.tensor_parameter_name = A_PARAM, .accessor_name = "src"},
+                TensorBinding{.tensor_parameter_name = B_PARAM, .accessor_name = "src_b"}};
+        } else {
+            // Single-tensor (scalar-b) reader: reads only src into c_0.
+            reader_k.runtime_arg_schema.runtime_arg_names = {
+                "start_tile_id",
+                "src_num_tiles",
+                "dst_num_tiles",
+                "dst_shard_width",
+                "nD_stride",
+                "d_stride",
+                "n_stride",
+                "c_stride",
+                "D",
+                "N",
+                "C",
+                "Ht",
+                "Wt",
+                "cND"};
+            reader_k.dfb_bindings = {DFBBinding{
+                .dfb_spec_name = SRC_DFB, .accessor_name = "src", .endpoint_type = DFBEndpointType::PRODUCER}};
+            reader_k.tensor_bindings = {TensorBinding{.tensor_parameter_name = A_PARAM, .accessor_name = "src"}};
+        }
     }
     reader_k.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER};
 
+    // ----------------------------------------------------------------------------------------
     // Writer KernelSpec.
+    // ----------------------------------------------------------------------------------------
     KernelSpec writer_k;
     writer_k.unique_id = WRITER_K;
     writer_k.source = std::filesystem::path(writer_src);
     writer_k.compiler_options.defines = writer_def_table;
-    writer_k.compile_time_args = {{"has_sharding", 0u}};
-    if (b_present) {
+    if (inputs_row_major) {
+        writer_k.compile_time_args = {};
         writer_k.runtime_arg_schema.runtime_arg_names = {
-            "start_tile_id", "dst_num_tiles", "dst_shard_width", "D", "N", "C", "Ht", "Wt", "cND"};
+            "row_width_elements",
+            "dst_num_tiles",
+            "outD",
+            "outN",
+            "outC",
+            "outHt",
+            "outND",
+            "current_block_start",
+            "rows_per_tile",
+            "alignment",
+            "tiles_per_row",
+            "stride_size_bytes"};
         writer_k.dfb_bindings = {
             DFBBinding{.dfb_spec_name = DST_DFB, .accessor_name = "dst", .endpoint_type = DFBEndpointType::CONSUMER}};
         writer_k.tensor_bindings = {TensorBinding{.tensor_parameter_name = C_PARAM, .accessor_name = "dst"}};
     } else {
-        // Scalar-b writer: fills the scalar tile into c_1 (src_b) AND writes c_2 (dst). The packed
-        // scalar is the leading named RTA `packed_scalar` (a value, mirroring legacy positional 0).
-        writer_k.runtime_arg_schema.runtime_arg_names = {
-            "packed_scalar", "start_tile_id", "dst_num_tiles", "dst_shard_width", "D", "N", "C", "Ht", "Wt", "cND"};
-        writer_k.dfb_bindings = {
-            DFBBinding{
-                .dfb_spec_name = SRC_B_DFB, .accessor_name = "src_b", .endpoint_type = DFBEndpointType::PRODUCER},
-            DFBBinding{.dfb_spec_name = DST_DFB, .accessor_name = "dst", .endpoint_type = DFBEndpointType::CONSUMER}};
-        writer_k.tensor_bindings = {TensorBinding{.tensor_parameter_name = C_PARAM, .accessor_name = "dst"}};
+        writer_k.compile_time_args = {{"has_sharding", 0u}};
+        if (b_present) {
+            writer_k.runtime_arg_schema.runtime_arg_names = {
+                "start_tile_id", "dst_num_tiles", "dst_shard_width", "D", "N", "C", "Ht", "Wt", "cND"};
+            writer_k.dfb_bindings = {DFBBinding{
+                .dfb_spec_name = DST_DFB, .accessor_name = "dst", .endpoint_type = DFBEndpointType::CONSUMER}};
+            writer_k.tensor_bindings = {TensorBinding{.tensor_parameter_name = C_PARAM, .accessor_name = "dst"}};
+        } else {
+            // Scalar-b writer: fills the scalar tile into c_1 (src_b) AND writes c_2 (dst). The
+            // packed scalar is the leading named RTA `packed_scalar` (mirroring legacy positional 0).
+            writer_k.runtime_arg_schema.runtime_arg_names = {
+                "packed_scalar", "start_tile_id", "dst_num_tiles", "dst_shard_width", "D", "N", "C", "Ht", "Wt", "cND"};
+            writer_k.dfb_bindings = {
+                DFBBinding{
+                    .dfb_spec_name = SRC_B_DFB, .accessor_name = "src_b", .endpoint_type = DFBEndpointType::PRODUCER},
+                DFBBinding{
+                    .dfb_spec_name = DST_DFB, .accessor_name = "dst", .endpoint_type = DFBEndpointType::CONSUMER}};
+            writer_k.tensor_bindings = {TensorBinding{.tensor_parameter_name = C_PARAM, .accessor_name = "dst"}};
+        }
     }
     writer_k.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER};
 
-    // Compute KernelSpec template (one per core group; only the num_tiles RTA is read by the
-    // no-bcast/scalar compute kernels). num_tiles_per_cycle is a named CTA.
-    // SFPU unpack-to-dest: legacy sets UnpackToDestFp32 on the operand CBs for non-POWER SFPU ops.
-    // The Metal 2.0 ComputeHardwareConfig rejects UnpackToDestFp32 unless fp32_dest_acc_en=true; in
-    // the legacy-inert case (fp32_dest_acc_en=false) the hardware ignored the mode anyway, so we
-    // faithfully map it to Default there (only plain ADD/SUB/MUL route here, never POWER).
+    // ----------------------------------------------------------------------------------------
+    // Work split. Tile path parallelizes across output tiles; RM path parallelizes across row
+    // blocks (rt_c_num_tiles = total_row_blocks). All other RM geometry (num_rows_per_tile,
+    // stride sizes) mirrors the legacy factory.
+    // ----------------------------------------------------------------------------------------
+    constexpr uint32_t num_tiles_per_cycle = 1;  // non-sharded default
+    const bool row_major_cores = true;           // unsharded path uses row-major core ordering
+
+    // RM geometry (only computed / used on the RM path).
+    uint32_t rm_num_rows_per_tile = 0;
+    uint32_t rm_tiles_per_row_width = 1;
+    uint32_t rm_common_row_width_elements = 0;
+    uint32_t rm_reader_stride_size_bytes = 0;
+    uint32_t rm_writer_stride_size_bytes = 0;
+    uint32_t rm_a_alignment = 0;
+    uint32_t rm_b_alignment = 0;
+    uint32_t rm_c_alignment = 0;
+
+    uint32_t rt_c_num_tiles;
+    const uint32_t tile_height = c.tensor_spec().tile().get_height();
+    const uint32_t tile_width = c.tensor_spec().tile().get_width();
+    const uint32_t tile_hw = tile_height * tile_width;
+
+    const auto out_rank = c.logical_shape().rank();
+    const auto aND = extract_nD_dims(a, out_rank);
+    const auto bND = b_present ? extract_nD_dims(*b_opt, out_rank) : 1u;
+    const auto cND = extract_nD_dims(c, out_rank);
+    const auto [aD, aN, aC, aHt, aWt] = get_shape_dims(a);
+    const auto [bD, bN, bC, bHt, bWt] = b_present ? get_shape_dims(*b_opt) : std::tuple{1u, 1u, 1u, 1u, 1u};
+    const auto [cD, cN, cC, cHt, cWt] = get_shape_dims(c);
+
+    const auto aHt_r = a.padded_shape()[-2];
+    const auto aWt_r = a.padded_shape()[-1];
+    const auto bHt_r = b_present ? b_opt->padded_shape()[-2] : 0u;
+    const auto bWt_r = b_present ? b_opt->padded_shape()[-1] : 0u;
+    const auto cHt_r = c.padded_shape()[-2];
+    const auto cWt_r = c.padded_shape()[-1];
+
+    if (inputs_row_major) {
+        rm_a_alignment = a.buffer()->alignment();
+        rm_b_alignment = b_present ? b_opt->buffer()->alignment() : rm_a_alignment;
+        rm_c_alignment = c.buffer()->alignment();
+
+        const uint32_t c_aligned_page_size = c.buffer()->aligned_page_size();
+        const uint32_t a_aligned_page_size = a.buffer()->aligned_page_size();
+        const uint32_t b_aligned_page_size = b_present ? b_opt->buffer()->aligned_page_size() : a_aligned_page_size;
+
+        const uint32_t c_row_width_elements_aligned = c_aligned_page_size / c.element_size();
+        const uint32_t a_row_width_elements_aligned = a_aligned_page_size / a.element_size();
+        const uint32_t b_row_width_elements_aligned =
+            b_present ? (b_aligned_page_size / b_opt->element_size()) : a_row_width_elements_aligned;
+
+        rm_common_row_width_elements = c_row_width_elements_aligned;
+        if (aWt_r == cWt_r) {
+            rm_common_row_width_elements = std::min(rm_common_row_width_elements, a_row_width_elements_aligned);
+        }
+        if (b_present && bWt_r == cWt_r) {
+            rm_common_row_width_elements = std::min(rm_common_row_width_elements, b_row_width_elements_aligned);
+        }
+        rm_common_row_width_elements = std::max<uint32_t>(1u, rm_common_row_width_elements);
+
+        rm_num_rows_per_tile = std::max<uint32_t>(1u, tile_hw / rm_common_row_width_elements);
+        const bool aligned_for_a =
+            (aWt_r == cWt_r) ? ((rm_common_row_width_elements * a.element_size()) == a_aligned_page_size) : true;
+        const bool aligned_for_b = (b_present && bWt_r == cWt_r)
+                                       ? ((rm_common_row_width_elements * b_opt->element_size()) == b_aligned_page_size)
+                                       : true;
+        const bool aligned_for_c = (rm_common_row_width_elements * c.element_size()) == c_aligned_page_size;
+        if (!aligned_for_a || !aligned_for_b || !aligned_for_c) {
+            rm_num_rows_per_tile = 1;
+        }
+
+        const uint32_t row_blocks_per_channel = tt::div_up(cHt_r, rm_num_rows_per_tile);
+        const uint32_t total_row_blocks = cND * cD * cN * cC * row_blocks_per_channel;
+        rm_tiles_per_row_width = tt::div_up(rm_common_row_width_elements, tile_hw);
+        const uint32_t a_tile_bytes = tile_hw * a.element_size();
+        const uint32_t a_row_width_bytes = rm_common_row_width_elements * a.element_size();
+        rm_reader_stride_size_bytes =
+            (a_row_width_bytes > a_tile_bytes) ? a_tile_bytes : tt::round_up(a_row_width_bytes, rm_a_alignment);
+        const uint32_t c_tile_bytes = tile_hw * c.element_size();
+        const uint32_t c_row_width_bytes = rm_common_row_width_elements * c.element_size();
+        rm_writer_stride_size_bytes =
+            (c_row_width_bytes > c_tile_bytes) ? c_tile_bytes : tt::round_up(c_row_width_bytes, rm_c_alignment);
+        rt_c_num_tiles = total_row_blocks;
+    } else {
+        rt_c_num_tiles = c.physical_volume() / tile_hw;
+    }
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(all_device_cores, rt_c_num_tiles, row_major_cores);
+    const auto cores = corerange_to_cores(all_device_cores, {}, row_major_cores);
+    const bool has_group_2 = !core_group_2.ranges().empty();
+
+    // ----------------------------------------------------------------------------------------
+    // Compute KernelSpec (one per core group, preserving work-split multiplicity). The no-bcast,
+    // scalar, and RM compute kernels read num_tiles only; the broadcast compute kernels also read
+    // tile_freq + tile_start (calculate_compute_kernel_args). The RM compute (FPU no-bcast) reads
+    // num_tiles = c_num_tiles_core * tiles_per_row_width.
+    // SFPU unpack-to-dest: legacy sets UnpackToDestFp32 on the operand CBs for non-POWER SFPU ops;
+    // ComputeHardwareConfig rejects it unless fp32_dest_acc_en, and the legacy-inert case is mapped
+    // to Default (only plain ADD/SUB/MUL route here, never POWER).
+    const bool compute_has_freq_counter = use_llk_bcast;  // broadcast kernels take 3 RTAs
     auto make_compute_k = [&](const KernelSpecName& id) {
         KernelSpec k;
         k.unique_id = id;
         k.source = std::filesystem::path(compute_src);
         k.compiler_options.defines = compute_def_table;
         k.compile_time_args = {{"num_tiles_per_cycle", num_tiles_per_cycle}};
-        k.runtime_arg_schema.runtime_arg_names = {"num_tiles"};
-        k.dfb_bindings = {
+        if (compute_has_freq_counter) {
+            k.runtime_arg_schema.runtime_arg_names = {"num_tiles", "tile_freq", "tile_start"};
+        } else {
+            k.runtime_arg_schema.runtime_arg_names = {"num_tiles"};
+        }
+        Group<DFBBinding> bindings = {
             DFBBinding{
                 .dfb_spec_name = SRC_DFB, .accessor_name = "pre_lhs", .endpoint_type = DFBEndpointType::CONSUMER},
             DFBBinding{
                 .dfb_spec_name = SRC_B_DFB, .accessor_name = "pre_rhs", .endpoint_type = DFBEndpointType::CONSUMER},
             DFBBinding{.dfb_spec_name = DST_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER}};
+        // The LLK-bcast compute kernel produces+consumes the intermediate c_5/c_6 DFB (self-loop).
+        if (use_llk_bcast && bcast_on_a) {
+            bindings.push_back(DFBBinding{
+                .dfb_spec_name = LLK_POST_A_DFB,
+                .accessor_name = "llk_post_a",
+                .endpoint_type = DFBEndpointType::PRODUCER});
+            bindings.push_back(DFBBinding{
+                .dfb_spec_name = LLK_POST_A_DFB,
+                .accessor_name = "llk_post_a",
+                .endpoint_type = DFBEndpointType::CONSUMER});
+        }
+        if (use_llk_bcast && bcast_on_b) {
+            bindings.push_back(DFBBinding{
+                .dfb_spec_name = LLK_POST_B_DFB,
+                .accessor_name = "llk_post_b",
+                .endpoint_type = DFBEndpointType::PRODUCER});
+            bindings.push_back(DFBBinding{
+                .dfb_spec_name = LLK_POST_B_DFB,
+                .accessor_name = "llk_post_b",
+                .endpoint_type = DFBEndpointType::CONSUMER});
+        }
+        k.dfb_bindings = bindings;
         ComputeHardwareConfig hw;
         hw.fp32_dest_acc_en = fp32_dest_acc_en;
         if (is_sfpu_op && fp32_dest_acc_en) {
@@ -333,16 +806,12 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
     spec.kernels.push_back(reader_k);
     spec.kernels.push_back(writer_k);
     spec.kernels.push_back(make_compute_k(COMPUTE_K1));
-    const bool has_group_2 = !core_group_2.ranges().empty();
     if (has_group_2) {
         spec.kernels.push_back(make_compute_k(COMPUTE_K2));
     }
 
-    // WorkUnitSpec: reader + writer + compute_g1 over core_group_1; a second WorkUnit for
-    // core_group_2 (reader + writer + compute_g2). Each DFB's producer and consumer share the
-    // same WorkUnitSpec (local-DFB rule): reader (producer of src[/src_b]) + writer (consumer of
-    // dst [and producer of the scalar src_b on the scalar path]) + compute (consumer of src/src_b,
-    // producer of dst) all co-located per group.
+    // WorkUnitSpec: reader + writer + compute_g{1,2} over their core groups. Each DFB's producer
+    // and consumer share the same WorkUnitSpec (local-DFB rule).
     {
         WorkUnitSpec wu1;
         wu1.name = "group_1";
@@ -360,28 +829,19 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
 
     // ----------------------------------------------------------------------------------------
     // ProgramRunArgs (per-core runtime arguments). Mirrors the legacy factory's inline per-core
-    // RTA emission for the no-bcast tile interleaved path, minus the buffer-address slots (now
-    // carried by the TensorBindings).
+    // RTA emission, minus the buffer-address slots (now carried by the TensorBindings).
     // ----------------------------------------------------------------------------------------
     ProgramRunArgs run_args;
-
     KernelRunArgs reader_run{.kernel = READER_K};
     KernelRunArgs writer_run{.kernel = WRITER_K};
     KernelRunArgs compute_run_1{.kernel = COMPUTE_K1};
     KernelRunArgs compute_run_2{.kernel = COMPUTE_K2};
 
-    const auto out_rank = c.logical_shape().rank();
-    const auto aND = extract_nD_dims(a, out_rank);
-    const auto bND = b_present ? extract_nD_dims(*b_opt, out_rank) : 1u;
-    const auto cND = extract_nD_dims(c, out_rank);
-    const auto [aD, aN, aC, aHt, aWt] = get_shape_dims(a);
-    const auto [bD, bN, bC, bHt, bWt] = b_present ? get_shape_dims(*b_opt) : std::tuple{1u, 1u, 1u, 1u, 1u};
-    const auto [cD, cN, cC, cHt, cWt] = get_shape_dims(c);
-
     // Packed scalar value for the scalar-b path (mirrors the legacy pack_scalar_runtime_arg call).
     const uint32_t packed_scalar =
         b_present ? 0u : pack_scalar_runtime_arg(*operation_attributes.scalar, a.dtype(), /*is_quant_op=*/false);
 
+    uint32_t current_block = 0;
     for (uint32_t i = 0, start_tile_id = 0; i < num_cores; i++) {
         const auto& core = cores[i];
         uint32_t c_num_tiles_core = 0;
@@ -393,7 +853,61 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
             continue;  // unused core: emit no per-core args (Metal 2.0 derives node set from WorkUnitSpec)
         }
 
-        // Reader RTAs (legacy slots, minus a/b base addresses now handled by ta:: bindings).
+        if (inputs_row_major) {
+            // RM reader RTAs (legacy order, minus a/b addresses + page-size overrides).
+            reader_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+                .node = core,
+                .args = {
+                    {"dst_num_tiles", c_num_tiles_core},
+                    {"aD", aD},
+                    {"aN", aN},
+                    {"aC", aC},
+                    {"aHt", aHt_r},
+                    {"aND", aND},
+                    {"bD", b_present ? bD : 1u},
+                    {"bN", b_present ? bN : 1u},
+                    {"bC", b_present ? bC : 1u},
+                    {"bHt", b_present ? bHt_r : 1u},
+                    {"bND", bND},
+                    {"cHt", cHt_r},
+                    {"cC", cC},
+                    {"cND", cND},
+                    {"current_block_start", current_block},
+                    {"rows_per_tile", rm_num_rows_per_tile},
+                    {"row_width_elements", rm_common_row_width_elements},
+                    {"alignment_a", rm_a_alignment},
+                    {"alignment_b", rm_b_alignment},
+                    {"tiles_per_row", rm_tiles_per_row_width},
+                    {"stride_size_bytes", rm_reader_stride_size_bytes},
+                }});
+            // RM writer RTAs.
+            writer_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+                .node = core,
+                .args = {
+                    {"row_width_elements", rm_common_row_width_elements},
+                    {"dst_num_tiles", c_num_tiles_core},
+                    {"outD", cD},
+                    {"outN", cN},
+                    {"outC", cC},
+                    {"outHt", cHt_r},
+                    {"outND", cND},
+                    {"current_block_start", current_block},
+                    {"rows_per_tile", rm_num_rows_per_tile},
+                    {"alignment", rm_c_alignment},
+                    {"tiles_per_row", rm_tiles_per_row_width},
+                    {"stride_size_bytes", rm_writer_stride_size_bytes},
+                }});
+            // RM compute RTA: num_tiles = c_num_tiles_core * tiles_per_row_width.
+            auto& compute_run = core_group_1.contains(core) ? compute_run_1 : compute_run_2;
+            compute_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+                .node = core, .args = {{"num_tiles", c_num_tiles_core * rm_tiles_per_row_width}}});
+
+            start_tile_id += c_num_tiles_core;
+            current_block += c_num_tiles_core;
+            continue;
+        }
+
+        // Tile path reader RTAs (legacy slots, minus a/b base addresses now handled by ta::).
         if (b_present) {
             reader_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
                 .node = core,
@@ -424,7 +938,7 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
                 .node = core,
                 .args = {
                     {"start_tile_id", start_tile_id},
-                    {"src_num_tiles", 0u},  // a_num_tiles: 0 on the interleaved (unsharded) path
+                    {"src_num_tiles", 0u},
                     {"dst_num_tiles", c_num_tiles_core},
                     {"dst_shard_width", 0u},
                     {"nD_stride", aHt * aWt * aC * aN * aD * (aND > 1)},
@@ -440,7 +954,7 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
                 }});
         }
 
-        // Writer RTAs (legacy slots, minus the c base address now handled by ta:: binding; on the
+        // Tile path writer RTAs (legacy slots, minus the c base address now handled by ta::; on the
         // scalar path the packed scalar value leads).
         if (b_present) {
             writer_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
@@ -473,12 +987,19 @@ ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFac
                 }});
         }
 
-        // Compute RTA: the no-bcast/scalar compute kernels read only num_tiles (= c_num_tiles_core
-        // on the tile path). freq/counter/scalar slots of the legacy 4-arg vector are dead for
-        // these kernels and dropped (superfluous named args are a Metal 2.0 validation error).
+        // Compute RTA. For the no-bcast / scalar paths, only num_tiles is read (= c_num_tiles_core).
+        // For the simple-broadcast paths, tile_freq + tile_start come from
+        // calculate_compute_kernel_args (legacy compute_runtime_args = {compute_tiles, freq, counter, ...};
+        // the trailing scalar slot is dead for plain ADD/SUB/MUL and dropped).
         auto& compute_run = core_group_1.contains(core) ? compute_run_1 : compute_run_2;
-        compute_run.runtime_arg_values.push_back(
-            KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"num_tiles", c_num_tiles_core}}});
+        if (compute_has_freq_counter) {
+            auto [freq, counter] = calculate_compute_kernel_args(sbt, start_tile_id, cHt, cWt);
+            compute_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+                .node = core, .args = {{"num_tiles", c_num_tiles_core}, {"tile_freq", freq}, {"tile_start", counter}}});
+        } else {
+            compute_run.runtime_arg_values.push_back(
+                KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"num_tiles", c_num_tiles_core}}});
+        }
 
         start_tile_id += c_num_tiles_core;
     }

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/binary_ng_program_factory_m2.cpp
@@ -1,0 +1,379 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 program factory for binary_ng.
+//
+// SCOPE: this factory handles ONLY the simplest path of the op:
+//   SubtileBroadcastType::NONE x tile layout x FPU (not SFPU, not where) x tensor-b-present x
+//   interleaved (not sharded) x no activations.
+// BinaryNgDeviceOperation::select_program_factory() routes only that exact case here; every
+// other path (row-major, all broadcast types, SFPU, where-op, scalar-b, sharded, activations)
+// stays on the legacy ProgramFactory::create_descriptor in binary_ng_program_factory.cpp.
+// The full set of remaining kernel entry points is enumerated in METAL2_PORT_REPORT.md.
+//
+// The legacy factory's logic for this path is preserved exactly (work-split, per-core tile
+// strides, CB sizes); only the host API is converted to Metal 2.0 ProgramSpec / ProgramRunArgs,
+// and the three kernels it binds are the forked *_m2.cpp ports.
+
+#include "binary_ng_device_operation.hpp"
+#include "binary_ng_utils.hpp"
+
+#include <tt-metalium/work_split.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/math.hpp>
+#include <tt-metalium/tt_backend_api_types.hpp>
+
+#include <filesystem>
+#include <map>
+#include <tuple>
+#include <utility>
+
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
+using namespace tt;
+using namespace tt::tt_metal;
+using namespace tt::tt_metal::experimental;
+
+namespace ttnn::operations::binary_ng {
+
+namespace {
+
+// Forked Metal 2.0 kernel sources (no-broadcast tile FPU interleaved path).
+constexpr const char* READER_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast_m2.cpp";
+constexpr const char* WRITER_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast_m2.cpp";
+constexpr const char* COMPUTE_M2 =
+    "ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast_m2.cpp";
+
+// Mirror of the legacy factory's get_shape_dims for the narrow (tile) path.
+std::tuple<uint32_t, uint32_t, uint32_t, uint32_t, uint32_t> get_shape_dims(const Tensor& x) {
+    const auto& shape = x.padded_shape();
+    const auto& tile = x.tensor_spec().tile();
+    return {
+        shape.rank() >= 5 ? shape[-5] : 1,
+        shape[-4],
+        shape[-3],
+        tt::div_up(shape[-2], tile.get_height()),
+        tt::div_up(shape[-1], tile.get_width())};
+}
+
+// For rank > 5 dims will be collapsed into a single dim (mirror of legacy extract_nD_dims).
+uint32_t extract_nD_dims(const Tensor& x, const int out_rank) {
+    const auto& shape = x.logical_shape();
+    uint32_t nD_dim = 1;
+    if (out_rank >= 6 && shape.rank() >= 6) {
+        for (int i = -6; i >= -out_rank; --i) {
+            nD_dim *= shape[i];
+        }
+    }
+    return nD_dim;
+}
+
+}  // namespace
+
+// Implements c = a op b, no-broadcast tile FPU interleaved path.
+ttnn::device_operation::ProgramArtifacts BinaryNgDeviceOperation::ProgramSpecFactory::create_program_spec(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args, tensor_return_value_t& c) {
+    const auto& a = tensor_args.input_tensor_a;
+    const auto& b = *tensor_args.input_tensor_b;  // present on this path (select_program_factory guarantees it)
+
+    const auto a_dtype = a.dtype();
+    const auto b_dtype = b.dtype();
+    const auto c_dtype = c.dtype();
+    const auto a_data_format = datatype_to_dataformat_converter(a_dtype);
+    const auto b_data_format = datatype_to_dataformat_converter(b_dtype);
+    const auto c_data_format = datatype_to_dataformat_converter(c_dtype);
+
+    const uint32_t a_single_tile_size = tt::tile_size(a_data_format);
+    const uint32_t b_single_tile_size = tt::tile_size(b_data_format);
+    const uint32_t c_single_tile_size = tt::tile_size(c_data_format);
+
+    // Compute defines for the binary op (FPU). Mirrors the legacy factory's OpConfig path for
+    // the no-activation FPU case (no lhs/rhs/post activations -> no PROCESS_* defines beyond the
+    // op itself). This path is only selected for plain ADD/SUB/MUL with no activations.
+    auto op_config = OpConfig(operation_attributes.binary_op_type, std::in_place_type<OpConfig::FpuBinaryOp>, a_dtype);
+    auto compute_kernel_defines = op_config.as_defines(a_dtype);
+    add_activation_defines(compute_kernel_defines, {}, "LHS", a_dtype);
+    add_activation_defines(compute_kernel_defines, {}, "RHS", b_dtype);
+    add_activation_defines(compute_kernel_defines, {}, "POST", operation_attributes.input_dtype);
+    compute_kernel_defines["BCAST_INPUT"] = "";  // NONE broadcast
+
+    // Dataflow defines (no broadcast, interleaved -> not sharded).
+    auto reader_defines = make_dataflow_defines(a_dtype, b_dtype);
+    reader_defines["SRC_SHARDED"] = "0";
+    reader_defines["SRC_SHARDED_B"] = "0";
+    reader_defines["BCAST_LLK"] = "0";
+    auto writer_defines = make_dataflow_defines(b_dtype);
+    writer_defines["SRC_SHARDED"] = "0";
+    writer_defines["DST_SHARDED"] = "0";
+
+    // fp32 dest accumulation, mirroring the legacy factory rule.
+    const bool fp32_dest_acc_en = c_data_format == tt::DataFormat::UInt32 || c_data_format == tt::DataFormat::Int32 ||
+                                  c_data_format == tt::DataFormat::Float32 ||
+                                  a_data_format == tt::DataFormat::Float32 ||
+                                  b_data_format == tt::DataFormat::Float32 ||
+                                  (a_data_format == tt::DataFormat::Int32 && b_data_format == tt::DataFormat::Int32) ||
+                                  (a_data_format == tt::DataFormat::UInt32 && b_data_format == tt::DataFormat::UInt32);
+
+    const auto& all_device_cores = operation_attributes.worker_grid;
+
+    // Work split: parallelize across output tiles (tile path, interleaved -> physical_volume).
+    const uint32_t tile_hw = c.tensor_spec().tile().get_tile_hw();
+    const uint32_t rt_c_num_tiles = c.physical_volume() / tile_hw;
+    const bool row_major = true;  // unsharded path uses row-major core ordering
+
+    auto [num_cores, all_cores, core_group_1, core_group_2, num_tiles_per_core_group_1, num_tiles_per_core_group_2] =
+        tt::tt_metal::split_work_to_cores(all_device_cores, rt_c_num_tiles, row_major);
+    const auto cores = corerange_to_cores(all_device_cores, {}, row_major);
+
+    constexpr uint32_t num_tiles_per_cycle = 1;  // non-sharded default
+
+    // ----------------------------------------------------------------------------------------
+    // ProgramSpec resources
+    // ----------------------------------------------------------------------------------------
+    ProgramSpec spec;
+    spec.name = "binary_ng_no_bcast_tile_fpu";
+
+    // Tensor parameters (one per distinct accessed tensor). eltwise dataflow kernels declare
+    // RuntimeTensorShape on the I/O tensors in the legacy factory, so mirror that relaxation
+    // with dynamic_tensor_shape = true (interleaved -> TensorAccessor config unchanged).
+    const TensorParamName A_PARAM{"a"};
+    const TensorParamName B_PARAM{"b"};
+    const TensorParamName C_PARAM{"c"};
+    TensorParameterAdvancedOptions dyn_shape;
+    dyn_shape.dynamic_tensor_shape = true;
+    spec.tensor_parameters.push_back(
+        TensorParameter{.unique_id = A_PARAM, .spec = a.tensor_spec(), .advanced_options = dyn_shape});
+    spec.tensor_parameters.push_back(
+        TensorParameter{.unique_id = B_PARAM, .spec = b.tensor_spec(), .advanced_options = dyn_shape});
+    spec.tensor_parameters.push_back(
+        TensorParameter{.unique_id = C_PARAM, .spec = c.tensor_spec(), .advanced_options = dyn_shape});
+
+    // DFBs (one per legacy CB). c_0 = a (src), c_1 = b (src_b), c_2 = c (dst).
+    const DFBSpecName SRC_DFB{"src"};
+    const DFBSpecName SRC_B_DFB{"src_b"};
+    const DFBSpecName DST_DFB{"dst"};
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = SRC_DFB,
+        .entry_size = a_single_tile_size,
+        .num_entries = 2,
+        .data_format_metadata = a_data_format});
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = SRC_B_DFB,
+        .entry_size = b_single_tile_size,
+        .num_entries = 2,
+        .data_format_metadata = b_data_format});
+    spec.dataflow_buffers.push_back(DataflowBufferSpec{
+        .unique_id = DST_DFB,
+        .entry_size = c_single_tile_size,
+        .num_entries = 2,
+        .data_format_metadata = c_data_format});
+
+    // Kernel names.
+    const KernelSpecName READER_K{"reader"};
+    const KernelSpecName WRITER_K{"writer"};
+    // Per the recipe, preserve work-split multiplicity: one compute KernelSpec per core group.
+    const KernelSpecName COMPUTE_K1{"compute_g1"};
+    const KernelSpecName COMPUTE_K2{"compute_g2"};
+
+    // op_config.as_defines() / make_dataflow_defines() return std::map<string,string>; the
+    // Table range constructor copies them in directly.
+    KernelSpec::CompilerOptions::Defines reader_def_table(reader_defines);
+    KernelSpec::CompilerOptions::Defines writer_def_table(writer_defines);
+    KernelSpec::CompilerOptions::Defines compute_def_table(compute_kernel_defines);
+
+    // Reader KernelSpec.
+    KernelSpec reader_k;
+    reader_k.unique_id = READER_K;
+    reader_k.source = std::filesystem::path(READER_M2);
+    reader_k.compiler_options.defines = reader_def_table;
+    reader_k.compile_time_args = {{"has_sharding", 0u}};
+    reader_k.runtime_arg_schema.runtime_arg_names = {
+        "start_tile_id",
+        "src_num_tiles",
+        "dst_num_tiles",
+        "dst_shard_width",
+        "nD_stride",
+        "d_stride",
+        "n_stride",
+        "c_stride",
+        "D",
+        "N",
+        "C",
+        "Ht",
+        "Wt",
+        "cND",
+        "nD_stride_b",
+        "d_stride_b",
+        "n_stride_b",
+        "c_stride_b",
+        "src_num_tiles_b"};
+    reader_k.dfb_bindings = {
+        DFBBinding{.dfb_spec_name = SRC_DFB, .accessor_name = "src", .endpoint_type = DFBEndpointType::PRODUCER},
+        DFBBinding{.dfb_spec_name = SRC_B_DFB, .accessor_name = "src_b", .endpoint_type = DFBEndpointType::PRODUCER}};
+    reader_k.tensor_bindings = {
+        TensorBinding{.tensor_parameter_name = A_PARAM, .accessor_name = "src"},
+        TensorBinding{.tensor_parameter_name = B_PARAM, .accessor_name = "src_b"}};
+    reader_k.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::READER};
+
+    // Writer KernelSpec.
+    KernelSpec writer_k;
+    writer_k.unique_id = WRITER_K;
+    writer_k.source = std::filesystem::path(WRITER_M2);
+    writer_k.compiler_options.defines = writer_def_table;
+    writer_k.compile_time_args = {{"has_sharding", 0u}};
+    writer_k.runtime_arg_schema.runtime_arg_names = {
+        "start_tile_id", "dst_num_tiles", "dst_shard_width", "D", "N", "C", "Ht", "Wt", "cND"};
+    writer_k.dfb_bindings = {
+        DFBBinding{.dfb_spec_name = DST_DFB, .accessor_name = "dst", .endpoint_type = DFBEndpointType::CONSUMER}};
+    writer_k.tensor_bindings = {TensorBinding{.tensor_parameter_name = C_PARAM, .accessor_name = "dst"}};
+    writer_k.hw_config = DataMovementHardwareConfig{.role = DataMovementRoleHint::WRITER};
+
+    // Compute KernelSpec template (one per core group; only the num_tiles RTA is read by the
+    // no-bcast compute kernel). num_tiles_per_cycle is a named CTA.
+    auto make_compute_k = [&](const KernelSpecName& id) {
+        KernelSpec k;
+        k.unique_id = id;
+        k.source = std::filesystem::path(COMPUTE_M2);
+        k.compiler_options.defines = compute_def_table;
+        k.compile_time_args = {{"num_tiles_per_cycle", num_tiles_per_cycle}};
+        k.runtime_arg_schema.runtime_arg_names = {"num_tiles"};
+        k.dfb_bindings = {
+            DFBBinding{
+                .dfb_spec_name = SRC_DFB, .accessor_name = "pre_lhs", .endpoint_type = DFBEndpointType::CONSUMER},
+            DFBBinding{
+                .dfb_spec_name = SRC_B_DFB, .accessor_name = "pre_rhs", .endpoint_type = DFBEndpointType::CONSUMER},
+            DFBBinding{.dfb_spec_name = DST_DFB, .accessor_name = "out", .endpoint_type = DFBEndpointType::PRODUCER}};
+        ComputeHardwareConfig hw;
+        hw.fp32_dest_acc_en = fp32_dest_acc_en;
+        k.hw_config = hw;
+        return k;
+    };
+
+    spec.kernels.push_back(reader_k);
+    spec.kernels.push_back(writer_k);
+    spec.kernels.push_back(make_compute_k(COMPUTE_K1));
+    const bool has_group_2 = !core_group_2.ranges().empty();
+    if (has_group_2) {
+        spec.kernels.push_back(make_compute_k(COMPUTE_K2));
+    }
+
+    // WorkUnitSpec: reader + writer + compute_g1 over core_group_1; a second WorkUnit for
+    // core_group_2 (reader + writer + compute_g2). Each DFB's producer and consumer share the
+    // same WorkUnitSpec (local-DFB rule): reader (producer of src/src_b) + writer (consumer of
+    // dst) + compute (consumer of src/src_b, producer of dst) all co-located per group.
+    {
+        WorkUnitSpec wu1;
+        wu1.name = "group_1";
+        wu1.kernels = {READER_K, WRITER_K, COMPUTE_K1};
+        wu1.target_nodes = core_group_1;
+        spec.work_units.push_back(wu1);
+    }
+    if (has_group_2) {
+        WorkUnitSpec wu2;
+        wu2.name = "group_2";
+        wu2.kernels = {READER_K, WRITER_K, COMPUTE_K2};
+        wu2.target_nodes = core_group_2;
+        spec.work_units.push_back(wu2);
+    }
+
+    // ----------------------------------------------------------------------------------------
+    // ProgramRunArgs (per-core runtime arguments). Mirrors the legacy factory's inline per-core
+    // RTA emission for the no-bcast tile interleaved b-present path, minus the buffer-address
+    // slots (now carried by the TensorBindings).
+    // ----------------------------------------------------------------------------------------
+    ProgramRunArgs run_args;
+
+    KernelRunArgs reader_run{.kernel = READER_K};
+    KernelRunArgs writer_run{.kernel = WRITER_K};
+    KernelRunArgs compute_run_1{.kernel = COMPUTE_K1};
+    KernelRunArgs compute_run_2{.kernel = COMPUTE_K2};
+
+    const auto out_rank = c.logical_shape().rank();
+    const auto aND = extract_nD_dims(a, out_rank);
+    const auto bND = extract_nD_dims(b, out_rank);
+    const auto cND = extract_nD_dims(c, out_rank);
+    const auto [aD, aN, aC, aHt, aWt] = get_shape_dims(a);
+    const auto [bD, bN, bC, bHt, bWt] = get_shape_dims(b);
+    const auto [cD, cN, cC, cHt, cWt] = get_shape_dims(c);
+
+    for (uint32_t i = 0, start_tile_id = 0; i < num_cores; i++) {
+        const auto& core = cores[i];
+        uint32_t c_num_tiles_core = 0;
+        if (core_group_1.contains(core)) {
+            c_num_tiles_core = num_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            c_num_tiles_core = num_tiles_per_core_group_2;
+        } else {
+            continue;  // unused core: emit no per-core args (Metal 2.0 derives node set from WorkUnitSpec)
+        }
+
+        // Reader RTAs (legacy slots, minus a/b base addresses now handled by ta:: bindings).
+        reader_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = core,
+            .args = {
+                {"start_tile_id", start_tile_id},
+                {"src_num_tiles", 0u},  // a_num_tiles: 0 on the interleaved (unsharded) path
+                {"dst_num_tiles", c_num_tiles_core},
+                {"dst_shard_width", 0u},
+                {"nD_stride", aHt * aWt * aC * aN * aD * (aND > 1)},
+                {"d_stride", aHt * aWt * aC * aN * (aD > 1)},
+                {"n_stride", aHt * aWt * aC * (aN > 1)},
+                {"c_stride", aHt * aWt * (aC > 1)},
+                {"D", cD},
+                {"N", cN},
+                {"C", cC},
+                {"Ht", cHt},
+                {"Wt", cWt},
+                {"cND", cND},
+                {"nD_stride_b", bHt * bWt * bC * bN * bD * (bND > 1)},
+                {"d_stride_b", bHt * bWt * bC * bN * (bD > 1)},
+                {"n_stride_b", bHt * bWt * bC * (bN > 1)},
+                {"c_stride_b", bHt * bWt * (bC > 1)},
+                {"src_num_tiles_b", 0u},  // b_num_tiles: 0 on the interleaved (unsharded) path
+            }});
+
+        // Writer RTAs (legacy slots, minus the c base address now handled by ta:: binding).
+        writer_run.runtime_arg_values.push_back(KernelRunArgs::NodeRuntimeArgs{
+            .node = core,
+            .args = {
+                {"start_tile_id", start_tile_id},
+                {"dst_num_tiles", c_num_tiles_core},
+                {"dst_shard_width", 0u},
+                {"D", cD},
+                {"N", cN},
+                {"C", cC},
+                {"Ht", cHt},
+                {"Wt", cWt},
+                {"cND", cND},
+            }});
+
+        // Compute RTA: the no-bcast compute kernel reads only num_tiles (= c_num_tiles_core on
+        // the tile path). freq/counter/scalar slots of the legacy 4-arg vector are dead for this
+        // kernel and dropped (superfluous named args are a Metal 2.0 validation error).
+        auto& compute_run = core_group_1.contains(core) ? compute_run_1 : compute_run_2;
+        compute_run.runtime_arg_values.push_back(
+            KernelRunArgs::NodeRuntimeArgs{.node = core, .args = {{"num_tiles", c_num_tiles_core}}});
+
+        start_tile_id += c_num_tiles_core;
+    }
+
+    run_args.kernel_run_args.push_back(std::move(reader_run));
+    run_args.kernel_run_args.push_back(std::move(writer_run));
+    run_args.kernel_run_args.push_back(std::move(compute_run_1));
+    if (has_group_2) {
+        run_args.kernel_run_args.push_back(std::move(compute_run_2));
+    }
+
+    // Tensor arguments: reference the SAME MeshTensors the factory received (matched by identity).
+    run_args.tensor_args.insert({A_PARAM, TensorArgument{a.mesh_tensor()}});
+    run_args.tensor_args.insert({B_PARAM, TensorArgument{b.mesh_tensor()}});
+    run_args.tensor_args.insert({C_PARAM, TensorArgument{c.mesh_tensor()}});
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run_args)};
+}
+
+}  // namespace ttnn::operations::binary_ng

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_no_bcast_m2.cpp
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port of kernels/compute/eltwise_binary_no_bcast.cpp.
+// Bound by BinaryNgDeviceOperation::ProgramSpecFactory (no-broadcast x tile x FPU x
+// tensor-b-present x interleaved path). Logic is unchanged from the legacy compute kernel;
+// only the resource-access mechanism is converted to Metal 2.0 named bindings:
+//   - CB ids c_0 / c_1 / c_2 -> dfb::pre_lhs / dfb::pre_rhs / dfb::out
+//   - activation-intermediate CB ids c_3 / c_4 -> dfb::post_lhs / dfb::post_rhs, bound only
+//     when the corresponding activation is present and #ifdef-gated here to match (the legacy
+//     `HAS_ACTIVATIONS(LHS) ? c_3 : c_0` C++ ternary is rewritten as a preprocessor #if so the
+//     conditionally-bound DFB name never enters name lookup when its activation is absent)
+//   - positional get_arg_val / get_compile_time_arg_val -> get_arg(args::...)
+// The dfb:: handles flow into the PREPROCESS / BINARY_OP / pack_tile / cb_* helpers via the
+// DataflowBuffer accessor's implicit conversion to uint32_t (no .id extraction).
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_binary.h"
+#include "experimental/kernel_args.h"
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils.hpp"
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg(args::num_tiles);
+
+    constexpr uint32_t num_tiles_per_cycle = get_arg(args::num_tiles_per_cycle);
+
+    constexpr auto cb_pre_lhs = dfb::pre_lhs;
+    constexpr auto cb_pre_rhs = dfb::pre_rhs;
+    constexpr auto cb_out = dfb::out;
+
+#if HAS_ACTIVATIONS(LHS)
+    constexpr auto cb_post_lhs = dfb::post_lhs;
+#else
+    constexpr auto cb_post_lhs = cb_pre_lhs;
+#endif
+#if HAS_ACTIVATIONS(RHS)
+    constexpr auto cb_post_rhs = dfb::post_rhs;
+#else
+    constexpr auto cb_post_rhs = cb_pre_rhs;
+#endif
+
+    binary_op_init_common(cb_post_lhs, cb_post_rhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+
+    // Inline helper to process n tiles
+    auto process_tiles = [&](uint32_t n) {
+        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, n);
+        cb_wait_front(cb_post_lhs, n);
+
+        PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, n);
+        cb_wait_front(cb_post_rhs, n);
+
+        cb_reserve_back(cb_out, n);
+
+#if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST)
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < n; ++i) {
+            BINARY_OP(cb_post_lhs, cb_post_rhs, i, i, i);
+            PROCESS_POST_ACTIVATIONS(i);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < n; ++i) {
+            pack_tile(i, cb_out);
+        }
+        tile_regs_release();
+
+        cb_push_back(cb_out, n);
+        cb_pop_front(cb_post_lhs, n);
+        cb_pop_front(cb_post_rhs, n);
+    };
+
+    // Process full chunks
+    uint32_t num_full_chunks = num_tiles / num_tiles_per_cycle;
+    for (uint32_t chunk = 0; chunk < num_full_chunks; ++chunk) {
+        process_tiles(num_tiles_per_cycle);
+    }
+
+    // Process remainder
+    uint32_t remainder = num_tiles % num_tiles_per_cycle;
+    if (remainder > 0) {
+        process_tiles(remainder);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_scalar_m2.cpp
@@ -1,0 +1,99 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port of kernels/compute/eltwise_binary_scalar.cpp.
+// Bound by BinaryNgDeviceOperation::ProgramSpecFactory on the
+//   no-broadcast x tile x FPU x scalar-b (no tensor b) x interleaved path.
+// The rhs is a single scalar tile filled once by the writer into dfb::pre_rhs. Logic is unchanged
+// from the legacy compute kernel; only the resource-access mechanism is converted to Metal 2.0
+// named bindings:
+//   - CB ids c_0 / c_1 / c_2 -> dfb::pre_lhs / dfb::pre_rhs / dfb::out
+//   - activation-intermediate CB ids c_3 / c_4 -> dfb::post_lhs / dfb::post_rhs, bound only when
+//     the corresponding activation is present and #ifdef-gated here to match (the legacy
+//     `HAS_ACTIVATIONS(LHS) ? c_3 : c_0` C++ ternary is rewritten as a preprocessor #if so the
+//     conditionally-bound DFB name never enters name lookup when its activation is absent)
+//   - positional get_arg_val / get_compile_time_arg_val -> get_arg(args::...)
+
+#include <cstdint>
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_binary.h"
+
+#include "experimental/kernel_args.h"
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils.hpp"
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg(args::num_tiles);
+
+    constexpr uint32_t num_tiles_per_cycle = get_arg(args::num_tiles_per_cycle);
+    // DPRINT("num_tiles_per_cycle: {}\n", num_tiles_per_cycle);
+    constexpr auto cb_pre_lhs = dfb::pre_lhs;
+    constexpr auto cb_pre_rhs = dfb::pre_rhs;
+    constexpr auto cb_out = dfb::out;
+
+#if HAS_ACTIVATIONS(LHS)
+    constexpr auto cb_post_lhs = dfb::post_lhs;
+#else
+    constexpr auto cb_post_lhs = cb_pre_lhs;
+#endif
+#if HAS_ACTIVATIONS(RHS)
+    constexpr auto cb_post_rhs = dfb::post_rhs;
+#else
+    constexpr auto cb_post_rhs = cb_pre_rhs;
+#endif
+
+    binary_op_init_common(cb_post_lhs, cb_post_rhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+
+    PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, 1);
+    cb_wait_front(cb_post_rhs, 1);
+
+    // Inline lambda to process n tiles with the scalar value
+    auto process_tiles = [&](uint32_t n) {
+        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, n);
+        cb_wait_front(cb_post_lhs, n);
+
+        cb_reserve_back(cb_out, n);
+
+#if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST)
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+        tile_regs_acquire();
+        for (uint32_t i = 0; i < n; ++i) {
+            BINARY_OP(cb_post_lhs, cb_post_rhs, i, 0, i);
+            PROCESS_POST_ACTIVATIONS(i);
+        }
+        tile_regs_commit();
+
+        tile_regs_wait();
+        for (uint32_t i = 0; i < n; ++i) {
+            pack_tile(i, cb_out);
+        }
+        tile_regs_release();
+
+        cb_pop_front(cb_post_lhs, n);
+        cb_push_back(cb_out, n);
+    };
+
+    // Process full chunks
+    uint32_t full_chunks = num_tiles / num_tiles_per_cycle;
+    for (uint32_t chunk = 0; chunk < full_chunks; ++chunk) {
+        process_tiles(num_tiles_per_cycle);
+    }
+
+    // Process remainder
+    uint32_t remainder = num_tiles % num_tiles_per_cycle;
+    if (remainder > 0) {
+        process_tiles(remainder);
+    }
+
+    // Pop the scalar tile from RHS CB
+    cb_pop_front(cb_post_rhs, 1);
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_no_bcast_m2.cpp
@@ -1,0 +1,140 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port of kernels/compute/eltwise_binary_sfpu_no_bcast.cpp.
+// Bound by BinaryNgDeviceOperation::ProgramSpecFactory (no-broadcast x tile x SFPU x
+// tensor-b-present x interleaved path). Logic is unchanged from the legacy SFPU compute kernel;
+// only the resource-access mechanism is converted to Metal 2.0 named bindings:
+//   - CB ids c_0 / c_1 / c_2 -> dfb::pre_lhs / dfb::pre_rhs / dfb::out
+//   - activation-intermediate CB ids c_3 / c_4 -> dfb::post_lhs / dfb::post_rhs, bound only
+//     when the corresponding activation is present and #ifdef-gated here to match (the legacy
+//     `HAS_ACTIVATIONS(LHS) ? c_3 : c_0` C++ ternary is rewritten as a preprocessor #if so the
+//     conditionally-bound DFB name never enters name lookup when its activation is absent)
+//   - positional get_arg_val / get_compile_time_arg_val -> get_arg(args::...)
+// The dfb:: handles flow into the PREPROCESS / BINARY_SFPU_OP / copy_tile / pack_tile / cb_*
+// helpers via the DataflowBuffer accessor's implicit conversion to uint32_t (no .id extraction).
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/binary_bitwise_sfpu.h"
+#include "api/compute/binary_shift.h"
+#include "api/compute/add_int_sfpu.h"
+#include "api/compute/sub_int_sfpu.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/div_int32_floor.h"
+#include "api/compute/div_int32_sfpu.h"
+#include "api/compute/binary_remainder.h"
+#include "api/compute/binary_fmod.h"
+#include "api/compute/quantization.h"
+#include "api/compute/binary_max_min.h"
+#include "api/compute/gcd.h"
+#include "api/compute/lcm.h"
+#include "api/compute/xlogy.h"
+#include "api/compute/atan2.h"
+#include "api/compute/binary_comp.h"
+#include "api/compute/isclose.h"
+
+#include "experimental/kernel_args.h"
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils_sfpu.hpp"
+FORCE_INLINE void process_sfpu_tiles(
+    uint32_t n,
+    uint32_t cb_pre_lhs,
+    uint32_t cb_post_lhs,
+    uint32_t cb_pre_rhs,
+    uint32_t cb_post_rhs,
+    uint32_t cb_out ISCLOSE_RT_ARG_PARAMS) {
+    PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, n);
+    cb_wait_front(cb_post_lhs, n);
+
+    PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, n);
+    cb_wait_front(cb_post_rhs, n);
+
+    cb_reserve_back(cb_out, n);
+
+#if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT;
+#endif
+
+    tile_regs_acquire();
+    copy_tile_to_dst_init_short_with_dt(cb_post_rhs, cb_post_lhs);
+    for (uint32_t i = 0; i < n; ++i) {
+        copy_tile(cb_post_lhs, i, i * 2);
+    }
+    copy_tile_to_dst_init_short_with_dt(cb_post_lhs, cb_post_rhs);
+    for (uint32_t i = 0; i < n; ++i) {
+        copy_tile(cb_post_rhs, i, i * 2 + 1);
+#if HAS_ACTIVATIONS(POST)
+        BINARY_SFPU_INIT;
+#endif
+#if ISCLOSE_OP
+        BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
+#else
+        BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
+#endif
+        PROCESS_POST_ACTIVATIONS(i * 2);
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    for (uint32_t i = 0; i < n; ++i) {
+        pack_tile(i * 2, cb_out);
+    }
+    tile_regs_release();
+
+    cb_push_back(cb_out, n);
+    cb_pop_front(cb_post_lhs, n);
+    cb_pop_front(cb_post_rhs, n);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg(args::num_tiles);
+#ifdef ISCLOSE_OP
+    const uint32_t rtol_bits = get_arg_val<uint32_t>(ISCLOSE_RTOL_RT_ARG_IDX);
+    const uint32_t atol_bits = get_arg_val<uint32_t>(ISCLOSE_ATOL_RT_ARG_IDX);
+#endif
+
+    constexpr uint32_t num_tiles_per_cycle = get_arg(args::num_tiles_per_cycle);
+
+    constexpr auto cb_pre_lhs = dfb::pre_lhs;
+    constexpr auto cb_pre_rhs = dfb::pre_rhs;
+    constexpr auto cb_out = dfb::out;
+
+#if HAS_ACTIVATIONS(LHS)
+    constexpr auto cb_post_lhs = dfb::post_lhs;
+#else
+    constexpr auto cb_post_lhs = cb_pre_lhs;
+#endif
+#if HAS_ACTIVATIONS(RHS)
+    constexpr auto cb_post_rhs = dfb::post_rhs;
+#else
+    constexpr auto cb_post_rhs = cb_pre_rhs;
+#endif
+
+    unary_op_init_common(cb_post_lhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT
+#endif
+
+    // Process full chunks
+    uint32_t num_full_chunks = num_tiles / num_tiles_per_cycle;
+    for (uint32_t chunk = 0; chunk < num_full_chunks; ++chunk) {
+        process_sfpu_tiles(
+            num_tiles_per_cycle, cb_pre_lhs, cb_post_lhs, cb_pre_rhs, cb_post_rhs, cb_out ISCLOSE_RT_ARG_FWD);
+    }
+
+    // Process remainder
+    uint32_t remainder = num_tiles % num_tiles_per_cycle;
+    if (remainder > 0) {
+        process_sfpu_tiles(remainder, cb_pre_lhs, cb_post_lhs, cb_pre_rhs, cb_post_rhs, cb_out ISCLOSE_RT_ARG_FWD);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_binary_sfpu_scalar_m2.cpp
@@ -1,0 +1,137 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port of kernels/compute/eltwise_binary_sfpu_scalar.cpp.
+// Bound by BinaryNgDeviceOperation::ProgramSpecFactory on the
+//   no-broadcast x tile x SFPU x scalar-b (no tensor b) x interleaved path.
+// The rhs is a single scalar tile filled once by the writer into dfb::pre_rhs. Logic is unchanged
+// from the legacy compute kernel; only the resource-access mechanism is converted to Metal 2.0
+// named bindings:
+//   - CB ids c_0 / c_1 / c_2 -> dfb::pre_lhs / dfb::pre_rhs / dfb::out
+//   - activation-intermediate CB ids c_3 / c_4 -> dfb::post_lhs / dfb::post_rhs, bound only when
+//     the corresponding activation is present and #ifdef-gated here to match (the legacy
+//     `HAS_ACTIVATIONS(LHS) ? c_3 : c_0` C++ ternary is rewritten as a preprocessor #if so the
+//     conditionally-bound DFB name never enters name lookup when its activation is absent)
+//   - positional get_arg_val / get_compile_time_arg_val -> get_arg(args::...)
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+
+#include "api/compute/eltwise_binary_sfpu.h"
+#include "api/compute/binary_bitwise_sfpu.h"
+#include "api/compute/binary_shift.h"
+#include "api/compute/add_int_sfpu.h"
+#include "api/compute/sub_int_sfpu.h"
+#include "api/compute/mul_int_sfpu.h"
+#include "api/compute/div_int32_sfpu.h"
+#include "api/compute/div_int32_floor.h"
+#include "api/compute/quantization.h"
+#include "api/compute/xlogy.h"
+#include "api/compute/atan2.h"
+#include "api/compute/binary_comp.h"
+#include "api/compute/isclose.h"
+
+#include "experimental/kernel_args.h"
+#include "eltwise_utils_common.hpp"
+#include "eltwise_utils_sfpu.hpp"
+
+// Process n LHS tiles against a scalar tile at index 0 in cb_post_rhs
+FORCE_INLINE void process_sfpu_scalar_tiles(
+    uint32_t n,
+    uint32_t cb_pre_lhs,
+    uint32_t cb_post_lhs,
+    uint32_t cb_post_rhs,
+    uint32_t cb_out ISCLOSE_RT_ARG_PARAMS) {
+    PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, n);
+    cb_wait_front(cb_post_lhs, n);
+
+    cb_reserve_back(cb_out, n);
+
+#if (HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT;
+#endif
+
+    tile_regs_acquire();
+    copy_tile_to_dst_init_short_with_dt(cb_post_rhs, cb_post_lhs);
+    for (uint32_t i = 0; i < n; ++i) {
+        copy_tile(cb_post_lhs, i, i * 2);
+    }
+    copy_tile_to_dst_init_short_with_dt(cb_post_lhs, cb_post_rhs);
+    for (uint32_t i = 0; i < n; ++i) {
+        copy_tile(cb_post_rhs, 0, i * 2 + 1);  // Always use scalar at index 0
+#if HAS_ACTIVATIONS(POST)
+        BINARY_SFPU_INIT;
+#endif
+#if ISCLOSE_OP
+        BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2, rtol_bits, atol_bits);
+#else
+        BINARY_SFPU_OP(i * 2, i * 2 + 1, i * 2);
+#endif
+        PROCESS_POST_ACTIVATIONS(i * 2);
+    }
+    tile_regs_commit();
+
+    tile_regs_wait();
+    for (uint32_t i = 0; i < n; ++i) {
+        pack_tile(i * 2, cb_out);
+    }
+    tile_regs_release();
+
+    cb_pop_front(cb_post_lhs, n);
+    cb_push_back(cb_out, n);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg(args::num_tiles);
+#ifdef ISCLOSE_OP
+    const uint32_t rtol_bits = get_arg(args::rtol_bits);
+    const uint32_t atol_bits = get_arg(args::atol_bits);
+#endif
+
+    constexpr uint32_t num_tiles_per_cycle = get_arg(args::num_tiles_per_cycle);
+
+    constexpr auto cb_pre_lhs = dfb::pre_lhs;
+    constexpr auto cb_pre_rhs = dfb::pre_rhs;
+    constexpr auto cb_out = dfb::out;
+
+#if HAS_ACTIVATIONS(LHS)
+    constexpr auto cb_post_lhs = dfb::post_lhs;
+#else
+    constexpr auto cb_post_lhs = cb_pre_lhs;
+#endif
+#if HAS_ACTIVATIONS(RHS)
+    constexpr auto cb_post_rhs = dfb::post_rhs;
+#else
+    constexpr auto cb_post_rhs = cb_pre_rhs;
+#endif
+
+    unary_op_init_common(cb_post_lhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS)) and not(HAS_ACTIVATIONS(POST))
+    BINARY_SFPU_INIT
+#endif
+
+    PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, 1);
+    cb_wait_front(cb_post_rhs, 1);
+
+    // Process full chunks
+    uint32_t full_chunks = num_tiles / num_tiles_per_cycle;
+    for (uint32_t chunk = 0; chunk < full_chunks; ++chunk) {
+        process_sfpu_scalar_tiles(num_tiles_per_cycle, cb_pre_lhs, cb_post_lhs, cb_post_rhs, cb_out ISCLOSE_RT_ARG_FWD);
+    }
+
+    // Process remainder
+    uint32_t remainder = num_tiles % num_tiles_per_cycle;
+    if (remainder > 0) {
+        process_sfpu_scalar_tiles(remainder, cb_pre_lhs, cb_post_lhs, cb_post_rhs, cb_out ISCLOSE_RT_ARG_FWD);
+    }
+
+    // Pop the scalar tile from RHS CB
+    cb_pop_front(cb_post_rhs, 1);
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/reader_interleaved_no_bcast_m2.cpp
@@ -1,0 +1,107 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port of kernels/dataflow/reader_interleaved_no_bcast.cpp (the SINGLE-tensor reader
+// used by the scalar-b path: a present, b absent -> only src is read; the scalar tile is filled
+// by the writer). Bound by BinaryNgDeviceOperation::ProgramSpecFactory on the
+//   no-broadcast x tile x FPU x scalar-b (no tensor b) x interleaved path.
+// Logic is unchanged from the legacy reader; only the resource-access mechanism is converted to
+// Metal 2.0 named bindings:
+//   - CB id    -> dfb::src
+//   - src address + TensorAccessorArgs -> ta::src (address auto-injected)
+//   - positional get_arg_val / get_compile_time_arg_val -> get_arg(args::...)
+// The #if SRC_SHARDED path is preserved verbatim; the ProgramSpecFactory only selects this kernel
+// on the interleaved (unsharded) path, so SRC_SHARDED is compiled out, but it is kept for
+// faithfulness to the source.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t start_tile_id = get_arg(args::start_tile_id);
+    const uint32_t src_num_tiles = get_arg(args::src_num_tiles);
+    const uint32_t dst_num_tiles = get_arg(args::dst_num_tiles);
+    const uint32_t dst_shard_width = get_arg(args::dst_shard_width);
+    const uint32_t nD_stride = get_arg(args::nD_stride);
+    const uint32_t d_stride = get_arg(args::d_stride);
+    const uint32_t n_stride = get_arg(args::n_stride);
+    const uint32_t c_stride = get_arg(args::c_stride);
+    const uint32_t D = get_arg(args::D);
+    const uint32_t N = get_arg(args::N);
+    const uint32_t C = get_arg(args::C);
+    const uint32_t Ht = get_arg(args::Ht);
+    const uint32_t Wt = get_arg(args::Wt);
+    const uint32_t cND = get_arg(args::cND);  // collapsed dims > 5
+
+    Noc noc;
+    CircularBuffer cb_src(dfb::src);
+
+#if SRC_SHARDED
+    cb_src.reserve_back(src_num_tiles);
+    cb_src.push_back(src_num_tiles);
+#else
+    constexpr uint32_t onetile = 1;
+    constexpr bool has_sharding = get_arg(args::has_sharding) == 1;
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const auto src = TensorAccessor(ta::src);
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset =
+        start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+                            cb_src.reserve_back(onetile);
+                            noc.async_read(
+                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                            noc.async_read_barrier();
+                            cb_src.push_back(onetile);
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+                        tile_offset += Wt;
+                    }
+                    tile_offset += next_c_shift;
+                }
+                tile_offset += next_n_shift;
+            }
+            tile_offset += next_d_shift;
+        }
+        tile_offset += next_nd_shift;
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/writer_interleaved_scalar_m2.cpp
@@ -1,0 +1,108 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port of kernels/dataflow/writer_interleaved_scalar.cpp.
+// Bound by BinaryNgDeviceOperation::ProgramSpecFactory on the
+//   no-broadcast x tile x FPU x scalar-b (no tensor b) x interleaved path.
+// This writer both fills the scalar tile into the rhs CB (once) and writes the output tiles.
+// Logic is unchanged from the legacy writer; only the resource-access mechanism is converted to
+// Metal 2.0 named bindings:
+//   - CB ids c_1 / c_2 -> dfb::src_b (scalar) / dfb::dst (output)
+//   - dst address + TensorAccessorArgs -> ta::dst (address auto-injected)
+//   - positional get_arg_val / get_compile_time_arg_val -> get_arg(args::...)
+// The #if DST_SHARDED path is preserved verbatim; the ProgramSpecFactory only selects this kernel
+// on the interleaved (unsharded) path, so DST_SHARDED is compiled out, but it is kept for
+// faithfulness to the source. The packed scalar arrives as the named runtime arg `packed_scalar`
+// (a value, not a pointer), matching the legacy positional slot 0.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+
+void kernel_main() {
+    const uint32_t packed_scalar = get_arg(args::packed_scalar);
+    const uint32_t start_tile_id = get_arg(args::start_tile_id);
+    const uint32_t dst_num_tiles = get_arg(args::dst_num_tiles);
+    const uint32_t dst_shard_width = get_arg(args::dst_shard_width);
+    const uint32_t D = get_arg(args::D);
+    const uint32_t N = get_arg(args::N);
+    const uint32_t C = get_arg(args::C);
+    const uint32_t Ht = get_arg(args::Ht);
+    const uint32_t Wt = get_arg(args::Wt);
+    const uint32_t cND = get_arg(args::cND);  // collapsed dims > 5
+    const uint32_t HtWt = Ht * Wt;
+
+    constexpr uint32_t onetile = 1;
+
+    Noc noc;
+    CircularBuffer cb_src(dfb::src_b);
+    CircularBuffer cb_dst(dfb::dst);
+
+    // we only need to fill a tile with the scalar value once
+    cb_src.reserve_back(onetile);
+#ifdef FILL_WITH_VALUE_FLOAT
+    const auto float_ptr = reinterpret_cast<const float*>(&packed_scalar);
+    FILL_WITH_VALUE_FLOAT(cb_src.get_write_ptr(), *float_ptr);
+#endif
+#ifdef FILL_WITH_VALUE
+    FILL_WITH_VALUE(cb_src.get_write_ptr(), packed_scalar);
+#endif
+    cb_src.push_back(onetile);
+
+#if !DST_SHARDED
+    const uint32_t dst_tile_bytes = cb_dst.get_tile_size();
+    const auto dst = TensorAccessor(ta::dst);
+    constexpr bool has_sharding = get_arg(args::has_sharding) == 1;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    uint32_t num_tiles_written = 0;
+    uint32_t dst_tile_offset = start_tile_id;
+
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_written < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_written < dst_num_tiles;
+                             ++tw, ++num_tiles_written) {
+                            // write a tile to dst
+                            cb_dst.wait_front(onetile);
+                            noc.async_write(
+                                cb_dst, dst, dst_tile_bytes, {}, {.page_id = dst_tile_offset + num_tiles_written});
+                            noc.async_write_barrier();
+                            cb_dst.pop_front(onetile);
+                        }
+                        if constexpr (has_sharding) {
+                            // adjust the output tile offset since we had to skip parts of the row
+                            dst_tile_offset += (Wt - dst_shard_width);
+                        } else {
+                            // otherwise, next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+                    }
+                }
+            }
+        }
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_col_bcast_m2.cpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/bcast.h"
+
+#include "experimental/kernel_args.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+
+ALWI void process_tile(
+    uint32_t cb_bcast,
+    uint32_t cb_llk_post,
+    uint32_t cb_pre_lhs,
+    uint32_t cb_post_lhs,
+    uint32_t cb_pre_rhs,
+    uint32_t cb_post_rhs,
+    uint32_t cb_out,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle) {
+    using namespace ckernel;
+
+#if BCAST_INPUT
+#define CB_PRE_BCAST cb_pre_rhs
+#define CB_POST_BCAST cb_post_rhs
+#define CB_PRE_OTHER cb_pre_lhs
+#define CB_POST_OTHER cb_post_lhs
+#else
+#define CB_PRE_BCAST cb_pre_lhs
+#define CB_POST_BCAST cb_post_lhs
+#define CB_PRE_OTHER cb_pre_rhs
+#define CB_POST_OTHER cb_post_rhs
+#endif
+    cb_wait_front(cb_bcast, num_tiles_per_cycle);
+    pack_reconfig_data_format(cb_out, cb_llk_post);
+    unary_bcast_init<BroadcastType::COL>(cb_bcast, cb_llk_post);
+    cb_reserve_back(cb_llk_post, num_tiles_per_cycle);
+    tile_regs_acquire();
+    unary_bcast<BroadcastType::COL>(cb_bcast, 0, 0);
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile(0, cb_llk_post);
+    cb_push_back(cb_llk_post, num_tiles_per_cycle);
+    tile_regs_release();
+
+    pack_reconfig_data_format(cb_llk_post, cb_out);
+#ifdef ARCH_BLACKHOLE
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+#endif
+
+    PREPROCESS(BCAST_OP, CB_PRE_BCAST, CB_POST_BCAST, cb_out, num_tiles_per_cycle);
+    cb_wait_front(CB_POST_BCAST, num_tiles_per_cycle);
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        PREPROCESS(OTHER_OP, CB_PRE_OTHER, CB_POST_OTHER, cb_out, num_tiles_per_cycle);
+        cb_wait_front(CB_POST_OTHER, num_tiles_per_cycle);
+
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
+
+#if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST)
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+        tile_regs_acquire();
+        BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
+        PROCESS_POST_ACTIVATIONS(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        cb_push_back(cb_out, num_tiles_per_cycle);
+        cb_pop_front(CB_POST_OTHER, num_tiles_per_cycle);
+    }
+    cb_pop_front(cb_bcast, num_tiles_per_cycle);
+    cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);
+}
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg(args::num_tiles);
+    uint32_t tile_freq = get_arg(args::tile_freq);
+    uint32_t tile_start = get_arg(args::tile_start);
+
+    constexpr uint32_t num_tiles_per_cycle = get_arg(args::num_tiles_per_cycle);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_out = dfb::out;
+
+#if SRC_BCAST
+    constexpr auto cb_bcast = dfb::pre_lhs;        // c_0
+    constexpr auto cb_llk_post = dfb::llk_post_a;  // c_5
+    constexpr auto cb_pre_lhs = cb_llk_post;
+    constexpr auto cb_pre_rhs = dfb::pre_rhs;  // c_1
+#if HAS_ACTIVATIONS(LHS)
+    constexpr auto cb_post_lhs = dfb::post_lhs;  // c_3
+#else
+    constexpr auto cb_post_lhs = cb_llk_post;
+#endif
+#if HAS_ACTIVATIONS(RHS)
+    constexpr auto cb_post_rhs = dfb::post_rhs;  // c_4
+#else
+    constexpr auto cb_post_rhs = dfb::pre_rhs;  // c_1
+#endif
+#endif
+#if SRC_BCAST_B
+    constexpr auto cb_bcast = dfb::pre_rhs;        // c_1
+    constexpr auto cb_llk_post = dfb::llk_post_b;  // c_6
+    constexpr auto cb_pre_lhs = dfb::pre_lhs;      // c_0
+    constexpr auto cb_pre_rhs = cb_llk_post;
+#if HAS_ACTIVATIONS(LHS)
+    constexpr auto cb_post_lhs = dfb::post_lhs;  // c_3
+#else
+    constexpr auto cb_post_lhs = dfb::pre_lhs;  // c_0
+#endif
+#if HAS_ACTIVATIONS(RHS)
+    constexpr auto cb_post_rhs = dfb::post_rhs;  // c_4
+#else
+    constexpr auto cb_post_rhs = cb_llk_post;
+#endif
+#endif
+
+    binary_op_init_common(cb_post_lhs, cb_post_rhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_bcast,
+            cb_llk_post,
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            tile_freq,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_bcast,
+            cb_llk_post,
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_row_bcast_m2.cpp
@@ -1,0 +1,109 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/bcast.h"
+
+#include "experimental/kernel_args.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+#include "api/dataflow/circular_buffer.h"
+
+void kernel_main() {
+    uint32_t num_tiles = get_arg(args::num_tiles);
+
+    constexpr uint32_t num_tiles_per_cycle = get_arg(args::num_tiles_per_cycle);
+    constexpr auto cb_out = dfb::out;
+    CircularBuffer exp_cb_out(cb_out);
+
+#if SRC_BCAST
+    constexpr auto cb_bcast = dfb::pre_lhs;        // c_0
+    constexpr auto cb_llk_post = dfb::llk_post_a;  // c_5
+    constexpr auto cb_pre_lhs = cb_llk_post;
+    constexpr auto cb_pre_rhs = dfb::pre_rhs;  // c_1
+#if HAS_ACTIVATIONS(LHS)
+    constexpr auto cb_post_lhs = dfb::post_lhs;  // c_3
+#else
+    constexpr auto cb_post_lhs = cb_llk_post;
+#endif
+#if HAS_ACTIVATIONS(RHS)
+    constexpr auto cb_post_rhs = dfb::post_rhs;  // c_4
+#else
+    constexpr auto cb_post_rhs = dfb::pre_rhs;  // c_1
+#endif
+#endif
+#if SRC_BCAST_B
+    constexpr auto cb_bcast = dfb::pre_rhs;        // c_1
+    constexpr auto cb_llk_post = dfb::llk_post_b;  // c_6
+    constexpr auto cb_pre_lhs = dfb::pre_lhs;      // c_0
+    constexpr auto cb_pre_rhs = cb_llk_post;
+#if HAS_ACTIVATIONS(LHS)
+    constexpr auto cb_post_lhs = dfb::post_lhs;  // c_3
+#else
+    constexpr auto cb_post_lhs = dfb::pre_lhs;  // c_0
+#endif
+#if HAS_ACTIVATIONS(RHS)
+    constexpr auto cb_post_rhs = dfb::post_rhs;  // c_4
+#else
+    constexpr auto cb_post_rhs = cb_llk_post;
+#endif
+#endif
+
+    CircularBuffer exp_cb_bcast(cb_bcast);
+    CircularBuffer exp_cb_llk_post(cb_llk_post);
+    CircularBuffer exp_cb_post_lhs(cb_post_lhs);
+    CircularBuffer exp_cb_post_rhs(cb_post_rhs);
+
+    binary_op_init_common(cb_post_lhs, cb_post_rhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+    for (uint32_t tile_id = 0; tile_id < num_tiles; ++tile_id) {
+        exp_cb_bcast.wait_front(num_tiles_per_cycle);
+        exp_cb_llk_post.reserve_back(num_tiles_per_cycle);
+        pack_reconfig_data_format(cb_out, cb_llk_post);
+        unary_bcast_init<BroadcastType::ROW>(cb_bcast, cb_llk_post);
+
+        tile_regs_acquire();
+        unary_bcast<BroadcastType::ROW>(cb_bcast, 0, 0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_llk_post);
+        exp_cb_llk_post.push_back(num_tiles_per_cycle);
+        tile_regs_release();
+        exp_cb_bcast.pop_front(num_tiles_per_cycle);
+        // unary_bcast_uninit<BroadcastType::ROW>(cb_bcast);
+        pack_reconfig_data_format(cb_llk_post, cb_out);
+#ifdef ARCH_BLACKHOLE
+        PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+#endif
+
+        PREPROCESS(LHS, cb_pre_lhs, cb_post_lhs, cb_out, num_tiles_per_cycle);
+        exp_cb_post_lhs.wait_front(num_tiles_per_cycle);
+
+        PREPROCESS(RHS, cb_pre_rhs, cb_post_rhs, cb_out, num_tiles_per_cycle);
+        exp_cb_post_rhs.wait_front(num_tiles_per_cycle);
+
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+        exp_cb_out.reserve_back(num_tiles_per_cycle);
+
+        tile_regs_acquire();
+        BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
+        PROCESS_POST_ACTIVATIONS(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        exp_cb_out.push_back(num_tiles_per_cycle);
+        exp_cb_post_lhs.pop_front(num_tiles_per_cycle);
+        exp_cb_post_rhs.pop_front(num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/compute/eltwise_binary_scalar_bcast_m2.cpp
@@ -1,0 +1,172 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include "api/compute/eltwise_unary/sfpu_split_includes.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/bcast.h"
+
+#include "experimental/kernel_args.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils_common.hpp"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/compute/eltwise_utils.hpp"
+
+ALWI void process_tile(
+    uint32_t cb_bcast,
+    uint32_t cb_llk_post,
+    uint32_t cb_pre_lhs,
+    uint32_t cb_post_lhs,
+    uint32_t cb_pre_rhs,
+    uint32_t cb_post_rhs,
+    uint32_t cb_out,
+    uint32_t freq,
+    uint32_t tile_start,
+    uint32_t num_tiles_per_cycle) {
+    using namespace ckernel;
+
+#if BCAST_INPUT
+#define CB_PRE_BCAST cb_pre_rhs
+#define CB_POST_BCAST cb_post_rhs
+#define CB_PRE_OTHER cb_pre_lhs
+#define CB_POST_OTHER cb_post_lhs
+#else
+#define CB_PRE_BCAST cb_pre_lhs
+#define CB_POST_BCAST cb_post_lhs
+#define CB_PRE_OTHER cb_pre_rhs
+#define CB_POST_OTHER cb_post_rhs
+#endif
+
+    cb_wait_front(cb_bcast, num_tiles_per_cycle);
+    pack_reconfig_data_format(cb_out, cb_llk_post);
+    unary_bcast_init<BroadcastType::SCALAR>(cb_bcast, cb_llk_post);
+    cb_reserve_back(cb_llk_post, num_tiles_per_cycle);
+    tile_regs_acquire();
+    unary_bcast<BroadcastType::SCALAR>(cb_bcast, 0, 0);
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile(0, cb_llk_post);
+    cb_push_back(cb_llk_post, num_tiles_per_cycle);
+    tile_regs_release();
+
+    pack_reconfig_data_format(cb_llk_post, cb_out);
+#ifdef ARCH_BLACKHOLE
+    PACK((llk_pack_hw_configure<DST_ACCUM_MODE>(cb_out)));
+#endif
+
+    PREPROCESS(BCAST_OP, CB_PRE_BCAST, CB_POST_BCAST, cb_out, num_tiles_per_cycle);
+    cb_wait_front(CB_POST_BCAST, num_tiles_per_cycle);
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+
+    for (uint32_t j = tile_start; j < freq; ++j) {
+        PREPROCESS(OTHER_OP, CB_PRE_OTHER, CB_POST_OTHER, cb_out, num_tiles_per_cycle);
+        cb_wait_front(CB_POST_OTHER, num_tiles_per_cycle);
+
+        cb_reserve_back(cb_out, num_tiles_per_cycle);
+
+#if HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST)
+        binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+        tile_regs_acquire();
+        BINARY_OP(cb_post_lhs, cb_post_rhs, 0, 0, 0);
+        PROCESS_POST_ACTIVATIONS(0);
+        tile_regs_commit();
+
+        tile_regs_wait();
+        pack_tile(0, cb_out);
+        tile_regs_release();
+
+        cb_push_back(cb_out, num_tiles_per_cycle);
+        cb_pop_front(CB_POST_OTHER, num_tiles_per_cycle);
+    }
+    cb_pop_front(cb_bcast, num_tiles_per_cycle);
+    cb_pop_front(CB_POST_BCAST, num_tiles_per_cycle);
+}
+void kernel_main() {
+    uint32_t num_tiles = get_arg(args::num_tiles);
+    uint32_t tile_freq = get_arg(args::tile_freq);
+    uint32_t tile_start = get_arg(args::tile_start);
+
+    constexpr uint32_t num_tiles_per_cycle = get_arg(args::num_tiles_per_cycle);
+
+    if (num_tiles == 0) {
+        return;
+    }
+
+    constexpr auto cb_out = dfb::out;
+
+#if SRC_BCAST
+    constexpr auto cb_bcast = dfb::pre_lhs;        // c_0
+    constexpr auto cb_llk_post = dfb::llk_post_a;  // c_5
+    constexpr auto cb_pre_lhs = cb_llk_post;
+    constexpr auto cb_pre_rhs = dfb::pre_rhs;  // c_1
+#if HAS_ACTIVATIONS(LHS)
+    constexpr auto cb_post_lhs = dfb::post_lhs;  // c_3
+#else
+    constexpr auto cb_post_lhs = cb_llk_post;
+#endif
+#if HAS_ACTIVATIONS(RHS)
+    constexpr auto cb_post_rhs = dfb::post_rhs;  // c_4
+#else
+    constexpr auto cb_post_rhs = dfb::pre_rhs;  // c_1
+#endif
+#endif
+#if SRC_BCAST_B
+    constexpr auto cb_bcast = dfb::pre_rhs;        // c_1
+    constexpr auto cb_llk_post = dfb::llk_post_b;  // c_6
+    constexpr auto cb_pre_lhs = dfb::pre_lhs;      // c_0
+    constexpr auto cb_pre_rhs = cb_llk_post;
+#if HAS_ACTIVATIONS(LHS)
+    constexpr auto cb_post_lhs = dfb::post_lhs;  // c_3
+#else
+    constexpr auto cb_post_lhs = dfb::pre_lhs;  // c_0
+#endif
+#if HAS_ACTIVATIONS(RHS)
+    constexpr auto cb_post_rhs = dfb::post_rhs;  // c_4
+#else
+    constexpr auto cb_post_rhs = cb_llk_post;
+#endif
+#endif
+
+    binary_op_init_common(cb_post_lhs, cb_post_rhs, cb_out);
+#ifdef PACK_RELU
+    PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+
+#if not(HAS_ACTIVATIONS(LHS) or HAS_ACTIVATIONS(RHS) or HAS_ACTIVATIONS(POST))
+    binary_tiles_init<true, BINARY_OP_TYPE>(cb_post_lhs, cb_post_rhs);
+#endif
+
+    uint32_t complete_iterations = (num_tiles + tile_start) / tile_freq;
+    uint32_t remaining_iterations = (num_tiles + tile_start) % tile_freq;
+
+    for (uint32_t i = 0; i < complete_iterations; ++i, tile_start = 0) {
+        process_tile(
+            cb_bcast,
+            cb_llk_post,
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            tile_freq,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+
+    if (remaining_iterations > 0) {
+        process_tile(
+            cb_bcast,
+            cb_llk_post,
+            cb_pre_lhs,
+            cb_post_lhs,
+            cb_pre_rhs,
+            cb_post_rhs,
+            cb_out,
+            remaining_iterations,
+            tile_start,
+            num_tiles_per_cycle);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_col_bcast_m2.cpp
@@ -1,0 +1,196 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t start_tile_id = get_arg(args::start_tile_id);
+    const uint32_t src_num_tiles = get_arg(args::src_num_tiles);
+    const uint32_t dst_num_tiles = get_arg(args::dst_num_tiles);
+    const uint32_t dst_shard_width = get_arg(args::dst_shard_width);
+    const uint32_t nD_stride = get_arg(args::nD_stride);
+    const uint32_t d_stride = get_arg(args::d_stride);
+    const uint32_t n_stride = get_arg(args::n_stride);
+    const uint32_t c_stride = get_arg(args::c_stride);
+    const uint32_t D = get_arg(args::D);
+    const uint32_t N = get_arg(args::N);
+    const uint32_t C = get_arg(args::C);
+    const uint32_t Ht = get_arg(args::Ht);
+    const uint32_t Wt = get_arg(args::Wt);
+    const uint32_t cND = get_arg(args::cND);  // collapsed dims > 5
+    const uint32_t nD_stride_b = get_arg(args::nD_stride_b);
+    const uint32_t d_stride_b = get_arg(args::d_stride_b);
+    const uint32_t n_stride_b = get_arg(args::n_stride_b);
+    const uint32_t c_stride_b = get_arg(args::c_stride_b);
+    const uint32_t src_num_tiles_b = get_arg(args::src_num_tiles_b);
+
+    Noc noc;
+    CircularBuffer cb_src(dfb::src);
+    CircularBuffer cb_src_b(dfb::src_b);
+
+#if SRC_SHARDED
+#if !SRC_BCAST
+    cb_src.reserve_back(src_num_tiles);
+    cb_src.push_back(src_num_tiles);
+#endif
+#else
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const auto src = TensorAccessor(ta::src);
+#endif
+#if SRC_SHARDED_B
+#if !SRC_BCAST_B
+    cb_src_b.reserve_back(src_num_tiles_b);
+    cb_src_b.push_back(src_num_tiles_b);
+#endif
+#else
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
+    const auto src_b = TensorAccessor(ta::src_b);
+#endif
+    constexpr uint32_t onetile = 1;
+    constexpr bool has_sharding = get_arg(args::has_sharding) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+#if !SRC_BCAST
+    tile_offset += start_th * Wt;
+#endif
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b;
+#if !SRC_BCAST_B
+    tile_offset_b += start_th * Wt;
+#endif
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+#if SRC_BCAST
+                        cb_src.reserve_back(onetile);
+#if !SRC_SHARDED
+                        noc.async_read(src, cb_src, src_tile_bytes, {.page_id = tile_offset + th}, {.offset_bytes = 0});
+                        noc.async_read_barrier();
+#endif
+#if !BCAST_LLK
+                        FILL_TILE_WITH_FIRST_COLUMN(cb_src.get_write_ptr());
+#endif
+                        cb_src.push_back(onetile);
+#endif
+#if SRC_BCAST_B
+                        cb_src_b.reserve_back(onetile);
+#if !SRC_SHARDED_B
+                        noc.async_read(
+                            src_b, cb_src_b, src_tile_bytes_b, {.page_id = tile_offset_b + th}, {.offset_bytes = 0});
+                        noc.async_read_barrier();
+#endif
+#if !BCAST_LLK
+                        FILL_TILE_WITH_FIRST_COLUMN_B(cb_src_b.get_write_ptr());
+#endif
+                        cb_src_b.push_back(onetile);
+#endif
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if !SRC_BCAST && !SRC_SHARDED
+                            cb_src.reserve_back(onetile);
+                            noc.async_read(
+                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                            noc.async_read_barrier();
+                            cb_src.push_back(onetile);
+#endif
+#if !SRC_BCAST_B && !SRC_SHARDED_B
+                            cb_src_b.reserve_back(onetile);
+                            noc.async_read(
+                                src_b,
+                                cb_src_b,
+                                src_tile_bytes_b,
+                                {.page_id = tile_offset_b + tw},
+                                {.offset_bytes = 0});
+                            noc.async_read_barrier();
+                            cb_src_b.push_back(onetile);
+#endif
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+#if !SRC_BCAST && !SRC_SHARDED
+                        tile_offset += Wt;
+#endif
+#if !SRC_BCAST_B && !SRC_SHARDED_B
+                        tile_offset_b += Wt;
+#endif
+                    }
+#if !SRC_SHARDED
+#if SRC_BCAST
+                    // same as following logically
+                    // tile_offset += HtWt;
+                    // tile_offset += next_c_shift;
+                    tile_offset += c_stride;
+#else
+                    tile_offset += next_c_shift;
+#endif
+#endif
+#if !SRC_SHARDED_B
+#if SRC_BCAST_B
+                    tile_offset_b += c_stride_b;
+#else
+                    tile_offset_b += next_c_shift_b;
+#endif
+#endif
+                }
+#if !SRC_SHARDED
+                tile_offset += next_n_shift;
+#endif
+#if !SRC_SHARDED_B
+                tile_offset_b += next_n_shift_b;
+#endif
+            }
+#if !SRC_SHARDED
+            tile_offset += next_d_shift;
+#endif
+#if !SRC_SHARDED_B
+            tile_offset_b += next_d_shift_b;
+#endif
+        }
+#if !SRC_SHARDED
+        tile_offset += next_nd_shift;
+#endif
+#if !SRC_SHARDED_B
+        tile_offset_b += next_nd_shift_b;
+#endif
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_no_bcast_m2.cpp
@@ -1,0 +1,151 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port of reader_interleaved_no_bcast.cpp.
+// Bound by BinaryNgDeviceOperation::ProgramSpecFactory (no-broadcast x tile x FPU x
+// tensor-b-present x interleaved path). Logic is unchanged from the legacy reader; only
+// the resource-access mechanism is converted to Metal 2.0 named bindings:
+//   - CB ids   -> dfb::src / dfb::src_b
+//   - tensor addresses + TensorAccessorArgs -> ta::src / ta::src_b (address auto-injected)
+//   - positional get_arg_val / get_compile_time_arg_val -> get_arg(args::...)
+// The #if SRC_SHARDED / SRC_SHARDED_B paths are preserved verbatim; the ProgramSpecFactory
+// only selects this kernel on the interleaved (unsharded) path, so the SHARDED branches are
+// compiled out, but they are kept for faithfulness to the source.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t start_tile_id = get_arg(args::start_tile_id);
+    const uint32_t src_num_tiles = get_arg(args::src_num_tiles);
+    const uint32_t dst_num_tiles = get_arg(args::dst_num_tiles);
+    const uint32_t dst_shard_width = get_arg(args::dst_shard_width);
+    const uint32_t nD_stride = get_arg(args::nD_stride);
+    const uint32_t d_stride = get_arg(args::d_stride);
+    const uint32_t n_stride = get_arg(args::n_stride);
+    const uint32_t c_stride = get_arg(args::c_stride);
+    const uint32_t D = get_arg(args::D);
+    const uint32_t N = get_arg(args::N);
+    const uint32_t C = get_arg(args::C);
+    const uint32_t Ht = get_arg(args::Ht);
+    const uint32_t Wt = get_arg(args::Wt);
+    const uint32_t cND = get_arg(args::cND);  // collapsed dims > 5
+    const uint32_t nD_stride_b = get_arg(args::nD_stride_b);
+    const uint32_t d_stride_b = get_arg(args::d_stride_b);
+    const uint32_t n_stride_b = get_arg(args::n_stride_b);
+    const uint32_t c_stride_b = get_arg(args::c_stride_b);
+    const uint32_t src_num_tiles_b = get_arg(args::src_num_tiles_b);
+
+    Noc noc;
+    CircularBuffer cb_src(dfb::src);
+    CircularBuffer cb_src_b(dfb::src_b);
+
+#if SRC_SHARDED
+    cb_src.reserve_back(src_num_tiles);
+    cb_src.push_back(src_num_tiles);
+#else
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const auto src = TensorAccessor(ta::src);
+#endif
+#if SRC_SHARDED_B
+    cb_src_b.reserve_back(src_num_tiles_b);
+    cb_src_b.push_back(src_num_tiles_b);
+#else
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
+    const auto src_b = TensorAccessor(ta::src_b);
+#endif
+#if !SRC_SHARDED || !SRC_SHARDED_B
+    constexpr uint32_t onetile = 1;
+    constexpr bool has_sharding = get_arg(args::has_sharding) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset =
+        start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride + start_th * Wt;
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b + start_th * Wt;
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if !SRC_SHARDED
+                            cb_src.reserve_back(onetile);
+                            noc.async_read(
+                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+#endif
+#if !SRC_SHARDED_B
+                            // read a tile from src_b
+                            cb_src_b.reserve_back(onetile);
+                            noc.async_read(
+                                src_b,
+                                cb_src_b,
+                                src_tile_bytes_b,
+                                {.page_id = tile_offset_b + tw},
+                                {.offset_bytes = 0});
+#endif
+#if !SRC_SHARDED || !SRC_SHARDED_B
+                            noc.async_read_barrier();
+#endif
+#if !SRC_SHARDED
+                            cb_src.push_back(onetile);
+#endif
+#if !SRC_SHARDED_B
+                            cb_src_b.push_back(onetile);
+#endif
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+                        tile_offset += Wt;
+                        tile_offset_b += Wt;
+                    }
+                    tile_offset += next_c_shift;
+                    tile_offset_b += next_c_shift_b;
+                }
+                tile_offset += next_n_shift;
+                tile_offset_b += next_n_shift_b;
+            }
+            tile_offset += next_d_shift;
+            tile_offset_b += next_d_shift_b;
+        }
+        tile_offset += next_nd_shift;
+        tile_offset_b += next_nd_shift_b;
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_rm_no_bcast_m2.cpp
@@ -1,0 +1,159 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/alignment.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t dst_num_tiles = get_arg(args::dst_num_tiles);
+
+    const uint32_t aD = get_arg(args::aD);
+    const uint32_t aN = get_arg(args::aN);
+    const uint32_t aC = get_arg(args::aC);
+    const uint32_t aHt = get_arg(args::aHt);
+    const uint32_t aND = get_arg(args::aND);
+
+    const uint32_t bD = get_arg(args::bD);
+    const uint32_t bN = get_arg(args::bN);
+    const uint32_t bC = get_arg(args::bC);
+    const uint32_t bHt = get_arg(args::bHt);
+    const uint32_t bND = get_arg(args::bND);
+
+    const uint32_t cHt = get_arg(args::cHt);
+    const uint32_t cC = get_arg(args::cC);
+    const uint32_t cND = get_arg(args::cND);
+    const uint32_t current_block_start = get_arg(args::current_block_start);
+    const uint32_t rows_per_tile = get_arg(args::rows_per_tile);
+    const uint32_t row_width_elements = get_arg(args::row_width_elements);
+    const uint32_t alignment_a = get_arg(args::alignment_a);
+    const uint32_t alignment_b = get_arg(args::alignment_b);
+    const uint32_t tiles_per_row = get_arg(args::tiles_per_row);
+    const uint32_t stride_size_bytes = get_arg(args::stride_size_bytes);
+
+    Noc noc;
+    CircularBuffer cb_src(dfb::src);
+    CircularBuffer cb_src_b(dfb::src_b);
+
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const uint32_t tile_hw = cb_src.get_tile_hw();
+    const uint32_t element_size = src_tile_bytes / tile_hw;
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const uint32_t outHt = cHt;
+    const uint32_t outC = cC;
+    const uint32_t outN = (aN > bN) ? aN : bN;
+    const uint32_t outD = (aD > bD) ? aD : bD;
+    const uint32_t outND = cND;
+
+    const auto src = TensorAccessor(ta::src);
+    const auto src_b = TensorAccessor(ta::src_b);
+
+    const uint32_t s_h_a = (aHt == 1) ? 0 : 1;
+    const uint32_t s_c_a = (aC == 1) ? 0 : aHt;
+    const uint32_t s_n_a = (aN == 1) ? 0 : aC * aHt;
+    const uint32_t s_d_a = (aD == 1) ? 0 : aN * aC * aHt;
+    const uint32_t s_nd_a = (aND == 1) ? 0 : aD * aN * aC * aHt;
+
+    const uint32_t s_h_b = (bHt == 1) ? 0 : 1;
+    const uint32_t s_c_b = (bC == 1) ? 0 : bHt;
+    const uint32_t s_n_b = (bN == 1) ? 0 : bC * bHt;
+    const uint32_t s_d_b = (bD == 1) ? 0 : bN * bC * bHt;
+    const uint32_t s_nd_b = (bND == 1) ? 0 : bD * bN * bC * bHt;
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_pushed = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_pushed < dst_num_tiles; ++nd, start_d = 0) {
+        const uint32_t ptr_nd_a = nd * s_nd_a;
+        const uint32_t ptr_nd_b = nd * s_nd_b;
+
+        for (uint32_t d = start_d; d < outD && row_blocks_pushed < dst_num_tiles; ++d, start_n = 0) {
+            const uint32_t ptr_d_a = ptr_nd_a + d * s_d_a;
+            const uint32_t ptr_d_b = ptr_nd_b + d * s_d_b;
+
+            for (uint32_t n = start_n; n < outN && row_blocks_pushed < dst_num_tiles; ++n, start_c = 0) {
+                const uint32_t ptr_n_a = ptr_d_a + n * s_n_a;
+                const uint32_t ptr_n_b = ptr_d_b + n * s_n_b;
+
+                for (uint32_t c = start_c; c < outC && row_blocks_pushed < dst_num_tiles; ++c, start_th = 0) {
+                    const uint32_t ptr_c_a = ptr_n_a + c * s_c_a;
+                    const uint32_t ptr_c_b = ptr_n_b + c * s_c_b;
+
+                    for (uint32_t th = start_th; th < outHt && row_blocks_pushed < dst_num_tiles; th += rows_per_tile) {
+                        const uint32_t rows_remaining_in_block = outHt - th;
+                        const uint32_t limit =
+                            (rows_remaining_in_block < rows_per_tile) ? rows_remaining_in_block : rows_per_tile;
+
+                        const uint32_t row_block_a = ptr_c_a + th * s_h_a;
+                        const uint32_t row_block_b = ptr_c_b + th * s_h_b;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            const uint32_t current_read_len_a = align(current_chunk_bytes, alignment_a);
+                            const uint32_t current_read_len_b = align(current_chunk_bytes, alignment_b);
+
+                            cb_src.reserve_back(1);
+                            const uint32_t l1_write_addr_src = cb_src.get_write_ptr();
+
+                            cb_src_b.reserve_back(1);
+                            const uint32_t l1_write_addr_src_b = cb_src_b.get_write_ptr();
+
+                            uint32_t curr_l1_a = l1_write_addr_src;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                const uint32_t row_idx_a = row_block_a + k * s_h_a;
+                                noc.async_read(
+                                    src,
+                                    CoreLocalMem<uint32_t>(curr_l1_a),
+                                    current_read_len_a,
+                                    {.page_id = row_idx_a, .offset_bytes = current_chunk_offset},
+                                    {});
+                                curr_l1_a += current_chunk_bytes;
+                            }
+                            noc.async_read_barrier();
+
+                            uint32_t curr_l1_b = l1_write_addr_src_b;
+                            for (uint32_t k = 0; k < limit; ++k) {
+                                const uint32_t row_idx_b = row_block_b + k * s_h_b;
+                                noc.async_read(
+                                    src_b,
+                                    CoreLocalMem<uint32_t>(curr_l1_b),
+                                    current_read_len_b,
+                                    {.page_id = row_idx_b, .offset_bytes = current_chunk_offset},
+                                    {});
+                                curr_l1_b += current_chunk_bytes;
+                            }
+                            noc.async_read_barrier();
+
+                            cb_src.push_back(1);
+                            cb_src_b.push_back(1);
+                        }
+
+                        row_blocks_pushed++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_row_bcast_m2.cpp
@@ -1,0 +1,167 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t start_tile_id = get_arg(args::start_tile_id);
+    const uint32_t src_num_tiles = get_arg(args::src_num_tiles);
+    const uint32_t dst_num_tiles = get_arg(args::dst_num_tiles);
+    const uint32_t dst_shard_width = get_arg(args::dst_shard_width);
+    const uint32_t nD_stride = get_arg(args::nD_stride);
+    const uint32_t d_stride = get_arg(args::d_stride);
+    const uint32_t n_stride = get_arg(args::n_stride);
+    const uint32_t c_stride = get_arg(args::c_stride);
+    const uint32_t D = get_arg(args::D);
+    const uint32_t N = get_arg(args::N);
+    const uint32_t C = get_arg(args::C);
+    const uint32_t Ht = get_arg(args::Ht);
+    const uint32_t Wt = get_arg(args::Wt);
+    const uint32_t cND = get_arg(args::cND);  // collapsed dims > 5
+    const uint32_t nD_stride_b = get_arg(args::nD_stride_b);
+    const uint32_t d_stride_b = get_arg(args::d_stride_b);
+    const uint32_t n_stride_b = get_arg(args::n_stride_b);
+    const uint32_t c_stride_b = get_arg(args::c_stride_b);
+    const uint32_t src_num_tiles_b = get_arg(args::src_num_tiles_b);
+
+    Noc noc;
+    CircularBuffer cb_src(dfb::src);
+    CircularBuffer cb_src_b(dfb::src_b);
+
+#if SRC_SHARDED
+    cb_src.reserve_back(src_num_tiles);
+    cb_src.push_back(src_num_tiles);
+#else
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const auto src = TensorAccessor(ta::src);
+#endif
+#if SRC_SHARDED_B
+    cb_src_b.reserve_back(src_num_tiles_b);
+    cb_src_b.push_back(src_num_tiles_b);
+#else
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
+    const auto src_b = TensorAccessor(ta::src_b);
+#endif
+#if !SRC_SHARDED || !SRC_SHARDED_B
+    constexpr uint32_t onetile = 1;
+    constexpr bool has_sharding = get_arg(args::has_sharding) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+#if !SRC_BCAST
+    tile_offset += start_th * Wt;
+#endif
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b;
+#if !SRC_BCAST_B
+    tile_offset_b += start_th * Wt;
+#endif
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if !SRC_SHARDED
+                            cb_src.reserve_back(onetile);
+                            noc.async_read(
+                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+#endif
+#if !SRC_SHARDED_B
+                            // read a tile from src_b
+                            cb_src_b.reserve_back(onetile);
+                            noc.async_read(
+                                src_b,
+                                cb_src_b,
+                                src_tile_bytes_b,
+                                {.page_id = tile_offset_b + tw},
+                                {.offset_bytes = 0});
+#endif
+#if !SRC_SHARDED || !SRC_SHARDED_B
+                            noc.async_read_barrier();
+#endif
+#if SRC_BCAST && !BCAST_LLK  // no sharding support for row bcast yet
+                            FILL_TILE_WITH_FIRST_ROW(cb_src.get_write_ptr());
+#endif
+#if SRC_BCAST_B && !BCAST_LLK  // no sharding support for row bcast yet
+                            FILL_TILE_WITH_FIRST_ROW_B(cb_src_b.get_write_ptr());
+#endif
+#if !SRC_SHARDED
+                            cb_src.push_back(onetile);
+#endif
+#if !SRC_SHARDED_B
+                            cb_src_b.push_back(onetile);
+#endif
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+#if !SRC_BCAST
+                        tile_offset += Wt;
+#endif
+#if !SRC_BCAST_B
+                        tile_offset_b += Wt;
+#endif
+                    }
+#if SRC_BCAST
+                    // same as following logically
+                    // tile_offset += HtWt;
+                    // tile_offset += next_c_shift;
+                    tile_offset += c_stride;
+#else
+                    tile_offset += next_c_shift;
+#endif
+#if SRC_BCAST_B
+                    tile_offset_b += c_stride_b;
+#else
+                    tile_offset_b += next_c_shift_b;
+#endif
+                }
+                tile_offset += next_n_shift;
+                tile_offset_b += next_n_shift_b;
+            }
+            tile_offset += next_d_shift;
+            tile_offset_b += next_d_shift_b;
+        }
+        tile_offset += next_nd_shift;
+        tile_offset_b += next_nd_shift_b;
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/reader_interleaved_scalar_bcast_m2.cpp
@@ -1,0 +1,197 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/eltwise/binary_ng/device/kernels/dataflow/fill_tile_utils.hpp"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t start_tile_id = get_arg(args::start_tile_id);
+    const uint32_t src_num_tiles = get_arg(args::src_num_tiles);
+    const uint32_t dst_num_tiles = get_arg(args::dst_num_tiles);
+    const uint32_t dst_shard_width = get_arg(args::dst_shard_width);
+    const uint32_t nD_stride = get_arg(args::nD_stride);
+    const uint32_t d_stride = get_arg(args::d_stride);
+    const uint32_t n_stride = get_arg(args::n_stride);
+    const uint32_t c_stride = get_arg(args::c_stride);
+    const uint32_t D = get_arg(args::D);
+    const uint32_t N = get_arg(args::N);
+    const uint32_t C = get_arg(args::C);
+    const uint32_t Ht = get_arg(args::Ht);
+    const uint32_t Wt = get_arg(args::Wt);
+    const uint32_t cND = get_arg(args::cND);  // collapsed dims > 5
+    const uint32_t nD_stride_b = get_arg(args::nD_stride_b);
+    const uint32_t d_stride_b = get_arg(args::d_stride_b);
+    const uint32_t n_stride_b = get_arg(args::n_stride_b);
+    const uint32_t c_stride_b = get_arg(args::c_stride_b);
+    const uint32_t src_num_tiles_b = get_arg(args::src_num_tiles_b);
+
+    Noc noc;
+    CircularBuffer cb_src(dfb::src);
+    CircularBuffer cb_src_b(dfb::src_b);
+
+#if SRC_SHARDED
+#if !SRC_BCAST
+    cb_src.reserve_back(src_num_tiles);
+    cb_src.push_back(src_num_tiles);
+#endif
+#else
+    const uint32_t src_tile_bytes = cb_src.get_tile_size();
+    const auto src = TensorAccessor(ta::src);
+#endif
+#if SRC_SHARDED_B
+#if !SRC_BCAST_B
+    cb_src_b.reserve_back(src_num_tiles_b);
+    cb_src_b.push_back(src_num_tiles_b);
+#endif
+#else
+    const uint32_t src_tile_bytes_b = cb_src_b.get_tile_size();
+    const auto src_b = TensorAccessor(ta::src_b);
+#endif
+    constexpr uint32_t onetile = 1;
+    constexpr bool has_sharding = get_arg(args::has_sharding) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    // this is the INPUT tile offset
+    uint32_t tile_offset = start_nd * nD_stride + start_d * d_stride + start_n * n_stride + start_c * c_stride;
+#if !SRC_BCAST
+    tile_offset += start_th * Wt;
+#endif
+    uint32_t next_c_shift = c_stride - HtWt;
+    uint32_t next_n_shift = n_stride - c_stride * C;
+    uint32_t next_d_shift = d_stride - n_stride * N;
+    uint32_t next_nd_shift = nD_stride - d_stride * D;
+
+    uint32_t tile_offset_b =
+        start_nd * nD_stride_b + start_d * d_stride_b + start_n * n_stride_b + start_c * c_stride_b;
+#if !SRC_BCAST_B
+    tile_offset_b += start_th * Wt;
+#endif
+    uint32_t next_c_shift_b = c_stride_b - HtWt;
+    uint32_t next_n_shift_b = n_stride_b - c_stride_b * C;
+    uint32_t next_d_shift_b = d_stride_b - n_stride_b * N;
+    uint32_t next_nd_shift_b = nD_stride_b - d_stride_b * D;
+
+    uint32_t num_tiles_read = 0;
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_read < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_read < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_read < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_read < dst_num_tiles; ++c, start_th = 0) {
+#if SRC_BCAST
+                    cb_src.reserve_back(onetile);
+#if !SRC_SHARDED
+                    noc.async_read(src, cb_src, src_tile_bytes, {.page_id = tile_offset}, {.offset_bytes = 0});
+                    noc.async_read_barrier();
+#endif
+#if !BCAST_LLK
+                    FILL_TILE_WITH_FIRST_ELEMENT(cb_src.get_write_ptr());
+#endif
+                    cb_src.push_back(onetile);
+#endif
+#if SRC_BCAST_B
+                    cb_src_b.reserve_back(onetile);
+#if !SRC_SHARDED_B
+                    noc.async_read(src_b, cb_src_b, src_tile_bytes_b, {.page_id = tile_offset_b}, {.offset_bytes = 0});
+                    noc.async_read_barrier();
+#endif
+#if !BCAST_LLK
+                    FILL_TILE_WITH_FIRST_ELEMENT_B(cb_src_b.get_write_ptr());
+#endif
+                    cb_src_b.push_back(onetile);
+#endif
+                    for (uint32_t th = start_th; th < Ht && num_tiles_read < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_read < dst_num_tiles;
+                             ++tw, ++num_tiles_read) {
+#if !SRC_BCAST
+                            cb_src.reserve_back(onetile);
+#if !SRC_SHARDED
+                            noc.async_read(
+                                src, cb_src, src_tile_bytes, {.page_id = tile_offset + tw}, {.offset_bytes = 0});
+                            noc.async_read_barrier();
+#endif
+                            cb_src.push_back(onetile);
+#endif
+#if !SRC_BCAST_B && !SRC_SHARDED_B
+                            cb_src_b.reserve_back(onetile);
+                            noc.async_read(
+                                src_b,
+                                cb_src_b,
+                                src_tile_bytes_b,
+                                {.page_id = tile_offset_b + tw},
+                                {.offset_bytes = 0});
+                            noc.async_read_barrier();
+                            cb_src_b.push_back(onetile);
+#endif
+                        }
+                        if constexpr (!has_sharding) {
+                            // next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+#if !SRC_BCAST && !SRC_SHARDED
+                        tile_offset += Wt;
+#endif
+#if !SRC_BCAST_B && !SRC_SHARDED_B
+                        tile_offset_b += Wt;
+#endif
+                    }
+#if !SRC_SHARDED
+#if SRC_BCAST
+                    // same as following logically
+                    // tile_offset += HtWt;
+                    // tile_offset += next_c_shift;
+                    tile_offset += c_stride;
+#else
+                    tile_offset += next_c_shift;
+#endif
+#endif
+#if !SRC_SHARDED_B
+#if SRC_BCAST_B
+                    tile_offset_b += c_stride_b;
+#else
+                    tile_offset_b += next_c_shift_b;
+#endif
+#endif
+                }
+#if !SRC_SHARDED
+                tile_offset += next_n_shift;
+#endif
+#if !SRC_SHARDED_B
+                tile_offset_b += next_n_shift_b;
+#endif
+            }
+#if !SRC_SHARDED
+            tile_offset += next_d_shift;
+#endif
+#if !SRC_SHARDED_B
+            tile_offset_b += next_d_shift_b;
+#endif
+        }
+#if !SRC_SHARDED
+        tile_offset += next_nd_shift;
+#endif
+#if !SRC_SHARDED_B
+        tile_offset_b += next_nd_shift_b;
+#endif
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_no_bcast_m2.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 port of writer_interleaved_no_bcast.cpp.
+// Bound by BinaryNgDeviceOperation::ProgramSpecFactory (no-broadcast x tile x FPU x
+// tensor-b-present x interleaved path). Logic is unchanged from the legacy writer; only the
+// resource-access mechanism is converted to Metal 2.0 named bindings:
+//   - CB id    -> dfb::dst
+//   - dst address + TensorAccessorArgs -> ta::dst (address auto-injected)
+//   - positional get_arg_val / get_compile_time_arg_val -> get_arg(args::...)
+// The #if DST_SHARDED path is preserved verbatim; the ProgramSpecFactory only selects this
+// kernel on the interleaved (unsharded) path, so DST_SHARDED is compiled out, but it is kept
+// for faithfulness to the source.
+
+#include <stdint.h>
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t start_tile_id = get_arg(args::start_tile_id);
+    const uint32_t dst_num_tiles = get_arg(args::dst_num_tiles);
+    const uint32_t dst_shard_width = get_arg(args::dst_shard_width);
+    const uint32_t D = get_arg(args::D);
+    const uint32_t N = get_arg(args::N);
+    const uint32_t C = get_arg(args::C);
+    const uint32_t Ht = get_arg(args::Ht);
+    const uint32_t Wt = get_arg(args::Wt);
+    const uint32_t cND = get_arg(args::cND);  // collapsed dims > 5
+
+    constexpr uint32_t onetile = 1;
+
+    Noc noc;
+    CircularBuffer cb_dst(dfb::dst);
+
+#if !DST_SHARDED
+    const uint32_t dst_tile_bytes = cb_dst.get_tile_size();
+    const auto dst = TensorAccessor(ta::dst);
+#endif
+
+#if !DST_SHARDED
+    constexpr bool has_sharding = get_arg(args::has_sharding) == 1;
+    const uint32_t HtWt = Ht * Wt;
+
+    const uint32_t tiles_per_n = C * HtWt;
+    const uint32_t tiles_per_d = N * tiles_per_n;
+    const uint32_t tiles_per_nd = D * tiles_per_d;
+    const uint32_t offset_nd = start_tile_id % tiles_per_nd;
+    const uint32_t offset_d = offset_nd % tiles_per_d;
+    const uint32_t offset_n = offset_d % tiles_per_n;
+    const uint32_t offset_c = offset_n % HtWt;
+    uint32_t start_nd = start_tile_id / tiles_per_nd;
+    uint32_t start_d = offset_nd / tiles_per_d;
+    uint32_t start_n = offset_d / tiles_per_n;
+    uint32_t start_c = offset_n / HtWt;
+    uint32_t start_th = offset_c / Wt;
+    uint32_t start_tw = offset_c % Wt;
+    uint32_t end_tw = has_sharding ? start_tw + dst_shard_width : Wt;
+
+    uint32_t num_tiles_written = 0;
+    uint32_t dst_tile_offset = start_tile_id;
+
+    for (uint32_t nd = start_nd; nd < cND && num_tiles_written < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < D && num_tiles_written < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < N && num_tiles_written < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < C && num_tiles_written < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < Ht && num_tiles_written < dst_num_tiles; ++th) {
+                        for (uint32_t tw = start_tw; tw < end_tw && num_tiles_written < dst_num_tiles;
+                             ++tw, ++num_tiles_written) {
+#if !DST_SHARDED
+                            //  write a tile to dst, since the dst shape is full, the tile offset simply grows linearly
+                            cb_dst.wait_front(onetile);
+                            noc.async_write(
+                                cb_dst, dst, dst_tile_bytes, {}, {.page_id = dst_tile_offset + num_tiles_written});
+                            noc.async_write_barrier();
+                            cb_dst.pop_front(onetile);
+#endif
+                        }
+                        if constexpr (has_sharding) {
+                            // adjust the output tile offset since we had to skip parts of the row
+                            dst_tile_offset += (Wt - dst_shard_width);
+                        } else {
+                            // otherwise, next row of tiles should start at the first column
+                            start_tw = 0;
+                        }
+                    }
+                }
+            }
+        }
+    }
+#endif
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/device/kernels_ng/dataflow/writer_interleaved_rm_no_bcast_m2.cpp
@@ -1,0 +1,96 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#include <stdint.h>
+
+#include "api/alignment.h"
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "api/core_local_mem.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t row_width_elements = get_arg(args::row_width_elements);
+    const uint32_t dst_num_tiles = get_arg(args::dst_num_tiles);
+
+    const uint32_t outD = get_arg(args::outD);
+    const uint32_t outN = get_arg(args::outN);
+    const uint32_t outC = get_arg(args::outC);
+    const uint32_t outHt = get_arg(args::outHt);
+    const uint32_t outND = get_arg(args::outND);
+
+    const uint32_t current_block_start = get_arg(args::current_block_start);
+    const uint32_t rows_per_tile = get_arg(args::rows_per_tile);
+    const uint32_t alignment = get_arg(args::alignment);
+    const uint32_t tiles_per_row = get_arg(args::tiles_per_row);
+    const uint32_t stride_size_bytes = get_arg(args::stride_size_bytes);
+
+    Noc noc;
+    CircularBuffer cb_out(dfb::dst);
+
+    const uint32_t tile_bytes = cb_out.get_tile_size();
+    const uint32_t tile_hw = cb_out.get_tile_hw();
+    const uint32_t element_size = tile_bytes / tile_hw;
+    const uint32_t row_width_bytes = row_width_elements * element_size;
+
+    const auto dst = TensorAccessor(ta::dst);
+
+    const uint32_t row_blocks_per_channel = (outHt + rows_per_tile - 1) / rows_per_tile;
+
+    uint32_t tmp = current_block_start;
+    uint32_t start_th = (tmp % row_blocks_per_channel) * rows_per_tile;
+    tmp /= row_blocks_per_channel;
+    uint32_t start_c = tmp % outC;
+    tmp /= outC;
+    uint32_t start_n = tmp % outN;
+    tmp /= outN;
+    uint32_t start_d = tmp % outD;
+    tmp /= outD;
+    uint32_t start_nd = tmp;
+
+    uint32_t row_blocks_written = 0;
+
+    for (uint32_t nd = start_nd; nd < outND && row_blocks_written < dst_num_tiles; ++nd, start_d = 0) {
+        for (uint32_t d = start_d; d < outD && row_blocks_written < dst_num_tiles; ++d, start_n = 0) {
+            for (uint32_t n = start_n; n < outN && row_blocks_written < dst_num_tiles; ++n, start_c = 0) {
+                for (uint32_t c = start_c; c < outC && row_blocks_written < dst_num_tiles; ++c, start_th = 0) {
+                    for (uint32_t th = start_th; th < outHt && row_blocks_written < dst_num_tiles;
+                         th += rows_per_tile) {
+                        const uint32_t rows_remaining = outHt - th;
+                        const uint32_t limit = (rows_remaining < rows_per_tile) ? rows_remaining : rows_per_tile;
+                        const uint32_t row_block_base_row = (((((nd * outD) + d) * outN + n) * outC + c) * outHt) + th;
+
+                        for (uint32_t t_i = 0; t_i < tiles_per_row; ++t_i) {
+                            const uint32_t current_chunk_offset = t_i * stride_size_bytes;
+                            const uint32_t bytes_left_in_row = row_width_bytes - current_chunk_offset;
+                            const uint32_t current_chunk_bytes =
+                                (stride_size_bytes < bytes_left_in_row) ? stride_size_bytes : bytes_left_in_row;
+                            const uint32_t current_write_len = align(current_chunk_bytes, alignment);
+
+                            cb_out.wait_front(1);
+
+                            uint32_t l1_read_addr = cb_out.get_read_ptr();
+                            for (uint32_t row = 0; row < limit; ++row) {
+                                const uint32_t row_abs_idx = row_block_base_row + row;
+                                noc.async_write(
+                                    CoreLocalMem<uint32_t>(l1_read_addr),
+                                    dst,
+                                    current_write_len,
+                                    {},
+                                    {.page_id = row_abs_idx, .offset_bytes = current_chunk_offset});
+                                l1_read_addr += current_chunk_bytes;
+                            }
+
+                            noc.async_write_barrier();
+                            cb_out.pop_front(1);
+                        }
+
+                        row_blocks_written++;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/eltwise/binary_ng/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_ng/sources.cmake
@@ -4,5 +4,6 @@
 set(TTNN_OP_ELTWISE_BINARY_NG_SRCS
     device/binary_ng_device_operation.cpp
     device/binary_ng_program_factory.cpp
+    device/binary_ng_program_factory_m2.cpp
     device/binary_ng_utils.cpp
 )

--- a/ttnn/cpp/ttnn/operations/matmul/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/matmul/device/METAL2_PORT_REPORT.md
@@ -76,3 +76,90 @@ matching the kernel variables, not re-derived to a "truer" meaning, to keep the 
 - **Not a blocker, flagged for owner:** the legacy factory's Blackhole `INTERMEDIATE_CB_READ`
   helper CBs are genuine scratch FIFOs; modeled as self-loops here (correct), but they are
   candidates for the forthcoming Metal 2.0 kernel-scratchpad resource.
+
+---
+
+# Metal 2.0 Port Report — MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory
+
+**Status:** PORTED
+**Factory:** `MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory` (`create_descriptor` → `create_program_spec`)
+**Concept:** `MetalV2FactoryConcept` (returns `ttnn::device_operation::ProgramArtifacts`)
+
+## Why this is NOT metal-blocked (correcting a prior pass)
+
+A prior pass marked this factory METAL-BLOCKED for "raw buffer-address-through-RTA on io tensors
+(remote storage cores / DRAM bank)". That was wrong. The factory has **zero semaphores** and all of
+its CBs are **same-node local FIFOs** (no mcast / no `RemoteDataflowBufferSpec`), so its DFB topology
+ports like the MatmulMultiCore / MatmulMultiCoreReuseOptimized exemplars. The raw addresses live in
+**data-movement (RISCV) kernels**, so they are **Case 2 — portable** via
+`TensorAccessor::get_bank_base_address()`: bind the tensor through the typed channel and pull the base
+kernel-side, keeping the explicit NoC / DRAM-bank arithmetic unchanged. No compute (TRISC) kernel needs
+a raw base, so no Case-2-in-compute block applies.
+
+## Kernels
+
+| Kernel | Disposition | Reason |
+|---|---|---|
+| `dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp` | Ported in place | Exclusive to this factory (grep confirmed). |
+| `dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp` | Ported in place | Exclusive to this factory (grep confirmed). |
+| `compute/bmm_large_block_zm_fused_bias_activation.cpp` | **Reused existing fork** `..._m2.cpp` | Shared by 6 matmul factories + a deepseek FFN kernel; the Metal 2.0 fork already created for MatmulMultiCoreReuseOptimized covers this factory's CTA layout (same positional order) + named CTAs (`bias_ntiles`, `last_subblock_w_valid`, `activation_*`). |
+
+## Structural decisions
+
+- **Case-2 base-address bridge (the flagged "blocker" — actually portable).**
+  - in0 reader: `input_shard_l1_addr` (legacy RTA fed by the in0 MeshTensor) →
+    `TensorAccessor(ta::a).get_bank_base_address()` (L1-sharded shard base on the remote storage core).
+  - in1 writer: `in1_tensor_addr` → `ta::b` DRAM-bank base; `in3_tensor_addr` (bias, FUSE_BIAS) →
+    `ta::bias` DRAM-bank base; `output_shard_l1_addr` → `ta::out` L1 shard base on the remote output
+    storage core. The explicit `UnicastEndpoint` NoC walks and `AllocatorBank<DRAM>` reads are
+    UNCHANGED — only the base now comes from the accessor.
+- **Local DFBs only.** c_0 in0, c_1 in1, c_3 bias (conditional), c_4 out, c_5 intermed0 are same-node
+  local FIFOs. When `interm0_data_format == output_data_format` the legacy uses ONE CBDescriptor with
+  two format_descriptors (c_4 + c_5); ported as two DFBs with mutual `advanced_options.alias_with`
+  (alias-size equality holds: equal tile size when formats match, and `out_shard_tiles == per_core_M *
+  per_core_N` for this batch-sharded layout). Otherwise two independent DFBs (legacy distinct sizes).
+- **Borrowed CBs c_2 / c_6 DROP.** Legacy c_2 (sharded in0 on input storage cores, `tensor=&in0`) and
+  c_6 (output reshard on output storage cores, `tensor=&out`) are bound by NO kernel — they were the
+  pre-Metal-2.0 way to reserve the io tensors' L1 on the storage cores. In Metal 2.0 the io tensors'
+  own buffer reservations cover that, and the kernels read/write those regions by raw NoC using the
+  Case-2 base addresses. So c_2/c_6 are subsumed by the `a` / `out` TensorParameters — no DFB needed.
+- **Single WorkUnitSpec.** No work-split CTA variation (per-core CTAs identical; only per-core RTAs
+  differ: bank_id, vc, storage-core NoC coords). One WorkUnitSpec hosts in0_reader + in1_writer +
+  compute on `all_cores_in_rect_grid` (workers + idle storage/gap cores). Idle cores supply
+  `worker_core_type`/`is_worker_core == 0` plus dummy values for the remaining named RTAs and return
+  early (named-RTA schema requires every name on every target node; the early return makes the dummies
+  harmless — behavior-preserving).
+- **Explicit Gen1 DM config.** Legacy pins in0 reader to RISCV_1 + preferred_noc_for_dram_write and
+  in1 writer to RISCV_0 + preferred_noc_for_dram_read; reproduced via
+  `DataMovementHardwareConfig::Gen1Config` (role = UNSPECIFIED), not the READER/WRITER role hint.
+- **Dropped plumbing:** buffer-address RTAs → `TensorBinding` + `get_bank_base_address`. Named-CB
+  CTAs (`get_named_compile_time_arg_val("cb_*")`) → `dfb::`. All positional CT/RT args → named
+  `get_arg(args::*)`. Writer's `use<CircularBuffer::AddrSelector::READ_PTR>(cb_out)` → bare `cb_out`.
+
+## Shared-fork edit (gated, does not affect other factories)
+
+The shared compute fork `bmm_large_block_zm_fused_bias_activation_m2.cpp` had one surviving positional
+RTA read `get_arg_val<uint32_t>(0)` under `#ifdef MATMUL_DRAM_SHARDED` (a worker-core gate). Converted
+to `get_arg(args::is_worker_core)` per the kernel-side whitelist. This line is preprocessed OUT for the
+reuse-optimized factory (it does not define `MATMUL_DRAM_SHARDED`), so that prior port is unaffected;
+only this factory (which defines `MATMUL_DRAM_SHARDED`) compiles and supplies the `is_worker_core` RTA.
+
+## Device-op-class / pybind edits
+
+- **Custom `compute_program_hash` KEPT** (shared across the matmul factory variant — must not be
+  deleted by a single-factory port).
+- **Pybind hook removed** (matmul_nanobind.cpp): deleted the
+  `MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory` `create_descriptor` `def_static`; kept the
+  bare `nb::class_` registration (the ttnn Python package imports the symbol).
+  *User-visible surface change:* any Python caller of
+  `MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory.create_descriptor` breaks.
+
+## Open items / friction
+
+- **Untested at runtime in this worktree** (no build dir; not built per instructions). Should be
+  validated on hardware: FUSE_BIAS on/off, fused activation (RELU vs SFPU) on/off, the aliased vs
+  separate out/intermed0 paths (packer_l1_acc / fp32 combinations), and the idle-core dummy-RTA path.
+- **Friction:** the named-RTA schema's "every name on every node" rule forces idle (non-worker)
+  cores to carry dummy values for args they never read (the kernel returns early). Faithful and safe,
+  but slightly noisier than the legacy variable-length positional RTA lists. A future "optional per
+  node" RTA, or routing the worker/idle flag through a per-WorkUnitSpec split, would be cleaner.

--- a/ttnn/cpp/ttnn/operations/matmul/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/matmul/device/METAL2_PORT_REPORT.md
@@ -1,0 +1,78 @@
+# Metal 2.0 Port Report — MatmulMultiCoreReuseOptimizedProgramFactory
+
+**Status:** PORTED
+**Factory:** `MatmulMultiCoreReuseOptimizedProgramFactory` (`create_descriptor` → `create_program_spec`)
+**Concept:** `MetalV2FactoryConcept` (returns `ttnn::device_operation::ProgramArtifacts`)
+
+## Kernels
+
+| Kernel | Disposition | Reason |
+|---|---|---|
+| `dataflow/reader_bmm_tile_layout_in0.cpp` | Ported in place | Exclusive to this factory (grep confirmed). |
+| `dataflow/reader_writer_bmm_tile_layout_in1.cpp` | Ported in place | Exclusive to this factory (grep confirmed). |
+| `compute/bmm_large_block_zm_fused_bias_activation.cpp` | **Forked** → `..._m2.cpp` | Shared by 6 matmul factories (mcast_1d, mcast_2d, two DRAM-sharded, sparse, this one) + a deepseek FFN kernel. |
+
+## Structural decisions
+
+- **Borrowed-memory DFBs from io tensors (the flagged risk): EXPRESSIBLE.**
+  The legacy sharded CBs set `cb_desc.tensor = &in0_buffer / &in1_buffer / &output`.
+  Modeled as `DataflowBufferSpec::borrowed_from = <io tensor's TensorParameter>`, gated on
+  `in0/in1/output_is_sharded`. The framework explicitly supports a `TensorParameter` referenced
+  *only* via `borrowed_from` with no kernel `TensorBinding` (program_spec.cpp:490-508 registers it
+  as "used (no kernel user)"). The L1_SMALL blocker does NOT apply: matmul sharded io tensors are
+  `BufferType::L1`, which is what the borrowed-DFB validator requires (program_spec.cpp:1264-1269).
+  On each sharded path the corresponding kernel-side `TensorAccessor` construction already lives
+  inside the existing `#ifndef IN*_SHARDED` block, so the factory binds the tensor to the kernel
+  only on the non-sharded (NoC) path; on the sharded path only the borrow is used.
+- **Aliased out/intermed0 (shared CB).** When `interm0_data_format == output_data_format` and not
+  (untilize_out && in1_num_subblocks>1), legacy uses ONE CBDescriptor with two format_descriptors
+  (c_4 + c_5). Ported as two DFBs (`out`, `intermed0`) with mutual `advanced_options.alias_with`.
+  Alias legality holds: same total size (equal tile size when formats match), same node coverage
+  (alias rule 3 is node-set, not kernel-identity — confirmed program_spec.cpp:1351-1360, so it is
+  fine that `out` is bound to compute+reader_writer while `intermed0` is bound to compute only), and
+  consistent `borrowed_from` (both borrow `out` when output is sharded; neither otherwise).
+- **Work-split multiplicity preserved.** Two compute `KernelSpec`s of the forked source (one per
+  core group, differing only in the per-group output-block count CTA, kernel-side name `batch`),
+  each in its own `WorkUnitSpec`. reader + reader_writer are shared across both WUs; per the
+  Local-DFB rule each WU contains reader + reader_writer + its compute so every DFB endpoint pair
+  shares the WU. No CTA was demoted to RTA.
+- **Conditional DFBs/bindings (all known at factory-construction time):**
+  - `in0_transposed` (c_10): bound + a self-loop on compute only when `in0_transpose_tile`. The
+    compute kernel references `cb_in0_transposed` from a file-scope ternary, so the kernel-side
+    handle is `#ifdef IN0_TRANSPOSE_TILE_CB`-gated (Conditional-DFB pattern) and the factory emits
+    that define alongside the binding.
+  - `in0_intermediate` (c_8) / `in1_intermediate` (c_9): Blackhole `INTERMEDIATE_CB_READ` workaround;
+    bound as real self-loops (reserve/push then wait/pop) on their reading kernel, gated on the
+    arch + odd-tile-size condition.
+- **Dropped plumbing:** `TensorAccessorArgs(...).append_to(cta)` + kernel `TensorAccessorArgs<N>()`
+  + buffer-address RTAs → `TensorBinding` / `ta::`. Named-CB CTAs
+  (`get_named_compile_time_arg_val("cb_*")`) → `dfb::`. All positional CTAs/RTAs → named
+  `get_arg(args::*)`. Writer's `use<CircularBuffer::AddrSelector::READ_PTR>(cb_out)` → bare `cb_out`.
+
+## Device-op-class / pybind edits (the two sanctioned exceptions)
+
+- **Custom `compute_program_hash` KEPT** (matmul_device_operation.cpp:2107) — per instruction it is
+  shared across the matmul factory variant and must not be deleted by a single-factory port.
+- **Pybind hook removed** (matmul_nanobind.cpp): deleted the
+  `MatmulMultiCoreReuseOptimizedProgramFactory` `create_descriptor` + `default_core_range`
+  `nb::class_`/`def_static` block (the legacy `create_descriptor` symbol no longer exists).
+  *User-visible surface change:* any Python caller of
+  `MatmulMultiCoreReuseOptimizedProgramFactory.create_descriptor` / `.default_core_range` breaks.
+
+## Naming note (kernel-side ↔ legacy CTA slot)
+
+The reader/reader_writer kernels' RTA slot 2 (kernel-side `batch`) carries
+`num_output_blocks_per_core`; the compute kernel's CTA slot 13 (kernel-side `batch`) also carries
+the per-group output-block count. Both faithfully reproduce the legacy positional values (the legacy
+kernels' loop variable is literally named `batch` although it counts output blocks); names were kept
+matching the kernel variables, not re-derived to a "truer" meaning, to keep the port mechanical.
+
+## Open items / friction
+
+- **Untested at runtime in this worktree** (no build dir). Borrowed-DFB-from-io-tensor + aliased
+  borrowed DFBs are an advanced, lightly-exercised path; the sharded + shared-out/intermed0 +
+  borrowed combination is the first matmul use and should be validated on hardware (interleaved and
+  each sharded layout, transpose_a/b on/off, the two-core-group split, Blackhole odd-tile path).
+- **Not a blocker, flagged for owner:** the legacy factory's Blackhole `INTERMEDIATE_CB_READ`
+  helper CBs are genuine scratch FIFOs; modeled as self-loops here (correct), but they are
+  candidates for the forthcoming Metal 2.0 kernel-scratchpad resource.

--- a/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/config/matmul_program_config.cpp
@@ -5,6 +5,7 @@
 #include "ttnn/operations/matmul/device/config/matmul_program_config.hpp"
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 #include "ttnn/types.hpp"
+#include <cstdlib>
 #include <ranges>
 
 namespace ttnn::operations::matmul {
@@ -989,6 +990,11 @@ MatmulProgramConfig get_program_config(
     const bool transpose_b,
     const uint32_t bias_single_tile_size,
     const ttnn::prim::MatmulParams& attributes) {
+    // MEASUREMENT-ONLY (env-gated): force the MatmulMultiCore fallback factory so the
+    // descriptor-vs-spec host-cost comparison runs on the same factory + shape. Not for prod.
+    if (std::getenv("FORCE_MM_MULTICORE") != nullptr) {
+        return MatmulMultiCoreProgramConfig{};
+    }
     if (attributes.program_config.has_value()) {
         return attributes.program_config.value();
     }

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.cpp
@@ -10,38 +10,36 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 using namespace tt;
 using namespace tt::constants;
-using tt::tt_metal::CBDescriptor;
-using tt::tt_metal::CBFormatDescriptor;
-using tt::tt_metal::ComputeConfigDescriptor;
-using tt::tt_metal::KernelDescriptor;
-using tt::tt_metal::ProgramDescriptor;
-using tt::tt_metal::ReaderConfigDescriptor;
-using tt::tt_metal::WriterConfigDescriptor;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
-ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts MatmulMultiCoreProgramFactory::create_program_spec(
     const ttnn::prim::MatmulParams& operation_attributes,
     const ttnn::prim::MatmulInputs& tensor_args,
-    std::vector<ttnn::Tensor>& tensor_return_value,
-    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    std::vector<ttnn::Tensor>& tensor_return_value) {
     if (!tensor_args.optional_input_tensors.empty()) {
         TT_FATAL(!tensor_args.optional_input_tensors[0].has_value(), "Bias is not supported for matmul multi core");
     }
 
-    const auto& a = tensor_args.input_tensors.at(0).mesh_tensor();
-    const auto& b = tensor_args.input_tensors.at(1).mesh_tensor();
-    const auto& output = tensor_return_value.at(0).mesh_tensor();
+    const auto& a = tensor_args.input_tensors.at(0);
+    const auto& b = tensor_args.input_tensors.at(1);
+    auto& output = tensor_return_value.at(0);
+    const auto& a_mesh = a.mesh_tensor();
+    const auto& b_mesh = b.mesh_tensor();
 
     TT_FATAL(operation_attributes.bcast_batch.has_value(), "Error: bcast_batch field should have been populated");
     bool bcast_batch = operation_attributes.bcast_batch.value();
 
-    const auto& ashape = a.padded_shape();
-    const auto& bshape = b.padded_shape();
+    const auto& ashape = a_mesh.padded_shape();
+    const auto& bshape = b_mesh.padded_shape();
 
     tt::DataFormat in0_data_format = tt_metal::datatype_to_dataformat_converter(a.dtype());
     tt::DataFormat in1_data_format = tt_metal::datatype_to_dataformat_converter(b.dtype());
@@ -50,25 +48,19 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
     uint32_t in1_single_tile_size = tt::tile_size(in1_data_format);
     uint32_t output_single_tile_size = tt::tile_size(output_data_format);
 
-    tt::tt_metal::IDevice* device = &a.mutable_device();
+    tt::tt_metal::IDevice* device = &a_mesh.mutable_device();
     TT_FATAL(operation_attributes.compute_kernel_config.has_value(), "Compute kernel config should have been provided");
     auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
         get_compute_kernel_config_args(device->arch(), operation_attributes.compute_kernel_config.value());
     (void)packer_l1_acc;
 
-    const auto& cshape = output.padded_shape();  // C=A*B, N1MK*11KN->N1MN
+    const auto& cshape = output.mesh_tensor().padded_shape();  // C=A*B, N1MK*11KN->N1MN
 
     TT_FATAL(
         operation_attributes.program_config.has_value(),
         "program_config must be provided for MatmulMultiCoreProgramFactory");
     auto pc = std::get<operations::matmul::MatmulMultiCoreProgramConfig>(operation_attributes.program_config.value());
     if (!pc.allowed_worker_cores.has_value()) {
-        log_warning(
-            tt::LogOp,
-            "MatmulMultiCoreProgramFactory: program_config.allowed_worker_cores not populated; auto-populating "
-            "from device compute_with_storage_grid_size. Callers that bypass ttnn::prim::matmul() should invoke "
-            "ttnn::operations::matmul::normalize_program_config() on the program config first. This will become "
-            "a hard error in a future release.");
         auto device_grid = device->compute_with_storage_grid_size();
         pc.allowed_worker_cores =
             CoreRangeSet(CoreRange(CoreCoord(0, 0), CoreCoord(device_grid.x - 1, device_grid.y - 1)));
@@ -86,8 +78,7 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
          num_output_tiles_per_core_group_2] =
             tt::tt_metal::split_work_to_cores(compute_with_storage_grid_size, num_output_tiles_total);
 
-    // C = A*B*...
-    // MN = MK*KN
+    // C = A*B*...; MN = MK*KN
     uint32_t B = get_batch_size(ashape);
     uint32_t Mt = ashape[-2] / TILE_HEIGHT;
     uint32_t Kt = ashape[-1] / TILE_WIDTH;
@@ -96,101 +87,68 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
     uint32_t MtKt = Mt * Kt;
     uint32_t MtNt = Mt * Nt;
 
-    ProgramDescriptor desc;
-
-    // Circular buffers
-    uint32_t num_input_tiles = 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * in0_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = 0,
-            .data_format = in0_data_format,
-            .page_size = in0_single_tile_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * in1_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = 1,
-            .data_format = in1_data_format,
-            .page_size = in1_single_tile_size,
-        }}},
-    });
-    uint32_t output_cb_index = tt::CBIndex::c_16;
-    uint32_t num_output_tiles = 2;
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_output_tiles * output_single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = output_data_format,
-            .page_size = output_single_tile_size,
-        }}},
-    });
-
-    // Reader kernel
     uint32_t last_ktile_w = a.logical_shape()[-1] % TILE_WIDTH;
     uint32_t last_ktile_h = 0;
-    std::vector<uint32_t> reader_compile_time_args = {(uint32_t)last_ktile_w, (uint32_t)last_ktile_h};
-    tt::tt_metal::TensorAccessorArgs(a).append_to(reader_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(b).append_to(reader_compile_time_args);
 
-    KernelDescriptor reader_desc;
-    reader_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp";
-    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_desc.core_ranges = all_cores;
-    reader_desc.compile_time_args = reader_compile_time_args;
-    reader_desc.named_compile_time_args = {{"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}};
-    reader_desc.config = ReaderConfigDescriptor{};
+    // ---- ProgramSpec (immutable) ----
+    constexpr uint32_t num_input_tiles = 2;
+    constexpr uint32_t num_output_tiles = 2;
+    m2::ProgramSpec spec;
+    spec.name = "matmul_multi_core";
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"in0"},
+            .entry_size = in0_single_tile_size,
+            .num_entries = num_input_tiles,
+            .data_format_metadata = in0_data_format},
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"in1"},
+            .entry_size = in1_single_tile_size,
+            .num_entries = num_input_tiles,
+            .data_format_metadata = in1_data_format},
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"out"},
+            .entry_size = output_single_tile_size,
+            .num_entries = num_output_tiles,
+            .data_format_metadata = output_data_format},
+    };
 
-    // Writer kernel
-    std::vector<uint32_t> writer_compile_time_args = {};
-    tt::tt_metal::TensorAccessorArgs(output).append_to(writer_compile_time_args);
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                                        "reader_bmm_8bank_output_tiles_partitioned.cpp"},
+        .dfb_bindings =
+            {m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"in0"},
+                 .accessor_name = "in0",
+                 .endpoint_type = m2::DFBEndpointType::PRODUCER},
+             m2::DFBBinding{
+                 .dfb_spec_name = m2::DFBSpecName{"in1"},
+                 .accessor_name = "in1",
+                 .endpoint_type = m2::DFBEndpointType::PRODUCER}},
+        .tensor_bindings =
+            {m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"a"}, .accessor_name = "a"},
+             m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"b"}, .accessor_name = "b"}},
+        .compile_time_args = {{"in0_last_ktile_w", last_ktile_w}, {"in0_last_ktile_h", last_ktile_h}},
+        .runtime_arg_schema =
+            {.runtime_arg_names = {"output_tile_start_id", "num_output_tiles"},
+             .common_runtime_arg_names = {"Mt", "Kt", "Nt", "MtKt", "KtNt", "batch", "bcast_B", "MtNt"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
+    };
 
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_unary_interleaved_start_id.cpp";
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = writer_compile_time_args;
-    writer_desc.named_compile_time_args = {{"cb_out", output_cb_index}};
-    writer_desc.config = WriterConfigDescriptor{};
-
-    // Per-core runtime args for reader and writer
-    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
-        CoreCoord core = {i / num_cores_y, i % num_cores_y};
-
-        uint32_t num_output_tiles_per_core = 0;
-        if (core_group_1.contains(core)) {
-            num_output_tiles_per_core = num_output_tiles_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            num_output_tiles_per_core = num_output_tiles_per_core_group_2;
-        } else {
-            TT_THROW("Core not in specified core ranges");
-        }
-        reader_desc.emplace_runtime_args(
-            core,
-            {a,
-             b,
-             Mt,
-             Kt,
-             Nt,
-             MtKt,
-             KtNt,
-             B,
-             uint32_t(bcast_batch),
-             num_tiles_written,
-             num_output_tiles_per_core,
-             MtNt});
-        writer_desc.emplace_runtime_args(core, {output, num_output_tiles_per_core, num_tiles_written});
-        num_tiles_written += num_output_tiles_per_core;
-    }
-
-    desc.kernels.push_back(std::move(reader_desc));
-    desc.kernels.push_back(std::move(writer_desc));
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                                        "writer_bmm_8bank_interleaved_start_id_m2.cpp"},
+        .dfb_bindings = {m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"out"},
+            .accessor_name = "out",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER}},
+        .tensor_bindings = {m2::TensorBinding{
+            .tensor_parameter_name = m2::TensorParamName{"out"}, .accessor_name = "out"}},
+        .runtime_arg_schema = {.runtime_arg_names = {"num_pages", "start_id"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
 
     const auto throttle_level = ttnn::get_throttle_level(operation_attributes.compute_kernel_config);
     std::map<std::string, std::string> mm_kernel_defines;
@@ -198,47 +156,117 @@ ProgramDescriptor MatmulMultiCoreProgramFactory::create_descriptor(
         device->arch(), num_cores, mm_kernel_defines);
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(
         device->arch(), num_cores, mm_kernel_defines, throttle_level);
-
-    // Compute kernel(s) — one per core group with different tile counts
-    // bmm compute kernel: B, Mt, Nt are just 3 for loops that act as 1 large loop,
-    // so only set Nt for simplicity
-    std::vector<uint32_t> compute_args_group_1 = {1, 1, Kt, num_output_tiles_per_core_group_1};
-
-    KernelDescriptor compute_desc_1;
-    compute_desc_1.kernel_source = "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp";
-    compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc_1.core_ranges = core_group_1;
-    compute_desc_1.compile_time_args = compute_args_group_1;
-    compute_desc_1.named_compile_time_args = {
-        {"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}, {"cb_out", tt::CBIndex::c_16}};
-    compute_desc_1.defines = {mm_kernel_defines.begin(), mm_kernel_defines.end()};
-    compute_desc_1.config = ComputeConfigDescriptor{
-        .math_fidelity = math_fidelity,
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .dst_full_sync_en = dst_full_sync_en,
-        .math_approx_mode = math_approx_mode};
-    desc.kernels.push_back(std::move(compute_desc_1));
-
-    if (!core_group_2.ranges().empty()) {
-        std::vector<uint32_t> compute_args_group_2 = {1, 1, Kt, num_output_tiles_per_core_group_2};
-
-        KernelDescriptor compute_desc_2;
-        compute_desc_2.kernel_source = "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm.cpp";
-        compute_desc_2.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_desc_2.core_ranges = core_group_2;
-        compute_desc_2.compile_time_args = compute_args_group_2;
-        compute_desc_2.named_compile_time_args = {
-            {"cb_in0", tt::CBIndex::c_0}, {"cb_in1", tt::CBIndex::c_1}, {"cb_out", tt::CBIndex::c_16}};
-        compute_desc_2.defines = {mm_kernel_defines.begin(), mm_kernel_defines.end()};
-        compute_desc_2.config = ComputeConfigDescriptor{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = dst_full_sync_en,
-            .math_approx_mode = math_approx_mode};
-        desc.kernels.push_back(std::move(compute_desc_2));
+    m2::KernelSpec::CompilerOptions::Defines defines_table;
+    for (const auto& [k, v] : mm_kernel_defines) {
+        defines_table.insert({k, v});
     }
 
-    return desc;
+    const char* COMPUTE_SRC = "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_m2.cpp";
+    auto make_compute = [&](const std::string& id, uint32_t per_core_nt) {
+        return m2::KernelSpec{
+            .unique_id = m2::KernelSpecName{id},
+            .source = std::filesystem::path{COMPUTE_SRC},
+            .compiler_options = {.defines = defines_table},
+            .dfb_bindings =
+                {m2::DFBBinding{
+                     .dfb_spec_name = m2::DFBSpecName{"in0"},
+                     .accessor_name = "in0",
+                     .endpoint_type = m2::DFBEndpointType::CONSUMER},
+                 m2::DFBBinding{
+                     .dfb_spec_name = m2::DFBSpecName{"in1"},
+                     .accessor_name = "in1",
+                     .endpoint_type = m2::DFBEndpointType::CONSUMER},
+                 m2::DFBBinding{
+                     .dfb_spec_name = m2::DFBSpecName{"out"},
+                     .accessor_name = "out",
+                     .endpoint_type = m2::DFBEndpointType::PRODUCER}},
+            // bmm uses B,Mt,Nt as 3 nested loops acting as one large loop; only Nt varies per group.
+            .compile_time_args = {{"batch", 1}, {"Mt", 1}, {"Kt", Kt}, {"Nt", per_core_nt}},
+            .hw_config =
+                m2::ComputeHardwareConfig{
+                    .math_fidelity = math_fidelity,
+                    .fp32_dest_acc_en = fp32_dest_acc_en,
+                    .dst_full_sync_en = dst_full_sync_en,
+                    .math_approx_mode = math_approx_mode},
+        };
+    };
+    m2::KernelSpec compute_1 = make_compute("compute_1", num_output_tiles_per_core_group_1);
+
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"a"}, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"b"}, .spec = b.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"out"}, .spec = output.tensor_spec()},
+    };
+
+    // Local DFBs (in0/in1/out) require their producer and consumer KernelSpecs to share the
+    // SAME WorkUnitSpec(s) — every node hosting the DFB must host both endpoints. So each core
+    // group gets one WorkUnitSpec containing reader + compute_<group> + writer (reader/writer
+    // are shared across both groups' WorkUnitSpecs; the per-group compute differs only in its
+    // Nt CTA).
+    const bool has_group_2 = !core_group_2.ranges().empty();
+    if (has_group_2) {
+        m2::KernelSpec compute_2 = make_compute("compute_2", num_output_tiles_per_core_group_2);
+        spec.kernels = {reader, writer, compute_1, compute_2};
+        spec.work_units = std::vector<m2::WorkUnitSpec>{
+            m2::WorkUnitSpec{
+                .name = "g1",
+                .kernels =
+                    {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"compute_1"}, m2::KernelSpecName{"writer"}},
+                .target_nodes = core_group_1},
+            m2::WorkUnitSpec{
+                .name = "g2",
+                .kernels =
+                    {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"compute_2"}, m2::KernelSpecName{"writer"}},
+                .target_nodes = core_group_2},
+        };
+    } else {
+        spec.kernels = {reader, writer, compute_1};
+        spec.work_units = std::vector<m2::WorkUnitSpec>{
+            m2::WorkUnitSpec{
+                .name = "g1",
+                .kernels =
+                    {m2::KernelSpecName{"reader"}, m2::KernelSpecName{"compute_1"}, m2::KernelSpecName{"writer"}},
+                .target_nodes = core_group_1},
+        };
+    }
+
+    // ---- ProgramRunArgs (mutable) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    reader_run.common_runtime_arg_values = {
+        {"Mt", Mt},
+        {"Kt", Kt},
+        {"Nt", Nt},
+        {"MtKt", MtKt},
+        {"KtNt", KtNt},
+        {"batch", B},
+        {"bcast_B", static_cast<uint32_t>(bcast_batch)},
+        {"MtNt", MtNt}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+
+    for (uint32_t i = 0, num_tiles_written = 0; i < num_cores; i++) {
+        CoreCoord core = {i / num_cores_y, i % num_cores_y};
+        uint32_t per_core = 0;
+        if (core_group_1.contains(core)) {
+            per_core = num_output_tiles_per_core_group_1;
+        } else if (core_group_2.contains(core)) {
+            per_core = num_output_tiles_per_core_group_2;
+        } else {
+            TT_THROW("Core not in specified core ranges");
+        }
+        reader_run.runtime_arg_values.push_back(
+            {core, {{"output_tile_start_id", num_tiles_written}, {"num_output_tiles", per_core}}});
+        writer_run.runtime_arg_values.push_back({core, {{"num_pages", per_core}, {"start_id", num_tiles_written}}});
+        num_tiles_written += per_core;
+    }
+    run.kernel_run_args = {reader_run, writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"a"}, a_mesh},
+        {m2::TensorParamName{"b"}, b_mesh},
+        {m2::TensorParamName{"out"}, output.mesh_tensor()},
+    };
+
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_program_factory.hpp
@@ -6,16 +6,15 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct MatmulMultiCoreProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const ttnn::prim::MatmulParams& operation_attributes,
         const ttnn::prim::MatmulInputs& tensor_args,
-        std::vector<ttnn::Tensor>& tensor_return_value,
-        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+        std::vector<ttnn::Tensor>& tensor_return_value);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.cpp
@@ -9,6 +9,7 @@
 #include <algorithm>
 #include <map>
 #include <set>
+#include <string>
 #include <utility>
 
 #include "hostdevcommon/common_values.hpp"
@@ -22,17 +23,16 @@
 #include "ttnn/tensor/tensor_utils.hpp"
 #include "ttnn/operations/matmul/shared_with_host/activation_type.hpp"
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
 using namespace tt;
 
 using ttnn::operations::unary::UnaryOpType;
 using ttnn::operations::unary::UnaryWithParam;
 
-using tt::tt_metal::CBDescriptor;
-using tt::tt_metal::CBFormatDescriptor;
-using tt::tt_metal::ComputeConfigDescriptor;
-using tt::tt_metal::DataMovementConfigDescriptor;
-using tt::tt_metal::KernelDescriptor;
-using tt::tt_metal::ProgramDescriptor;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 namespace reuse_batched_hs_dram_sharded_optimized_helpers {
@@ -43,9 +43,25 @@ using dram_sharded_helpers::get_optimal_dram_bank_to_reader_assignment;
 // Batch-sharded DRAM matmul
 // For batched matmul: [1, B, M, K] x [1, B, K, N] = [1, B, M, N]
 // Sharded by batch dimension - each worker handles B/num_workers complete matmuls
-// ProgramDescriptor variant: translates the same logic as create_program_batch_sharded
-// into a lightweight ProgramDescriptor (no Program object created).
-static ProgramDescriptor create_program_batch_sharded_descriptor(
+// Metal 2.0 ProgramSpec variant: translates the same logic as the legacy create_descriptor into
+// a ProgramSpec + ProgramRunArgs.
+//
+// Notes on the structural translation:
+//  - Local CBs (c_0 in0, c_1 in1, c_3 bias, c_4 out, c_5 intermed0) become same-node DFBs. When
+//    interm0_data_format == output_data_format the legacy uses ONE CBDescriptor with two
+//    format_descriptors (c_4 + c_5 over one L1 region); that is expressed as two DFBs sharing
+//    backing memory via advanced_options.alias_with.
+//  - The legacy borrowed CBs c_2 (sharded in0 on input storage cores, backed by in0_tensor) and
+//    c_6 (output reshard on output storage cores, backed by out_tensor) are NOT bound by any
+//    kernel — they were the pre-Metal-2.0 way to reserve the io tensors' L1 on the storage cores.
+//    In Metal 2.0 the io tensors' own buffer reservations cover that, and the kernels obtain the
+//    shard base addresses via the typed `a`/`out` tensor bindings (Case-2 bridge). So c_2/c_6
+//    drop, subsumed by the TensorParameters.
+//  - Raw addresses (in0 shard L1, in1/bias DRAM bank base, out shard L1) flowed through RTAs in
+//    the legacy data-movement kernels; they now flow through the typed tensor channel and the
+//    kernels pull the base via TensorAccessor::get_bank_base_address(), keeping the explicit NoC
+//    walks unchanged (Case-2 portable).
+static ttnn::device_operation::ProgramArtifacts create_program_batch_sharded_spec(
     tt::tt_metal::IDevice* device,
     const CoreRangeSet& input_all_storage_cores,
     const CoreRangeSet& output_all_storage_cores,
@@ -63,10 +79,10 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     uint32_t per_core_M,
     uint32_t per_core_N,
     std::optional<UnaryWithParam> fused_activation,
-    const tt_metal::MeshTensor& in0_tensor,
-    const tt_metal::MeshTensor& in1_tensor,
-    ttsl::optional_reference<const tt_metal::MeshTensor> bias_tensor,
-    const tt_metal::MeshTensor& out_tensor,
+    const ttnn::Tensor& in0_tensor,
+    const ttnn::Tensor& in1_tensor,
+    const std::optional<const ttnn::Tensor>& bias_tensor,
+    const ttnn::Tensor& out_tensor,
     const tt::tt_metal::Tile& in0_tile,
     const tt::tt_metal::Tile& in1_tile,
     const tt::tt_metal::Tile& bias_tile,
@@ -171,27 +187,25 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     uint32_t output_single_tile_size = output_tile.get_tile_size(output_data_format);
     uint32_t interm0_single_tile_size = output_tile.get_tile_size(interm0_data_format);
 
-    // CB sizes
+    // CB / DFB sizes (in tiles; entry_size carries the per-tile byte size)
     uint32_t in0_block_tiles = per_core_M * in0_block_w;
     uint32_t in0_CB_tiles = in0_block_tiles * 2;
-    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
 
     uint32_t in1_block_tiles = in0_block_w * per_core_N;
     uint32_t in1_CB_tiles = in1_block_tiles * 3;
-    uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
 
     uint32_t out_block_tiles = per_core_M * per_core_N;
-    uint32_t interm0_CB_size = out_block_tiles * interm0_single_tile_size;
+    uint32_t interm0_CB_tiles = out_block_tiles;
 
     uint32_t in0_shard_tiles = in0_tensor.shard_spec()->shape[0] / in0_tile.get_tile_shape()[0] *
                                in0_tensor.shard_spec()->shape[1] / in0_tile.get_tile_shape()[1];
     uint32_t in2_CB_size = in0_shard_tiles * in0_single_tile_size;
 
     uint32_t in3_block_tiles = per_core_N;
-    uint32_t in3_CB_size = in3_block_tiles * bias_single_tile_size;
 
     uint32_t out_shard_tiles = out_tensor.shard_spec()->shape[0] / output_tile.get_tile_shape()[0] *
                                out_tensor.shard_spec()->shape[1] / output_tile.get_tile_shape()[1];
+    uint32_t out_reshard_CB_tiles = out_shard_tiles;
     uint32_t out_reshard_CB_size = out_shard_tiles * output_single_tile_size;
 
     // Page sizes for DRAM reads
@@ -209,126 +223,92 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     uint32_t out_batch_stride_bytes = per_core_M * per_core_N * output_single_tile_size;
 
     ////////////////////////////////////////////////////////////////////////////
-    //                      Build CBDescriptors
+    //                      ProgramSpec (immutable)
     ////////////////////////////////////////////////////////////////////////////
-    ProgramDescriptor desc;
+    m2::ProgramSpec spec;
+    spec.name = "matmul_multi_core_reuse_batched_hs_dram_sharded";
 
-    tt::tt_metal::TileDescriptor in0_tile_desc{in0_tile};
-    tt::tt_metal::TileDescriptor in1_tile_desc{in1_tile};
-    tt::tt_metal::TileDescriptor bias_tile_desc{bias_tile};
-    tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
+    const bool has_bias = bias_tensor.has_value();
 
-    // CB 0: in0 (activations) - on all cores in bounding box
-    {
-        CBDescriptor cb_desc;
-        cb_desc.total_size = in0_CB_size;
-        cb_desc.core_ranges = all_cores_in_rect_grid;
-        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = tt::CBIndex::c_0,
-            .data_format = in0_data_format,
-            .page_size = in0_single_tile_size,
-            .tile = in0_tile_desc});
-        desc.cbs.push_back(std::move(cb_desc));
+    // ---- DataflowBufferSpecs (one per legacy local CBDescriptor) ----
+    // c_0: in0 activations (local FIFO on all cores in the bounding box).
+    spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+        .unique_id = m2::DFBSpecName{"in0"},
+        .entry_size = in0_single_tile_size,
+        .num_entries = in0_CB_tiles,
+        .data_format_metadata = in0_data_format,
+        .tile_format_metadata = in0_tile});
+    // c_1: in1 weights (local FIFO).
+    spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+        .unique_id = m2::DFBSpecName{"in1"},
+        .entry_size = in1_single_tile_size,
+        .num_entries = in1_CB_tiles,
+        .data_format_metadata = in1_data_format,
+        .tile_format_metadata = in1_tile});
+    // c_3: bias (local FIFO, only when fused).
+    if (has_bias) {
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"bias"},
+            .entry_size = bias_single_tile_size,
+            .num_entries = in3_block_tiles,
+            .data_format_metadata = bias_data_format,
+            .tile_format_metadata = bias_tile});
     }
-
-    // CB 1: in1 (weights) - on all cores in bounding box
-    {
-        CBDescriptor cb_desc;
-        cb_desc.total_size = in1_CB_size;
-        cb_desc.core_ranges = all_cores_in_rect_grid;
-        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = tt::CBIndex::c_1,
-            .data_format = in1_data_format,
-            .page_size = in1_single_tile_size,
-            .tile = in1_tile_desc});
-        desc.cbs.push_back(std::move(cb_desc));
-    }
-
-    // CB 2: sharded in0 buffer - on INPUT storage cores, backed by in0_buffer
-    {
-        CBDescriptor cb_desc;
-        cb_desc.total_size = in2_CB_size;
-        cb_desc.core_ranges = input_all_storage_cores;
-        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = tt::CBIndex::c_2,
-            .data_format = in0_data_format,
-            .page_size = in0_single_tile_size,
-            .tile = in0_tile_desc});
-        cb_desc.tensor = &in0_tensor;
-        desc.cbs.push_back(std::move(cb_desc));
-    }
-
-    // CB 3: bias (if fused) - on all cores in bounding box
-    if (bias_tensor.has_value()) {
-        CBDescriptor cb_desc;
-        cb_desc.total_size = in3_CB_size;
-        cb_desc.core_ranges = all_cores_in_rect_grid;
-        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = tt::CBIndex::c_3,
-            .data_format = bias_data_format,
-            .page_size = bias_single_tile_size,
-            .tile = bias_tile_desc});
-        desc.cbs.push_back(std::move(cb_desc));
-    }
-
-    // CB 4 & 5: output and intermediate - on worker cores
-    uint32_t output_cb_index = tt::CBIndex::c_4;
-    uint32_t interm0_cb_index = tt::CBIndex::c_5;
+    // c_4 (out) and c_5 (intermed0). Legacy keeps them as a single CB (one CBDescriptor, two
+    // format_descriptors) when the formats match; that aliasing is expressed as two DFBs sharing
+    // backing memory via advanced_options.alias_with. The out DFB sizing matches the legacy
+    // out_reshard_CB_size; intermed0 uses interm0 tiles. (Both share one L1 region in the aliased
+    // case; their entry_size*num_entries must be equal, which holds because the reshard tile count
+    // equals out_block_tiles for this batch-sharded layout.)
     if (interm0_data_format != output_data_format) {
-        // Separate CBs for output and intermediate
-        {
-            CBDescriptor cb_desc;
-            cb_desc.total_size = out_reshard_CB_size;
-            cb_desc.core_ranges = all_worker_cores;
-            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-                .buffer_index = output_cb_index,
-                .data_format = output_data_format,
-                .page_size = output_single_tile_size,
-                .tile = output_tile_desc});
-            desc.cbs.push_back(std::move(cb_desc));
-        }
-        {
-            CBDescriptor cb_desc;
-            cb_desc.total_size = interm0_CB_size;
-            cb_desc.core_ranges = all_worker_cores;
-            cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-                .buffer_index = interm0_cb_index,
-                .data_format = interm0_data_format,
-                .page_size = interm0_single_tile_size,
-                .tile = output_tile_desc});
-            desc.cbs.push_back(std::move(cb_desc));
-        }
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"out"},
+            .entry_size = output_single_tile_size,
+            .num_entries = out_reshard_CB_tiles,
+            .data_format_metadata = output_data_format,
+            .tile_format_metadata = output_tile});
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"intermed0"},
+            .entry_size = interm0_single_tile_size,
+            .num_entries = interm0_CB_tiles,
+            .data_format_metadata = interm0_data_format,
+            .tile_format_metadata = output_tile});
     } else {
-        // Output and intermediate share the same buffer
-        CBDescriptor cb_desc;
-        cb_desc.total_size = out_reshard_CB_size;
-        cb_desc.core_ranges = all_worker_cores;
-        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = output_cb_index,
-            .data_format = output_data_format,
-            .page_size = output_single_tile_size,
-            .tile = output_tile_desc});
-        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = interm0_cb_index,
-            .data_format = interm0_data_format,
-            .page_size = interm0_single_tile_size,
-            .tile = output_tile_desc});
-        desc.cbs.push_back(std::move(cb_desc));
+        m2::DataflowBufferSpec out_dfb{
+            .unique_id = m2::DFBSpecName{"out"},
+            .entry_size = output_single_tile_size,
+            .num_entries = out_reshard_CB_tiles,
+            .data_format_metadata = output_data_format,
+            .tile_format_metadata = output_tile};
+        out_dfb.advanced_options.alias_with = {m2::DFBSpecName{"intermed0"}};
+        // Aliased: out and intermed0 share one L1 region (legacy single CBDescriptor sized to
+        // out_reshard_CB_size). Alias legality requires entry_size*num_entries equal; here
+        // interm0_data_format == output_data_format so the tile sizes match and intermed0 uses
+        // the same out_reshard_CB_tiles count, matching legacy's shared allocation size.
+        m2::DataflowBufferSpec interm_dfb{
+            .unique_id = m2::DFBSpecName{"intermed0"},
+            .entry_size = interm0_single_tile_size,
+            .num_entries = out_reshard_CB_tiles,
+            .data_format_metadata = interm0_data_format,
+            .tile_format_metadata = output_tile};
+        interm_dfb.advanced_options.alias_with = {m2::DFBSpecName{"out"}};
+        spec.dataflow_buffers.push_back(std::move(out_dfb));
+        spec.dataflow_buffers.push_back(std::move(interm_dfb));
     }
 
-    // CB 6: output reshard buffer - on OUTPUT storage cores, backed by out_buffer
-    {
-        CBDescriptor cb_desc;
-        cb_desc.total_size = out_reshard_CB_size;
-        cb_desc.core_ranges = output_all_storage_cores;
-        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = tt::CBIndex::c_6,
-            .data_format = output_data_format,
-            .page_size = output_single_tile_size,
-            .tile = output_tile_desc});
-        cb_desc.tensor = &out_tensor;
-        desc.cbs.push_back(std::move(cb_desc));
+    // ---- TensorParameters (one per distinct accessed tensor) ----
+    // a / out provide the storage-core shard L1 base addresses (Case-2 bridge); b / bias provide
+    // the DRAM-bank base addresses. The legacy borrowed CBs c_2/c_6 are subsumed by `a`/`out`.
+    spec.tensor_parameters.push_back(
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"a"}, .spec = in0_tensor.tensor_spec()});
+    spec.tensor_parameters.push_back(
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"b"}, .spec = in1_tensor.tensor_spec()});
+    if (has_bias) {
+        spec.tensor_parameters.push_back(
+            m2::TensorParameter{.unique_id = m2::TensorParamName{"bias"}, .spec = bias_tensor->tensor_spec()});
     }
+    spec.tensor_parameters.push_back(
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"out"}, .spec = out_tensor.tensor_spec()});
 
     ////////////////////////////////////////////////////////////////////////////
     //                      Kernel defines
@@ -337,7 +317,7 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     std::map<std::string, std::string> reader_defines;
     std::map<std::string, std::string> writer_defines;
 
-    if (bias_tensor.has_value()) {
+    if (has_bias) {
         mm_kernel_defines["FUSE_BIAS"] = "1";
         writer_defines["FUSE_BIAS"] = "1";
     }
@@ -367,179 +347,240 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(
         device->arch(), num_cores, mm_kernel_defines, throttle_level);
 
-    // Helper to convert std::map defines to KernelDescriptor::Defines
-    auto map_to_defines = [](const std::map<std::string, std::string>& m) -> KernelDescriptor::Defines {
-        KernelDescriptor::Defines result;
-        result.reserve(m.size());
+    writer_defines["OUT_SHARDED"] = "1";
+
+    // Helper to convert std::map defines to a Metal 2.0 Defines table.
+    auto map_to_defines = [](const std::map<std::string, std::string>& m) -> m2::KernelSpec::CompilerOptions::Defines {
+        m2::KernelSpec::CompilerOptions::Defines result;
         for (const auto& [k, v] : m) {
-            result.emplace_back(k, v);
+            result.insert({k, v});
         }
         return result;
     };
 
     ////////////////////////////////////////////////////////////////////////////
-    //                      Compile-time args
+    //                      Subblock / compute parameters
     ////////////////////////////////////////////////////////////////////////////
-    std::vector<uint32_t> in0_reader_compile_args = {
-        (uint32_t)in0_block_tiles,
-        (uint32_t)in0_block_tiles * in0_single_tile_size,
-        (uint32_t)num_blocks,
-        (uint32_t)batches_per_core,
-        (uint32_t)in0_batch_stride_bytes,
-        (uint32_t)in2_CB_size,
-    };
-
-    std::vector<uint32_t> in1_writer_compile_args = {
-        (uint32_t)in1_buffer_page_size,
-        (uint32_t)in1_buffer_num_pages,
-        (uint32_t)per_core_N,
-        (uint32_t)in1_block_tiles,
-        (uint32_t)num_blocks,
-        (uint32_t)out_block_tiles,
-        (uint32_t)batches_per_core,
-        (uint32_t)in1_batch_stride_bytes,
-        (uint32_t)out_batch_stride_bytes,
-        (uint32_t)out_reshard_CB_size,
-    };
-    if (bias_tensor.has_value()) {
-        in1_writer_compile_args.push_back(bias_buffer_page_size);
-        in1_writer_compile_args.push_back(bias_buffer_num_pages);
-        in1_writer_compile_args.push_back(in3_block_tiles);
-    }
-
     uint32_t in0_num_subblocks = per_core_M / out_subblock_h;
     uint32_t in1_num_subblocks = per_core_N / out_subblock_w;
     uint32_t in0_subblock_num_tiles = out_subblock_h * in0_block_w;
     uint32_t out_subblock_num_tiles = out_subblock_h * out_subblock_w;
 
-    std::vector<uint32_t> compute_kernel_args = {
-        in0_block_w,
-        in0_num_subblocks,
-        in0_block_tiles,
-        in0_subblock_num_tiles,
-        in1_num_subblocks,
-        in1_block_tiles,
-        per_core_N,
-        num_blocks,
-        1,
-        1,
-        out_subblock_h,
-        out_subblock_w,
-        out_subblock_num_tiles,
-        batches_per_core,
-        out_block_tiles,
-        untilize_out ? 1u : 0u,
-        0u,
-        0u,
-    };
-    if (bias_tensor.has_value()) {
-        compute_kernel_args.push_back(1u);  // row_broadcast_bias: DRAM sharded always uses row broadcast
-    }
-
     ////////////////////////////////////////////////////////////////////////////
-    //                      Build Kernel Descriptors
+    //                      Build KernelSpecs
     ////////////////////////////////////////////////////////////////////////////
     tt_metal::NOC in0_noc = tt::tt_metal::detail::preferred_noc_for_dram_write(device->arch());
 
-    writer_defines["OUT_SHARDED"] = "1";
-
     // in0 reader kernel
-    KernelDescriptor in0_reader_kernel_desc;
-    in0_reader_kernel_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
-        "reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp";
-    in0_reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    in0_reader_kernel_desc.core_ranges = all_cores_in_rect_grid;
-    in0_reader_kernel_desc.compile_time_args = in0_reader_compile_args;
-    in0_reader_kernel_desc.defines = map_to_defines(reader_defines);
-    in0_reader_kernel_desc.named_compile_time_args = {
-        {"cb_in0", tt::CBIndex::c_0},
+    m2::KernelSpec in0_reader{
+        .unique_id = m2::KernelSpecName{"in0_reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                                        "reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp"},
+        .compiler_options = {.defines = map_to_defines(reader_defines)},
+        .compile_time_args =
+            {{"in0_block_num_tiles", in0_block_tiles},
+             {"in0_block_size_bytes", in0_block_tiles * in0_single_tile_size},
+             {"num_blocks", num_blocks},
+             {"num_batches_per_core", batches_per_core},
+             {"in0_tensor_stride_batch_bytes", in0_batch_stride_bytes},
+             {"in0_shard_size_bytes", in2_CB_size}},
+        .runtime_arg_schema = {.runtime_arg_names = {"worker_core_type", "input_storage_noc_x", "input_storage_noc_y"}},
+        .hw_config =
+            m2::DataMovementHardwareConfig{
+                .gen1_config =
+                    m2::DataMovementHardwareConfig::Gen1Config{
+                        .processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc}},
     };
-    in0_reader_kernel_desc.config =
-        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_1, .noc = in0_noc};
+    in0_reader.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{"in0"},
+        .accessor_name = "cb_in0",
+        .endpoint_type = m2::DFBEndpointType::PRODUCER});
+    in0_reader.tensor_bindings.push_back(
+        m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"a"}, .accessor_name = "a"});
 
-    // in1 writer kernel
-    KernelDescriptor in1_writer_kernel_desc;
-    in1_writer_kernel_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
-        "reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp";
-    in1_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    in1_writer_kernel_desc.core_ranges = all_cores_in_rect_grid;
-    in1_writer_kernel_desc.compile_time_args = in1_writer_compile_args;
-    in1_writer_kernel_desc.defines = map_to_defines(writer_defines);
-    in1_writer_kernel_desc.named_compile_time_args = {
-        {"cb_in1", tt::CBIndex::c_1},
-        {"cb_bias", tt::CBIndex::c_3},
-        {"cb_out", tt::CBIndex::c_4},
+    // in1 reader / output writer kernel
+    m2::KernelSpec::CompilerOptions::Defines writer_defines_table = map_to_defines(writer_defines);
+    m2::KernelSpec in1_writer{
+        .unique_id = m2::KernelSpecName{"in1_writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                                        "reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp"},
+        .compiler_options = {.defines = writer_defines_table},
+        .runtime_arg_schema =
+            {.runtime_arg_names =
+                 {"is_worker_core", "dram_bank_id", "vc", "output_storage_noc_x", "output_storage_noc_y"}},
+        .hw_config =
+            m2::DataMovementHardwareConfig{
+                .gen1_config =
+                    m2::DataMovementHardwareConfig::Gen1Config{
+                        .processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc}},
     };
-    in1_writer_kernel_desc.config =
-        DataMovementConfigDescriptor{.processor = tt_metal::DataMovementProcessor::RISCV_0, .noc = in1_noc};
-
-    // compute kernel
-    KernelDescriptor compute_kernel_desc;
-    compute_kernel_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp";
-    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_kernel_desc.core_ranges = all_cores_in_rect_grid;
-    compute_kernel_desc.compile_time_args = compute_kernel_args;
-    compute_kernel_desc.defines = map_to_defines(mm_kernel_defines);
     {
-        KernelDescriptor::NamedCompileTimeArgs named_compile_args = {
-            {"cb_in0", tt::CBIndex::c_0},
-            {"cb_in1", tt::CBIndex::c_1},
-            {"cb_bias", tt::CBIndex::c_3},
-            {"cb_out", tt::CBIndex::c_4},
-            {"cb_intermed0", tt::CBIndex::c_5},
-            {"cb_in0_intermediate", tt::CBIndex::c_8},
-            {"cb_in1_intermediate", tt::CBIndex::c_9},
-            {"cb_in0_transposed", tt::CBIndex::c_10},
-            {"bias_ntiles", per_core_N},
-            // This factory does not pad per_core_N_compute beyond per_core_N_in1_sender, so the
-            // last subblock is always fully valid. Pass out_subblock_w so the compute kernel takes
-            // its original full-width path (last_subblock_padded == false).
-            {"last_subblock_w_valid", out_subblock_w},
-        };
-        if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
-            using ttnn::operations::matmul::utilities::get_activation_params;
-            const auto params = get_activation_params(fused_activation.value());
-            named_compile_args.push_back({"activation_type", static_cast<uint32_t>(params.type)});
-            named_compile_args.push_back({"activation_param0", params.param0});
-            named_compile_args.push_back({"activation_param1", params.param1});
-            named_compile_args.push_back({"activation_param2", params.param2});
+        m2::KernelSpec::CompileTimeArgs writer_cta = {
+            {"in1_page_size", in1_buffer_page_size},
+            {"in1_num_pages", in1_buffer_num_pages},
+            {"in1_block_w", per_core_N},
+            {"in1_block_num_tiles", in1_block_tiles},
+            {"num_blocks", num_blocks},
+            {"out_block_num_tiles", out_block_tiles},
+            {"num_batches_per_core", batches_per_core},
+            {"in1_tensor_stride_batch_bytes", in1_batch_stride_bytes},
+            {"out_tensor_stride_batch_bytes", out_batch_stride_bytes},
+            {"out_shard_size_bytes", out_reshard_CB_size}};
+        if (has_bias) {
+            writer_cta.insert({"in3_page_size", bias_buffer_page_size});
+            writer_cta.insert({"in3_num_pages", bias_buffer_num_pages});
+            writer_cta.insert({"in3_block_tiles", in3_block_tiles});
         }
-        compute_kernel_desc.named_compile_time_args = std::move(named_compile_args);
+        in1_writer.compile_time_args = std::move(writer_cta);
     }
-    compute_kernel_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = math_fidelity,
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .dst_full_sync_en = dst_full_sync_en,
-        .math_approx_mode = math_approx_mode};
+    in1_writer.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{"in1"},
+        .accessor_name = "cb_in1",
+        .endpoint_type = m2::DFBEndpointType::PRODUCER});
+    in1_writer.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{"out"},
+        .accessor_name = "cb_out",
+        .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    if (has_bias) {
+        in1_writer.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"bias"},
+            .accessor_name = "cb_bias",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER});
+    }
+    in1_writer.tensor_bindings.push_back(
+        m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"b"}, .accessor_name = "b"});
+    if (has_bias) {
+        in1_writer.tensor_bindings.push_back(
+            m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"bias"}, .accessor_name = "bias"});
+    }
+    in1_writer.tensor_bindings.push_back(
+        m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"out"}, .accessor_name = "out"});
+
+    // compute kernel (forked Metal 2.0 source). CTA layout matches the legacy positional emission
+    // order; num_blocks_w_dim and num_blocks_h_dim are both 1, batch is batches_per_core, and the
+    // in0-transpose / get-batch-from-reader paths are off for this batch-sharded factory.
+    const char* COMPUTE_SRC =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_m2.cpp";
+    m2::KernelSpec::CompileTimeArgs compute_cta = {
+        {"in0_block_w", in0_block_w},
+        {"in0_num_subblocks", in0_num_subblocks},
+        {"in0_block_num_tiles", in0_block_tiles},
+        {"in0_subblock_num_tiles", in0_subblock_num_tiles},
+        {"in1_num_subblocks", in1_num_subblocks},
+        {"in1_block_num_tiles", in1_block_tiles},
+        {"in1_block_w", per_core_N},
+        {"num_blocks_inner_dim", num_blocks},
+        {"num_blocks_w_dim", 1},
+        {"num_blocks_h_dim", 1},
+        {"out_subblock_h", out_subblock_h},
+        {"out_subblock_w", out_subblock_w},
+        {"out_subblock_num_tiles", out_subblock_num_tiles},
+        {"batch", batches_per_core},
+        {"out_block_num_tiles", out_block_tiles},
+        {"untilize_out", untilize_out ? 1u : 0u},
+        {"get_batch_from_reader", 0u},
+        {"in0_transpose_tile", 0u},
+        // bias_ntiles / last_subblock_w_valid are named CTAs read by the compute kernel; this
+        // factory does not pad per_core_N beyond per_core_N (last subblock always fully valid),
+        // so last_subblock_w_valid == out_subblock_w (kernel takes its full-width path).
+        {"bias_ntiles", per_core_N},
+        {"last_subblock_w_valid", out_subblock_w}};
+    if (has_bias) {
+        // row_broadcast_bias: DRAM sharded always uses row broadcast.
+        compute_cta.insert({"row_broadcast_bias", 1u});
+    }
+    if (fused_activation.has_value() && fused_activation.value().op_type != UnaryOpType::RELU) {
+        using ttnn::operations::matmul::utilities::get_activation_params;
+        const auto params = get_activation_params(fused_activation.value());
+        compute_cta.insert({"activation_type", static_cast<uint32_t>(params.type)});
+        compute_cta.insert({"activation_param0", params.param0});
+        compute_cta.insert({"activation_param1", params.param1});
+        compute_cta.insert({"activation_param2", params.param2});
+    }
+
+    m2::KernelSpec compute{
+        .unique_id = m2::KernelSpecName{"compute"},
+        .source = std::filesystem::path{COMPUTE_SRC},
+        .compiler_options = {.defines = map_to_defines(mm_kernel_defines)},
+        .compile_time_args = std::move(compute_cta),
+        .runtime_arg_schema = {.runtime_arg_names = {"is_worker_core"}},
+        .hw_config =
+            m2::ComputeHardwareConfig{
+                .math_fidelity = math_fidelity,
+                .fp32_dest_acc_en = fp32_dest_acc_en,
+                .dst_full_sync_en = dst_full_sync_en,
+                .math_approx_mode = math_approx_mode},
+    };
+    compute.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{"in0"},
+        .accessor_name = "cb_in0",
+        .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    compute.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{"in1"},
+        .accessor_name = "cb_in1",
+        .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    compute.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{"out"},
+        .accessor_name = "cb_out",
+        .endpoint_type = m2::DFBEndpointType::PRODUCER});
+    // intermed0: PRODUCER + CONSUMER on compute (the kernel spills partials and reloads them — a
+    // real self-loop).
+    compute.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{"intermed0"},
+        .accessor_name = "cb_intermed0",
+        .endpoint_type = m2::DFBEndpointType::PRODUCER});
+    compute.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{"intermed0"},
+        .accessor_name = "cb_intermed0",
+        .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    if (has_bias) {
+        compute.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"bias"},
+            .accessor_name = "cb_bias",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    }
+
+    // ---- Kernels + WorkUnitSpec ----
+    // All three kernels run on the full bounding box (workers + idle storage cores). Idle cores
+    // supply only worker_core_type/is_worker_core == 0 and return early. The local DFBs require
+    // their producer & consumer KernelSpecs to share the same WorkUnitSpec, so there is one
+    // WorkUnitSpec hosting in0_reader + in1_writer + compute on all_cores_in_rect_grid.
+    spec.kernels = {in0_reader, in1_writer, compute};
+    spec.work_units = std::vector<m2::WorkUnitSpec>{m2::WorkUnitSpec{
+        .name = "wu",
+        .kernels = {m2::KernelSpecName{"in0_reader"}, m2::KernelSpecName{"in1_writer"}, m2::KernelSpecName{"compute"}},
+        .target_nodes = all_cores_in_rect_grid}};
 
     ////////////////////////////////////////////////////////////////////////////
-    //                      Runtime Args (per-core loop)
+    //                      ProgramRunArgs (mutable)
     ////////////////////////////////////////////////////////////////////////////
     std::vector<CoreCoord> all_cores_in_rect_grid_vec = corerange_to_cores(all_cores_in_rect_grid);
     std::set<CoreCoord> worker_cores_set(all_worker_cores_ordered.begin(), all_worker_cores_ordered.end());
 
-    std::vector<uint32_t> bank_ids;
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs in0_reader_run{.kernel = m2::KernelSpecName{"in0_reader"}};
+    m2::KernelRunArgs in1_writer_run{.kernel = m2::KernelSpecName{"in1_writer"}};
+    m2::KernelRunArgs compute_run{.kernel = m2::KernelSpecName{"compute"}};
 
-    // Idle cores in the bounding box
+    // Idle cores in the bounding box: worker_core_type / is_worker_core == 0, dummy values for the
+    // remaining named args (the kernels return early before reading them).
     for (const auto& core : all_cores_in_rect_grid_vec) {
-        bool is_worker = worker_cores_set.contains(core);
-
-        if (!is_worker) {
-            std::vector<uint32_t> in0_idle_args = {0u};
-            in0_reader_kernel_desc.runtime_args.emplace_back(core, in0_idle_args);
-
-            std::vector<uint32_t> in1_idle_args = {0u};
-            in1_writer_kernel_desc.runtime_args.emplace_back(core, in1_idle_args);
-
-            std::vector<uint32_t> compute_idle_args = {0u};
-            compute_kernel_desc.runtime_args.emplace_back(core, compute_idle_args);
+        if (!worker_cores_set.contains(core)) {
+            in0_reader_run.runtime_arg_values.push_back(
+                {core, {{"worker_core_type", 0u}, {"input_storage_noc_x", 0u}, {"input_storage_noc_y", 0u}}});
+            in1_writer_run.runtime_arg_values.push_back(
+                {core,
+                 {{"is_worker_core", 0u},
+                  {"dram_bank_id", 0u},
+                  {"vc", 0u},
+                  {"output_storage_noc_x", 0u},
+                  {"output_storage_noc_y", 0u}}});
+            compute_run.runtime_arg_values.push_back({core, {{"is_worker_core", 0u}}});
         }
     }
 
     // Worker cores
+    std::vector<uint32_t> bank_ids;
     for (uint32_t worker_idx = 0; worker_idx < all_worker_cores_ordered.size(); ++worker_idx) {
         auto core = all_worker_cores_ordered[worker_idx];
 
@@ -554,62 +595,52 @@ static ProgramDescriptor create_program_batch_sharded_descriptor(
             }
         }
 
-        // in0 reader runtime args
-        KernelDescriptor::RTArgList in0_reader_args;
-        in0_reader_args.push_back(uint32_t{1u});
-        in0_reader_args.push_back(uint32_t{input_storage_noc_x[worker_idx]});
-        in0_reader_args.push_back(uint32_t{input_storage_noc_y[worker_idx]});
-        in0_reader_args.push_back(in0_tensor);
-        in0_reader_kernel_desc.emplace_runtime_args(core, in0_reader_args);
-
-        // in1 writer runtime args
-        KernelDescriptor::RTArgList in1_writer_args;
-        in1_writer_args.push_back(uint32_t{1u});
-        in1_writer_args.push_back(in1_tensor);
-        if (bias_tensor.has_value()) {
-            in1_writer_args.push_back(*bias_tensor);
-        } else {
-            in1_writer_args.push_back(uint32_t{0u});
-        }
-        in1_writer_args.push_back(uint32_t{bank_id});
-        in1_writer_args.push_back(uint32_t{vc});
-        in1_writer_args.push_back(uint32_t{output_storage_noc_x[worker_idx]});
-        in1_writer_args.push_back(uint32_t{output_storage_noc_y[worker_idx]});
-        in1_writer_args.push_back(out_tensor);
-        in1_writer_kernel_desc.emplace_runtime_args(core, in1_writer_args);
-
-        // Compute runtime args
-        std::vector<uint32_t> compute_runtime_args = {
-            1u,
-        };
-        compute_kernel_desc.runtime_args.emplace_back(core, compute_runtime_args);
+        in0_reader_run.runtime_arg_values.push_back(
+            {core,
+             {{"worker_core_type", 1u},
+              {"input_storage_noc_x", input_storage_noc_x[worker_idx]},
+              {"input_storage_noc_y", input_storage_noc_y[worker_idx]}}});
+        in1_writer_run.runtime_arg_values.push_back(
+            {core,
+             {{"is_worker_core", 1u},
+              {"dram_bank_id", bank_id},
+              {"vc", vc},
+              {"output_storage_noc_x", output_storage_noc_x[worker_idx]},
+              {"output_storage_noc_y", output_storage_noc_y[worker_idx]}}});
+        compute_run.runtime_arg_values.push_back({core, {{"is_worker_core", 1u}}});
     }
 
-    // Push all kernel descriptors
-    desc.kernels.push_back(std::move(in0_reader_kernel_desc));
-    desc.kernels.push_back(std::move(in1_writer_kernel_desc));
-    desc.kernels.push_back(std::move(compute_kernel_desc));
+    run.kernel_run_args = {in0_reader_run, in1_writer_run, compute_run};
+    run.tensor_args.insert({m2::TensorParamName{"a"}, in0_tensor.mesh_tensor()});
+    run.tensor_args.insert({m2::TensorParamName{"b"}, in1_tensor.mesh_tensor()});
+    if (has_bias) {
+        run.tensor_args.insert({m2::TensorParamName{"bias"}, bias_tensor->mesh_tensor()});
+    }
+    run.tensor_args.insert({m2::TensorParamName{"out"}, out_tensor.mesh_tensor()});
 
-    return desc;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace reuse_batched_hs_dram_sharded_optimized_helpers
 
-ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create_program_spec(
     const ttnn::prim::MatmulParams& operation_attributes,
     const ttnn::prim::MatmulInputs& tensor_args,
-    std::vector<ttnn::Tensor>& tensor_return_value,
-    const std::optional<CoreRangeSet>& /*core_range_set*/) {
+    std::vector<ttnn::Tensor>& tensor_return_value) {
     const auto& input_tensors = tensor_args.input_tensors;
     const auto& optional_input_tensors = tensor_args.optional_input_tensors;
-    const auto& output_tensors = tensor_return_value;
+    auto& output_tensors = tensor_return_value;
 
-    const auto& a = input_tensors.at(0).mesh_tensor();
-    const auto& b = input_tensors.at(1).mesh_tensor();
-    auto bias = tt::tt_metal::as_optional_mesh_tensor(optional_input_tensors.at(0));
-    const auto& output = output_tensors.at(0).mesh_tensor();
-    const auto& ashape = a.padded_shape();
-    const auto& bshape = b.padded_shape();
+    const auto& a = input_tensors.at(0);
+    const auto& b = input_tensors.at(1);
+    std::optional<const ttnn::Tensor> bias =
+        optional_input_tensors.empty() ? std::nullopt : optional_input_tensors.at(0);
+    const auto& output = output_tensors.at(0);
+    const auto& a_mesh = a.mesh_tensor();
+    const auto& b_mesh = b.mesh_tensor();
+    [[maybe_unused]] const auto& out_mesh = output.mesh_tensor();
+    const auto& ashape = a_mesh.padded_shape();
+    const auto& bshape = b_mesh.padded_shape();
     auto in0_tile = a.tensor_spec().tile();
     auto in1_tile = b.tensor_spec().tile();
     auto in0_tile_shape = in0_tile.get_tile_shape();
@@ -623,12 +654,12 @@ ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create
 
     tt::DataFormat bias_data_format = tt::DataFormat::Bfp8_b;
     if (bias.has_value()) {
-        const auto& c = bias.value();
-        TT_FATAL(&a.device() == &c.device(), "Operands to matmul need to be on the same device!");
-        bias_data_format = tt_metal::datatype_to_dataformat_converter(c.dtype());
+        const auto& c = bias.value().mesh_tensor();
+        TT_FATAL(&a_mesh.device() == &c.device(), "Operands to matmul need to be on the same device!");
+        bias_data_format = tt_metal::datatype_to_dataformat_converter(bias.value().dtype());
     }
 
-    tt::tt_metal::IDevice* device = &a.mutable_device();
+    tt::tt_metal::IDevice* device = &a_mesh.mutable_device();
 
     TT_FATAL(
         a.shard_spec().has_value() && output.shard_spec().has_value(), "Both input A and output must have shard specs");
@@ -639,14 +670,14 @@ ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create
     uint32_t in1_single_tile_size = in1_tile.get_tile_size(tt_metal::datatype_to_dataformat_converter(b.dtype()));
 
     TT_FATAL(
-        a.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
+        a_mesh.mesh_buffer().device_local_size() % in0_single_tile_size == 0,
         "Input A buffer size ({}) must be divisible by single tile size ({})",
-        a.mesh_buffer().device_local_size(),
+        a_mesh.mesh_buffer().device_local_size(),
         in0_single_tile_size);
     TT_FATAL(
-        b.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
+        b_mesh.mesh_buffer().device_local_size() % in1_single_tile_size == 0,
         "Input B buffer size ({}) must be divisible by single tile size ({})",
-        b.mesh_buffer().device_local_size(),
+        b_mesh.mesh_buffer().device_local_size(),
         in1_single_tile_size);
 
     TT_FATAL(
@@ -681,7 +712,7 @@ ProgramDescriptor MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create
     TT_FATAL(per_core_N == N, "For batch sharding, per_core_N ({}) must equal N ({})", per_core_N, N);
     TT_FATAL(K % in0_block_w == 0, "K ({}) must be divisible by in0_block_w ({})", K, in0_block_w);
 
-    return reuse_batched_hs_dram_sharded_optimized_helpers::create_program_batch_sharded_descriptor(
+    return reuse_batched_hs_dram_sharded_optimized_helpers::create_program_batch_sharded_spec(
         device,
         input_all_cores_storage,
         output_all_cores_storage,

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_batched_hs_dram_sharded_program_factory.hpp
@@ -6,16 +6,15 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const ttnn::prim::MatmulParams& operation_attributes,
         const ttnn::prim::MatmulInputs& tensor_args,
-        std::vector<ttnn::Tensor>& tensor_return_value,
-        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+        std::vector<ttnn::Tensor>& tensor_return_value);
 };
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.cpp
@@ -6,7 +6,6 @@
 #include <tt-metalium/tt_metal.hpp>
 #include <tt-metalium/host_api.hpp>
 #include <tt-metalium/work_split.hpp>
-#include <tt-metalium/tensor_accessor_args.hpp>
 #include "ttnn/operations/matmul/device/utilities/matmul_utilities.hpp"
 
 #include <map>
@@ -15,15 +14,13 @@
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include "ttnn/tensor/shape/shape.hpp"
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
 using namespace tt;
-using tt::tt_metal::CBDescriptor;
-using tt::tt_metal::CBFormatDescriptor;
-using tt::tt_metal::ComputeConfigDescriptor;
-using tt::tt_metal::KernelDescriptor;
-using tt::tt_metal::ProgramDescriptor;
-using tt::tt_metal::ReaderConfigDescriptor;
 using tt::tt_metal::Tensor;
-using tt::tt_metal::WriterConfigDescriptor;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace ttnn::prim {
 
@@ -32,12 +29,12 @@ CoreRangeSet MatmulMultiCoreReuseOptimizedProgramFactory::default_core_range(IDe
     return CoreRangeSet({CoreRange({0, 0}, {grid_size.x - 1, grid_size.y - 1})});
 }
 
-tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::create_descriptor(
+ttnn::device_operation::ProgramArtifacts MatmulMultiCoreReuseOptimizedProgramFactory::create_program_spec(
     const ttnn::prim::MatmulParams& operation_attributes,
     const ttnn::prim::MatmulInputs& tensor_args,
-    std::vector<ttnn::Tensor>& tensor_return_value,
-    const std::optional<CoreRangeSet>& core_range_set) {
-    TT_FATAL(operation_attributes.program_config.has_value(), "program_config must be provided for create_descriptor");
+    std::vector<ttnn::Tensor>& tensor_return_value) {
+    TT_FATAL(
+        operation_attributes.program_config.has_value(), "program_config must be provided for create_program_spec");
     const auto& program_config =
         std::get<operations::matmul::MatmulMultiCoreReuseProgramConfig>(operation_attributes.program_config.value());
 
@@ -47,7 +44,8 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
 
     const auto& a = tensor_args.input_tensors.at(0);
     const auto& b = tensor_args.input_tensors.at(1);
-    const auto& output = tensor_return_value.at(0).mesh_tensor();
+    auto& output_tensor = tensor_return_value.at(0);
+    const auto& output = output_tensor.mesh_tensor();
 
     bool bcast_batch = operation_attributes.bcast_batch.value();
     bool transpose_a = operation_attributes.transpose_a;
@@ -135,7 +133,6 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     } else {
         in0_CB_tiles *= 2;
     }
-    uint32_t in0_CB_size = in0_CB_tiles * in0_single_tile_size;
     uint32_t in1_block_num_tiles = per_core_N * in0_block_w;
     uint32_t in1_CB_tiles = in1_block_num_tiles;
     if (in1_is_sharded) {
@@ -143,11 +140,8 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     } else {
         in1_CB_tiles *= 2;
     }
-    uint32_t in1_CB_size = in1_CB_tiles * in1_single_tile_size;
     uint32_t out_block_tiles = per_core_M * per_core_N;
     uint32_t out_CB_tiles = out_block_tiles;
-    uint32_t out_CB_size = out_CB_tiles * output_single_tile_size;
-    uint32_t interm0_CB_size = out_CB_tiles * interm0_single_tile_size;
 
     // Compute kernel args
     uint32_t in0_num_subblocks = (per_core_M_per_batch / out_subblock_h);
@@ -177,17 +171,6 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         num_cores = all_cores.num_cores();
         core_group_1 = all_cores;
         num_blocks_per_core_group_1 = num_output_blocks_total / num_cores * batch_scale_factor;
-    } else if (core_range_set.has_value()) {
-        std::tie(
-            num_cores,
-            all_cores,
-            core_group_1,
-            core_group_2,
-            num_blocks_per_core_group_1,
-            num_blocks_per_core_group_2) =
-            tt::tt_metal::split_work_to_cores(core_range_set.value(), num_output_blocks_total);
-        num_blocks_per_core_group_1 *= batch_scale_factor;
-        num_blocks_per_core_group_2 *= batch_scale_factor;
     } else {
         if (!program_config.allowed_worker_cores.has_value()) {
             log_warning(
@@ -232,109 +215,237 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     const auto in1_tensor_stride_h = transpose_b ? 1 : N;
     const auto in1_tensor_next_block_stride = in0_block_w * in1_tensor_stride_h;
 
-    // Compile time args for reader
-    std::vector<uint32_t> reader_compile_time_args = {
-        (std::uint32_t)in0_tensor_stride_w,
-        (std::uint32_t)in0_tensor_stride_h,
-        (std::uint32_t)in0_tensor_next_block_stride,
-        (std::uint32_t)in0_block_w,
-        (std::uint32_t)per_core_M_per_batch,
-        (std::uint32_t)in0_block_num_tiles,
-        (std::uint32_t)in0_last_ktile_w,
-        (std::uint32_t)in0_last_ktile_h,
-        (std::uint32_t)num_blocks,
-        (std::uint32_t)bcast_batch,
-        (std::uint32_t)M * K,
-    };
-    tt::tt_metal::TensorAccessorArgs(in0_buffer).append_to(reader_compile_time_args);
-
-    // Compile time args for reader/writer
-    std::vector<uint32_t> reader_writer_compile_time_args = {
-        (std::uint32_t)in1_tensor_stride_w,
-        (std::uint32_t)in1_tensor_stride_h,
-        (std::uint32_t)in1_tensor_next_block_stride,
-        (std::uint32_t)per_core_N,
-        (std::uint32_t)in0_block_w,
-        (std::uint32_t)in1_block_num_tiles,
-        (std::uint32_t)num_blocks,
-        (std::uint32_t)bcast_batch,
-        (std::uint32_t)K * N,
-        (std::uint32_t)1,
-        (std::uint32_t)N,
-        (std::uint32_t)out_subblock_w,
-        (std::uint32_t)out_subblock_h * N,
-        (std::uint32_t)out_subblock_w,
-        (std::uint32_t)out_subblock_h,
-        (std::uint32_t)(out_subblock_w * out_subblock_h),
-        (std::uint32_t)out_num_subblocks_w,
-        (std::uint32_t)out_num_subblocks_h,
-        (std::uint32_t)M * N,
-    };
-    tt::tt_metal::TensorAccessorArgs(in1_buffer).append_to(reader_writer_compile_time_args);
-    tt::tt_metal::TensorAccessorArgs(output).append_to(reader_writer_compile_time_args);
-
-    // Reader defines
-    KernelDescriptor::Defines reader_defines;
-    KernelDescriptor::Defines reader_writer_defines;
-    if (in0_is_sharded) {
-        reader_defines.emplace_back("IN0_SHARDED", "1");
-    }
-    if (in1_is_sharded) {
-        reader_writer_defines.emplace_back("IN1_SHARDED", "1");
-    }
-    if (output_is_sharded) {
-        reader_writer_defines.emplace_back("OUT_SHARDED", "1");
-    }
-
     // Blackhole intermediate CB read workaround
     bool in0_needs_intermediate_cb_read = false;
     bool in1_needs_intermediate_cb_read = false;
     if (device->arch() == tt::ARCH::BLACKHOLE) {
         in0_needs_intermediate_cb_read = ((in0_single_tile_size % 64) != 0);
-        if (in0_needs_intermediate_cb_read) {
-            reader_defines.emplace_back("INTERMEDIATE_CB_READ", "1");
-        }
         in1_needs_intermediate_cb_read = ((in1_single_tile_size % 64) != 0);
-        if (in1_needs_intermediate_cb_read) {
-            reader_writer_defines.emplace_back("INTERMEDIATE_CB_READ", "1");
-        }
     }
 
-    // Named compile-time args for CB indices (enables fusion/chaining)
-    KernelDescriptor::NamedCompileTimeArgs cb_named_args = {
-        {"cb_in0", tt::CBIndex::c_0},
-        {"cb_in1", tt::CBIndex::c_1},
-        {"cb_bias", tt::CBIndex::c_3},
-        {"cb_out", tt::CBIndex::c_4},
-        {"cb_intermed0", tt::CBIndex::c_5},
-        {"cb_in0_intermediate", tt::CBIndex::c_8},
-        {"cb_in1_intermediate", tt::CBIndex::c_9},
-        {"cb_in0_transposed", tt::CBIndex::c_10},
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ProgramSpec (immutable)
+    ////////////////////////////////////////////////////////////////////////////
+    m2::ProgramSpec spec;
+    spec.name = "matmul_multi_core_reuse_optimized";
+
+    // ---- DataflowBufferSpecs (one per legacy CBDescriptor) ----
+    // Sharded input/output CBs borrow their backing L1 from the corresponding io tensor
+    // (legacy CBDescriptor::tensor = &buffer); model as borrowed-memory DFBs.
+    spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+        .unique_id = m2::DFBSpecName{"in0"},
+        .entry_size = in0_single_tile_size,
+        .num_entries = in0_CB_tiles,
+        .data_format_metadata = in0_data_format,
+        .tile_format_metadata = in0_tile,
+        .borrowed_from = in0_is_sharded ? std::optional<m2::TensorParamName>{m2::TensorParamName{"a"}} : std::nullopt});
+    spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+        .unique_id = m2::DFBSpecName{"in1"},
+        .entry_size = in1_single_tile_size,
+        .num_entries = in1_CB_tiles,
+        .data_format_metadata = in1_data_format,
+        .tile_format_metadata = in1_tile,
+        .borrowed_from = in1_is_sharded ? std::optional<m2::TensorParamName>{m2::TensorParamName{"b"}} : std::nullopt});
+
+    // CB 4 and CB 5: Output and intermediate accumulator. Legacy keeps them as a single CB
+    // (one CBDescriptor, two format_descriptors) when the formats match; that aliasing is
+    // expressed as two DFBs sharing backing memory via advanced_options.alias_with.
+    const bool separate_out_interm =
+        (interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1));
+    if (separate_out_interm) {
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"out"},
+            .entry_size = output_single_tile_size,
+            .num_entries = out_CB_tiles,
+            .data_format_metadata = output_data_format,
+            .tile_format_metadata = output_tile,
+            .borrowed_from =
+                output_is_sharded ? std::optional<m2::TensorParamName>{m2::TensorParamName{"out"}} : std::nullopt});
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"intermed0"},
+            .entry_size = interm0_single_tile_size,
+            .num_entries = out_CB_tiles,
+            .data_format_metadata = interm0_data_format,
+            .tile_format_metadata = output_tile});
+    } else {
+        // Shared output+intermediate region: two aliased DFBs over one L1 allocation. The
+        // borrowed-memory consistency rule requires aliased members to agree on borrowed_from, so
+        // when the output is sharded the intermediate alias borrows from the same TensorParameter.
+        std::optional<m2::TensorParamName> out_borrow =
+            output_is_sharded ? std::optional<m2::TensorParamName>{m2::TensorParamName{"out"}} : std::nullopt;
+        m2::DataflowBufferSpec out_dfb{
+            .unique_id = m2::DFBSpecName{"out"},
+            .entry_size = output_single_tile_size,
+            .num_entries = out_CB_tiles,
+            .data_format_metadata = output_data_format,
+            .tile_format_metadata = output_tile,
+            .borrowed_from = out_borrow};
+        out_dfb.advanced_options.alias_with = {m2::DFBSpecName{"intermed0"}};
+        m2::DataflowBufferSpec interm_dfb{
+            .unique_id = m2::DFBSpecName{"intermed0"},
+            .entry_size = interm0_single_tile_size,
+            .num_entries = out_CB_tiles,
+            .data_format_metadata = interm0_data_format,
+            .tile_format_metadata = output_tile,
+            .borrowed_from = out_borrow};
+        interm_dfb.advanced_options.alias_with = {m2::DFBSpecName{"out"}};
+        spec.dataflow_buffers.push_back(std::move(out_dfb));
+        spec.dataflow_buffers.push_back(std::move(interm_dfb));
+    }
+
+    // Optional CBs for Blackhole intermediate reads
+    if (in1_needs_intermediate_cb_read) {
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"in1_intermediate"},
+            .entry_size = in1_single_tile_size,
+            .num_entries = 1,
+            .data_format_metadata = in1_data_format,
+            .tile_format_metadata = in1_tile});
+    }
+    if (in0_needs_intermediate_cb_read) {
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"in0_intermediate"},
+            .entry_size = in0_single_tile_size,
+            .num_entries = 1,
+            .data_format_metadata = in0_data_format,
+            .tile_format_metadata = in0_tile});
+    }
+    // Optional transpose CB
+    if (in0_transpose_tile) {
+        spec.dataflow_buffers.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"in0_transposed"},
+            .entry_size = in0_single_tile_size,
+            .num_entries = in0_CB_tiles,
+            .data_format_metadata = in0_data_format,
+            .tile_format_metadata = in0_tile});
+    }
+
+    // ---- TensorParameters (one per distinct accessed tensor) ----
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"a"}, .spec = a.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"b"}, .spec = b.tensor_spec()},
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"out"}, .spec = output_tensor.tensor_spec()},
     };
 
-    // Compute kernel compile time args (group 1)
-    std::vector<uint32_t> compute_kernel_args_group_1 = {
-        in0_block_w,
-        in0_num_subblocks,
-        in0_block_num_tiles,
-        in0_subblock_num_tiles,
-        in1_num_subblocks,
-        in1_block_num_tiles,
-        in1_per_core_w,
-        num_blocks,
-        1,  // out_num_blocks_x
-        1,  // out_num_blocks_y
-        out_subblock_h,
-        out_subblock_w,
-        out_subblock_num_tiles,
-        num_blocks_per_core_group_1,
-        out_block_tiles,
-        untilize_out,
-        false,  // get_batch_from_reader
-        in0_transpose_tile,
+    // ---- Reader kernel (in0) ----
+    m2::KernelSpec::CompilerOptions::Defines reader_defines;
+    if (in0_is_sharded) {
+        reader_defines.insert({"IN0_SHARDED", "1"});
+    }
+    if (in0_needs_intermediate_cb_read) {
+        reader_defines.insert({"INTERMEDIATE_CB_READ", "1"});
+    }
+    m2::KernelSpec reader{
+        .unique_id = m2::KernelSpecName{"reader"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                                        "reader_bmm_tile_layout_in0.cpp"},
+        .compiler_options = {.defines = reader_defines},
+        .compile_time_args =
+            {{"in0_tensor_stride_w", static_cast<uint32_t>(in0_tensor_stride_w)},
+             {"in0_tensor_stride_h", static_cast<uint32_t>(in0_tensor_stride_h)},
+             {"in0_tensor_next_block_stride", static_cast<uint32_t>(in0_tensor_next_block_stride)},
+             {"in0_block_w", in0_block_w},
+             {"in0_block_h", per_core_M_per_batch},
+             {"in0_block_num_tiles", in0_block_num_tiles},
+             {"last_ktile_w", static_cast<uint32_t>(in0_last_ktile_w)},
+             {"last_ktile_h", static_cast<uint32_t>(in0_last_ktile_h)},
+             {"num_blocks", num_blocks},
+             {"bcast_B", static_cast<uint32_t>(bcast_batch)},
+             {"MtKt", M * K}},
+        .runtime_arg_schema = {.runtime_arg_names = {"in0_tensor_start_tile_id", "batch"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::READER},
     };
+    // in0 DFB binding: PRODUCER (reader fills it). Bind tensor `a` only on the non-sharded
+    // (NoC-read) path — when sharded, the in0 DFB borrows tensor `a`'s memory directly.
+    reader.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{"in0"},
+        .accessor_name = "cb_in0",
+        .endpoint_type = m2::DFBEndpointType::PRODUCER});
+    if (!in0_is_sharded) {
+        reader.tensor_bindings.push_back(
+            m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"a"}, .accessor_name = "a"});
+    }
+    if (in0_needs_intermediate_cb_read) {
+        // Helper CB used as a real producer/consumer FIFO inside the reader (reserve/push then
+        // wait/pop), so it self-loops on this kernel.
+        reader.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in0_intermediate"},
+            .accessor_name = "cb_in0_intermediate",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER});
+        reader.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in0_intermediate"},
+            .accessor_name = "cb_in0_intermediate",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    }
 
-    // Compute defines
+    // ---- Reader/Writer kernel (reads in1, writes output) ----
+    m2::KernelSpec::CompilerOptions::Defines rw_defines;
+    if (in1_is_sharded) {
+        rw_defines.insert({"IN1_SHARDED", "1"});
+    }
+    if (output_is_sharded) {
+        rw_defines.insert({"OUT_SHARDED", "1"});
+    }
+    if (in1_needs_intermediate_cb_read) {
+        rw_defines.insert({"INTERMEDIATE_CB_READ", "1"});
+    }
+    m2::KernelSpec reader_writer{
+        .unique_id = m2::KernelSpecName{"reader_writer"},
+        .source = std::filesystem::path{"ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/"
+                                        "reader_writer_bmm_tile_layout_in1.cpp"},
+        .compiler_options = {.defines = rw_defines},
+        .compile_time_args =
+            {{"in1_tensor_stride_w", static_cast<uint32_t>(in1_tensor_stride_w)},
+             {"in1_tensor_stride_h", static_cast<uint32_t>(in1_tensor_stride_h)},
+             {"in1_tensor_next_block_stride", static_cast<uint32_t>(in1_tensor_next_block_stride)},
+             {"in1_block_w", per_core_N},
+             {"in1_block_h", in0_block_w},
+             {"in1_block_num_tiles", in1_block_num_tiles},
+             {"num_blocks", num_blocks},
+             {"bcast_B", static_cast<uint32_t>(bcast_batch)},
+             {"KtNt", K * N},
+             {"out_tensor_stride_w", 1},
+             {"out_tensor_stride_h", N},
+             {"out_tensor_next_subblock_stride_w", out_subblock_w},
+             {"out_tensor_next_subblock_stride_h", out_subblock_h * N},
+             {"out_subblock_w", out_subblock_w},
+             {"out_subblock_h", out_subblock_h},
+             {"out_subblock_tile_count", out_subblock_w * out_subblock_h},
+             {"out_num_subblocks_w", out_num_subblocks_w},
+             {"out_num_subblocks_h", out_num_subblocks_h},
+             {"MtNt", M * N}},
+        .runtime_arg_schema = {.runtime_arg_names = {"in1_tensor_start_tile_id", "batch", "out_tensor_start_tile_id"}},
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+    // in1 DFB: PRODUCER (reader fills it); out DFB: CONSUMER (writer drains it).
+    reader_writer.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{"in1"},
+        .accessor_name = "cb_in1",
+        .endpoint_type = m2::DFBEndpointType::PRODUCER});
+    reader_writer.dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{"out"},
+        .accessor_name = "cb_out",
+        .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    if (!in1_is_sharded) {
+        reader_writer.tensor_bindings.push_back(
+            m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"b"}, .accessor_name = "b"});
+    }
+    if (!output_is_sharded) {
+        reader_writer.tensor_bindings.push_back(
+            m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{"out"}, .accessor_name = "out"});
+    }
+    if (in1_needs_intermediate_cb_read) {
+        reader_writer.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in1_intermediate"},
+            .accessor_name = "cb_in1_intermediate",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER});
+        reader_writer.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in1_intermediate"},
+            .accessor_name = "cb_in1_intermediate",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    }
+
+    // ---- Compute kernel(s) (one KernelSpec per core group) ----
     std::map<std::string, std::string> mm_kernel_defines;
     if (packer_l1_acc_en) {
         mm_kernel_defines["PACKER_L1_ACC"] = "1";
@@ -350,9 +461,131 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         device->arch(), num_cores, mm_kernel_defines);
     ttnn::operations::compute_throttle_utils::throttle_mm_perf(
         device->arch(), num_cores, mm_kernel_defines, throttle_level);
-    KernelDescriptor::Defines compute_defines{mm_kernel_defines.begin(), mm_kernel_defines.end()};
+    m2::KernelSpec::CompilerOptions::Defines compute_defines;
+    for (const auto& [k, v] : mm_kernel_defines) {
+        compute_defines.insert({k, v});
+    }
+    // cb_in0_transposed is bound only on the in0-transpose path; gate the kernel-side handle
+    // on a matching define so its dfb:: token isn't name-looked-up in the non-transpose build.
+    if (in0_transpose_tile) {
+        compute_defines.insert({"IN0_TRANSPOSE_TILE_CB", "1"});
+    }
 
-    // Build per-core runtime args
+    const char* COMPUTE_SRC =
+        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_m2.cpp";
+    auto make_compute = [&](const std::string& id, uint32_t num_blocks_per_core_group) {
+        m2::KernelSpec compute{
+            .unique_id = m2::KernelSpecName{id},
+            .source = std::filesystem::path{COMPUTE_SRC},
+            .compiler_options = {.defines = compute_defines},
+            // Compute CTA layout matches the legacy positional emission order; here num_blocks_w_dim
+            // and num_blocks_h_dim are both 1, batch is the per-group output-block count, and
+            // out_block_num_tiles is out_block_tiles.
+            .compile_time_args =
+                {{"in0_block_w", in0_block_w},
+                 {"in0_num_subblocks", in0_num_subblocks},
+                 {"in0_block_num_tiles", in0_block_num_tiles},
+                 {"in0_subblock_num_tiles", in0_subblock_num_tiles},
+                 {"in1_num_subblocks", in1_num_subblocks},
+                 {"in1_block_num_tiles", in1_block_num_tiles},
+                 {"in1_block_w", in1_per_core_w},
+                 {"num_blocks_inner_dim", num_blocks},
+                 {"num_blocks_w_dim", 1},
+                 {"num_blocks_h_dim", 1},
+                 {"out_subblock_h", out_subblock_h},
+                 {"out_subblock_w", out_subblock_w},
+                 {"out_subblock_num_tiles", out_subblock_num_tiles},
+                 {"batch", num_blocks_per_core_group},
+                 {"out_block_num_tiles", out_block_tiles},
+                 {"untilize_out", static_cast<uint32_t>(untilize_out)},
+                 {"get_batch_from_reader", 0},
+                 {"in0_transpose_tile", static_cast<uint32_t>(in0_transpose_tile)}},
+            .hw_config =
+                m2::ComputeHardwareConfig{
+                    .math_fidelity = math_fidelity,
+                    .fp32_dest_acc_en = fp32_dest_acc_en,
+                    .dst_full_sync_en = dst_full_sync_en,
+                    .math_approx_mode = math_approx_mode},
+        };
+        // in0 / in1: CONSUMER; out + intermed0: PRODUCER (intermed0 also CONSUMER — the kernel
+        // spills partials into it and reloads them, a real self-loop). cb_in0_transposed
+        // self-loops on the compute kernel (reads cb_in0, transposes, writes cb_in0_transposed,
+        // then reads it back as matmul input).
+        compute.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in0"},
+            .accessor_name = "cb_in0",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+        compute.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"in1"},
+            .accessor_name = "cb_in1",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+        compute.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"out"},
+            .accessor_name = "cb_out",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER});
+        compute.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"intermed0"},
+            .accessor_name = "cb_intermed0",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER});
+        compute.dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{"intermed0"},
+            .accessor_name = "cb_intermed0",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+        if (in0_transpose_tile) {
+            compute.dfb_bindings.push_back(m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"in0_transposed"},
+                .accessor_name = "cb_in0_transposed",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER});
+            compute.dfb_bindings.push_back(m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{"in0_transposed"},
+                .accessor_name = "cb_in0_transposed",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER});
+        }
+        return compute;
+    };
+    m2::KernelSpec compute_1 = make_compute("compute_1", num_blocks_per_core_group_1);
+
+    // ---- Kernels + WorkUnitSpecs ----
+    // Local DFBs require producer and consumer KernelSpecs to share the same WorkUnitSpec(s):
+    // every node hosting a DFB must host both endpoints. Each core group becomes one
+    // WorkUnitSpec containing reader + reader_writer + compute_<group> (reader/reader_writer are
+    // shared across both groups; the per-group compute differs only in its batch CTA).
+    const bool has_group_2 = !core_group_2.ranges().empty();
+    if (has_group_2) {
+        m2::KernelSpec compute_2 = make_compute("compute_2", num_blocks_per_core_group_2);
+        spec.kernels = {reader, reader_writer, compute_1, compute_2};
+        spec.work_units = std::vector<m2::WorkUnitSpec>{
+            m2::WorkUnitSpec{
+                .name = "g1",
+                .kernels =
+                    {m2::KernelSpecName{"reader"},
+                     m2::KernelSpecName{"reader_writer"},
+                     m2::KernelSpecName{"compute_1"}},
+                .target_nodes = core_group_1},
+            m2::WorkUnitSpec{
+                .name = "g2",
+                .kernels =
+                    {m2::KernelSpecName{"reader"},
+                     m2::KernelSpecName{"reader_writer"},
+                     m2::KernelSpecName{"compute_2"}},
+                .target_nodes = core_group_2},
+        };
+    } else {
+        spec.kernels = {reader, reader_writer, compute_1};
+        spec.work_units = std::vector<m2::WorkUnitSpec>{
+            m2::WorkUnitSpec{
+                .name = "g1",
+                .kernels =
+                    {m2::KernelSpecName{"reader"},
+                     m2::KernelSpecName{"reader_writer"},
+                     m2::KernelSpecName{"compute_1"}},
+                .target_nodes = core_group_1},
+        };
+    }
+
+    ////////////////////////////////////////////////////////////////////////////
+    //                      ProgramRunArgs (mutable)
+    ////////////////////////////////////////////////////////////////////////////
     bool row_major = false;
     if (shard_spec.has_value()) {
         row_major = shard_spec.value().orientation == tt::tt_metal::ShardOrientation::ROW_MAJOR;
@@ -367,36 +600,9 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
     uint32_t in0_m_block_stride = per_core_M_per_batch * (transpose_a ? 1 : K);
     uint32_t in1_n_block_stride = per_core_N * (transpose_b ? K : 1);
 
-    ////////////////////////////////////////////////////////////////////////////
-    //                      Build ProgramDescriptor
-    ////////////////////////////////////////////////////////////////////////////
-    ProgramDescriptor program_descriptor;
-
-    // Reader kernel descriptor (created before loop so emplace_runtime_args can be called in loop)
-    KernelDescriptor reader_kernel_desc;
-    reader_kernel_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp";
-    reader_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_kernel_desc.core_ranges = all_cores;
-    reader_kernel_desc.compile_time_args = reader_compile_time_args;
-    reader_kernel_desc.named_compile_time_args = cb_named_args;
-    reader_kernel_desc.defines = reader_defines;
-    reader_kernel_desc.config = ReaderConfigDescriptor{};
-
-    // Reader/Writer kernel descriptor (reads in1, writes output)
-    KernelDescriptor reader_writer_kernel_desc;
-    reader_writer_kernel_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp";
-    reader_writer_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader_writer_kernel_desc.core_ranges = all_cores;
-    reader_writer_kernel_desc.compile_time_args = reader_writer_compile_time_args;
-    reader_writer_kernel_desc.named_compile_time_args = cb_named_args;
-    reader_writer_kernel_desc.defines = reader_writer_defines;
-    reader_writer_kernel_desc.config = WriterConfigDescriptor{};
-
-    KernelDescriptor::RuntimeArgs compute_runtime_args_g1;
-    KernelDescriptor::RuntimeArgs compute_runtime_args_g2;
-    compute_runtime_args_g1.reserve(g1_numcores);
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader_run{.kernel = m2::KernelSpecName{"reader"}};
+    m2::KernelRunArgs reader_writer_run{.kernel = m2::KernelSpecName{"reader_writer"}};
 
     for (uint32_t i = 0, num_blocks_written = 0; i < cores.size(); ++i) {
         const CoreCoord& core = cores[i];
@@ -411,173 +617,29 @@ tt::tt_metal::ProgramDescriptor MatmulMultiCoreReuseOptimizedProgramFactory::cre
         uint32_t in0_start_tile_id = (start_batch * in0_batch_stride) + (start_m_block * in0_m_block_stride);
         uint32_t in1_start_tile_id =
             (bcast_batch ? 0 : (start_batch * in1_batch_stride)) + (start_n_block * in1_n_block_stride);
-
-        reader_kernel_desc.emplace_runtime_args(core, {in0_buffer, in0_start_tile_id, num_output_blocks_per_core});
-
         uint32_t out_start_tile_id =
             (start_batch * M * N) + (start_m_block * per_core_M_per_batch * N) + (start_n_block * per_core_N);
-        reader_writer_kernel_desc.emplace_runtime_args(
-            core, {in1_buffer, in1_start_tile_id, num_output_blocks_per_core, output, out_start_tile_id});
 
-        // Compute kernels have no per-core runtime args
-        if (i < g1_numcores) {
-            compute_runtime_args_g1.emplace_back(core, std::vector<uint32_t>{});
-        } else {
-            compute_runtime_args_g2.emplace_back(core, std::vector<uint32_t>{});
-        }
+        // The reader/reader-writer kernels iterate their "batch" loop num_output_blocks_per_core
+        // times (the legacy reader's RTA #2), one per output block this core handles.
+        reader_run.runtime_arg_values.push_back(
+            {core, {{"in0_tensor_start_tile_id", in0_start_tile_id}, {"batch", num_output_blocks_per_core}}});
+        reader_writer_run.runtime_arg_values.push_back(
+            {core,
+             {{"in1_tensor_start_tile_id", in1_start_tile_id},
+              {"batch", num_output_blocks_per_core},
+              {"out_tensor_start_tile_id", out_start_tile_id}}});
 
         num_blocks_written += num_output_blocks_per_core;
     }
-
-    program_descriptor.kernels.push_back(std::move(reader_kernel_desc));
-    program_descriptor.kernels.push_back(std::move(reader_writer_kernel_desc));
-
-    // Compute kernel descriptor (core group 1)
-    KernelDescriptor compute_kernel_desc;
-    compute_kernel_desc.kernel_source =
-        "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp";
-    compute_kernel_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_kernel_desc.core_ranges = core_group_1;
-    compute_kernel_desc.compile_time_args = compute_kernel_args_group_1;
-    compute_kernel_desc.named_compile_time_args = cb_named_args;
-    compute_kernel_desc.defines = compute_defines;
-    compute_kernel_desc.runtime_args = std::move(compute_runtime_args_g1);
-    compute_kernel_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = math_fidelity,
-        .fp32_dest_acc_en = fp32_dest_acc_en,
-        .dst_full_sync_en = dst_full_sync_en,
-        .math_approx_mode = math_approx_mode};
-    program_descriptor.kernels.push_back(std::move(compute_kernel_desc));
-
-    // Core group 2 compute kernel (if needed)
-    if (!core_group_2.ranges().empty()) {
-        std::vector<uint32_t> compute_kernel_args_group_2 = {
-            in0_block_w,
-            in0_num_subblocks,
-            in0_block_num_tiles,
-            in0_subblock_num_tiles,
-            in1_num_subblocks,
-            in1_block_num_tiles,
-            in1_per_core_w,
-            num_blocks,
-            1,  // out_num_blocks_x
-            1,  // out_num_blocks_y
-            out_subblock_h,
-            out_subblock_w,
-            out_subblock_num_tiles,
-            num_blocks_per_core_group_2,
-            out_block_tiles,
-            untilize_out,
-            false,  // get_batch_from_reader
-            in0_transpose_tile,
-        };
-
-        KernelDescriptor compute_kernel_desc_g2;
-        compute_kernel_desc_g2.kernel_source =
-            "ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/"
-            "bmm_large_block_zm_fused_bias_activation.cpp";
-        compute_kernel_desc_g2.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        compute_kernel_desc_g2.core_ranges = core_group_2;
-        compute_kernel_desc_g2.compile_time_args = compute_kernel_args_group_2;
-        compute_kernel_desc_g2.named_compile_time_args = cb_named_args;
-        compute_kernel_desc_g2.defines = compute_defines;
-        compute_kernel_desc_g2.runtime_args = std::move(compute_runtime_args_g2);
-        compute_kernel_desc_g2.config = ComputeConfigDescriptor{
-            .math_fidelity = math_fidelity,
-            .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = dst_full_sync_en,
-            .math_approx_mode = math_approx_mode};
-        program_descriptor.kernels.push_back(std::move(compute_kernel_desc_g2));
-    }
-
-    ////////////////////////////////////////////////////////////////////////////
-    //                      Build CBDescriptors
-    ////////////////////////////////////////////////////////////////////////////
-    auto make_cb_descriptor = [&all_cores](
-                                  uint32_t total_size,
-                                  uint8_t buffer_index,
-                                  tt::DataFormat data_format,
-                                  uint32_t page_size,
-                                  const tt::tt_metal::Tile& tile,
-                                  const tt_metal::MeshTensor* tensor = nullptr) {
-        CBDescriptor cb_desc;
-        cb_desc.total_size = total_size;
-        cb_desc.core_ranges = all_cores;
-        tt::tt_metal::TileDescriptor tile_desc{tile};
-        cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = buffer_index, .data_format = data_format, .page_size = page_size, .tile = tile_desc});
-        cb_desc.tensor = tensor;
-        return cb_desc;
+    run.kernel_run_args = {reader_run, reader_writer_run};
+    run.tensor_args = {
+        {m2::TensorParamName{"a"}, in0_buffer},
+        {m2::TensorParamName{"b"}, in1_buffer},
+        {m2::TensorParamName{"out"}, output},
     };
 
-    // CB 0: Input A
-    program_descriptor.cbs.push_back(make_cb_descriptor(
-        in0_CB_size,
-        tt::CBIndex::c_0,
-        in0_data_format,
-        in0_single_tile_size,
-        in0_tile,
-        in0_is_sharded ? &in0_buffer : nullptr));
-
-    // CB 1: Input B
-    program_descriptor.cbs.push_back(make_cb_descriptor(
-        in1_CB_size,
-        tt::CBIndex::c_1,
-        in1_data_format,
-        in1_single_tile_size,
-        in1_tile,
-        in1_is_sharded ? &in1_buffer : nullptr));
-
-    // CB 4 and CB 5: Output and intermediate accumulator
-    if ((interm0_data_format != output_data_format) || (untilize_out && (in1_num_subblocks > 1))) {
-        // Separate output and intermediate CBs
-        program_descriptor.cbs.push_back(make_cb_descriptor(
-
-            out_CB_size,
-            tt::CBIndex::c_4,
-            output_data_format,
-            output_single_tile_size,
-            output_tile,
-            output_is_sharded ? &output : nullptr));
-        program_descriptor.cbs.push_back(make_cb_descriptor(
-            interm0_CB_size, tt::CBIndex::c_5, interm0_data_format, interm0_single_tile_size, output_tile));
-    } else {
-        // Shared output+intermediate CB
-        CBDescriptor output_cb_desc;
-        output_cb_desc.total_size = out_CB_size;
-        output_cb_desc.core_ranges = all_cores;
-        tt::tt_metal::TileDescriptor output_tile_desc{output_tile};
-        output_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = tt::CBIndex::c_4,
-            .data_format = output_data_format,
-            .page_size = output_single_tile_size,
-            .tile = output_tile_desc});
-        output_cb_desc.format_descriptors.push_back(CBFormatDescriptor{
-            .buffer_index = tt::CBIndex::c_5,
-            .data_format = interm0_data_format,
-            .page_size = interm0_single_tile_size,
-            .tile = output_tile_desc});
-        output_cb_desc.tensor = output_is_sharded ? &output : nullptr;
-        program_descriptor.cbs.push_back(std::move(output_cb_desc));
-    }
-
-    // Optional CBs for Blackhole intermediate reads
-    if (in1_needs_intermediate_cb_read) {
-        program_descriptor.cbs.push_back(make_cb_descriptor(
-            in1_single_tile_size, tt::CBIndex::c_9, in1_data_format, in1_single_tile_size, in1_tile));
-    }
-    if (in0_needs_intermediate_cb_read) {
-        program_descriptor.cbs.push_back(make_cb_descriptor(
-            in0_single_tile_size, tt::CBIndex::c_8, in0_data_format, in0_single_tile_size, in0_tile));
-    }
-
-    // Optional transpose CB
-    if (in0_transpose_tile) {
-        program_descriptor.cbs.push_back(
-            make_cb_descriptor(in0_CB_size, tt::CBIndex::c_10, in0_data_format, in0_single_tile_size, in0_tile));
-    }
-
-    return program_descriptor;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/factory/matmul_multicore_reuse_optimized_program_factory.hpp
@@ -5,16 +5,15 @@
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/operations/matmul/device/matmul_device_operation_types.hpp"
-#include <tt-metalium/program_descriptors.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::prim {
 
 struct MatmulMultiCoreReuseOptimizedProgramFactory {
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
+    static ttnn::device_operation::ProgramArtifacts create_program_spec(
         const ttnn::prim::MatmulParams& operation_attributes,
         const ttnn::prim::MatmulInputs& tensor_args,
-        std::vector<ttnn::Tensor>& tensor_return_value,
-        const std::optional<CoreRangeSet>& core_range_set = std::nullopt);
+        std::vector<ttnn::Tensor>& tensor_return_value);
 
     static CoreRangeSet default_core_range(IDevice* device);
 };

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_m2.cpp
@@ -4,13 +4,14 @@
 
 // Metal 2.0 fork of bmm_large_block_zm_fused_bias_activation.cpp. Forked (not edited in
 // place) because the original is shared by 6 matmul factories (mcast_1d, mcast_2d, two
-// DRAM-sharded variants, sparse, and this reuse-optimized factory) plus a deepseek FFN
-// kernel; only the MatmulMultiCoreReuseOptimized factory's compute kernel moves to the
-// Metal 2.0 named-binding form. Logic, #ifdefs, and loop bounds are identical to the
-// original; only the access mechanism changes: named CB indices
-// (get_named_compile_time_arg_val("cb_*")) -> dfb::* handles, positional CTAs ->
-// get_arg(args::*). The conditionally-bound in0-transpose CB is gated on the
-// IN0_TRANSPOSE_TILE_CB define the factory emits alongside the binding.
+// DRAM-sharded variants, sparse, and the reuse-optimized factory) plus a deepseek FFN
+// kernel. This Metal 2.0 fork is bound by the Metal-2.0-ported matmul factories:
+// MatmulMultiCoreReuseOptimized and MatmulMultiCoreReuseBatchedHSDRAMSharded (the latter
+// defines MATMUL_DRAM_SHARDED, which selects the worker-core RTA gate below). Logic,
+// #ifdefs, and loop bounds are identical to the original; only the access mechanism
+// changes: named CB indices (get_named_compile_time_arg_val("cb_*")) -> dfb::* handles,
+// positional CT/RT args -> get_arg(args::*). The conditionally-bound in0-transpose CB is
+// gated on the IN0_TRANSPOSE_TILE_CB define the factory emits alongside the binding.
 
 #include <cstdint>
 
@@ -160,7 +161,7 @@ inline void reblock_and_untilize(
 void kernel_main() {
 // RUNTIME ARGS
 #ifdef MATMUL_DRAM_SHARDED
-    const bool is_worker_core = get_arg_val<uint32_t>(0) == 1;
+    const bool is_worker_core = get_arg(args::is_worker_core) == 1;
     // if not worker core, skip
     if (not is_worker_core) {
         return;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation_m2.cpp
@@ -1,0 +1,607 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of bmm_large_block_zm_fused_bias_activation.cpp. Forked (not edited in
+// place) because the original is shared by 6 matmul factories (mcast_1d, mcast_2d, two
+// DRAM-sharded variants, sparse, and this reuse-optimized factory) plus a deepseek FFN
+// kernel; only the MatmulMultiCoreReuseOptimized factory's compute kernel moves to the
+// Metal 2.0 named-binding form. Logic, #ifdefs, and loop bounds are identical to the
+// original; only the access mechanism changes: named CB indices
+// (get_named_compile_time_arg_val("cb_*")) -> dfb::* handles, positional CTAs ->
+// get_arg(args::*). The conditionally-bound in0-transpose CB is gated on the
+// IN0_TRANSPOSE_TILE_CB define the factory emits alongside the binding.
+
+#include <cstdint>
+
+#include "api/compute/matmul.h"
+#include "api/compute/pack_untilize.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/transpose_wh.h"
+#include "api/dataflow/circular_buffer.h"
+#include "internal/mod_div_lib.h"
+#include "experimental/kernel_args.h"
+
+#ifdef FUSE_BIAS
+#include "api/compute/bcast.h"
+#endif
+
+#include "api/compute/eltwise_binary.h"
+#ifdef SFPU_ACTIVATION
+#include "bmm_fused_activation.hpp"
+#endif
+
+// Please update
+// tests/tt_metal/tt_metal/perf_microbenchmark/1_compute_mm/kernels/bmm_large_block_zm_fused_bias_activation_copy.cpp
+// when making any changes to this file.
+// Have to keep a copy because cannot import ttnn into tests/tt_metal.
+// With FUSE_BIAS: row_broadcast_bias (row-broadcast vs elementwise add_tiles) is compile-time arg 18 here;
+// the perf copy uses index 14 (different compile-time arg layout).
+
+/**
+ * @brief Transposes a block of tiles from one circular buffer to another.
+ *
+ * This function reads a block of tiles from the input circular buffer (cb), performs a width-height
+ * (WH) transpose on each tile, and writes the transposed tiles to the output circular buffer.
+ * The operation is performed in blocks of `block_size` tiles for efficiency, with a separate loop
+ * at the end to handle any leftover tiles when the total tile count is not divisible by
+ * `block_size`. The default block size is 4, since there are guaranteed to be 4 tiles in the dst
+ *               regs irrespective of dst sync mode or data format.
+ *
+ * @tparam in0_block_num_tiles The number of tiles in the block to be transposed.
+ * @tparam block_size The number of tiles in each block to be transposed.
+ * @param in0_transpose_cb_id Circular buffer ID to read the original tiles from.
+ * @param in0_cb_id Circular buffer ID to which the transposed tiles are written.
+ */
+template <uint32_t in0_block_num_tiles, uint32_t block_size = 4>
+FORCE_INLINE void transpose_tile_block(uint32_t in0_transpose_cb_id, uint32_t in0_cb_id) {
+    CircularBuffer in0_transpose_cb(in0_transpose_cb_id);
+    CircularBuffer in0_cb(in0_cb_id);
+    constexpr uint32_t num_blocks = in0_block_num_tiles / block_size;
+    constexpr uint32_t last_block_size = in0_block_num_tiles % block_size;
+    // Lets do 2 passes: One loop until last and one last for the left overs
+    for (uint32_t block_idx = 0; block_idx < num_blocks; ++block_idx) {
+        in0_transpose_cb.wait_front(block_size);
+        tile_regs_acquire();
+        for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
+            transpose_wh_tile(in0_transpose_cb_id, tile_idx, tile_idx);
+        }
+        tile_regs_commit();
+        in0_transpose_cb.pop_front(block_size);
+
+        in0_cb.reserve_back(block_size);
+        tile_regs_wait();
+        for (uint32_t tile_idx = 0; tile_idx < block_size; tile_idx++) {
+            pack_tile(tile_idx, in0_cb_id);
+        }
+        tile_regs_release();
+        in0_cb.push_back(block_size);
+    }
+
+    if constexpr (last_block_size > 0) {
+        in0_transpose_cb.wait_front(last_block_size);
+        tile_regs_acquire();
+        for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
+            transpose_wh_tile(in0_transpose_cb_id, tile_idx, tile_idx);
+        }
+        tile_regs_commit();
+        in0_transpose_cb.pop_front(last_block_size);
+
+        in0_cb.reserve_back(last_block_size);
+        tile_regs_wait();
+        for (uint32_t tile_idx = 0; tile_idx < last_block_size; tile_idx++) {
+            pack_tile(tile_idx, in0_cb_id);
+        }
+        tile_regs_release();
+        in0_cb.push_back(last_block_size);
+    }
+}
+
+FORCE_INLINE void reload_from_cb_to_dst(
+    uint32_t in0_cb_id,
+    uint32_t in1_cb_id,
+    uint32_t mm_partials_cb_id,
+    bool in1_transpose_tile,
+    uint32_t out_subblock_num_tiles,
+    uint32_t out_subblock_w,
+    uint32_t out_subblock_h,
+    uint32_t in0_block_w) {
+    CircularBuffer mm_partials_cb(mm_partials_cb_id);
+    // Reconfigure input
+    copy_tile_to_dst_init_short_with_dt(in1_cb_id, mm_partials_cb_id);
+    mm_partials_cb.wait_front(out_subblock_num_tiles);
+
+    uint32_t start_dst_index = 0;
+    uint32_t start_tile_index = 0;
+    copy_block_matmul_partials(mm_partials_cb_id, start_tile_index, start_dst_index, out_subblock_num_tiles);
+
+    mm_partials_cb.pop_front(out_subblock_num_tiles);
+    // Reconfigure srcA back
+    mm_block_init_short_with_dt(
+        in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+}
+
+template <uint32_t out_subblock_w, uint32_t out_block_w>
+inline void reblock_and_untilize(
+    uint32_t num_out_subblocks_in_col,
+    uint32_t out_subblock_num_tiles,
+    uint32_t out_subblock_h,
+    uint32_t interm_cb_id,
+    uint32_t out_cb_id) {
+    CircularBuffer interm_cb(interm_cb_id);
+    CircularBuffer out_cb(out_cb_id);
+    uint32_t num_tiles_in_row_of_subblocks = mulsi3(out_subblock_num_tiles, num_out_subblocks_in_col);
+    interm_cb.wait_front(num_tiles_in_row_of_subblocks);
+
+    uint32_t within_block_index = 0;
+    for (uint32_t h = 0; h < out_subblock_h; h++) {
+        uint32_t block_offset = 0;
+
+        out_cb.reserve_back(out_block_w);
+        for (uint32_t n = 0; n < num_out_subblocks_in_col; n++) {
+            tile_regs_acquire();
+            for (uint32_t w = 0; w < out_subblock_w; w++) {
+                uint32_t tile_index = block_offset + within_block_index + w;
+                copy_tile(interm_cb_id, tile_index, w);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            pack_untilize_dest<out_subblock_w, out_block_w>(out_cb_id, 1, n);
+            tile_regs_release();
+            block_offset += out_subblock_num_tiles;
+        }
+        out_cb.push_back(out_block_w);
+
+        within_block_index += out_subblock_w;
+    }
+    interm_cb.pop_front(num_tiles_in_row_of_subblocks);
+}
+
+void kernel_main() {
+// RUNTIME ARGS
+#ifdef MATMUL_DRAM_SHARDED
+    const bool is_worker_core = get_arg_val<uint32_t>(0) == 1;
+    // if not worker core, skip
+    if (not is_worker_core) {
+        return;
+    }
+#endif
+
+    constexpr uint32_t in0_block_w = get_arg(args::in0_block_w);  // inner block size in tiles
+    constexpr uint32_t in0_num_subblocks =
+        get_arg(args::in0_num_subblocks);  // outer row block size (in inner row blocks)
+    constexpr uint32_t in0_block_num_tiles =
+        get_arg(args::in0_block_num_tiles);  // out_subblock_h*in0_block_w*in0_num_subblocks;
+    constexpr uint32_t in0_subblock_num_tiles = get_arg(args::in0_subblock_num_tiles);  // out_subblock_h*in0_block_w
+    constexpr uint32_t in1_num_subblocks =
+        get_arg(args::in1_num_subblocks);  // outer column block size (in inner column blocks)
+    constexpr uint32_t in1_block_num_tiles =
+        get_arg(args::in1_block_num_tiles);                       // out_subblock_w*in0_block_w* in1_num_subblocks;
+    constexpr uint32_t in1_block_w = get_arg(args::in1_block_w);  // out_subblock_w*in1_num_subblocks
+    constexpr uint32_t num_blocks_inner_dim =
+        get_arg(args::num_blocks_inner_dim);                                // outer inner dim (in inner dim blocks)
+    constexpr uint32_t num_blocks_w_dim = get_arg(args::num_blocks_w_dim);  // outer inner dim (in inner dim blocks)
+    constexpr uint32_t num_blocks_h_dim = get_arg(args::num_blocks_h_dim);  // outer inner dim (in inner dim blocks)
+    constexpr uint32_t out_subblock_h = get_arg(args::out_subblock_h);      // inner row block size in tiles
+    constexpr uint32_t out_subblock_w = get_arg(args::out_subblock_w);      // inner column block size in tiles
+    constexpr uint32_t out_subblock_num_tiles =
+        get_arg(args::out_subblock_num_tiles);                                    // out_subblock_h * out_subblock_w;
+    constexpr uint32_t batch = get_arg(args::batch);                              // batch dim
+    constexpr uint32_t out_block_num_tiles = get_arg(args::out_block_num_tiles);  // number of tiles in out_block
+    constexpr bool untilize_out = get_arg(args::untilize_out);                    // untilize output
+    // This boolean is set when the number of batches is only known at runtime, typically based on a sparsity tensor.
+    constexpr bool get_batch_from_reader = (bool)get_arg(args::get_batch_from_reader);
+    constexpr bool in0_transpose_tile = (bool)get_arg(args::in0_transpose_tile);
+
+    constexpr uint32_t out_block_w = out_subblock_w * in1_num_subblocks;
+
+    // When in0 needs to be transposed, the original data is read from cb_in0 (in0_transpose_cb_id),
+    // transposed, and the result is written to cb_in0_transposed (in0_cb_id), which is then used
+    // as input for the matmul call. cb_in0_transposed is bound by the factory only on the transpose
+    // path, so its dfb:: handle is gated on the matching IN0_TRANSPOSE_TILE_CB define.
+#ifdef IN0_TRANSPOSE_TILE_CB
+    constexpr uint32_t in0_cb_id = dfb::cb_in0_transposed;
+#else
+    constexpr uint32_t in0_cb_id = dfb::cb_in0;
+#endif
+    constexpr uint32_t in1_cb_id = dfb::cb_in1;
+    constexpr uint32_t out_cb_id = dfb::cb_out;
+    constexpr uint32_t mm_partials_cb_id = dfb::cb_intermed0;
+    constexpr uint32_t untilize_mode_out_cb_id = untilize_out ? mm_partials_cb_id : out_cb_id;
+    constexpr uint32_t in0_transpose_cb_id = dfb::cb_in0;
+
+    CircularBuffer in0_cb(in0_cb_id);
+    CircularBuffer in1_cb(in1_cb_id);
+    CircularBuffer out_cb(out_cb_id);
+    CircularBuffer mm_partials_cb(mm_partials_cb_id);
+    CircularBuffer untilize_mode_out_cb(untilize_mode_out_cb_id);
+
+#ifdef FUSE_BIAS
+    constexpr uint32_t bias_cb_id = dfb::cb_bias;
+    constexpr uint32_t bias_ntiles = get_named_compile_time_arg_val("bias_ntiles");
+    constexpr uint32_t mm_out_cb_id = mm_partials_cb_id;
+    // true: row-0 broadcast ([N] / [...,1,N]); false: elementwise add_tiles (bias has multiple M rows).
+    constexpr bool row_broadcast_bias = (bool)get_arg(args::row_broadcast_bias);
+    CircularBuffer bias_cb(bias_cb_id);
+#else
+    constexpr uint32_t mm_out_cb_id = untilize_mode_out_cb_id;
+#endif
+    CircularBuffer mm_out_cb(mm_out_cb_id);
+
+    // Number of valid in1 columns in the last in1 subblock. For the DRAM-sharded variant the
+    // planner may pad per_core_N_compute beyond per_core_N_in1_sender so that out_subblock_w can be
+    // larger; the reader only pushes per_core_N_in1_sender tiles per block into cb_in1. To avoid
+    // reading those non-existent (padded) cb_in1 tiles, the compute kernel narrows the matmul_block
+    // call on the last in1 subblock to last_subblock_w_valid lanes. When no padding occurs this
+    // equals out_subblock_w and the original full-width path is preserved.
+#ifdef MATMUL_DRAM_SHARDED
+    constexpr uint32_t last_subblock_w_valid = get_named_compile_time_arg_val("last_subblock_w_valid");
+#else
+    constexpr uint32_t last_subblock_w_valid = out_subblock_w;
+#endif
+    constexpr bool last_subblock_padded = last_subblock_w_valid < out_subblock_w;
+
+#ifdef SFPU_ACTIVATION
+    constexpr KernelActivation activation_type =
+        static_cast<KernelActivation>(get_named_compile_time_arg_val("activation_type"));
+    constexpr uint32_t activation_param0 = get_named_compile_time_arg_val("activation_param0");
+    constexpr uint32_t activation_param1 = get_named_compile_time_arg_val("activation_param1");
+    constexpr uint32_t activation_param2 = get_named_compile_time_arg_val("activation_param2");
+
+    ActivationInitHelper<activation_type, activation_param0, activation_param1>::init();
+#endif
+
+#ifdef IN1_TRANSPOSE_TILE
+    constexpr uint32_t in1_transpose_tile = true;
+#else
+    constexpr uint32_t in1_transpose_tile = false;
+#endif
+
+    constexpr bool spill = num_blocks_inner_dim > 1;
+
+    mm_block_init(
+        in0_cb_id, in1_cb_id, mm_partials_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+    for (uint32_t b = 0; b < batch; b++) {
+        if constexpr (get_batch_from_reader) {
+            // Check whether this batch is valid
+            bool is_batch_valid = false;
+            UNPACK(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
+            MATH(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
+            PACK(is_batch_valid = (bool)mailbox_read(ckernel::ThreadId::BriscThreadId);)
+            if (!is_batch_valid) {
+                continue;
+            }
+        }
+
+        for (uint32_t bh = 0; bh < num_blocks_h_dim; ++bh) {
+            for (uint32_t bw = 0; bw < num_blocks_w_dim; ++bw) {
+                bool enable_reload = false;
+
+#ifdef PACK_RELU
+                // for each batch we start with relu disabled so that intermediate results are not relu'd
+                if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
+                    PACK((llk_pack_relu_config(ReluConfig::none())));
+                }
+#endif
+
+                if constexpr (batch > 1 || num_blocks_h_dim > 1 || num_blocks_w_dim > 1) {
+                    PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+                }
+
+                for (uint32_t block = 0; block < num_blocks_inner_dim; block++) {
+                    bool last_out = block == (num_blocks_inner_dim - 1);
+// Configure packer once for pack out without Bias
+#if not defined FUSE_BIAS and defined PACK_RELU
+                    if (last_out) {
+                        // if last block we pack the final result with relu enabled
+                        PACK((llk_pack_relu_config(ReluConfig::zero())));
+                    }
+#endif
+
+                    if constexpr (in0_transpose_tile) {
+                        reconfig_data_format_srca(in1_cb_id, in0_transpose_cb_id);
+                        transpose_wh_init_short(in0_transpose_cb_id);
+                        PACK((pack_reconfig_data_format(in0_cb_id)));
+#ifdef PACKER_L1_ACC
+                        PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+                        transpose_tile_block<in0_block_num_tiles>(in0_transpose_cb_id, in0_cb_id);
+                        mm_block_init_short_with_dt(
+                            in0_cb_id,
+                            in1_cb_id,
+                            in0_transpose_cb_id,
+                            in1_transpose_tile,
+                            out_subblock_w,
+                            out_subblock_h,
+                            in0_block_w);
+                        PACK((pack_reconfig_data_format(mm_partials_cb_id)));
+                    }
+
+                    in0_cb.wait_front(in0_block_num_tiles);
+                    in1_cb.wait_front(in1_block_num_tiles);
+
+                    if (block == 0 && !last_out) {
+                        out_cb.reserve_back(out_block_num_tiles);
+                    }
+
+                    int in0_index_subblock_offset = 0;
+                    for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
+                        int in1_index_subblock_offset = 0;
+                        for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+                            // When last_subblock_padded is true the last in1 subblock has
+                            // (out_subblock_w - last_subblock_w_valid) padded lanes whose cb_in1 tiles were
+                            // never pushed by the reader. Narrow matmul_block so the unpacker only touches
+                            // tiles that exist; the padded dst lanes are left at whatever the previous
+                            // operation wrote there and the output writer (BRISC) drops those columns.
+                            const bool is_last_in1_subblock_padded =
+                                last_subblock_padded && (in1_subblock == in1_num_subblocks - 1);
+                            const uint32_t effective_subblock_w =
+                                is_last_in1_subblock_padded ? last_subblock_w_valid : out_subblock_w;
+
+                            tile_regs_acquire();
+                            if (enable_reload) {
+                                reload_from_cb_to_dst(
+                                    in0_cb_id,
+                                    in1_cb_id,
+                                    mm_partials_cb_id,
+                                    in1_transpose_tile,
+                                    out_subblock_num_tiles,
+                                    out_subblock_w,
+                                    out_subblock_h,
+                                    in0_block_w);
+                            }
+
+#ifndef SKIP_COMPUTE
+                            // Compute output sub-block
+                            uint32_t dst_index =
+                                0;  // start at 0, each call to matmul_block internally increments dst_index
+                            uint32_t in0_index = in0_index_subblock_offset;  // offset into in0 block
+                            uint32_t in1_index = in1_index_subblock_offset;  // offset into in1 block
+                            // inner dim that we accumulate is the inner dim of in0/in1, which is in0_block_w
+                            for (uint32_t inner_dim_idx = 0; inner_dim_idx < in0_block_w; ++inner_dim_idx) {
+                                // matmul outer product of (out_subblock_h x out_subblock_w) tiles that fill dst
+                                // accumulation is done by iterating matmul_block across inner dim
+                                // in0_block_w is passed as innder dim (kt) to matmul_block, internally used to stride
+                                // in0
+                                matmul_block(
+                                    in0_cb_id,
+                                    in1_cb_id,
+                                    in0_index,
+                                    in1_index,
+                                    dst_index,
+                                    in1_transpose_tile,
+                                    effective_subblock_w,
+                                    out_subblock_h,
+                                    in0_block_w);
+                                in0_index++;               // stride right by 1
+                                in1_index += in1_block_w;  // to stride down by 1 need to stride by in_per_core_w
+                                                           // (should be called in1_block_w)
+                            }
+
+#endif  // SKIP_COMPUTE
+
+                            if (last_out) {
+                                tile_regs_commit();
+                                mm_out_cb.reserve_back(out_subblock_num_tiles);
+
+#if defined SFPU_ACTIVATION and not defined FUSE_BIAS
+                                apply_activation_from_pack<
+                                    activation_type,
+                                    activation_param0,
+                                    activation_param1,
+                                    activation_param2>(out_subblock_num_tiles);
+#else
+                                tile_regs_wait();
+#endif
+
+#if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
+                                PACK((pack_reconfig_data_format(mm_out_cb_id)));
+#endif
+
+#ifdef PACKER_L1_ACC
+#ifdef FUSE_BIAS
+                                if (block == 0) {  // no accumulation for first iteration
+                                    PACK((llk_pack_reconfig_l1_acc(0)));
+                                } else {
+                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                }
+#else
+                                PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+#endif
+                                uint32_t start_dst_index = 0;
+                                pack_tile_block(start_dst_index, mm_out_cb_id, out_subblock_num_tiles);
+
+                                tile_regs_release();
+                                mm_out_cb.push_back(out_subblock_num_tiles);
+
+                            } else {
+                                tile_regs_commit();
+                                mm_partials_cb.reserve_back(out_subblock_num_tiles);
+                                tile_regs_wait();
+
+#ifdef PACKER_L1_ACC
+                                if (block == 0) {  // no accumulation for first iteration
+                                    PACK((llk_pack_reconfig_l1_acc(0)));
+                                } else if (block == 1) {
+                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                } else if (in0_transpose_tile) {
+                                    // For each block, l1_acc would have been enabled during the
+                                    // transpose stage. So let us put it back here.
+                                    PACK((llk_pack_reconfig_l1_acc(1)));
+                                }
+#endif
+
+                                uint32_t start_dst_index = 0;
+                                pack_tile_block(start_dst_index, mm_partials_cb_id, out_subblock_num_tiles);
+
+                                tile_regs_release();
+                                mm_partials_cb.push_back(out_subblock_num_tiles);
+                            }
+
+                            in1_index_subblock_offset += out_subblock_w;
+                        }
+                        in0_index_subblock_offset += in0_subblock_num_tiles;
+                    }
+
+#ifdef PACKER_L1_ACC
+#ifdef FUSE_BIAS
+                    if (block < num_blocks_inner_dim - 1) {
+                        // Wait/pop in subblock-sized steps so the step size
+                        // matches the bias section's wait_front(out_subblock_num_tiles),
+                        // satisfying the CB API requirement that all wait_front
+                        // increments on a given CB are identical.
+                        for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
+                            mm_partials_cb.wait_front(out_subblock_num_tiles);
+                            mm_partials_cb.pop_front(out_subblock_num_tiles);
+                        }
+                    }
+                    // never reload when with bias, bias uses interm buffer
+                    enable_reload = false;
+#else
+                    // Last iteration does spill and reload to output buffer
+                    if (block < num_blocks_inner_dim - 2) {
+                        for (uint32_t s = 0; s < out_block_num_tiles; s += out_subblock_num_tiles) {
+                            mm_partials_cb.wait_front(out_subblock_num_tiles);
+                            mm_partials_cb.pop_front(out_subblock_num_tiles);
+                        }
+                    }
+                    if (block == num_blocks_inner_dim - 2) {
+                        enable_reload = true;
+                    }  // reload when last iteration
+#endif
+#else
+                    if constexpr (spill) {
+                        enable_reload = true;
+                    }
+#endif
+
+                    in0_cb.pop_front(in0_block_num_tiles);
+                    in1_cb.pop_front(in1_block_num_tiles);
+                }
+
+#ifdef FUSE_BIAS
+#ifdef PACK_RELU
+                // if last block we pack the final result with relu enabled
+                PACK((llk_pack_relu_config(ReluConfig::zero())));
+#endif
+#if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
+                PACK((pack_reconfig_data_format(out_cb_id)));
+#endif
+#ifdef PACKER_L1_ACC
+                PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+                reconfig_data_format(in1_cb_id, mm_partials_cb_id, in0_cb_id, bias_cb_id);
+                if constexpr (row_broadcast_bias) {
+                    add_bcast_rows_init_short(mm_partials_cb_id, bias_cb_id);
+                } else {
+                    add_tiles_init(mm_partials_cb_id, bias_cb_id);
+                }
+                // Reader only pushes bias once when num_blocks_w_dim == 1;
+                // the tiles stay in the CB for reuse across bh/batch iterations.
+                if ((b == 0 && bh == 0) || num_blocks_w_dim > 1) {
+                    bias_cb.wait_front(bias_ntiles);
+                }
+                for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {
+                    int in1_index_subblock_offset = 0;
+                    for (uint32_t in1_subblock = 0; in1_subblock < in1_num_subblocks; in1_subblock++) {
+                        // See matmul stage: the last in1 subblock has padded lanes whose bias tile was
+                        // never pushed by the reader. Redirect those out-of-range bias_tile_idx reads to
+                        // tile 0 of cb_bias to keep them in-bounds; the resulting padded output columns
+                        // are dropped by the writer.
+                        const bool is_last_in1_subblock_padded =
+                            last_subblock_padded && (in1_subblock == in1_num_subblocks - 1);
+                        // Redundant wait since we know data was just pushed
+                        mm_partials_cb.wait_front(out_subblock_num_tiles);
+                        tile_regs_acquire();
+                        for (uint32_t i = 0, j = 0; j < out_subblock_h; j++) {
+                            uint32_t bias_tile_idx = in1_index_subblock_offset;
+                            for (uint32_t k = 0; k < out_subblock_w; k++, i++) {
+                                const uint32_t safe_bias_tile_idx =
+                                    (is_last_in1_subblock_padded && k >= last_subblock_w_valid)
+                                        ? 0u              // Padded output columns with tile 0 of cb_bias added are
+                                        : bias_tile_idx;  // dropped by the writer.
+
+                                if constexpr (row_broadcast_bias) {
+                                    add_tiles_bcast_rows(mm_partials_cb_id, bias_cb_id, i, safe_bias_tile_idx, i);
+                                } else {
+                                    add_tiles(mm_partials_cb_id, bias_cb_id, i, safe_bias_tile_idx, i);
+                                }
+                                bias_tile_idx++;
+                            }
+                        }
+                        tile_regs_commit();
+
+                        mm_partials_cb.pop_front(out_subblock_num_tiles);
+
+                        // Pack out to output buffer
+                        untilize_mode_out_cb.reserve_back(out_subblock_num_tiles);
+
+#ifdef SFPU_ACTIVATION
+                        PACK(TTI_SEMWAIT(
+                            p_stall::STALL_TDMA | p_stall::STALL_CFG,
+                            semaphore::t6_sem(semaphore::MATH_PACK),
+                            p_stall::STALL_ON_ZERO));
+
+                        // Flip destination register offset for PACKER access
+                        PACK(TT_SETC16(
+                            DEST_TARGET_REG_CFG_MATH_Offset_ADDR32, ckernel::packer::get_packer_dest_offset()));
+
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            ActivationApplyHelper<activation_type, activation_param0, activation_param1>::apply(i);
+                        }
+
+                        PACK(TTI_STALLWAIT(p_stall::STALL_PACK, p_stall::WAIT_SFPU));
+#else
+                        tile_regs_wait();
+#endif
+                        for (uint32_t i = 0; i < out_subblock_num_tiles; i++) {
+                            pack_tile(i, untilize_mode_out_cb_id);
+                        }
+                        tile_regs_release();
+                        untilize_mode_out_cb.push_back(out_subblock_num_tiles);
+
+                        in1_index_subblock_offset += out_subblock_w;
+                    }
+                }
+                if constexpr (num_blocks_w_dim > 1) {
+                    bias_cb.pop_front(bias_ntiles);
+                }
+#endif  // FUSE_BIAS
+                if constexpr (untilize_out) {
+#ifdef PACK_RELU
+                    PACK((llk_pack_relu_config(ReluConfig::none())));
+#endif  // PACK_RELU
+#ifndef FUSE_BIAS
+                    reconfig_data_format_srca(in1_cb_id, mm_partials_cb_id);
+#if defined FP32_DEST_ACC_EN or defined PACKER_L1_ACC
+                    PACK((pack_reconfig_data_format(out_cb_id)));
+#endif
+#ifdef PACKER_L1_ACC
+                    PACK((llk_pack_reconfig_l1_acc(0)));
+#endif
+#endif  // FUSE_BIAS
+                    pack_untilize_dest_init<out_subblock_w, out_block_w>(out_cb_id);
+                    copy_tile_to_dst_init_short(mm_partials_cb_id);
+                    for (uint32_t in0_subblock_i = 0; in0_subblock_i < in0_num_subblocks; ++in0_subblock_i) {
+                        reblock_and_untilize<out_subblock_w, out_block_w>(
+                            in1_num_subblocks, out_subblock_num_tiles, out_subblock_h, mm_partials_cb_id, out_cb_id);
+                    }
+                    pack_untilize_uninit(mm_partials_cb_id);
+                }
+                if constexpr (batch > 1 || num_blocks_w_dim > 1 || num_blocks_h_dim > 1) {
+#ifdef FUSE_BIAS
+                    // reconfigure unpacker df for src A and src B
+                    reconfig_data_format(mm_partials_cb_id, in1_cb_id, bias_cb_id, in0_cb_id);
+#else
+                    // reconfigure unpacker df for src A
+                    reconfig_data_format_srca(mm_partials_cb_id, in1_cb_id);
+#endif
+                    // reconfigure init for matmul
+                    mm_block_init_short(
+                        in0_cb_id, in1_cb_id, in1_transpose_tile, out_subblock_w, out_subblock_h, in0_block_w);
+                }
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_m2.cpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of bmm.cpp. Forked (not edited in place) because bmm.cpp is also
+// used by moreh_matmul; only the MatmulMultiCore factory's compute kernel moves to
+// the Metal 2.0 named-binding form. Logic is identical to bmm.cpp.
+
+#include <cstdint>
+
+#include "api/compute/matmul.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"
+#include "experimental/kernel_args.h"
+
+using std::uint32_t;
+
+// matmul C=A*B using dims MK*KN = MN (row major order)
+//
+void kernel_main() {
+    constexpr int onetile = 1;
+
+    constexpr uint32_t batch = get_arg(args::batch);
+    constexpr uint32_t Mt = get_arg(args::Mt);
+    constexpr uint32_t Kt = get_arg(args::Kt);
+    constexpr uint32_t Nt = get_arg(args::Nt);
+
+    constexpr uint32_t cb_in0 = dfb::in0;
+    constexpr uint32_t cb_in1 = dfb::in1;
+    constexpr uint32_t cb_out = dfb::out;
+
+    DataflowBuffer in0_cb(dfb::in0);
+    DataflowBuffer in1_cb(dfb::in1);
+    DataflowBuffer out_cb(dfb::out);
+
+    mm_init(cb_in0, cb_in1, cb_out);
+
+    // the simplest possible version of outer product blocked matmul
+    // the reader is expected to read the A's and B's tile rows and tile columns for each output tile
+    for (uint32_t nb = 0; nb < batch; nb++) {
+        for (uint32_t mt_C = 0; mt_C < Mt; ++mt_C) {    // output tile of C
+            for (uint32_t nt_C = 0; nt_C < Nt; ++nt_C)  // output tile index of C
+            {
+                tile_regs_acquire();
+                for (uint32_t kt = 0; kt < Kt; kt++) {
+                    in0_cb.wait_front(onetile);
+                    in1_cb.wait_front(onetile);
+
+                    matmul_tiles(cb_in0, cb_in1, 0, 0, 0);
+
+                    in0_cb.pop_front(onetile);
+                    in1_cb.pop_front(onetile);
+                }
+
+                tile_regs_commit();
+
+                out_cb.reserve_back(onetile);
+
+                tile_regs_wait();
+                pack_tile(0, cb_out);
+                tile_regs_release();
+
+                out_cb.push_back(onetile);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_8bank_output_tiles_partitioned.cpp
@@ -2,6 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port. Used only by the MatmulMultiCore factory, so ported in place.
+// Logic unchanged from the legacy reader; only the access mechanism moves to named
+// bindings: tensor addresses -> ta::a / ta::b, CB ids -> dfb::in0 / dfb::in1,
+// positional runtime args -> get_arg(args::...).
+
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
@@ -9,33 +14,25 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    // same arg indices as in reader_binary_diff_lengths for compat
-    uint32_t src0_addr = get_arg_val<uint32_t>(0);
-    uint32_t src1_addr = get_arg_val<uint32_t>(1);
-    uint32_t Mt = get_arg_val<uint32_t>(2);
-    uint32_t Kt = get_arg_val<uint32_t>(3);
-    uint32_t Nt = get_arg_val<uint32_t>(4);
-    uint32_t MtKt = get_arg_val<uint32_t>(5);  // if 0
-    uint32_t KtNt = get_arg_val<uint32_t>(6);
-    uint32_t batch = get_arg_val<uint32_t>(7);
-    uint32_t bcast_B = get_arg_val<uint32_t>(8);  // if 1 we broadcast B to batch
-    uint32_t output_tile_start_id = get_arg_val<uint32_t>(9);
-    uint32_t num_output_tiles = get_arg_val<uint32_t>(10);
-    uint32_t MtNt = get_arg_val<uint32_t>(11);
+    uint32_t Mt = get_arg(args::Mt);
+    uint32_t Kt = get_arg(args::Kt);
+    uint32_t Nt = get_arg(args::Nt);
+    uint32_t MtKt = get_arg(args::MtKt);  // if 0
+    uint32_t KtNt = get_arg(args::KtNt);
+    uint32_t batch = get_arg(args::batch);
+    uint32_t bcast_B = get_arg(args::bcast_B);  // if 1 we broadcast B to batch
+    uint32_t output_tile_start_id = get_arg(args::output_tile_start_id);
+    uint32_t num_output_tiles = get_arg(args::num_output_tiles);
+    uint32_t MtNt = get_arg(args::MtNt);
 
-    constexpr uint32_t in0_last_ktile_w = get_compile_time_arg_val(0);
-    constexpr uint32_t in0_last_ktile_h = get_compile_time_arg_val(1);
-    constexpr auto src0_args = TensorAccessorArgs<2>();
-    constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
+    constexpr uint32_t in0_last_ktile_w = get_arg(args::in0_last_ktile_w);
+    constexpr uint32_t in0_last_ktile_h = get_arg(args::in0_last_ktile_h);
 
-    // DPRINT("Mt={} Kt={} Nt={} MtKt={} KtNt={}\n", Mt, Kt, Nt, MtKt, KtNt);
-    // DPRINT("src0={} src1={}\n", src0_addr, src1_addr);
-    // DPRINT("batch={}\n", batch);
-
-    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
-    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
+    constexpr uint32_t cb_id_in0 = dfb::in0;
+    constexpr uint32_t cb_id_in1 = dfb::in1;
 
     constexpr uint32_t onetile = 1;
     const uint32_t in0_tile_bytes = get_tile_size(cb_id_in0);
@@ -51,12 +48,12 @@ void kernel_main() {
         itileB += output_tile_start_id / MtNt * KtNt;  // offset into correct batch if not bcasting
     }
 
-    const auto s0 = TensorAccessor(src0_args, src0_addr);
-    const auto s1 = TensorAccessor(src1_args, src1_addr);
+    const auto s0 = TensorAccessor(ta::a);
+    const auto s1 = TensorAccessor(ta::b);
 
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
-    CircularBuffer cb_in1(cb_id_in1);
+    DataflowBuffer cb_in0(dfb::in0);
+    DataflowBuffer cb_in1(dfb::in1);
 
     for (uint32_t n = 0; n < num_output_tiles; n++) {
         for (uint32_t kt = 0; kt < Kt; kt++) {
@@ -85,7 +82,6 @@ void kernel_main() {
                 noc.async_read_barrier();
                 cb_in1.push_back(onetile);
             }
-            // DPRINT("Pushed itileA={} itileB={}\n", itileA, itileB);
 
             itileA += 1;   // A is MK
             itileB += Nt;  // B is KN, so to get k++ we stride by Nt

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0.cpp
@@ -2,6 +2,15 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port. Used only by the MatmulMultiCoreReuseOptimized factory, so ported in
+// place. Logic, #ifdefs, and loop bounds are unchanged from the legacy reader; only the
+// access mechanism moves to named bindings: the in0 tensor address -> ta::a, CB ids ->
+// dfb::cb_in0 / dfb::cb_in0_intermediate, positional CT/RT args -> get_arg(args::...).
+// On the IN0_SHARDED path the in0 CB is a borrowed-memory DFB backed by tensor `a`, so
+// the tensor is not accessed via a TensorAccessor; the ta::a construction lives inside
+// the existing #ifndef IN0_SHARDED block, so the factory binds tensor `a` to this kernel
+// only on the non-sharded (NoC-read) path.
+
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
@@ -9,36 +18,33 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // RUNTIME ARGS
-    uint32_t rt_args_idx = 0;
-    // in0 tensor args
-    const uint32_t in0_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t in0_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+    // in0 tensor args (addr now arrives via the ta::a binding)
+    uint32_t in0_tensor_start_tile_id = get_arg(args::in0_tensor_start_tile_id);
     // batch args
-    const uint32_t batch = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t batch = get_arg(args::batch);
 
     // COMPILE TIME ARGS
     // in0 tensor args
-    constexpr uint32_t in0_tensor_stride_w = get_compile_time_arg_val(0);
-    constexpr uint32_t in0_tensor_stride_h = get_compile_time_arg_val(1);
-    constexpr uint32_t in0_tensor_next_block_stride = get_compile_time_arg_val(2);
+    constexpr uint32_t in0_tensor_stride_w = get_arg(args::in0_tensor_stride_w);
+    constexpr uint32_t in0_tensor_stride_h = get_arg(args::in0_tensor_stride_h);
+    constexpr uint32_t in0_tensor_next_block_stride = get_arg(args::in0_tensor_next_block_stride);
     // in0 block args
-    constexpr uint32_t in0_block_w = get_compile_time_arg_val(3);
-    constexpr uint32_t in0_block_h = get_compile_time_arg_val(4);
-    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(5);
-    constexpr uint32_t last_ktile_w = get_compile_time_arg_val(6);
-    constexpr uint32_t last_ktile_h = get_compile_time_arg_val(7);
+    constexpr uint32_t in0_block_w = get_arg(args::in0_block_w);
+    constexpr uint32_t in0_block_h = get_arg(args::in0_block_h);
+    constexpr uint32_t in0_block_num_tiles = get_arg(args::in0_block_num_tiles);
+    constexpr uint32_t last_ktile_w = get_arg(args::last_ktile_w);
+    constexpr uint32_t last_ktile_h = get_arg(args::last_ktile_h);
     // in0/in1 common args
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(8);
+    constexpr uint32_t num_blocks = get_arg(args::num_blocks);
     // batch args
-    constexpr uint32_t bcast_B = get_compile_time_arg_val(9);
-    constexpr uint32_t MtKt = get_compile_time_arg_val(10);
+    constexpr uint32_t bcast_B = get_arg(args::bcast_B);
+    constexpr uint32_t MtKt = get_arg(args::MtKt);
 
-    constexpr auto in0_args = TensorAccessorArgs<11>();
-
-    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t cb_id_in0 = dfb::cb_in0;
     constexpr uint32_t one_tile = 1;
 
     Noc noc;
@@ -53,10 +59,10 @@ void kernel_main() {
     constexpr uint32_t in0_single_tile_size_bytes = get_tile_size(cb_id_in0);
     constexpr const uint32_t in0_tile_hw = get_tile_hw(cb_id_in0);
 
-    const auto s0 = TensorAccessor(in0_args, in0_tensor_addr);
+    const auto s0 = TensorAccessor(ta::a);
 
 #ifdef INTERMEDIATE_CB_READ
-    constexpr uint32_t in0_intermediate_cb_index = get_named_compile_time_arg_val("cb_in0_intermediate");
+    constexpr uint32_t in0_intermediate_cb_index = dfb::cb_in0_intermediate;
     CircularBuffer cb_helper(in0_intermediate_cb_index);
 #endif
 

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in0_sender_dram_sharded_height.cpp
@@ -8,6 +8,13 @@
 // Input A is L1 sharded by batch on INPUT STORAGE CORES
 // Workers are on OPTIMAL DRAM READER CORES (different from storage cores)
 // Workers NOC read their in0 shard from their corresponding input storage core
+//
+// Metal 2.0: only the access mechanism changes. The in0 CB id -> dfb::cb_in0; positional
+// CT/RT args -> get_arg(args::...). The in0 shard's L1 base address used to arrive as a raw
+// RTA (the resolved buffer address); it is now a Case-2 binding (this is a data-movement
+// kernel performing explicit remote-NoC address arithmetic) — `a` is bound as a tensor and
+// the base is pulled via TensorAccessor::get_bank_base_address(), keeping the raw NoC walk
+// to the remote input storage core unchanged.
 
 #include <stdint.h>
 
@@ -16,32 +23,39 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/endpoints.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // COMPILE TIME ARGS
-    constexpr uint32_t in0_block_num_tiles = get_compile_time_arg_val(0);   // tiles per block (M * in0_block_w)
-    constexpr uint32_t in0_block_size_bytes = get_compile_time_arg_val(1);  // bytes per block
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(2);            // K / in0_block_w (K blocks in inner loop)
-    constexpr uint32_t num_batches_per_core = get_compile_time_arg_val(3);  // B / num_cores
-    constexpr uint32_t in0_tensor_stride_batch_bytes = get_compile_time_arg_val(4);  // bytes per batch in in0
-    constexpr uint32_t in0_shard_size_bytes = get_compile_time_arg_val(5);           // full shard size in bytes
+    constexpr uint32_t in0_block_num_tiles = get_arg(args::in0_block_num_tiles);    // tiles per block (M * in0_block_w)
+    constexpr uint32_t in0_block_size_bytes = get_arg(args::in0_block_size_bytes);  // bytes per block
+    constexpr uint32_t num_blocks = get_arg(args::num_blocks);  // K / in0_block_w (K blocks in inner loop)
+    constexpr uint32_t num_batches_per_core = get_arg(args::num_batches_per_core);  // B / num_cores
+    constexpr uint32_t in0_tensor_stride_batch_bytes =
+        get_arg(args::in0_tensor_stride_batch_bytes);                               // bytes per batch in in0
+    constexpr uint32_t in0_shard_size_bytes = get_arg(args::in0_shard_size_bytes);  // full shard size in bytes
 
     // RUNTIME ARGS
-    const uint32_t worker_core_type = get_arg_val<uint32_t>(0);
+    const uint32_t worker_core_type = get_arg(args::worker_core_type);
     if (worker_core_type == 0) {
         return;  // idle core
     }
 
-    // Get the input storage core coordinates and L1 address (where in0 shard is located)
-    const uint32_t input_storage_noc_x = get_arg_val<uint32_t>(1);
-    const uint32_t input_storage_noc_y = get_arg_val<uint32_t>(2);
-    const uint32_t input_shard_l1_addr = get_arg_val<uint32_t>(3);
+    // Get the input storage core coordinates (where in0 shard is located)
+    const uint32_t input_storage_noc_x = get_arg(args::input_storage_noc_x);
+    const uint32_t input_storage_noc_y = get_arg(args::input_storage_noc_y);
 
-    constexpr uint32_t cb_id_in0 = get_named_compile_time_arg_val("cb_in0");
+    constexpr uint32_t cb_id_in0 = dfb::cb_in0;
+
+    // The in0 shard L1 address now comes from the typed tensor binding (Case-2 bridge), not a
+    // raw RTA. For an L1-sharded tensor this returns the local L1 base of the shard region,
+    // which is the same address the legacy RTA carried.
+    const auto in0 = TensorAccessor(ta::a);
+    const uint32_t input_shard_l1_addr = in0.get_bank_base_address();
 
     // Build NOC address for the remote input storage core
     Noc noc;
-    CircularBuffer cb_in0(cb_id_in0);
+    DataflowBuffer cb_in0(cb_id_in0);
     UnicastEndpoint src_core;
 
     // Process each batch

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded_height.cpp
@@ -7,6 +7,14 @@
 // Each worker handles B/num_workers batches independently
 // Input B (weights) is DRAM sharded by batch - each bank has B/12 complete [N, K] matrices
 // Output is NOC written to OUTPUT STORAGE CORES (different from worker cores)
+//
+// Metal 2.0: only the access mechanism changes. CB ids -> dfb::cb_in1 / dfb::cb_out /
+// dfb::cb_bias; positional CT/RT args -> get_arg(args::...). The in1 (DRAM bank) base, the
+// bias (DRAM bank) base, and the output shard's L1 base all used to arrive as raw RTAs (the
+// resolved buffer addresses); they are now Case-2 bindings (this is a data-movement kernel
+// performing explicit DRAM-bank and remote-NoC address arithmetic) — `b`, `bias`, and `out`
+// are bound as tensors and their bases are pulled via TensorAccessor::get_bank_base_address(),
+// keeping the raw DRAM-bank reads and remote-NoC output write unchanged.
 
 #include <stdint.h>
 
@@ -15,61 +23,71 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/endpoints.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // RUNTIME ARGS
-    const bool is_worker_core = get_arg_val<uint32_t>(0) == 1;
+    const bool is_worker_core = get_arg(args::is_worker_core) == 1;
     if (not is_worker_core) {
         return;
     }
 
-    const uint32_t in1_tensor_addr = get_arg_val<uint32_t>(1);
-#ifdef FUSE_BIAS
-    const uint32_t in3_tensor_addr = get_arg_val<uint32_t>(2);
-#endif
-    const uint32_t dram_bank_id = get_arg_val<uint32_t>(3);
-    const uint32_t vc = get_arg_val<uint32_t>(4);
+    const uint32_t dram_bank_id = get_arg(args::dram_bank_id);
+    const uint32_t vc = get_arg(args::vc);
 
-    // Output storage core coordinates and L1 address (where to NOC write output)
-    const uint32_t output_storage_noc_x = get_arg_val<uint32_t>(5);
-    const uint32_t output_storage_noc_y = get_arg_val<uint32_t>(6);
-    const uint32_t output_shard_l1_addr = get_arg_val<uint32_t>(7);
+    // Output storage core coordinates (where to NOC write output)
+    const uint32_t output_storage_noc_x = get_arg(args::output_storage_noc_x);
+    const uint32_t output_storage_noc_y = get_arg(args::output_storage_noc_y);
 
     // COMPILE TIME ARGS
-    constexpr uint32_t in1_page_size = get_compile_time_arg_val(0);
-    constexpr uint32_t in1_num_pages = get_compile_time_arg_val(1);
-    constexpr uint32_t in1_block_w = get_compile_time_arg_val(2);                    // K tiles per block
-    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(3);            // in0_block_w * K
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(4);                     // N / in0_block_w
-    constexpr uint32_t out_block_num_tiles = get_compile_time_arg_val(5);            // M * K
-    constexpr uint32_t num_batches_per_core = get_compile_time_arg_val(6);           // B / num_cores
-    constexpr uint32_t in1_tensor_stride_batch_bytes = get_compile_time_arg_val(7);  // bytes per batch in in1
-    constexpr uint32_t out_tensor_stride_batch_bytes = get_compile_time_arg_val(8);  // bytes per batch in output
-    constexpr uint32_t out_shard_size_bytes = get_compile_time_arg_val(9);           // full output shard size
+    constexpr uint32_t in1_page_size = get_arg(args::in1_page_size);
+    constexpr uint32_t in1_num_pages = get_arg(args::in1_num_pages);
+    constexpr uint32_t in1_block_w = get_arg(args::in1_block_w);                    // K tiles per block
+    constexpr uint32_t in1_block_num_tiles = get_arg(args::in1_block_num_tiles);    // in0_block_w * K
+    constexpr uint32_t num_blocks = get_arg(args::num_blocks);                      // N / in0_block_w
+    constexpr uint32_t out_block_num_tiles = get_arg(args::out_block_num_tiles);    // M * K
+    constexpr uint32_t num_batches_per_core = get_arg(args::num_batches_per_core);  // B / num_cores
+    constexpr uint32_t in1_tensor_stride_batch_bytes =
+        get_arg(args::in1_tensor_stride_batch_bytes);  // bytes per batch in in1
+    constexpr uint32_t out_tensor_stride_batch_bytes =
+        get_arg(args::out_tensor_stride_batch_bytes);                               // bytes per batch in output
+    constexpr uint32_t out_shard_size_bytes = get_arg(args::out_shard_size_bytes);  // full output shard size
 
 #ifdef FUSE_BIAS
-    constexpr uint32_t in3_page_size = get_compile_time_arg_val(10);
-    constexpr uint32_t in3_num_pages = get_compile_time_arg_val(11);
-    constexpr uint32_t in3_block_tiles = get_compile_time_arg_val(12);  // K tiles for bias
-    constexpr uint32_t cb_id_in3 = get_named_compile_time_arg_val("cb_bias");
+    constexpr uint32_t in3_page_size = get_arg(args::in3_page_size);
+    constexpr uint32_t in3_num_pages = get_arg(args::in3_num_pages);
+    constexpr uint32_t in3_block_tiles = get_arg(args::in3_block_tiles);  // K tiles for bias
+    constexpr uint32_t cb_id_in3 = dfb::cb_bias;
 #endif
 
-    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
-    constexpr uint32_t cb_id_out = get_named_compile_time_arg_val("cb_out");  // Local output CB (compute writes here)
+    constexpr uint32_t cb_id_in1 = dfb::cb_in1;
+    constexpr uint32_t cb_id_out = dfb::cb_out;  // Local output CB (compute writes here)
     constexpr uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
     constexpr uint32_t out_single_tile_size_bytes = get_tile_size(cb_id_out);
     constexpr uint32_t in1_block_size_bytes = in1_block_num_tiles * in1_single_tile_size_bytes;
     constexpr uint32_t out_block_size_bytes = out_block_num_tiles * out_single_tile_size_bytes;
 
+    // Tensor base addresses now arrive via the typed tensor bindings (Case-2 bridge), not raw
+    // RTAs. For DRAM-sharded `b`/`bias` this is the DRAM bank base; for the L1-sharded output
+    // it is the remote output shard's local L1 base — the same addresses the legacy RTAs carried.
+    const auto in1 = TensorAccessor(ta::b);
+    const uint32_t in1_tensor_addr = in1.get_bank_base_address();
+#ifdef FUSE_BIAS
+    const auto in3 = TensorAccessor(ta::bias);
+    const uint32_t in3_tensor_addr = in3.get_bank_base_address();
+#endif
+    const auto out = TensorAccessor(ta::out);
+    const uint32_t output_shard_l1_addr = out.get_bank_base_address();
+
     Noc noc;
-    CircularBuffer cb_in1(cb_id_in1);
-    CircularBuffer cb_out(cb_id_out);
+    DataflowBuffer cb_in1(cb_id_in1);
+    DataflowBuffer cb_out(cb_id_out);
     // DRAM read setup
     AllocatorBank<AllocatorBankType::DRAM> dram_bank;
     // Output reshard setup - build NOC address for remote output storage core
     UnicastEndpoint remote;
 #ifdef FUSE_BIAS
-    CircularBuffer cb_in3(cb_id_in3);
+    DataflowBuffer cb_in3(cb_id_in3);
 #endif
 
     // Process each batch
@@ -124,7 +142,7 @@ void kernel_main() {
         // NOC write output to remote output storage core (CB6)
         uint32_t out_batch_offset = batch * out_tensor_stride_batch_bytes;
         noc.async_write(
-            use<CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+            cb_out,
             remote,
             out_block_size_bytes,
             {.offset_bytes = 0},

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_writer_bmm_tile_layout_in1.cpp
@@ -2,65 +2,69 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port. Used only by the MatmulMultiCoreReuseOptimized factory, so ported in
+// place. Logic, #ifdefs, and loop bounds are unchanged from the legacy reader/writer;
+// only the access mechanism moves to named bindings: the in1 / out tensor addresses ->
+// ta::b / ta::out, CB ids -> dfb::cb_in1 / dfb::cb_out / dfb::cb_in1_intermediate,
+// positional CT/RT args -> get_arg(args::...). The in1 CB (IN1_SHARDED) and out CB
+// (OUT_SHARDED) become borrowed-memory DFBs backed by tensors `b` / `out`; on those
+// paths the matching ta:: construction lives inside the existing #ifndef block, so the
+// factory binds the tensor to this kernel only on the corresponding NoC path.
+
 #include <stdint.h>
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
     // RUNTIME ARGS
     // READER
-    uint32_t rt_args_idx = 0;
-    // in1 tensor args
-    const uint32_t in1_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t in1_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+    // in1 tensor args (addr now arrives via the ta::b binding)
+    uint32_t in1_tensor_start_tile_id = get_arg(args::in1_tensor_start_tile_id);
     // batch args
-    const uint32_t batch = get_arg_val<uint32_t>(rt_args_idx++);
+    const uint32_t batch = get_arg(args::batch);
 
     // WRITER
-    // out tensor args
-    const uint32_t out_tensor_addr = get_arg_val<uint32_t>(rt_args_idx++);
-    uint32_t out_tensor_start_tile_id = get_arg_val<uint32_t>(rt_args_idx++);
+    // out tensor args (addr now arrives via the ta::out binding)
+    uint32_t out_tensor_start_tile_id = get_arg(args::out_tensor_start_tile_id);
 
     // COMPILE TIME ARGS
     // READER
     // in1 tensor args
-    constexpr uint32_t in1_tensor_stride_w = get_compile_time_arg_val(0);
-    constexpr uint32_t in1_tensor_stride_h = get_compile_time_arg_val(1);
-    constexpr uint32_t in1_tensor_next_block_stride = get_compile_time_arg_val(2);
+    constexpr uint32_t in1_tensor_stride_w = get_arg(args::in1_tensor_stride_w);
+    constexpr uint32_t in1_tensor_stride_h = get_arg(args::in1_tensor_stride_h);
+    constexpr uint32_t in1_tensor_next_block_stride = get_arg(args::in1_tensor_next_block_stride);
     // in1 block args
-    constexpr uint32_t in1_block_w = get_compile_time_arg_val(3);
-    constexpr uint32_t in1_block_h = get_compile_time_arg_val(4);
-    constexpr uint32_t in1_block_num_tiles = get_compile_time_arg_val(5);
+    constexpr uint32_t in1_block_w = get_arg(args::in1_block_w);
+    constexpr uint32_t in1_block_h = get_arg(args::in1_block_h);
+    constexpr uint32_t in1_block_num_tiles = get_arg(args::in1_block_num_tiles);
     // in0/in1 common args
-    constexpr uint32_t num_blocks = get_compile_time_arg_val(6);
+    constexpr uint32_t num_blocks = get_arg(args::num_blocks);
     // batch args
-    constexpr uint32_t bcast_B = get_compile_time_arg_val(7);
-    constexpr uint32_t KtNt = get_compile_time_arg_val(8);
+    constexpr uint32_t bcast_B = get_arg(args::bcast_B);
+    constexpr uint32_t KtNt = get_arg(args::KtNt);
 
     // WRITER
     // out tensor args
-    constexpr uint32_t out_tensor_stride_w = get_compile_time_arg_val(9);
-    constexpr uint32_t out_tensor_stride_h = get_compile_time_arg_val(10);
-    constexpr uint32_t out_tensor_next_subblock_stride_w = get_compile_time_arg_val(11);
-    constexpr uint32_t out_tensor_next_subblock_stride_h = get_compile_time_arg_val(12);
-    constexpr uint32_t out_subblock_w = get_compile_time_arg_val(13);
-    constexpr uint32_t out_subblock_h = get_compile_time_arg_val(14);
-    constexpr uint32_t out_subblock_tile_count = get_compile_time_arg_val(15);
-    constexpr uint32_t out_num_subblocks_w = get_compile_time_arg_val(16);
-    constexpr uint32_t out_num_subblocks_h = get_compile_time_arg_val(17);
+    constexpr uint32_t out_tensor_stride_w = get_arg(args::out_tensor_stride_w);
+    constexpr uint32_t out_tensor_stride_h = get_arg(args::out_tensor_stride_h);
+    constexpr uint32_t out_tensor_next_subblock_stride_w = get_arg(args::out_tensor_next_subblock_stride_w);
+    constexpr uint32_t out_tensor_next_subblock_stride_h = get_arg(args::out_tensor_next_subblock_stride_h);
+    constexpr uint32_t out_subblock_w = get_arg(args::out_subblock_w);
+    constexpr uint32_t out_subblock_h = get_arg(args::out_subblock_h);
+    constexpr uint32_t out_subblock_tile_count = get_arg(args::out_subblock_tile_count);
+    constexpr uint32_t out_num_subblocks_w = get_arg(args::out_num_subblocks_w);
+    constexpr uint32_t out_num_subblocks_h = get_arg(args::out_num_subblocks_h);
     // batch args
-    constexpr uint32_t MtNt = get_compile_time_arg_val(18);
+    constexpr uint32_t MtNt = get_arg(args::MtNt);
 
-    constexpr uint32_t cb_id_in1 = get_named_compile_time_arg_val("cb_in1");
+    constexpr uint32_t cb_id_in1 = dfb::cb_in1;
     constexpr uint32_t one_tile = 1;
     // WRITER
-    constexpr uint32_t cb_id_out0 = get_named_compile_time_arg_val("cb_out");
-
-    constexpr auto in1_args = TensorAccessorArgs<19>();
-    constexpr auto out_args = TensorAccessorArgs<in1_args.next_compile_time_args_offset()>();
+    constexpr uint32_t cb_id_out0 = dfb::cb_out;
 
     Noc noc;
     CircularBuffer cb_in1(cb_id_in1);
@@ -72,12 +76,12 @@ void kernel_main() {
     cb_in1.push_back(in1_num_tiles);
 #else
     const uint32_t in1_single_tile_size_bytes = get_tile_size(cb_id_in1);
-    const auto s1 = TensorAccessor(in1_args, in1_tensor_addr);
+    const auto s1 = TensorAccessor(ta::b);
 #endif  // IN1_SHARDED
 
 #ifndef OUT_SHARDED
     const uint32_t output_single_tile_size_bytes = get_tile_size(cb_id_out0);
-    const auto s = TensorAccessor(out_args, out_tensor_addr);
+    const auto s = TensorAccessor(ta::out);
 #endif  // OUT_SHARDED
 
 #if not defined IN1_SHARDED or not defined OUT_SHARDED
@@ -88,7 +92,7 @@ void kernel_main() {
             cb_in1.reserve_back(in1_block_num_tiles);
 
 #ifdef INTERMEDIATE_CB_READ
-            constexpr uint32_t in1_intermediate_cb_index = get_named_compile_time_arg_val("cb_in1_intermediate");
+            constexpr uint32_t in1_intermediate_cb_index = dfb::cb_in1_intermediate;
             CircularBuffer cb_helper(in1_intermediate_cb_index);
             cb_helper.reserve_back(one_tile);
 #endif  // INTERMEDIATE_CB_READ
@@ -155,8 +159,10 @@ void kernel_main() {
                 for (uint32_t h = 0; h < out_subblock_h; ++h) {
                     uint32_t out_tensor_tile_id = out_tensor_sb_row_start_tile_id;
                     for (uint32_t w = 0; w < out_subblock_w; ++w) {
+                        // A bare DFB used as a NoC source is already read-pointer-sourced, so the
+                        // legacy use<CircularBuffer::AddrSelector::READ_PTR>(cb_out) wrapper drops.
                         noc.async_write(
-                            use<CircularBuffer::AddrSelector::READ_PTR>(cb_out),
+                            cb_out,
                             s,
                             output_single_tile_size_bytes,
                             {.offset_bytes = out_read_offset},

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_8bank_interleaved_start_id_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/writer_bmm_8bank_interleaved_start_id_m2.cpp
@@ -1,0 +1,44 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of writer_unary_interleaved_start_id.cpp, specialized for the
+// MatmulMultiCore (bmm) output path: writes output tiles from the `out` DFB to an
+// interleaved output tensor. Forked (rather than edited in place) because the
+// original is a shared kernel used by ~31 ops; only this matmul factory needs the
+// Metal 2.0 named-binding form.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "experimental/kernel_args.h"
+
+void kernel_main() {
+    const uint32_t num_pages = get_arg(args::num_pages);
+    const uint32_t start_id = get_arg(args::start_id);
+
+    constexpr uint32_t cb_id_out = dfb::out;
+
+    // Get page size from CB interface (works for both TILE and ROW_MAJOR layouts)
+    const uint32_t page_bytes = get_local_cb_interface(cb_id_out).fifo_page_size;
+
+    Noc noc;
+    DataflowBuffer cb_out(dfb::out);
+
+    // single-page ublocks (works for both TILE and ROW_MAJOR layouts)
+    constexpr uint32_t onepage = 1;
+
+    const auto s = TensorAccessor(ta::out);
+
+    uint32_t end_id = start_id + num_pages;
+    for (uint32_t i = start_id; i < end_id; ++i) {
+        cb_out.wait_front(onepage);
+        // A bare DFB used as a NoC source is already read-pointer-sourced, so the
+        // legacy use<CircularBuffer::AddrSelector::READ_PTR>(cb_out) wrapper drops.
+        noc.async_write(cb_out, s, page_bytes, {.offset_bytes = 0}, {.page_id = i});
+        noc.async_writes_flushed();
+        cb_out.pop_front(onepage);
+    }
+    noc.async_write_barrier();
+}

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -1268,22 +1268,11 @@ void py_module(nb::module_& mod) {
             nb::arg("tensor_return_value"),
             nb::arg("core_range_set") = std::nullopt);
 
-    // Bind MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory for descriptor creation
+    // MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory was migrated to the Metal 2.0
+    // ProgramSpec concept (create_program_spec); its legacy create_descriptor pybind hook is
+    // removed. The class binding stays (the ttnn Python package imports this symbol).
     nb::class_<ttnn::prim::MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory>(
-        mod, "MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory")
-        .def_static(
-            "create_descriptor",
-            [](const ttnn::prim::MatmulParams& operation_attributes,
-               const ttnn::prim::MatmulInputs& tensor_args,
-               std::vector<ttnn::Tensor>& tensor_return_value,
-               const std::optional<CoreRangeSet>& core_range_set) {
-                return ttnn::prim::MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory::create_descriptor(
-                    operation_attributes, tensor_args, tensor_return_value, core_range_set);
-            },
-            nb::arg("operation_attributes"),
-            nb::arg("tensor_args"),
-            nb::arg("tensor_return_value"),
-            nb::arg("core_range_set") = std::nullopt);
+        mod, "MatmulMultiCoreReuseBatchedHSDRAMShardedProgramFactory");
 
     // Bind select_program_factory for Python-side factory dispatch
     mod.def(

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -1227,21 +1227,8 @@ void py_module(nb::module_& mod) {
             &ttnn::prim::MatmulMultiCoreReuseOptimizedProgramFactory::default_core_range,
             nb::arg("device"));
 
-    // Bind MatmulMultiCoreProgramFactory for descriptor creation
-    nb::class_<ttnn::prim::MatmulMultiCoreProgramFactory>(mod, "MatmulMultiCoreProgramFactory")
-        .def_static(
-            "create_descriptor",
-            [](const ttnn::prim::MatmulParams& operation_attributes,
-               const ttnn::prim::MatmulInputs& tensor_args,
-               std::vector<ttnn::Tensor>& tensor_return_value,
-               const std::optional<CoreRangeSet>& core_range_set) {
-                return ttnn::prim::MatmulMultiCoreProgramFactory::create_descriptor(
-                    operation_attributes, tensor_args, tensor_return_value, core_range_set);
-            },
-            nb::arg("operation_attributes"),
-            nb::arg("tensor_args"),
-            nb::arg("tensor_return_value"),
-            nb::arg("core_range_set") = std::nullopt);
+    // MatmulMultiCoreProgramFactory was migrated to the Metal 2.0 ProgramSpec concept
+    // (create_program_spec); its legacy create_descriptor pybind hook is removed.
 
     // Bind MatmulMultiCoreReuseMcast1DProgramFactory for descriptor creation
     nb::class_<ttnn::prim::MatmulMultiCoreReuseMcast1DProgramFactory>(mod, "MatmulMultiCoreReuseMcast1DProgramFactory")

--- a/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/matmul_nanobind.cpp
@@ -1206,22 +1206,11 @@ void py_module(nb::module_& mod) {
             nb::arg("operation_attributes"),
             nb::arg("tensor_args"));
 
-    // Bind MatmulMultiCoreReuseOptimizedProgramFactory for descriptor creation
+    // MatmulMultiCoreReuseOptimizedProgramFactory was migrated to the Metal 2.0 ProgramSpec
+    // concept (create_program_spec); its legacy create_descriptor pybind hook is removed. The
+    // class binding + default_core_range stay (the ttnn Python package imports this symbol).
     nb::class_<ttnn::prim::MatmulMultiCoreReuseOptimizedProgramFactory>(
         mod, "MatmulMultiCoreReuseOptimizedProgramFactory")
-        .def_static(
-            "create_descriptor",
-            [](const ttnn::prim::MatmulParams& operation_attributes,
-               const ttnn::prim::MatmulInputs& tensor_args,
-               std::vector<ttnn::Tensor>& tensor_return_value,
-               const std::optional<CoreRangeSet>& core_range_set) {
-                return ttnn::prim::MatmulMultiCoreReuseOptimizedProgramFactory::create_descriptor(
-                    operation_attributes, tensor_args, tensor_return_value, core_range_set);
-            },
-            nb::arg("operation_attributes"),
-            nb::arg("tensor_args"),
-            nb::arg("tensor_return_value"),
-            nb::arg("core_range_set") = std::nullopt)
         .def_static(
             "default_core_range",
             &ttnn::prim::MatmulMultiCoreReuseOptimizedProgramFactory::default_core_range,

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/METAL2_PORT_REPORT.md
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/METAL2_PORT_REPORT.md
@@ -1,0 +1,80 @@
+# Metal 2.0 Port Report — Pool2D (`pool/generic`)
+
+Factory: `Pool2D::MultiCore` — ported `create_workload_descriptor` (WorkloadDescriptorFactoryConcept)
+→ `create_program_spec` (MetalV2FactoryConcept / `ttnn::device_operation::ProgramArtifacts`).
+
+Scope as scoped by the invoker: the **L1 config path** (`!config_tensor_in_dram`), non-`return_indices`
+path (`reader_pool_2d.cpp` + `compute_pool_2d.cpp`). The DRAM-config path and the MPWI / return_indices
+path are gated out of the spec build and remain BLOCKED (see below).
+
+## TTNN ProgramFactory
+
+- Concept realized: `MetalV2FactoryConcept` (single-program, structurally identical per mesh coord —
+  confirmed by the legacy comment at the old per-coord copy loop).
+- Custom `compute_program_hash`: **KEPT** (per invoker instruction — it is shared and load-bearing for
+  the pool family). This is a deliberate deviation from the recipe's default "delete the custom hash"
+  rule; recorded here as instructed.
+- Pybind entry points removed: none (the op's nanobind does not reference the factory method directly).
+
+## Op-owned tensors (NEW capability exercised)
+
+Two host-populated, sharded device tensors are pushed into `ProgramArtifacts::op_owned_tensors`:
+
+1. **reader_indices** — the per-core sliding-window halo lookup table built on host
+   (`sliding_window::move_config_tensor_to_device`). Sharded L1 placement. Backs the
+   `reader_indices` DFB via `borrowed_from`.
+2. **scalar_config** (avg-pool, `!one_scalar_per_core` only) — the per-output-stick scalar config
+   table (`create_scalar_config_tensor`), uploaded to L1_SMALL sharded. Backs the `config` DFB via
+   `borrowed_from`. Omitted entirely when `one_scalar_per_core`.
+
+Both are populated ttnn::Tensors with sharded placement — pushed straight in, NOT re-allocated empty
+(per the branch's op-owned capability). TensorArguments referencing them are built against the
+vector's elements after population (identity footgun honored).
+
+## Dropped / changed plumbing
+
+- **Live-allocator introspection DROPPED** (legacy `pool_multi_core_program_factory.cpp:996-1012`):
+  `input.device()->allocator()->get_statistics(L1).total_allocated_bytes` and the
+  `actual_global_cb_size` / `is_graph_capture_no_dispatch_mode` TT_FATAL guards. This is a host-side
+  sanity guard with no functional effect on the program, and the framework gap list names
+  live-allocator introspection as unsupported. The local-CB-size TT_FATAL that did not need the
+  allocator is also dropped because it was paired with the global one (both were debugging guards on
+  the legacy CB accounting, which no longer exists once CBs become DFBs).
+- **`buffer->address()` through CTAs GATED OUT** (legacy `:791-794`): `config_buffer->address()`,
+  `config_buffer->page_size()`, `reader_indices_buffer->address()`, `reader_indices_buffer->page_size()`
+  fed CTA slots 33/34/35/36 and were consumed ONLY under `if constexpr (config_in_dram)` in the kernel
+  (the DRAM path). In the L1 path they are dead. The ported spec hard-sets `config_in_dram = 0` and
+  passes these four CTAs as named `0` constants, so no raw address crosses the CTA channel. The DRAM
+  path STAYS BLOCKED.
+- **`TensorAccessorArgs(...).append_to(reader0_ct_args)` DROPPED** (legacy `:816-819`): only the DRAM
+  path's `load_config_tensor_if_in_dram` consumed these (`TensorAccessorArgs<reader_tensor_args_index>`).
+  Gated out with the DRAM path.
+- Magic CB indices in CTAs → `DFBBinding` (every `*_cb_id` CTA slot).
+- Positional CTAs → named CTAs.
+
+## Blockers (precise)
+
+- **DRAM-config path** (`config_tensor_in_dram == true`): threads `reader_indices_buffer->address()`
+  and `scalar_config_buffer->address()` through CTAs into the kernel's
+  `load_config_tensor_if_in_dram<dram_addr, page_size, tensor_args_index, cb_id>()` +
+  `TensorAccessorArgs<N>()` plumbing. This is raw-address-through-CTA into a data-movement kernel — a
+  hard stop signal. The spec build `TT_FATAL`s if `config_tensor_in_dram` is requested.
+- **return_indices / MPWI path** (`reader_mpwi.cpp` + `compute_mpwi.cpp`): out of scope for this port;
+  the spec build `TT_FATAL`s if `return_indices` is requested. (Not a framework blocker — just not done.)
+
+## Applied patterns
+
+- Borrowed-memory DFBs (`borrowed_from`) for input (`raw_in`), output (`out`), reader_indices, config.
+- Aliased DFBs (`advanced_options.alias_with`) for the pre_tilize / fast_tilize pair (legacy aliased CB).
+- Conditional / optional DFB bindings: `in_scalar_1` (split-reader second scalar), `in_1`
+  (split-reader second input), `pre_tilize`/`fast_tilize` (tiled output), `config` (avg-pool).
+- Preserved multiplicity: reader0 / reader1 are two KernelSpecs of the same source when split_reader.
+
+## Open items for downstream
+
+- `raw_in` DFB is a borrowed-memory **tensor-local-view** fake-CB: the reader reads it only as an
+  address source (`in_shard_cb.get_read_ptr()`), never as a FIFO. Bound as a borrowed-from DFB with a
+  CONSUMER endpoint on the reader. (No producer kernel writes it — it is the input shard.) Flag for the
+  eventual local-`TensorAccessor` migration.
+- The DRAM-config path and the return_indices/MPWI path remain on the legacy WorkloadDescriptor concept
+  and need a follow-up port (the latter needs the same treatment for reader_mpwi/compute_mpwi).

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d_m2.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d_m2.cpp
@@ -1,0 +1,312 @@
+// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+// Metal 2.0 fork of compute_pool_2d.cpp. Forked (not edited in place) because compute_pool_2d.cpp is
+// also used by the rotate and grid_sample factories; only the Pool2D::MultiCore factory's compute
+// kernel moves to the Metal 2.0 named-binding form. Logic is identical to compute_pool_2d.cpp; only
+// the access mechanism changes: CB-id CTAs -> dfb::<name>, scalar/dimension CTAs -> get_arg(args::),
+// the positional runtime arg -> get_arg(args::out_nhw_this_core).
+
+#include <cstdint>
+
+#include "api/compute/pack_untilize.h"
+#include "api/compute/reduce.h"
+#include "api/compute/tilize.h"
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/pack.h"
+#include "api/compute/eltwise_unary/eltwise_unary.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/add_int_sfpu.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include "experimental/kernel_args.h"
+
+#define DEBUG_PRINT 0
+
+#if DEBUG_PRINT == 1
+#include "api/debug/dprint.h"
+#include "api/debug/dprint_pages.h"
+#include "api/debug/dprint_tensix.h"
+#include "tools/profiler/kernel_profiler.hpp"
+#endif
+
+#define ALWI inline __attribute__((always_inline))
+
+#define FACE_HEIGHT 16
+#define FACE_WIDTH 16
+#define TILE_HEIGHT 32
+#define TILE_WIDTH 32
+
+void kernel_main() {
+    // NOTE: here it is assumed that in_ntiles_hw == 1. General cases not handled yet. When ntiles_hw > 1 the large
+    // kernel is called
+    constexpr uint32_t in_ntiles_c = get_arg(args::in_ntiles_c);
+    constexpr uint32_t window_size_hw = get_arg(args::window_size_hw);
+
+    constexpr uint32_t split_reader = get_arg(args::split_reader);
+
+    constexpr uint32_t max_out_sticks_per_core = get_arg(args::max_out_sticks_per_core);
+    constexpr uint32_t in_c = get_arg(args::in_c);
+    constexpr uint32_t in_nblocks_c = get_arg(args::in_nblocks_c);
+    constexpr uint32_t max_sticks_for_reduction = get_arg(args::max_sticks_for_reduction);
+
+    constexpr uint32_t in_cb_id_0 = dfb::in_0;
+#ifdef SPLIT_READER
+    constexpr uint32_t in_cb_id_1 = dfb::in_1;  // for split reader
+#endif
+    constexpr uint32_t in_scalar_cb_id_0 = dfb::in_scalar_0;
+#ifdef HAS_SECOND_SCALAR_CB
+    constexpr uint32_t in_scalar_cb_id_1 = dfb::in_scalar_1;
+#endif
+    constexpr uint32_t out_cb_id = dfb::out;
+    constexpr bool one_scalar_per_core = get_arg(args::one_scalar_per_core);
+#ifdef IS_OUTPUT_TILED
+    constexpr uint32_t pre_tilize_cb_id = dfb::pre_tilize;
+#endif
+    constexpr bool is_output_tiled = get_arg(args::is_output_tiled);  // 1 = TILED, 0 = ROW_MAJOR
+    constexpr bool is_output_block_format = (bool)get_arg(args::is_output_block_format);
+    // fast_tilize_cb_id is a consumer-view alias of pre_tilize_cb_id (same L1 region,
+    // full-tile face_geometry = {face_r_dim=16, num_faces=4}). Used as the input operand
+    // to fast_tilize so the unpacker/math read the correct face count from CB metadata.
+#ifdef IS_OUTPUT_TILED
+    constexpr uint32_t fast_tilize_cb_id = dfb::fast_tilize;
+#endif
+
+    constexpr bool use_split_reader = split_reader;
+
+    constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
+    constexpr uint32_t num_faces_in_input_tile =
+        (max_sticks_for_reduction < TILE_HEIGHT || window_size_hw <= FACE_HEIGHT) ? 2 : 4;
+    // "Single partial tile per core that fits in one face": when there is only one output tile
+    // per core (in_c < TILE_WIDTH) and it fits in a single face (in_c <= FACE_WIDTH), pack just
+    // one face for that tile. The host correspondingly aligns output_shard_width to FACE_WIDTH,
+    // so the per-shard layout has no internal padding and downstream consumers (e.g.
+    // sharded_to_interleaved) read contiguous data.
+    constexpr bool single_partial_fits_in_face = last_tile_is_partial && in_c <= FACE_WIDTH;
+    constexpr uint32_t num_faces_in_output_tile = single_partial_fits_in_face ? 1 : 2;
+    // When the last tile has exactly FACE_WIDTH valid channels (channels % 32 == 16) OR the only
+    // tile is partial-fits-in-one-face, pack 1 face for the last tile.
+    constexpr uint32_t num_faces_in_last_output_tile =
+        last_tile_is_partial && (in_c % TILE_WIDTH == FACE_WIDTH || single_partial_fits_in_face) ? 1 : 2;
+
+    constexpr bool is_avg_pool = REDUCE_OP == PoolType::AVG;
+    // average pool with large kernels requires fp32 accumulation so we can only reduce 4 tiles at a time,
+    // otherwise we can reduce 8 tiles at a time. Callers (e.g. grid_sample under fp32_dest_acc_en) can
+    // also force the 4-tile limit via ct_arg[16] so each chunk fits in half-sync DEST (= 4 fp32 tiles)
+    // without forcing dst_full_sync_en.
+    constexpr bool is_large_kernel = window_size_hw > max_sticks_for_reduction;
+    constexpr bool force_max_tiles_per_reduction_4 = get_arg(args::force_max_tiles_per_reduction_4);
+    constexpr uint32_t MAX_TILES_PER_REDUCTION =
+        (force_max_tiles_per_reduction_4 || (is_avg_pool && is_large_kernel)) ? 4 : 8;
+    constexpr uint32_t max_tiles_per_iter =
+        in_ntiles_c < MAX_TILES_PER_REDUCTION ? in_ntiles_c : MAX_TILES_PER_REDUCTION;
+    constexpr uint32_t partial_iter_output_tiles =
+        in_ntiles_c % MAX_TILES_PER_REDUCTION == 0 ? max_tiles_per_iter : in_ntiles_c % MAX_TILES_PER_REDUCTION;
+
+    static_assert(REDUCE_OP == PoolType::MAX || REDUCE_OP == PoolType::AVG, "Only supports REDUCE_OP = MAX or AVG");
+    constexpr bool neginf_srca_maxpool = (REDUCE_OP == PoolType::MAX) ? true : false;
+    constexpr bool zero_srca_avgpool = (REDUCE_OP == PoolType::AVG) ? true : false;
+
+    // tilize reconfiguration can be beneficial when we have a wide tensor with a non MAX_TILES_PER_REDUCTION number of
+    // C tiles, but we only use it when the window size fits within a face such that the tilize can be done only on the
+    // rows populated with data, otherwise we need to call clear_out_tiles between reconfigs to avoid untilizing junk
+    // data which is much slower than just untilizing the entire MAX_TILES_PER_REDUCTION
+    constexpr bool tilize_reconfig = in_nblocks_c > 1 && in_ntiles_c % MAX_TILES_PER_REDUCTION != 0 &&
+                                     window_size_hw <= FACE_HEIGHT && !last_tile_is_partial;
+
+    // tilize_untilize_cb selects the pre_tilize view for TILED output, else the output CB. When the
+    // op is not tiled, dfb::pre_tilize is unbound (no IS_OUTPUT_TILED define), so the ternary that
+    // referenced pre_tilize_cb_id is #ifdef-gated to the bound branch.
+#ifdef IS_OUTPUT_TILED
+    constexpr uint32_t tilize_untilize_cb = is_output_tiled ? pre_tilize_cb_id : out_cb_id;
+#else
+    constexpr uint32_t tilize_untilize_cb = out_cb_id;
+#endif
+
+    experimental::CB in_scalar_cb_0(in_scalar_cb_id_0);
+#ifdef HAS_SECOND_SCALAR_CB
+    experimental::CB in_scalar_cb_1(in_scalar_cb_id_1);
+#endif
+    experimental::CB in_cb_0(in_cb_id_0);
+#ifdef SPLIT_READER
+    experimental::CB in_cb_1(in_cb_id_1);
+#endif
+    experimental::CB out_cb(out_cb_id);
+#ifdef IS_OUTPUT_TILED
+    experimental::CB pre_tilize_cb(pre_tilize_cb_id);
+    experimental::CB fast_tilize_cb(fast_tilize_cb_id);
+#endif
+
+    tilizeA_B_reduce_init<neginf_srca_maxpool, zero_srca_avgpool>(
+        in_cb_id_0, in_scalar_cb_id_0, max_tiles_per_iter, tilize_untilize_cb);
+
+    pack_untilize_dest_init<max_tiles_per_iter>(tilize_untilize_cb);
+
+    constexpr uint32_t remaining_elems = window_size_hw % max_sticks_for_reduction;
+    constexpr uint32_t interm_reduction_chunks =
+        remaining_elems ? window_size_hw / max_sticks_for_reduction + 1 : window_size_hw / max_sticks_for_reduction;
+
+    // wait for initialization to complete
+    if constexpr (one_scalar_per_core) {
+        in_scalar_cb_0.wait_front(1);
+    }
+
+    // if max out sticks is non-zero then this will be used as the number of out sticks for every core
+    // otherwise the runtime args are referenced for core-specific number of out sticks, for Pool2D
+    // runtime args are used while for grid sample the max out sticks is set
+    uint32_t num_out_sticks_this_core =
+        max_out_sticks_per_core ? max_out_sticks_per_core : get_arg(args::out_nhw_this_core);
+    uint32_t last_tile_height =
+        num_out_sticks_this_core % TILE_HEIGHT == 0 ? TILE_HEIGHT : num_out_sticks_this_core % TILE_HEIGHT;
+
+    uint32_t tilize_stick_counter = 0;
+    uint32_t tilize_stick_total = 0;
+    for (uint32_t n = 0; n < num_out_sticks_this_core; ++n) {
+        const bool reader0 = !(use_split_reader && (n & 0x1));
+        const bool use_reader1_scalar = !reader0 && !one_scalar_per_core;
+        // The "reader1" operands (in_scalar_1 / in_1) only exist when their DFB is bound, i.e. when
+        // split-reader (and, for the scalar, the second-scalar) DFB is present. When unbound the
+        // ternary's reader1 branch can never be taken at runtime (use_reader1_scalar / !reader0 are
+        // always false without split-reader), so #ifdef-select the reader0 operand directly.
+#ifdef HAS_SECOND_SCALAR_CB
+        const uint32_t curr_scalar_cb_id = use_reader1_scalar ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
+        experimental::CB curr_scalar_cb = use_reader1_scalar ? in_scalar_cb_1 : in_scalar_cb_0;
+#else
+        const uint32_t curr_scalar_cb_id = in_scalar_cb_id_0;
+        experimental::CB curr_scalar_cb = in_scalar_cb_0;
+#endif
+#ifdef SPLIT_READER
+        const uint32_t curr_in_cb_id = !reader0 ? in_cb_id_1 : in_cb_id_0;
+        experimental::CB curr_in_cb = reader0 ? in_cb_0 : in_cb_1;
+#else
+        const uint32_t curr_in_cb_id = in_cb_id_0;
+        experimental::CB curr_in_cb = in_cb_0;
+#endif
+        if constexpr (!one_scalar_per_core) {
+            curr_scalar_cb.wait_front(1);
+        }
+        if (is_output_tiled && !tilize_stick_counter) {
+            out_cb.reserve_back(in_ntiles_c);
+        }
+        for (uint32_t c_i = 0; c_i < in_nblocks_c; c_i++) {
+            const bool last_c_block = c_i == in_nblocks_c - 1;
+            const bool first_c_block = c_i == 0;
+            const uint32_t tiles_to_reduce =
+                tilize_reconfig ? (last_c_block ? partial_iter_output_tiles : max_tiles_per_iter) : max_tiles_per_iter;
+            const uint32_t number_of_tiles = last_c_block ? partial_iter_output_tiles : max_tiles_per_iter;
+            const uint32_t output_faces =
+                (last_tile_is_partial && last_c_block &&
+                 (in_c % TILE_WIDTH == FACE_WIDTH || single_partial_fits_in_face))
+                    ? (number_of_tiles - 1) * num_faces_in_output_tile + num_faces_in_last_output_tile
+                    : number_of_tiles * num_faces_in_output_tile;
+            if constexpr (!is_output_tiled) {
+                out_cb.reserve_back(output_faces);
+            }
+            if constexpr (tilize_reconfig) {
+                if (first_c_block || last_c_block) {
+                    UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                        in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce)));
+                }
+            }
+            tile_regs_acquire();
+            for (uint32_t chunk = 0; chunk < interm_reduction_chunks; chunk++) {
+                curr_in_cb.wait_front(1);
+                unpack_tilizeA_B_block<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                    curr_in_cb_id,
+                    curr_scalar_cb_id,
+                    tiles_to_reduce,
+                    0 /*tile idx for Src b is 0 because only 1 tile of constants is loaded*/);
+                for (uint32_t math_tile_idx = 0; math_tile_idx < tiles_to_reduce; ++math_tile_idx) {
+                    reduce_tile_math<REDUCE_OP, REDUCE_DIM>(math_tile_idx, num_faces_in_input_tile);
+                }
+                curr_in_cb.pop_front(1);
+            }
+            tile_regs_commit();
+            tile_regs_wait();
+            if constexpr (is_output_tiled) {
+                // TILED output: accumulate sticks and perform tilization when needed.
+                // dfb::pre_tilize / dfb::fast_tilize are only bound on the tiled path (IS_OUTPUT_TILED),
+                // which is exactly when is_output_tiled is true; #ifdef-guard the body so the unbound
+                // tokens never enter name lookup on the row-major build.
+#ifdef IS_OUTPUT_TILED
+                if (last_c_block) {
+                    pack_untilize_dest<partial_iter_output_tiles>(pre_tilize_cb_id, 1, 0);
+                    pre_tilize_cb.push_back(partial_iter_output_tiles);
+                    tilize_stick_counter++;
+                    tilize_stick_total++;
+                } else {
+                    pack_untilize_dest<max_tiles_per_iter>(pre_tilize_cb_id, 1, 0);
+                    pre_tilize_cb.push_back(max_tiles_per_iter);
+                }
+                tile_regs_release();
+
+                bool last_tile = num_out_sticks_this_core - tilize_stick_total < last_tile_height;
+                if (tilize_stick_counter == TILE_HEIGHT || (last_tile && tilize_stick_counter == last_tile_height)) {
+                    if (last_tile && last_tile_height != TILE_HEIGHT) {
+                        pre_tilize_cb.wait_front(last_tile_height * in_ntiles_c);
+                        // if the last tile is not whole we won't have pushed enough sticks, so we need to
+                        // push some filler sticks to reach TILE_HEIGHT to make sure the CB pointers are correct
+                        // before calling tilize
+                        uint32_t filler_stick_tiles =
+                            (TILE_HEIGHT - last_tile_height) *
+                            ((in_nblocks_c - 1) * max_tiles_per_iter + partial_iter_output_tiles);
+                        pre_tilize_cb.push_back(filler_stick_tiles);
+                    }
+                    PACK((pack_untilize_uninit(pre_tilize_cb_id)));
+
+                    unpack_tilizeA_B_uninit(curr_in_cb_id);
+                    pack_reconfig_data_format(out_cb_id);
+
+                    // Hand the freshly-written L1 region off to the consumer view of the
+                    // multi-format CB. pre_tilize_cb_id was pushed in TILE_HEIGHT*in_ntiles_c
+                    // stick-pages (page_size = TILE_WIDTH*nbytes); fast_tilize_cb_id sees the
+                    // same bytes as in_ntiles_c full tiles (page_size = tile_size). Both views
+                    // advance by the same number of bytes per round so their rd/wr pointers
+                    // stay aligned. The producer-view wait_front/pop_front/reserve_back below
+                    // continues to drive the producer pointer ledger.
+                    fast_tilize_cb.push_back(in_ntiles_c);
+                    fast_tilize_cb.wait_front(in_ntiles_c);
+
+                    fast_tilize_init(fast_tilize_cb_id, in_ntiles_c, out_cb_id);
+                    fast_tilize_block(fast_tilize_cb_id, in_ntiles_c, out_cb_id);
+                    fast_tilize_uninit(fast_tilize_cb_id, out_cb_id, in_ntiles_c);
+
+                    out_cb.push_back(in_ntiles_c);
+                    fast_tilize_cb.pop_front(in_ntiles_c);
+                    fast_tilize_cb.reserve_back(in_ntiles_c);
+                    pre_tilize_cb.pop_front(TILE_HEIGHT * in_ntiles_c);
+                    pre_tilize_cb.reserve_back(TILE_HEIGHT * in_ntiles_c);
+
+                    tilize_stick_counter = 0;
+
+                    UNPACK((llk_unpack_tilizeA_B_init<neginf_srca_maxpool, true, false, zero_srca_avgpool>(
+                        in_cb_id_0, in_scalar_cb_id_0, tiles_to_reduce)));
+                    // init math for reduction again since FPU gets reprogrammed by tilize
+                    MATH((llk_math_reduce_init<REDUCE_OP, REDUCE_DIM, DST_ACCUM_MODE, MATH_FIDELITY>()));
+#ifdef ARCH_BLACKHOLE
+                    // need this on BH to set swizzle bit before pack untilize dest
+                    MATH((llk_math_reconfig_remap(true)));
+#endif
+
+                    if constexpr (is_output_block_format) {
+                        pack_reconfig_data_format(pre_tilize_cb_id);
+                    }
+                    PACK((llk_pack_untilize_init<max_tiles_per_iter, max_tiles_per_iter, false, false, TILE_C_DIM>(
+                        pre_tilize_cb_id)));
+                }
+#endif  // IS_OUTPUT_TILED
+            } else {
+                // ROW_MAJOR output: pack directly to output CB
+                if (last_c_block) {
+                    pack_untilize_dest<partial_iter_output_tiles>(out_cb_id, 1, 0);
+                } else {
+                    pack_untilize_dest<max_tiles_per_iter>(out_cb_id, 1, 0);
+                }
+                out_cb.push_back(output_faces);
+                tile_regs_release();
+            }
+        }
+        if constexpr (!one_scalar_per_core) {
+            curr_scalar_cb.pop_front(1);
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp
@@ -1,11 +1,18 @@
 // SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+// Metal 2.0 port. Used only by the Pool2D::MultiCore factory, so ported in place. Logic is
+// unchanged; only the access mechanism moves to named bindings: CB ids -> dfb::<name>, scalar/
+// dimension CTAs -> get_arg(args::...), positional runtime args -> get_arg(args::...). The
+// DRAM-config path (load_config_tensor_if_in_dram / TensorAccessorArgs) is gated out by the host
+// (config_in_dram forced to 0) and stays on the legacy concept.
+
 #include <sys/types.h>
 
 #include <cstdint>
 #include <api/dataflow/dataflow_api.h>
 #include <ttnn/cpp/ttnn/operations/pool/device/kernels/pool_kernels_common.hpp>
+#include "experimental/kernel_args.h"
 
 #define ENABLE_DEBUG_PRINT 0
 
@@ -163,60 +170,62 @@ ALWI void read_kernel_with_top_left_index(uint32_t ind, uint32_t in_l1_read_base
  * Pool 2D (Max pool 2D and Avg pool 2D)
  */
 void kernel_main() {
-    constexpr uint32_t reader_nindices = get_compile_time_arg_val(0);
-    constexpr uint32_t kernel_h = get_compile_time_arg_val(1);
-    constexpr uint32_t kernel_w = get_compile_time_arg_val(2);
+    constexpr uint32_t reader_nindices = get_arg(args::reader_nindices);
+    constexpr uint32_t kernel_h = get_arg(args::kernel_h);
+    constexpr uint32_t kernel_w = get_arg(args::kernel_w);
 
-    constexpr int32_t pad_w = get_compile_time_arg_val(3);
+    constexpr int32_t pad_w = get_arg(args::pad_w);
 
     // channel size in bytes
-    constexpr uint32_t in_nbytes_leftover = get_compile_time_arg_val(4);
+    constexpr uint32_t in_nbytes_leftover = get_arg(args::in_nbytes_leftover);
 
     // input tensor height / width / channels
-    constexpr int32_t in_w = get_compile_time_arg_val(5);
+    constexpr int32_t in_w = get_arg(args::in_w);
 
-    constexpr uint32_t in_c = get_compile_time_arg_val(6);
+    constexpr uint32_t in_c = get_arg(args::in_c);
 
-    constexpr uint32_t split_reader = get_compile_time_arg_val(7);
-    constexpr uint32_t reader_id = get_compile_time_arg_val(8);
+    constexpr uint32_t split_reader = get_arg(args::split_reader);
+    constexpr uint32_t reader_id = get_arg(args::reader_id);
 
-    constexpr uint32_t bf16_scalar = get_compile_time_arg_val(9);
-    constexpr uint32_t bf16_init_value = get_compile_time_arg_val(10);
+    constexpr uint32_t bf16_scalar = get_arg(args::bf16_scalar);
+    constexpr uint32_t bf16_init_value = get_arg(args::bf16_init_value);
 
-    constexpr uint32_t in_nblocks_c = get_compile_time_arg_val(11);
-    constexpr uint32_t in_cb_sz = get_compile_time_arg_val(12);
-    constexpr uint32_t max_sticks_for_reduction = get_compile_time_arg_val(13);
-    constexpr uint32_t ceil_pad_w = get_compile_time_arg_val(14);
+    constexpr uint32_t in_nblocks_c = get_arg(args::in_nblocks_c);
+    constexpr uint32_t in_cb_sz = get_arg(args::in_cb_sz);
+    constexpr uint32_t max_sticks_for_reduction = get_arg(args::max_sticks_for_reduction);
+    constexpr uint32_t ceil_pad_w = get_arg(args::ceil_pad_w);
 
-    constexpr uint32_t in_cb_id = (reader_id == 1) ? get_compile_time_arg_val(16) : get_compile_time_arg_val(15);
-    constexpr uint32_t in_shard_cb_id = get_compile_time_arg_val(17);
-    constexpr uint32_t in_reader_indices_cb_id = get_compile_time_arg_val(18);
-    constexpr uint32_t in_scalar_cb_id_0 = get_compile_time_arg_val(19);
-    constexpr uint32_t in_scalar_cb_id_1 = get_compile_time_arg_val(20);
-    constexpr uint32_t clear_value_cb_id = get_compile_time_arg_val(21);
-    constexpr bool is_avg_pool = (bool)get_compile_time_arg_val(22);
-    constexpr bool one_scalar_per_core = get_compile_time_arg_val(23);
-    constexpr uint32_t config_cb_id = get_compile_time_arg_val(24);
-    constexpr uint32_t in_nbytes_c = get_compile_time_arg_val(25);
-    constexpr uint32_t shard_width_bytes = get_compile_time_arg_val(26);
-    constexpr uint32_t multi_buffering_factor = get_compile_time_arg_val(27);
-    constexpr uint32_t stride_w = get_compile_time_arg_val(28);
-    constexpr uint32_t dilation_h = get_compile_time_arg_val(29);
-    constexpr uint32_t dilation_w = get_compile_time_arg_val(30);
-    constexpr bool zero_pages = (bool)get_compile_time_arg_val(31);
-    constexpr uint32_t config_in_dram = get_compile_time_arg_val(32);
-    constexpr uint32_t config_dram_addr = get_compile_time_arg_val(33);
-    constexpr uint32_t config_page_size = get_compile_time_arg_val(34);
-    constexpr uint32_t reader_dram_addr = get_compile_time_arg_val(35);
-    constexpr uint32_t reader_page_size = get_compile_time_arg_val(36);
+    // The reader's input / scalar DFBs are bound under the SAME accessor name on both readers
+    // (reader0 -> in_0/in_scalar_0, reader1 -> in_1/in_scalar_1), so the kernel uses one handle.
+    constexpr uint32_t in_cb_id = dfb::in;
+    constexpr uint32_t in_shard_cb_id = dfb::raw_in;
+    constexpr uint32_t in_reader_indices_cb_id = dfb::reader_indices;
+    constexpr bool is_avg_pool = (bool)get_arg(args::pool_type);
+    constexpr bool one_scalar_per_core = get_arg(args::one_scalar_per_core);
+    constexpr uint32_t in_nbytes_c = get_arg(args::in_nbytes_c);
+    constexpr uint32_t shard_width_bytes = get_arg(args::shard_width_bytes);
+    constexpr uint32_t multi_buffering_factor = get_arg(args::multi_buffering_factor);
+    constexpr uint32_t stride_w = get_arg(args::stride_w);
+    constexpr uint32_t dilation_h = get_arg(args::dilation_h);
+    constexpr uint32_t dilation_w = get_arg(args::dilation_w);
+    constexpr bool zero_pages = (bool)get_arg(args::zero_pages);
+    constexpr uint32_t config_in_dram = get_arg(args::config_in_dram);
+    constexpr uint32_t config_dram_addr = get_arg(args::config_dram_addr);
+    constexpr uint32_t config_page_size = get_arg(args::config_page_size);
+    constexpr uint32_t reader_dram_addr = get_arg(args::reader_dram_addr);
+    constexpr uint32_t reader_page_size = get_arg(args::reader_page_size);
     constexpr uint32_t reader_tensor_args_index = 55;
 
     constexpr bool use_split_reader = split_reader;
 
     constexpr uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
     constexpr bool last_tile_is_partial = in_c % TILE_WIDTH != 0;
-    constexpr uint32_t in_scalar_cb_id =
-        use_split_reader && reader_id == 1 && !one_scalar_per_core ? in_scalar_cb_id_1 : in_scalar_cb_id_0;
+    // Each reader binds its own scalar DFB (reader0 -> in_scalar_0, reader1 -> in_scalar_1) under the
+    // shared accessor "in_scalar". When this reader does not bind a scalar DFB (reader1 without a
+    // second scalar CB), READER_BINDS_SCALAR is undefined and the scalar handle is gated out below.
+#ifdef READER_BINDS_SCALAR
+    constexpr uint32_t in_scalar_cb_id = dfb::in_scalar;
+#endif
 
     constexpr uint32_t window_size_hw = kernel_h * kernel_w;
     constexpr uint32_t face_r_dim = window_size_hw < FACE_HEIGHT ? window_size_hw : FACE_HEIGHT;
@@ -233,11 +242,15 @@ void kernel_main() {
          interm_reduction_chunks <= multi_buffering_factor);
     constexpr uint32_t in_cb_ntiles = in_cb_sz / (TILE_WIDTH * TILE_HEIGHT);  // only use the non-multi buffering size
 
-    experimental::CB clear_value_cb(clear_value_cb_id);
+    experimental::CB clear_value_cb(dfb::clear_value);
+#ifdef READER_BINDS_SCALAR
     experimental::CB in_scalar_cb(in_scalar_cb_id);
+#endif
     experimental::CB in_shard_cb(in_shard_cb_id);
     experimental::CB reader_indices_cb(in_reader_indices_cb_id);
-    experimental::CB config_cb(config_cb_id);
+#ifdef HAS_CONFIG_CB
+    experimental::CB config_cb(dfb::config);
+#endif
 
     // fill the clear cb
     if constexpr (is_avg_pool || need_to_initialize_in_cb) {
@@ -250,7 +263,7 @@ void kernel_main() {
         }
         // for average pool clear out tiles runs in loop, no need to initialize here
         if constexpr (!is_avg_pool || !is_large_kernel) {
-            clear_out_tiles<in_cb_id, clear_value_cb_id>(Noc(), experimental::CB(in_cb_id), clear_value_cb);
+            clear_out_tiles<in_cb_id, dfb::clear_value>(Noc(), experimental::CB(in_cb_id), clear_value_cb);
         }
     }
 
@@ -262,7 +275,7 @@ void kernel_main() {
         fill_with_val(in_scalar_cb.get_write_ptr(), FACE_WIDTH, bf16_scalar >> 16);
         in_scalar_cb.push_back(1);
     }
-    const uint32_t core_nhw_index = get_arg_val<uint32_t>(1);
+    const uint32_t core_nhw_index = get_arg(args::core_nhw_index);
 
     const uint32_t in_l1_read_base_addr = in_shard_cb.get_read_ptr();
     if constexpr (config_in_dram) {
@@ -290,6 +303,7 @@ void kernel_main() {
     uint32_t scalar_value;
     uint32_t scalar_end;
     uint32_t counter = reader_id;
+#ifdef HAS_CONFIG_CB
     if constexpr (!one_scalar_per_core) {
         uint32_t config_l1_addr = config_cb.get_read_ptr();
         if constexpr (config_in_dram) {
@@ -300,7 +314,7 @@ void kernel_main() {
                     config_dram_addr,
                     config_page_size,
                     config_tensor_args_index,
-                    config_cb_id>(Noc(), config_cb, core_nhw_index);
+                    dfb::config>(Noc(), config_cb, core_nhw_index);
             } else {
                 config_cb.wait_front(1);
             }
@@ -310,6 +324,7 @@ void kernel_main() {
         scalar_value = config_ptr[1];
         scalar_end = config_ptr[2];
     }
+#endif
 
     uint16_t num_segments = reader_indices_ptr[0] & 0xffff;
     bool first_row_value = reader_id == 0 || !use_split_reader;
@@ -326,6 +341,9 @@ void kernel_main() {
 
         constexpr uint32_t stride_multiple = use_split_reader ? 2 : 1;
         for (uint16_t ind = start; ind <= end; ind += stride_multiple * stride_w) {
+#ifdef READER_BINDS_SCALAR
+            // fill_scalar only runs on the !one_scalar_per_core (avg) path; the scalar DFB is bound
+            // exactly on the readers that reach this code, so it is gated on READER_BINDS_SCALAR.
             if constexpr (!one_scalar_per_core) {
                 fill_scalar<
                     one_scalar_per_core,
@@ -335,6 +353,7 @@ void kernel_main() {
                     multi_buffering_factor>(
                     in_scalar_cb, scalar_start, scalar_end, scalar_value, scalar_index, counter, config_ptr);
             }
+#endif
             read_kernel_with_top_left_index<
                 in_nblocks_c,
                 in_cb_id,
@@ -347,7 +366,7 @@ void kernel_main() {
                 total_elems_to_reduce,
                 is_avg_pool,
                 wide_reduction,
-                clear_value_cb_id,
+                dfb::clear_value,
                 in_cb_ntiles,
                 in_nbytes_c,
                 shard_width_bytes,

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_multi_core_program_factory.cpp
@@ -2,11 +2,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include "pool_op.hpp"
-#include "tt-metalium/circular_buffer_config.hpp"
 #include "tt-metalium/constants.hpp"
-#include "tt-metalium/tensor_accessor_args.hpp"
 #include "tt-metalium/tt_backend_api_types.hpp"
-#include "ttnn/operations/cb_utils.hpp"
 #include "ttnn/operations/pool/pool_utils.hpp"
 #include "tt-metalium/host_buffer.hpp"
 #include "tt-metalium/buffer.hpp"
@@ -19,14 +16,17 @@
 #include <tt-metalium/host_api.hpp>
 #include "ttnn/tensor/storage.hpp"
 #include <tt-metalium/hal.hpp>
-#include <tt-metalium/program_descriptors.hpp>
 #include <algorithm>
 #include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
+
 namespace ttnn::operations::pool {
 
-// Circular buffer ID used to indicate an unallocated/invalid CB
-constexpr uint32_t INVALID_CB_ID = 32;
+using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 /**
  * Generic pool implementation that uses the new sliding window infrastructure.
@@ -257,809 +257,43 @@ std::vector<uint32_t> generate_core_starting_indices(
     return starting_indices;
 }
 
-static tt::tt_metal::ProgramDescriptor pool2d_multi_core_sharded_with_halo_v2_impl_new(
-    const Tensor& input,
-    tt::tt_metal::Buffer* reader_indices_buffer,
-    tt::tt_metal::Buffer* scalar_config_buffer,
-    uint32_t reader_indices_size,
-    std::vector<Tensor>& outputs,
-    Pool2DType pool_type,
-    uint32_t in_n,
-    uint32_t in_c,
-    uint32_t in_h,
-    uint32_t in_w,
-    uint32_t out_h,
-    uint32_t out_w,
-    uint32_t out_c,
-    uint32_t kernel_h,
-    uint32_t kernel_w,
-    uint32_t stride_h,
-    uint32_t stride_w,
-    uint32_t pad_t,
-    uint32_t pad_b,
-    uint32_t pad_l,
-    uint32_t pad_r,
-    uint32_t ceil_pad_h,
-    uint32_t ceil_pad_w,
-    bool ceil_mode,
-    bool return_indices,
-    std::vector<uint32_t> core_starting_indices,
-    bool count_include_pad,
-    uint32_t dilation_h,
-    uint32_t dilation_w,
-    uint32_t num_shards_c,
-    const std::optional<DeviceComputeKernelConfig>& compute_kernel_config,
-    std::optional<int32_t> divisor_override,
-    uint32_t memory_used,
-    const Layout& output_layout,
-    bool config_tensor_in_dram) {
-    using namespace tt::tt_metal;
-
-    TT_FATAL(
-        reader_indices_buffer != nullptr,
-        "Pool2D::MultiCore::create_workload_descriptor must populate the reader-indices buffer before building "
-        "programs");
-
-    const bool is_block_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
-    const bool is_width_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
-
-    // distributing out_hw across the grid
-    const auto all_cores = input.shard_spec().value().grid;
-    const uint32_t ncores = all_cores.num_cores();
-    const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
-    const uint32_t rectangular_x = is_block_sharded ? all_cores.ranges()[0].end_coord.x + 1 : num_cores_x;
-    const uint32_t max_out_nhw_per_core = outputs[0].shard_spec()->shape[0];
-    const uint32_t max_in_nhw_per_core = input.shard_spec()->shape[0];
-    TT_FATAL(
-        max_in_nhw_per_core <= std::numeric_limits<uint16_t>::max(),
-        "Input nhw per core {} exceeds uint16_t limit, this will cause overflow because the reader indices are stored "
-        "as uint16_t",
-        max_in_nhw_per_core);
-
-    const uint32_t bf16_scalar = get_bf16_pool_scalar(pool_type, kernel_h, kernel_w, divisor_override);
-    const uint32_t bf16_init_value = get_bf16_pool_init_value(pool_type);
-    FactoryParameters params = get_factory_parameters(
-        num_shards_c,
-        input.dtype(),
-        outputs[0].dtype(),
-        kernel_h,
-        kernel_w,
-        in_c,
-        pool_type,
-        return_indices,
-        in_h,
-        in_w,
-        output_layout);
-    uint32_t eff_kernel_h = ((kernel_h - 1) * dilation_h) + 1;
-    uint32_t eff_kernel_w = ((kernel_w - 1) * dilation_w) + 1;
-    uint32_t pad_h = pad_t + pad_b;
-    uint32_t pad_w = pad_l + pad_r;
-    const uint32_t in_h_padded = in_h + pad_h + ceil_pad_h;
-    const uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
-    const bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
-        pool_type, ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
-
-    // Compute CB sizes centrally - used for both CB creation and L1 validation.
-    // When the DRAM config-tensor path is active, the reader indices tensor is already built on
-    // host so we pass its real per-core page size. Auto-shard evaluation in pool_utils.cpp still
-    // falls back to the worst case because the buffers do not exist yet there. The scalar config
-    // tensor (only created for avg pool without one_scalar_per_core) is not yet known at this
-    // point, so its prediction remains the worst case; that matches how the CB is created below.
-    auto output_shard_shape = outputs[0].shard_spec().value().shape;
-    std::optional<uint32_t> reader_indices_actual_page_size;
-    if (config_tensor_in_dram) {
-        reader_indices_actual_page_size = reader_indices_buffer->page_size();
-    }
-    PoolCBSizes cb_sizes = calculate_pool_cb_sizes(
-        params,
-        one_scalar_per_core,
-        return_indices,
-        output_layout,
-        outputs[0].dtype(),
-        {output_shard_shape[0], output_shard_shape[1]},
-        config_tensor_in_dram,
-        reader_indices_actual_page_size);
-
-    const auto& input_shape = input.padded_shape();
-    const uint32_t shard_width = input.shard_spec()->shape[1];
-    const uint32_t in_c_per_shard_ceil = in_c % shard_width != 0 && num_shards_c > 1
-                                             ? (in_c - (in_c % shard_width)) / (num_shards_c - 1)
-                                             : in_c / num_shards_c;
-    const uint32_t in_nbytes_c = in_c_per_shard_ceil * params.nbytes;  // row of input (channels)
-    const uint32_t shard_width_bytes = input_shape[3] / num_shards_c * params.nbytes;
-
-    TT_FATAL(
-        input_shape[3] % num_shards_c == 0,
-        "Input channels {} should be divisible by number of shards {}",
-        input_shape[3],
-        num_shards_c);
-    const uint32_t in_nbytes_leftover =
-        params.is_wide_reduction &&
-                (input_shape[3] / num_shards_c) % (params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH) != 0
-            ? tt::round_up(
-                  (input_shape[3] / num_shards_c) % (params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH),
-                  tt::constants::TILE_WIDTH) *
-                  params.nbytes
-            : tt::round_up(input_shape[3] / num_shards_c, tt::constants::TILE_WIDTH) * params.nbytes;
-
-    ProgramDescriptor desc;
-
-    // Helper to add a non-globally-allocated (local) CB to desc with a single format.
-    auto add_local_cb = [&](uint32_t cb_id,
-                            uint32_t page_size,
-                            uint32_t num_pages,
-                            tt::DataFormat data_format,
-                            std::optional<FaceGeometry> face_geometry = std::nullopt,
-                            std::optional<TileDescriptor> tile = std::nullopt) {
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = page_size * num_pages,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(cb_id),
-                .data_format = data_format,
-                .page_size = page_size,
-                .tile = tile,
-                .face_geometry = face_geometry,
-            }}},
-        });
-    };
-    // Helper for sharded (globally-allocated) CBs whose address is patched on cache hit.
-    auto add_sharded_cb = [&](uint32_t cb_id,
-                              uint32_t page_size,
-                              uint32_t num_pages,
-                              tt::DataFormat data_format,
-                              tt::tt_metal::Buffer* buffer,
-                              std::optional<FaceGeometry> face_geometry = std::nullopt,
-                              std::optional<TileDescriptor> tile = std::nullopt) {
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = page_size * num_pages,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(cb_id),
-                .data_format = data_format,
-                .page_size = page_size,
-                .tile = tile,
-                .face_geometry = face_geometry,
-            }}},
-            .buffer = buffer,
-        });
-    };
-
-    uint32_t next_cb_index = tt::CBIndex::c_0;
-    const uint32_t in_scalar_cb_id_0 = next_cb_index++;
-    const uint32_t in_scalar_cb_pagesize = cb_sizes.scalar_cb_pagesize;
-    const uint32_t in_scalar_cb_npages = cb_sizes.scalar_cb_npages;
-    const auto scalar_face_geometry = FaceGeometry{.face_r_dim = 1, .num_faces = 4};
-    add_local_cb(
-        in_scalar_cb_id_0, in_scalar_cb_pagesize, in_scalar_cb_npages, params.data_format, scalar_face_geometry);
-    log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_scalar_cb_id_0, in_scalar_cb_pagesize, in_scalar_cb_npages);
-
-    uint32_t in_scalar_cb_id_1 = INVALID_CB_ID;
-    if (cb_sizes.has_second_scalar_cb) {
-        in_scalar_cb_id_1 = next_cb_index++;
-        add_local_cb(
-            in_scalar_cb_id_1, in_scalar_cb_pagesize, in_scalar_cb_npages, params.data_format, scalar_face_geometry);
-        log_debug(
-            tt::LogOp, "CB {} :: PS = {}, NP = {}", in_scalar_cb_id_1, in_scalar_cb_pagesize, in_scalar_cb_npages);
-    }
-
-    // CB storing just "clear value" (-inf for maxpool, 0 for avgpool)
-    uint32_t clear_value_cb_id = next_cb_index++;
-    add_local_cb(clear_value_cb_id, cb_sizes.clear_value_cb_size, 1, params.data_format);
-    log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", clear_value_cb_id, cb_sizes.clear_value_cb_size, 1);
-
-    // incoming data is the input cb instead of raw l1/dram addr
-    // this input shard has halo and padding inserted.
-    const uint32_t raw_in_cb_npages = input.shard_spec().value().shape[0];
-    const uint32_t raw_in_cb_pagesize = in_nbytes_c;
-    const uint32_t raw_in_cb_id = next_cb_index++;
-    add_sharded_cb(raw_in_cb_id, raw_in_cb_pagesize, raw_in_cb_npages, params.data_format, input.buffer());
-
-    log_debug(tt::LogOp, "Raw In CB {} :: PS = {}, NP = {}", raw_in_cb_id, raw_in_cb_pagesize, raw_in_cb_npages);
-
-    // reader indices
-    const uint32_t in_reader_indices_cb_id = next_cb_index++;
-    const uint32_t in_reader_indices_cb_pagesize =
-        tt::round_up(reader_indices_size, 4);  // pagesize needs to be multiple of 4
-    constexpr uint32_t in_reader_indices_cb_npages = 1;
-
-    const uint32_t max_reader_indices_size =
-        (max_out_nhw_per_core * 3 * sizeof(uint16_t)) + 2;  // worst case of 3 indices per output element
-    const uint32_t actual_reader_indices_buffer_page_size = reader_indices_buffer->page_size();
-    TT_FATAL(
-        actual_reader_indices_buffer_page_size <= max_reader_indices_size,
-        "Reader indices buffer page size {} exceeds max expected size {}",
-        actual_reader_indices_buffer_page_size,
-        max_reader_indices_size);
-
-    if (config_tensor_in_dram) {
-        // DRAM-backed reader indices buffer: the CB is purely local scratch; the kernel
-        // reads from DRAM via TensorAccessor and the CB is sized to the actual buffer
-        // page size (see PR #43193) to keep the L1 footprint tight. The worst-case
-        // value above is only used as an upper-bound check.
-        add_local_cb(
-            in_reader_indices_cb_id,
-            actual_reader_indices_buffer_page_size,
-            in_reader_indices_cb_npages,
-            tt::DataFormat::UInt16);
-    } else {
-        add_sharded_cb(
-            in_reader_indices_cb_id,
-            in_reader_indices_cb_pagesize,
-            in_reader_indices_cb_npages,
-            tt::DataFormat::UInt16,
-            reader_indices_buffer);
-    }
-
-    log_debug(
-        tt::LogOp,
-        "In Reader Indices CB {} :: PS = {}, NP = {}",
-        in_reader_indices_cb_id,
-        in_reader_indices_cb_pagesize,
-        in_reader_indices_cb_npages);
-    // in_nblocks_c is factory-specific (used for kernel args), derived from the shared in_cb_raw_size
-    uint32_t in_nblocks_c = 1;
-    if (return_indices || params.is_wide_reduction) {
-        in_nblocks_c =
-            static_cast<uint32_t>(std::ceil(static_cast<float>(params.in_ntiles_c) / params.MAX_TILES_PER_REDUCTION));
-    }
-
-    // reader output == input to tilize
-    const uint32_t in_cb_id_0 = next_cb_index++;  // input rows for "multiple (out_nelems)" output pixels
-    uint32_t in_cb_id_1 = INVALID_CB_ID;          // input rows for "multiple (out_nelems)" output pixels
-    const uint32_t in_cb_pagesize = cb_sizes.in_cb_pagesize;
-    const uint32_t in_cb_npages = cb_sizes.in_cb_npages;
-
-    const uint32_t window_size_hw = kernel_h * kernel_w;
-    const uint32_t raw_face_r = std::min(window_size_hw, 16u);
-    const uint32_t num_faces_in_input_tile_for_cb =
-        (params.max_rows_for_reduction < tt::constants::TILE_HEIGHT || window_size_hw <= tt::constants::FACE_HEIGHT)
-            ? 2u
-            : 4u;
-    const std::optional<FaceGeometry> input_face_geometry =
-        return_indices
-            ? std::nullopt
-            : std::optional{FaceGeometry{.face_r_dim = raw_face_r, .num_faces = num_faces_in_input_tile_for_cb}};
-
-    add_local_cb(in_cb_id_0, in_cb_pagesize, in_cb_npages, params.data_format, input_face_geometry);
-    log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_cb_id_0, in_cb_pagesize, in_cb_npages);
-
-    if (cb_sizes.has_split_reader) {
-        in_cb_id_1 = next_cb_index++;
-        add_local_cb(in_cb_id_1, in_cb_pagesize, in_cb_npages, params.data_format, input_face_geometry);
-        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_cb_id_1, in_cb_pagesize, in_cb_npages);
-    }
-
-    uint32_t in_idx_cb_id = INVALID_CB_ID;
-    uint32_t pack_tmp_cb_id = INVALID_CB_ID;
-    uint32_t pack_idx_tmp_cb_id = INVALID_CB_ID;
-    uint32_t right_inc_cb_id = INVALID_CB_ID;
-    uint32_t down_left_wrap_inc_cb_id = INVALID_CB_ID;
-    uint32_t up_left_wrap_inc_cb_id = INVALID_CB_ID;
-    uint32_t intra_kernel_right_inc_cb_id = INVALID_CB_ID;
-    uint32_t intra_kernel_down_left_wrap_inc_cb_id = INVALID_CB_ID;
-    uint32_t compute_tmp_idx_cb_id = INVALID_CB_ID;
-    uint32_t right_inc = 0;
-    uint32_t down_left_wrap_inc = 0;
-    uint32_t up_left_wrap_inc = 0;
-    uint32_t intra_kernel_right_inc = 0;
-    uint32_t intra_kernel_down_left_wrap_inc = 0;
-    bool indexes_32_bit = false;
-    if (return_indices) {
-        indexes_32_bit = params.index_format == tt::DataFormat::UInt32;
-        uint32_t tile_elems = tt::constants::TILE_WIDTH * tt::constants::TILE_HEIGHT;
-        in_idx_cb_id = next_cb_index++;
-        add_local_cb(in_idx_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
-        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", in_idx_cb_id, params.index_nbytes * tile_elems, 1);
-        pack_tmp_cb_id = next_cb_index++;
-        add_local_cb(pack_tmp_cb_id, params.nbytes * tile_elems, 1, params.data_format);
-        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", pack_tmp_cb_id, params.nbytes * tile_elems, 1);
-        pack_idx_tmp_cb_id = next_cb_index++;
-        add_local_cb(pack_idx_tmp_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
-        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", pack_idx_tmp_cb_id, params.index_nbytes * tile_elems, 1);
-        right_inc_cb_id = next_cb_index++;
-        add_local_cb(right_inc_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
-        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", right_inc_cb_id, params.index_nbytes * tile_elems, 1);
-        down_left_wrap_inc_cb_id = next_cb_index++;
-        add_local_cb(down_left_wrap_inc_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
-        log_debug(
-            tt::LogOp, "CB {} :: PS = {}, NP = {}", down_left_wrap_inc_cb_id, params.index_nbytes * tile_elems, 1);
-        up_left_wrap_inc_cb_id = next_cb_index++;
-        add_local_cb(up_left_wrap_inc_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
-        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", up_left_wrap_inc_cb_id, params.index_nbytes * tile_elems, 1);
-
-        compute_tmp_idx_cb_id = next_cb_index++;
-        add_local_cb(compute_tmp_idx_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
-        log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", compute_tmp_idx_cb_id, params.index_nbytes * tile_elems, 1);
-
-        // compute increments for index tile population
-        right_inc = stride_w;
-        down_left_wrap_inc = in_w * stride_h + (1 - out_w) * stride_w;
-        up_left_wrap_inc =
-            (1 - out_h) * stride_h * in_w + (1 - out_w) * stride_w;  // allow overflow for negative values
-
-        // edit incs for large kernels
-        if (params.is_large_kernel) {
-            intra_kernel_right_inc_cb_id = next_cb_index++;
-            add_local_cb(intra_kernel_right_inc_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
-            log_debug(
-                tt::LogOp,
-                "CB {} :: PS = {}, NP = {}",
-                intra_kernel_right_inc_cb_id,
-                params.index_nbytes * tile_elems,
-                1);
-            intra_kernel_down_left_wrap_inc_cb_id = next_cb_index++;
-            add_local_cb(
-                intra_kernel_down_left_wrap_inc_cb_id, params.index_nbytes * tile_elems, 1, params.index_format);
-            log_debug(
-                tt::LogOp,
-                "CB {} :: PS = {}, NP = {}",
-                intra_kernel_down_left_wrap_inc_cb_id,
-                params.index_nbytes * tile_elems,
-                1);
-
-            // for large kernels we process row by row since inc's aren't consistent if we just process fixed-size
-            // batches this means we process multiple top left positions within the kernel for a single top left
-            // position in the tensor, so when we move the kernel to a new position in the tensor we need to subtract
-            // the difference between the first top left index in the kernel and the last one
-            uint32_t sticks_per_chunk =
-                kernel_w <= params.max_rows_for_reduction ? kernel_w : params.max_rows_for_reduction;
-            uint32_t w_chunks =
-                kernel_w % sticks_per_chunk == 0 ? kernel_w / sticks_per_chunk : (kernel_w / sticks_per_chunk) + 1;
-            uint32_t last_w_chunk_w_offset = (w_chunks - 1) * sticks_per_chunk * dilation_w;
-            uint32_t first_top_left_kernel_index = 0;
-            uint32_t last_top_left_kernel_index = ((kernel_h - 1) * dilation_h * in_w) + last_w_chunk_w_offset;
-            uint32_t index_correction = last_top_left_kernel_index - first_top_left_kernel_index;
-            right_inc -= index_correction;
-            down_left_wrap_inc -= index_correction;
-            up_left_wrap_inc -= index_correction;
-
-            intra_kernel_right_inc = dilation_w * sticks_per_chunk;
-            intra_kernel_down_left_wrap_inc = dilation_h * in_w - last_w_chunk_w_offset;
-        }
-    }
-
-    const bool is_output_tiled = output_layout == Layout::TILE;
-    const bool is_output_block_format = is_block_float(outputs[0].dtype());
-    const bool zero_pages = is_output_tiled && is_output_block_format;
-
-    // Conditionally allocate temporary CB - only needed for TILED output
-    uint32_t pre_tilize_cb_id = INVALID_CB_ID;
-    uint32_t fast_tilize_cb_id = INVALID_CB_ID;
-
-    constexpr uint32_t pack_untilize_face_r_dim = 1;
-    const bool last_tile_is_partial = in_c % tt::constants::TILE_WIDTH != 0;
-    const bool single_partial_fits_in_face = last_tile_is_partial && in_c <= tt::constants::FACE_WIDTH;
-    const uint32_t pack_untilize_num_faces = single_partial_fits_in_face ? 1u : 2u;
-    const auto pack_untilize_face_geometry =
-        FaceGeometry{.face_r_dim = pack_untilize_face_r_dim, .num_faces = pack_untilize_num_faces};
-    const std::optional<TileDescriptor> pack_untilize_tile =
-        single_partial_fits_in_face ? std::optional{TileDescriptor{1, tt::constants::FACE_WIDTH, false}} : std::nullopt;
-
-    if (cb_sizes.has_pre_tilize) {
-        pre_tilize_cb_id = next_cb_index++;
-        fast_tilize_cb_id = next_cb_index++;
-        // pre_tilize_cb is a multi-format CB: one L1 allocation backs two CB indices that
-        // present different face_geometry/page_size views of the same bytes.
-        //   * pre_tilize_cb_id  -- producer view, used by pack_untilize. Stick-packed
-        //                          (face_r_dim=1, num_faces<=2), pagesize=TILE_WIDTH*nbytes.
-        //   * fast_tilize_cb_id -- consumer view, used by fast_tilize. Full-tile
-        //                          (face_r_dim=16, num_faces=4), pagesize=tile_size.
-        // The kernel keeps both FIFOs in lock-step by pushing/popping the same byte amount
-        // per round, so their rd/wr pointers always point at matching L1 addresses.
-        const uint32_t pre_tilize_total_size = cb_sizes.pre_tilize_cb_pagesize * cb_sizes.pre_tilize_cb_npages;
-        const uint32_t fast_tilize_page_size = tt::tile_size(params.data_format);
-        TT_FATAL(
-            pre_tilize_total_size % fast_tilize_page_size == 0,
-            "pre_tilize_cb total size {} must be a multiple of fast_tilize tile size {}",
-            pre_tilize_total_size,
-            fast_tilize_page_size);
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = pre_tilize_total_size,
-            .core_ranges = all_cores,
-            .format_descriptors = {{
-                CBFormatDescriptor{
-                    .buffer_index = static_cast<uint8_t>(pre_tilize_cb_id),
-                    .data_format = params.data_format,
-                    .page_size = cb_sizes.pre_tilize_cb_pagesize,
-                    .tile = pack_untilize_tile,
-                    .face_geometry = pack_untilize_face_geometry,
-                },
-                CBFormatDescriptor{
-                    .buffer_index = static_cast<uint8_t>(fast_tilize_cb_id),
-                    .data_format = params.data_format,
-                    .page_size = fast_tilize_page_size,
-                    // tile/face_geometry left nullopt -> default 32x32, 4 faces of 16x16.
-                },
-            }},
-        });
-        log_debug(
-            tt::LogOp,
-            "CB {} :: PS = {}, NP = {} (aliased as fast_tilize CB {} PS = {} NP = {})",
-            pre_tilize_cb_id,
-            cb_sizes.pre_tilize_cb_pagesize,
-            cb_sizes.pre_tilize_cb_npages,
-            fast_tilize_cb_id,
-            fast_tilize_page_size,
-            pre_tilize_total_size / fast_tilize_page_size);
-    }
-
-    const uint32_t out_cb_pagesize = cb_sizes.out_cb_pagesize;
-    const uint32_t out_cb_npages = cb_sizes.out_cb_npages;
-
-    const uint32_t out_cb_id = next_cb_index++;
-    add_sharded_cb(
-        out_cb_id,
-        out_cb_pagesize,
-        out_cb_npages,
-        params.output_data_format,
-        outputs[0].buffer(),
-        is_output_tiled ? std::nullopt : std::optional{pack_untilize_face_geometry},
-        is_output_tiled ? std::nullopt : pack_untilize_tile);
-
-    uint32_t out_idx_cb_id = INVALID_CB_ID;
-    if (cb_sizes.has_out_idx) {
-        TT_FATAL(
-            outputs.size() == 2,
-            "When return_indices is true, there should be two outputs, but got {}",
-            outputs.size());
-        out_idx_cb_id = next_cb_index++;
-        add_sharded_cb(
-            out_idx_cb_id,
-            cb_sizes.out_idx_cb_pagesize,
-            cb_sizes.out_idx_cb_npages,
-            params.index_format,
-            outputs[1].buffer());
-    }
-    log_debug(tt::LogOp, "CB {} :: PS = {}, NP = {}", out_cb_id, out_cb_pagesize, out_cb_npages);
-
-    for (const auto& output : outputs) {
-        TT_FATAL(
-            output.memory_config().is_sharded(),
-            "Output memory config needs to be sharded, but got {}",
-            output.memory_config());
-    }
-
-    /**
-     * Reader Kernel: input rows -> input cb
-     */
-    uint32_t config_cb_id = INVALID_CB_ID;
-    tt::tt_metal::Buffer* config_buffer = nullptr;
-    if (!one_scalar_per_core) {
-        // The scalar config tensor was uploaded once in create_workload_descriptor
-        // and parked in WorkloadDescriptor::buffers; the framework keeps it
-        // alive for the cached workload's lifetime.  scalar_config_buffer must
-        // be non-null whenever !one_scalar_per_core (avg-pool with non-trivial
-        // scalar layout).
-        TT_FATAL(scalar_config_buffer != nullptr, "scalar config buffer must be populated when !one_scalar_per_core");
-
-        constexpr tt::DataFormat config_df = tt::DataFormat::RawUInt32;
-        config_buffer = scalar_config_buffer;
-        const uint32_t config_buffer_page_size = config_buffer->page_size();
-        uint32_t max_config_tensor_size =
-            max_out_nhw_per_core * 3 * sizeof(uint16_t);  // worst case of 3 entries per output element
-
-        TT_FATAL(
-            config_buffer->page_size() <= max_config_tensor_size,
-            "Config tensor buffer page size {} exceeds max expected size {}",
-            config_buffer->page_size(),
-            max_config_tensor_size);
-
-        config_cb_id = next_cb_index++;
-        if (config_tensor_in_dram) {
-            // DRAM-backed: kernel reads from DRAM via TensorAccessor; the CB is
-            // local scratch sized to the worst-case payload of one page.
-            add_local_cb(config_cb_id, max_config_tensor_size, 1, config_df);
-        } else {
-            add_sharded_cb(config_cb_id, config_buffer_page_size, 1, config_df, config_buffer);
-        }
-    }
-    KernelDescriptor::CompileTimeArgs reader0_ct_args = {
-        max_out_nhw_per_core,                                  // 0
-        kernel_h,                                              // 1
-        kernel_w,                                              // 2
-        pad_w,                                                 // 3
-        in_nbytes_leftover,                                    // 4
-        in_w,                                                  // 5
-        in_c_per_shard_ceil,                                   // 6
-        params.split_reader,                                   // enable split reader //7
-        0,                                                     // split reader id //8
-        bf16_scalar,                                           // 9
-        bf16_init_value,                                       // 10
-        in_nblocks_c,                                          // 11
-        cb_sizes.in_cb_raw_size,                               // 12
-        params.max_rows_for_reduction,                         // 13
-        ceil_pad_w,                                            // 14
-        in_cb_id_0,                                            // 15
-        in_cb_id_1,                                            // 16
-        raw_in_cb_id,                                          // 17
-        in_reader_indices_cb_id,                               // 18
-        in_scalar_cb_id_0,                                     // 19
-        in_scalar_cb_id_1,                                     // 20
-        clear_value_cb_id,                                     // 21
-        static_cast<uint32_t>(pool_type),                      // 22
-        one_scalar_per_core,                                   // 23
-        config_cb_id,                                          // 24
-        in_nbytes_c,                                           // 25
-        shard_width_bytes,                                     // 26
-        params.multi_buffering_factor,                         // 27
-        stride_w,                                              // 28
-        dilation_h,                                            // 29
-        dilation_w,                                            // 30
-        static_cast<uint32_t>(zero_pages),                     // 31
-        config_tensor_in_dram,                                 // 32
-        one_scalar_per_core ? 0 : config_buffer->address(),    // 33
-        one_scalar_per_core ? 0 : config_buffer->page_size(),  // 34
-        reader_indices_buffer->address(),                      // 35
-        reader_indices_buffer->page_size(),                    // 36
-        // MPWI-only args start here (for reader_mpwi.cpp, not used by reader_pool_2d.cpp)
-        in_idx_cb_id,                           // 37
-        pack_tmp_cb_id,                         // 38
-        pack_idx_tmp_cb_id,                     // 39
-        right_inc_cb_id,                        // 40
-        down_left_wrap_inc_cb_id,               // 41
-        up_left_wrap_inc_cb_id,                 // 42
-        pad_t,                                  // 43
-        pad_l,                                  // 44
-        right_inc,                              // 45
-        down_left_wrap_inc,                     // 46
-        up_left_wrap_inc,                       // 47
-        intra_kernel_right_inc,                 // 48
-        intra_kernel_down_left_wrap_inc,        // 49
-        out_cb_id,                              // 50
-        out_idx_cb_id,                          // 51
-        intra_kernel_right_inc_cb_id,           // 52
-        intra_kernel_down_left_wrap_inc_cb_id,  // 53
-        static_cast<uint32_t>(indexes_32_bit),  // 54
-    };
-
-    tt::tt_metal::TensorAccessorArgs(reader_indices_buffer).append_to(reader0_ct_args);
-    if (!one_scalar_per_core) {
-        tt::tt_metal::TensorAccessorArgs(config_buffer).append_to(reader0_ct_args);
-    }
-    KernelDescriptor::CompileTimeArgs reader1_ct_args = reader0_ct_args;
-    reader1_ct_args[8] = 1;  // split reader id for reader1
-
-    std::string reader_kernel_fname = return_indices ? "ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/"
-                                                       "reader_mpwi.cpp"
-                                                     : "ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/"
-                                                       "reader_pool_2d.cpp";
-
-    KernelDescriptor reader0_desc;
-    reader0_desc.kernel_source = reader_kernel_fname;
-    reader0_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    reader0_desc.core_ranges = all_cores;
-    reader0_desc.compile_time_args = std::move(reader0_ct_args);
-    reader0_desc.config = DataMovementConfigDescriptor{
-        .processor = tt::tt_metal::DataMovementProcessor::RISCV_0,
-        .noc = tt::tt_metal::NOC::RISCV_0_default,
-    };
-
-    std::optional<KernelDescriptor> reader1_desc;
-    if (params.split_reader) {
-        KernelDescriptor rd;
-        rd.kernel_source = reader_kernel_fname;
-        rd.source_type = KernelDescriptor::SourceType::FILE_PATH;
-        rd.core_ranges = all_cores;
-        rd.compile_time_args = std::move(reader1_ct_args);
-        rd.config = DataMovementConfigDescriptor{
-            .processor = tt::tt_metal::DataMovementProcessor::RISCV_1,
-            .noc = tt::tt_metal::NOC::RISCV_1_default,
-        };
-        reader1_desc = std::move(rd);
-    }
-
-    /**
-     * Compute Kernel: input cb -> tilize_block -> input tiles -> reduce_h max -> output tiles -> untilize_block ->
-     * output cb
-     */
-
-    KernelDescriptor::CompileTimeArgs compute_ct_args = {
-        params.in_ntiles_c,             // 0
-        kernel_h * kernel_w,            // 1
-        params.split_reader,            // 2
-        0,                              // 3 - max_out_nhw_per_core, used for grid sample but not for pool
-        in_c_per_shard_ceil,            // 4
-        in_nblocks_c,                   // 5
-        params.max_rows_for_reduction,  // 6
-        in_cb_id_0,                     // 7
-        in_cb_id_1,                     // 8
-        in_scalar_cb_id_0,              // 9
-        in_scalar_cb_id_1,              // 10
-        out_cb_id,                      // 11
-        one_scalar_per_core,            // 12
-        pre_tilize_cb_id,               // 13
-        is_output_tiled,                // 14
-        is_output_block_format,         // 15
-        0,                              // 16: force_max_tiles_per_reduction_4 (off for pool2d)
-        // MPWI-only args start here (for compute_mpwi.cpp, not used by compute_pool_2d.cpp)
-        in_idx_cb_id,                           // 17
-        pack_tmp_cb_id,                         // 18
-        pack_idx_tmp_cb_id,                     // 19
-        right_inc_cb_id,                        // 20
-        down_left_wrap_inc_cb_id,               // 21
-        up_left_wrap_inc_cb_id,                 // 22
-        out_idx_cb_id,                          // 23
-        stride_h,                               // 24
-        stride_w,                               // 25
-        in_h_padded,                            // 26
-        in_w_padded,                            // 27
-        eff_kernel_h,                           // 28
-        eff_kernel_w,                           // 29
-        pad_l,                                  // 30
-        intra_kernel_right_inc_cb_id,           // 31
-        intra_kernel_down_left_wrap_inc_cb_id,  // 32
-        compute_tmp_idx_cb_id,                  // 33
-        clear_value_cb_id,                      // 34
-        kernel_h,                               // 35
-        kernel_w,                               // 36
-        static_cast<uint32_t>(indexes_32_bit),  // 37
-        // compute_pool_2d.cpp-only arg (ignored by compute_mpwi.cpp)
-        fast_tilize_cb_id  // 38 - consumer-view alias of pre_tilize_cb_id (full-tile face_geometry)
-    };
-
-    // Get device arch for compute kernel config initialization
-    auto device_arch = input.device()->arch();
-
-    // Initialize device compute kernel config with user-provided config or defaults
-    auto device_compute_kernel_config = init_device_compute_kernel_config(
-        device_arch,
-        compute_kernel_config,
-        tt::tt_metal::MathFidelity::HiFi4,
-        false,                                                             // math_approx_mode
-        (params.is_avg_pool && params.is_large_kernel) || indexes_32_bit,  // fp32_dest_acc_en
-        false,                                                             // packer_l1_acc
-        (params.is_large_kernel && return_indices) || indexes_32_bit       // dst_full_sync_en
-    );
-
-    const auto pool_defines_map = get_defines(pool_type);
-    KernelDescriptor::Defines compute_defines(pool_defines_map.begin(), pool_defines_map.end());
-
-    std::string compute_kernel_fname =
-        return_indices ? "ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_mpwi.cpp"
-                       : "ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d.cpp";
-
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source = compute_kernel_fname;
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = std::move(compute_ct_args);
-    compute_desc.defines = std::move(compute_defines);
-    compute_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = get_math_fidelity(device_compute_kernel_config),
-        .fp32_dest_acc_en = get_fp32_dest_acc_en(device_compute_kernel_config),
-        .dst_full_sync_en = get_dst_full_sync_en(device_compute_kernel_config),
-        .math_approx_mode = false,
-    };
-
-    // set the starting indices for each core as runtime args
-    uint32_t total_out_nhw = in_n * out_h * out_w;
-    for (uint32_t core_i = 0; core_i < ncores; core_i++) {
-        const uint32_t core_x_i = core_i % rectangular_x;
-        const uint32_t core_y_i = core_i / rectangular_x;
-        const CoreCoord core(core_x_i, core_y_i);
-
-        uint32_t total_out_nhw_processed;
-        uint32_t core_nhw_index = 0;
-        if (is_block_sharded) {
-            total_out_nhw_processed = core_y_i * max_out_nhw_per_core;
-            core_nhw_index = core_y_i;
-        } else if (is_width_sharded) {
-            total_out_nhw_processed = 0;
-            core_nhw_index = 0;
-        } else {
-            total_out_nhw_processed = core_i * max_out_nhw_per_core;
-            core_nhw_index = core_i;
-        }
-        uint32_t remaining_out_nhw =
-            total_out_nhw_processed < total_out_nhw ? total_out_nhw - total_out_nhw_processed : 0;
-        uint32_t out_nhw_this_core = std::min(max_out_nhw_per_core, remaining_out_nhw);
-        KernelDescriptor::CoreRuntimeArgs args = {out_nhw_this_core, core_nhw_index};
-
-        if (return_indices) {
-            TT_FATAL(core_starting_indices.size() == ncores, "core starting indices size should match number of cores");
-            const uint32_t start_index = core_starting_indices[core_i];
-            const uint32_t start_mod_batch = start_index % (in_w_padded * in_h_padded);
-            const uint32_t start_row = start_mod_batch / in_w_padded;
-            const uint32_t start_col = start_mod_batch % in_w_padded;
-
-            args.push_back(start_row);
-            args.push_back(start_col);
-        }
-        reader0_desc.runtime_args.emplace_back(core, args);
-        if (params.split_reader) {
-            reader1_desc->runtime_args.emplace_back(core, args);
-        }
-        compute_desc.runtime_args.emplace_back(core, std::move(args));
-    }
-
-    // Push kernels in deterministic order: reader0 (BRISC), reader1 (NCRISC) when
-    // split_reader is enabled, then compute. The framework patches per-core runtime
-    // args by kernel index, so this ordering MUST match between every invocation.
-    desc.kernels.push_back(std::move(reader0_desc));
-    if (reader1_desc.has_value()) {
-        desc.kernels.push_back(std::move(*reader1_desc));
-    }
-    desc.kernels.push_back(std::move(compute_desc));
-
-    // Validate local and global CB sizes separately to prevent two errors from cancelling out.
-    // Note: local CBs are non-globally-allocated (computed by the program); global CBs are
-    // tensor-backed (sharded onto an existing buffer). We compute these directly from the
-    // descriptor's CBs rather than from a Program object since we no longer create one here.
-    uint32_t actual_local_cb_size = 0;
-    for (const auto& cb : desc.cbs) {
-        if (cb.buffer == nullptr) {
-            actual_local_cb_size += cb.total_size;
-        }
-    }
-
-    uint32_t post_allocate_size =
-        input.device()->allocator()->get_statistics(tt::tt_metal::BufferType::L1).total_allocated_bytes;
-    uint32_t actual_global_cb_size = post_allocate_size == 0 ? 0 : post_allocate_size - memory_used;
-
-    // For now assume that if post_op_l1_allocation_size == 0 op is being run
-    // in graph capture NO_DISPATCH mode.
-    bool is_graph_capture_no_dispatch_mode = post_allocate_size == 0;
-    TT_FATAL(
-        actual_local_cb_size == cb_sizes.local_cb_total() || is_graph_capture_no_dispatch_mode,
-        "Local CB size mismatch: actual {} != expected {}",
-        actual_local_cb_size,
-        cb_sizes.local_cb_total());
-    TT_FATAL(
-        actual_global_cb_size == cb_sizes.global_cb_total() || is_graph_capture_no_dispatch_mode,
-        "Global CB size mismatch: actual {} != expected {}",
-        actual_global_cb_size,
-        cb_sizes.global_cb_total());
-
-    {  // debug
-        log_debug(tt::LogOp, "raw_in_cb :: PS = {}, NP = {}", raw_in_cb_pagesize, raw_in_cb_npages);
-        log_debug(tt::LogOp, "in_cb :: PS = {}, NP = {}", in_cb_pagesize, in_cb_npages);
-        log_debug(
-            tt::LogOp,
-            "in_reader_indices_cb :: PS = {}, NP = {}",
-            in_reader_indices_cb_pagesize,
-            in_reader_indices_cb_npages);
-        log_debug(tt::LogOp, "in_scalar_cb :: PS = {}, NP = {}", in_scalar_cb_pagesize, in_scalar_cb_npages);
-        log_debug(tt::LogOp, "out_cb :: PS = {}, NP = {}", out_cb_pagesize, out_cb_npages);
-        log_debug(tt::LogOp, "in_reader_indices_addr: {}", reader_indices_buffer->address());
-        log_debug(
-            tt::LogOp,
-            "scalar_config_addr: {}",
-            config_buffer != nullptr ? std::to_string(config_buffer->address()) : "not set");
-        log_debug(tt::LogOp, "kernel_h: {}", kernel_h);
-        log_debug(tt::LogOp, "kernel_w: {}", kernel_w);
-        log_debug(tt::LogOp, "stride_h: {}", stride_h);
-        log_debug(tt::LogOp, "stride_w: {}", stride_w);
-        log_debug(tt::LogOp, "pad_h: {}", pad_h);
-        log_debug(tt::LogOp, "pad_w: {}", pad_w);
-        log_debug(tt::LogOp, "out_h: {}", out_h);
-        log_debug(tt::LogOp, "out_w: {}", out_w);
-        log_debug(tt::LogOp, "out_c: {}", out_c);
-        log_debug(tt::LogOp, "in_h: {}", in_h);
-        log_debug(tt::LogOp, "in_w: {}", in_w);
-        log_debug(tt::LogOp, "in_c: {}", in_c);
-        log_debug(tt::LogOp, "in_ntiles_c: {}", params.in_ntiles_c);
-        log_debug(tt::LogOp, "out_ntiles_c: {}", params.out_ntiles_c);
-        log_debug(tt::LogOp, "in_nblocks_c: {}", in_nblocks_c);
-        log_debug(tt::LogOp, "in_nbytes_c: {}", in_nbytes_c);
-        log_debug(tt::LogOp, "ncores: {}", ncores);
-        log_debug(tt::LogOp, "max_out_nhw_per_core: {}", max_out_nhw_per_core);
-        log_debug(tt::LogOp, "split_reader: {}", params.split_reader);
-        log_debug(tt::LogOp, "multi_buffering_factor: {}", params.multi_buffering_factor);
-        log_debug(tt::LogOp, "is_wide_reduction: {}", params.is_wide_reduction);
-        log_debug(tt::LogOp, "is_in_sharded: {}", input.memory_config().is_sharded());
-        log_debug(tt::LogOp, "is_out_sharded: {}", outputs[0].memory_config().is_sharded());
-    }
-
-    return desc;
-}
-
 namespace {
-// Common preamble shared between the resource-allocation phase and the
-// per-coord program build of create_workload_descriptor(): pulls per-op fields out
-// of the SlidingWindowConfig and computes the parallel config / output shape
-// pieces we need in both phases.  Lives in an anonymous namespace because it's
-// purely a local helper for this factory.
+
+// Metal 2.0 DFB / tensor-parameter / kernel names. Each name replaces a legacy magic CB index
+// (or a tensor buffer-address RTA/CTA) with a typed, named binding.
+constexpr const char* DFB_IN_SCALAR_0 = "in_scalar_0";
+constexpr const char* DFB_IN_SCALAR_1 = "in_scalar_1";
+constexpr const char* DFB_CLEAR_VALUE = "clear_value";
+constexpr const char* DFB_RAW_IN = "raw_in";
+constexpr const char* DFB_READER_INDICES = "reader_indices";
+constexpr const char* DFB_IN_0 = "in_0";
+constexpr const char* DFB_IN_1 = "in_1";
+constexpr const char* DFB_PRE_TILIZE = "pre_tilize";
+constexpr const char* DFB_FAST_TILIZE = "fast_tilize";
+constexpr const char* DFB_OUT = "out";
+constexpr const char* DFB_CONFIG = "config";
+
+constexpr const char* TP_INPUT = "input";
+constexpr const char* TP_OUTPUT = "output";
+constexpr const char* TP_READER_INDICES = "reader_indices_tensor";
+constexpr const char* TP_CONFIG = "config_tensor";
+
+constexpr const char* KERNEL_READER0 = "reader0";
+constexpr const char* KERNEL_READER1 = "reader1";
+constexpr const char* KERNEL_COMPUTE = "compute";
+
+// Forked compute kernel (compute_pool_2d.cpp is shared by rotate / grid_sample, so it is forked
+// to a Metal 2.0 *_m2 copy and the factory points here). The reader is exclusive to this factory
+// and ported in place.
+constexpr const char* READER_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/pool/generic/device/kernels/dataflow/reader_pool_2d.cpp";
+constexpr const char* COMPUTE_KERNEL_PATH =
+    "ttnn/cpp/ttnn/operations/pool/generic/device/kernels/compute/compute_pool_2d_m2.cpp";
+
+// Common preamble shared between the resource-allocation phase and the spec build of
+// create_program_spec(): pulls per-op fields out of the SlidingWindowConfig and computes the
+// parallel config / output shape pieces we need in both phases. Lives in an anonymous namespace
+// because it's purely a local helper for this factory.
 struct PoolSetup {
     sliding_window::ParallelConfig parallel_config;
     bool is_block_sharded;
@@ -1109,93 +343,137 @@ PoolSetup compute_pool_setup(const Pool2D::operation_attributes_t& op_attr, cons
     setup.num_shards_c = sliding_window_config.num_cores_c;
     return setup;
 }
+
 }  // namespace
 
-tt::tt_metal::WorkloadDescriptor Pool2D::MultiCore::create_workload_descriptor(
-    const operation_attributes_t& op_attr,
-    const tensor_args_t& tensor_args,
-    tensor_return_value_t& output_tensors,
-    const ttnn::MeshCoordinateRangeSet& tensor_coords) {
+ttnn::device_operation::ProgramArtifacts Pool2D::MultiCore::create_program_spec(
+    const operation_attributes_t& op_attr, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors) {
     const auto& input = tensor_args.input_tensor_;
     const auto& sliding_window_config = op_attr.sliding_window_config_;
     PoolSetup setup = compute_pool_setup(op_attr, input);
 
-    // Build the per-core sliding-window halo lookup table on host, then upload it.
-    // The resulting MeshBuffer must outlive the program, so we park its
-    // shared_ptr on the WorkloadDescriptor (held by the program cache).
+    const Pool2DType pool_type = op_attr.pool_type_;
+    const Layout output_layout = op_attr.output_layout_;
+    const bool count_include_pad = op_attr.count_include_pad_;
+    const std::optional<int32_t> divisor_override = op_attr.divisor_override_;
+    const bool return_indices = op_attr.return_indices_;
+
+    // ----- SCOPE GUARDS (this port covers only the L1-config, non-return-indices path) -----
+    // The DRAM-config path threads buffer->address() through CTAs into the kernel's
+    // load_config_tensor_if_in_dram<> / TensorAccessorArgs<> plumbing — a raw-address-through-CTA
+    // into a data-movement kernel. That is a Metal 2.0 stop signal and stays BLOCKED; gate it out.
+    TT_FATAL(
+        !op_attr.config_tensor_in_dram,
+        "Pool2D Metal 2.0 port: the DRAM-config path is not ported (raw buffer->address() through "
+        "CTAs is a blocker). Use the L1 config path (config_tensor_in_dram == false).");
+    // The return_indices (MPWI) path uses reader_mpwi.cpp / compute_mpwi.cpp — out of scope here.
+    TT_FATAL(
+        !return_indices,
+        "Pool2D Metal 2.0 port: the return_indices (MPWI) path is not ported yet. Only the "
+        "reader_pool_2d / compute_pool_2d path is on Metal 2.0.");
+
+    const bool is_block_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::BLOCK_SHARDED;
+    const bool is_width_sharded = input.memory_config().memory_layout() == TensorMemoryLayout::WIDTH_SHARDED;
+
+    // distributing out_hw across the grid
+    const auto all_cores = input.shard_spec().value().grid;
+    const uint32_t ncores = all_cores.num_cores();
+    const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
+    const uint32_t rectangular_x = is_block_sharded ? all_cores.ranges()[0].end_coord.x + 1 : num_cores_x;
+    const uint32_t max_out_nhw_per_core = output_tensors[0].shard_spec()->shape[0];
+    const uint32_t max_in_nhw_per_core = input.shard_spec()->shape[0];
+    TT_FATAL(
+        max_in_nhw_per_core <= std::numeric_limits<uint16_t>::max(),
+        "Input nhw per core {} exceeds uint16_t limit, this will cause overflow because the reader indices are stored "
+        "as uint16_t",
+        max_in_nhw_per_core);
+
+    const uint32_t in_n = setup.in_n;
+    const uint32_t in_c = setup.in_c;
+    const uint32_t in_h = setup.in_h;
+    const uint32_t in_w = setup.in_w;
+    const uint32_t out_h = setup.out_h;
+    const uint32_t out_w = setup.out_w;
+    const uint32_t kernel_h = setup.kernel_h;
+    const uint32_t kernel_w = setup.kernel_w;
+    const uint32_t stride_h = setup.stride_h;
+    const uint32_t stride_w = setup.stride_w;
+    const uint32_t pad_t = setup.pad_t;
+    const uint32_t pad_l = setup.pad_l;
+    const uint32_t ceil_pad_w = setup.ceil_pad_w;
+    const uint32_t ceil_pad_h = setup.ceil_pad_h;
+    const uint32_t dilation_h = setup.dilation_h;
+    const uint32_t dilation_w = setup.dilation_w;
+    const uint32_t num_shards_c = setup.num_shards_c;
+
+    const uint32_t bf16_scalar = get_bf16_pool_scalar(pool_type, kernel_h, kernel_w, divisor_override);
+    const uint32_t bf16_init_value = get_bf16_pool_init_value(pool_type);
+    FactoryParameters params = get_factory_parameters(
+        num_shards_c,
+        input.dtype(),
+        output_tensors[0].dtype(),
+        kernel_h,
+        kernel_w,
+        in_c,
+        pool_type,
+        return_indices,
+        in_h,
+        in_w,
+        output_layout);
+    uint32_t pad_h = pad_t + setup.pad_b;
+    uint32_t pad_w = pad_l + setup.pad_r;
+    [[maybe_unused]] const uint32_t in_h_padded = in_h + pad_h + ceil_pad_h;
+    [[maybe_unused]] const uint32_t in_w_padded = in_w + pad_w + ceil_pad_w;
+    const bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
+        pool_type, setup.ceil_mode, ceil_pad_h, ceil_pad_w, count_include_pad, pad_h, pad_w, divisor_override);
+
+    // ---------------------------------------------------------------------------------------------
+    // Op-owned tensors: build & upload the per-core sliding-window halo lookup table, and (for
+    // avg-pool variants that need it) the per-output-stick scalar config tensor. These are
+    // host-POPULATED, sharded ttnn::Tensors that get parked in ProgramArtifacts::op_owned_tensors.
+    // The framework holds them alive (stable address) for the cached Program's life and reuses them
+    // on a cache hit; we do NOT re-allocate them empty.
+    // ---------------------------------------------------------------------------------------------
     std::vector<uint32_t> op_trace_metadata =
         ttnn::operations::sliding_window::generate_op_trace_metadata(sliding_window_config);
     std::vector<sliding_window::ShardBoundary> shard_boundaries =
         ttnn::operations::sliding_window::generate_shard_boundaries(sliding_window_config);
     std::vector<std::vector<uint16_t>> top_left_indices =
-        sliding_window::generate_sliding_window_op_config(op_trace_metadata, shard_boundaries, setup.stride_w);
+        sliding_window::generate_sliding_window_op_config(op_trace_metadata, shard_boundaries, stride_w);
+    const uint32_t reader_indices_size = top_left_indices[0].size();
 
     Tensor reader_indices_host = sliding_window::construct_on_host_config_tensor(
         top_left_indices, setup.parallel_config, op_attr.config_tensor_in_dram);
     Tensor reader_indices_on_device = sliding_window::move_config_tensor_to_device(
-        reader_indices_host,
-        setup.parallel_config,
-        setup.is_block_sharded,
-        input.device(),
-        op_attr.config_tensor_in_dram);
+        reader_indices_host, setup.parallel_config, is_block_sharded, input.device(), op_attr.config_tensor_in_dram);
 
-    tt::tt_metal::WorkloadDescriptor workload_descriptor;
-    // Keep the source Tensor alive in the cached workload.  Holding only a
-    // shared_ptr<MeshBuffer> would not be enough: when the local Tensor went
-    // out of scope here, ~Tensor would call DeviceStorage::deallocate which
-    // force-frees the underlying device memory regardless of shared_ptr
-    // ownership (see is_sole_owner_of_device_memory).  Wrapping the Tensor in
-    // a shared_ptr held by WorkloadBuffer.owner defers ~Tensor until the
-    // cached workload itself is evicted.
-    auto reader_indices_tensor_owner = std::make_shared<Tensor>(std::move(reader_indices_on_device));
-    tt::tt_metal::Buffer* reader_indices_buffer = reader_indices_tensor_owner->buffer();
-    workload_descriptor.buffers.push_back({reader_indices_tensor_owner, reader_indices_buffer});
-
-    // For avg-pool, decide whether a single bf16 scalar per core is sufficient.  When it isn't
-    // (ceil_mode w/ ceil_pad, or !count_include_pad with non-zero padding, both with no
-    // divisor_override), we materialize the per-output-stick scalar config tensor and upload it.
-    const uint32_t pad_h = setup.pad_t + setup.pad_b;
-    const uint32_t pad_w = setup.pad_l + setup.pad_r;
-    const bool one_scalar_per_core = is_pool_op_one_scalar_per_core(
-        op_attr.pool_type_,
-        setup.ceil_mode,
-        setup.ceil_pad_h,
-        setup.ceil_pad_w,
-        op_attr.count_include_pad_,
-        pad_h,
-        pad_w,
-        op_attr.divisor_override_);
+    // op_owned_tensors[0] = reader_indices, op_owned_tensors[1] = scalar config (if !one_scalar_per_core)
+    std::vector<tt::tt_metal::Tensor> op_owned_tensors;
+    op_owned_tensors.reserve(2);
+    op_owned_tensors.push_back(std::move(reader_indices_on_device));
 
     if (!one_scalar_per_core) {
-        const uint32_t max_out_nhw_per_core = output_tensors[0].shard_spec()->shape[0];
-        const uint32_t ncores = input.shard_spec().value().grid.num_cores();
-
         AvgPoolConfig avg_pool_config = {
-            .kernel_h = setup.kernel_h,
-            .kernel_w = setup.kernel_w,
-            .in_h = setup.in_h,
-            .in_w = setup.in_w,
-            .out_h = setup.out_h,
-            .out_w = setup.out_w,
-            .stride_h = setup.stride_h,
-            .stride_w = setup.stride_w,
+            .kernel_h = kernel_h,
+            .kernel_w = kernel_w,
+            .in_h = in_h,
+            .in_w = in_w,
+            .out_h = out_h,
+            .out_w = out_w,
+            .stride_h = stride_h,
+            .stride_w = stride_w,
             .ceil_mode = setup.ceil_mode,
-            .ceil_h = setup.ceil_pad_h,
-            .ceil_w = setup.ceil_pad_w,
-            .count_include_pad = op_attr.count_include_pad_,
-            .pad_t = setup.pad_t,
+            .ceil_h = ceil_pad_h,
+            .ceil_w = ceil_pad_w,
+            .count_include_pad = count_include_pad,
+            .pad_t = pad_t,
             .pad_b = setup.pad_b,
-            .pad_l = setup.pad_l,
+            .pad_l = pad_l,
             .pad_r = setup.pad_r,
             .max_out_nhw_per_core = max_out_nhw_per_core,
-            .divisor_override = op_attr.divisor_override_};
+            .divisor_override = divisor_override};
         Tensor config_tensor = create_scalar_config_tensor(
-            avg_pool_config,
-            input.memory_config().memory_layout(),
-            setup.in_n,
-            setup.num_shards_c,
-            ncores,
-            op_attr.config_tensor_in_dram);
+            avg_pool_config, input.memory_config().memory_layout(), in_n, num_shards_c, ncores, /*in_dram=*/false);
 
         const std::array<uint32_t, 2> shard_shape =
             std::array<uint32_t, 2>({1, static_cast<uint32_t>(config_tensor.logical_shape()[-1])});
@@ -1205,80 +483,622 @@ tt::tt_metal::WorkloadDescriptor Pool2D::MultiCore::create_workload_descriptor(
         const MemoryConfig l1_small_memory_config{
             TensorMemoryLayout::HEIGHT_SHARDED, BufferType::L1_SMALL, config_shard_spec};
 
-        Tensor config_tensor_on_device = config_tensor.to_device(
-            input.device(), op_attr.config_tensor_in_dram ? DRAM_MEMORY_CONFIG : l1_small_memory_config);
-        auto scalar_config_tensor_owner = std::make_shared<Tensor>(std::move(config_tensor_on_device));
-        tt::tt_metal::Buffer* scalar_config_buf = scalar_config_tensor_owner->buffer();
-        workload_descriptor.buffers.push_back({std::move(scalar_config_tensor_owner), scalar_config_buf});
-    }
-    tt::tt_metal::Buffer* scalar_config_buffer =
-        workload_descriptor.buffers.size() > 1 ? workload_descriptor.buffers[1].buffer : nullptr;
-
-    // Single-device op: the kernel program is structurally identical for every
-    // coord in `tensor_coords` (Pool2D doesn't depend on cluster position).
-    // Build the per-coord ProgramDescriptor ONCE and copy it into each
-    // coord-range entry to avoid redundant work on multi-coord workloads.
-    const auto& pool_type = op_attr.pool_type_;
-    const auto& compute_kernel_config = op_attr.compute_kernel_config_;
-    const auto& output_layout = op_attr.output_layout_;
-    bool count_include_pad = op_attr.count_include_pad_;
-    std::optional<int32_t> divisor_override = op_attr.divisor_override_;
-    bool return_indices = op_attr.return_indices_;
-
-    std::vector<uint32_t> core_starting_indices;
-    if (return_indices) {
-        const uint32_t num_cores_x = input.memory_config().shard_spec()->grid.bounding_box().grid_size().x;
-        const uint32_t ncores = input.shard_spec().value().grid.num_cores();
-        const TensorMemoryLayout shard_scheme = input.memory_config().memory_layout();
-        core_starting_indices =
-            generate_core_starting_indices(op_trace_metadata, shard_boundaries, shard_scheme, num_cores_x, ncores);
+        op_owned_tensors.push_back(config_tensor.to_device(input.device(), l1_small_memory_config));
     }
 
-    tt::tt_metal::ProgramDescriptor desc = pool2d_multi_core_sharded_with_halo_v2_impl_new(
-        tensor_args.input_tensor_,
-        reader_indices_buffer,
-        scalar_config_buffer,
-        top_left_indices[0].size(),
-        output_tensors,
-        pool_type,
-        setup.in_n,
-        setup.in_c,
-        setup.in_h,
-        setup.in_w,
-        setup.out_h,
-        setup.out_w,
-        setup.out_c,
-        setup.kernel_h,
-        setup.kernel_w,
-        setup.stride_h,
-        setup.stride_w,
-        setup.pad_t,
-        setup.pad_b,
-        setup.pad_l,
-        setup.pad_r,
-        setup.ceil_pad_h,
-        setup.ceil_pad_w,
-        setup.ceil_mode,
+    // Bind the op-owned tensors AFTER the vector is fully populated (identity footgun: TensorArguments
+    // must reference the vector's elements, never a pre-move local).
+    const tt::tt_metal::Tensor& reader_indices_owned = op_owned_tensors[0];
+    const tt::tt_metal::Tensor* config_owned = one_scalar_per_core ? nullptr : &op_owned_tensors[1];
+
+    tt::tt_metal::Buffer* reader_indices_buffer = reader_indices_owned.buffer();
+    tt::tt_metal::Buffer* config_buffer = config_owned != nullptr ? config_owned->buffer() : nullptr;
+
+    // ---------------------------------------------------------------------------------------------
+    // CB / DFB sizing (unchanged from the legacy factory; just feeds DataflowBufferSpecs now).
+    // ---------------------------------------------------------------------------------------------
+    auto output_shard_shape = output_tensors[0].shard_spec().value().shape;
+    PoolCBSizes cb_sizes = calculate_pool_cb_sizes(
+        params,
+        one_scalar_per_core,
         return_indices,
-        core_starting_indices,
-        count_include_pad,
-        setup.dilation_h,
-        setup.dilation_w,
-        setup.num_shards_c,
-        compute_kernel_config,
-        divisor_override,
-        op_attr.memory_used,
         output_layout,
-        op_attr.config_tensor_in_dram);
-    auto ranges = tensor_coords.ranges();
-    workload_descriptor.programs.reserve(ranges.size());
-    for (size_t i = 0; i + 1 < ranges.size(); ++i) {
-        workload_descriptor.programs.push_back({ranges[i], desc});
+        output_tensors[0].dtype(),
+        {output_shard_shape[0], output_shard_shape[1]},
+        /*config_tensor_in_dram=*/false,
+        /*reader_indices_actual_page_size=*/std::nullopt);
+
+    const auto& input_shape = input.padded_shape();
+    const uint32_t shard_width = input.shard_spec()->shape[1];
+    const uint32_t in_c_per_shard_ceil = in_c % shard_width != 0 && num_shards_c > 1
+                                             ? (in_c - (in_c % shard_width)) / (num_shards_c - 1)
+                                             : in_c / num_shards_c;
+    const uint32_t in_nbytes_c = in_c_per_shard_ceil * params.nbytes;  // row of input (channels)
+    const uint32_t shard_width_bytes = input_shape[3] / num_shards_c * params.nbytes;
+
+    TT_FATAL(
+        input_shape[3] % num_shards_c == 0,
+        "Input channels {} should be divisible by number of shards {}",
+        input_shape[3],
+        num_shards_c);
+    const uint32_t in_nbytes_leftover =
+        params.is_wide_reduction &&
+                (input_shape[3] / num_shards_c) % (params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH) != 0
+            ? tt::round_up(
+                  (input_shape[3] / num_shards_c) % (params.MAX_TILES_PER_REDUCTION * tt::constants::TILE_WIDTH),
+                  tt::constants::TILE_WIDTH) *
+                  params.nbytes
+            : tt::round_up(input_shape[3] / num_shards_c, tt::constants::TILE_WIDTH) * params.nbytes;
+
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "pool2d_multi_core";
+
+    // DFBs are added to this vector; the helper lambdas mirror the legacy add_local_cb / add_sharded_cb.
+    auto& dfbs = spec.dataflow_buffers;
+    auto add_local_dfb = [&](const char* name,
+                             uint32_t page_size,
+                             uint32_t num_pages,
+                             tt::DataFormat data_format,
+                             std::optional<FaceGeometry> face_geometry = std::nullopt,
+                             std::optional<tt::tt_metal::Tile> tile = std::nullopt) {
+        dfbs.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{name},
+            .entry_size = page_size,
+            .num_entries = num_pages,
+            .data_format_metadata = data_format,
+            .tile_format_metadata = tile,
+            .unpack_face_geometry_metadata = face_geometry,
+        });
+    };
+    // Borrowed (globally-allocated) DFB: backing memory comes from a TensorParameter's buffer.
+    // The backing L1 address resolves at runtime from the corresponding TensorArgument.
+    auto add_borrowed_dfb = [&](const char* name,
+                                uint32_t page_size,
+                                uint32_t num_pages,
+                                tt::DataFormat data_format,
+                                const char* tensor_param_name,
+                                std::optional<FaceGeometry> face_geometry = std::nullopt,
+                                std::optional<tt::tt_metal::Tile> tile = std::nullopt) {
+        dfbs.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{name},
+            .entry_size = page_size,
+            .num_entries = num_pages,
+            .data_format_metadata = data_format,
+            .tile_format_metadata = tile,
+            .unpack_face_geometry_metadata = face_geometry,
+            .borrowed_from = m2::TensorParamName{tensor_param_name},
+        });
+    };
+
+    // ---- scalar CBs ----
+    const auto scalar_face_geometry = FaceGeometry{.face_r_dim = 1, .num_faces = 4};
+    add_local_dfb(
+        DFB_IN_SCALAR_0,
+        cb_sizes.scalar_cb_pagesize,
+        cb_sizes.scalar_cb_npages,
+        params.data_format,
+        scalar_face_geometry);
+    if (cb_sizes.has_second_scalar_cb) {
+        add_local_dfb(
+            DFB_IN_SCALAR_1,
+            cb_sizes.scalar_cb_pagesize,
+            cb_sizes.scalar_cb_npages,
+            params.data_format,
+            scalar_face_geometry);
     }
-    if (!ranges.empty()) {
-        workload_descriptor.programs.push_back({ranges.back(), std::move(desc)});
+
+    // CB storing just "clear value" (-inf for maxpool, 0 for avgpool)
+    add_local_dfb(DFB_CLEAR_VALUE, cb_sizes.clear_value_cb_size, 1, params.data_format);
+
+    // incoming data is the input cb instead of raw l1/dram addr; this input shard has halo and
+    // padding inserted. Borrowed from the input tensor (read only as an address source by the reader).
+    const uint32_t raw_in_cb_npages = input.shard_spec().value().shape[0];
+    const uint32_t raw_in_cb_pagesize = in_nbytes_c;
+    add_borrowed_dfb(DFB_RAW_IN, raw_in_cb_pagesize, raw_in_cb_npages, params.data_format, TP_INPUT);
+
+    // reader indices (L1 path: sharded, backed by the op-owned reader_indices tensor)
+    const uint32_t in_reader_indices_cb_pagesize =
+        tt::round_up(reader_indices_size, 4);  // pagesize needs to be multiple of 4
+    constexpr uint32_t in_reader_indices_cb_npages = 1;
+    const uint32_t max_reader_indices_size =
+        (max_out_nhw_per_core * 3 * sizeof(uint16_t)) + 2;  // worst case of 3 indices per output element
+    const uint32_t actual_reader_indices_buffer_page_size = reader_indices_buffer->page_size();
+    TT_FATAL(
+        actual_reader_indices_buffer_page_size <= max_reader_indices_size,
+        "Reader indices buffer page size {} exceeds max expected size {}",
+        actual_reader_indices_buffer_page_size,
+        max_reader_indices_size);
+    add_borrowed_dfb(
+        DFB_READER_INDICES,
+        in_reader_indices_cb_pagesize,
+        in_reader_indices_cb_npages,
+        tt::DataFormat::UInt16,
+        TP_READER_INDICES);
+
+    // in_nblocks_c is factory-specific (used for kernel args), derived from the shared in_cb_raw_size
+    uint32_t in_nblocks_c = 1;
+    if (return_indices || params.is_wide_reduction) {
+        in_nblocks_c =
+            static_cast<uint32_t>(std::ceil(static_cast<float>(params.in_ntiles_c) / params.MAX_TILES_PER_REDUCTION));
     }
-    return workload_descriptor;
+
+    // reader output == input to tilize
+    const uint32_t in_cb_pagesize = cb_sizes.in_cb_pagesize;
+    const uint32_t in_cb_npages = cb_sizes.in_cb_npages;
+
+    const uint32_t window_size_hw = kernel_h * kernel_w;
+    const uint32_t raw_face_r = std::min(window_size_hw, 16u);
+    const uint32_t num_faces_in_input_tile_for_cb =
+        (params.max_rows_for_reduction < tt::constants::TILE_HEIGHT || window_size_hw <= tt::constants::FACE_HEIGHT)
+            ? 2u
+            : 4u;
+    const std::optional<FaceGeometry> input_face_geometry =
+        return_indices
+            ? std::nullopt
+            : std::optional{FaceGeometry{.face_r_dim = raw_face_r, .num_faces = num_faces_in_input_tile_for_cb}};
+
+    add_local_dfb(DFB_IN_0, in_cb_pagesize, in_cb_npages, params.data_format, input_face_geometry);
+    if (cb_sizes.has_split_reader) {
+        add_local_dfb(DFB_IN_1, in_cb_pagesize, in_cb_npages, params.data_format, input_face_geometry);
+    }
+
+    const bool is_output_tiled = output_layout == Layout::TILE;
+    const bool is_output_block_format = is_block_float(output_tensors[0].dtype());
+    const bool zero_pages = is_output_tiled && is_output_block_format;
+
+    constexpr uint32_t pack_untilize_face_r_dim = 1;
+    const bool last_tile_is_partial = in_c % tt::constants::TILE_WIDTH != 0;
+    const bool single_partial_fits_in_face = last_tile_is_partial && in_c <= tt::constants::FACE_WIDTH;
+    const uint32_t pack_untilize_num_faces = single_partial_fits_in_face ? 1u : 2u;
+    const auto pack_untilize_face_geometry =
+        FaceGeometry{.face_r_dim = pack_untilize_face_r_dim, .num_faces = pack_untilize_num_faces};
+    const std::optional<tt::tt_metal::Tile> pack_untilize_tile =
+        single_partial_fits_in_face ? std::optional{tt::tt_metal::Tile{{1, tt::constants::FACE_WIDTH}, false}}
+                                    : std::nullopt;
+
+    // pre_tilize_cb / fast_tilize_cb are two ALIASED DFBs: one L1 allocation backs two DFBs that
+    // present different face_geometry/page_size views of the same bytes (legacy multi-format CB).
+    //   * pre_tilize -- producer view, used by pack_untilize. Stick-packed (face_r_dim=1,
+    //                   num_faces<=2), pagesize=TILE_WIDTH*nbytes.
+    //   * fast_tilize -- consumer view, used by fast_tilize. Full-tile (face_r_dim=16, num_faces=4),
+    //                    pagesize=tile_size.
+    // The kernel keeps both FIFOs in lock-step by pushing/popping the same byte amount per round,
+    // so their rd/wr pointers always point at matching L1 addresses.
+    if (cb_sizes.has_pre_tilize) {
+        const uint32_t pre_tilize_total_size = cb_sizes.pre_tilize_cb_pagesize * cb_sizes.pre_tilize_cb_npages;
+        const uint32_t fast_tilize_page_size = tt::tile_size(params.data_format);
+        TT_FATAL(
+            pre_tilize_total_size % fast_tilize_page_size == 0,
+            "pre_tilize_cb total size {} must be a multiple of fast_tilize tile size {}",
+            pre_tilize_total_size,
+            fast_tilize_page_size);
+        // pre_tilize (producer view)
+        dfbs.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{DFB_PRE_TILIZE},
+            .entry_size = cb_sizes.pre_tilize_cb_pagesize,
+            .num_entries = cb_sizes.pre_tilize_cb_npages,
+            .data_format_metadata = params.data_format,
+            .tile_format_metadata = pack_untilize_tile,
+            .unpack_face_geometry_metadata = pack_untilize_face_geometry,
+            .advanced_options = m2::DFBAdvancedOptions{.alias_with = {m2::DFBSpecName{DFB_FAST_TILIZE}}},
+        });
+        // fast_tilize (consumer view): full-tile face_geometry (default 32x32, 4 faces of 16x16).
+        dfbs.push_back(m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{DFB_FAST_TILIZE},
+            .entry_size = fast_tilize_page_size,
+            .num_entries = pre_tilize_total_size / fast_tilize_page_size,
+            .data_format_metadata = params.data_format,
+            .advanced_options = m2::DFBAdvancedOptions{.alias_with = {m2::DFBSpecName{DFB_PRE_TILIZE}}},
+        });
+    }
+
+    // out CB: borrowed from the output tensor (compute writes directly into the sharded output buffer).
+    add_borrowed_dfb(
+        DFB_OUT,
+        cb_sizes.out_cb_pagesize,
+        cb_sizes.out_cb_npages,
+        params.output_data_format,
+        TP_OUTPUT,
+        is_output_tiled ? std::nullopt : std::optional{pack_untilize_face_geometry},
+        is_output_tiled ? std::nullopt : pack_untilize_tile);
+
+    for (const auto& out : output_tensors) {
+        TT_FATAL(
+            out.memory_config().is_sharded(),
+            "Output memory config needs to be sharded, but got {}",
+            out.memory_config());
+    }
+
+    // config (scalar config) CB: borrowed from the op-owned scalar config tensor (avg-pool only).
+    if (!one_scalar_per_core) {
+        TT_FATAL(config_buffer != nullptr, "scalar config buffer must be populated when !one_scalar_per_core");
+        uint32_t max_config_tensor_size =
+            max_out_nhw_per_core * 3 * sizeof(uint16_t);  // worst case of 3 entries per output element
+        TT_FATAL(
+            config_buffer->page_size() <= max_config_tensor_size,
+            "Config tensor buffer page size {} exceeds max expected size {}",
+            config_buffer->page_size(),
+            max_config_tensor_size);
+        add_borrowed_dfb(DFB_CONFIG, config_buffer->page_size(), 1, tt::DataFormat::RawUInt32, TP_CONFIG);
+    }
+
+    // ---------------------------------------------------------------------------------------------
+    // Reader kernel CTAs. CB-index CTA slots become DFB bindings (named via dfb::), so they are NOT
+    // in this Table. The four legacy CTA slots that carried buffer addresses/page-sizes for the DRAM
+    // path (config_dram_addr/page_size, reader_dram_addr/page_size) are passed as named 0 constants
+    // — the L1 path's kernel never reads them (they are under `if constexpr (config_in_dram)`), and
+    // no raw address crosses the CTA channel.
+    // ---------------------------------------------------------------------------------------------
+    m2::KernelSpec::CompileTimeArgs reader_cta = {
+        {"reader_nindices", max_out_nhw_per_core},
+        {"kernel_h", kernel_h},
+        {"kernel_w", kernel_w},
+        {"pad_w", pad_w},
+        {"in_nbytes_leftover", in_nbytes_leftover},
+        {"in_w", in_w},
+        {"in_c", in_c_per_shard_ceil},
+        {"split_reader", params.split_reader},
+        // reader_id is the only per-kernel-differing CTA; set per reader below.
+        {"bf16_scalar", bf16_scalar},
+        {"bf16_init_value", bf16_init_value},
+        {"in_nblocks_c", in_nblocks_c},
+        {"in_cb_sz", cb_sizes.in_cb_raw_size},
+        {"max_sticks_for_reduction", params.max_rows_for_reduction},
+        {"ceil_pad_w", ceil_pad_w},
+        {"pool_type", static_cast<uint32_t>(pool_type)},
+        {"one_scalar_per_core", one_scalar_per_core},
+        {"in_nbytes_c", in_nbytes_c},
+        {"shard_width_bytes", shard_width_bytes},
+        {"multi_buffering_factor", params.multi_buffering_factor},
+        {"stride_w", stride_w},
+        {"dilation_h", dilation_h},
+        {"dilation_w", dilation_w},
+        {"zero_pages", static_cast<uint32_t>(zero_pages)},
+        // DRAM-path CTAs: forced to 0 on the L1 path (see note above). config_in_dram drives the
+        // dead `if constexpr` branches in the kernel, so the addresses are never consumed.
+        {"config_in_dram", 0},
+        {"config_dram_addr", 0},
+        {"config_page_size", 0},
+        {"reader_dram_addr", 0},
+        {"reader_page_size", 0},
+    };
+
+    // Per-reader DFB bindings. reader0 produces in_0 + in_scalar_0; reader1 produces in_1 +
+    // in_scalar_1 (each reader writes its OWN input/scalar CB; compute consumes both). raw_in /
+    // reader_indices / config are borrowed-memory DFBs the reader reads only as an address source
+    // (get_read_ptr) — bound as self-loop (PRODUCER + CONSUMER on the reader) to satisfy the DFB
+    // producer/consumer invariant (no real FIFO peer). clear_value is filled by reader0 (PRODUCER)
+    // and waited on by reader1 (CONSUMER) — bind both endpoints on each reader (self-loop) so the
+    // per-node invariant holds regardless of which reader runs on the node.
+    // Both reader KernelSpecs compile the SAME source, so each binds its own input/scalar DFB under
+    // the SAME kernel-side accessor name ("in" / "in_scalar"). reader0 -> in_0/in_scalar_0,
+    // reader1 -> in_1/in_scalar_1. The kernel just constructs dfb::in / dfb::in_scalar.
+    auto reader_dfb_bindings = [&](uint32_t reader_id) {
+        m2::Group<m2::DFBBinding> b;
+        const char* in_name = (reader_id == 0) ? DFB_IN_0 : DFB_IN_1;
+        b.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{in_name},
+            .accessor_name = "in",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER});
+        // scalar CB binding (accessor "in_scalar"):
+        //   - reader0 always produces in_scalar_0.
+        //   - reader1 produces in_scalar_1 ONLY when a second scalar CB exists (avg && split &&
+        //     !one_scalar). Otherwise reader1 does NOT bind a scalar CB (it never touches one), so a
+        //     second producer/consumer of in_scalar_0 is not introduced on the node. The kernel gates
+        //     its dfb::in_scalar handle on the READER_BINDS_SCALAR define accordingly.
+        const bool reader_binds_scalar = (reader_id == 0) || cb_sizes.has_second_scalar_cb;
+        if (reader_binds_scalar) {
+            const char* scalar_name = (reader_id == 1) ? DFB_IN_SCALAR_1 : DFB_IN_SCALAR_0;
+            b.push_back(m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{scalar_name},
+                .accessor_name = "in_scalar",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER});
+        }
+        // clear_value: reader0 fills it (PRODUCER), reader1 waits on it (CONSUMER). With split_reader
+        // the two readers form the producer/consumer pair on the node. Without split_reader, reader0
+        // is the only kernel, so it self-loops (PRODUCER + CONSUMER) to satisfy the invariant.
+        if (reader_id == 0) {
+            b.push_back(m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{DFB_CLEAR_VALUE},
+                .accessor_name = "clear_value",
+                .endpoint_type = m2::DFBEndpointType::PRODUCER});
+            if (!cb_sizes.has_split_reader) {
+                b.push_back(m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{DFB_CLEAR_VALUE},
+                    .accessor_name = "clear_value",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER});
+            }
+        } else {
+            b.push_back(m2::DFBBinding{
+                .dfb_spec_name = m2::DFBSpecName{DFB_CLEAR_VALUE},
+                .accessor_name = "clear_value",
+                .endpoint_type = m2::DFBEndpointType::CONSUMER});
+        }
+        // raw_in / reader_indices / config are borrowed-memory DFBs read by BOTH readers purely as an
+        // address source (get_read_ptr). To satisfy "exactly one producer + one consumer per node"
+        // without a real FIFO: with split_reader, reader0 = PRODUCER, reader1 = CONSUMER; without
+        // split, reader0 self-loops (PRODUCER + CONSUMER). The endpoint role is a formality here — the
+        // kernel only reads the backing tensor's base pointer.
+        auto bind_address_source = [&](const char* dfb_name, const char* accessor) {
+            if (reader_id == 0) {
+                b.push_back(m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{dfb_name},
+                    .accessor_name = accessor,
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER});
+                if (!cb_sizes.has_split_reader) {
+                    b.push_back(m2::DFBBinding{
+                        .dfb_spec_name = m2::DFBSpecName{dfb_name},
+                        .accessor_name = accessor,
+                        .endpoint_type = m2::DFBEndpointType::CONSUMER});
+                }
+            } else {
+                b.push_back(m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{dfb_name},
+                    .accessor_name = accessor,
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER});
+            }
+        };
+        bind_address_source(DFB_RAW_IN, "raw_in");
+        bind_address_source(DFB_READER_INDICES, "reader_indices");
+        if (!one_scalar_per_core) {
+            bind_address_source(DFB_CONFIG, "config");
+        }
+        return b;
+    };
+
+    // Tensor bindings the reader needs (raw_in / reader_indices / config back borrowed DFBs).
+    auto reader_tensor_bindings = [&]() {
+        m2::Group<m2::TensorBinding> t;
+        t.push_back(
+            m2::TensorBinding{.tensor_parameter_name = m2::TensorParamName{TP_INPUT}, .accessor_name = "input"});
+        t.push_back(m2::TensorBinding{
+            .tensor_parameter_name = m2::TensorParamName{TP_READER_INDICES}, .accessor_name = "reader_indices_tensor"});
+        if (!one_scalar_per_core) {
+            t.push_back(m2::TensorBinding{
+                .tensor_parameter_name = m2::TensorParamName{TP_CONFIG}, .accessor_name = "config_tensor"});
+        }
+        return t;
+    };
+
+    auto make_reader = [&](const char* id, uint32_t reader_id, DataMovementProcessor proc) {
+        m2::KernelSpec::CompileTimeArgs cta = reader_cta;
+        cta.insert({"reader_id", reader_id});
+        // Per-reader conditional-DFB defines (gate the dfb:: tokens that aren't bound on this kernel).
+        m2::KernelSpec::CompilerOptions::Defines defines;
+        const bool reader_binds_scalar = (reader_id == 0) || cb_sizes.has_second_scalar_cb;
+        if (reader_binds_scalar) {
+            defines.insert({"READER_BINDS_SCALAR", "1"});
+        }
+        if (!one_scalar_per_core) {
+            defines.insert({"HAS_CONFIG_CB", "1"});
+        }
+        return m2::KernelSpec{
+            .unique_id = m2::KernelSpecName{id},
+            .source = std::filesystem::path{READER_KERNEL_PATH},
+            .compiler_options = {.defines = std::move(defines)},
+            .dfb_bindings = reader_dfb_bindings(reader_id),
+            .tensor_bindings = reader_tensor_bindings(),
+            .compile_time_args = std::move(cta),
+            .runtime_arg_schema = {.runtime_arg_names = {"out_nhw_this_core", "core_nhw_index"}},
+            .hw_config =
+                m2::DataMovementHardwareConfig{
+                    .role = (proc == DataMovementProcessor::RISCV_0) ? m2::DataMovementRoleHint::READER
+                                                                     : m2::DataMovementRoleHint::WRITER},
+        };
+    };
+
+    m2::KernelSpec reader0 = make_reader(KERNEL_READER0, 0, DataMovementProcessor::RISCV_0);
+    std::optional<m2::KernelSpec> reader1;
+    if (params.split_reader) {
+        reader1 = make_reader(KERNEL_READER1, 1, DataMovementProcessor::RISCV_1);
+    }
+
+    // ---- Compute kernel ----
+    m2::KernelSpec::CompileTimeArgs compute_cta = {
+        {"in_ntiles_c", params.in_ntiles_c},
+        {"window_size_hw", kernel_h * kernel_w},
+        {"split_reader", params.split_reader},
+        {"max_out_sticks_per_core", 0},  // used for grid sample but not for pool
+        {"in_c", in_c_per_shard_ceil},
+        {"in_nblocks_c", in_nblocks_c},
+        {"max_sticks_for_reduction", params.max_rows_for_reduction},
+        {"one_scalar_per_core", one_scalar_per_core},
+        {"is_output_tiled", is_output_tiled},
+        {"is_output_block_format", is_output_block_format},
+        {"force_max_tiles_per_reduction_4", 0},  // off for pool2d
+    };
+
+    // Get device arch for compute kernel config initialization
+    auto device_arch = input.device()->arch();
+    auto device_compute_kernel_config = init_device_compute_kernel_config(
+        device_arch,
+        op_attr.compute_kernel_config_,
+        tt::tt_metal::MathFidelity::HiFi4,
+        false,                                                             // math_approx_mode
+        (params.is_avg_pool && params.is_large_kernel) || return_indices,  // fp32_dest_acc_en
+        false,                                                             // packer_l1_acc
+        (params.is_large_kernel && return_indices) || return_indices       // dst_full_sync_en
+    );
+
+    const auto pool_defines_map = get_defines(pool_type);
+    m2::KernelSpec::CompilerOptions::Defines compute_defines;
+    for (const auto& [k, v] : pool_defines_map) {
+        compute_defines.insert({k, v});
+    }
+    // Conditional DFB bindings need a matching kernel-side preprocessor flag (Metal 2.0 conditional-
+    // binding pattern): the dfb:: token for a DFB that isn't bound on this path must not enter name
+    // lookup. SPLIT_READER gates dfb::in_1; HAS_SECOND_SCALAR_CB gates dfb::in_scalar_1
+    // (is_avg_pool && split_reader && !one_scalar_per_core); IS_OUTPUT_TILED gates the aliased
+    // dfb::pre_tilize / dfb::fast_tilize pair.
+    if (cb_sizes.has_split_reader) {
+        compute_defines.insert({"SPLIT_READER", "1"});
+    }
+    if (cb_sizes.has_second_scalar_cb) {
+        compute_defines.insert({"HAS_SECOND_SCALAR_CB", "1"});
+    }
+    if (cb_sizes.has_pre_tilize) {
+        compute_defines.insert({"IS_OUTPUT_TILED", "1"});
+    }
+
+    // Compute DFB bindings: consumes in_0/in_1/scalars, produces out, and self-loops the aliased
+    // pre_tilize/fast_tilize pair (compute is their only user).
+    m2::Group<m2::DFBBinding> compute_dfb_bindings;
+    compute_dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{DFB_IN_0},
+        .accessor_name = "in_0",
+        .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    if (cb_sizes.has_split_reader) {
+        compute_dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{DFB_IN_1},
+            .accessor_name = "in_1",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    }
+    compute_dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{DFB_IN_SCALAR_0},
+        .accessor_name = "in_scalar_0",
+        .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    if (cb_sizes.has_second_scalar_cb) {
+        compute_dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{DFB_IN_SCALAR_1},
+            .accessor_name = "in_scalar_1",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    }
+    // out: compute produces it (and is its only user — self-loop to satisfy the invariant).
+    compute_dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{DFB_OUT},
+        .accessor_name = "out",
+        .endpoint_type = m2::DFBEndpointType::PRODUCER});
+    compute_dfb_bindings.push_back(m2::DFBBinding{
+        .dfb_spec_name = m2::DFBSpecName{DFB_OUT},
+        .accessor_name = "out",
+        .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    if (cb_sizes.has_pre_tilize) {
+        compute_dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{DFB_PRE_TILIZE},
+            .accessor_name = "pre_tilize",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER});
+        compute_dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{DFB_PRE_TILIZE},
+            .accessor_name = "pre_tilize",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+        compute_dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{DFB_FAST_TILIZE},
+            .accessor_name = "fast_tilize",
+            .endpoint_type = m2::DFBEndpointType::PRODUCER});
+        compute_dfb_bindings.push_back(m2::DFBBinding{
+            .dfb_spec_name = m2::DFBSpecName{DFB_FAST_TILIZE},
+            .accessor_name = "fast_tilize",
+            .endpoint_type = m2::DFBEndpointType::CONSUMER});
+    }
+
+    m2::KernelSpec compute{
+        .unique_id = m2::KernelSpecName{KERNEL_COMPUTE},
+        .source = std::filesystem::path{COMPUTE_KERNEL_PATH},
+        .compiler_options = {.defines = std::move(compute_defines)},
+        .dfb_bindings = std::move(compute_dfb_bindings),
+        .compile_time_args = std::move(compute_cta),
+        // compute_pool_2d only reads out_nhw_this_core (RTA slot 0); core_nhw_index is reader-only.
+        .runtime_arg_schema = {.runtime_arg_names = {"out_nhw_this_core"}},
+        .hw_config =
+            m2::ComputeHardwareConfig{
+                .math_fidelity = get_math_fidelity(device_compute_kernel_config),
+                .fp32_dest_acc_en = get_fp32_dest_acc_en(device_compute_kernel_config),
+                .dst_full_sync_en = get_dst_full_sync_en(device_compute_kernel_config),
+                .math_approx_mode = false,
+            },
+    };
+
+    // ---- Tensor parameters ----
+    spec.tensor_parameters.push_back(
+        m2::TensorParameter{.unique_id = m2::TensorParamName{TP_INPUT}, .spec = input.tensor_spec()});
+    spec.tensor_parameters.push_back(
+        m2::TensorParameter{.unique_id = m2::TensorParamName{TP_OUTPUT}, .spec = output_tensors[0].tensor_spec()});
+    spec.tensor_parameters.push_back(m2::TensorParameter{
+        .unique_id = m2::TensorParamName{TP_READER_INDICES}, .spec = reader_indices_owned.tensor_spec()});
+    if (!one_scalar_per_core) {
+        spec.tensor_parameters.push_back(
+            m2::TensorParameter{.unique_id = m2::TensorParamName{TP_CONFIG}, .spec = config_owned->tensor_spec()});
+    }
+
+    // ---- Kernels + WorkUnitSpec ----
+    // All kernels share the single core grid `all_cores`. The local DFBs (in_0/in_1/scalars/
+    // clear_value/pre_tilize/fast_tilize) require their producer and consumer to share the SAME
+    // WorkUnitSpec — so reader0 (+reader1) and compute all live in one WorkUnitSpec on all_cores.
+    m2::Group<m2::KernelSpecName> wu_kernels;
+    spec.kernels.push_back(reader0);
+    wu_kernels.push_back(m2::KernelSpecName{KERNEL_READER0});
+    if (reader1.has_value()) {
+        spec.kernels.push_back(*reader1);
+        wu_kernels.push_back(m2::KernelSpecName{KERNEL_READER1});
+    }
+    spec.kernels.push_back(compute);
+    wu_kernels.push_back(m2::KernelSpecName{KERNEL_COMPUTE});
+
+    spec.work_units.push_back(m2::WorkUnitSpec{
+        .name = "pool2d",
+        .kernels = std::move(wu_kernels),
+        .target_nodes = all_cores,
+    });
+
+    // ---- ProgramRunArgs (mutable; per-core runtime args + tensor args) ----
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs reader0_run{.kernel = m2::KernelSpecName{KERNEL_READER0}};
+    m2::KernelRunArgs reader1_run{.kernel = m2::KernelSpecName{KERNEL_READER1}};
+    m2::KernelRunArgs compute_run{.kernel = m2::KernelSpecName{KERNEL_COMPUTE}};
+
+    // set the starting indices for each core as runtime args
+    uint32_t total_out_nhw = in_n * out_h * out_w;
+    for (uint32_t core_i = 0; core_i < ncores; core_i++) {
+        const uint32_t core_x_i = core_i % rectangular_x;
+        const uint32_t core_y_i = core_i / rectangular_x;
+        const CoreCoord core(core_x_i, core_y_i);
+
+        uint32_t total_out_nhw_processed;
+        uint32_t core_nhw_index = 0;
+        if (is_block_sharded) {
+            total_out_nhw_processed = core_y_i * max_out_nhw_per_core;
+            core_nhw_index = core_y_i;
+        } else if (is_width_sharded) {
+            total_out_nhw_processed = 0;
+            core_nhw_index = 0;
+        } else {
+            total_out_nhw_processed = core_i * max_out_nhw_per_core;
+            core_nhw_index = core_i;
+        }
+        uint32_t remaining_out_nhw =
+            total_out_nhw_processed < total_out_nhw ? total_out_nhw - total_out_nhw_processed : 0;
+        uint32_t out_nhw_this_core = std::min(max_out_nhw_per_core, remaining_out_nhw);
+
+        m2::ProgramRunArgs::KernelRunArgs::RuntimeArgValues reader_args = {
+            {"out_nhw_this_core", out_nhw_this_core}, {"core_nhw_index", core_nhw_index}};
+
+        reader0_run.runtime_arg_values.push_back({core, reader_args});
+        if (params.split_reader) {
+            reader1_run.runtime_arg_values.push_back({core, reader_args});
+        }
+        // compute reads only out_nhw_this_core.
+        compute_run.runtime_arg_values.push_back({core, {{"out_nhw_this_core", out_nhw_this_core}}});
+    }
+
+    run.kernel_run_args.push_back(std::move(reader0_run));
+    if (params.split_reader) {
+        run.kernel_run_args.push_back(std::move(reader1_run));
+    }
+    run.kernel_run_args.push_back(std::move(compute_run));
+
+    // Tensor arguments: io tensors + op-owned tensors (referenced by mesh_tensor() identity).
+    run.tensor_args = {
+        {m2::TensorParamName{TP_INPUT}, input.mesh_tensor()},
+        {m2::TensorParamName{TP_OUTPUT}, output_tensors[0].mesh_tensor()},
+        {m2::TensorParamName{TP_READER_INDICES}, reader_indices_owned.mesh_tensor()},
+    };
+    if (!one_scalar_per_core) {
+        run.tensor_args.insert({m2::TensorParamName{TP_CONFIG}, config_owned->mesh_tensor()});
+    }
+
+    return ttnn::device_operation::ProgramArtifacts{
+        .spec = std::move(spec), .run_params = std::move(run), .op_owned_tensors = std::move(op_owned_tensors)};
 }
 
 }  // namespace ttnn::operations::pool

--- a/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/generic/device/pool_op.hpp
@@ -17,8 +17,7 @@
 #include "ttnn/types.hpp"
 #include "ttnn/operation.hpp"
 #include "ttnn/distributed/types.hpp"
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/workload_descriptor.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 #include <utility>
 
 namespace ttnn::operations::pool {
@@ -46,21 +45,24 @@ struct Pool2D {
     using tensor_return_value_t = std::vector<Tensor>;
 
     struct MultiCore {
-        // Builds the entire workload in one call (cache miss):
-        //   1. Uploads the halo lookup table (and, for avg-pool variants that
-        //      need it, the per-stick scalar config tensor) and parks the
-        //      backing MeshBuffers in the descriptor's `buffers` vector so
-        //      they outlive the cached workload.
-        //   2. Loops `tensor_coords` and pushes a ProgramDescriptor per coord
-        //      into `programs`.
-        static tt::tt_metal::WorkloadDescriptor create_workload_descriptor(
+        // Metal 2.0 program factory (MetalV2FactoryConcept). Builds the immutable ProgramSpec and its
+        // mutable ProgramRunArgs, plus the op-owned config tensors (the sliding-window halo
+        // reader-indices table and, for avg-pool variants that need it, the per-stick scalar config
+        // tensor). The framework adapter parks the op-owned tensors in the cache entry (stable
+        // address) for the cached Program's lifetime and stamps one Program per mesh coordinate.
+        //
+        // Scope: L1-config, non-return-indices path only (reader_pool_2d.cpp / compute_pool_2d_m2.cpp).
+        // The DRAM-config path and the return_indices (MPWI) path are gated out (TT_FATAL).
+        static ttnn::device_operation::ProgramArtifacts create_program_spec(
             const operation_attributes_t& op_attr,
             const tensor_args_t& tensor_args,
-            tensor_return_value_t& output_tensors,
-            const ttnn::MeshCoordinateRangeSet& tensor_coords);
+            tensor_return_value_t& output_tensors);
     };
 
     using program_factory_t = std::variant<MultiCore>;
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&) {
+        return MultiCore{};
+    }
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp
@@ -5,20 +5,21 @@
 #include "api/compute/compute_kernel_api.h"
 #include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_unary/rand.h"
+#include "experimental/kernel_args.h"
 
 void kernel_main() {
-    constexpr uint32_t intermed_cb_id = get_compile_time_arg_val(0);
+    constexpr uint32_t intermed_cb_id = dfb::intermed;
 
-    const uint32_t seed = get_arg_val<uint32_t>(0);
+    const uint32_t seed = get_arg(args::seed);
     union {
         float f;
         uint32_t u;
     } f2u_from, f2u_to, f2u_scale;
-    f2u_from.u = get_arg_val<uint32_t>(1);
-    f2u_to.u = get_arg_val<uint32_t>(2);
+    f2u_from.u = get_arg(args::from);
+    f2u_to.u = get_arg(args::to);
     f2u_scale.f = f2u_to.f - f2u_from.f;
-    const uint32_t start_id = get_arg_val<uint32_t>(3);
-    const uint32_t num_tiles = get_arg_val<uint32_t>(4);
+    const uint32_t start_id = get_arg(args::start_id);
+    const uint32_t num_tiles = get_arg(args::num_tiles);
     const uint32_t end_id = start_id + num_tiles;
 
     init_sfpu(intermed_cb_id, intermed_cb_id);

--- a/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp
@@ -4,20 +4,19 @@
 
 #include <tt-metalium/constants.hpp>
 #include "api/dataflow/dataflow_api.h"
+#include "experimental/kernel_args.h"
 
 using namespace tt;
 
 void kernel_main() {
-    constexpr uint32_t intermed_cb_id = get_compile_time_arg_val(0);
-    constexpr uint32_t dst_cb_id = get_compile_time_arg_val(1);
-    constexpr auto dst_args = TensorAccessorArgs<2>();
+    constexpr uint32_t intermed_cb_id = dfb::intermed;
+    constexpr uint32_t dst_cb_id = dfb::dst;
 
-    uint32_t dst_addr = get_arg_val<uint32_t>(0);
-    uint32_t start_id = get_arg_val<uint32_t>(1);
-    uint32_t num_tiles = get_arg_val<uint32_t>(2);
+    uint32_t start_id = get_arg(args::start_id);
+    uint32_t num_tiles = get_arg(args::num_tiles);
     uint32_t end_id = start_id + num_tiles;
 
-    const auto output_addrg = TensorAccessor(dst_args, dst_addr);
+    const auto output_addrg = TensorAccessor(ta::output);
 
     cb_reserve_back(dst_cb_id, 1);
     uint32_t dst_cb_write_ptr = get_write_ptr(dst_cb_id);

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_device_operation.hpp
@@ -6,12 +6,12 @@
 
 #include <optional>
 
+#include <variant>
 #include <vector>
 
 #include "ttnn/device_operation.hpp"
 #include "ttnn/distributed/types.hpp"
-#include <tt-metalium/program_descriptors.hpp>
-#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include "ttnn/metal2_artifacts.hpp"
 
 namespace ttnn::operations::rand {
 
@@ -41,27 +41,27 @@ struct RandDeviceOperation {
     using spec_return_value_t = TensorSpec;
     using tensor_return_value_t = Tensor;
 
-    static tt::tt_metal::ProgramDescriptor create_descriptor(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+    // Metal 2.0 program factory: builds the immutable ProgramSpec and its mutable
+    // ProgramRunArgs. seed/from/to are excluded from the program hash (calls differing only
+    // in those values cache-hit instead of recompiling); they live in ProgramRunArgs and are
+    // re-applied on every dispatch by the framework adapter (cache miss and cache hit alike),
+    // so a cache hit still sees a fresh per-core seed. The test_rand_different_seed_values
+    // regression test enforces this.
+    struct RandProgramFactory {
+        static ttnn::device_operation::ProgramArtifacts create_program_spec(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& output);
+    };
+    using program_factory_t = std::variant<RandProgramFactory>;
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&) {
+        return RandProgramFactory{};
+    }
 
     static void validate_inputs(const operation_attributes_t& attributes, const tensor_args_t& tensor_args);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    // seed/from/to are excluded from the program hash (so calls differing only in
-    // those values cache-hit instead of recompiling).  They are therefore DYNAMIC: this returns the
-    // current per-core (seed) and per-call (from/to) values so the framework re-applies them to the
-    // cached program on every dispatch.  Must mirror the seed/from/to runtime args built in
-    // create_descriptor() — the test_rand_different_seed_values regression test enforces this.
-    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& output,
-        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
 };
 
 }  // namespace ttnn::operations::rand

--- a/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/rand/device/rand_program_factory.cpp
@@ -10,12 +10,16 @@
 #include <tt-metalium/work_split.hpp>
 #include "ttnn/tensor/types.hpp"
 #include "rand_device_operation.hpp"
-#include <tt-metalium/tensor_accessor_args.hpp>
+
+#include "ttnn/metal2_artifacts.hpp"
+#include <tt-metalium/experimental/metal2_host_api/program_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/program_run_args.hpp>
 
 namespace ttnn::operations::rand {
 
 using namespace tt;
 using namespace tt::tt_metal;
+namespace m2 = tt::tt_metal::experimental;
 
 namespace {
 
@@ -27,8 +31,8 @@ auto get_random_seed() -> uint32_t { return distribution(rng); }
 constexpr const char* WRITER_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/writer_uniform.cpp";
 constexpr const char* COMPUTE_KERNEL_PATH = "ttnn/cpp/ttnn/operations/rand/device/kernels/compute_uniform.cpp";
 
-// Work split + per-device seed offset, shared by create_descriptor (cache miss) and
-// get_dynamic_runtime_args (cache hit) so both derive the identical core list and seed offset.
+// Work split + per-device seed offset, shared so the miss-build and the hit-refresh
+// (create_program_spec re-run from the adapter) derive the identical core list and seed offset.
 struct RandWorkSplit {
     uint32_t num_cores = 0;
     CoreRangeSet all_cores;
@@ -77,7 +81,7 @@ RandWorkSplit compute_rand_work_split(
         device_seed_offset};
 }
 
-// Per-core seed; shared so the miss-build and the hit-patch produce identical values.
+// Per-core seed; shared so the miss-build and the hit-refresh produce identical values.
 uint32_t rand_seed_for_core(
     const RandDeviceOperation::operation_attributes_t& attrs, int i, uint32_t device_seed_offset) {
     return attrs.seed != 0 ? attrs.seed + i + device_seed_offset : get_random_seed();
@@ -85,150 +89,161 @@ uint32_t rand_seed_for_core(
 
 }  // namespace
 
-ProgramDescriptor RandDeviceOperation::create_descriptor(
+// Metal 2.0 program factory. Produces the immutable ProgramSpec plus its mutable
+// ProgramRunArgs. seed/from/to live in ProgramRunArgs (NOT the spec), so they are
+// re-applied on every dispatch (cache miss and cache hit) — the structural replacement
+// for the old custom-hash-excludes-seed + get_dynamic_runtime_args() patching dance.
+ttnn::device_operation::ProgramArtifacts RandDeviceOperation::RandProgramFactory::create_program_spec(
     const operation_attributes_t& operation_attributes,
     const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output,
-    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    auto
-        [num_cores,
-         all_cores,
-         core_group_1,
-         core_group_2,
-         units_per_core_group_1,
-         units_per_core_group_2,
-         cores,
-         device_seed_offset] = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
-    const auto num_cores_total = cores.size();
+    tensor_return_value_t& output) {
+    auto ws = compute_rand_work_split(operation_attributes, output, /*mesh_dispatch_coordinate=*/std::nullopt);
 
-    DataType output_dtype = output.dtype();
-    auto out_data_format = datatype_to_dataformat_converter(output_dtype);
+    const DataType output_dtype = output.dtype();
+    const auto out_data_format = datatype_to_dataformat_converter(output_dtype);
     const uint32_t dtype_tile_size = tile_size(out_data_format);
     const uint32_t intermed_tile_size = tile_size(tt::DataFormat::Float32);
 
-    constexpr uint32_t in_out_num_tiles = 1;
     constexpr uint32_t intermed_num_tiles = 2;
+    constexpr uint32_t in_out_num_tiles = 1;
 
-    constexpr uint32_t intermed_cb_id = CBIndex::c_24;
-    constexpr uint32_t dst_cb_id = CBIndex::c_0;
+    // ---- ProgramSpec (immutable) ----
+    m2::ProgramSpec spec;
+    spec.name = "rand";
 
-    ProgramDescriptor desc;
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = intermed_num_tiles * intermed_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = intermed_cb_id,
-            .data_format = tt::DataFormat::Float32,
-            .page_size = intermed_tile_size,
-        }}},
-    });
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = in_out_num_tiles * dtype_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = dst_cb_id,
-            .data_format = out_data_format,
-            .page_size = dtype_tile_size,
-        }}},
-    });
-
-    KernelDescriptor::CompileTimeArgs writer_ct_args;
-    writer_ct_args.reserve(8);
-    writer_ct_args.push_back(intermed_cb_id);
-    writer_ct_args.push_back(dst_cb_id);
-    TensorAccessorArgs(*output.buffer()).append_to(writer_ct_args);
-
-    KernelDescriptor writer_desc;
-    writer_desc.kernel_source = WRITER_KERNEL_PATH;
-    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    writer_desc.core_ranges = all_cores;
-    writer_desc.compile_time_args = std::move(writer_ct_args);
-    writer_desc.config = WriterConfigDescriptor{};
-    switch (output_dtype) {
-        case DataType::BFLOAT16: writer_desc.defines.emplace_back("OUTPUT_DTYPE_BFLOAT16", "1"); break;
-        case DataType::FLOAT32: writer_desc.defines.emplace_back("OUTPUT_DTYPE_FLOAT32", "1"); break;
-        default:
-            // The writer kernel only implements float32 and bfloat16 output paths.
-            // Fail fast here so we never instantiate a program that can hang at runtime.
-            TT_THROW("RandDeviceOperation: unsupported output dtype for writer kernel");
-    }
-    writer_desc.runtime_args.reserve(num_cores_total);
-
-    KernelDescriptor compute_desc;
-    compute_desc.kernel_source = COMPUTE_KERNEL_PATH;
-    compute_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
-    compute_desc.core_ranges = all_cores;
-    compute_desc.compile_time_args = {intermed_cb_id};
-    compute_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
-        .fp32_dest_acc_en = true,  // if fp32_dest_acc_en set to false a precision error may occur which makes
-                                   // generated number out of range [from, to)
-        .dst_full_sync_en = false,
-        .math_approx_mode = true,
+    // "intermed" (legacy CB c_24): fp32 staging, produced by compute, consumed by writer.
+    // "dst" (legacy CB c_0): output-dtype L1 scratch the writer uses to pack bf16 before the
+    // NoC write; it has no FIFO peer (the writer is its only user), so it is bound as a
+    // self-loop (producer + consumer on the writer) to satisfy the producer/consumer invariant.
+    spec.dataflow_buffers = {
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"intermed"},
+            .entry_size = intermed_tile_size,
+            .num_entries = intermed_num_tiles,
+            .data_format_metadata = tt::DataFormat::Float32,
+        },
+        m2::DataflowBufferSpec{
+            .unique_id = m2::DFBSpecName{"dst"},
+            .entry_size = dtype_tile_size,
+            .num_entries = in_out_num_tiles,
+            .data_format_metadata = out_data_format,
+        },
     };
-    compute_desc.runtime_args.reserve(num_cores_total);
 
+    m2::KernelSpec compute{
+        .unique_id = m2::KernelSpecName{"compute"},
+        .source = std::filesystem::path{COMPUTE_KERNEL_PATH},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"intermed"},
+                    .accessor_name = "intermed",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"seed", "start_id", "num_tiles"},
+                .common_runtime_arg_names = {"from", "to"},
+            },
+        .hw_config =
+            m2::ComputeHardwareConfig{
+                .math_fidelity = MathFidelity::HiFi4,
+                // if fp32_dest_acc_en is false a precision error may occur which makes the
+                // generated number fall out of range [from, to)
+                .fp32_dest_acc_en = true,
+                .dst_full_sync_en = false,
+                .math_approx_mode = true,
+            },
+    };
+
+    m2::KernelSpec writer{
+        .unique_id = m2::KernelSpecName{"writer"},
+        .source = std::filesystem::path{WRITER_KERNEL_PATH},
+        .dfb_bindings =
+            {
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"intermed"},
+                    .accessor_name = "intermed",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"dst"},
+                    .accessor_name = "dst",
+                    .endpoint_type = m2::DFBEndpointType::PRODUCER,
+                },
+                m2::DFBBinding{
+                    .dfb_spec_name = m2::DFBSpecName{"dst"},
+                    .accessor_name = "dst",
+                    .endpoint_type = m2::DFBEndpointType::CONSUMER,
+                },
+            },
+        .tensor_bindings =
+            {
+                m2::TensorBinding{
+                    .tensor_parameter_name = m2::TensorParamName{"output"},
+                    .accessor_name = "output",
+                },
+            },
+        .runtime_arg_schema =
+            {
+                .runtime_arg_names = {"start_id", "num_tiles"},
+            },
+        .hw_config = m2::DataMovementHardwareConfig{.role = m2::DataMovementRoleHint::WRITER},
+    };
+    // The writer kernel only implements float32 and bfloat16 output paths. Gate the path via a
+    // compile-time define, and fail fast on anything else so we never build a hangable program.
+    switch (output_dtype) {
+        case DataType::BFLOAT16: writer.compiler_options.defines = {{"OUTPUT_DTYPE_BFLOAT16", "1"}}; break;
+        case DataType::FLOAT32: writer.compiler_options.defines = {{"OUTPUT_DTYPE_FLOAT32", "1"}}; break;
+        default: TT_THROW("RandDeviceOperation: unsupported output dtype for writer kernel");
+    }
+
+    spec.kernels = {compute, writer};
+    spec.tensor_parameters = {
+        m2::TensorParameter{.unique_id = m2::TensorParamName{"output"}, .spec = output.tensor_spec()},
+    };
+    spec.work_units = std::vector<m2::WorkUnitSpec>{
+        m2::WorkUnitSpec{
+            .name = "rand",
+            .kernels = {m2::KernelSpecName{"compute"}, m2::KernelSpecName{"writer"}},
+            .target_nodes = ws.all_cores,
+        },
+    };
+
+    // ---- ProgramRunArgs (mutable; seed/from/to refreshed every dispatch) ----
     const float eps = 1e-6f;
     const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
     const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
 
+    m2::ProgramRunArgs run;
+    m2::KernelRunArgs compute_run{.kernel = m2::KernelSpecName{"compute"}};
+    compute_run.common_runtime_arg_values = {{"from", from_bits}, {"to", to_bits}};
+    m2::KernelRunArgs writer_run{.kernel = m2::KernelSpecName{"writer"}};
+
     uint32_t tile_offset = 0;
-    for (int i = 0; i < static_cast<int>(cores.size()); ++i) {
-        const auto& core = cores[i];
+    for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
+        const auto& core = ws.cores[i];
         uint32_t units_per_core;
-        if (core_group_1.contains(core)) {
-            units_per_core = units_per_core_group_1;
-        } else if (core_group_2.contains(core)) {
-            units_per_core = units_per_core_group_2;
+        if (ws.core_group_1.contains(core)) {
+            units_per_core = ws.units_per_core_group_1;
+        } else if (ws.core_group_2.contains(core)) {
+            units_per_core = ws.units_per_core_group_2;
         } else {
             TT_THROW("Core not in specified core ranges");
         }
+        const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);
 
-        uint32_t seed = rand_seed_for_core(operation_attributes, i, device_seed_offset);
-
-        // seed/from/to are DYNAMIC (excluded from compute_program_hash): baked here for the
-        // cache-miss build, and re-applied on every cache hit via get_dynamic_runtime_args().
-        compute_desc.runtime_args.emplace_back(
-            core, KernelDescriptor::CoreRuntimeArgs{seed, from_bits, to_bits, tile_offset, units_per_core});
-
-        // Register the output address as a Buffer* binding so rand takes the fast cache-hit path
-        // (real program caching) with the address correctly re-patched each dispatch.
-        writer_desc.emplace_runtime_args(core, {output.buffer(), tile_offset, units_per_core});
+        compute_run.runtime_arg_values.push_back(
+            {core, {{"seed", seed}, {"start_id", tile_offset}, {"num_tiles", units_per_core}}});
+        writer_run.runtime_arg_values.push_back({core, {{"start_id", tile_offset}, {"num_tiles", units_per_core}}});
 
         tile_offset += units_per_core;
     }
+    run.kernel_run_args = {compute_run, writer_run};
+    run.tensor_args = {{m2::TensorParamName{"output"}, output.mesh_tensor()}};
 
-    desc.kernels.push_back(std::move(writer_desc));
-    desc.kernels.push_back(std::move(compute_desc));
-
-    return desc;
-}
-
-std::vector<tt::tt_metal::DynamicRuntimeArg> RandDeviceOperation::get_dynamic_runtime_args(
-    const operation_attributes_t& operation_attributes,
-    const tensor_args_t& /*tensor_args*/,
-    tensor_return_value_t& output,
-    const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate) {
-    // compute is kernel 1; its runtime args are {seed, from_bits, to_bits, tile_offset, units_per_core}.
-    // seed/from/to are excluded from the hash and re-applied here; the rest are static.
-    constexpr uint32_t kComputeKernelIdx = 1;
-    auto ws = compute_rand_work_split(operation_attributes, output, mesh_dispatch_coordinate);
-
-    const float eps = 1e-6f;
-    const uint32_t from_bits = std::bit_cast<uint32_t>(operation_attributes.from);
-    const uint32_t to_bits = std::bit_cast<uint32_t>(operation_attributes.to - eps);
-
-    std::vector<tt::tt_metal::DynamicRuntimeArg> dynamic_args;
-    dynamic_args.reserve(ws.cores.size() * 3);
-    for (int i = 0; i < static_cast<int>(ws.cores.size()); ++i) {
-        const uint32_t seed = rand_seed_for_core(operation_attributes, i, ws.device_seed_offset);
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 0, seed});
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 1, from_bits});
-        dynamic_args.push_back({kComputeKernelIdx, ws.cores[i], 2, to_bits});
-    }
-    return dynamic_args;
+    return ttnn::device_operation::ProgramArtifacts{.spec = std::move(spec), .run_params = std::move(run)};
 }
 
 }  // namespace ttnn::operations::rand


### PR DESCRIPTION
**Draft / exploratory — not for merge as-is.** Backs the Metal 2.0 host-cost numbers and the spec-as-key reuse study. Built clean on WH B0; rand correctness validated (PCC + seed-refresh + full pytest), matmul validated (PCC 0.999968).

## What's here
1. **rand → Metal 2.0 ProgramSpec** (`5a5c8ff`, clean-ish): `create_program_spec` factory, kernels on `dfb::`/`ta::`/`args::`, `program_factory_t` variant, dropped `get_dynamic_runtime_args`. Plus adapter changes: device-sourcing fallback for input-less ops; cache-hit re-applies all run-args (refreshes the per-dispatch seed) via `SetProgramRunArgs(skip_validation=true)`.
2. **matmul MatmulMultiCore → ProgramSpec** (faithful 1:1 port, no shortcuts): reader ported in place, `writer`/`bmm` forked to `*_m2` (shared kernels), per-core-group work units, pybind hook removed.
3. **Measurement-only scaffolding** (must be stripped/reverted before any real PR): `metal2_speckey_proto` spec-hash (env `SPECKEY_LOG`); `FORCE_MM_MULTICORE` env gate in `matmul_program_config.cpp`.

## Numbers (WH B0, 1000 cache-hit calls)
| op | descriptor | Metal 2.0 | note |
|---|---|---|---|
| rand 512×512 (pipelined) | 48 µs | 81 µs (1.7×) | with `skip_validation`; dynamic seed forces full run-arg refresh; ~30 µs op-side string-keyed rebuild is the wall |
| matmul 4×256 (pipelined) | 84.9 µs | ~87.7 µs (~parity) | no dynamic scalar + device-bound → host overhead overlaps |
| matmul 4×256 (synced) | 139.7 µs | ~175 µs (+25%) | host cost exposed; from one-size-fits-all full-rerun hit policy |

## Spec-as-key reuse (rand, 5 shapes; 2 ideal program classes)
current **7** entries → strict spec-key 5 → **relaxed spec-key 2** (ideal). Relaxation-aware spec-key collapses same-volume shapes — declaratively replaces volume custom-hashes and fixes 3.5× over-fragmentation.

## Follow-ups
- Real fix for rand's hit cost: Advanced concept (immutable/dynamic split) or in-place `ProgramRunArgsView` (declared, not impl).
- Per-op hit-path policy (tensor-only vs full re-apply) so matmul-like ops don't pay rand's refresh cost.
- Wire relaxation-aware spec-as-key as the live cache key (kills custom `compute_program_hash`).
