### PR TITLE
[Bug fix] jit_build: join all build steps before propagating (fix use-after-scope SEGV)

### DIFF
--- a/tt_metal/jit_build/build.cpp
+++ b/tt_metal/jit_build/build.cpp
@@ -15,6 +15,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <exception>
 #include <filesystem>
 #include <fstream>
 #include <iostream>
@@ -892,8 +893,24 @@ void launch_build_step(const std::function<void()>& build_func, std::vector<std:
 }
 
 void sync_build_steps(std::vector<std::shared_future<void>>& events) {
+    // Join EVERY task before propagating, even if one throws. The build steps are spawned
+    // onto other pool workers and capture this / out_dir / settings — all owned by the
+    // compile() call chain (out_dir's string lives in the caller frame). Returning on the
+    // first exception unwinds that chain while sibling tasks are still running and still
+    // dereference those captures → use-after-scope (benign serially, a SEGV under parallel
+    // load that immediately reuses the freed stack). Stash the first error, join all, rethrow.
+    std::exception_ptr first_error;
     for (auto& event : events) {
-        event.get();
+        try {
+            event.get();
+        } catch (...) {
+            if (!first_error) {
+                first_error = std::current_exception();
+            }
+        }
+    }
+    if (first_error) {
+        std::rethrow_exception(first_error);
     }
 }
 


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
`JitBuildState::compile()` fans its per-source compile steps onto the taskflow build pool via `launch_build_step`, then blocks on `sync_build_steps()` to join them. `sync_build_steps()` called `event.get()` in a loop and returned on the **first** future that threw — leaving sibling tasks still running on the pool.

Each spawned step is the lambda `[this, &out_dir, settings, i]`: it dereferences `this` (the `JitBuildState`), `out_dir` (whose backing string is owned by the caller, `build_kernel`), and `settings` (a `const JitBuildSettings*`) — all owned by the `compile()` call chain. Returning early from `sync_build_steps()` unwinds that chain while those sibling tasks are still in flight and still dereferencing the captures → **use-after-scope**.

It is benign when builds run serially (the freed stack is never reused before the task finishes), but under parallel load — where the stack is immediately reused — it manifests as an intermittent **SEGV** during JIT compilation.

The fix joins **every** future before propagating: each `event.get()` is wrapped, the first exception is stashed in an `std::exception_ptr`, and `std::rethrow_exception` runs only after all tasks have completed. No spawned task can outlive the `compile()` frame anymore, and the original compile error still surfaces unchanged.

### Notes for reviewers
- Happy path is unchanged: with no exception the loop joins all futures exactly as before and returns normally.
- The first thrown error is preserved and rethrown (subsequent failures are swallowed, matching the prior "first error wins" behavior); all that changes is that joins complete first.
- Surfaced while stressing the build pool from up-front parallel precompile (#46626), but the bug and fix are confined to `jit_build/build.cpp` and independent of that feature — split out so it can land on its own.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mstaletovic/jit-build-sync-segv-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mstaletovic/jit-build-sync-segv-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mstaletovic/jit-build-sync-segv-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mstaletovic/jit-build-sync-segv-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mstaletovic/jit-build-sync-segv-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mstaletovic/jit-build-sync-segv-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mstaletovic/jit-build-sync-segv-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mstaletovic/jit-build-sync-segv-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mstaletovic/jit-build-sync-segv-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mstaletovic/jit-build-sync-segv-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mstaletovic/jit-build-sync-segv-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mstaletovic/jit-build-sync-segv-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mstaletovic/jit-build-sync-segv-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mstaletovic/jit-build-sync-segv-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mstaletovic/jit-build-sync-segv-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mstaletovic/jit-build-sync-segv-fix)
