### PR TITLE
[Cleanup] Templatize HostTensor::pad to match from_xxx<T> API convention

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -310,8 +310,12 @@ TEST(HostTensorPadTest, PadFloat32FillsCorrectValue) {
     // 1×2 tensor padded to 1×4 with pad_value = 9.0f
     auto t = make_tensor<float>({1.0f, 2.0f}, Shape{1, 2}, DataType::FLOAT32);
     auto padded = pad<float>(t, Shape{1, 4}, Shape{0, 0}, 9.0f);
-    auto data = padded.to_vector<float>();
-    EXPECT_EQ(data.size(), 4u);
+
+    EXPECT_EQ(padded.logical_shape(), (Shape{1, 2}));
+    EXPECT_EQ(padded.padded_shape(), (Shape{1, 4}));
+
+    auto data = host_buffer::get_as<float>(padded);
+    ASSERT_EQ(data.size(), 4u);
     EXPECT_FLOAT_EQ(data[0], 1.0f);
     EXPECT_FLOAT_EQ(data[1], 2.0f);
     EXPECT_FLOAT_EQ(data[2], 9.0f);
@@ -321,19 +325,23 @@ TEST(HostTensorPadTest, PadFloat32FillsCorrectValue) {
 TEST(HostTensorPadTest, PadBfloat16FillsCorrectValue) {
     auto t = make_tensor<bfloat16>({bfloat16(3.0f), bfloat16(4.0f)}, Shape{1, 2}, DataType::BFLOAT16);
     auto padded = pad<bfloat16>(t, Shape{1, 4}, Shape{0, 0}, bfloat16(0.0f));
-    auto data = padded.to_vector<bfloat16>();
+
+    auto data = host_buffer::get_as<bfloat16>(padded);
     ASSERT_EQ(data.size(), 4u);
-    EXPECT_FLOAT_EQ(data[0].to_float(), 3.0f);
-    EXPECT_FLOAT_EQ(data[1].to_float(), 4.0f);
-    EXPECT_FLOAT_EQ(data[2].to_float(), 0.0f);
-    EXPECT_FLOAT_EQ(data[3].to_float(), 0.0f);
+    EXPECT_FLOAT_EQ(float(data[0]), 3.0f);
+    EXPECT_FLOAT_EQ(float(data[1]), 4.0f);
+    EXPECT_FLOAT_EQ(float(data[2]), 0.0f);
+    EXPECT_FLOAT_EQ(float(data[3]), 0.0f);
 }
 
 TEST(HostTensorPadTest, PadUint32FillsCorrectValue) {
     auto t = make_tensor<uint32_t>({7u, 8u}, Shape{1, 2}, DataType::UINT32);
     auto padded = pad<uint32_t>(t, Shape{1, 4}, Shape{0, 0}, 42u);
-    auto data = padded.to_vector<uint32_t>();
+
+    auto data = host_buffer::get_as<uint32_t>(padded);
     ASSERT_EQ(data.size(), 4u);
+    EXPECT_EQ(data[0], 7u);
+    EXPECT_EQ(data[1], 8u);
     EXPECT_EQ(data[2], 42u);
     EXPECT_EQ(data[3], 42u);
 }
@@ -341,8 +349,10 @@ TEST(HostTensorPadTest, PadUint32FillsCorrectValue) {
 TEST(HostTensorPadTest, PadZeroFill) {
     auto t = make_tensor<float>({5.0f}, Shape{1, 1}, DataType::FLOAT32);
     auto padded = pad<float>(t, Shape{1, 4}, Shape{0, 0}, 0.0f);
-    auto data = padded.to_vector<float>();
+
+    auto data = host_buffer::get_as<float>(padded);
     ASSERT_EQ(data.size(), 4u);
+    EXPECT_FLOAT_EQ(data[0], 5.0f);
     EXPECT_FLOAT_EQ(data[1], 0.0f);
     EXPECT_FLOAT_EQ(data[2], 0.0f);
     EXPECT_FLOAT_EQ(data[3], 0.0f);
@@ -355,14 +365,20 @@ TEST(HostTensorPadTest, PadDtypeMismatchFatals) {
 }
 
 TEST(HostTensorPadToTileTest, PadToTileFloat32ShapeAndFill) {
-    // 1×20 tensor → should pad to 1×32 (next multiple of TILE_WIDTH)
+    // pad_to_tile() rounds the last TWO dims up to TILE_HEIGHT×TILE_WIDTH, so a 1×20 tensor pads
+    // to 32×32: row 0 holds the 20 logical values then 12 width-pads, rows 1..31 are all pad.
     std::vector<float> data(20, 1.0f);
     auto t = make_tensor<float>(data, Shape{1, 20}, DataType::FLOAT32);
     auto padded = pad_to_tile<float>(t, 0.0f);
-    EXPECT_EQ(padded.padded_shape()[-1], 32u);
-    auto out = padded.to_vector<float>();
-    ASSERT_EQ(out.size(), 32u);
-    for (int i = 20; i < 32; ++i) {
+
+    EXPECT_EQ(padded.padded_shape(), (Shape{32, 32}));
+
+    auto out = host_buffer::get_as<float>(padded);
+    ASSERT_EQ(out.size(), 32u * 32u);
+    for (int col = 0; col < 32; ++col) {
+        EXPECT_FLOAT_EQ(out[col], col < 20 ? 1.0f : 0.0f);
+    }
+    for (size_t i = 32; i < out.size(); ++i) {
         EXPECT_FLOAT_EQ(out[i], 0.0f);
     }
 }
@@ -371,17 +387,27 @@ TEST(HostTensorPadToTileTest, PadToTileZeroFill) {
     std::vector<float> data(4, 7.0f);
     auto t = make_tensor<float>(data, Shape{1, 4}, DataType::FLOAT32);
     auto padded = pad_to_tile<float>(t, 0.0f);
-    auto out = padded.to_vector<float>();
-    ASSERT_EQ(out.size(), 32u);
-    EXPECT_FLOAT_EQ(out[4], 0.0f);
+
+    EXPECT_EQ(padded.padded_shape(), (Shape{32, 32}));
+
+    auto out = host_buffer::get_as<float>(padded);
+    ASSERT_EQ(out.size(), 32u * 32u);
+    EXPECT_FLOAT_EQ(out[0], 7.0f);   // logical value
+    EXPECT_FLOAT_EQ(out[4], 0.0f);   // width pad on row 0
+    EXPECT_FLOAT_EQ(out[32], 0.0f);  // height pad (row 1)
 }
 
 TEST(HostTensorPadToTileTest, PadToTileAlreadyAlignedIsNoop) {
-    std::vector<float> data(32, 5.0f);
-    auto t = make_tensor<float>(data, Shape{1, 32}, DataType::FLOAT32);
+    // A 32×32 tensor is already tile-aligned in both dims, so pad_to_tile is a no-op:
+    // padded_shape stays 32×32 and every element keeps its original value.
+    std::vector<float> data(32 * 32, 5.0f);
+    auto t = make_tensor<float>(data, Shape{32, 32}, DataType::FLOAT32);
     auto padded = pad_to_tile<float>(t, -1.0f);
-    auto out = padded.to_vector<float>();
-    ASSERT_EQ(out.size(), 32u);
+
+    EXPECT_EQ(padded.padded_shape(), (Shape{32, 32}));
+
+    auto out = host_buffer::get_as<float>(padded);
+    ASSERT_EQ(out.size(), 32u * 32u);
     for (auto v : out) {
         EXPECT_FLOAT_EQ(v, 5.0f);
     }

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -338,9 +338,9 @@ TEST(HostTensorPadTest, PadUint32FillsCorrectValue) {
     EXPECT_EQ(data[3], 42u);
 }
 
-TEST(HostTensorPadTest, PadDefaultValueIsZero) {
+TEST(HostTensorPadTest, PadZeroFill) {
     auto t = make_tensor<float>({5.0f}, Shape{1, 1}, DataType::FLOAT32);
-    auto padded = pad<float>(t, Shape{1, 4}, Shape{0, 0});
+    auto padded = pad<float>(t, Shape{1, 4}, Shape{0, 0}, 0.0f);
     auto data = padded.to_vector<float>();
     ASSERT_EQ(data.size(), 4u);
     EXPECT_FLOAT_EQ(data[1], 0.0f);
@@ -367,10 +367,10 @@ TEST(HostTensorPadToTileTest, PadToTileFloat32ShapeAndFill) {
     }
 }
 
-TEST(HostTensorPadToTileTest, PadToTileDefaultValueIsZero) {
+TEST(HostTensorPadToTileTest, PadToTileZeroFill) {
     std::vector<float> data(4, 7.0f);
     auto t = make_tensor<float>(data, Shape{1, 4}, DataType::FLOAT32);
-    auto padded = pad_to_tile<float>(t);
+    auto padded = pad_to_tile<float>(t, 0.0f);
     auto out = padded.to_vector<float>();
     ASSERT_EQ(out.size(), 32u);
     EXPECT_FLOAT_EQ(out[4], 0.0f);

--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -9,6 +9,7 @@
 // - Construction with DistributedHostBuffer, TensorSpec, and TensorTopology
 // - Copy and move semantics
 // - Getter methods for tensor properties
+// - pad() and pad_to_tile() with typed pad_value
 
 #include <gtest/gtest.h>
 #include <gmock/gmock.h>
@@ -16,6 +17,7 @@
 #include <type_traits>
 
 #include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/tensor_layout.hpp>
 #include <tt-metalium/experimental/tensor/spec/layout/page_config.hpp>
@@ -292,6 +294,97 @@ TEST(HostTensorTest, IsValuelessAfterMoveReturnsTrueAfterMoveAssignment) {
 
     EXPECT_TRUE(source.is_valueless_after_move());  // NOLINT(bugprone-use-after-move)
     EXPECT_FALSE(target.is_valueless_after_move());
+}
+
+// ==================================================================================
+// pad() and pad_to_tile() — typed pad_value
+// ==================================================================================
+
+// Helper: build a 1-shard HostTensor with actual data from a vector<T>.
+template <typename T>
+HostTensor make_tensor(const std::vector<T>& data, const Shape& shape, DataType dtype) {
+    return HostTensor::from_vector(data, create_simple_spec(shape, dtype));
+}
+
+TEST(HostTensorPadTest, PadFloat32FillsCorrectValue) {
+    // 1×2 tensor padded to 1×4 with pad_value = 9.0f
+    auto t = make_tensor<float>({1.0f, 2.0f}, Shape{1, 2}, DataType::FLOAT32);
+    auto padded = pad<float>(t, Shape{1, 4}, Shape{0, 0}, 9.0f);
+    auto data = padded.to_vector<float>();
+    EXPECT_EQ(data.size(), 4u);
+    EXPECT_FLOAT_EQ(data[0], 1.0f);
+    EXPECT_FLOAT_EQ(data[1], 2.0f);
+    EXPECT_FLOAT_EQ(data[2], 9.0f);
+    EXPECT_FLOAT_EQ(data[3], 9.0f);
+}
+
+TEST(HostTensorPadTest, PadBfloat16FillsCorrectValue) {
+    auto t = make_tensor<bfloat16>({bfloat16(3.0f), bfloat16(4.0f)}, Shape{1, 2}, DataType::BFLOAT16);
+    auto padded = pad<bfloat16>(t, Shape{1, 4}, Shape{0, 0}, bfloat16(0.0f));
+    auto data = padded.to_vector<bfloat16>();
+    ASSERT_EQ(data.size(), 4u);
+    EXPECT_FLOAT_EQ(data[0].to_float(), 3.0f);
+    EXPECT_FLOAT_EQ(data[1].to_float(), 4.0f);
+    EXPECT_FLOAT_EQ(data[2].to_float(), 0.0f);
+    EXPECT_FLOAT_EQ(data[3].to_float(), 0.0f);
+}
+
+TEST(HostTensorPadTest, PadUint32FillsCorrectValue) {
+    auto t = make_tensor<uint32_t>({7u, 8u}, Shape{1, 2}, DataType::UINT32);
+    auto padded = pad<uint32_t>(t, Shape{1, 4}, Shape{0, 0}, 42u);
+    auto data = padded.to_vector<uint32_t>();
+    ASSERT_EQ(data.size(), 4u);
+    EXPECT_EQ(data[2], 42u);
+    EXPECT_EQ(data[3], 42u);
+}
+
+TEST(HostTensorPadTest, PadDefaultValueIsZero) {
+    auto t = make_tensor<float>({5.0f}, Shape{1, 1}, DataType::FLOAT32);
+    auto padded = pad<float>(t, Shape{1, 4}, Shape{0, 0});
+    auto data = padded.to_vector<float>();
+    ASSERT_EQ(data.size(), 4u);
+    EXPECT_FLOAT_EQ(data[1], 0.0f);
+    EXPECT_FLOAT_EQ(data[2], 0.0f);
+    EXPECT_FLOAT_EQ(data[3], 0.0f);
+}
+
+TEST(HostTensorPadTest, PadDtypeMismatchFatals) {
+    // Passing bfloat16 pad_value to a FLOAT32 tensor must fatal.
+    auto t = make_tensor<float>({1.0f, 2.0f}, Shape{1, 2}, DataType::FLOAT32);
+    EXPECT_ANY_THROW((pad<bfloat16>(t, Shape{1, 4}, Shape{0, 0}, bfloat16(0.0f))));
+}
+
+TEST(HostTensorPadToTileTest, PadToTileFloat32ShapeAndFill) {
+    // 1×20 tensor → should pad to 1×32 (next multiple of TILE_WIDTH)
+    std::vector<float> data(20, 1.0f);
+    auto t = make_tensor<float>(data, Shape{1, 20}, DataType::FLOAT32);
+    auto padded = pad_to_tile<float>(t, 0.0f);
+    EXPECT_EQ(padded.padded_shape()[-1], 32u);
+    auto out = padded.to_vector<float>();
+    ASSERT_EQ(out.size(), 32u);
+    for (int i = 20; i < 32; ++i) {
+        EXPECT_FLOAT_EQ(out[i], 0.0f);
+    }
+}
+
+TEST(HostTensorPadToTileTest, PadToTileDefaultValueIsZero) {
+    std::vector<float> data(4, 7.0f);
+    auto t = make_tensor<float>(data, Shape{1, 4}, DataType::FLOAT32);
+    auto padded = pad_to_tile<float>(t);
+    auto out = padded.to_vector<float>();
+    ASSERT_EQ(out.size(), 32u);
+    EXPECT_FLOAT_EQ(out[4], 0.0f);
+}
+
+TEST(HostTensorPadToTileTest, PadToTileAlreadyAlignedIsNoop) {
+    std::vector<float> data(32, 5.0f);
+    auto t = make_tensor<float>(data, Shape{1, 32}, DataType::FLOAT32);
+    auto padded = pad_to_tile<float>(t, -1.0f);
+    auto out = padded.to_vector<float>();
+    ASSERT_EQ(out.size(), 32u);
+    for (auto v : out) {
+        EXPECT_FLOAT_EQ(v, 5.0f);
+    }
 }
 
 }  // namespace

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_apis.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_apis.hpp
@@ -130,12 +130,12 @@ HostTensor to_layout(const HostTensor& tensor, Layout target_layout);
 
 template <typename T>
 HostTensor pad(
-    const HostTensor& tensor, const Shape& output_padded_shape, const Shape& input_tensor_start, T pad_value = T{});
+    const HostTensor& tensor, const Shape& output_padded_shape, const Shape& input_tensor_start, T pad_value);
 
 HostTensor unpad(const HostTensor& tensor, const Shape& output_tensor_start, const Shape& output_tensor_end);
 
 template <typename T>
-HostTensor pad_to_tile(const HostTensor& input_tensor, T pad_value = T{});
+HostTensor pad_to_tile(const HostTensor& input_tensor, T pad_value);
 
 HostTensor unpad_from_tile(const HostTensor& input_tensor, const Shape& output_tensor_shape);
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_apis.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_apis.hpp
@@ -128,12 +128,14 @@ HostTensor to_layout(const HostTensor& tensor, Layout target_layout);
 //                                  .pad() and .unpad()
 // ======================================================================================
 
+template <typename T>
 HostTensor pad(
-    const HostTensor& tensor, const Shape& output_padded_shape, const Shape& input_tensor_start, float pad_value);
+    const HostTensor& tensor, const Shape& output_padded_shape, const Shape& input_tensor_start, T pad_value = T{});
 
 HostTensor unpad(const HostTensor& tensor, const Shape& output_tensor_start, const Shape& output_tensor_end);
 
-HostTensor pad_to_tile(const HostTensor& input_tensor, float pad_value);
+template <typename T>
+HostTensor pad_to_tile(const HostTensor& input_tensor, T pad_value = T{});
 
 HostTensor unpad_from_tile(const HostTensor& input_tensor, const Shape& output_tensor_shape);
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
@@ -66,6 +66,17 @@ bool is_floating_point(DataType dtype);
 
 bool is_block_float(DataType dtype);
 
+// Returns true if a buffer of element type T is a valid source or fill value for a tensor with
+// the given dtype.  Rules (same as HostTensor::from_xxx):
+//   - exact match: convert_to_data_type<T>() == dtype
+//   - block-float (BFLOAT8_B / BFLOAT4_B): T must be float (values are packed/unpacked as float)
+template <typename T>
+constexpr bool is_buffer_type_compatible_with_dtype(DataType dtype) noexcept {
+    constexpr DataType buffer_dtype = convert_to_data_type<T>();
+    return buffer_dtype == dtype ||
+           ((dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B) && buffer_dtype == DataType::FLOAT32);
+}
+
 tt::DataFormat datatype_to_dataformat_converter(DataType datatype);
 tt::tt_metal::DataType dataformat_to_datatype_converter(tt::DataFormat dataformat);
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/tensor_types.hpp
@@ -66,17 +66,6 @@ bool is_floating_point(DataType dtype);
 
 bool is_block_float(DataType dtype);
 
-// Returns true if a buffer of element type T is a valid source or fill value for a tensor with
-// the given dtype.  Rules (same as HostTensor::from_xxx):
-//   - exact match: convert_to_data_type<T>() == dtype
-//   - block-float (BFLOAT8_B / BFLOAT4_B): T must be float (values are packed/unpacked as float)
-template <typename T>
-constexpr bool is_buffer_type_compatible_with_dtype(DataType dtype) noexcept {
-    constexpr DataType buffer_dtype = convert_to_data_type<T>();
-    return buffer_dtype == dtype ||
-           ((dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B) && buffer_dtype == DataType::FLOAT32);
-}
-
 tt::DataFormat datatype_to_dataformat_converter(DataType datatype);
 tt::tt_metal::DataType dataformat_to_datatype_converter(tt::DataFormat dataformat);
 

--- a/tt_metal/impl/tensor/host_tensor_factory.cpp
+++ b/tt_metal/impl/tensor/host_tensor_factory.cpp
@@ -2,6 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
+#include "host_tensor_impl.hpp"
+
 #include <tt-metalium/bfloat16.hpp>
 #include <tt-metalium/bfloat4.hpp>
 #include <tt-metalium/bfloat8.hpp>

--- a/tt_metal/impl/tensor/host_tensor_factory.cpp
+++ b/tt_metal/impl/tensor/host_tensor_factory.cpp
@@ -39,6 +39,11 @@ HostTensor from_span_impl(std::span<const T> buffer, const TensorSpec& spec, T p
 
     TT_FATAL(
         buffer.size() == volume, "Current buffer size is {} different from shape volume {}", buffer.size(), volume);
+    TT_FATAL(
+        is_buffer_type_compatible_with_dtype<T>(spec.data_type()),
+        "Buffer element type {} is not compatible with tensor dtype {}; use float for block-float dtypes",
+        convert_to_data_type<T>(),
+        spec.data_type());
     if (spec.data_type() == DataType::BFLOAT8_B || spec.data_type() == DataType::BFLOAT4_B) {
         TT_FATAL(spec.layout() == Layout::TILE, "Block float types are only supported in TILE layout");
     }
@@ -86,6 +91,11 @@ HostTensor HostTensor::from_vector(std::vector<T>&& buffer, const TensorSpec& sp
     size_t volume = spec.logical_shape().volume();
     TT_FATAL(buffer.size() == volume, "Buffer size {} differs from shape volume {}", buffer.size(), volume);
 
+    TT_FATAL(
+        is_buffer_type_compatible_with_dtype<T>(spec.data_type()),
+        "Buffer element type {} is not compatible with tensor dtype {}; use float for block-float dtypes",
+        convert_to_data_type<T>(),
+        spec.data_type());
     if (spec.data_type() == DataType::BFLOAT8_B || spec.data_type() == DataType::BFLOAT4_B) {
         TT_FATAL(spec.layout() == Layout::TILE, "Block float types only supported in TILE layout");
     }

--- a/tt_metal/impl/tensor/host_tensor_impl.hpp
+++ b/tt_metal/impl/tensor/host_tensor_impl.hpp
@@ -24,12 +24,12 @@ namespace tt::tt_metal {
 // Returns true if a buffer of element type T is a valid source or fill value for a tensor with
 // the given dtype.  Rules (same as HostTensor::from_xxx):
 //   - exact match: convert_to_data_type<T>() == dtype
-//   - block-float (BFLOAT8_B / BFLOAT4_B): T must be float (values are packed/unpacked as float)
+//   - block-float (BFLOAT8_B / BFLOAT4_B): T must be float or bfloat16 (packed/unpacked via float)
 template <typename T>
 constexpr bool is_buffer_type_compatible_with_dtype(DataType dtype) noexcept {
     constexpr DataType buffer_dtype = convert_to_data_type<T>();
-    return buffer_dtype == dtype ||
-           ((dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B) && buffer_dtype == DataType::FLOAT32);
+    return buffer_dtype == dtype || ((dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B) &&
+                                     (buffer_dtype == DataType::FLOAT32 || buffer_dtype == DataType::BFLOAT16));
 }
 
 class HostTensorImpl {

--- a/tt_metal/impl/tensor/host_tensor_impl.hpp
+++ b/tt_metal/impl/tensor/host_tensor_impl.hpp
@@ -9,6 +9,7 @@
 #include <tt-metalium/distributed_host_buffer.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
+#include <tt-metalium/experimental/tensor/tensor_types.hpp>
 
 /**
  * Internal implementation header for HostTensor.
@@ -19,6 +20,17 @@
  */
 
 namespace tt::tt_metal {
+
+// Returns true if a buffer of element type T is a valid source or fill value for a tensor with
+// the given dtype.  Rules (same as HostTensor::from_xxx):
+//   - exact match: convert_to_data_type<T>() == dtype
+//   - block-float (BFLOAT8_B / BFLOAT4_B): T must be float (values are packed/unpacked as float)
+template <typename T>
+constexpr bool is_buffer_type_compatible_with_dtype(DataType dtype) noexcept {
+    constexpr DataType buffer_dtype = convert_to_data_type<T>();
+    return buffer_dtype == dtype ||
+           ((dtype == DataType::BFLOAT8_B || dtype == DataType::BFLOAT4_B) && buffer_dtype == DataType::FLOAT32);
+}
 
 class HostTensorImpl {
 public:

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -978,29 +978,26 @@ HostTensor unpad_impl<float8_e4m3>(const HostTensor&, const tt::tt_metal::Shape&
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
-template <typename PadT>
+template <typename T>
 HostTensor pad(
     const HostTensor& tensor,
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
-    PadT pad_value) {
+    T pad_value) {
     TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for padding");
-    // Block-float dtypes (BFLOAT8_B, BFLOAT4_B) require a float pad_value; all other dtypes
-    // must use the matching C++ type to avoid silent precision loss.
     TT_FATAL(
-        convert_to_data_type<PadT>() == tensor.dtype() ||
-            (is_block_float(tensor.dtype()) && convert_to_data_type<PadT>() == DataType::FLOAT32),
+        is_buffer_type_compatible_with_dtype<T>(tensor.dtype()),
         "pad_value type {} does not match tensor dtype {}; use float for block-float dtypes",
-        convert_to_data_type<PadT>(),
+        convert_to_data_type<T>(),
         tensor.dtype());
-    return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
-        return CMAKE_UNIQUE_NAMESPACE::pad_impl<T>(
+    return tensor_impl::dispatch(tensor.dtype(), [&]<typename StorageT>() {
+        return CMAKE_UNIQUE_NAMESPACE::pad_impl<StorageT>(
             tensor, output_padded_shape, input_tensor_start, static_cast<float>(pad_value));
     });
 }
 
-template <typename PadT>
-HostTensor pad_to_tile(const HostTensor& tensor, PadT pad_value) {
+template <typename T>
+HostTensor pad_to_tile(const HostTensor& tensor, T pad_value) {
     uint32_t height = tensor.padded_shape()[-2];
     uint32_t width = tensor.padded_shape()[-1];
     uint32_t padded_height = round_up(height, constants::TILE_HEIGHT);

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -985,6 +985,14 @@ HostTensor pad(
     const tt::tt_metal::Shape& input_tensor_start,
     PadT pad_value) {
     TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for padding");
+    // Block-float dtypes (BFLOAT8_B, BFLOAT4_B) require a float pad_value; all other dtypes
+    // must use the matching C++ type to avoid silent precision loss.
+    TT_FATAL(
+        convert_to_data_type<PadT>() == tensor.dtype() ||
+            (is_block_float(tensor.dtype()) && convert_to_data_type<PadT>() == DataType::FLOAT32),
+        "pad_value type {} does not match tensor dtype {}; use float for block-float dtypes",
+        convert_to_data_type<PadT>(),
+        tensor.dtype());
     return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
         return CMAKE_UNIQUE_NAMESPACE::pad_impl<T>(
             tensor, output_padded_shape, input_tensor_start, static_cast<float>(pad_value));

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -978,18 +978,21 @@ HostTensor unpad_impl<float8_e4m3>(const HostTensor&, const tt::tt_metal::Shape&
 }  // namespace CMAKE_UNIQUE_NAMESPACE
 }  // namespace
 
+template <typename PadT>
 HostTensor pad(
     const HostTensor& tensor,
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
-    float pad_value) {
+    PadT pad_value) {
     TT_FATAL(tensor.layout() == Layout::ROW_MAJOR, "Tensor layout must be ROW_MAJOR for padding");
     return tensor_impl::dispatch(tensor.dtype(), [&]<typename T>() {
-        return CMAKE_UNIQUE_NAMESPACE::pad_impl<T>(tensor, output_padded_shape, input_tensor_start, pad_value);
+        return CMAKE_UNIQUE_NAMESPACE::pad_impl<T>(
+            tensor, output_padded_shape, input_tensor_start, static_cast<float>(pad_value));
     });
 }
 
-HostTensor pad_to_tile(const HostTensor& tensor, float pad_value) {
+template <typename PadT>
+HostTensor pad_to_tile(const HostTensor& tensor, PadT pad_value) {
     uint32_t height = tensor.padded_shape()[-2];
     uint32_t width = tensor.padded_shape()[-1];
     uint32_t padded_height = round_up(height, constants::TILE_HEIGHT);
@@ -1014,6 +1017,20 @@ HostTensor pad_to_tile(const HostTensor& tensor, float pad_value) {
         tt::tt_metal::Shape{std::move(input_tensor_start)},
         pad_value);
 }
+
+template HostTensor pad<bfloat16>(const HostTensor&, const tt::tt_metal::Shape&, const tt::tt_metal::Shape&, bfloat16);
+template HostTensor pad<float>(const HostTensor&, const tt::tt_metal::Shape&, const tt::tt_metal::Shape&, float);
+template HostTensor pad<int32_t>(const HostTensor&, const tt::tt_metal::Shape&, const tt::tt_metal::Shape&, int32_t);
+template HostTensor pad<uint32_t>(const HostTensor&, const tt::tt_metal::Shape&, const tt::tt_metal::Shape&, uint32_t);
+template HostTensor pad<uint16_t>(const HostTensor&, const tt::tt_metal::Shape&, const tt::tt_metal::Shape&, uint16_t);
+template HostTensor pad<uint8_t>(const HostTensor&, const tt::tt_metal::Shape&, const tt::tt_metal::Shape&, uint8_t);
+
+template HostTensor pad_to_tile<bfloat16>(const HostTensor&, bfloat16);
+template HostTensor pad_to_tile<float>(const HostTensor&, float);
+template HostTensor pad_to_tile<int32_t>(const HostTensor&, int32_t);
+template HostTensor pad_to_tile<uint32_t>(const HostTensor&, uint32_t);
+template HostTensor pad_to_tile<uint16_t>(const HostTensor&, uint16_t);
+template HostTensor pad_to_tile<uint8_t>(const HostTensor&, uint8_t);
 
 HostTensor unpad(
     const HostTensor& tensor,

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -781,21 +781,20 @@ HostTensor pad_impl(
     const HostTensor& tensor,
     const tt::tt_metal::Shape& output_padded_shape,
     const tt::tt_metal::Shape& input_tensor_start,
-    float pad_value) {
-    auto pad_value_ = static_cast<T>(pad_value);
+    T pad_value) {
     auto input_padded_shape = tensor.padded_shape();
     if (input_padded_shape.rank() < 2) {
         input_padded_shape = input_padded_shape.to_rank(2);
     }
     const auto input_strides = tensor.strides();
 
-    auto pad = [&input_padded_shape, &output_padded_shape, &input_tensor_start, &pad_value_](
+    auto pad = [&input_padded_shape, &output_padded_shape, &input_tensor_start, pad_value](
                    const HostBuffer& input_host_buffer) {
         const auto input_buffer = input_host_buffer.view_as<T>();
         const auto rank = input_padded_shape.rank();
 
         auto output_buffer = std::vector<T>(output_padded_shape.volume());
-        std::fill(output_buffer.begin(), output_buffer.end(), pad_value_);
+        std::fill(output_buffer.begin(), output_buffer.end(), pad_value);
 
         if (input_padded_shape.volume() == 0) {
             return output_buffer;
@@ -867,32 +866,6 @@ HostTensor pad_impl(
                 tensor.logical_shape(),
                 output_padded_shape)),
         tensor.tensor_topology());
-}
-
-template <>
-HostTensor pad_impl<tensor_impl::bfloat8_b>(
-    const HostTensor& tensor,
-    const tt::tt_metal::Shape& output_padded_shape,
-    const tt::tt_metal::Shape& input_tensor_start,
-    float pad_value) {
-    return pad_bfloat8_b(tensor, output_padded_shape, input_tensor_start, pad_value);
-}
-
-template <>
-HostTensor pad_impl<tensor_impl::bfloat4_b>(
-    const HostTensor& tensor,
-    const tt::tt_metal::Shape& output_padded_shape,
-    const tt::tt_metal::Shape& input_tensor_start,
-    float pad_value) {
-    return pad_bfloat4_b(tensor, output_padded_shape, input_tensor_start, pad_value);
-}
-
-template <>
-HostTensor pad_impl<float8_e4m3>(const HostTensor&, const tt::tt_metal::Shape&, const tt::tt_metal::Shape&, float) {
-    // FP8_E4M3 host-side pad is not wired up; no current op needs it. The generic body
-    // would actually compile (float8_e4m3 is a 1-byte trivially-copyable type with a float
-    // constructor), but leaving this as an explicit throw documents the intentional scope.
-    TT_THROW("pad: FP8_E4M3 is not supported");
 }
 
 template <typename T>
@@ -990,9 +963,21 @@ HostTensor pad(
         "pad_value type {} does not match tensor dtype {}; use float for block-float dtypes",
         convert_to_data_type<T>(),
         tensor.dtype());
-    return tensor_impl::dispatch(tensor.dtype(), [&]<typename StorageT>() {
-        return CMAKE_UNIQUE_NAMESPACE::pad_impl<StorageT>(
-            tensor, output_padded_shape, input_tensor_start, static_cast<float>(pad_value));
+    return tensor_impl::dispatch(tensor.dtype(), [&]<typename StorageT>() -> HostTensor {
+        if constexpr (std::is_same_v<StorageT, tensor_impl::bfloat8_b>) {
+            // T is float by invariant; no roundtrip needed
+            return CMAKE_UNIQUE_NAMESPACE::pad_bfloat8_b(
+                tensor, output_padded_shape, input_tensor_start, static_cast<float>(pad_value));
+        } else if constexpr (std::is_same_v<StorageT, tensor_impl::bfloat4_b>) {
+            return CMAKE_UNIQUE_NAMESPACE::pad_bfloat4_b(
+                tensor, output_padded_shape, input_tensor_start, static_cast<float>(pad_value));
+        } else if constexpr (std::is_same_v<StorageT, float8_e4m3>) {
+            TT_THROW("pad: FP8_E4M3 is not supported");
+        } else {
+            // T == StorageT for all remaining types — static_cast is identity, no float roundtrip
+            return CMAKE_UNIQUE_NAMESPACE::pad_impl<StorageT>(
+                tensor, output_padded_shape, input_tensor_start, static_cast<StorageT>(pad_value));
+        }
     });
 }
 

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -22,6 +22,7 @@
 #include "ttnn/graph/graph_serialization.hpp"
 
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
+#include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
 
 namespace tt::tt_metal {
 
@@ -209,7 +210,19 @@ Tensor pad(
     }
 
     auto output =
-        Tensor(tt::tt_metal::pad(input_tensor.host_tensor(), output_padded_shape, input_tensor_start, pad_value));
+        Tensor(tensor_impl::dispatch(input_tensor.host_tensor().dtype(), [&]<typename StorageT>() -> HostTensor {
+            if constexpr (
+                std::is_same_v<StorageT, tensor_impl::bfloat8_b> || std::is_same_v<StorageT, tensor_impl::bfloat4_b>) {
+                return tt::tt_metal::pad<float>(
+                    input_tensor.host_tensor(), output_padded_shape, input_tensor_start, pad_value);
+            } else {
+                return tt::tt_metal::pad<StorageT>(
+                    input_tensor.host_tensor(),
+                    output_padded_shape,
+                    input_tensor_start,
+                    static_cast<StorageT>(pad_value));
+            }
+        }));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;
@@ -240,7 +253,16 @@ Tensor pad_to_tile(const Tensor& input_tensor, float pad_value) {
 
     GraphTracker::instance().track_function_start("Tensor::pad_to_tile", input_tensor, pad_value);
     TT_FATAL(is_cpu_tensor(input_tensor), "Tensor must be on host for pad_to_tile conversion");
-    auto output = Tensor(tt::tt_metal::pad_to_tile(input_tensor.host_tensor(), pad_value));
+    auto output =
+        Tensor(tensor_impl::dispatch(input_tensor.host_tensor().dtype(), [&]<typename StorageT>() -> HostTensor {
+            if constexpr (
+                std::is_same_v<StorageT, tensor_impl::bfloat8_b> || std::is_same_v<StorageT, tensor_impl::bfloat4_b>) {
+                return tt::tt_metal::pad_to_tile<float>(input_tensor.host_tensor(), pad_value);
+            } else {
+                return tt::tt_metal::pad_to_tile<StorageT>(
+                    input_tensor.host_tensor(), static_cast<StorageT>(pad_value));
+            }
+        }));
     output = tt::tt_metal::set_tensor_id(output);
     GraphTracker::instance().track_function_end(output);
     return output;


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Templatize `HostTensor::pad` and `pad_to_tile` on the pad value type `T`, consistent with the existing `from_xxx<T>` API convention.

Previously, both functions took `float pad_value`, making them the only host tensor mutation APIs that don't express the element type in the signature. This meant callers had to implicit-convert their native element type through `float` — risking silent truncation or precision loss (e.g. large `uint32_t` values, or future integer dtypes). By templating on `T`, the pad value is expressed in the correct element type in-place, and dtype compatibility is enforced using the same invariant as `from_xxx`.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/pad-template)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/pad-template)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/pad-template)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/pad-template)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/pad-template)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/pad-template)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/pad-template)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/pad-template)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/pad-template)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/pad-template)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/pad-template)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/pad-template)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/pad-template)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/pad-template)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/pad-template)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/pad-template)