### PR TITLE
[Bugfix] Minor legality check and messaging ergonomic tweaks for Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -1535,6 +1535,12 @@ TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_LeavesNamedCRTAsUnchanged) {
 }
 
 TEST_F(ProgramRunArgsTestGen1, UpdateTensorArgs_PatchesAllKernelsBoundToSameTensor) {
+    // TEMPORARILY SKIPPED: this test binds the shared tensor to the compute kernel (kernels[1]),
+    // which ValidateProgramSpec now rejects until compute-path tensor bindings are supported (a day
+    // or two out). The host-side patching it exercises is unaffected by that gap; re-enable this test
+    // when the temporary compute-kernel tensor-binding guard in ValidateProgramSpec is removed.
+    GTEST_SKIP() << "Compute-kernel tensor bindings are temporarily rejected by ValidateProgramSpec.";
+
     NodeCoord node{0, 0};
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("shared_tensor");
@@ -1862,37 +1868,30 @@ TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_DTypeMismatchStillFails) {
             ::testing::HasSubstr("tensor_layout does not match the binding's declared layout")));
 }
 
-TEST_F(ProgramRunArgsTestGen1, TensorBindingOnlyKernelMissingFromRunArgsFails) {
-    // A kernel with tensor bindings but an empty RTA/CRTA schema must still appear in
-    // kernel_run_args: SetProgramRunArgs fills the binding section CRTAs (base
-    // addresses, dynamic accessor fields) from the per-kernel entries, so omitting the
-    // kernel would leave its binding CRTAs uninitialized.
-    NodeCoord node{0, 0};
+TEST_F(ProgramRunArgsTestGen1, TensorBindingOnlyKernelOmittedFromRunArgsSucceeds) {
+    // A kernel with tensor bindings but an empty RTA/CRTA schema may be omitted from
+    // kernel_run_args: SetProgramRunArgs fills its binding-section CRTAs (base addresses, dynamic
+    // accessor fields) in a second pass over all binding-bearing kernels, so the binding address
+    // still reaches the device. (Gen1 counterpart of the Quasar BindingOnlyKernelOmitted... test.)
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
     auto binding = MakeMinimalTensorParameter("input_tensor");
     spec.tensor_parameters = {binding};
-    // Bind to dm_kernel (compute_kernel has no bindings). dm_kernel has no named RTAs/CRTAs
-    // and no varargs, so its RTA/CRTA schema is empty — the binding is the only thing forcing
-    // a kernel_run_args entry.
+    // Bind to dm_kernel (compute_kernel has no bindings). dm_kernel has no named RTAs/CRTAs and no
+    // varargs, so the binding is its only per-enqueue state — and no longer forces a run-args entry.
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
     Program program = MakeProgramFromSpec(*mesh_device_, spec);
 
-    // Omit dm_kernel from kernel_run_args (only supply compute_kernel). Provide a tensor_arg
-    // so that ValidateTensorArgs passes; the failure should come from the kernel-completeness
-    // check on the binding-owning kernel.
+    // Supply the bound tensor but no kernel_run_args entry for the binding kernel.
     MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, binding.spec, TensorTopology{});
     ProgramRunArgs params;
-    params.kernel_run_args.push_back(MakeKernelRunArgs(KernelSpecName{"compute_kernel"}, node, {}, {}));
     params.tensor_args = {
         {TensorParamName{"input_tensor"}, TensorArgument{tensor}},
     };
 
-    EXPECT_THAT(
-        [&] { SetProgramRunArgs(program, params); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("Kernel 'dm_kernel' is registered in the Program with a non-empty RTA/CRTA schema "
-                                 "but has no runtime parameters specified in ProgramRunArgs")));
+    EXPECT_NO_THROW(SetProgramRunArgs(program, params));
+    EXPECT_EQ(ReadBindingAddressFromCRTA(program, "dm_kernel", "input_tensor"), static_cast<uint32_t>(tensor.address()))
+        << "binding address should be written even though the kernel was omitted from kernel_run_args";
 }
 
 TEST_F(ProgramRunArgsTestGen1, MatchPaddedShapeOnly_DynamicWinsWhenBothSet) {

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -1180,6 +1180,39 @@ TEST_F(ProgramRunArgsTestQuasar, BindingOnlyKernelOmittedFromRunArgsSucceeds) {
         << "binding base address should be written even though the kernel was omitted from kernel_run_args";
 }
 
+TEST_F(ProgramRunArgsTestQuasar, BindingOnlyKernelOmittedFromRunArgsReSetSucceeds) {
+    // Regression: SetProgramRunArgs must be re-callable on a program whose binding-only kernel is
+    // omitted from kernel_run_args. The first call allocates the kernel's CRTA buffer in the second
+    // pass; a second call must patch it in place — set_common_runtime_args fatals if called twice, so
+    // the second pass has to use the same first-time/patch logic as the main loop.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    const std::string tensor_param = "bound_input";
+    spec.tensor_parameters = {MakeMinimalTensorParameter(tensor_param)};
+    BindTensorParameterToKernel(spec.kernels[0], tensor_param, "in_ta");  // kernels[0] == dm_kernel
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    MeshTensor tensor1 =
+        MeshTensor::allocate_on_device(*mesh_device_, spec.tensor_parameters[0].spec, TensorTopology{});
+    ProgramRunArgs params1;
+    params1.tensor_args = {{TensorParamName{tensor_param}, TensorArgument{tensor1}}};
+    EXPECT_NO_THROW(SetProgramRunArgs(program, params1));
+
+    // Second enqueue with a different tensor: must not re-allocate (no fatal), and the binding
+    // address must update in place.
+    MeshTensor tensor2 =
+        MeshTensor::allocate_on_device(*mesh_device_, spec.tensor_parameters[0].spec, TensorTopology{});
+    ASSERT_NE(tensor1.address(), tensor2.address())
+        << "test pre-condition: two live allocations should have distinct addresses";
+    ProgramRunArgs params2;
+    params2.tensor_args = {{TensorParamName{tensor_param}, TensorArgument{tensor2}}};
+    EXPECT_NO_THROW(SetProgramRunArgs(program, params2));
+
+    auto kernel = program.impl().get_kernel_by_spec_name("dm_kernel");
+    EXPECT_EQ(kernel->common_runtime_args()[0], static_cast<uint32_t>(tensor2.address()))
+        << "second SetProgramRunArgs should patch the binding address in place to the new tensor";
+}
+
 // ============================================================================
 // SECTION 5: Gen1 (WH/BH) Tests
 // ============================================================================

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_run_args.cpp
@@ -1148,6 +1148,38 @@ TEST_F(ProgramRunArgsTestQuasar, BorrowedDFB_UpdateTensorArgsRefreshesAddress) {
         << "DFB base addr should refresh to the new MeshTensor's address after UpdateTensorArgs";
 }
 
+// Regression: a kernel that binds a tensor but declares no scalar args (no named/vararg RTAs or
+// CRTAs) may be omitted from kernel_run_args. SetProgramRunArgs must still validate, and must write
+// the binding's base address into that kernel's CRTA buffer via its second pass — the binding
+// address is per-enqueue state that has to reach the device whether or not the user supplies an
+// (otherwise-empty) kernel_run_args entry.
+TEST_F(ProgramRunArgsTestQuasar, BindingOnlyKernelOmittedFromRunArgsSucceeds) {
+    // dm_kernel binds a TensorParameter but has an empty RTA/CRTA schema; compute_kernel is empty
+    // too. Neither has scalar args, so neither needs a kernel_run_args entry.
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    const std::string tensor_param = "bound_input";
+    spec.tensor_parameters = {MakeMinimalTensorParameter(tensor_param)};
+    BindTensorParameterToKernel(spec.kernels[0], tensor_param, "in_ta");  // kernels[0] == dm_kernel
+
+    Program program = MakeProgramFromSpec(*mesh_device_, spec);
+
+    // Supply the bound tensor via tensor_args, but provide NO kernel_run_args entry for the binding
+    // kernel (the whole point of the relaxation — pre-fix this aborted in ValidateProgramRunArgs).
+    MeshTensor tensor = MeshTensor::allocate_on_device(*mesh_device_, spec.tensor_parameters[0].spec, TensorTopology{});
+    ProgramRunArgs params;
+    params.tensor_args = {{TensorParamName{tensor_param}, TensorArgument{tensor}}};
+
+    EXPECT_NO_THROW(SetProgramRunArgs(program, params));
+
+    // The second pass must have allocated the kernel's CRTA buffer and written the binding address.
+    // MakeMinimalTensorParameter is non-sharded, so the binding is a single address word at offset 0.
+    auto kernel = program.impl().get_kernel_by_spec_name("dm_kernel");
+    ASSERT_FALSE(kernel->common_runtime_args().empty())
+        << "binding-only kernel's CRTA buffer should have been allocated by SetProgramRunArgs";
+    EXPECT_EQ(kernel->common_runtime_args()[0], static_cast<uint32_t>(tensor.address()))
+        << "binding base address should be written even though the kernel was omitted from kernel_run_args";
+}
+
 // ============================================================================
 // SECTION 5: Gen1 (WH/BH) Tests
 // ============================================================================

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -1164,6 +1164,19 @@ TEST_F(ProgramSpecTestQuasar, KernelSemaphoreBindingDuplicateAccessorFails) {
         ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("duplicate semaphore accessor_name 'same'")));
 }
 
