### PR TITLE
Add test and support for choosing different core grids for dispatch to run on

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_sdpa_loop.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_dispatch_sdpa_loop.py
@@ -1,0 +1,370 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal repro: MoE dispatch (edge-column vs edge-row cores) back-to-back with ring-joint SDPA.
+
+Loops two ops on a 2x4 FABRIC_2D mesh: the prefill dispatch op with its sender+untilize cores
+forced onto a single worker edge line (first_col / first_row via core_grid_override), immediately
+followed by ring-joint SDPA. No correctness check — this isolates a suspected dispatch<->ring-SDPA
+hang, so it only measures hang vs no-hang. first_row is the control.
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.common.utility_functions import is_blackhole
+from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    ExpertMapping,
+    compute_constants,
+    create_fabric_router_config,
+    extract_mesh_config,
+    get_dispatch_input_mesh_mapper,
+    get_gate_outputs,
+    get_max_payload_size,
+    initialize_test_inputs,
+)
+from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
+from models.demos.deepseek_v3_d_p.utils.test_utils import WH_WORKER_L1_SIZE
+from models.tt_dit.utils.padding import get_padded_vision_seq_len
+from tests.ttnn.unit_tests.operations.sdpa.sdpa_test_utils import fa_rand
+
+# Dispatch shape (matches test_prefill_dispatch_subdevices.py, the config that reproduces the
+# column-dispatch hang at 5K+ ISL).
+NUM_ROUTED_EXPERTS = 64
+NUM_EXPERTS_PER_TOK = 4
+DISPATCH_BUFFER_CAPACITY_FACTOR = 4
+EMB_DIM = DeepSeekV3Config.EMB_SIZE
+
+# SDPA shape (MLA prefill, scaled from the 32x4 production config as in test_ring_joint_mla.py).
+PRODUCTION_UP = 4
+NHQ_V_PRODUCTION = 128
+NHK = 1
+HEAD_DIM_Q_K = 576
+HEAD_DIM_V = 128
+Q_CHUNK_SIZE = 32
+K_CHUNK_SIZE = 32
+Q_DTYPE = ttnn.bfloat16
+KV_DTYPE = ttnn.bfloat8_b
+
+
+def _dispatch_edge_core_range_set(grid_x, grid_y, edge):
+    if edge == "first_col":
+        return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, grid_y - 1))})
+    if edge == "first_row":
+        return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, 0))})
+    raise ValueError(f"unknown dispatch_edge: {edge}")
+
+
+def run_dispatch_sdpa_loop(mesh_device, dispatch_edge, n_iters, seq_len_per_chip):
+    torch.manual_seed(42)
+
+    rp_axis, up_axis = 0, 1
+    mesh_shape = list(mesh_device.shape)
+    rp_factor = mesh_shape[rp_axis]
+    up_factor = mesh_shape[up_axis]
+
+    grid = mesh_device.compute_with_storage_grid_size()
+    grid_x, grid_y = grid.x, grid.y
+
+    # ---- Ring-joint SDPA setup (verbatim from run_ring_joint_sdpa) ----
+    nhq_v = (NHQ_V_PRODUCTION // PRODUCTION_UP) * up_factor
+    base_seq_len = seq_len_per_chip * rp_factor
+    padded_seq_len = get_padded_vision_seq_len(base_seq_len, rp_factor)
+    joint_seq_len = 0
+
+    sdpa_compute_grid = (grid_x - 1, grid_y)
+    ccl_core_grid_offset = (grid_x - 1, 0)
+
+    ccl_sub_device_crs = ttnn.CoreRangeSet(
+        {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}
+    )
+    worker_sub_device = ttnn.SubDevice([ccl_sub_device_crs])
+    worker_sub_device_id = ttnn.SubDeviceId(0)
+    sub_device_manager = mesh_device.create_sub_device_manager([worker_sub_device], 0)
+    mesh_device.load_sub_device_manager(sub_device_manager)
+    mesh_device.set_sub_device_stall_group([worker_sub_device_id])
+
+    # One semaphore pair, reused every iteration to mirror the model reusing the ring-attention
+    # semaphores across all layers. Fresh per-iteration handles would mask any cross-layer state.
+    ccl_semaphore_handles = [
+        [ttnn.create_global_semaphore(mesh_device, ccl_sub_device_crs, 0) for _ in range(2)] for _ in range(1)
+    ]
+
+    ag_output_shape_k = (1, NHK, padded_seq_len, HEAD_DIM_Q_K)
+    ag_output_shape_v = (1, nhq_v, padded_seq_len, HEAD_DIM_V)
+
+    kv_shard_dims = [None, None]
+    kv_shard_dims[up_axis] = 1
+    persistent_k_output_shard_dims = [None, None]
+
+    persistent_output_buffers = [
+        [
+            ttnn.as_tensor(
+                torch.zeros(ag_output_shape_k),
+                device=mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=KV_DTYPE,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=persistent_k_output_shard_dims
+                ),
+            ),
+            ttnn.as_tensor(
+                torch.zeros(ag_output_shape_v),
+                device=mesh_device,
+                layout=ttnn.TILE_LAYOUT,
+                dtype=KV_DTYPE,
+                memory_config=ttnn.DRAM_MEMORY_CONFIG,
+                mesh_mapper=ttnn.ShardTensor2dMesh(
+                    mesh_device, mesh_shape=tuple(mesh_device.shape), dims=kv_shard_dims
+                ),
+            ),
+        ]
+        for _ in range(1)
+    ]
+
+    program_config = ttnn.SDPAProgramConfig(
+        compute_with_storage_grid_size=sdpa_compute_grid,
+        q_chunk_size=Q_CHUNK_SIZE,
+        k_chunk_size=K_CHUNK_SIZE,
+        exp_approx_mode=False,
+    )
+    compute_kernel_config = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2,
+        math_approx_mode=False,
+        fp32_dest_acc_en=False,
+        packer_l1_acc=False,
+    )
+
+    Q = fa_rand(1, nhq_v, base_seq_len, HEAD_DIM_Q_K)
+    K = fa_rand(1, NHK, base_seq_len, HEAD_DIM_Q_K)
+    V = fa_rand(1, nhq_v, base_seq_len, HEAD_DIM_V)
+    padded_Q = torch.cat([Q, torch.zeros(1, nhq_v, padded_seq_len - base_seq_len, HEAD_DIM_Q_K)], dim=2)
+    padded_K = torch.cat([K, torch.zeros(1, NHK, padded_seq_len - base_seq_len, HEAD_DIM_Q_K)], dim=2)
+    padded_V = torch.cat([V, torch.zeros(1, nhq_v, padded_seq_len - base_seq_len, HEAD_DIM_V)], dim=2)
+
+    joint_Q = fa_rand(1, nhq_v, joint_seq_len, HEAD_DIM_Q_K)
+    joint_K = fa_rand(1, NHK, joint_seq_len, HEAD_DIM_Q_K)
+    joint_V = fa_rand(1, nhq_v, joint_seq_len, HEAD_DIM_V)
+
+    sdpa_input_shard_dims = [None, None]
+    sdpa_input_shard_dims[rp_axis] = 2
+    sdpa_input_shard_dims[up_axis] = 1
+
+    sdpa_joint_shard_dims = [None, None]
+    sdpa_joint_shard_dims[up_axis] = 1
+
+    sdpa_k_input_shard_dims = [None, None]
+    sdpa_k_input_shard_dims[rp_axis] = 2
+    sdpa_k_input_shard_dims[up_axis] = None if NHK == 1 else 1
+
+    tt_Q = ttnn.as_tensor(
+        padded_Q,
+        dtype=Q_DTYPE,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_input_shard_dims
+        ),
+    )
+    tt_K = ttnn.as_tensor(
+        padded_K,
+        dtype=KV_DTYPE,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_k_input_shard_dims
+        ),
+    )
+    tt_V = ttnn.as_tensor(
+        padded_V,
+        dtype=KV_DTYPE,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        memory_config=ttnn.DRAM_MEMORY_CONFIG,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_input_shard_dims
+        ),
+    )
+    tt_joint_Q = ttnn.from_torch(
+        joint_Q,
+        dtype=Q_DTYPE,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_joint_shard_dims
+        ),
+    )
+    joint_k_mesh_mapper = (
+        ttnn.ShardTensor2dMesh(mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_k_input_shard_dims)
+        if NHK > 1
+        else ttnn.ReplicateTensorToMesh(mesh_device)
+    )
+    tt_joint_K = ttnn.from_torch(
+        joint_K,
+        dtype=KV_DTYPE,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=joint_k_mesh_mapper,
+    )
+    tt_joint_V = ttnn.from_torch(
+        joint_V,
+        dtype=KV_DTYPE,
+        layout=ttnn.TILE_LAYOUT,
+        device=mesh_device,
+        mesh_mapper=ttnn.ShardTensor2dMesh(
+            mesh_device, mesh_shape=tuple(mesh_device.shape), dims=sdpa_joint_shard_dims
+        ),
+    )
+
+    # ---- Dispatch setup (verbatim from run_dispatch), cores forced onto the edge line ----
+    mesh_config = extract_mesh_config(mesh_device)
+    sp_axis = mesh_config.sp_axis
+    dispatch_group_size = mesh_config.dispatch_group_size
+    num_dispatch_groups = mesh_config.num_dispatch_groups
+    num_devices = mesh_device.get_num_devices()
+
+    (
+        experts_per_chip,
+        metadata_len,
+        max_dispatch_buffer_token_size,
+        max_dispatched_tokens_per_expert,
+    ) = compute_constants(
+        seq_len_per_chip,
+        NUM_ROUTED_EXPERTS,
+        NUM_EXPERTS_PER_TOK,
+        num_devices,
+        dispatch_group_size,
+        DISPATCH_BUFFER_CAPACITY_FACTOR,
+    )
+
+    x, weights, indices = initialize_test_inputs(
+        dispatch_group_size=dispatch_group_size,
+        seq_len_per_chip=seq_len_per_chip,
+        emb_dim=EMB_DIM,
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
+        max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+
+    expert_dispatch_table = ExpertMapping.create_dispatch_table(
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+        dispatch_group_size=dispatch_group_size,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+    expert_offsets, _, _, _ = get_gate_outputs(
+        indices,
+        dispatch_group_size,
+        NUM_ROUTED_EXPERTS,
+        experts_per_chip,
+        seq_len_per_chip,
+        NUM_EXPERTS_PER_TOK,
+        expert_dispatch_table=expert_dispatch_table,
+    )
+
+    dispatch_mesh_mapper = get_dispatch_input_mesh_mapper(mesh_device, sp_axis)
+    tt_x = ttnn.from_torch(
+        x, mesh_mapper=dispatch_mesh_mapper, layout=ttnn.TILE_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16
+    )
+    tt_weights = ttnn.from_torch(
+        weights, mesh_mapper=dispatch_mesh_mapper, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16
+    )
+    tt_indices = ttnn.from_torch(
+        indices, mesh_mapper=dispatch_mesh_mapper, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.uint16
+    )
+    tt_expert_offsets = TtDispatchModule.shard_expert_offsets(mesh_device, expert_offsets)
+    tt_expert_dispatch_table = TtDispatchModule.shard_expert_dispatch_table(mesh_device, expert_dispatch_table, sp_axis)
+
+    edge_core_range_set = _dispatch_edge_core_range_set(grid_x, grid_y, dispatch_edge)
+    logger.info(f"dispatch_edge={dispatch_edge} core_grid_override={edge_core_range_set}")
+
+    tt_dispatch_module = TtDispatchModule(
+        mesh_device=mesh_device,
+        dispatch_group_size=dispatch_group_size,
+        experts_per_chip=experts_per_chip,
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
+        metadata_len=metadata_len,
+        max_dispatch_buffer_token_size=max_dispatch_buffer_token_size,
+        seq_len_per_chip=seq_len_per_chip,
+        emb_dim=EMB_DIM,
+        cluster_axis=sp_axis,
+        num_links=1,
+        topology=ttnn.Topology.Linear,
+        core_grid_override=edge_core_range_set,
+    )
+
+    # ---- The loop under test: dispatch then ring-joint SDPA, per iter ----
+    try:
+        for i in range(n_iters):
+            logger.info(f"[iter {i}/{n_iters}] ring_joint_sdpa")
+            ttnn.transformer.ring_joint_scaled_dot_product_attention(
+                tt_Q,
+                tt_K,
+                tt_V,
+                tt_joint_Q,
+                tt_joint_K,
+                tt_joint_V,
+                persistent_output_buffer_k=persistent_output_buffers[0][0],
+                persistent_output_buffer_v=persistent_output_buffers[0][1],
+                joint_strategy="rear",
+                logical_n=base_seq_len,
+                program_config=program_config,
+                compute_kernel_config=compute_kernel_config,
+                dim=2,
+                multi_device_global_semaphore=ccl_semaphore_handles[0],
+                num_links=1,
+                cluster_axis=rp_axis,
+                mesh_device=mesh_device,
+                topology=ttnn.Topology.Linear,
+                subdevice_id=worker_sub_device_id,
+                ccl_core_grid_offset=ccl_core_grid_offset,
+                use_column_major_ccl=True,
+                is_causal=True,
+                is_balanced=False,
+            )
+
+            ttnn.synchronize_device(mesh_device)
+            logger.info(f"[iter {i}/{n_iters}] synchronized after sdpa")
+
+            logger.info(f"[iter {i}/{n_iters}] dispatch ({dispatch_edge})")
+            tt_dispatch_module(tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table)
+
+            ttnn.synchronize_device(mesh_device)
+            logger.info(f"[iter {i}/{n_iters}] synchronized")
+    finally:
+        mesh_device.clear_loaded_sub_device_manager()
+        mesh_device.remove_sub_device_manager(sub_device_manager)
+
+    logger.info(f"✅ completed {n_iters} dispatch+sdpa iterations (dispatch_edge={dispatch_edge})")
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params",
+    [
+        (
+            (2, 4),
+            {
+                "fabric_config": ttnn.FabricConfig.FABRIC_2D,
+                "fabric_router_config": create_fabric_router_config(max_payload_size=get_max_payload_size()),
+                "reliability_mode": ttnn.FabricReliabilityMode.RELAXED_INIT,
+                "worker_l1_size": ttnn._ttnn.device.DEFAULT_WORKER_L1_SIZE if is_blackhole() else WH_WORKER_L1_SIZE,
+            },
+        ),
+    ],
+    indirect=["mesh_device", "device_params"],
+    ids=["fabric2d-mesh-2x4"],
+)
+@pytest.mark.parametrize("dispatch_edge", ["first_col", "first_row"])
+@pytest.mark.parametrize("seq_len_per_chip", [128, 2560], ids=["seq128", "seq2560"])
+@pytest.mark.parametrize("n_iters", [2, 20], ids=["iters2", "iters20"])
+@pytest.mark.timeout(0)
+def test_dispatch_sdpa_loop(mesh_device, device_params, dispatch_edge, seq_len_per_chip, n_iters):
+    run_dispatch_sdpa_loop(mesh_device, dispatch_edge, n_iters, seq_len_per_chip)

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch_subdevices.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch_subdevices.py
@@ -1,0 +1,346 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Local-only test: dispatch op under edge-row / edge-column worker subdevices.
+
+The dispatch kernel lays its sender + untilize cores along a single 1-D line of the
+worker grid.  When ``subdevice_id`` is None it uses the first row of the full grid
+(legacy behavior).  When an explicit subdevice is given, the kernel must lay the cores
+along whatever line that subdevice spans — a first/last ROW (varies in x) or a
+first/last COLUMN (varies in y).  This test confines dispatch to each of the four edge
+lines (plus the None default) and checks the dispatched buffer + metadata still match the
+torch reference, exercising both the row-oriented and the column-oriented core layouts.
+
+This file MUST NOT run in CI.  It is collected by every *DeepSeek_PREFILL_OP_TESTS job
+(some of which run the op_unit_tests/ folder unfiltered, e.g. bh_p150 / bh_p300), so a
+``-k`` filter cannot exclude it.  Instead it skips itself in CI via the is_ci_env /
+is_ci_v2_env fixtures (same mechanism as test_sub_device_load_clear_timing.py): all CI
+jobs collect it but report it as skipped, while it still runs locally with no env var.
+
+Run locally (needs an 8-chip box for the mesh-4x2 config):
+
+    pytest models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch_subdevices.py -vvv --tb=short
+"""
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+from models.demos.deepseek_v3_d_p.reference.tt.moe.dispatch import TorchDispatchModule
+from models.demos.deepseek_v3_d_p.tests.pcc.mesh_configs import ALL_MESH_CONFIGS
+from models.demos.deepseek_v3_d_p.tt.moe.init_helpers import (
+    ExpertMapping,
+    compute_constants,
+    extract_mesh_config,
+    get_dispatch_input_mesh_mapper,
+    get_ep_mesh_composer,
+    get_gate_outputs,
+    initialize_test_inputs,
+)
+from models.demos.deepseek_v3_d_p.tt.moe.tt_dispatch import TtDispatchModule
+from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
+    assert_output_shape,
+    validate_dispatch_buffer,
+    validate_dispatch_metadata,
+)
+from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_validation_results
+
+# A single representative 2-D mesh config (8 chips). The subdevice placement under test is
+# a property of the per-chip worker grid, independent of the mesh topology, so one config
+# is enough to exercise all four edge lines.
+MESH_CONFIGS = [p for p in ALL_MESH_CONFIGS if p.id == "mesh-4x2"]
+
+# Small PCC-checked data case (same shape as test_prefill_dispatch.py's "pcc" case).
+SEQ_LEN_PER_CHIP = 32
+EMB_DIM = 7 * 1024
+NUM_ROUTED_EXPERTS = 16
+NUM_EXPERTS_PER_TOK = 4
+DISPATCH_BUFFER_CAPACITY_FACTOR = 4
+
+# The five placements the dispatch op must support, plus one it must reject: a 2-D subdevice
+# block (>1 row AND >1 column, smaller than the full grid) has no single-line core layout, so
+# dispatch must TT_FATAL on it.
+SUBDEVICE_EDGES = ["none", "first_row", "last_row", "first_col", "last_col", "grid_2d"]
+
+
+def _edge_core_range_set(grid_x, grid_y, edge):
+    """Build a CoreRangeSet covering exactly one edge line of the worker grid.
+
+    CoreCoord is (x=column, y=row); CoreRange is an inclusive rectangle. A single row
+    collapses the y axis; a single column collapses the x axis.
+    """
+    if edge == "first_row":
+        return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, 0))})
+    if edge == "last_row":
+        return ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(0, grid_y - 1), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}
+        )
+    if edge == "first_col":
+        return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, grid_y - 1))})
+    if edge == "last_col":
+        return ttnn.CoreRangeSet(
+            {ttnn.CoreRange(ttnn.CoreCoord(grid_x - 1, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}
+        )
+    if edge == "grid_2d":
+        # Rejected case: a true 2-D block (rows 0..1 across every column, so >1 row AND >1
+        # column) that is strictly smaller than the full grid. The dispatch kernel has no
+        # single-line layout for this, so the op must TT_FATAL.
+        return ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, 1))})
+    raise ValueError(f"unknown edge: {edge}")
+
+
+def _enumerate_cores(core_range_set):
+    """Expand a CoreRangeSet into the explicit sorted list of (x, y) cores it contains."""
+    cores = []
+    for r in core_range_set.ranges():
+        for y in range(r.start.y, r.end.y + 1):
+            for x in range(r.start.x, r.end.x + 1):
+                cores.append((x, y))
+    return sorted(cores)
+
+
+def _assert_edge_geometry(edge, core_range_set, grid_x, grid_y):
+    """Prove (and log) that ``core_range_set`` is exactly the named edge of the worker grid.
+
+    This is the geometric half of the proof: it confirms the subdevice we hand the op is
+    literally row 0 / the last row / column 0 / the last column. Combined with the op's
+    ``worker_cores(TENSIX, sub_device_id)`` contract (it lays its sender + untilize kernels
+    on exactly this set), it pins down which cores dispatch actually runs on.
+    """
+    cores = _enumerate_cores(core_range_set)
+    xs = sorted({x for x, _ in cores})
+    ys = sorted({y for _, y in cores})
+    logger.info(f"[proof] subdevice='{edge}' worker_grid=({grid_x}x{grid_y}) n_cores={len(cores)} cores={cores}")
+
+    if edge == "first_row":
+        assert ys == [0], f"first_row must lie on y==0, got rows {ys}"
+        assert xs == list(range(grid_x)), f"first_row must span every column 0..{grid_x - 1}, got {xs}"
+        which = "row y=0 (first row)"
+    elif edge == "last_row":
+        assert ys == [grid_y - 1], f"last_row must lie on y=={grid_y - 1}, got rows {ys}"
+        assert xs == list(range(grid_x)), f"last_row must span every column 0..{grid_x - 1}, got {xs}"
+        which = f"row y={grid_y - 1} (last row)"
+    elif edge == "first_col":
+        assert xs == [0], f"first_col must lie on x==0, got cols {xs}"
+        assert ys == list(range(grid_y)), f"first_col must span every row 0..{grid_y - 1}, got {ys}"
+        which = "column x=0 (first column)"
+    elif edge == "last_col":
+        assert xs == [grid_x - 1], f"last_col must lie on x=={grid_x - 1}, got cols {xs}"
+        assert ys == list(range(grid_y)), f"last_col must span every row 0..{grid_y - 1}, got {ys}"
+        which = f"column x={grid_x - 1} (last column)"
+    else:
+        raise ValueError(f"unknown edge: {edge}")
+    logger.info(f"[proof] ✓ subdevice='{edge}' is exactly {which}")
+
+
+@pytest.mark.parametrize(
+    "mesh_device, device_params, num_links, topology",
+    MESH_CONFIGS,
+    indirect=["mesh_device", "device_params"],
+)
+@pytest.mark.parametrize("subdevice_edge", SUBDEVICE_EDGES)
+def test_dispatch_subdevice_placement(
+    mesh_device, device_params, num_links, topology, subdevice_edge, is_ci_env, is_ci_v2_env
+):
+    """Run dispatch confined to an edge-row/column worker subdevice and validate vs torch.
+
+    The four edge subdevices overlap at the grid corners, so they cannot share one
+    sub-device manager; each placement gets its own manager, created and torn down here.
+    """
+    # Local-only: this file is collected by every DeepSeek_PREFILL_OP_TESTS job (some
+    # unfiltered, e.g. bh_p150/bh_p300), so a -k filter cannot exclude it. Skip in CI the
+    # same way test_sub_device_load_clear_timing.py does; runs locally with no env var.
+    if is_ci_env or is_ci_v2_env:
+        pytest.skip("Local-only dispatch subdevice test; skipped in CI")
+
+    torch.manual_seed(42)
+    num_devices = mesh_device.get_num_devices()
+
+    mesh_config = extract_mesh_config(mesh_device)
+    sp_axis = mesh_config.sp_axis
+    dispatch_group_size = mesh_config.dispatch_group_size
+    num_dispatch_groups = mesh_config.num_dispatch_groups
+
+    grid = mesh_device.compute_with_storage_grid_size()
+    logger.info(
+        f"subdevice_edge={subdevice_edge} mesh={tuple(mesh_device.shape)} worker_grid=({grid.x}x{grid.y}) "
+        f"dispatch_group_size={dispatch_group_size} num_dispatch_groups={num_dispatch_groups}"
+    )
+
+    (
+        experts_per_chip,
+        metadata_len,
+        max_dispatch_buffer_token_size,
+        max_dispatched_tokens_per_expert,
+    ) = compute_constants(
+        SEQ_LEN_PER_CHIP,
+        NUM_ROUTED_EXPERTS,
+        NUM_EXPERTS_PER_TOK,
+        num_devices,
+        dispatch_group_size,
+        DISPATCH_BUFFER_CAPACITY_FACTOR,
+    )
+
+    # --- Torch inputs ---
+    x, weights, indices = initialize_test_inputs(
+        dispatch_group_size=dispatch_group_size,
+        seq_len_per_chip=SEQ_LEN_PER_CHIP,
+        emb_dim=EMB_DIM,
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
+        max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+
+    expert_dispatch_table = ExpertMapping.create_dispatch_table(
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+        dispatch_group_size=dispatch_group_size,
+        num_dispatch_groups=num_dispatch_groups,
+    )
+
+    expert_offsets, expert_token_counts, expert_region_offsets, _ = get_gate_outputs(
+        indices,
+        dispatch_group_size,
+        NUM_ROUTED_EXPERTS,
+        experts_per_chip,
+        SEQ_LEN_PER_CHIP,
+        NUM_EXPERTS_PER_TOK,
+        expert_dispatch_table=expert_dispatch_table,
+    )
+
+    # --- Host -> device (TILE input; x replicated across EP, sharded across SP axis) ---
+    mesh_mapper = get_dispatch_input_mesh_mapper(mesh_device, sp_axis)
+    tt_x = ttnn.from_torch(x, mesh_mapper=mesh_mapper, layout=ttnn.TILE_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16)
+    tt_weights = ttnn.from_torch(
+        weights, mesh_mapper=mesh_mapper, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.bfloat16
+    )
+    tt_indices = ttnn.from_torch(
+        indices, mesh_mapper=mesh_mapper, layout=ttnn.ROW_MAJOR_LAYOUT, device=mesh_device, dtype=ttnn.uint16
+    )
+    tt_expert_offsets = TtDispatchModule.shard_expert_offsets(mesh_device, expert_offsets)
+    tt_expert_dispatch_table = TtDispatchModule.shard_expert_dispatch_table(mesh_device, expert_dispatch_table, sp_axis)
+
+    # --- Torch golden ---
+    torch_dispatch_module = TorchDispatchModule(
+        dispatch_group_size=dispatch_group_size,
+        experts_per_chip=experts_per_chip,
+        num_routed_experts=NUM_ROUTED_EXPERTS,
+        num_experts_per_tok=NUM_EXPERTS_PER_TOK,
+        metadata_len=metadata_len,
+        max_dispatched_tokens_per_expert=max_dispatched_tokens_per_expert,
+        max_dispatch_buffer_token_size=max_dispatch_buffer_token_size,
+        seq_len_per_chip=SEQ_LEN_PER_CHIP,
+        emb_dim=EMB_DIM,
+        num_dispatch_groups=num_dispatch_groups,
+        expert_dispatch_table=expert_dispatch_table,
+    )
+    torch_dispatched, torch_metadata = torch_dispatch_module(x, weights, indices, expert_offsets)
+
+    def _build_module(subdevice_id):
+        return TtDispatchModule(
+            mesh_device=mesh_device,
+            dispatch_group_size=dispatch_group_size,
+            experts_per_chip=experts_per_chip,
+            num_routed_experts=NUM_ROUTED_EXPERTS,
+            num_experts_per_tok=NUM_EXPERTS_PER_TOK,
+            metadata_len=metadata_len,
+            max_dispatch_buffer_token_size=max_dispatch_buffer_token_size,
+            seq_len_per_chip=SEQ_LEN_PER_CHIP,
+            emb_dim=EMB_DIM,
+            cluster_axis=sp_axis,
+            num_links=num_links,
+            topology=topology,
+            subdevice_id=subdevice_id,
+        )
+
+    # --- Rejected case: a 2-D subdevice block must make dispatch TT_FATAL ---
+    if subdevice_edge == "grid_2d":
+        if grid.y < 3:
+            pytest.skip(f"grid_2d needs a worker grid taller than 2 rows; got {grid.x}x{grid.y}")
+        edge_cores = _edge_core_range_set(grid.x, grid.y, "grid_2d")
+        xs = sorted({x_ for x_, _ in _enumerate_cores(edge_cores)})
+        ys = sorted({y_ for _, y_ in _enumerate_cores(edge_cores)})
+        assert len(xs) > 1 and len(ys) > 1, f"grid_2d must span >1 row AND >1 column, got cols={xs} rows={ys}"
+        logger.info(f"[proof] subdevice='grid_2d' is a {len(xs)}x{len(ys)} block (cols={xs}, rows={ys})")
+        sd_manager = mesh_device.create_sub_device_manager([ttnn.SubDevice([edge_cores])], 0)
+        mesh_device.load_sub_device_manager(sd_manager)
+        try:
+            with pytest.raises(RuntimeError, match="2-D subdevice core grid"):
+                module = _build_module(ttnn.SubDeviceId(0))
+                module(tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table)
+        finally:
+            mesh_device.clear_loaded_sub_device_manager()
+            mesh_device.remove_sub_device_manager(sd_manager)
+        logger.info("✅ dispatch correctly rejected a 2-D subdevice core grid")
+        return
+
+    # --- Build the edge subdevice (None == legacy first-row-of-full-grid path) ---
+    sd_manager = None
+    subdevice_id = None
+    if subdevice_edge == "none":
+        # Legacy path: no subdevice -> dispatch uses the first row of the full worker grid.
+        logger.info(f"[proof] subdevice='none' -> legacy path: first row (y=0) of the full {grid.x}x{grid.y} grid")
+    else:
+        edge_cores = _edge_core_range_set(grid.x, grid.y, subdevice_edge)
+        # Prove the subdevice we pass is exactly the named edge before handing it to the op.
+        _assert_edge_geometry(subdevice_edge, edge_cores, grid.x, grid.y)
+        # Each edge line shares one manager-of-one; the four edges overlap at corners so
+        # they cannot coexist in a single manager.
+        sd_manager = mesh_device.create_sub_device_manager([ttnn.SubDevice([edge_cores])], 0)
+        mesh_device.load_sub_device_manager(sd_manager)
+        subdevice_id = ttnn.SubDeviceId(0)
+
+    try:
+        tt_dispatch_module = _build_module(subdevice_id)
+        tt_dispatched, tt_metadata = tt_dispatch_module(
+            tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table
+        )
+
+        mesh_composer = get_ep_mesh_composer(mesh_device)
+        tt_out_dispatched = ttnn.to_torch(tt_dispatched, mesh_composer=mesh_composer, dtype=torch.float32)
+        tt_out_metadata = ttnn.to_torch(tt_metadata, mesh_composer=mesh_composer)
+    finally:
+        if sd_manager is not None:
+            mesh_device.clear_loaded_sub_device_manager()
+            mesh_device.remove_sub_device_manager(sd_manager)
+
+    # --- Validate dispatched buffer + metadata vs the torch reference ---
+    assert_output_shape(tt_out_dispatched, num_dispatch_groups, dispatch_group_size, "dispatched buffer")
+
+    buffer_result = validate_dispatch_buffer(
+        torch_dispatched,
+        tt_out_dispatched,
+        expert_region_offsets,
+        expert_token_counts,
+        expert_dispatch_table,
+        num_dispatch_groups,
+        dispatch_group_size,
+        experts_per_chip,
+        verbose=True,
+    )
+    metadata_result = validate_dispatch_metadata(
+        torch_metadata,
+        tt_out_metadata,
+        expert_region_offsets,
+        expert_token_counts,
+        expert_dispatch_table,
+        num_dispatch_groups,
+        dispatch_group_size,
+        experts_per_chip,
+        verbose=True,
+    )
+
+    log_validation_results(
+        results=[buffer_result, metadata_result],
+        num_dispatch_groups=num_dispatch_groups,
+        dispatch_group_size=dispatch_group_size,
+        title=f"Dispatch Validation Results (subdevice={subdevice_edge})",
+    )
+
+    assert buffer_result.passed and metadata_result.passed, (
+        f"Dispatch mismatch (subdevice={subdevice_edge}): "
+        f"buffer={buffer_result.passed} metadata={metadata_result.passed}"
+    )
+    logger.info(f"✅ dispatch matches torch reference under subdevice={subdevice_edge}")

--- a/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch_subdevices.py
+++ b/models/demos/deepseek_v3_d_p/tests/op_unit_tests/test_prefill_dispatch_subdevices.py
@@ -50,12 +50,13 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_valida
 # A single representative 2-D mesh config (8 chips). The subdevice placement under test is
 # a property of the per-chip worker grid, independent of the mesh topology, so one config
 # is enough to exercise all four edge lines.
-MESH_CONFIGS = [p for p in ALL_MESH_CONFIGS if p.id == "mesh-4x2"]
+MESH_CONFIGS = [p for p in ALL_MESH_CONFIGS if p.id == "fabric2d-mesh-8x4-2link"]
 
 # Small PCC-checked data case (same shape as test_prefill_dispatch.py's "pcc" case).
-SEQ_LEN_PER_CHIP = 32
+# NOTE: bumped 32 -> 640 (=5K ISL / 8 sp) to reproduce the column-dispatch hang seen at 5K+.
+SEQ_LEN_PER_CHIP = 640
 EMB_DIM = 7 * 1024
-NUM_ROUTED_EXPERTS = 16
+NUM_ROUTED_EXPERTS = 64  # 32-dev mesh: experts_per_chip = 64 // 32 = 2 (matches original 16//8=2)
 NUM_EXPERTS_PER_TOK = 4
 DISPATCH_BUFFER_CAPACITY_FACTOR = 4
 
@@ -267,7 +268,7 @@ def test_dispatch_subdevice_placement(
         sd_manager = mesh_device.create_sub_device_manager([ttnn.SubDevice([edge_cores])], 0)
         mesh_device.load_sub_device_manager(sd_manager)
         try:
-            with pytest.raises(RuntimeError, match="2-D subdevice core grid"):
+            with expect_error(RuntimeError, match="2-D subdevice core grid"):
                 module = _build_module(ttnn.SubDeviceId(0))
                 module(tt_x, tt_weights, tt_indices, tt_expert_offsets, tt_expert_dispatch_table)
         finally:

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_block.py
@@ -97,6 +97,7 @@ def run_model(
     determinism_check: bool = False,
     num_iterations: int = 1,
     use_pretrained: bool = False,
+    dispatch_subdevice_edge: str = "first_row",
 ):
     if (is_ci_env or is_ci_v2_env) and pcc_validation == False and not determinism_check:
         pytest.skip("Skip non-PCC test in CI to save time")
@@ -338,6 +339,7 @@ def run_model(
         tp_axis=tp_axis,
         weight_cache_path=cache_dir,
         is_balanced=is_balanced,
+        dispatch_subdevice_edge=dispatch_subdevice_edge,
     )
     if gate_fallback_mode is not None:
         block_kwargs["gate_fallback_mode"] = gate_fallback_mode
@@ -623,6 +625,11 @@ def run_model(
 @pytest.mark.parametrize("variant", ["deepseek_v3_d_p"], indirect=True, ids=["deepseek_v3"])
 @pytest.mark.parametrize("determinism_check", [False, True], ids=["no_determinism", "with_determinism"])
 @pytest.mark.parametrize("num_iterations", [1, 2, 5, 25, 2000], ids=["iter1", "iter2", "iter5", "iter25", "iter2000"])
+@pytest.mark.parametrize(
+    "dispatch_subdevice_edge",
+    ["first_row", "last_row", "first_col", "last_col"],
+    ids=["disp-first_row", "disp-last_row", "disp-first_col", "disp-last_col"],
+)
 @pytest.mark.timeout(600)
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
 def test_ds_prefill_block(
@@ -646,6 +653,7 @@ def test_ds_prefill_block(
     num_iterations,
     use_pretrained,
     request,
+    dispatch_subdevice_edge,
 ):
     # FABRIC_2D on the 2x4 mesh regresses the MoE/device-gate PCC ~3 points below the 0.992 gate.
     # xfail this exact combo (keeping the real threshold for every other config) until it is fixed;
@@ -685,6 +693,7 @@ def test_ds_prefill_block(
         num_iterations=num_iterations,
         thresholds=DSV3_THRESHOLDS,
         use_pretrained=use_pretrained,
+        dispatch_subdevice_edge=dispatch_subdevice_edge,
     )
 
 
@@ -726,6 +735,11 @@ def test_ds_prefill_block(
 @pytest.mark.parametrize("variant", ["kimi_k2_6"], indirect=True, ids=["kimi"])
 @pytest.mark.parametrize("determinism_check", [False, True], ids=["no_determinism", "with_determinism"])
 @pytest.mark.parametrize("num_iterations", [1, 2, 5, 25, 2000], ids=["iter1", "iter2", "iter5", "iter25", "iter2000"])
+@pytest.mark.parametrize(
+    "dispatch_subdevice_edge",
+    ["first_row", "last_row", "first_col", "last_col"],
+    ids=["disp-first_row", "disp-last_row", "disp-first_col", "disp-last_col"],
+)
 @pytest.mark.skipif(not is_blackhole(), reason="Kimi requires Blackhole")
 @pytest.mark.timeout(900)
 @pytest.mark.parametrize("use_pretrained", [False, True], ids=["random", "pretrained"])
@@ -750,6 +764,7 @@ def test_kimi_prefill_block(
     num_iterations,
     use_pretrained,
     request,
+    dispatch_subdevice_edge,
 ):
     run_model(
         variant,
@@ -773,6 +788,7 @@ def test_kimi_prefill_block(
         num_iterations=num_iterations,
         thresholds=KIMI_THRESHOLDS,
         use_pretrained=use_pretrained,
+        dispatch_subdevice_edge=dispatch_subdevice_edge,
     )
 
 
@@ -982,6 +998,7 @@ def test_glm_prefill_block(
         tp_axis=tp_axis,
         gate_fallback_mode=GateComputeMode.DEVICE_FP32,
         weight_cache_path=device_cache,
+        dispatch_subdevice_edge=dispatch_subdevice_edge,
     )
     kvpe_cache = init_kvpe_cache(
         kvpe_cache_head_dim=config.kv_lora_rank + config.qk_rope_head_dim,

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer.py
@@ -159,6 +159,7 @@ def run_model(
     is_ci_v2_env,
     tokenizer,
     request,
+    dispatch_subdevice_edge="first_row",
 ):
     torch.manual_seed(42)
 
@@ -428,6 +429,7 @@ def run_model(
         gate_fallback_mode=gate_fallback_mode,
         weight_cache_path=effective_cache_path,
         lm_head_is_column_parallel=True,
+        dispatch_subdevice_edge=dispatch_subdevice_edge,
     )
     ttnn.ReadDeviceProfiler(mesh_device)
     ttnn.synchronize_device(mesh_device)
@@ -894,7 +896,7 @@ def run_model(
 @pytest.mark.parametrize("is_balanced", [True, False], ids=["balanced", "regular"])
 @pytest.mark.parametrize(
     "isl_total, dispatch_buffer_capacity_factor",
-    [(SEQ_LEN_1K, 8), (SEQ_LEN_25K, 8)],
+    [(SEQ_LEN_1K, 8), (SEQ_LEN_5K, 8), (SEQ_LEN_25K, 8)],
 )
 @pytest.mark.parametrize(
     "num_layers",
@@ -955,6 +957,11 @@ def run_model(
     indirect=["mesh_device", "device_params"],
 )
 @pytest.mark.parametrize("variant", ["deepseek_v3_d_p"], indirect=True, ids=["deepseek_v3"])
+@pytest.mark.parametrize(
+    "dispatch_subdevice_edge",
+    ["first_row", "last_row", "first_col", "last_col"],
+    ids=["disp-first_row", "disp-last_row", "disp-first_col", "disp-last_col"],
+)
 @pytest.mark.timeout(0)
 def test_ds_prefill_transformer(
     variant,
@@ -981,6 +988,7 @@ def test_ds_prefill_transformer(
     is_ci_v2_env,
     tokenizer,
     request,
+    dispatch_subdevice_edge,
 ):
     run_model(
         variant,
@@ -1007,6 +1015,7 @@ def test_ds_prefill_transformer(
         is_ci_v2_env,
         tokenizer,
         request,
+        dispatch_subdevice_edge=dispatch_subdevice_edge,
     )
 
 

--- a/models/demos/deepseek_v3_d_p/tt/mla/mla.py
+++ b/models/demos/deepseek_v3_d_p/tt/mla/mla.py
@@ -1076,7 +1076,9 @@ class ttMLA:
     def _dense_single_attn(self, *, tt_q, tt_kvpe, tt_kv_nope, kvpe_cache, cache_layer_idx, seq_len_local, **_):
         # Single-shot prefill: materialize V before causal ring SDPA.
         self._write_kvpe(kvpe_cache, tt_kvpe, cache_layer_idx)
+        ttnn.synchronize_device(self.mesh_device)
         tt_v_embedding = self._apply_wkv_b2(tt_kv_nope, seq_len_local)
+        ttnn.synchronize_device(self.mesh_device)
         attn_out, _, _ = ttnn.transformer.ring_joint_scaled_dot_product_attention(
             tt_q,
             tt_kvpe,
@@ -1102,6 +1104,7 @@ class ttMLA:
             scale=self.scale,
             is_balanced=self.is_balanced,
         )
+        ttnn.synchronize_device(self.mesh_device)
         return attn_out
 
     def _cache_batch_idx(self, cache_user_id: int, cache_layer_idx: int) -> int:

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_combine.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_combine.py
@@ -60,6 +60,7 @@ class TtCombineModule(LightweightModule):
         memory_config: ttnn.MemoryConfig = ttnn.DRAM_MEMORY_CONFIG,
         init_zeros: bool = True,
         fp8_output: bool = False,
+        core_grid_override=None,
     ):
         """
         Initialize combine module with configuration parameters.
@@ -93,6 +94,9 @@ class TtCombineModule(LightweightModule):
         self.memory_config = memory_config
         self.init_zeros = init_zeros
         self.fp8_output = fp8_output
+        # Optional explicit CoreRangeSet: place combine cores here directly (bypasses
+        # subdevice/worker_cores). Used to run combine on an edge (row/column) layout.
+        self.core_grid_override = core_grid_override
 
     def forward(
         self,
@@ -155,6 +159,7 @@ class TtCombineModule(LightweightModule):
             memory_config=self.memory_config,
             init_zeros=self.init_zeros,
             use_fp8_combine=self.fp8_output,
+            core_grid_override=self.core_grid_override,
         )
 
         return output

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_dispatch.py
@@ -68,6 +68,7 @@ class TtDispatchModule(LightweightModule):
         fp8_output: bool = False,
         subdevice_id=None,
         num_untilizers_per_sender: int = 2,
+        core_grid_override=None,
     ):
         """
         Initialize dispatch module with configuration parameters.
@@ -107,6 +108,9 @@ class TtDispatchModule(LightweightModule):
         self.topology = topology
         self.fp8_output = fp8_output
         self.subdevice_id = subdevice_id
+        # Optional explicit CoreRangeSet: place dispatch sender+untilize cores here directly
+        # (bypasses subdevice/worker_cores). Used to test edge core layouts without a sub-device.
+        self.core_grid_override = core_grid_override
         # num_untilizers_per_sender >= 1 is validated on the device op side
         # (DispatchDeviceOperation::validate_on_program_cache_miss).
         self.num_untilizers_per_sender = num_untilizers_per_sender
@@ -280,6 +284,7 @@ class TtDispatchModule(LightweightModule):
             use_fp8_dispatch=self.fp8_output,
             subdevice_id=self.subdevice_id,
             num_untilizers_per_sender=self.num_untilizers_per_sender,
+            core_grid_override=self.core_grid_override,
         )
 
         tt_dispatched_buffer_shape = tt_dispatched_buffer.shape

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -127,6 +127,36 @@ class TtMoe(LightweightModule):
                 f"layer_{layer_idx}.shared_expert",
             )
 
+    @staticmethod
+    def _edge_dispatch_core_ranges(edge: str, grid_x: int, grid_y: int):
+        """Split the worker grid into a dispatch edge line and its complementary block.
+
+        Returns (dispatch_cores, shared_cores) as CoreRangeSets. The dispatch line is a
+        single row or column on the requested edge; the shared block is everything else
+        (always a rectangle for an edge line). CoreCoord is (x=column, y=row).
+        """
+        if edge == "first_row":
+            assert grid_y > 1, f"first_row dispatch needs grid_y > 1, got {grid_y}"
+            dispatch = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, 0))
+            shared = ttnn.CoreRange(ttnn.CoreCoord(0, 1), ttnn.CoreCoord(grid_x - 1, grid_y - 1))
+        elif edge == "last_row":
+            assert grid_y > 1, f"last_row dispatch needs grid_y > 1, got {grid_y}"
+            dispatch = ttnn.CoreRange(ttnn.CoreCoord(0, grid_y - 1), ttnn.CoreCoord(grid_x - 1, grid_y - 1))
+            shared = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 2))
+        elif edge == "first_col":
+            assert grid_x > 1, f"first_col dispatch needs grid_x > 1, got {grid_x}"
+            dispatch = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(0, grid_y - 1))
+            shared = ttnn.CoreRange(ttnn.CoreCoord(1, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))
+        elif edge == "last_col":
+            assert grid_x > 1, f"last_col dispatch needs grid_x > 1, got {grid_x}"
+            dispatch = ttnn.CoreRange(ttnn.CoreCoord(grid_x - 1, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))
+            shared = ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 2, grid_y - 1))
+        else:
+            raise ValueError(
+                f"unknown dispatch_subdevice_edge={edge!r}; " "expected one of first_row, last_row, first_col, last_col"
+            )
+        return ttnn.CoreRangeSet({dispatch}), ttnn.CoreRangeSet({shared})
+
     def __init__(
         self,
         mesh_device: ttnn.MeshDevice,
@@ -159,6 +189,7 @@ class TtMoe(LightweightModule):
         overlap_shared_expert_with_dispatch: bool = True,
         routing_use_l1_small_for_semaphores: bool = False,
         is_balanced: bool = False,
+        dispatch_subdevice_edge: str = "first_row",
     ):
         """
         Initialize TtMoe module.
