### PR TITLE
fix(sfpu): optimize atanh, asinh, and acosh for numerical stability

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -13,6 +13,7 @@
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_log.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
+#include "ckernel_sfpu_log1p.h"
 #include "sfpi.h"
 
 using namespace sfpi;
@@ -789,21 +790,21 @@ inline void _calculate_cosine_(const int iterations) {
 }
 
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
-// acosh(x) = log(x + sqrt(x^2 - 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_acosh() {
-    // SFPU microcode
+// acosh(x) = log(x + sqrt(x^2 - 1)) -> log1p(x - 1 + sqrt((x - 1) * (x + 1)))
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_acosh_impl() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
         sfpi::vFloat res;
         v_if(inp < sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
         v_elseif(inp == sfpi::vConst1) { res = sfpi::vConst0; }
         v_else {
-            sfpi::vFloat tmp = inp * inp;
-            tmp = tmp - sfpi::vConst1;
-            tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp = tmp + inp;
-            res = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat xm1 = inp - sfpi::vConst1;
+            sfpi::vFloat xp1 = inp + sfpi::vConst1;
+            sfpi::vFloat tmp = xm1 * xp1;
+            sfpi::vFloat sqrt_val = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+            sfpi::vFloat log1p_arg = xm1 + sqrt_val;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(log1p_arg);
         }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -811,16 +812,30 @@ inline void calculate_acosh() {
     }
 }
 