+TEST_F(ProgramSpecTestQuasar, TensorBindingOnComputeKernelTemporarilyUnsupportedFails) {
+    // TEMPORARY restriction: a TensorAccessor cannot yet be constructed in a compute kernel, so
+    // binding a tensor to one is rejected up front in ValidateProgramSpec with an apologetic message.
+    // Delete this test when compute-path tensor bindings are supported (the guard goes with it).
+    ProgramSpec spec = MakeMinimalValidProgramSpec();
+    spec.tensor_parameters = {MakeMinimalTensorParameter("t")};
+    BindTensorParameterToKernel(spec.kernels[1], "t", "t_acc");  // kernels[1] == compute_kernel
+
+    EXPECT_THAT(
+        [&] { MakeProgramFromSpec(*mesh_device_, spec); },
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("compute kernel with a tensor binding")));
+}
+
 TEST_F(ProgramSpecTestQuasar, SemaphoreNonZeroInitialValueFailsOnQuasar) {
     ProgramSpec spec = MakeMinimalValidProgramSpec();
 

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -473,8 +473,8 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInSameWorkUnitFails) {
     auto dfb = MakeMinimalDFB("dfb");
     dfb.data_format_metadata = tt::DataFormat::Float16_b;
 
-    // Two PRODUCER bindings on the same DFB, both KernelSpecs in the same WorkUnitSpec.
-    // Multi-binding requires non-overlapping WU membership per role; this should fail.
+    // Two PRODUCER bindings on the same DFB, both KernelSpecs in the same WorkUnitSpec (so both
+    // land on the same node). A local DFB allows only one producer instance per node, so this fails.
     producer1.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
     producer2.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
     consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
@@ -486,8 +486,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleProducersInSameWorkUnitFails) {
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("DFB 'dfb' has multiple PRODUCER KernelSpecs sharing WorkUnitSpec 'work_unit'")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("2 producer instance(s)")));
 }
 
 TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInSameWorkUnitFails) {
@@ -516,8 +515,7 @@ TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInSameWorkUnitFails) {
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(
-            ::testing::HasSubstr("DFB 'dfb' has multiple CONSUMER KernelSpecs sharing WorkUnitSpec 'work_unit'")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("2 consumer instance(s)")));
 }
 
 TEST_F(ProgramSpecTestQuasar, DFBWithMultipleConsumersInDifferentWorkUnitsSucceeds) {
@@ -593,7 +591,8 @@ TEST_F(ProgramSpecTestQuasar, DFBProducerConsumerCoverageMismatchFails) {
     producer.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
     consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
 
-    // Producer covers wu_p; consumer covers wu_c. Their coverages differ — invalid.
+    // Producer covers node0; consumer covers node1. Every node ends up with only one role —
+    // the per-node census rejects it (each node hosting the DFB needs both a producer and consumer).
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
     spec.work_units = std::vector<WorkUnitSpec>{
@@ -603,7 +602,39 @@ TEST_F(ProgramSpecTestQuasar, DFBProducerConsumerCoverageMismatchFails) {
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("do not cover the same WorkUnitSpec(s)")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("is malformed at node")));
+}
+
+// The canonical 2D-matmul placement: one compute consumer spanning the whole grid, with a
+// separate specialized DM producer per node group. The producer role has several KernelSpecs (one
+// per group's WorkUnitSpec); the single consumer joins every group's WorkUnitSpec. Each node ends
+// up with exactly one producer and one consumer instance, so the per-node census accepts it.
+TEST_F(ProgramSpecTestQuasar, LocalDFBAllGridConsumerWithPerGroupProducersSucceeds) {
+    ProgramSpec spec;
+    spec.name = "test_program";
+
+    auto consumer = MakeMinimalComputeKernel("compute");
+    auto dfb = MakeMinimalDFB("dfb");
+    dfb.data_format_metadata = tt::DataFormat::Float16_b;
+    consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
+
+    std::vector<KernelSpec> kernels;
+    std::vector<WorkUnitSpec> work_units;
+    for (uint32_t i = 0; i < 4; ++i) {
+        const std::string dm_name = "dm" + std::to_string(i);
+        auto dm = MakeMinimalDMKernel(dm_name);
+        dm.dfb_bindings.push_back(ProducerOf(DFBSpecName{"dfb"}, "out"));
+        kernels.push_back(dm);
+        // One node per group: the per-group DM lives there, and the all-grid compute joins it.
+        work_units.push_back(MakeMinimalWorkUnit("wu" + std::to_string(i), NodeCoord{i, 0}, {dm_name, "compute"}));
+    }
+    kernels.push_back(consumer);
+
+    spec.kernels = std::move(kernels);
+    spec.dataflow_buffers = {dfb};
+    spec.work_units = std::move(work_units);
+
+    EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
 TEST_F(ProgramSpecTestQuasar, DFBMultiBindingAccessPatternMismatchFails) {
@@ -1642,9 +1673,9 @@ TEST_F(ProgramSpecTestQuasar, WorkUnitWithMultipleComputeKernelsFails) {
             ::testing::HasSubstr("WorkUnitSpec 'work_unit' has more than one compute kernel")));
 }
 
-TEST_F(ProgramSpecTestQuasar, LocalDFBProducerConsumerWorkUnitMembershipMismatchFails) {
-    // A local DFB requires its producer and consumer kernels to share IDENTICAL
-    // WorkUnitSpec membership.
+TEST_F(ProgramSpecTestQuasar, LocalDFBConsumerOnNodeWithoutProducerFails) {
+    // A local DFB requires every node it lives on to host both a producer and a consumer. Here the
+    // consumer covers an extra node where no producer runs, so the per-node census rejects it.
     NodeCoord node0{0, 0};
     NodeCoord node1{1, 0};
 
@@ -1660,7 +1691,7 @@ TEST_F(ProgramSpecTestQuasar, LocalDFBProducerConsumerWorkUnitMembershipMismatch
 
     spec.kernels = {producer, consumer};
     spec.dataflow_buffers = {dfb};
-    // Producer is on work_unit_0 only; consumer is on both work_units — membership doesn't match.
+    // Producer covers node0 only; consumer covers node0 and node1 — node1 has a consumer but no producer.
     spec.work_units = std::vector<WorkUnitSpec>{
         MakeMinimalWorkUnit("work_unit_0", node0, {"producer", "consumer"}),
         MakeMinimalWorkUnit("work_unit_1", node1, {"consumer"}),
@@ -1668,7 +1699,7 @@ TEST_F(ProgramSpecTestQuasar, LocalDFBProducerConsumerWorkUnitMembershipMismatch
 
     EXPECT_THAT(
         [&] { MakeProgramFromSpec(*mesh_device_, spec); },
-        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("do not cover the same WorkUnitSpec(s)")));
+        ::testing::ThrowsMessage<std::runtime_error>(::testing::HasSubstr("This node has a consumer but no producer")));
 }
 
 // ----------------------------------------------------------------------------

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -269,13 +269,12 @@ void ValidateProgramRunArgs(const Program& program, const ProgramRunArgs& params
     }
 
     // Validate that all registered kernels with a non-empty RTA/CRTA schema have parameters.
-    // Kernels whose schema declares no named RTAs, no named CRTAs, no vararg RTAs, no vararg
-    // CRTAs, AND no tensor bindings have nothing to supply per enqueue and do not need a
-    // kernel_run_args entry. Tensor bindings count as "something to supply" because their
-    // base address (and any dynamic accessor fields) are written into the kernel's CRTA buffer
-    // by SetProgramRunArgs from the corresponding TensorArgument — and SetProgramRunArgs
-    // only walks kernels present in params.kernel_run_args, so a kernel with tensor bindings
-    // omitted from kernel_run_args would have its binding CRTAs left uninitialized.
+    // Kernels whose schema declares no named RTAs, no named CRTAs, no vararg RTAs, and no vararg
+    // CRTAs have no scalar runtime arguments to supply per enqueue and do not need a kernel_run_args
+    // entry. This holds even if the kernel binds tensors: a TensorBinding's base address (and any
+    // dynamic accessor fields) is filled automatically by SetProgramRunArgs for every binding-bearing
+    // kernel — including a binding-only kernel omitted from kernel_run_args, via its second pass —
+    // so tensor bindings alone no longer force an (otherwise-empty) kernel_run_args entry.
     auto registered_names = program_impl.get_registered_kernel_names();
     for (const auto& name : registered_names) {
         if (kernels_with_params.contains(KernelSpecName{name})) {
@@ -285,17 +284,13 @@ void ValidateProgramRunArgs(const Program& program, const ProgramRunArgs& params
         if (schema == nullptr) {
             continue;
         }
-        auto kernel = program_impl.get_kernel_by_spec_name(name);
-        const bool has_tensor_bindings = kernel != nullptr && !kernel->tensor_binding_handles().empty();
-        const bool has_anything_to_supply = !schema->runtime_arg_names.empty() ||
-                                            !schema->common_runtime_arg_names.empty() ||
-                                            !schema->num_runtime_varargs_per_node.empty() ||
-                                            schema->num_common_runtime_varargs > 0 || has_tensor_bindings;
+        const bool has_anything_to_supply =
+            !schema->runtime_arg_names.empty() || !schema->common_runtime_arg_names.empty() ||
+            !schema->num_runtime_varargs_per_node.empty() || schema->num_common_runtime_varargs > 0;
         TT_FATAL(
             !has_anything_to_supply,
             "Kernel '{}' is registered in the Program with a non-empty RTA/CRTA schema but has no "
-            "runtime parameters specified in ProgramRunArgs (the schema is non-empty, or the "
-            "kernel binds tensor parameters whose addresses are filled from kernel_run_args)",
+            "runtime parameters specified in ProgramRunArgs.",
             name);
     }
 
@@ -486,6 +481,23 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
         tensor_by_param.emplace(param_name.get(), &mesh_tensor_of(tensor_arg));
     }
 
+    // Append a kernel's TensorBinding CRTA section to `out`, in binding-handle order. Each binding
+    // contributes (1 + num_runtime_field_crta_words) words: [base address, optional runtime accessor
+    // fields...], sourced from the bound MeshTensor via tensor_by_param. Shared by the main
+    // kernel_run_args loop below and the binding-only second pass after it.
+    auto append_binding_crtas = [&](const auto& binding_handles, std::vector<uint32_t>& out) {
+        for (const auto& handle : binding_handles) {
+            auto t_it = tensor_by_param.find(handle.tensor_parameter_name);
+            TT_FATAL(
+                t_it != tensor_by_param.end(),
+                "Internal error: tensor binding '{}' has no resolved MeshTensor (validation should have caught "
+                "this).",
+                handle.tensor_parameter_name);
+            const auto values = ComputeBindingCrtaValues(handle, *t_it->second);
+            out.insert(out.end(), values.begin(), values.end());
+        }
+    };
+
     // Process kernel runtime arguments.
     // Named RTAs/CRTAs and vararg RTAs/CRTAs share a single dispatch buffer each (RTA + CRTA).
     //
@@ -580,16 +592,7 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
                 kernel_name);
             combined_crtas.push_back(v_it->second);
         }
-        for (const auto& handle : binding_handles) {
-            auto t_it = tensor_by_param.find(handle.tensor_parameter_name);
-            TT_FATAL(
-                t_it != tensor_by_param.end(),
-                "Internal error: tensor binding '{}' has no resolved MeshTensor (validation should have caught "
-                "this).",
-                handle.tensor_parameter_name);
-            const auto values = ComputeBindingCrtaValues(handle, *t_it->second);
-            combined_crtas.insert(combined_crtas.end(), values.begin(), values.end());
-        }
+        append_binding_crtas(binding_handles, combined_crtas);
         combined_crtas.insert(
             combined_crtas.end(),
             kernel_common_runtime_varargs(kernel_params).begin(),
@@ -613,6 +616,38 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
                     combined_crtas.size());
                 std::memcpy(crta.data(), combined_crtas.data(), combined_crtas.size() * sizeof(uint32_t));
             }
+        }
+    }
+
+    // Second pass: kernels that bind tensors but were omitted from kernel_run_args.
+    // A kernel whose only per-enqueue state is TensorBinding addresses (no named RTAs/CRTAs and no
+    // varargs) is allowed to be absent from kernel_run_args (see ValidateProgramRunArgs). The loop
+    // above only visits kernels present in kernel_run_args, so such a kernel's binding CRTA section
+    // would never be written. Fill it here. This mirrors the fast path UpdateTensorArgs, which
+    // likewise fills bindings for every binding-bearing kernel independent of kernel_run_args.
+    // Kernels without tensor bindings need no CRTA buffer, so this allocates nothing extra for them.
+    std::unordered_set<std::string> kernels_in_run_args;
+    kernels_in_run_args.reserve(params.kernel_run_args.size());
+    for (const auto& kernel_params : params.kernel_run_args) {
+        kernels_in_run_args.insert(kernel_params.kernel.get());
+    }
+    for (const auto& kernel_name : program_impl.get_registered_kernel_names()) {
+        if (kernels_in_run_args.contains(kernel_name)) {
+            continue;  // Already filled (and its CRTA buffer allocated) by the loop above.
+        }
+        std::shared_ptr<Kernel> kernel = program_impl.get_kernel_by_spec_name(kernel_name);
+        const auto& binding_handles = kernel->tensor_binding_handles();
+        if (binding_handles.empty()) {
+            continue;  // No bindings => nothing to supply; no CRTA dispatch buffer needed.
+        }
+        // Binding-only kernel: its CRTA buffer is exactly the binding section (it has no named CRTAs
+        // or varargs, else validation would have required a kernel_run_args entry). It was never
+        // visited above, so its CRTA storage is unallocated — assemble and allocate via
+        // set_common_runtime_args (the first-time path), not an in-place patch.
+        std::vector<uint32_t> combined_crtas;
+        append_binding_crtas(binding_handles, combined_crtas);
+        if (!combined_crtas.empty()) {
+            kernel->set_common_runtime_args(combined_crtas);
         }
     }
 

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -498,6 +498,30 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
         }
     };
 