@@ -197,6 +228,9 @@ class TtMoe(LightweightModule):
                 setup and run them sequentially on the full Tensix grid.
             is_balanced: If True, uses zigzag sequence placement for padding awareness.
                 Should match the is_balanced flag used in MLA/transformer.
+            dispatch_subdevice_edge: Which edge line of the worker grid the dispatch
+                sub-device occupies when overlap is enabled. One of "first_row", "last_row",
+                "first_col", "last_col". The shared expert takes the complementary block.
         """
         super().__init__()
         self.mesh_device = mesh_device
@@ -211,7 +245,31 @@ class TtMoe(LightweightModule):
         self.seq_len_per_chip = seq_len_per_chip
         self.emb_dim = emb_dim
         self.hidden_dim = hidden_dim
-        self.overlap_shared_expert_with_dispatch = overlap_shared_expert_with_dispatch
+        # Experiment gate (env, no plumbing through Block/Transformer/tests): keep dispatch
+        # confined to the `dispatch_subdevice_edge` subdevice, but run the shared expert on
+        # the FULL grid (no dispatch<->shared overlap). Used to isolate whether the column
+        # hang comes from the shared expert running on a column-shaped subdevice.
+        self._dispatch_edge_no_overlap = os.getenv("TT_DS_DISPATCH_ON_EDGE_NO_OVERLAP", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        # Experiment gate 2: place dispatch cores on the `dispatch_subdevice_edge` line via an
+        # EXPLICIT CoreRangeSet passed straight to the op (no sub-device manager created at all).
+        # Isolates whether the column hang comes from the sub-device mechanism or the column
+        # core layout itself: if dispatch-on-column-cores (no sub-device) also hangs, it's the
+        # layout; if it runs, the sub-device lifecycle was the culprit.
+        self._dispatch_core_grid_override = os.getenv("TT_DS_DISPATCH_CORE_GRID_OVERRIDE", "0").lower() in (
+            "1",
+            "true",
+            "yes",
+        )
+        # Effective overlap: either env experiment forces overlap off (shared runs full-grid).
+        self.overlap_shared_expert_with_dispatch = (
+            overlap_shared_expert_with_dispatch
+            and not self._dispatch_edge_no_overlap
+            and not self._dispatch_core_grid_override
+        )
 
         # Unpack row/col CCL config
         if isinstance(num_links, tuple):
@@ -281,35 +339,71 @@ class TtMoe(LightweightModule):
 
         # ========================================
         # Sub-devices: when overlap is enabled, split the Tensix grid into a "dispatch"
-        # strip and a "shared expert" strip so the two ops run on disjoint cores and the
+        # edge line and a "shared expert" block so the two ops run on disjoint cores and the
         # Fast-Dispatch per-sub-device counters let them overlap on-chip.
-        #   sub-device 0 (dispatch_sd):     rows [0, dispatch_sd_rows)
-        #   sub-device 1 (shared_sd):       rows [dispatch_sd_rows, grid_y)
+        #   sub-device 0 (dispatch_sd):     one edge line of the worker grid
+        #   sub-device 1 (shared_sd):       the complementary block (all remaining cores)
+        # The dispatch kernel lays its sender + untilize cores along a single 1-D line, so
+        # the dispatch sub-device is always a single row or column. Its edge is selected by
+        # `dispatch_subdevice_edge` (first/last row/column); the shared expert takes whatever
+        # is left, which is always a rectangle for an edge line.
         # When overlap is disabled, both ops run sequentially on the full grid and no
         # sub-device manager is created.
         # ========================================
-        if overlap_shared_expert_with_dispatch:
-            dispatch_sd_rows = 1
+        # Default: no explicit dispatch core-grid override (dispatch derives cores from its
+        # sub-device, or the legacy first-row path).
+        self.dispatch_core_grid = None
+
+        # Optional (independent of dispatch): run the COMBINE op on an explicit edge core-grid
+        # with no sub-device. Set TT_DS_COMBINE_CORE_GRID_OVERRIDE_EDGE=first_row|last_row|
+        # first_col|last_col. Lets us e.g. keep dispatch on a row but push combine onto a
+        # column, to tell whether the column hang is dispatch-specific or a general NoC issue.
+        self.combine_core_grid = None
+        _combine_edge = os.getenv("TT_DS_COMBINE_CORE_GRID_OVERRIDE_EDGE", "").strip()
+        if _combine_edge:
+            _cgrid = mesh_device.compute_with_storage_grid_size()
+            self.combine_core_grid, _ = self._edge_dispatch_core_ranges(_combine_edge, _cgrid.x, _cgrid.y)
+            logger.debug(f"Combine CORE-GRID OVERRIDE: edge={_combine_edge}, cores={self.combine_core_grid}")
+
+        if self._dispatch_core_grid_override:
+            # Experiment: NO sub-device manager at all. Dispatch places its cores on the
+            # explicit edge CoreRangeSet; shared expert runs on the full grid.
+            grid = mesh_device.compute_with_storage_grid_size()
+            self.dispatch_core_grid, _ = self._edge_dispatch_core_ranges(dispatch_subdevice_edge, grid.x, grid.y)
+            self.sd_manager_id = None
+            self.dispatch_sd_id = None
+            self.shared_sd_id = None
+            self.shared_sd_cores = None
+            logger.debug(
+                f"Dispatch CORE-GRID OVERRIDE (no sub-device): edge={dispatch_subdevice_edge}, "
+                f"cores={self.dispatch_core_grid}"
+            )
+        elif self.overlap_shared_expert_with_dispatch or self._dispatch_edge_no_overlap:
             grid = mesh_device.compute_with_storage_grid_size()
             grid_x, grid_y = grid.x, grid.y
-            assert 0 < dispatch_sd_rows < grid_y, f"dispatch_sd_rows={dispatch_sd_rows} must be in (0, grid_y={grid_y})"
-            dispatch_cores = ttnn.CoreRangeSet(
-                {ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, dispatch_sd_rows - 1))}
-            )
-            shared_cores = ttnn.CoreRangeSet(
-                {ttnn.CoreRange(ttnn.CoreCoord(0, dispatch_sd_rows), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}
-            )
+            dispatch_cores, shared_cores = self._edge_dispatch_core_ranges(dispatch_subdevice_edge, grid_x, grid_y)
             dispatch_sd = ttnn.SubDevice([dispatch_cores])
             shared_sd = ttnn.SubDevice([shared_cores])
             self.sd_manager_id = mesh_device.create_sub_device_manager([dispatch_sd, shared_sd], 0)
             self.dispatch_sd_id = ttnn.SubDeviceId(0)
-            self.shared_sd_id = ttnn.SubDeviceId(1)
-            # Stash the CoreRangeSet of the shared sub-device so TtSharedExpert can build
-            # sub-device-confined shard_specs in Python without a C++ worker_cores binding.
-            self.shared_sd_cores = shared_cores
+            if self.overlap_shared_expert_with_dispatch:
+                # Overlap: shared runs confined to the complementary sub-device so it and
+                # dispatch occupy disjoint cores and overlap on-chip.
+                self.shared_sd_id = ttnn.SubDeviceId(1)
+                # Stash the CoreRangeSet of the shared sub-device so TtSharedExpert can build
+                # sub-device-confined shard_specs in Python without a C++ worker_cores binding.
+                self.shared_sd_cores = shared_cores
+            else:
+                # Env experiment: dispatch stays on the edge sub-device, but the shared expert
+                # runs on the FULL grid (no confinement); forward loads the manager only around
+                # the dispatch op (see forward()).
+                self.shared_sd_id = None
+                self.shared_sd_cores = None
             logger.debug(
-                f"Sub-devices: grid={grid_x}x{grid_y}, dispatch=rows[0,{dispatch_sd_rows}), "
-                f"shared=rows[{dispatch_sd_rows},{grid_y})"
+                f"Sub-devices: grid={grid_x}x{grid_y}, dispatch_edge={dispatch_subdevice_edge}, "
+                f"dispatch={dispatch_cores}, shared={shared_cores}, "
+                f"overlap={self.overlap_shared_expert_with_dispatch}, "
+                f"dispatch_edge_no_overlap={self._dispatch_edge_no_overlap}"
             )
         else:
             self.sd_manager_id = None
@@ -333,6 +427,7 @@ class TtMoe(LightweightModule):
             num_links=self.row_num_links,
             topology=self.row_topology,
             subdevice_id=self.dispatch_sd_id,
+            core_grid_override=self.dispatch_core_grid,
         )
 
         # Initialize combine module (row axis: axis 0)
@@ -347,6 +442,7 @@ class TtMoe(LightweightModule):
             num_links=self.row_num_links,
             topology=self.row_topology,
             init_zeros=False,
+            core_grid_override=self.combine_core_grid,
         )
 
         # Build (group, chip, local_expert) -> global expert id table, sharded
@@ -536,6 +632,7 @@ class TtMoe(LightweightModule):
         logger.debug(f"[TtMoe.forward] x (after all_gather) shape: {x.shape}")
 
         signpost("shared_expert_and_dispatch_start")
+        # Overlap mode: load the manager around BOTH ops (they run on disjoint sub-devices).
         if self.overlap_shared_expert_with_dispatch:
             self.mesh_device.load_sub_device_manager(self.sd_manager_id)
 
@@ -548,6 +645,14 @@ class TtMoe(LightweightModule):
 
         shared_output = self.shared_expert(x)
         logger.debug(f"[TtMoe.forward] Shared expert output shape: {shared_output.shape}")
+
+        # Env experiment (no overlap, dispatch-on-edge): the shared expert just ran on the
+        # full grid with no manager loaded. Force a full device sync so the shared expert is
+        # completely finished before dispatch starts (truly sequential, no on-chip overlap),
+        # then load the manager so dispatch is confined to its edge sub-device.
+        if self._dispatch_edge_no_overlap:
+            ttnn.synchronize_device(self.mesh_device)
+            self.mesh_device.load_sub_device_manager(self.sd_manager_id)
 
         # ========================================
         # Step 2: Dispatch (enabled)
@@ -562,7 +667,7 @@ class TtMoe(LightweightModule):
             self.tt_expert_dispatch_table,
             padding_config=padding_config,
         )
-        if self.overlap_shared_expert_with_dispatch:
+        if self.overlap_shared_expert_with_dispatch or self._dispatch_edge_no_overlap:
             self.mesh_device.clear_loaded_sub_device_manager()
         # padding_config was shared with both the gate and dispatch; free it now that
         # dispatch (its last consumer) has been issued.

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -648,10 +648,12 @@ class TtMoe(LightweightModule):
 
         # Env experiment (no overlap, dispatch-on-edge): the shared expert just ran on the
         # full grid with no manager loaded. Force a full device sync so the shared expert is
-        # completely finished before dispatch starts (truly sequential, no on-chip overlap),
-        # then load the manager so dispatch is confined to its edge sub-device.
-        if self._dispatch_edge_no_overlap:
+        # completely finished before dispatch starts (truly sequential, no on-chip overlap).
+        if self._dispatch_edge_no_overlap or self._dispatch_core_grid_override:
             ttnn.synchronize_device(self.mesh_device)
+        # edge_no_overlap confines dispatch to a sub-device; load its manager now. The
+        # core-grid override path passes cores to the op directly and has no manager.
+        if self._dispatch_edge_no_overlap:
             self.mesh_device.load_sub_device_manager(self.sd_manager_id)
 
         # ========================================
@@ -667,6 +669,11 @@ class TtMoe(LightweightModule):
             self.tt_expert_dispatch_table,
             padding_config=padding_config,
         )
+        # Dispatch-on-edge experiments: full device barrier right after dispatch so none of its
+        # fabric/NoC traffic is still in flight when downstream ops (and the next layer's ring
+        # SDPA) run. Pairs with the pre-dispatch sync above to fully quiesce dispatch.
+        if self._dispatch_edge_no_overlap or self._dispatch_core_grid_override:
+            ttnn.synchronize_device(self.mesh_device)
         if self.overlap_shared_expert_with_dispatch or self._dispatch_edge_no_overlap:
             self.mesh_device.clear_loaded_sub_device_manager()
         # padding_config was shared with both the gate and dispatch; free it now that

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -30,9 +30,8 @@ COMPUTE_KERNEL_CONFIG_HIFI2 = ttnn.WormholeComputeKernelConfig(
 )
 
 
-def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
+def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int, grid: ttnn.CoreCoord):
     """Program configs for the gate / up / down matmuls on Blackhole."""
-    grid = ttnn.CoreCoord(11, 9)
     gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
         in0_block_w=4,
@@ -67,9 +66,8 @@ def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int
     return gate, up, down
 
 
-def get_wh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int):
+def get_wh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int, grid: ttnn.CoreCoord):
     """Program configs for the gate / up / down matmuls on Wormhole."""
-    grid = ttnn.CoreCoord(8, 7)
     gate = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
         in0_block_w=4,
@@ -420,9 +418,15 @@ class TtSharedExpert(LightweightModule):
         ), f"Matmul shape mismatch: gate_proj[-1]={self.gate_proj.shape[-1]} != down_proj[-2]={self.down_proj.shape[-2]}"
 
         # ===== Inlined shared expert FFN — height-sharded sub-device matmuls =====
-        # Available compute grid: BH = 11x9, WH = 8x7.
+        # The matmul grid is anchored at the sub-device's start corner, so it must fit inside
+        # the confined region. Derive it from the sub-device bounding box (e.g. 10x10 when
+        # dispatch owns one edge column); fall back to the full worker grid when unconfined.
         TILE = 32
-        max_cores = 11 * 9 if is_blackhole() else 8 * 7
+        if self.subdevice_cores is not None:
+            grid = self.subdevice_cores.bounding_box().grid_size()
+        else:
+            grid = ttnn.CoreCoord(11, 9) if is_blackhole() else ttnn.CoreCoord(8, 7)
+        max_cores = grid.x * grid.y
 
         # Pick the largest divisor of M_tiles that fits in the sub-device — gives
         # max parallelism with no padding waste.
@@ -436,11 +440,11 @@ class TtSharedExpert(LightweightModule):
         down_n_tiles = self.down_proj.padded_shape[-1] // TILE
         if is_blackhole():
             gate_program_config, up_program_config, down_program_config = get_bh_program_configs(
-                per_core_M, gate_n_tiles, down_n_tiles
+                per_core_M, gate_n_tiles, down_n_tiles, grid
             )
         else:
             gate_program_config, up_program_config, down_program_config = get_wh_program_configs(
-                per_core_M, gate_n_tiles, down_n_tiles
+                per_core_M, gate_n_tiles, down_n_tiles, grid
             )
 
         # 1) Compute gate and up projections

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -204,6 +204,7 @@ class TtPrefillBlock(LightweightModule):
         max_seq_len: Optional[int] = None,
         kv_only: bool = False,
         routing_use_l1_small_for_semaphores: bool = False,
+        dispatch_subdevice_edge: str = "first_row",
     ):
         super().__init__()
         self.routing_use_l1_small_for_semaphores = routing_use_l1_small_for_semaphores
@@ -306,6 +307,7 @@ class TtPrefillBlock(LightweightModule):
                 dispatch_buffer_capacity_factor=dispatch_buffer_capacity_factor,
                 routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
                 is_balanced=is_balanced,
+                dispatch_subdevice_edge=dispatch_subdevice_edge,
             )
         else:
             # emb_dim/hidden_dim default to DSv3/Kimi's 7168/18432 in TtFfn; pass the variant's real dims
@@ -346,6 +348,7 @@ class TtPrefillBlock(LightweightModule):
         layer_idx=0,
         routing_use_l1_small_for_semaphores=False,
         is_balanced=False,
+        dispatch_subdevice_edge="first_row",
     ):
         mesh_config = extract_mesh_config(mesh_device)
         sp_factor = mesh_device.shape[sp_axis]
@@ -396,6 +399,7 @@ class TtPrefillBlock(LightweightModule):
             overlap_shared_expert_with_dispatch=True,
             routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
             is_balanced=is_balanced,
+            dispatch_subdevice_edge=dispatch_subdevice_edge,
         )
 
     def forward(

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -135,6 +135,7 @@ class TtPrefillTransformer(LightweightModule):
         first_layer_idx: int = 0,
         is_first_rank: bool = True,
         is_last_rank: bool = True,
+        dispatch_subdevice_edge: str = "first_row",
     ):
         super().__init__()
         self.mesh_device = mesh_device
@@ -212,6 +213,7 @@ class TtPrefillTransformer(LightweightModule):
                 max_seq_len=max_seq_len,
                 kv_only=kv_only_last_layer and is_last,
                 routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
+                dispatch_subdevice_edge=dispatch_subdevice_edge,
             )
             self.layers.append(layer)
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.cpp
@@ -28,11 +28,21 @@ ttnn::Tensor combine(
     std::optional<tt::tt_fabric::Topology> topology,
     bool init_zeros,
     bool use_l1_small_for_semaphores,
-    bool use_fp8_combine) {
+    bool use_fp8_combine,
+    const std::optional<CoreRangeSet>& core_grid_override) {
     // Get device and subdevice info
     auto* mesh_device = dispatched_buffer.device();
-    auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
+    // Core selection: normally derived from the sub-device via worker_cores(); when
+    // `core_grid_override` is provided we place the combine cores on exactly that
+    // CoreRangeSet with NO sub-device involved (experiment: run combine on an edge
+    // row/column layout to compare with dispatch's column-hang behavior).
+    CoreRangeSet subdevice_core_range_set;
+    if (core_grid_override.has_value()) {
+        subdevice_core_range_set = *core_grid_override;
+    } else {
+        auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
+        subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
+    }
 
     // Validate fabric configuration - only tested values are supported
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine.hpp
@@ -7,6 +7,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
 #include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 
 namespace ttnn::operations::experimental::deepseek_prefill::combine {
@@ -27,7 +28,11 @@ ttnn::Tensor combine(
     std::optional<tt::tt_fabric::Topology> topology = tt::tt_fabric::Topology::Linear,
     bool init_zeros = true,
     bool use_l1_small_for_semaphores = false,
-    bool use_fp8_combine = false);
+    bool use_fp8_combine = false,
+    // Debug/experiment: place the combine cores on exactly this CoreRangeSet instead of
+    // deriving them from `subdevice_id` via worker_cores(). Lets us run combine on an edge
+    // (first/last row/column) core layout WITHOUT a sub-device.
+    const std::optional<CoreRangeSet>& core_grid_override = std::nullopt);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::combine
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine_nanobind.cpp
@@ -13,6 +13,7 @@
 #include "ttnn-nanobind/bind_function.hpp"
 #include "combine.hpp"
 #include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 
 namespace ttnn::operations::experimental::deepseek_prefill::combine::detail {
@@ -94,7 +95,8 @@ void bind_combine(nb::module_& mod) {
         nb::arg("topology") = nb::cast(tt::tt_fabric::Topology::Linear),
         nb::arg("init_zeros") = true,
         nb::arg("use_l1_small_for_semaphores") = false,
-        nb::arg("use_fp8_combine") = false);
+        nb::arg("use_fp8_combine") = false,
+        nb::arg("core_grid_override") = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::combine::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/device/dispatch_program_factory.cpp
@@ -186,24 +186,70 @@ tt::tt_metal::ProgramDescriptor create_at_tile_layout(
     uint32_t num_cores = effective_num_links;
 
     // ==================== Core layout: senders + untilize cores ====================
-    // Collect all cores in the first row (y == subdevice_cores[0].y), sorted by x.
-    // Each sender owns num_untilizers consecutive untilize cores (u1..uN): cores are
-    // laid out [sender, u1, ..., uN] consecutively along x per sender group.
-    uint32_t sender_row_y = subdevice_cores.at(0).y;
-    std::vector<CoreCoord> all_row_cores;
+    // Lay the sender + untilize groups along a single 1-D line of worker cores taken from the
+    // (sub)device grid. The subdevice is guaranteed to be a single line — first/last row OR
+    // first/last column — and the orientation is inferred here from the grid shape (no extra
+    // API flag is needed):
+    //   - single-column grid (all cores share x): use the whole column, ordered by y.
+    //   - single-row grid, or the default full 2-D worker grid (subdevice_id == None): use the
+    //     first row (smallest y), ordered by x — byte-identical to the previous behavior.
+    // Each sender owns num_untilizers consecutive untilize cores (u1..uN): cores are laid out
+    // [sender, u1, ..., uN] consecutively along the line per sender group. Everything downstream
+    // is geometry-agnostic: it treats all_row_cores as an ordered line and addresses cores by
+    // absolute NOC coordinates, so a column needs no further changes.
+    uint32_t min_x = subdevice_cores.at(0).x, max_x = subdevice_cores.at(0).x;
+    uint32_t min_y = subdevice_cores.at(0).y, max_y = subdevice_cores.at(0).y;
     for (const auto& core : subdevice_cores) {
-        if (core.y == sender_row_y) {
-            all_row_cores.push_back(core);
-        }
+        min_x = std::min(min_x, (uint32_t)core.x);
+        max_x = std::max(max_x, (uint32_t)core.x);
+        min_y = std::min(min_y, (uint32_t)core.y);
+        max_y = std::max(max_y, (uint32_t)core.y);
     }
-    std::sort(
-        all_row_cores.begin(), all_row_cores.end(), [](const CoreCoord& a, const CoreCoord& b) { return a.x < b.x; });
+    // The sender/untilize pipeline is laid out along a single line of cores, so the worker
+    // subdevice must be a single row (first/last row) or single column (first/last column).
+    // A subdevice spanning both multiple rows and multiple columns has no defined line layout.
+    // The legacy no-subdevice path passes the full device worker grid (also 2-D) and is handled
+    // by taking its first row, so that case is exempted.
+    if ((max_x > min_x) && (max_y > min_y)) {
+        auto compute_grid = mesh_device->compute_with_storage_grid_size();
+        const bool is_full_worker_grid = min_x == 0 && min_y == 0 && max_x == compute_grid.x - 1 &&
+                                         max_y == compute_grid.y - 1 &&
+                                         subdevice_cores.size() == compute_grid.x * compute_grid.y;
+        TT_FATAL(
+            is_full_worker_grid,
+            "Dispatch requires the worker subdevice to be a single row (first/last row) or single column "
+            "(first/last column); a 2-D subdevice core grid spanning x=[{}, {}] y=[{}, {}] is not supported.",
+            min_x,
+            max_x,
+            min_y,
+            max_y);
+    }
+    const bool is_single_column = (min_x == max_x) && (max_y > min_y);
+
+    std::vector<CoreCoord> all_row_cores;
+    if (is_single_column) {
+        // First/last-column subdevice: every core shares x, so order the line by y.
+        all_row_cores = subdevice_cores;
+        std::sort(all_row_cores.begin(), all_row_cores.end(), [](const CoreCoord& a, const CoreCoord& b) {
+            return a.y < b.y;
+        });
+    } else {
+        // First/last-row subdevice or full 2-D grid: take the first row, ordered by x (legacy path).
+        for (const auto& core : subdevice_cores) {
+            if (core.y == min_y) {
+                all_row_cores.push_back(core);
+            }
+        }
+        std::sort(all_row_cores.begin(), all_row_cores.end(), [](const CoreCoord& a, const CoreCoord& b) {
+            return a.x < b.x;
+        });
+    }
 
     uint32_t total_row_cores = static_cast<uint32_t>(all_row_cores.size());
     uint32_t cores_per_sender = 1 + num_untilizers;  // 1 sender + N untilize cores (u1..uN)
     TT_FATAL(
         total_row_cores >= cores_per_sender * num_cores,
-        "Same-row has only {} cores for {} senders — need {} cores per sender (>= {} required)",
+        "Worker line has only {} cores for {} senders — need {} cores per sender (>= {} required)",
         total_row_cores,
         num_cores,
         cores_per_sender,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.cpp
@@ -32,10 +32,21 @@ std::array<ttnn::Tensor, 2> dispatch(
     std::optional<tt::tt_fabric::Topology> topology,
     bool use_l1_small_for_semaphores,
     bool use_fp8_dispatch,
-    uint32_t num_untilizers_per_sender) {
+    uint32_t num_untilizers_per_sender,
+    const std::optional<CoreRangeSet>& core_grid_override) {
     auto* mesh_device = input_tensor.device();
-    auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
+    // Core selection: normally derived from the sub-device via worker_cores(); when
+    // `core_grid_override` is provided we place the dispatch sender+untilize cores on
+    // exactly that CoreRangeSet with NO sub-device involved (experiment: isolate whether
+    // a first/last row/column layout hangs because of the sub-device mechanism or the
+    // column core layout itself).
+    CoreRangeSet subdevice_core_range_set;
+    if (core_grid_override.has_value()) {
+        subdevice_core_range_set = *core_grid_override;
+    } else {
+        auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
+        subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
+    }
 
     // Validate fabric configuration - only tested values are supported
     TT_FATAL(

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch.hpp
@@ -9,6 +9,7 @@
 #include "ttnn/tensor/tensor.hpp"
 #include "ttnn/types.hpp"
 #include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 
 namespace ttnn::operations::experimental::deepseek_prefill::dispatch {
@@ -33,7 +34,11 @@ std::array<ttnn::Tensor, 2> dispatch(
     std::optional<tt::tt_fabric::Topology> topology = tt::tt_fabric::Topology::Linear,
     bool use_l1_small_for_semaphores = false,
     bool use_fp8_dispatch = false,
-    uint32_t num_untilizers_per_sender = 2);
+    uint32_t num_untilizers_per_sender = 2,
+    // Debug/experiment: place the dispatch sender+untilize cores on exactly this
+    // CoreRangeSet instead of deriving them from `subdevice_id` via worker_cores().
+    // Lets us test an edge (first/last row/column) core layout WITHOUT a sub-device.
+    const std::optional<CoreRangeSet>& core_grid_override = std::nullopt);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
@@ -15,6 +15,7 @@
 #include "ttnn-nanobind/bind_function.hpp"
 #include "dispatch.hpp"
 #include <tt-metalium/sub_device_types.hpp>
+#include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/experimental/fabric/fabric_edm_types.hpp>
 
 namespace ttnn::operations::experimental::deepseek_prefill::dispatch::detail {
@@ -113,7 +114,8 @@ void bind_dispatch(nb::module_& mod) {
         nb::arg("topology") = nb::cast(tt::tt_fabric::Topology::Linear),
         nb::arg("use_l1_small_for_semaphores") = false,
         nb::arg("use_fp8_dispatch") = false,
-        nb::arg("num_untilizers_per_sender") = 2);
+        nb::arg("num_untilizers_per_sender") = 2,
+        nb::arg("core_grid_override") = nb::none());
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::dispatch::detail

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/ring_joint_sdpa_program_factory.cpp
@@ -1639,6 +1639,29 @@ tt::tt_metal::ProgramDescriptor build_ring_joint_sdpa_program_descriptor(
         next_global_chunk += chunk_count;
     }
 
+    {
+        std::string participating;
+        bool col0_participates = false;
+        for (uint32_t i = 0; i < num_cores; ++i) {
+            if (core_work.at(i).global_q_count > 0) {
+                const auto c = core_work.at(i).logical_core;
+                participating += fmt::format("({},{}):{} ", c.x, c.y, core_work.at(i).global_q_count);
+                if (c.x == 0) {
+                    col0_participates = true;
+                }
+            }
+        }
+        log_info(
+            tt::LogOp,
+            "[RING_SDPA_CORES] grid={}x{} num_cores={} total_q_chunks={} col0_participates={} participating={}",
+            grid_size.x,
+            grid_size.y,
+            num_cores,
+            total_q_chunks,
+            col0_participates,
+            participating);
+    }
+
     // Helper: build a linear chain from sorted (core_idx, q_chunk_count) pairs.
     // - chain_segs[i].second = q iterations the i-th core will process in this chain scope
     // - injector = first core with head_work.size() == 1 (single head segment = no straddling)


### PR DESCRIPTION
- Currently, dispatch run's on the first row of the tensix grid
- In order to measure perf and check which option is the best (options : first/last row/column) this change was made
- adds a local test for dispatch on different core grids

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_subdevice_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nostojic/dispatch_subdevice_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_subdevice_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nostojic/dispatch_subdevice_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=nostojic/dispatch_subdevice_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:nostojic/dispatch_subdevice_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nostojic/dispatch_subdevice_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nostojic/dispatch_subdevice_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nostojic/dispatch_subdevice_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nostojic/dispatch_subdevice_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nostojic/dispatch_subdevice_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nostojic/dispatch_subdevice_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nostojic/dispatch_subdevice_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nostojic/dispatch_subdevice_layout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nostojic/dispatch_subdevice_layout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nostojic/dispatch_subdevice_layout)