-// asinh(x) = log(x + sqrt(x^2 + 1))
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_asinh() {
-    // SFPU microcode
+inline void calculate_acosh() {
+    calculate_acosh_impl<APPROXIMATION_MODE, false, ITERATIONS>();
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_acosh() {
+    calculate_acosh_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>();
+}
+
+// asinh(x) = log(x + sqrt(x^2 + 1)) -> log1p(abs(x) + x^2 / (sqrt(x^2 + 1) + 1))
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_asinh_impl() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp = tmp + sfpi::abs(inp);
-        auto res = _calculate_log_body_no_init_(tmp);
+        sfpi::vFloat abs_inp = sfpi::abs(inp);
+        sfpi::vFloat sq = abs_inp * abs_inp;
+        sfpi::vFloat tmp = sq + sfpi::vConst1;
+        sfpi::vFloat sqrt_val = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+        sfpi::vFloat denom = sqrt_val + sfpi::vConst1;
+        sfpi::vFloat recip_denom = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(denom);
+        sfpi::vFloat term = sq * recip_denom;
+        sfpi::vFloat log1p_arg = abs_inp + term;
+        sfpi::vFloat res = calculate_log1p_fp32<is_fp32_dest_acc_en>(log1p_arg);
         v_if(inp < sfpi::vConst0) { res = -res; }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -828,10 +843,19 @@ inline void calculate_asinh() {
     }
 }
 
-// atanh[x] = 0.5 * ln((1 + x) / (1 - x))
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_asinh() {
+    calculate_asinh_impl<APPROXIMATION_MODE, false, ITERATIONS>();
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_asinh() {
+    calculate_asinh_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>();
+}
+
+// atanh[x] = 0.5 * ln((1 + x) / (1 - x)) -> 0.5 * log1p(2 * abs(x) / (1 - abs(x)))
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_atanh() {
-    // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
         sfpi::vFloat abs_inp = sfpi::abs(inp);
@@ -842,8 +866,8 @@ inline void calculate_atanh() {
             res = sfpi::copysgn(inf, inp);
         }
         v_else {
-            sfpi::vFloat num = sfpi::vConst1 + inp;
-            sfpi::vFloat den = sfpi::vConst1 - inp;
+            sfpi::vFloat two_abs_inp = 2.0f * abs_inp;
+            sfpi::vFloat den = sfpi::vConst1 - abs_inp;
             sfpi::vFloat tmp = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
             tmp = sfpi::copysgn(tmp, den);
             if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
@@ -851,9 +875,10 @@ inline void calculate_atanh() {
             } else {
                 den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
             }
-            num = num * den;
-            den = _calculate_log_body_no_init_(num);
-            res = 0.5f * den;
+            sfpi::vFloat log1p_arg = two_abs_inp * den;
+            sfpi::vFloat log_val = calculate_log1p_fp32<is_fp32_dest_acc_en>(log1p_arg);
+            res = 0.5f * log_val;
+            res = sfpi::copysgn(res, inp);
         }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -861,14 +886,16 @@ inline void calculate_atanh() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX = false, bool is_fp32_dest_acc_en = false>
 void init_inverse_hyperbolic() {
     sqrt_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX = false, bool is_fp32_dest_acc_en = false>
 void init_atanh() {
     _init_sfpu_reciprocal_<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -13,6 +13,7 @@
 #include "ckernel_sfpu_exp.h"
 #include "sfpu/ckernel_sfpu_log.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
+#include "ckernel_sfpu_log1p.h"
 #include "sfpi.h"
 
 using namespace sfpi;
@@ -818,36 +819,52 @@ inline void _calculate_cosine_(const int iterations) {
 }
 
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
-// acosh(x) = log(x + sqrt(x^2 - 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_acosh() {
-    // SFPU microcode
+// acosh(x) = log(x + sqrt(x^2 - 1)) -> log1p(x - 1 + sqrt((x - 1) * (x + 1)))
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_acosh_impl() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
-        v_if(inp < sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(inp == sfpi::vConst1) { sfpi::dst_reg[0] = sfpi::vConst0; }
+        sfpi::vFloat res;
+        v_if(inp < sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
+        v_elseif(inp == sfpi::vConst1) { res = sfpi::vConst0; }
         v_else {
-            sfpi::vFloat tmp = inp * inp;
-            tmp = tmp - sfpi::vConst1;
-            tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp = tmp + inp;
-            sfpi::dst_reg[0] = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat xm1 = inp - sfpi::vConst1;
+            sfpi::vFloat xp1 = inp + sfpi::vConst1;
+            sfpi::vFloat tmp = xm1 * xp1;
+            sfpi::vFloat sqrt_val = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+            sfpi::vFloat log1p_arg = xm1 + sqrt_val;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(log1p_arg);
         }
         v_endif;
+        sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }
 
-// asinh(x) = log(x + sqrt(x^2 + 1))
 template <bool APPROXIMATION_MODE, int ITERATIONS>
-inline void calculate_asinh() {
-    // SFPU microcode
+inline void calculate_acosh() {
+    calculate_acosh_impl<APPROXIMATION_MODE, false, ITERATIONS>();
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_acosh() {
+    calculate_acosh_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>();
+}
+
+// asinh(x) = log(x + sqrt(x^2 + 1)) -> log1p(abs(x) + x^2 / (sqrt(x^2 + 1) + 1))
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_asinh_impl() {
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp = tmp + sfpi::abs(inp);
-        auto res = _calculate_log_body_no_init_(tmp);
+        sfpi::vFloat abs_inp = sfpi::abs(inp);
+        sfpi::vFloat sq = abs_inp * abs_inp;
+        sfpi::vFloat tmp = sq + sfpi::vConst1;
+        sfpi::vFloat sqrt_val = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+        sfpi::vFloat denom = sqrt_val + sfpi::vConst1;
+        sfpi::vFloat recip_denom = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(denom);
+        sfpi::vFloat term = sq * recip_denom;
+        sfpi::vFloat log1p_arg = abs_inp + term;
+        sfpi::vFloat res = calculate_log1p_fp32<is_fp32_dest_acc_en>(log1p_arg);
         v_if(inp < sfpi::vConst0) { res = -res; }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -855,10 +872,19 @@ inline void calculate_asinh() {
     }
 }
 
-// atanh[x] = 0.5 * ln((1 + x) / (1 - x))
+template <bool APPROXIMATION_MODE, int ITERATIONS>
+inline void calculate_asinh() {
+    calculate_asinh_impl<APPROXIMATION_MODE, false, ITERATIONS>();
+}
+
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
+inline void calculate_asinh() {
+    calculate_asinh_impl<APPROXIMATION_MODE, is_fp32_dest_acc_en, ITERATIONS>();
+}
+
+// atanh[x] = 0.5 * ln((1 + x) / (1 - x)) -> 0.5 * log1p(2 * abs(x) / (1 - abs(x)))
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_atanh() {
-    // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
         sfpi::vFloat abs_inp = sfpi::abs(inp);
@@ -869,8 +895,8 @@ inline void calculate_atanh() {
             res = sfpi::copysgn(inf, inp);
         }
         v_else {
-            sfpi::vFloat num = sfpi::vConst1 + inp;
-            sfpi::vFloat den = sfpi::vConst1 - inp;
+            sfpi::vFloat two_abs_inp = 2.0f * abs_inp;
+            sfpi::vFloat den = sfpi::vConst1 - abs_inp;
             sfpi::vFloat tmp = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
             tmp = sfpi::copysgn(tmp, den);
             if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
@@ -878,9 +904,10 @@ inline void calculate_atanh() {
             } else {
                 den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
             }
-            num = num * den;
-            den = _calculate_log_body_no_init_(num);
-            res = 0.5f * den;
+            sfpi::vFloat log1p_arg = two_abs_inp * den;
+            sfpi::vFloat log_val = calculate_log1p_fp32<is_fp32_dest_acc_en>(log1p_arg);
+            res = 0.5f * log_val;
+            res = sfpi::copysgn(res, inp);
         }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -888,14 +915,16 @@ inline void calculate_atanh() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX = false, bool is_fp32_dest_acc_en = false>
 void init_inverse_hyperbolic() {
     sqrt_init<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool FAST_APPROX = false, bool is_fp32_dest_acc_en = false>
 void init_atanh() {
     _init_sfpu_reciprocal_<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, FAST_APPROX, is_fp32_dest_acc_en>();
 }
 
 }  // namespace ckernel::sfpu


### PR DESCRIPTION
This PR optimizes the SFPU implementations of `atanh`, `asinh`, and `acosh` using numerically stable `log1p`-based formulations.

### Improvements:
- **`atanh(x)`**: Reformulated from `0.5 * log((1 + x) / (1 - x))` to `0.5 * log1p(2 * abs(x) / (1 - abs(x))) * sign(x)`. Resolves precision loss and cancellation near $x pprox 0$.
- **`asinh(x)`**: Reformulated from `log(x + sqrt(x^2 + 1))` to `log1p(abs(x) + x^2 / (sqrt(x^2 + 1) + 1)) * sign(x)`. Avoids underflow precision loss near $x pprox 0$.
- **`acosh(x)`**: Reformulated from `log(x + sqrt(x^2 - 1))` to `log1p(x - 1 + sqrt((x - 1) * (x + 1)))`. Resolves precision loss near $x pprox 1$.

### C++ Robustness & Compatibility:
- Added template overloads for `calculate_asinh` and `calculate_acosh` to maintain backwards compatibility with existing call sites that do not specify the `is_fp32_dest_acc_en` parameter.
- Integrated `log1p_init` into `init_inverse_hyperbolic` and `init_atanh` to ensure the required constants are loaded.

/claim #46862