+    // Install a kernel's assembled CRTA buffer. set_common_runtime_args allocates storage but fatals
+    // if called twice, so it can only be used the first time; on subsequent SetProgramRunArgs calls
+    // (e.g. re-enqueue with new args) the already-allocated buffer is patched in place. Shared by the
+    // main kernel_run_args loop and the binding-only second pass so both handle the re-set case.
+    auto install_crtas = [](const std::shared_ptr<Kernel>& kernel,
+                            const std::vector<uint32_t>& combined_crtas,
+                            std::string_view kernel_name) {
+        if (combined_crtas.empty()) {
+            return;
+        }
+        if (kernel->common_runtime_args().empty()) {
+            kernel->set_common_runtime_args(combined_crtas);
+        } else {
+            RuntimeArgsData& crta = kernel->common_runtime_args_data();
+            TT_FATAL(
+                crta.size() == combined_crtas.size(),
+                "Kernel '{}' common runtime args count cannot change from {} to {}",
+                kernel_name,
+                crta.size(),
+                combined_crtas.size());
+            std::memcpy(crta.data(), combined_crtas.data(), combined_crtas.size() * sizeof(uint32_t));
+        }
+    };
+
     // Process kernel runtime arguments.
     // Named RTAs/CRTAs and vararg RTAs/CRTAs share a single dispatch buffer each (RTA + CRTA).
     //
