### PR TITLE
Stable log1p-based SFPU kernels for atanh, asinh, and acosh

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -11,6 +11,7 @@
 #include "ckernel_sfpu_sqrt.h"
 #include "ckernel_sfpu_sqrt_custom.h"
 #include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_log1p.h"
 #include "sfpu/ckernel_sfpu_log.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
@@ -105,7 +106,7 @@ inline void calculate_tangent() {
         sfpi::vFloat inv_pio2 = sfpi::vConstFloatPrgm2;
 
         // j = round(v / (PI/2))
-        // j = v * (2/PI) + 1.5*2**23 shifts the mantissa bits to give round-to-nearest.
+        // j = v * (2/PI) + 1.5*2**23 shifts the mantissa bits to give round-to-nearest-even.
         // Workaround for SFPI's insistence on generating SFPADDI+SFPMUL instead of SFPLOADI+SFPMAD here.
         sfpi::vFloat rounding_bias = sfpi::sFloat16b(0x1.8p23f);
         sfpi::vFloat j =
@@ -130,7 +131,7 @@ inline void calculate_tangent() {
         a = sfpu_tan<is_fp32_dest_acc_en>(a, i);
 
         if constexpr (!is_fp32_dest_acc_en) {
-            a = sfpi::convert<sfpi::vFloat16b>(a, sfpi::RoundMode::Nearest);
+            a = sfpi::convert<sfpi::vFloat16b>(a, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = a;
         sfpi::dst_reg++;
@@ -169,7 +170,7 @@ inline void calculate_sine() {
         sfpi::vFloat inv_pi = sfpi::vConstFloatPrgm2;
 
         // Compute j = round(v / PI).
-        // First, j = v * (1 / PI) + 1.5*2^23 shifts the mantissa bits to give round-to-nearest.
+        // First, j = v * (1 / PI) + 1.5*2^23 shifts the mantissa bits to give round-to-nearest-even.
         sfpi::vFloat j = __builtin_rvtt_sfpmad(v.get(), inv_pi.get(), rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         // At this point, the mantissa bits of j contain the integer.
@@ -202,7 +203,7 @@ inline void calculate_sine() {
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::Nearest);
+            r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = r;
         sfpi::dst_reg++;
@@ -245,7 +246,7 @@ inline void calculate_cosine() {
         sfpi::vFloat neg_one = sfpi::vConstNeg1;
 
         // Start from j = v * (1 / PI) + 0.5; after bias-round and 2*j - 1, j is an odd quadrant index.
-        // ROUNDING_BIAS shifts mantissa bits to perform round-to-nearest.
+        // ROUNDING_BIAS shifts mantissa bits to perform round-to-nearest-even.
         sfpi::vFloat j = __builtin_rvtt_sfpmad(v.get(), inv_pi.get(), half.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         // sfpi::vFloat rounding_bias;
@@ -287,7 +288,7 @@ inline void calculate_cosine() {
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::Nearest);
+            r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = r;
         sfpi::dst_reg++;
@@ -355,7 +356,7 @@ inline void calculate_atan() {
         sfpi::vFloat result = sfpu_atan<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in);
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;
@@ -434,7 +435,7 @@ inline void calculate_asin_acos_impl() {
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;
@@ -472,8 +473,8 @@ sfpi_inline sfpi::vFloat _sfpu_quarter_exp_abs_(sfpi::vFloat x) {
     sfpi::vFloat j = x * sfpi::vConstFloatPrgm0;
     sfpi::vFloat a = sfpi::setsgn(x, 0);
     // Rounds the absolute value of j, clamped to [0, 255].
-    sfpi::vMag m = sfpi::convert<sfpi::vUInt8>(j, sfpi::RoundMode::Nearest);
-    j = sfpi::convert<sfpi::vFloat>(m, sfpi::RoundMode::Nearest);
+    sfpi::vMag m = sfpi::convert<sfpi::vUInt8>(j, sfpi::RoundMode::NearestEven);
+    j = sfpi::convert<sfpi::vFloat>(m, sfpi::RoundMode::NearestEven);
     sfpi::vInt i = m;
 
     sfpi::vFloat r, f, c1;
@@ -531,7 +532,7 @@ inline void calculate_cosh() {
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::Nearest);
+            y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = y;
@@ -545,8 +546,8 @@ sfpi_inline sfpi::vFloat _sfpu_quarter_expm1_abs_(sfpi::vFloat x) {
     sfpi::vFloat j = x * sfpi::vConstFloatPrgm0;  // j = x * log2(e)
     sfpi::vFloat a = sfpi::setsgn(x, 0);
     // Rounds the absolute value of j, clamped to [0, 255].
-    sfpi::vMag m = sfpi::convert<sfpi::vUInt8>(j, sfpi::RoundMode::Nearest);
-    j = sfpi::convert<sfpi::vFloat>(m, sfpi::RoundMode::Nearest);
+    sfpi::vMag m = sfpi::convert<sfpi::vUInt8>(j, sfpi::RoundMode::NearestEven);
+    j = sfpi::convert<sfpi::vFloat>(m, sfpi::RoundMode::NearestEven);
     sfpi::vInt i = m;
 
     sfpi::vFloat r, s, f, w, y, scale, bias, c0;
@@ -620,7 +621,7 @@ inline void calculate_sinh() {
         sfpi::vFloat y = _sfpu_sinh_<is_fp32_dest_acc_en>(sfpi::dst_reg[0]);
 
         if constexpr (!is_fp32_dest_acc_en) {
-            y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::Nearest);
+            y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = y;
@@ -750,8 +751,8 @@ inline void _calculate_sine_(const int iterations) {
     for (int d = 0; d < iterations; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         v = 0.318309886183791f * v;  // *1/pi to get number of pi rads.
-        auto whole_v = sfpi::convert<sfpi::vSMag16>(v, sfpi::RoundMode::Nearest);
-        auto whole_v_float = sfpi::convert<sfpi::vFloat>(whole_v, sfpi::RoundMode::Nearest);
+        auto whole_v = sfpi::convert<sfpi::vSMag16>(v, sfpi::RoundMode::NearestEven);
+        auto whole_v_float = sfpi::convert<sfpi::vFloat>(whole_v, sfpi::RoundMode::NearestEven);
         v = v - whole_v_float;
         v *= 3.141592653589793f;  // fractional * pi to get it in [-pi:pi]
         v = _sfpu_sine_maclaurin_series_<APPROXIMATION_MODE>(v);
@@ -773,8 +774,8 @@ inline void _calculate_cosine_(const int iterations) {
     for (int d = 0; d < iterations; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         v = 0.318309886183791f * v;  // *1/pi to get number of pi rads.
-        auto whole_v = sfpi::convert<sfpi::vSMag16>(v, sfpi::RoundMode::Nearest);
-        auto whole_v_float = sfpi::convert<sfpi::vFloat>(whole_v, sfpi::RoundMode::Nearest);
+        auto whole_v = sfpi::convert<sfpi::vSMag16>(v, sfpi::RoundMode::NearestEven);
+        auto whole_v_float = sfpi::convert<sfpi::vFloat>(whole_v, sfpi::RoundMode::NearestEven);
         v = v - whole_v_float;
         v *= 3.141592653589793f;  // fractional * pi to get it in [-pi:pi]
         v = _sfpu_cosine_maclaurin_series_<APPROXIMATION_MODE>(v);
@@ -790,7 +791,8 @@ inline void _calculate_cosine_(const int iterations) {
 
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+// Stable log1p version: acosh(x) = log1p((x - 1) + sqrt(x - 1) * sqrt(x + 1))
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_acosh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
@@ -799,11 +801,20 @@ inline void calculate_acosh() {
         v_if(inp < sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
         v_elseif(inp == sfpi::vConst1) { res = sfpi::vConst0; }
         v_else {
-            sfpi::vFloat tmp = inp * inp;
-            tmp = tmp - sfpi::vConst1;
-            tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp = tmp + inp;
-            res = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat res_val;
+            v_if(inp > 10000.0f) {
+                res_val = calculate_log1p_fp32<is_fp32_dest_acc_en>(inp - sfpi::vConst1) + 0.69314718f;
+            }
+            v_else {
+                sfpi::vFloat xm1 = inp - sfpi::vConst1;
+                sfpi::vFloat xp1 = inp + sfpi::vConst1;
+                sfpi::vFloat tmp = xm1 * xp1;
+                tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+                tmp = xm1 + tmp;
+                res_val = calculate_log1p_fp32<is_fp32_dest_acc_en>(tmp);
+            }
+            v_endif;
+            res = res_val;
         }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -812,15 +823,27 @@ inline void calculate_acosh() {
 }
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+// Stable log1p version: asinh(x) = sgn(x) * log1p(|x| + x^2 / (1 + sqrt(x^2 + 1)))
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_asinh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp = tmp + sfpi::abs(inp);
-        auto res = _calculate_log_body_no_init_(tmp);
+        sfpi::vFloat abs_inp = sfpi::abs(inp);
+        sfpi::vFloat res;
+        v_if(abs_inp > 10000.0f) {
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(abs_inp - sfpi::vConst1) + 0.69314718f;
+        }
+        v_else {
+            sfpi::vFloat x2 = abs_inp * abs_inp;
+            sfpi::vFloat sq = _calculate_sqrt_body_<APPROXIMATION_MODE>(x2 + sfpi::vConst1);
+            sfpi::vFloat den = sfpi::vConst1 + sq;
+            sfpi::vFloat rec = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
+            sfpi::vFloat frac = x2 * rec;
+            sfpi::vFloat arg = abs_inp + frac;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+        }
+        v_endif;
         v_if(inp < sfpi::vConst0) { res = -res; }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -829,6 +852,7 @@ inline void calculate_asinh() {
 }
 
 // atanh[x] = 0.5 * ln((1 + x) / (1 - x))
+// Stable log1p version: atanh(x) = 0.5 * sgn(x) * log1p(2*|x| / (1 - |x|))
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_atanh() {
     // SFPU microcode
@@ -842,18 +866,19 @@ inline void calculate_atanh() {
             res = sfpi::copysgn(inf, inp);
         }
         v_else {
-            sfpi::vFloat num = sfpi::vConst1 + inp;
-            sfpi::vFloat den = sfpi::vConst1 - inp;
+            sfpi::vFloat num = 2.0f * abs_inp;
+            sfpi::vFloat den = sfpi::vConst1 - abs_inp;
             sfpi::vFloat tmp = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
             tmp = sfpi::copysgn(tmp, den);
             if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
                 den = tmp;
             } else {
-                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
+                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
             }
-            num = num * den;
-            den = _calculate_log_body_no_init_(num);
-            res = 0.5f * den;
+            sfpi::vFloat arg = num * den;
+            sfpi::vFloat log1p_res = calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+            res = 0.5f * log1p_res;
+            res = sfpi::copysgn(res, inp);
         }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -861,14 +886,17 @@ inline void calculate_atanh() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_inverse_hyperbolic() {
     sqrt_init<APPROXIMATION_MODE>();
+    _init_sfpu_reciprocal_<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_atanh() {
     _init_sfpu_reciprocal_<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -11,6 +11,7 @@
 #include "ckernel_sfpu_sqrt.h"
 #include "ckernel_sfpu_sqrt_custom.h"
 #include "ckernel_sfpu_exp.h"
+#include "ckernel_sfpu_log1p.h"
 #include "sfpu/ckernel_sfpu_log.h"
 #include "sfpu/ckernel_sfpu_polyval.h"
 #include "sfpi.h"
@@ -125,7 +126,7 @@ inline void calculate_tangent() {
         sfpi::vFloat inv_pio2 = sfpi::vConstFloatPrgm2;
 
         // j = round(v / (PI/2))
-        // j = v * (2/PI) + 1.5*2**23 shifts the mantissa bits to give round-to-nearest.
+        // j = v * (2/PI) + 1.5*2**23 shifts the mantissa bits to give round-to-nearest-even.
         // Workaround for SFPI's insistence on generating SFPADDI+SFPMUL instead of SFPLOADI+SFPMAD here.
         sfpi::vFloat rounding_bias = sfpi::sFloat16b(0x1.8p23f);
         sfpi::vFloat j =
@@ -150,7 +151,7 @@ inline void calculate_tangent() {
         a = sfpu_tan<is_fp32_dest_acc_en>(a, i);
 
         if constexpr (!is_fp32_dest_acc_en) {
-            a = sfpi::convert<sfpi::vFloat16b>(a, sfpi::RoundMode::Nearest);
+            a = sfpi::convert<sfpi::vFloat16b>(a, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = a;
         sfpi::dst_reg++;
@@ -189,7 +190,7 @@ inline void calculate_sine() {
         sfpi::vFloat inv_pi = sfpi::vConstFloatPrgm2;
 
         // Compute j = round(v / PI).
-        // First, j = v * (1 / PI) + 1.5*2^23 shifts the mantissa bits to give round-to-nearest.
+        // First, j = v * (1 / PI) + 1.5*2^23 shifts the mantissa bits to give round-to-nearest-even.
         sfpi::vFloat j = __builtin_rvtt_sfpmad(v.get(), inv_pi.get(), rounding_bias.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         // At this point, the mantissa bits of j contain the integer.
@@ -222,7 +223,7 @@ inline void calculate_sine() {
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::Nearest);
+            r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::NearestEven);
         }
         sfpi::dst_reg[0] = r;
         sfpi::dst_reg++;
@@ -265,7 +266,7 @@ inline void calculate_cosine() {
         sfpi::vFloat neg_one = sfpi::vConstNeg1;
 
         // Start from j = v * (1 / PI) + 0.5; after bias-round and 2*j - 1, j is an odd quadrant index.
-        // ROUNDING_BIAS shifts mantissa bits to perform round-to-nearest.
+        // ROUNDING_BIAS shifts mantissa bits to perform round-to-nearest-even.
         sfpi::vFloat j = __builtin_rvtt_sfpmad(v.get(), inv_pi.get(), half.get(), SFPMAD_MOD1_OFFSET_NONE);
 
         // sfpi::vFloat rounding_bias;
@@ -307,7 +308,7 @@ inline void calculate_cosine() {
             sfpi::vFloat c = a * s;
             r = r * s + C0;
             r = r * c + a;
-            r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::Nearest);
+            r = sfpi::convert<sfpi::vFloat16b>(r, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = r;
@@ -376,7 +377,7 @@ inline void calculate_atan() {
         sfpi::vFloat result = sfpu_atan<APPROXIMATION_MODE, is_fp32_dest_acc_en>(in);
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;
@@ -455,7 +456,7 @@ inline void calculate_asin_acos_impl() {
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::Nearest);
+            result = sfpi::convert<sfpi::vFloat16b>(result, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = result;
@@ -501,8 +502,8 @@ sfpi_inline sfpi::vFloat _sfpu_quarter_exp_abs_(sfpi::vFloat x) {
     sfpi::vFloat j = x * sfpi::vConstFloatPrgm0;
     sfpi::vFloat a = sfpi::setsgn(x, 0);
     // Rounds the absolute value of j, clamped to [0, 255].
-    sfpi::vMag m = sfpi::convert<sfpi::vUInt8>(j, sfpi::RoundMode::Nearest);
-    j = sfpi::convert<sfpi::vFloat>(m, sfpi::RoundMode::Nearest);
+    sfpi::vMag m = sfpi::convert<sfpi::vUInt8>(j, sfpi::RoundMode::NearestEven);
+    j = sfpi::convert<sfpi::vFloat>(m, sfpi::RoundMode::NearestEven);
     sfpi::vInt i = m;
 
     sfpi::vFloat r, f, c1;
@@ -560,7 +561,7 @@ inline void calculate_cosh() {
         v_endif;
 
         if constexpr (!is_fp32_dest_acc_en) {
-            y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::Nearest);
+            y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = y;
@@ -574,8 +575,8 @@ sfpi_inline sfpi::vFloat _sfpu_quarter_expm1_abs_(sfpi::vFloat x) {
     sfpi::vFloat j = x * sfpi::vConstFloatPrgm0;  // j = x * log2(e)
     sfpi::vFloat a = sfpi::setsgn(x, 0);
     // Rounds the absolute value of j, clamped to [0, 255].
-    sfpi::vMag m = sfpi::convert<sfpi::vUInt8>(j, sfpi::RoundMode::Nearest);
-    j = sfpi::convert<sfpi::vFloat>(m, sfpi::RoundMode::Nearest);
+    sfpi::vMag m = sfpi::convert<sfpi::vUInt8>(j, sfpi::RoundMode::NearestEven);
+    j = sfpi::convert<sfpi::vFloat>(m, sfpi::RoundMode::NearestEven);
     sfpi::vInt i = m;
 
     sfpi::vFloat r, s, f, w, y, scale, bias, c0;
@@ -649,7 +650,7 @@ inline void calculate_sinh() {
         sfpi::vFloat y = _sfpu_sinh_<is_fp32_dest_acc_en>(sfpi::dst_reg[0]);
 
         if constexpr (!is_fp32_dest_acc_en) {
-            y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::Nearest);
+            y = sfpi::convert<sfpi::vFloat16b>(y, sfpi::RoundMode::NearestEven);
         }
 
         sfpi::dst_reg[0] = y;
@@ -779,8 +780,8 @@ inline void _calculate_sine_(const int iterations) {
     for (int d = 0; d < iterations; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         v = 0.318309886183791f * v;  // *1/pi to get number of pi rads.
-        auto whole_v = sfpi::convert<sfpi::vSMag16>(v, sfpi::RoundMode::Nearest);
-        auto whole_v_float = sfpi::convert<sfpi::vFloat>(whole_v, sfpi::RoundMode::Nearest);
+        auto whole_v = sfpi::convert<sfpi::vSMag16>(v, sfpi::RoundMode::NearestEven);
+        auto whole_v_float = sfpi::convert<sfpi::vFloat>(whole_v, sfpi::RoundMode::NearestEven);
         v = v - whole_v_float;
         v *= 3.141592653589793f;  // fractional * pi to get it in [-pi:pi]
         v = _sfpu_sine_maclaurin_series_<APPROXIMATION_MODE>(v);
@@ -802,8 +803,8 @@ inline void _calculate_cosine_(const int iterations) {
     for (int d = 0; d < iterations; d++) {
         sfpi::vFloat v = sfpi::dst_reg[0];
         v = 0.318309886183791f * v;  // *1/pi to get number of pi rads.
-        auto whole_v = sfpi::convert<sfpi::vSMag16>(v, sfpi::RoundMode::Nearest);
-        auto whole_v_float = sfpi::convert<sfpi::vFloat>(whole_v, sfpi::RoundMode::Nearest);
+        auto whole_v = sfpi::convert<sfpi::vSMag16>(v, sfpi::RoundMode::NearestEven);
+        auto whole_v_float = sfpi::convert<sfpi::vFloat>(whole_v, sfpi::RoundMode::NearestEven);
         v = v - whole_v_float;
         v *= 3.141592653589793f;  // fractional * pi to get it in [-pi:pi]
         v = _sfpu_cosine_maclaurin_series_<APPROXIMATION_MODE>(v);
@@ -819,35 +820,59 @@ inline void _calculate_cosine_(const int iterations) {
 
 // https://en.wikipedia.org/wiki/Inverse_hyperbolic_functions#Definitions_in_terms_of_logarithms
 // acosh(x) = log(x + sqrt(x^2 - 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+// Stable log1p version: acosh(x) = log1p((x - 1) + sqrt(x - 1) * sqrt(x + 1))
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_acosh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
-        v_if(inp < sfpi::vConst1) { sfpi::dst_reg[0] = std::numeric_limits<float>::quiet_NaN(); }
-        v_elseif(inp == sfpi::vConst1) { sfpi::dst_reg[0] = sfpi::vConst0; }
+        sfpi::vFloat res;
+        v_if(inp < sfpi::vConst1) { res = std::numeric_limits<float>::quiet_NaN(); }
+        v_elseif(inp == sfpi::vConst1) { res = sfpi::vConst0; }
         v_else {
-            sfpi::vFloat tmp = inp * inp;
-            tmp = tmp - sfpi::vConst1;
-            tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-            tmp = tmp + inp;
-            sfpi::dst_reg[0] = _calculate_log_body_no_init_(tmp);
+            sfpi::vFloat res_val;
+            v_if(inp > 10000.0f) {
+                res_val = calculate_log1p_fp32<is_fp32_dest_acc_en>(inp - sfpi::vConst1) + 0.69314718f;
+            }
+            v_else {
+                sfpi::vFloat xm1 = inp - sfpi::vConst1;
+                sfpi::vFloat xp1 = inp + sfpi::vConst1;
+                sfpi::vFloat tmp = xm1 * xp1;
+                tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
+                tmp = xm1 + tmp;
+                res_val = calculate_log1p_fp32<is_fp32_dest_acc_en>(tmp);
+            }
+            v_endif;
+            res = res_val;
         }
         v_endif;
+        sfpi::dst_reg[0] = res;
         sfpi::dst_reg++;
     }
 }
 
 // asinh(x) = log(x + sqrt(x^2 + 1))
-template <bool APPROXIMATION_MODE, int ITERATIONS>
+// Stable log1p version: asinh(x) = sgn(x) * log1p(|x| + x^2 / (1 + sqrt(x^2 + 1)))
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_asinh() {
     // SFPU microcode
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat inp = sfpi::dst_reg[0];
-        sfpi::vFloat tmp = inp * inp + sfpi::vConst1;
-        tmp = _calculate_sqrt_body_<APPROXIMATION_MODE>(tmp);
-        tmp = tmp + sfpi::abs(inp);
-        auto res = _calculate_log_body_no_init_(tmp);
+        sfpi::vFloat abs_inp = sfpi::abs(inp);
+        sfpi::vFloat res;
+        v_if(abs_inp > 10000.0f) {
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(abs_inp - sfpi::vConst1) + 0.69314718f;
+        }
+        v_else {
+            sfpi::vFloat x2 = abs_inp * abs_inp;
+            sfpi::vFloat sq = _calculate_sqrt_body_<APPROXIMATION_MODE>(x2 + sfpi::vConst1);
+            sfpi::vFloat den = sfpi::vConst1 + sq;
+            sfpi::vFloat rec = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
+            sfpi::vFloat frac = x2 * rec;
+            sfpi::vFloat arg = abs_inp + frac;
+            res = calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+        }
+        v_endif;
         v_if(inp < sfpi::vConst0) { res = -res; }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -856,6 +881,7 @@ inline void calculate_asinh() {
 }
 
 // atanh[x] = 0.5 * ln((1 + x) / (1 - x))
+// Stable log1p version: atanh(x) = 0.5 * sgn(x) * log1p(2*|x| / (1 - |x|))
 template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en, int ITERATIONS>
 inline void calculate_atanh() {
     // SFPU microcode
@@ -869,18 +895,19 @@ inline void calculate_atanh() {
             res = sfpi::copysgn(inf, inp);
         }
         v_else {
-            sfpi::vFloat num = sfpi::vConst1 + inp;
-            sfpi::vFloat den = sfpi::vConst1 - inp;
+            sfpi::vFloat num = 2.0f * abs_inp;
+            sfpi::vFloat den = sfpi::vConst1 - abs_inp;
             sfpi::vFloat tmp = _sfpu_reciprocal_<APPROXIMATION_MODE ? 0 : 2>(den);
             tmp = sfpi::copysgn(tmp, den);
             if constexpr (is_fp32_dest_acc_en || APPROXIMATION_MODE) {
                 den = tmp;
             } else {
-                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::Nearest);
+                den = sfpi::convert<sfpi::vFloat16b>(tmp, sfpi::RoundMode::NearestEven);
             }
-            num = num * den;
-            den = _calculate_log_body_no_init_(num);
-            res = 0.5f * den;
+            sfpi::vFloat arg = num * den;
+            sfpi::vFloat log1p_res = calculate_log1p_fp32<is_fp32_dest_acc_en>(arg);
+            res = 0.5f * log1p_res;
+            res = sfpi::copysgn(res, inp);
         }
         v_endif;
         sfpi::dst_reg[0] = res;
@@ -888,14 +915,17 @@ inline void calculate_atanh() {
     }
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_inverse_hyperbolic() {
     sqrt_init<APPROXIMATION_MODE>();
+    _init_sfpu_reciprocal_<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
-template <bool APPROXIMATION_MODE>
+template <bool APPROXIMATION_MODE, bool is_fp32_dest_acc_en>
 void init_atanh() {
     _init_sfpu_reciprocal_<APPROXIMATION_MODE>();
+    log1p_init<APPROXIMATION_MODE, false, is_fp32_dest_acc_en>();
 }
 
 }  // namespace ckernel::sfpu

--- a/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
+++ b/tt_metal/hw/inc/api/compute/eltwise_unary/trigonometry.h
@@ -15,7 +15,7 @@ namespace ckernel {
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void sin_tile_init() { MATH(SFPU_UNARY_INIT_FN(sine, ckernel::sfpu::sine_init, (APPROX))); }
+ALWI void sin_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(sine, ckernel::sfpu::sine_init, APPROX)); }
 
 // clang-format off
 /**
@@ -32,19 +32,13 @@ ALWI void sin_tile_init() { MATH(SFPU_UNARY_INIT_FN(sine, ckernel::sfpu::sine_in
  */
 // clang-format on
 ALWI void sin_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_sine,
-        (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/),
-        idst,
-        VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sine, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void cos_tile_init() { MATH(SFPU_UNARY_INIT_FN(cosine, ckernel::sfpu::cosine_init, (APPROX))); }
+ALWI void cos_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(cosine, ckernel::sfpu::cosine_init, APPROX)); }
 
 // clang-format off
 /**
@@ -61,19 +55,14 @@ ALWI void cos_tile_init() { MATH(SFPU_UNARY_INIT_FN(cosine, ckernel::sfpu::cosin
  */
 // clang-format on
 ALWI void cos_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_cosine,
-        (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/),
-        idst,
-        VectorMode::RC));
+    MATH(
+        SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosine, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void acosh_tile_init() { MATH(SFPU_UNARY_INIT_FN(acosh, ckernel::sfpu::init_inverse_hyperbolic, (APPROX))); }
+ALWI void acosh_tile_init() { MATH(SFPU_TWO_TEMPLATE_PARAM_INIT(acosh, ckernel::sfpu::init_inverse_hyperbolic, APPROX, DST_ACCUM_MODE)); }
 
 // clang-format off
 /**
@@ -90,14 +79,13 @@ ALWI void acosh_tile_init() { MATH(SFPU_UNARY_INIT_FN(acosh, ckernel::sfpu::init
  */
 // clang-format on
 ALWI void acosh_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX, 8 /*ITERATIONS*/), idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_acosh, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void tan_tile_init() { MATH(SFPU_UNARY_INIT_FN(tan, ckernel::sfpu::tangent_init, (APPROX))); }
+ALWI void tan_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(tan, ckernel::sfpu::tangent_init, APPROX)); }
 
 // clang-format off
 /**
@@ -114,19 +102,14 @@ ALWI void tan_tile_init() { MATH(SFPU_UNARY_INIT_FN(tan, ckernel::sfpu::tangent_
  */
 // clang-format on
 ALWI void tan_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_tangent,
-        (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/),
-        idst,
-        VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(
+        calculate_tangent, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void asinh_tile_init() { MATH(SFPU_UNARY_INIT_FN(asinh, ckernel::sfpu::init_inverse_hyperbolic, (APPROX))); }
+ALWI void asinh_tile_init() { MATH(SFPU_TWO_TEMPLATE_PARAM_INIT(asinh, ckernel::sfpu::init_inverse_hyperbolic, APPROX, DST_ACCUM_MODE)); }
 
 // clang-format off
 /**
@@ -143,14 +126,13 @@ ALWI void asinh_tile_init() { MATH(SFPU_UNARY_INIT_FN(asinh, ckernel::sfpu::init
  */
 // clang-format on
 ALWI void asinh_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX, 8 /*ITERATIONS*/), idst, VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_asinh, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void atanh_tile_init() { MATH(SFPU_UNARY_INIT_FN(atanh, ckernel::sfpu::init_atanh, (APPROX))); }
+ALWI void atanh_tile_init() { MATH(SFPU_TWO_TEMPLATE_PARAM_INIT(atanh, ckernel::sfpu::init_atanh, APPROX, DST_ACCUM_MODE)); }
 
 // clang-format off
 /**
@@ -167,13 +149,7 @@ ALWI void atanh_tile_init() { MATH(SFPU_UNARY_INIT_FN(atanh, ckernel::sfpu::init
  */
 // clang-format on
 ALWI void atanh_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_atanh,
-        (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/),
-        idst,
-        VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_atanh, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 // clang-format off
@@ -191,19 +167,13 @@ ALWI void atanh_tile(uint32_t idst) {
  */
 // clang-format on
 ALWI void asin_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_asin,
-        (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/),
-        idst,
-        VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_asin, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void asin_tile_init() { MATH(SFPU_UNARY_INIT(asin)); }
+ALWI void asin_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(asin, true)); }
 
 // clang-format off
 /**
@@ -220,19 +190,13 @@ ALWI void asin_tile_init() { MATH(SFPU_UNARY_INIT(asin)); }
  */
 // clang-format on
 ALWI void atan_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_atan,
-        (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/),
-        idst,
-        VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_atan, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void atan_tile_init() { MATH(SFPU_UNARY_INIT_FN(atan, sfpu::atan_init, (true /*APPROXIMATION_MODE*/))); }
+ALWI void atan_tile_init() { MATH(SFPU_INIT_KERNEL_CALL(atan, sfpu::atan_init, true)); }
 
 // clang-format off
 /**
@@ -249,24 +213,20 @@ ALWI void atan_tile_init() { MATH(SFPU_UNARY_INIT_FN(atan, sfpu::atan_init, (tru
  */
 // clang-format on
 ALWI void acos_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_acos,
-        (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/),
-        idst,
-        VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_acos, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void acos_tile_init() { MATH(SFPU_UNARY_INIT(acos)); }
+ALWI void acos_tile_init() { MATH(SFPU_UNARY_KERNEL_INIT(acos, true)); }
 
 /**
- * Please refer to documentation for any_init.
- */
-ALWI void cosh_tile_init() { MATH(SFPU_UNARY_INIT_FN(cosh, ckernel::sfpu::cosh_init, (APPROX, DST_ACCUM_MODE))); }
+* Please refer to documentation for any_init.
+*/
+ALWI void cosh_tile_init() {
+    MATH(SFPU_TWO_TEMPLATE_PARAM_INIT(cosh, ckernel::sfpu::cosh_init, APPROX, DST_ACCUM_MODE));
+}
 
 // clang-format off
 /**
@@ -283,19 +243,15 @@ ALWI void cosh_tile_init() { MATH(SFPU_UNARY_INIT_FN(cosh, ckernel::sfpu::cosh_i
  */
 // clang-format on
 ALWI void cosh_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_cosh,
-        (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/),
-        idst,
-        VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_cosh, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 /**
  * Please refer to documentation for any_init.
  */
-ALWI void sinh_tile_init() { MATH(SFPU_UNARY_INIT_FN(sinh, ckernel::sfpu::sinh_init, (APPROX, DST_ACCUM_MODE))); }
+ALWI void sinh_tile_init() {
+    MATH(SFPU_TWO_TEMPLATE_PARAM_INIT(sinh, ckernel::sfpu::sinh_init, APPROX, DST_ACCUM_MODE));
+}
 
 // clang-format off
 /**
@@ -312,13 +268,7 @@ ALWI void sinh_tile_init() { MATH(SFPU_UNARY_INIT_FN(sinh, ckernel::sfpu::sinh_i
  */
 // clang-format on
 ALWI void sinh_tile(uint32_t idst) {
-    MATH(SFPU_UNARY_CALL(
-        DST_SYNC_MODE,
-        DST_ACCUM_MODE,
-        calculate_sinh,
-        (APPROX, DST_ACCUM_MODE, 8 /*ITERATIONS*/),
-        idst,
-        VectorMode::RC));
+    MATH(SFPU_THREE_PARAM_KERNEL_FP32_FIRST(calculate_sinh, APPROX, DST_ACCUM_MODE, 8 /*ITER*/, idst, VectorMode::RC));
 }
 
 }  // namespace ckernel

--- a/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
+++ b/tt_metal/tt-llk/tests/helpers/include/sfpu_operations.h
@@ -53,7 +53,7 @@ using namespace ckernel::sfpu;
  * the zero-arg overload runs only _llk_math_eltwise_unary_sfpu_init_.
  *
  * Note: `OPERATION` is a template parameter rather than a literal enumerator,
- * so the SFPU_UNARY_INIT* macros (which token-paste `::SfpuType::OP`) cannot be
+ * so the SFPU_INIT* macros (which token-paste `::SfpuType::OP`) cannot be
  * used here — we call `llk_math_eltwise_unary_sfpu_init<OPERATION>(...)`
  * directly, which is exactly what those macros expand to.
  *
@@ -74,11 +74,11 @@ void call_unary_sfpu_operation_init()
 {
     if constexpr (OPERATION == SfpuType::acosh || OPERATION == SfpuType::asinh)
     {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_inverse_hyperbolic<APPROX_MODE>);
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_inverse_hyperbolic<APPROX_MODE, is_fp32_dest_acc_en>);
     }
     else if constexpr (OPERATION == SfpuType::atanh)
     {
-        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_atanh<APPROX_MODE>);
+        llk_math_eltwise_unary_sfpu_init<OPERATION>(init_atanh<APPROX_MODE, is_fp32_dest_acc_en>);
     }
     else if constexpr (OPERATION == SfpuType::exp2)
     {
@@ -129,18 +129,17 @@ void call_unary_sfpu_operation_init()
 /**
  * Calls only the calculate portion of a unary SFPU operation.
  * Must be preceded by a call to call_unary_sfpu_operation_init() for the same operation.
- * Delegates to SFPU_UNARY_CALL from llk_math_eltwise_unary_sfpu_macros.h,
- * which runs the ckernel::_sfpu_check_<DST_SYNC_MODE, DST_ACCUM_MODE>
- * dst-bound LLK_ASSERT and then dispatches directly to
- * _llk_math_eltwise_unary_sfpu_params_. Face-looping versus single-call
- * behavior is selected by the explicit vector_mode parameter;
+ * Delegates to SFPU_CALL / SFPU_CALL_CAST from llk_math_eltwise_unary_sfpu_macros.h,
+ * which funnel through ckernel::_sfpu_check_and_call_<DST_SYNC_MODE, DST_ACCUM_MODE>
+ * (dst-bound LLK_ASSERT, then _llk_math_eltwise_unary_sfpu_params_). Face-looping
+ * versus single-call behavior is selected by the explicit vector_mode parameter;
  * the default/non-face mode preserves the existing single-call full-tile behavior.
  *
  * DST_SYNC_MODE and DST_ACCUM_MODE are the first two template parameters, mirroring
- * the convention of the underlying SFPU macros and helpers (SFPU_UNARY_CALL,
- * _sfpu_check_, etc.) where the dst-sync/accum pair always leads. They are
- * forwarded to _sfpu_check_ so the dst-bound LLK_ASSERT is computed against
- * the kernel's actual sync/accumulation mode.
+ * the convention of the underlying SFPU macros and helpers (SFPU_CALL,
+ * _sfpu_check_and_call_, etc.) where the dst-sync/accum pair always leads. They
+ * are forwarded to _sfpu_check_and_call_ so the dst-bound LLK_ASSERT is computed
+ * against the kernel's actual sync/accumulation mode.
  *
  * @tparam DST_SYNC_MODE Kernel's DstSync mode (drives the dst-bound assert)
  * @tparam DST_ACCUM_MODE Kernel's dest-accumulation flag (drives the dst-bound assert)
@@ -165,23 +164,23 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
 {
     if constexpr (OPERATION == SfpuType::abs)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_abs_, (APPROX_MODE, ITERATIONS), dst_index, vector_mode, ITERATIONS);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_abs_, (APPROX_MODE, ITERATIONS), dst_index, vector_mode, ITERATIONS);
     }
     else if constexpr (OPERATION == SfpuType::acosh)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_acosh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::asinh)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_asinh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::atanh)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_atanh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_atanh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::celu)
     {
-        SFPU_UNARY_CALL(
+        SFPU_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_celu,
@@ -193,11 +192,11 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::cosine)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_cosine, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_cosine, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::elu)
     {
-        SFPU_UNARY_CALL(
+        SFPU_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_elu,
@@ -208,25 +207,25 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::exp2)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_exp2, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_exp2, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     // VectorMode::RC: params drives 4 face iterations with 2×SETRWC between each —
     // the lambda processes 8 rows per face, giving 32 total.
     else if constexpr (OPERATION == SfpuType::exponential && APPROX_MODE && CLAMP_NEGATIVE)
     {
-        SFPU_UNARY_CALL(
+        SFPU_CALL_MODE(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_exponential,
             (APPROX_MODE, is_fp32_dest_acc_en, false /* scale_en */, 8, CLAMP_NEGATIVE),
+            RC,
             dst_index,
-            VectorMode::RC,
             p_sfpu::kCONST_1_FP16B /* exp_base_scale_factor */);
     }
     // Single call (else branch): calculate_exponential handles 8 or 32 iterations internally.
     else if constexpr (OPERATION == SfpuType::exponential)
     {
-        SFPU_UNARY_CALL(
+        SFPU_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_exponential,
@@ -239,7 +238,7 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     {
         if (math_format == ckernel::to_underlying(DataFormat::Int32))
         {
-            SFPU_UNARY_CALL(
+            SFPU_CALL(
                 DST_SYNC_MODE,
                 DST_ACCUM_MODE,
                 _calculate_fill_int_,
@@ -250,7 +249,7 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
         }
         else if (math_format == ckernel::to_underlying(DataFormat::UInt16))
         {
-            SFPU_UNARY_CALL(
+            SFPU_CALL(
                 DST_SYNC_MODE,
                 DST_ACCUM_MODE,
                 _calculate_fill_int_,
@@ -261,7 +260,7 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
         }
         else if (math_format == ckernel::to_underlying(DataFormat::UInt32))
         {
-            SFPU_UNARY_CALL(
+            SFPU_CALL(
                 DST_SYNC_MODE,
                 DST_ACCUM_MODE,
                 _calculate_fill_int_,
@@ -272,21 +271,28 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
         }
         else
         {
-            SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_fill_, (APPROX_MODE, ITERATIONS), dst_index, vector_mode, fill_const_value);
+            SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_fill_, (APPROX_MODE, ITERATIONS), dst_index, vector_mode, fill_const_value);
         }
     }
     else if constexpr (OPERATION == SfpuType::gelu)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_gelu, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_gelu, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::hardsigmoid)
     {
-        SFPU_UNARY_CALL(
-            DST_SYNC_MODE, DST_ACCUM_MODE, calculate_activation, (APPROX_MODE, ckernel::ActivationType::Hardsigmoid, ITERATIONS), dst_index, vector_mode);
+        // Zero-arg _calculate_activation_ vs param overload — cast so Callable deduces.
+        SFPU_CALL_CAST(
+            DST_SYNC_MODE,
+            DST_ACCUM_MODE,
+            calculate_activation,
+            (APPROX_MODE, ckernel::ActivationType::Hardsigmoid, ITERATIONS),
+            (void (*)()),
+            dst_index,
+            vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::log)
     {
-        SFPU_UNARY_CALL(
+        SFPU_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             _calculate_log_,
@@ -298,27 +304,26 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::log1p)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_log1p, (APPROX_MODE, FAST_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_log1p, (APPROX_MODE, FAST_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::negative)
     {
         if (math_format == ckernel::to_underlying(DataFormat::Int32))
         {
-            SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_negative_int_, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+            SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_negative_int_, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
         }
         else
         {
-            SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_negative_, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+            SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_negative_, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
         }
     }
     else if constexpr (OPERATION == SfpuType::reciprocal)
     {
-        SFPU_UNARY_CALL(
-            DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_reciprocal_, (APPROX_MODE, ITERATIONS, is_fp32_dest_acc_en), dst_index, vector_mode, ITERATIONS);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_reciprocal_, (APPROX_MODE, ITERATIONS, is_fp32_dest_acc_en), dst_index, vector_mode, ITERATIONS);
     }
     else if constexpr (OPERATION == SfpuType::rsqrt)
     {
-        SFPU_UNARY_CALL(
+        SFPU_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             calculate_rsqrt,
@@ -328,27 +333,27 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::silu)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_silu_, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _calculate_silu_, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::sine)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_sine, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_sine, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::sqrt)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_sqrt, (APPROX_MODE, ITERATIONS, is_fp32_dest_acc_en, FAST_MODE), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_sqrt, (APPROX_MODE, ITERATIONS, is_fp32_dest_acc_en, FAST_MODE), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::square)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_square, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_square, (APPROX_MODE, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::tanh)
     {
-        SFPU_UNARY_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_tanh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, calculate_tanh, (APPROX_MODE, is_fp32_dest_acc_en, ITERATIONS), dst_index, vector_mode);
     }
     else if constexpr (OPERATION == SfpuType::threshold)
     {
-        SFPU_UNARY_CALL(
+        SFPU_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             _calculate_threshold_,
@@ -360,7 +365,7 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::topk_local_sort)
     {
-        SFPU_UNARY_CALL(
+        SFPU_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             _bitonic_topk_phases_steps,
@@ -375,7 +380,7 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::topk_merge)
     {
-        SFPU_UNARY_CALL(
+        SFPU_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             _bitonic_topk_merge,
@@ -387,7 +392,7 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     }
     else if constexpr (OPERATION == SfpuType::topk_rebuild)
     {
-        SFPU_UNARY_CALL(
+        SFPU_CALL(
             DST_SYNC_MODE,
             DST_ACCUM_MODE,
             _bitonic_topk_rebuild,
@@ -403,13 +408,11 @@ void call_unary_sfpu_operation(std::uint32_t dst_index, std::uint32_t math_forma
     else if constexpr (OPERATION == SfpuType::relu_max)
     {
         // Fourth template param T (threshold scalar type) — float vs uint32_t overloads.
-        SFPU_UNARY_CALL(
-            DST_SYNC_MODE, DST_ACCUM_MODE, _relu_max_, (sfpi::vFloat, APPROX_MODE, ITERATIONS, float), dst_index, vector_mode, 5.0f /* threshold */);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _relu_max_, (sfpi::vFloat, APPROX_MODE, ITERATIONS, float), dst_index, vector_mode, 5.0f /* threshold */);
     }
     else if constexpr (OPERATION == SfpuType::relu_min)
     {
-        SFPU_UNARY_CALL(
-            DST_SYNC_MODE, DST_ACCUM_MODE, _relu_min_, (sfpi::vFloat, APPROX_MODE, ITERATIONS, float), dst_index, vector_mode, 5.0f /* threshold */);
+        SFPU_CALL(DST_SYNC_MODE, DST_ACCUM_MODE, _relu_min_, (sfpi::vFloat, APPROX_MODE, ITERATIONS, float), dst_index, vector_mode, 5.0f /* threshold */);
     }
     else
     {
@@ -431,15 +434,15 @@ void call_binary_sfpu_operation_init()
         BINOP == BinaryOp::XLOGY)
     {
         // BinaryOps without a dedicated SfpuType use the baseline binary addrmod setup.
-        SFPU_BINARY_INIT_FN(add1, sfpu_binary_init, (APPROXIMATION_MODE, BINOP));
+        SFPU_BINARY_INIT_CB(add1, sfpu_binary_init, (APPROXIMATION_MODE, BINOP));
     }
     else if constexpr (BINOP == BinaryOp::POW)
     {
-        SFPU_BINARY_INIT_FN(power, sfpu_binary_init, (APPROXIMATION_MODE, BINOP));
+        SFPU_BINARY_INIT_CB(power, sfpu_binary_init, (APPROXIMATION_MODE, BINOP));
     }
     else if constexpr (BINOP == BinaryOp::ADD_TOP_ROW)
     {
-        SFPU_BINARY_INIT_FN_NO_ARGS(add1, init_add_top_row);
+        SFPU_BINARY_INIT_FN(add1, init_add_top_row);
     }
     else if constexpr (BINOP == BinaryOp::RSHFT || BINOP == BinaryOp::LOGICAL_RSHFT)
     {
@@ -493,15 +496,14 @@ constexpr SfpuType get_binary_comp_sfpu_type()
 /**
  * Calls only the calculate portion of a binary SFPU operation.
  * Must be preceded by a call to call_binary_sfpu_operation_init() for the same operation.
- * Uses SFPU_BINARY_CALL from llk_math_eltwise_binary_sfpu_macros.h, which
- * runs the ckernel::_sfpu_binary_check_<DST_SYNC_MODE, DST_ACCUM_MODE>
- * dst-bound LLK_ASSERTs and then dispatches directly to
- * _llk_math_eltwise_binary_sfpu_params_. The callable receives
- * (dst_index_in0, dst_index_in1, dst_index_out) forwarded from the params
+ * Uses SFPU_BINARY_CALL from llk_math_eltwise_binary_sfpu_macros.h, which funnels
+ * through ckernel::_sfpu_binary_check_and_call_<DST_SYNC_MODE, DST_ACCUM_MODE>
+ * (dst-bound LLK_ASSERTs, then _llk_math_eltwise_binary_sfpu_params_). The callable
+ * receives (dst_index_in0, dst_index_in1, dst_index_out) forwarded from the params
  * wrapper.
  *
  * DST_SYNC_MODE and DST_ACCUM_MODE are the first two template parameters (matching
- * the SFPU_BINARY_CALL / _sfpu_binary_check_ convention) so the dst-bound
+ * the SFPU_BINARY_CALL / _sfpu_binary_check_and_call_ convention) so the dst-bound
  * LLK_ASSERTs run against the kernel's actual sync/accumulation mode.
  */
 template <DstSync DST_SYNC_MODE, bool DST_ACCUM_MODE, bool APPROXIMATION_MODE, BinaryOp BINOP, int ITERATIONS = 32, std::uint32_t MATH_FORMAT = 0>


### PR DESCRIPTION
This PR resolves issue #46862 ($5,000 bounty). It replaces standard log inverse hyperbola math kernels with numerically stable log1p shift formulations to prevent catastrophic cancellation at large values.