### PR TITLE
[Fix] layernorm: add missing partial scaler tile in rm_gb reader

### DIFF
--- a/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
+++ b/tests/ttnn/unit_tests/operations/fused/test_layer_norm.py
@@ -546,3 +546,60 @@ def test_layer_norm_inputs_requires_input_tensor():
 
     with pytest.raises(TypeError):
         ttnn.LayerNormInputs()
+
+
+@pytest.mark.parametrize("h", [32])
+@pytest.mark.parametrize("w", [42, 127, 519])
+@pytest.mark.parametrize("op_name", ["layer_norm", "rms_norm"])
+def test_norm_row_major_weight_partial_tile_padding(device, h, w, op_name):
+    """Row-major weight/bias with a TILE input whose logical W is not tile-aligned must
+    not let implicit-padding values pollute per-row mean/variance.
+
+    The interleaved row-major-gamma reader generates only a single full-tile reduce
+    scaler. The reduce LLK then sums across all 32 columns of the last tile, including
+    the implicit padded region past the logical width. If those padded bytes are
+    non-zero, sum(x) and sum(x^2) absorb them and the resulting normalization is wrong.
+    A correct kernel must either zero the input padding before the reduce or generate
+    a masked partial-last-tile scaler so the padded columns contribute zero.
+
+    Welford is excluded from this case: layer_norm-Welford handles the partial last
+    tile via last_tile_rows in the compute kernel, and rms_norm forbids Welford.
+    """
+    torch.manual_seed(0)
+    dtype = torch.bfloat16
+    tile_w = 32
+    padded_w = (w + tile_w - 1) // tile_w * tile_w
+    wt = padded_w // tile_w
+
+    torch_input_tensor = torch.rand((h, w), dtype=dtype)
+    torch_weight = torch.rand((w,), dtype=dtype)
+    torch_bias = torch.rand((w,), dtype=dtype)
+
+    # Row-major weight/bias must have padded last dim == tile_width and physical volume
+    # == padded_W. Pad the logical W values with zeros and reshape to (Wt, 32) so the
+    # Wt-element tile pages match the padded input width.
+    weight_rm = torch.cat([torch_weight, torch.zeros(padded_w - w, dtype=dtype)]).reshape(wt, tile_w)
+    bias_rm = torch.cat([torch_bias, torch.zeros(padded_w - w, dtype=dtype)]).reshape(wt, tile_w)
+
+    input_tensor = ttnn.from_torch(torch_input_tensor, layout=ttnn.TILE_LAYOUT, device=device)
+    input_tensor = ttnn.fill_implicit_tile_padding(input_tensor, PAD_VALUE)
+    weight = ttnn.from_torch(weight_rm, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+    bias = ttnn.from_torch(bias_rm, layout=ttnn.ROW_MAJOR_LAYOUT, device=device)
+
+    program_config = ttnn.LayerNormDefaultProgramConfig(use_welford=False)
+
+    if op_name == "layer_norm":
+        torch_output_tensor = torch.nn.functional.layer_norm(
+            torch_input_tensor, normalized_shape=[w], weight=torch_weight, bias=torch_bias
+        )
+        output_tensor = ttnn.layer_norm(input_tensor, weight=weight, bias=bias, program_config=program_config)
+    else:
+        x = torch_input_tensor.float()
+        rms = torch.rsqrt(x.pow(2).mean(-1, keepdim=True) + 1e-12)
+        torch_output_tensor = (x * rms * torch_weight.float() + torch_bias.float()).to(dtype)
+        output_tensor = ttnn.rms_norm(input_tensor, weight=weight, bias=bias, program_config=program_config)
+
+    output_tensor = ttnn.from_device(output_tensor)
+    output_tensor = ttnn.to_torch(output_tensor)
+
+    assert_output_accuracy(torch_output_tensor, output_tensor)

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
@@ -47,7 +47,7 @@ void kernel_main() {
 
     constexpr uint32_t blk = get_compile_time_arg_val(0);  // needed for correctness of softmax/LN kernels
     constexpr bool use_welford = get_compile_time_arg_val(1) == 1;
-    [[maybe_unused]] constexpr uint32_t W = get_compile_time_arg_val(2);
+    constexpr uint32_t W = get_compile_time_arg_val(2);
     constexpr auto src0_args = TensorAccessorArgs<3>();
     constexpr auto src1_args = TensorAccessorArgs<src0_args.next_compile_time_args_offset()>();
     constexpr auto gamma_args = TensorAccessorArgs<src1_args.next_compile_time_args_offset()>();

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
@@ -77,6 +77,15 @@ void kernel_main() {
             ckernel::ReduceDim::REDUCE_ROW,
             dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
             /*compute_uses_reduce_tile=*/true>();
+        constexpr uint32_t partial_last_tile_cols = W % tt::constants::TILE_WIDTH;
+        if constexpr (partial_last_tile_cols > 0) {
+            dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
+                cb_in_2,
+                ckernel::PoolType::SUM,
+                ckernel::ReduceDim::REDUCE_ROW,
+                dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
+                /*compute_uses_reduce_tile=*/true>(partial_last_tile_cols);
+        }
     }
     constexpr uint32_t eps_cb_id = get_named_compile_time_arg_val("cb_eps");
     const uint32_t eps = get_arg_val<uint32_t>(5);


### PR DESCRIPTION
### Summary

Resolves #43913.

When gamma is in `ROW_MAJOR` layout and `W % 32 != 0`, the device hangs. This PR fixes the hang by pushing the missing masked partial-tile scaler in the `rm_gb` reader kernel.

### Problem Description

The compute kernel (`numeric.h`) checks `W % tile_width` at runtime. When the last tile is partial, it calls `cb_wait_front(cb_scaler, 2)` - it needs two scaler tiles: one full scaler (all `1.0`s) for complete tiles and one masked scaler (first N ones, rest zeros) for the partial last tile.

`reader_unary_interleaved_ln_rm_gb.cpp` only ever pushed scaler tile 0. It never checked `W % 32` and never pushed tile 1. The `W` compile-time arg was already read on line 50 but marked `[[maybe_unused]]` - the partial check was simply never written.

This caused a deadlock:
- Compute calls `cb_wait_front(cb_scaler, 2)` and blocks
- Reader finishes its one scaler push, fills `cb_in` until full, then blocks waiting for compute to free space
- Neither can move -> device hangs

The non-rm_gb reader (`reader_unary_interleaved_ln.cpp`) already handles this correctly. The `rm_gb` reader was the outlier.

### Changes Made

**Files modified:**
- `ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp` - add partial-tile masked scaler push after the existing full scaler push, mirroring lines 130–147 of `reader_unary_interleaved_ln.cpp`

**Kernel fix:**

After pushing the full scaler tile, check whether `W % 32 != 0`. If the last tile is partial, push a masked scaler tile with `1.0` in the valid positions and `0.0` in the padded positions.

### Tests

Added `test_norm_row_major_weight_partial_tile_padding` covering `ROW_MAJOR` gamma for both `layer_norm` and `rms_norm`.

Coverage:
- Non-tile-aligned widths: `[42, 127, 519]`

Verified the hang is resolved and existing tile-aligned behavior remains unchanged.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/fix-ln-rm-gamma-hang-43913)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/fix-ln-rm-gamma-hang-43913)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/fix-ln-rm-gamma-hang-43913)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/fix-ln-rm-gamma-hang-43913)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/fix-ln-rm-gamma-hang-43913)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/fix-ln-rm-gamma-hang-43913)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/fix-ln-rm-gamma-hang-43913)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/fix-ln-rm-gamma-hang-43913)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/fix-ln-rm-gamma-hang-43913)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/fix-ln-rm-gamma-hang-43913)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/fix-ln-rm-gamma-hang-43913)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/fix-ln-rm-gamma-hang-43913)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/fix-ln-rm-gamma-hang-43913)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/fix-ln-rm-gamma-hang-43913)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/fix-ln-rm-gamma-hang-43913)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/fix-ln-rm-gamma-hang-43913)