@@ -598,25 +622,7 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
             kernel_common_runtime_varargs(kernel_params).begin(),
             kernel_common_runtime_varargs(kernel_params).end());
 
-        // Set common runtime args
-        // TODO: Why on earth does SetCommonRuntimeArgs() only work the first time??
-        if (!combined_crtas.empty()) {
-            if (kernel->common_runtime_args().empty()) {
-                // First time: use the normal setter which allocates storage
-                kernel->set_common_runtime_args(combined_crtas);
-            } else {
-                // Subsequent calls: update in-place
-                // (set_common_runtime_args fatals if called twice, so use direct access)
-                RuntimeArgsData& crta = kernel->common_runtime_args_data();
-                TT_FATAL(
-                    crta.size() == combined_crtas.size(),
-                    "Kernel '{}' common runtime args count cannot change from {} to {}",
-                    kernel_name,
-                    crta.size(),
-                    combined_crtas.size());
-                std::memcpy(crta.data(), combined_crtas.data(), combined_crtas.size() * sizeof(uint32_t));
-            }
-        }
+        install_crtas(kernel, combined_crtas, kernel_name.get());
     }
 
     // Second pass: kernels that bind tensors but were omitted from kernel_run_args.
@@ -641,14 +647,12 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
             continue;  // No bindings => nothing to supply; no CRTA dispatch buffer needed.
         }
         // Binding-only kernel: its CRTA buffer is exactly the binding section (it has no named CRTAs
