### PR TITLE
[Bug fix] Bump Blackhole SD_TRACE_REGION_SIZE to fix stable_diffusion perf test

### DIFF
--- a/models/demos/vision/generative/stable_diffusion/wormhole/common.py
+++ b/models/demos/vision/generative/stable_diffusion/wormhole/common.py
@@ -7,4 +7,4 @@ from models.common.utility_functions import is_blackhole
 # L1 Small Size Constants
 SD_L1_SMALL_SIZE = 21760 if is_blackhole() else 20928
 # Trace Region Size Constants
-SD_TRACE_REGION_SIZE = 920000000 if is_blackhole() else 789835776
+SD_TRACE_REGION_SIZE = 922700000 if is_blackhole() else 789835776


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
The `stable_diffusion` model perf test fails deterministically on Blackhole in the
single-card `perf-models` pipeline (`cnn_javelin P150 BH`):

    TT_FATAL @ tt_metal/distributed/mesh_trace.cpp:78:
    get_trace_buffers_size() <= trace_region_size
    Creating trace buffers of size 922656768B on MeshDevice 1,
    but only 920000000B is allocated for trace region.

The captured SD trace measures ~922.66 MB, just over the hardcoded 920 MB
`SD_TRACE_REGION_SIZE`. This bumps the Blackhole value to 922.7 MB so the trace
fits. Wormhole is unaffected and left unchanged.

### Root cause
Bisected to #46526 ("Invalidating DM l2 cache prior to each kernel run"). That PR's
cache-invalidation logic is tt-2xx (Quasar) only and does not run on Blackhole, but
it also added a `kernel_text_size[MaxProcessorsPerCoreType]` field (+32 B with
padding) to the **shared** `kernel_config_msg_t` in `hostdev/dev_msgs.h`, and bumped
`MEM_MAILBOX_SIZE` on Blackhole/Wormhole accordingly. That struct lives in the
per-program launch message, which is recorded once per program in a trace. Summed
across Stable Diffusion's large captured graph (50 steps x UNet/VAE), the +32 B/program
adds ~2.66 MB to the trace — enough to cross the 920 MB ceiling.

### Verification (Blackhole P150, local)
- Reproduced the assert on `main` (trace = 922,656,768 B > 920,000,000 B).
- On-device `git bisect` over the regressing range → first bad commit = 05cca6ae77f (#46526),
  each step reproducing the genuine trace assert.
- With this change: `test_stable_diffusion_perf[1-50-3600-2.8-device_params0]` **PASSED**
  (inference 2.43 s, within tolerance).

922.7 MB clears the worst observed trace size (922,664,960 B) with a small margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI
Model perf tests (this branch):
[![](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml/badge.svg?branch=sjovic/sd-bh-trace-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/perf-models.yaml?query=branch:sjovic/sd-bh-trace-fix)