-        // or varargs, else validation would have required a kernel_run_args entry). It was never
-        // visited above, so its CRTA storage is unallocated — assemble and allocate via
-        // set_common_runtime_args (the first-time path), not an in-place patch.
+        // or varargs, else validation would have required a kernel_run_args entry). install_crtas
+        // allocates the buffer on the first SetProgramRunArgs call and patches it in place on later
+        // ones (e.g. re-enqueue with a new tensor), mirroring the main loop.
         std::vector<uint32_t> combined_crtas;
         append_binding_crtas(binding_handles, combined_crtas);
-        if (!combined_crtas.empty()) {
-            kernel->set_common_runtime_args(combined_crtas);
-        }
+        install_crtas(kernel, combined_crtas, kernel_name);
     }
 
     // Process DFB runtime parameters:

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1316,9 +1316,9 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             tp_name);
         const TensorSpec& tensor_spec = it->second->spec;
         TT_FATAL(
-            tensor_spec.memory_config().buffer_type() == tt::tt_metal::BufferType::L1,
+            tensor_spec.memory_config().is_l1(),
             "DFB '{}' borrows memory from TensorParameter '{}', but its TensorSpec is not L1-resident (L1 is "
-            "required).",
+            "required). Both L1 and L1_SMALL are accepted.",
             dfb.unique_id,
             tp_name);
         // Coarse spec-time sizing check against the TensorSpec's full packed size. No Buffer is

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -464,6 +464,20 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
 
     // Validate kernel tensor bindings
     for (const auto& kernel : spec.kernels) {
+        // TEMPORARY: tensor bindings on compute kernels are not yet supported end-to-end. A
+        // TensorAccessor cannot currently be constructed in a compute kernel, so a spec that binds a
+        // tensor to a compute kernel looks valid here but fails once it reaches the kernel. Reject it
+        // up front with an honest message until the compute-path support lands (expected within a day
+        // or two of 2026-06-16). Remove this guard when that ships.
+        TT_FATAL(
+            !kernel.is_compute_kernel() || kernel.tensor_bindings.empty(),
+            "Kernel '{}' is a compute kernel with a tensor binding ('{}'). Tensor bindings on compute "
+            "kernels are not yet supported — a TensorAccessor cannot currently be constructed in a "
+            "compute kernel, so this spec would compile but fail in the kernel. This is a temporary "
+            "restriction that will be lifted soon.",
+            kernel.unique_id,
+            kernel.tensor_bindings.empty() ? std::string{} : kernel.tensor_bindings.front().accessor_name);
+
         std::unordered_set<std::string> accessor_names;
         for (const auto& binding : kernel.tensor_bindings) {
             auto [it, inserted] = accessor_names.insert(binding.accessor_name);

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1058,29 +1058,20 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
 
     // Validate local DFB endpoint placement and multi-binding consistency.
     //
-    // The hardware invariant is local: at each node where the DFB is instantiated, exactly one
-    // producer kernel instance and one consumer kernel instance run on that node. This is
-    // sufficient — but not strictly necessary — to enforce at the spec level via "one producer
-    // KernelSpec, one consumer KernelSpec". Metal 2.0 also permits multiple PRODUCER KernelSpecs
-    // (and multiple CONSUMER KernelSpecs) per DFB, provided:
-    //   1. Within each role (producer / consumer): KernelSpecs' WorkUnitSpec memberships are
-    //      pairwise disjoint (so no node has two same-role instances).
-    //   2. Across roles: union of producer KernelSpecs' WU memberships ==
-    //      union of consumer KernelSpecs' WU memberships (so every node where the DFB lives
-    //      has both a producer instance and a consumer instance).
+    // The hardware invariant is local: a local DFB lives in shared SRAM on each node, so at every
+    // node where the DFB is instantiated, exactly one producer kernel instance and exactly one
+    // consumer kernel instance must run on that node. Metal 2.0 permits multiple PRODUCER
+    // KernelSpecs (and multiple CONSUMER KernelSpecs) per DFB, so we enforce that invariant directly
+    // as a per-node census, plus per-role uniformity of the binding-site config:
+    //   1./2. Placement: every node hosting the DFB runs exactly one producer instance and exactly
+    //         one consumer instance (the per-node census below). This subsumes both "no node has two
+    //         same-role instances" and "producer and consumer node coverage coincide".
     //   3. All bindings on the same role have matching `access_pattern` (the DFB scheduler
     //      config is shared per role).
     //   4. All KernelSpecs on the same role have matching `num_threads` (the per-side
     //      credit-tracking config is shared per role).
     // Self-loop (a kernel that appears in both producers and consumers of a DFB) is currently
     // restricted to the simple single-producer-single-consumer case.
-    auto kernel_work_unit_set = [&](const KernelSpecName& name) {
-        std::set<const WorkUnitSpec*> work_units;
-        for (const WorkUnitSpec* w : collected.kernel_work_units.at(name)) {
-            work_units.insert(w);
-        }
-        return work_units;
-    };
     for (const auto& dfb : spec.dataflow_buffers) {
         const auto& endpoints = collected.dfb_endpoints.at(dfb.unique_id);
 
@@ -1132,36 +1123,79 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         check_role_uniformity(endpoints.producers, "PRODUCER");
         check_role_uniformity(endpoints.consumers, "CONSUMER");
 
-        // (1) and (2): WU membership disjointness within each role + cross-role equality.
-        // Compute per-role unions while also checking within-role pairwise disjointness.
-        auto compute_role_union = [&](const auto& records, std::string_view role) {
-            std::set<const WorkUnitSpec*> role_union;
+        // (1)/(2) Placement — per-node census. A local DFB lives in shared SRAM on each node, so
+        // every node it is instantiated on must run exactly one producer instance and exactly one
+        // consumer instance. Tally instances per node directly from the bindings: this subsumes the
+        // old within-role disjointness check (a node with >1 same-role instance) and the cross-role
+        // coverage check (a node with one role but not the other), and reports the offending node in
+        // node terms rather than WorkUnitSpec terms. It counts actual node occupancy, so overlapping
+        // same-role placements are caught regardless of how the WorkUnitSpec bookkeeping produced
+        // them. (Self-loops fall out naturally: a self-looping kernel tallies as one producer AND
+        // one consumer on each of its nodes.)
+        std::unordered_map<NodeCoord, std::vector<const KernelSpec*>> producers_on_node;
+        std::unordered_map<NodeCoord, std::vector<const KernelSpec*>> consumers_on_node;
+        auto tally_role = [&](const auto& records, auto& on_node) {
             for (const auto& rec : records) {
-                const auto wu_set = kernel_work_unit_set(rec.kernel->unique_id);
-                for (const WorkUnitSpec* wu : wu_set) {
-                    auto [it, inserted] = role_union.insert(wu);
-                    TT_FATAL(
-                        inserted,
-                        "DFB '{}' has multiple {} KernelSpecs sharing WorkUnitSpec '{}' (kernel '{}' collides with a "
-                        "prior {} binding). Same-role bindings must have pairwise-disjoint WorkUnitSpec membership.",
-                        dfb.unique_id,
-                        role,
-                        wu->name,
-                        rec.kernel->unique_id,
-                        role);
+                for (const NodeCoord& node : corerange_to_cores(collected.kernel_node_set.at(rec.kernel->unique_id))) {
+                    on_node[node].push_back(rec.kernel);
                 }
             }
-            return role_union;
         };
-        const auto producer_wu_union = compute_role_union(endpoints.producers, "PRODUCER");
-        const auto consumer_wu_union = compute_role_union(endpoints.consumers, "CONSUMER");
-        TT_FATAL(
-            producer_wu_union == consumer_wu_union,
-            "Local DFB '{}' producer and consumer KernelSpecs do not cover the same WorkUnitSpec(s). "
-            "Local DFBs require every node where the DFB is instantiated to host both a producer "
-            "and a consumer kernel instance; either refactor the placement, or model this as "
-            "a RemoteDataflowBufferSpec.",
-            dfb.unique_id);
+        tally_role(endpoints.producers, producers_on_node);
+        tally_role(endpoints.consumers, consumers_on_node);
+
+        // Footprint = every node hosting any instance of either role. A std::set gives deterministic
+        // iteration order, hence deterministic error messages.
+        std::set<NodeCoord> footprint;
+        for (const auto& [node, kernels] : producers_on_node) {
+            footprint.insert(node);
+        }
+        for (const auto& [node, kernels] : consumers_on_node) {
+            footprint.insert(node);
+        }
+
+        auto names_at = [](const std::unordered_map<NodeCoord, std::vector<const KernelSpec*>>& on_node,
+                           const NodeCoord& node) -> std::string {
+            auto it = on_node.find(node);
+            if (it == on_node.end() || it->second.empty()) {
+                return "none";
+            }
+            std::string names;
+            for (const KernelSpec* k : it->second) {
+                names += (names.empty() ? "'" : ", '") + k->unique_id.get() + "'";
+            }
+            return names;
+        };
+
+        for (const NodeCoord& node : footprint) {
+            auto p_it = producers_on_node.find(node);
+            auto c_it = consumers_on_node.find(node);
+            const size_t num_producers = p_it == producers_on_node.end() ? 0 : p_it->second.size();
+            const size_t num_consumers = c_it == consumers_on_node.end() ? 0 : c_it->second.size();
+            if (num_producers == 1 && num_consumers == 1) {
+                continue;
+            }
+            const std::string_view guidance =
+                num_producers == 0 ? "This node has a consumer but no producer — ensure a producer kernel covers it "
+                                     "(via its WorkUnitSpec membership)."
+                : num_consumers == 0
+                    ? "This node has a producer but no consumer — ensure a consumer kernel covers it "
+                      "(via its WorkUnitSpec membership)."
+                    : "Multiple same-role kernel instances land on this node — their placements overlap; "
+                      "give each disjoint nodes.";
+            TT_FATAL(
+                false,
+                "Local DFB '{}' is malformed at node {}: {} producer instance(s) ({}) and {} consumer "
+                "instance(s) ({}). A local DFB lives in shared SRAM on each node, so every node it is "
+                "instantiated on must run exactly one producer and one consumer kernel instance. {}",
+                dfb.unique_id,
+                node.str(),
+                num_producers,
+                names_at(producers_on_node, node),
+                num_consumers,
+                names_at(consumers_on_node, node),
+                guidance);
+        }
 
         // Self-loop interplay with multi-binding: when ANY kernel self-loops a DFB (appears in
         // both producers and consumers), the producer set must equal the consumer set as sets

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -1189,14 +1189,20 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
             if (num_producers == 1 && num_consumers == 1) {
                 continue;
             }
-            const std::string_view guidance =
-                num_producers == 0 ? "This node has a consumer but no producer — ensure a producer kernel covers it "
-                                     "(via its WorkUnitSpec membership)."
-                : num_consumers == 0
-                    ? "This node has a producer but no consumer — ensure a consumer kernel covers it "
-                      "(via its WorkUnitSpec membership)."
-                    : "Multiple same-role kernel instances land on this node — their placements overlap; "
-                      "give each disjoint nodes.";
+            std::string_view guidance;
+            if (num_producers == 0) {
+                guidance =
+                    "This node has a consumer but no producer — ensure a producer kernel covers it "
+                    "(via its WorkUnitSpec membership).";
+            } else if (num_consumers == 0) {
+                guidance =
+                    "This node has a producer but no consumer — ensure a consumer kernel covers it "
+                    "(via its WorkUnitSpec membership).";
+            } else {
+                guidance =
+                    "Multiple same-role kernel instances land on this node — their placements overlap; "
+                    "give each disjoint nodes.";
+            }
             TT_FATAL(
                 false,
                 "Local DFB '{}' is malformed at node {}: {} producer instance(s) ({}) and {} consumer "


### PR DESCRIPTION
### PR Category
Bugfix

### Summary
This PR makes some minor small fixes to Metal 2.0, all in response to porter AI feedback:
 - **Don't force a ProgramRunArgs entry for binding-only kernels**. A kernel that binds a tensor but declares no runtime args shouldn't need a `kernel_run_args` entry, but validation wanted an empty one anyways.
 - **Give per-node error messages for local-DFB placement**. Every node hosting the DFB must run exactly one producer and one consumer instance. Previously, the error messaging used the WorkUnitSpec indirection, which confused porters. Now it's more concrete and per-node.
 - **(Temporarily) reject tensor bindings on compute kernels**. I hope to fix this one soon. Since `TensorAccessor` doesn't work on compute kernels, you can't actually use the tensor bindings there. Better to surface the error in Metal 2.0 legality checks than let the AI figure this out the hard way...
 - **Allow L1_SMALL for borrowed mem DFB backing**. Previously, this was checking for L1, which omitted L1_SMALL.

### Notes for reviewers
-

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/misc-op-port-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/misc-op-port-fixes2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/misc-op-port-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/misc-op-port-fixes2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/misc-op-port-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/misc-op-port-fixes2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/misc-op-port-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/misc-op-port-fixes2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/misc-op-port-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/misc-op-port-fixes2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/misc-op-port-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/misc-op-port-fixes2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/misc-op-port-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/misc-op-port-fixes2)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/misc-op-port-fixes2)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/misc-op-port-fixes2)