### PR TITLE
std/var precision fix for biased FP32 inputs and scalar != 1.0

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_reduction_ops.py
@@ -586,9 +586,6 @@ def test_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype)
         if reduction_count <= 1:
             pytest.skip("Bessel-corrected std/var with reduction count of 1 produces NaN output")
 
-    if op in ("var", "std") and scalar != 1.0 and dtype == torch.float32:
-        pytest.xfail("FPU SrcA TF32 floor on do_scale path: cb_in loses precision before the mul. Issue #45222.")
-
     torch.manual_seed(0)
     torch_input = torch.randn(shape, dtype=dtype)
 
@@ -607,11 +604,12 @@ def test_generic_ops_w_scalar(device, op, scalar, correction, dim, shape, dtype)
         torch_result = torch_op(scalar * torch_input, dim=dim)
 
     if dtype == torch.float32 and op in ("var", "std"):
-        # var/std with scalar == 1.0 uses the Welford single-pass path, which
-        # avoids the FPU scale-mul and operates at full FP32 precision
-        # (eps = 2^-23 ~= 1.19e-7). Welford has relative error bounded by
-        # O(sqrt(N) * eps); for N up to 177408 this is ~5e-5. rtol = 1e-4 covers
-        # this with margin, and atol = 1e-4 handles the small-magnitude regime.
+        # var/std always run the Welford single-pass path unscaled and apply the scalar
+        # afterwards (var(s*x) = s^2 var(x), std(s*x) = |s| std(x)), so the reduction stays
+        # at full FP32 precision (eps = 2^-23 ~= 1.19e-7) and avoids the FPU scale-mul.
+        # Welford has relative error bounded by O(sqrt(N) * eps); for N up to 177408 this is
+        # ~5e-5. rtol = 1e-4 covers this with margin, and atol = 1e-4 handles the
+        # small-magnitude regime.
         rtol = 1e-4
         atol = 1e-4
         frobenius_threshold = 1e-4

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -101,23 +101,15 @@ def test_var(device, batch_size, h, w, dim, keepdim, correction):
 # variance of N consecutive integers is (N^2 - 1) / 12 (population); with N=32 and Bessel's
 # correction, sample variance = 32 * (32^2 - 1) / (12 * 31) = 88.0 exactly. Variance is
 # translation-invariant *and* sign-invariant, so neither adding a large offset to every
-# element nor flipping its sign should change the answer. If the unpacker silently routes
-# fp32 input through SrcA as TF32 (10-bit mantissa instead of 23), values that differ by
-# less than the TF32 ULP collapse to the same representation; at offset=1e6 the TF32 ULP
-# is ~512, so all 32 consecutive integers become identical and the apparent variance drops
-# to 0. scalar=-1.0 routes through the do_scale path (mul_tiles_bcast_scalar +
-# transpose_wh_tile of cb_scaled) without changing the expected variance, exercising a
-# different inner-loop pattern than scalar=1.0 (which short-circuits to !do_scale). This
-# test covers all three reduction kernels (H, W, HW) and both code paths.
-@pytest.mark.parametrize("scalar", [1.0, -1.0])
+# element nor flipping its sign should change the answer.the scalar is applied after the
+# reduction as var(s*x) = s^2 * var(x).
+# test covers all three reduction kernels (H, W, HW) and both code paths
+@pytest.mark.parametrize("scalar", [1.0, 0, -1.0])
 @pytest.mark.parametrize("offset", [0.0, 1e6])
 @pytest.mark.parametrize("dim", [-1, -2, (-2, -1)])
 def test_var_fp32_translation_invariance(device, dim, offset, scalar):
     correction = True
-    # a non-unity scalar used to route inputs through mul_tiles_bcast_scalar,
-    # whose FPU SrcA read truncated cb_in to TF32 (10-bit mantissa); at offset=1e6 the TF32
-    # ULP is ~512 so all 32 consecutive integers collapsed to a constant and the variance was
-    # pinned to zero. The scalar is now applied after the (unscaled, precise) Welford reduction
+    # The input is read at full fp32 and reduced unscaled; scalar is now applied after the (unscaled, precise) Welford reduction
     # as var(s*x) = s^2 * var(x), so this case is accurate regardless of offset.
     N = 32
     seq = torch.arange(N, dtype=torch.float32) + offset
@@ -138,17 +130,14 @@ def test_var_fp32_translation_invariance(device, dim, offset, scalar):
     tt_out = ttnn.var(tt_in, dim=dim, scalar=scalar, keepdim=True, correction=correction)
     actual = ttnn.to_torch(ttnn.from_device(tt_out))
 
-    # Tolerances are tight: with the precision-preserving unpacker path the answer is
-    # exact (deviation = 0). atol=1e-3 here is many orders of magnitude tighter than what
-    # the buggy TF32-via-SrcA path produces (which at offset=1e6 returns exactly 0.0
-    # against an expected ~88) while still allowing some small accumulation noise from
-    # the SFPU Welford recurrence itself.
+    # Tight tolerances: the unscaled fp32 reduction is essentially exact, so we only allow
+    # small accumulation noise from the SFPU Welford recurrence.
     assert_numeric_metrics(
         torch_ref,
         actual,
-        rtol=1e-4,
-        atol=1e-3,
-        frobenius_threshold=1e-4,
+        rtol=1e-5,
+        atol=1e-4,
+        frobenius_threshold=1e-5,
         pcc_threshold=0.9999,
         check_ulp=False,
     )

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -114,7 +114,7 @@ def test_var(device, batch_size, h, w, dim, keepdim, correction):
 @pytest.mark.parametrize("dim", [-1, -2, (-2, -1)])
 def test_var_fp32_translation_invariance(device, dim, offset, scalar):
     correction = True
-    # Issue #45222: a non-unity scalar used to route inputs through mul_tiles_bcast_scalar,
+    # a non-unity scalar used to route inputs through mul_tiles_bcast_scalar,
     # whose FPU SrcA read truncated cb_in to TF32 (10-bit mantissa); at offset=1e6 the TF32
     # ULP is ~512 so all 32 consecutive integers collapsed to a constant and the variance was
     # pinned to zero. The scalar is now applied after the (unscaled, precise) Welford reduction

--- a/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
+++ b/tests/ttnn/unit_tests/operations/reduce/test_reduction.py
@@ -114,16 +114,11 @@ def test_var(device, batch_size, h, w, dim, keepdim, correction):
 @pytest.mark.parametrize("dim", [-1, -2, (-2, -1)])
 def test_var_fp32_translation_invariance(device, dim, offset, scalar):
     correction = True
-    # do_scale path (scalar != 1.0) routes inputs through mul_tiles_bcast_scalar, whose FPU
-    # SrcA reads cb_in at TF32 (10-bit mantissa) regardless of any precision-preservation
-    # plumbing downstream. At offset=1e6 the TF32 ULP is ~512, so all 32 consecutive integers
-    # in cb_in collapse to a single TF32 value before the mul fires -- the variance is
-    # structurally pinned to zero on all three reduction kernels (W, H, HW) and there is no
-    # kernel-side workaround. Mark these combinations xfail to document the hardware floor.
-    if scalar != 1.0 and abs(offset) >= 1024:
-        pytest.xfail(
-            "FPU SrcA TF32 floor on do_scale path: cb_in collapses to a constant before the mul. Issue #45222."
-        )
+    # Issue #45222: a non-unity scalar used to route inputs through mul_tiles_bcast_scalar,
+    # whose FPU SrcA read truncated cb_in to TF32 (10-bit mantissa); at offset=1e6 the TF32
+    # ULP is ~512 so all 32 consecutive integers collapsed to a constant and the variance was
+    # pinned to zero. The scalar is now applied after the (unscaled, precise) Welford reduction
+    # as var(s*x) = s^2 * var(x), so this case is accurate regardless of offset.
     N = 32
     seq = torch.arange(N, dtype=torch.float32) + offset
     # Lay out the input so the reduction axis is the integer sequence.

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_h.cpp
@@ -15,6 +15,11 @@
 #include "api/compute/compute_kernel_hw_startup.h"
 #include "api/dataflow/circular_buffer.h"
 
+#ifdef WELFORD_POST_MUL
+// SFPU multiply-by-scalar (mul_unary_tile) applied to the reduced output. See issue #45222.
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#endif
+
 void kernel_main() {
     // Runtime arg: number of independent column-reductions this core must perform.
     // Each column-reduction processes Ht tiles vertically and produces one output tile.
@@ -27,8 +32,11 @@ void kernel_main() {
     constexpr uint32_t H = get_compile_time_arg_val(1);
     // Number of elements per tile in the H dimension (typically 32).
     constexpr uint32_t tile_height = get_compile_time_arg_val(2);
-    // Whether input scaling is required.
-    constexpr bool do_scale = get_compile_time_arg_val(3) != 0;
+#ifdef WELFORD_POST_MUL
+    // Packed fp32 post-multiplier applied to the reduced output via mul_unary_tile (SFPU).
+    // For var this is scalar^2, for std it is |scalar| (see welford_reduce_program_factory).
+    constexpr uint32_t post_mul_scaler_bits = get_compile_time_arg_val(3);
+#endif
     // Whether to apply Bessel's correction (divide by N-1 instead of N).
     constexpr bool correction = get_compile_time_arg_val(4) != 0;
     // Whether to compute standard deviation (sqrt of variance) instead of variance.
@@ -37,21 +45,13 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     // Circular buffer that the reader kernel fills with input tiles.
-    // For FP32 input + do_scale=false: c_0 is flagged UnpackToDestFp32 by the program factory
-    // so copy_tile preserves the FP32 mantissa into DEST for the welford SFPU consumer.
-    // For do_scale=true: c_0 stays Default so the FPU mul_tiles_bcast_scalar SrcA read works.
-    // (H-reduce does not need the FP32-input compile-time flag the W kernel uses for its
-    // cb_scaled hw_configure pairing; this kernel's do_scale path hands the FPU mul's output
-    // straight to welford via DEST with no CB hop in between, and no UnpackToDest-mode
-    // CB is read in the inner loop.)
+    // For FP32 input c_0 is flagged UnpackToDestFp32 by the program factory so copy_tile
+    // preserves the FP32 mantissa into DEST for the welford SFPU consumer. BF16 input: Default.
     constexpr auto cb_in = tt::CBIndex::c_0;
-    // Scalar tile produced by the reader via generate_reduce_scaler.
-    constexpr auto cb_scalar = tt::CBIndex::c_2;
     // Circular buffer where the final variance/std output tile is written.
     constexpr auto cb_out = tt::CBIndex::c_16;
 
     CircularBuffer cb_in_obj(cb_in);
-    CircularBuffer cb_scalar_obj(cb_scalar);
     CircularBuffer cb_out_obj(cb_out);
 
     // Destination register indices inside the Tensix DST register file.
@@ -71,11 +71,6 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_in, cb_out);
     pack_reconfig_data_format(cb_out);
 
-    if constexpr (do_scale) {
-        // Scalar tile stays resident across all columns
-        cb_scalar_obj.wait_front(onetile);
-    }
-
     for (uint32_t ncwt = 0; ncwt < NCWt; ncwt++) {
         // Welford accumulation along the H dimension for one column of tiles.
 
@@ -94,32 +89,10 @@ void kernel_main() {
         // across tile_regs_release/acquire cycles -- only DST contents are
         // affected by the handshake, not the SFPU accumulators.
         //
-        // DST/tile_regs flow:
-        // - tile_regs_acquire() gives the MATH thread ownership of the DST tile registers.
-        // - tile_regs_commit() -- MATH signals it is done writing DST.
-        // - tile_regs_wait() lets the PACK thread safely see those DST tiles.
-        // - tile_regs_release() releases the PACK side of DST ownership.
-        // - do_scale path mixes two incompatible operation types each iteration:
-        //   1. mul_tiles_bcast_scalar  -- an FPU operation
-        //   2. welford_update          -- an SFPU operation
-        //   In this path, we do a full acquire/commit/wait/release on non-final iterations
-        //   even though nothing is packed. That handshake is used to leave the scalar-mul
-        //   configuration in a clean, fully closed state before the next iteration reconfigures
-        //   the compute engines for another scaled input.
-        // - In the !do_scale path, only SFPU-compatible operations are used
-        //   (copy_tile + welford_update), so no configuration conflict exists
-        //   and the entire loop can run in a single DST window (one acquire
-        //   before the loop, one commit after the last tile).
-        //   Only the final iteration needs to expose result tiles to PACK.
-        //
-        // Init/reinit flow:
-        // - welford_init() is the full Welford setup. It programs the Welford SFPU path and
-        //   clears any previous running mean/M2 state, so it must be done once before the loop,
-        //   not inside the loop.
-        // - mul_tiles_bcast_scalar_init_short(cb_in, cb_scalar) reconfigures for FPU scalar multiply.
-        // - welford_reinit(cb_in) restores UNPACK+MATH to the datacopy-style state Welford needs
-        //   after the mul (see llk_math_welfords_sfpu_reinit); it does not clear LREG4/5.
-        // - In the !do_scale path we use copy_tile_to_dst_init_short once, then copy_tile per tile.
+        // Only SFPU-compatible operations are used (copy_tile + welford_update), so no
+        // configuration conflict exists and the entire loop can run in a single DST window
+        // (one acquire before the loop, one commit after the last tile). Only the final
+        // iteration needs to expose result tiles to PACK.
         //
         // Per iteration:
         // - For all non-last H tiles, welford_update(input_dst, start_N, ...) consumes the full
@@ -131,47 +104,21 @@ void kernel_main() {
         // - If is_std, sqrt_tile() turns variance into standard deviation in place.
         // - start_N advances by one tile height each iteration so Welford sees the correct
         //   element count / divisor progression across the whole H reduction.
-        if constexpr (!do_scale) {
-            copy_tile_to_dst_init_short(cb_in);
-            tile_regs_acquire();
-        }
+        copy_tile_to_dst_init_short(cb_in);
+        tile_regs_acquire();
 
         // Welford SFPU state (running mean in LREG4, M2 in LREG5)
         // persists across DST cycles because LREGs are separate from
         // the DST register file managed by tile_regs_acquire/release.
         for (uint32_t ht = 0; ht < Ht; ++ht) {
             cb_in_obj.wait_front(onetile);
-
-            if constexpr (do_scale) {
-                tile_regs_acquire();
-                // FPU mul reads cb_in (Default mode -- no UnpackToDest conflict on SrcA).
-                mul_tiles_bcast_scalar_init_short(cb_in, cb_scalar);
-                mul_tiles_bcast_scalar(cb_in, cb_scalar, 0, 0, input_dst);
-
-                // welford_reinit programs the welford SFPU's UNPACK_A/MATH init. Welford reads
-                // input_dst (DEST) directly, so the operand passed here is just for the init's
-                // bookkeeping -- cb_in is fine regardless of FP32/BF16.
-                welford_reinit(cb_in);
-            } else {
-                // copy_tile reads cb_in. For FP32 input, c_0 carries UnpackToDestFp32 so the
-                // FP32 mantissa is preserved into DEST for the welford SFPU consumer.
-                copy_tile(cb_in, 0, input_dst);
-            }
+            // copy_tile reads cb_in. For FP32 input, c_0 carries UnpackToDestFp32 so the
+            // FP32 mantissa is preserved into DEST for the welford SFPU consumer.
+            copy_tile(cb_in, 0, input_dst);
             cb_in_obj.pop_front(onetile);
 
             if (ht < (Ht - 1)) {
                 welford_update<0>(input_dst, start_N, {});
-                if constexpr (do_scale) {
-                    // Even on non-final iterations we must complete the full DST handshake here.
-                    // We are not producing a packed output tile yet; this commit/wait/release is
-                    // only to fully close out the current DST and compute-engine state after
-                    // mul_tiles_bcast_scalar, before the next iteration reconfigures UNPACK+MATH
-                    // for another scaled input. Without this handshake, the next iteration can
-                    // inherit stale DST or UNPACK+MATH configuration.
-                    tile_regs_commit();
-                    tile_regs_wait();
-                    tile_regs_release();
-                }
             } else {
                 // Last tile: process only valid rows, then finalize
                 welford_update_rows<0>(input_dst, start_N, 0, last_tile_rows, {});
@@ -184,6 +131,13 @@ void kernel_main() {
                     sqrt_tile_init();
                     sqrt_tile(var_dst);
                 }
+#ifdef WELFORD_POST_MUL
+                // Apply the user scalar to the reduced output: var(s*x)=s^2 var(x),
+                // std(s*x)=|s| std(x). mul_unary_tile is an SFPU op on DEST at full fp32
+                // precision (issue #45222).
+                binop_with_scalar_tile_init();
+                mul_unary_tile(var_dst, post_mul_scaler_bits);
+#endif
                 tile_regs_commit();
             }
             start_N += tile_height;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_h.cpp
@@ -134,7 +134,7 @@ void kernel_main() {
 #ifdef WELFORD_POST_MUL
                 // Apply the user scalar to the reduced output: var(s*x)=s^2 var(x),
                 // std(s*x)=|s| std(x). mul_unary_tile is an SFPU op on DEST at full fp32
-                // precision (issue #45222).
+                // precision .
                 binop_with_scalar_tile_init();
                 mul_unary_tile(var_dst, post_mul_scaler_bits);
 #endif

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_hw.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_hw.cpp
@@ -13,7 +13,8 @@
 // Phase 2 (per output): Reads the combined Float32 scalar tile from
 // cb_combined (produced by the writer after W-combining all partials
 // and applying Bessel's correction), applies sqrt_tile when computing
-// std, and re-packs to cb_out in the output data format.  This ensures
+// std, applies the user scalar via SFPU post-multiplication, and
+// re-packs to cb_out in the output data format.  This ensures
 // the packer hardware handles format conversion (required for
 // BFLOAT8_B and for matching the output dtype to the input dtype).
 
@@ -27,6 +28,11 @@
 #include "api/compute/compute_kernel_hw_startup.h"
 #include "api/dataflow/circular_buffer.h"
 
+#ifdef WELFORD_POST_MUL
+// SFPU multiply-by-scalar (mul_unary_tile) applied to the reduced output. See issue #45222.
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#endif
+
 void kernel_main() {
     // Runtime arg: total number of NC slices this core must process.
     uint32_t NC_per_core = get_arg_val<uint32_t>(0);
@@ -36,18 +42,19 @@ void kernel_main() {
     constexpr uint32_t H = get_compile_time_arg_val(1);
     constexpr uint32_t tile_height = get_compile_time_arg_val(2);
     constexpr uint32_t Wt = get_compile_time_arg_val(3);
-    constexpr bool do_scale = get_compile_time_arg_val(4) != 0;
+#ifdef WELFORD_POST_MUL
+    // Packed fp32 post-multiplier applied to the reduced output via mul_unary_tile (SFPU).
+    // For var this is scalar^2, for std it is |scalar| (see welford_reduce_program_factory).
+    constexpr uint32_t post_mul_scaler_bits = get_compile_time_arg_val(4);
+#endif
     constexpr uint32_t reduce_batch_size = get_compile_time_arg_val(5);
     constexpr bool is_std = get_compile_time_arg_val(6) != 0;
 
     constexpr uint32_t onetile = 1;
 
-    // cb_in: For FP32 input + do_scale=false it is flagged UnpackToDestFp32 (program factory),
-    // preserving FP32 mantissa for the copy_tile -> welford SFPU consumer path. On do_scale=true
-    // it stays Default for the FPU mul SrcA read. (Like H-reduce, HW Phase 1 does not need
-    // the FP32-input compile-time flag the W kernel uses for cb_scaled hw_configure pairing.)
+    // cb_in: For FP32 input it is flagged UnpackToDestFp32 (program factory), preserving FP32
+    // mantissa for the copy_tile -> welford SFPU consumer path. BF16 input: Default.
     constexpr auto cb_in = tt::CBIndex::c_0;
-    constexpr auto cb_scalar = tt::CBIndex::c_2;
     // Final output CB (output data format), consumed by the writer for NOC write.
     constexpr auto cb_out = tt::CBIndex::c_16;
     // Intermediate CB for mean+var tile pairs, consumed by writer kernel.
@@ -56,7 +63,6 @@ void kernel_main() {
     constexpr auto cb_combined = tt::CBIndex::c_22;
 
     CircularBuffer cb_in_obj(cb_in);
-    CircularBuffer cb_scalar_obj(cb_scalar);
     CircularBuffer cb_out_obj(cb_out);
     CircularBuffer cb_partial_obj(cb_partial);
     CircularBuffer cb_combined_obj(cb_combined);
@@ -73,10 +79,6 @@ void kernel_main() {
 
     compute_kernel_hw_startup(cb_in, cb_partial);
     pack_reconfig_data_format(cb_partial);
-
-    if constexpr (do_scale) {
-        cb_scalar_obj.wait_front(onetile);
-    }
 
     uint32_t num_outputs = NC_per_core / reduce_batch_size;
 
@@ -102,31 +104,10 @@ void kernel_main() {
                 // across tile_regs_release/acquire cycles -- only DST contents are
                 // affected by the handshake, not the SFPU accumulators.
                 //
-                // DST/tile_regs flow:
-                // - tile_regs_acquire() gives the MATH thread ownership of the DST tile registers.
-                // - tile_regs_commit() -- MATH signals it is done writing DST.
-                // - tile_regs_wait() lets the PACK thread safely see those DST tiles.
-                // - tile_regs_release() releases the PACK side of DST ownership.
-                // - do_scale path mixes two incompatible operation types each iteration:
-                //   1. mul_tiles_bcast_scalar  -- an FPU operation
-                //   2. welford_update          -- an SFPU operation
-                //   In this path, we do a full acquire/commit/wait/release on non-final iterations
-                //   even though nothing is packed. That handshake is used to leave the scalar-mul
-                //   configuration in a clean, fully closed state before the next iteration reconfigures
-                //   the compute engines for another scaled input.
-                // - In the !do_scale path, only SFPU-compatible operations are used
-                //   (copy_tile + welford_update), so no configuration conflict exists
-                //   and the entire loop can run in a single DST window (one acquire
-                //   before the loop, one commit after the last tile).
-                //   Only the final iteration needs to expose result tiles to PACK.
-                //
-                // Init/reinit flow:
-                // - welford_init() is the full Welford setup. It programs the Welford SFPU path and
-                //   clears any previous running mean/M2 state, so it must be done once before the loop,
-                //   not inside the loop.
-                // - mul_tiles_bcast_scalar_init_short reconfigures for FPU scalar multiply.
-                // - welford_reinit(cb_in) restores UNPACK+MATH after the mul (llk_math_welfords_sfpu_reinit).
-                // - In the !do_scale path we use copy_tile_to_dst_init_short once, then copy_tile per tile.
+                // Only SFPU-compatible operations are used (copy_tile + welford_update), so no
+                // configuration conflict exists and the entire loop can run in a single DST
+                // window (one acquire before the loop, one commit after the last tile). Only the
+                // final iteration needs to expose result tiles to PACK.
                 //
                 // Per iteration:
                 // - For all non-last H tiles, welford_update(input_dst, start_N, ...) consumes the full
@@ -135,47 +116,23 @@ void kernel_main() {
                 //   rows so only valid elements participate in the statistics.
                 // - welford_finalize_to_row(mean_dst, scale_idx, ...) converts M2 into variance and
                 //   writes final mean/variance tiles into DST.
-                // - If is_std, sqrt_tile() turns variance into standard deviation in place.
                 // - start_N advances by one tile height each iteration so Welford sees the correct
                 //   element count / divisor progression across the whole H reduction.
-                if constexpr (!do_scale) {
-                    copy_tile_to_dst_init_short(cb_in);
-                    tile_regs_acquire();
-                }
+                copy_tile_to_dst_init_short(cb_in);
+                tile_regs_acquire();
 
                 // Welford SFPU state (running mean in LREG4, M2 in LREG5)
                 // persists across DST cycles because LREGs are separate from
                 // the DST register file managed by tile_regs_acquire/release.
                 for (uint32_t ht = 0; ht < Ht; ++ht) {
                     cb_in_obj.wait_front(onetile);
-                    if constexpr (do_scale) {
-                        tile_regs_acquire();
-                        // FPU mul reads cb_in (Default mode).
-                        mul_tiles_bcast_scalar_init_short(cb_in, cb_scalar);
-                        mul_tiles_bcast_scalar(cb_in, cb_scalar, 0, 0, input_dst);
-                        // welford_reinit bookkeeping (welford reads input_dst from DEST; the CB
-                        // arg is just init metadata, so cb_in is fine regardless of FP32/BF16).
-                        welford_reinit(cb_in);
-                    } else {
-                        // copy_tile reads cb_in. For FP32 input, c_0 carries UnpackToDestFp32
-                        // so the FP32 mantissa is preserved into DEST.
-                        copy_tile(cb_in, 0, input_dst);
-                    }
+                    // copy_tile reads cb_in. For FP32 input, c_0 carries UnpackToDestFp32
+                    // so the FP32 mantissa is preserved into DEST.
+                    copy_tile(cb_in, 0, input_dst);
                     cb_in_obj.pop_front(onetile);
 
                     if (ht < (Ht - 1)) {
                         welford_update<0>(input_dst, start_N, {});
-                        if constexpr (do_scale) {
-                            // Even on non-final iterations we must complete the full DST handshake here.
-                            // We are not producing a packed output tile yet; this commit/wait/release is
-                            // only to fully close out the current DST and compute-engine state after
-                            // mul_tiles_bcast_scalar, before the next iteration reconfigures UNPACK+MATH
-                            // for another scaled input. Without this handshake, the next iteration can
-                            // inherit stale DST or UNPACK+MATH configuration.
-                            tile_regs_commit();
-                            tile_regs_wait();
-                            tile_regs_release();
-                        }
                     } else {
                         // Last tile: process only valid rows, then finalize.
                         welford_update_rows<0>(input_dst, start_N, 0, last_tile_rows, {});
@@ -203,12 +160,12 @@ void kernel_main() {
             }
         }
 
-        // --- Phase 2: Read combined scalar from writer, apply sqrt if std, repack ---
+        // --- Phase 2: Read combined scalar from writer, apply sqrt if std, post-mul, repack ---
         // The writer W-combines all per-column partials from Phase 1 into a
         // single Float32 scalar tile in cb_combined (with Bessel's correction
-        // already applied).  We unpack it, apply sqrt_tile for std, and
-        // re-pack into cb_out using the packer, which converts to the output
-        // data format (handles BFLOAT8_B and all other formats).
+        // already applied).  We unpack it, apply sqrt_tile for std, apply the
+        // user scalar, and re-pack into cb_out using the packer, which converts
+        // to the output data format (handles BFLOAT8_B and all other formats).
         cb_combined_obj.wait_front(onetile);
         // Explicit srca reconfig is required because the unpacker was last
         // configured for cb_in's format (e.g. Float16_b) during Phase 1.
@@ -221,6 +178,12 @@ void kernel_main() {
             sqrt_tile_init();
             sqrt_tile(input_dst);
         }
+#ifdef WELFORD_POST_MUL
+        // Apply the user scalar to the reduced output: var(s*x)=s^2 var(x), std(s*x)=|s| std(x).
+        // mul_unary_tile is an SFPU op on DEST at full fp32 precision (issue #45222).
+        binop_with_scalar_tile_init();
+        mul_unary_tile(input_dst, post_mul_scaler_bits);
+#endif
         tile_regs_commit();
         cb_combined_obj.pop_front(onetile);
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_w.cpp
@@ -164,7 +164,7 @@ void kernel_main() {
         }
 #ifdef WELFORD_POST_MUL
         // Apply the user scalar to the reduced output: var(s*x)=s^2 var(x), std(s*x)=|s| std(x).
-        // mul_unary_tile is an SFPU op operating on DEST at full fp32 precision (issue #45222).
+        // mul_unary_tile is an SFPU op operating on DEST at full fp32 precision.
         binop_with_scalar_tile_init();
         mul_unary_tile(var_dst, post_mul_scaler_bits);
 #endif

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_w.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/welford_reduce_w.cpp
@@ -12,6 +12,11 @@
 
 #include "api/dataflow/circular_buffer.h"
 
+#ifdef WELFORD_POST_MUL
+// SFPU multiply-by-scalar (mul_unary_tile) applied to the reduced output. See issue #45222.
+#include "api/compute/eltwise_unary/binop_with_scalar.h"
+#endif
+
 void kernel_main() {
     // Runtime args:
     // Total number of outer-loop iterations (N * C * Ht),
@@ -26,8 +31,11 @@ void kernel_main() {
     // Number of elements per tile in the W dimension
     // (typically 32, but can be smaller for narrow tiles).
     constexpr uint32_t tile_width = get_compile_time_arg_val(2);
-    // Whether input scaling is required.
-    constexpr bool do_scale = get_compile_time_arg_val(3) != 0;
+#ifdef WELFORD_POST_MUL
+    // Packed fp32 post-multiplier applied to the reduced output via mul_unary_tile (SFPU).
+    // For var this is scalar^2, for std it is |scalar| (see welford_reduce_program_factory).
+    constexpr uint32_t post_mul_scaler_bits = get_compile_time_arg_val(3);
+#endif
     // Whether to apply Bessel's correction (divide by N-1 instead of N).
     constexpr bool correction = get_compile_time_arg_val(4) != 0;
     // Whether to compute standard deviation (sqrt of variance) instead of variance.
@@ -36,20 +44,13 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
 
     // Circular buffer that the reader kernel fills with input tiles.
-    // For FP32 input + do_scale=false: c_0 is flagged UnpackToDestFp32 by the program factory
-    // so the welford SFPU intake (transpose_wh_tile) reads with full FP32 precision.
-    // For FP32 input + do_scale=true: c_0 stays Default for the FPU mul SrcA read; precision
-    // preservation lives on cb_scaled (c_20) below.
-    // For BF16 input: c_0 is Default regardless.
+    // For FP32 input c_0 is flagged UnpackToDestFp32 by the program factory so the welford SFPU
+    // intake (transpose_wh_tile) reads with full FP32 precision. For BF16 input c_0 is Default.
     constexpr auto cb_in = tt::CBIndex::c_0;
-    // True when input is FP32; gates full hw_configure pairs in the do_scale Wt-inner loop
-    // to flip UNPACK between cb_in (Default, for FPU mul) and cb_scaled (UnpackToDestFp32,
-    // for welford-intake transpose). On BF16 input neither CB carries UnpackToDestFp32, so
-    // _init_short calls suffice.
+    // True when input is FP32; gates the transpose_wh re-init / welford PreserveStats recovery
+    // in the Wt-inner loop (transpose_wh_tile's UnpackToDestFp32 path clobbers the welford SFPU
+    // replay buffer). On BF16 input that path is inactive, so the recovery is gated out.
     constexpr bool welford_fp32_input = get_named_compile_time_arg_val("welford_fp32_input") != 0;
-    // Scalar tile produced by the reader via generate_reduce_scaler.
-    // Used to scale every input tile before Welford processing.
-    constexpr auto cb_scalar = tt::CBIndex::c_2;
     // Circular buffer where the final variance output tile is written
     // for the writer kernel to consume.
     constexpr auto cb_out = tt::CBIndex::c_16;
@@ -58,19 +59,10 @@ void kernel_main() {
     // we transpose back to column orientation via this buffer,
     // and transpose operation can't take data from the DST register).
     constexpr auto cb_var = tt::CBIndex::c_19;
-    // 1-tile intermediate: holds the scaled input tile between the
-    // mul_tiles_bcast_scalar (scale step) and transpose_wh_tile (Welford step).
-    // Only used when do_scale is true.
-    // The reason this is needed is because mul_tiles_bcast_scalar writes data
-    // to the DST register, but transpose_wh_tile is an unpack operation, so
-    // it expects data in a CB. Thus, this CB is used to hold the scaled input tile.
-    constexpr auto cb_scaled = tt::CBIndex::c_20;
 
     CircularBuffer cb_in_obj(cb_in);
-    CircularBuffer cb_scalar_obj(cb_scalar);
     CircularBuffer cb_out_obj(cb_out);
     CircularBuffer cb_var_obj(cb_var);
-    CircularBuffer cb_scaled_obj(cb_scaled);
 
     // Destination register indices inside the Tensix DST register file.
     // Welford's LLK uses three adjacent dst registers:
@@ -89,16 +81,9 @@ void kernel_main() {
     compute_kernel_hw_startup(cb_in, cb_out);
     pack_reconfig_data_format(cb_out);
 
-    if constexpr (do_scale) {
-        // Scalar tile stays resident across all rows
-        cb_scalar_obj.wait_front(onetile);
-    }
-
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         // Simultaneous calculation of E[x] and Var[x] using Welford's algorithm.
-        // When do_scale is true, each input tile is first multiplied by the scalar,
-        // packed to cb_scaled, then transposed and fed to welford_update.
-        // When do_scale is false, input tiles are transposed directly from cb_in.
+        // Input tiles are transposed directly from cb_in and fed to welford_update.
         // The Welford SFPU state (running mean in LREG4, M2 in LREG5) persists
         // across tile_regs_release/acquire cycles because LREGs are SFPU registers,
         // separate from the DST register file managed by tile_regs_acquire/release.
@@ -111,66 +96,26 @@ void kernel_main() {
         // Programs SFPU replay buffer + clears LREG4/5
         welford_init();
 
-        // When scaling, DST must be acquired/released per tile because
-        // the FPU mul is incompatible with SFPU Welford. The scaled
-        // result is packed to cb_scaled so that transpose_wh_tile (an
-        // unpack operation) can read it back.
-        // Without scaling, transpose and welford (both SFPU-compatible)
-        // can share a single DST window for the entire loop.
-        // On the do_scale path, transpose_wh_init_short(cb_scaled) runs before each
-        // welford_update; it re-inits UNPACK and MATH via llk_math_eltwise_unary_datacopy_init,
-        // so a separate UNPACK/MATH reinit after the FPU mul is not required here.
-        if constexpr (!do_scale) {
-            reconfig_data_format_srca(cb_in);
-            // cb_in's UnpackToDestFp32 mode (FP32 input only) was already programmed by
-            // compute_kernel_hw_startup(cb_in, cb_out) at kernel entry, so _init_short is
-            // enough here. For BF16 input cb_in is Default mode and the same call works.
-            transpose_wh_init_short(cb_in);
-            tile_regs_acquire();
-        }
-        // In contrast, on do_scale path, full init_bcast and full transpose_wh_init happen inside
-        // the Wt loop (each iteration) to pair UNPACK mode flips for cb_in (Default, FPU mul SrcA)
-        // and cb_scaled (UnpackToDestFp32, unpack-to-DEST consumer for the welford-intake transpose).
-        // The first iteration's init_bcast also resets the leaked UnpackToDest mode from the
-        // previous NCHt iteration's final transpose_wh_init(cb_var, cb_out), so no separate
-        // outer-loop reset is needed.
+        // transpose and welford (both SFPU-compatible) share a single DST window for the entire
+        // loop: one acquire before the loop, one commit after the last tile.
+        reconfig_data_format_srca(cb_in);
+        // cb_in's UnpackToDestFp32 mode (FP32 input only) was already programmed by
+        // compute_kernel_hw_startup(cb_in, cb_out) at kernel entry, so _init_short is
+        // enough here. For BF16 input cb_in is Default mode and the same call works.
+        transpose_wh_init_short(cb_in);
+        tile_regs_acquire();
 
         // Welford SFPU state (running mean in LREG4, M2 in LREG5)
         // persists across DST cycles because LREGs are separate from
         // the DST register file managed by tile_regs_acquire/release.
         for (uint32_t wt = 0; wt < Wt; ++wt) {
-            if constexpr (do_scale) {
-                // --- Scale step: multiply input tile by scalar ---
-                cb_in_obj.wait_front(onetile);
-                tile_regs_acquire();
-                reconfig_data_format_srca(cb_in);
-                mul_tiles_bcast_scalar_init_short(cb_in, cb_scalar);
-                mul_tiles_bcast_scalar(cb_in, cb_scalar, 0, 0, input_dst);
-                tile_regs_commit();
-                cb_in_obj.pop_front(1);
-                cb_scaled_obj.reserve_back(onetile);
-                tile_regs_wait();
-                pack_reconfig_data_format(cb_scaled);
-                pack_tile(input_dst, cb_scaled);
-                tile_regs_release();
-                cb_scaled_obj.push_back(onetile);
-
-                // --- Transpose scaled tile back into DST ---
-                cb_scaled_obj.wait_front(onetile);
-                tile_regs_acquire();
-                reconfig_data_format_srca(cb_scaled);
-                transpose_wh_init_short(cb_scaled);
-                transpose_wh_tile(cb_scaled, 0, input_dst);
-                cb_scaled_obj.pop_front(onetile);
-            } else {
-                cb_in_obj.wait_front(onetile);
-                if constexpr (welford_fp32_input) {
-                    // Re-records the transpose-dest setup at math-thread replay slots [16, 32).
-                    transpose_wh_init_short(cb_in);
-                }
-                transpose_wh_tile(cb_in, 0, input_dst);
-                cb_in_obj.pop_front(onetile);
+            cb_in_obj.wait_front(onetile);
+            if constexpr (welford_fp32_input) {
+                // Re-records the transpose-dest setup at math-thread replay slots [16, 32).
+                transpose_wh_init_short(cb_in);
             }
+            transpose_wh_tile(cb_in, 0, input_dst);
+            cb_in_obj.pop_front(onetile);
 
             // For fp32 input, transpose_wh_tile takes the UnpackToDest path whose math-side init
             // overwrites the upper half of the SFPU replay buffer (slots [16, 32)), clobbering
@@ -187,11 +132,6 @@ void kernel_main() {
 
             if (wt < (Wt - 1)) {
                 welford_update<0>(input_dst, start_N, {});
-                if constexpr (do_scale) {
-                    tile_regs_commit();
-                    tile_regs_wait();
-                    tile_regs_release();
-                }
             } else {
                 // Last tile: finalize and keep DST acquired for variance packing
                 welford_update_rows<0>(input_dst, start_N, 0, last_tile_rows, {});
@@ -222,6 +162,12 @@ void kernel_main() {
             sqrt_tile_init();
             sqrt_tile(var_dst);
         }
+#ifdef WELFORD_POST_MUL
+        // Apply the user scalar to the reduced output: var(s*x)=s^2 var(x), std(s*x)=|s| std(x).
+        // mul_unary_tile is an SFPU op operating on DEST at full fp32 precision (issue #45222).
+        binop_with_scalar_tile_init();
+        mul_unary_tile(var_dst, post_mul_scaler_bits);
+#endif
         tile_regs_commit();
         cb_var_obj.pop_front(onetile);
 

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
@@ -169,11 +169,10 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
     ProgramDescriptor desc;
 
     // Input CB c_0. The unpack_to_dest_mode flag below makes c_0 UnpackToDestFp32 for FP32
-    // input on the !do_scale path so the welford SFPU intake (copy_tile / transpose_wh_tile)
-    // reads via the precision-preserving unpack-to-DEST path. On the do_scale path c_0 stays
-    // Default so the FPU mul_tiles_bcast_scalar SrcA read works (UnpackToDest is incompatible
-    // with FPU SrcA); the SFPU welford on that path reads cb_scaled instead, and cb_scaled's
-    // own UnpackToDestFp32 flag preserves the FPU mul output mantissa.
+    // input so the welford SFPU intake (copy_tile / transpose_wh_tile) reads via the
+    // precision-preserving unpack-to-DEST path instead of the FPU SrcA path (which would
+    // truncate FP32 to TF32). The user scalar is applied as an SFPU post-multiplication on
+    // the reduced output, not by pre-scaling the input -- see post_mul_scaler below.
     CBIndex input_cb_index = CBIndex::c_0;
     uint32_t input_tiles_per_cb = 2;
     desc.cbs.push_back(CBDescriptor{
@@ -231,23 +230,17 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
         });
     }
 
-    // cb_scaled (c_20): only W-reduce needs this when do_scale is true.
-    // transpose_wh_tile is an unpack operation that reads from a CB, not
-    // DST, so the FPU mul result must be packed to this intermediate CB.
-    // H and HW reduce don't need the transpose.
-    bool do_scale = (operation_attributes.scalar != 1.0f);
-    if (do_scale && reduce_w) {
-        CBIndex scaled_cb_index = CBIndex::c_20;
-        desc.cbs.push_back(CBDescriptor{
-            .total_size = input_single_tile_size,
-            .core_ranges = all_cores,
-            .format_descriptors = {{CBFormatDescriptor{
-                .buffer_index = static_cast<uint8_t>(scaled_cb_index),
-                .data_format = input_cb_data_format,
-                .page_size = input_single_tile_size,
-            }}},
-        });
-    }
+    // Post-reduction scaling (issue #45222): the reduction always runs unscaled (the precise
+    // UnpackToDestFp32 path), and the user scalar is applied to the small-magnitude result via
+    // SFPU mul_unary_tile inside the compute kernel, gated by the WELFORD_POST_MUL define.
+    // Pre-scaling the input (the old do_scale path) read cb_in via the FPU SrcA operand at TF32
+    // precision and collapsed large-offset inputs to a constant before the multiply. The
+    // post-multiplier follows var(s*x)=s^2 var(x) and std(s*x)=|s| std(x):
+    //   var: scalar^2   std: |scalar|.
+    const bool use_post_mul = (operation_attributes.scalar != 1.0f);
+    const float post_mul_scaler =
+        is_std ? std::abs(operation_attributes.scalar) : operation_attributes.scalar * operation_attributes.scalar;
+    const uint32_t post_mul_scaler_bits = std::bit_cast<uint32_t>(post_mul_scaler);
 
     // cb_partial (c_21): HW-reduce only -- holds per-column mean+var tile pairs
     // from the compute kernel, consumed by the writer kernel.
@@ -296,11 +289,17 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
         reduce_op_utils::get_defines(operation_attributes.math_op, operation_attributes.reduce_dim);
     reduce_defines["ENABLE_FP32_DEST_ACC"] = fp32_dest_acc_en ? "1" : "0";
     reduce_defines["DST_SYNC_FULL"] = dst_full_sync_en ? "1" : "0";
+    // Enables the SFPU post-multiplication of the reduced output by the user scalar in the
+    // compute kernel (see post_mul_scaler above). Only the compute kernel reads this; the
+    // reader/writer ignore it.
+    if (use_post_mul) {
+        reduce_defines["WELFORD_POST_MUL"] = "1";
+    }
 
-    // welford_fp32_input gates the full hw_configure pairs in the W-reduce compute kernel
-    // in the do_scale wt-inner loop that switch UNPACK between cb_in's Default mode
-    // (FPU mul SrcA) and cb_scaled's UnpackToDestFp32 mode (welford-intake transpose). H- and
-    // HW-reduce kernels don't have a cb_scaled-style intermediate and don't need this flag.
+    // welford_fp32_input gates the transpose_wh re-init / welford PreserveStats recovery in the
+    // W-reduce compute kernel's wt-inner loop, needed because transpose_wh_tile's UnpackToDestFp32
+    // path clobbers the welford SFPU replay buffer on FP32 input. H- and HW-reduce kernels read
+    // the input via copy_tile (no transpose) and don't need this flag.
     std::vector<std::pair<std::string, uint32_t>> welford_named_args;
     if (reduce_w) {
         welford_named_args.push_back(
@@ -380,13 +379,13 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
     std::string compute_kernel;
 
     if (reduce_hw) {
-        // HW-reduce compile args: {Ht, H, tile_height, Wt, do_scale, reduce_batch_size, is_std}
+        // HW-reduce compile args: {Ht, H, tile_height, Wt, post_mul_scaler_bits, reduce_batch_size, is_std}
         compute_compile_args = {
             Ht,
             H,
             tile_height,
             Wt,
-            static_cast<uint32_t>(do_scale),
+            post_mul_scaler_bits,
             reduce_batch_size,
             static_cast<uint32_t>(is_std),
         };
@@ -400,13 +399,13 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
                 reduce_size);
         }
 
-        // W-reduce compile args: {Wt, W, tile_width, do_scale, correction, is_std}
-        // H-reduce compile args: {Ht, H, tile_height, do_scale, correction, is_std}
+        // W-reduce compile args: {Wt, W, tile_width, post_mul_scaler_bits, correction, is_std}
+        // H-reduce compile args: {Ht, H, tile_height, post_mul_scaler_bits, correction, is_std}
         compute_compile_args = {
             reduce_w ? Wt : Ht,
             reduce_w ? W : H,
             reduce_w ? tile_width : tile_height,
-            static_cast<uint32_t>(do_scale),
+            post_mul_scaler_bits,
             static_cast<uint32_t>(operation_attributes.correction),
             static_cast<uint32_t>(is_std),
         };
@@ -423,29 +422,20 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
     //
     // Apply this to every Float32 CB the compute kernel reads back via copy_tile /
     // transpose_wh_tile:
-    //   - Input CB: needed on all three reduction paths (H, W, HW), but only on the !do_scale
-    //     path with FP32 input, where the Welford SFPU intake reads c_0 directly via
-    //     copy_tile/transpose_wh_tile, so UnpackToDestFp32 preserves the full FP32 into DEST.
-    //     On the do_scale path input CB is read by the FPU mul (SrcA), which is incompatible
-    //     with UnpackToDest mode. The precision-preserving plumbing lives downstream on cb_scaled.
+    //   - Input CB: needed on all three reduction paths (H, W, HW) with FP32 input. The Welford
+    //     SFPU intake reads c_0 directly via copy_tile/transpose_wh_tile, so UnpackToDestFp32
+    //     preserves the full FP32 into DEST (there is no input pre-scaling -- see post_mul_scaler).
     //   - W-reduce only: cb_var (c_19) -- the variance tile is read back after the initial
     //     transpose to undo it.
-    //   - W-reduce + do_scale only: cb_scaled (c_20) -- the FPU-scaled input tile is read
-    //     back by transpose_wh_tile, whose result feeds the SFPU welford on DEST.
-    //     flagged UnpackToDestFp32 to preserve the up-to-22 mantissa bits the FPU mul output
-    //     can carry beyond its TF32 inputs.
     //   - HW-reduce only: cb_combined (c_22) -- the variance tile is read back after the
     //     writer-side cross-core re-reduction.
     std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
         NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
-    if (input_cb_data_format == tt::DataFormat::Float32 && !do_scale) {
+    if (input_cb_data_format == tt::DataFormat::Float32) {
         unpack_to_dest_mode[static_cast<uint32_t>(CBIndex::c_0)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
     if (reduce_w && fp32_dest_acc_en && !narrow_scratch_to_bf16) {
         unpack_to_dest_mode[static_cast<uint32_t>(CBIndex::c_19)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
-    }
-    if (reduce_w && do_scale && input_cb_data_format == tt::DataFormat::Float32) {
-        unpack_to_dest_mode[static_cast<uint32_t>(CBIndex::c_20)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
     }
     if (reduce_hw && fp32_dest_acc_en && !narrow_scratch_to_bf16) {
         unpack_to_dest_mode[static_cast<uint32_t>(CBIndex::c_22)] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_program_factory.cpp
@@ -230,7 +230,7 @@ tt::tt_metal::ProgramDescriptor WelfordReduceDeviceOperation::WelfordReduceProgr
         });
     }
 
-    // Post-reduction scaling (issue #45222): the reduction always runs unscaled (the precise
+    // Post-reduction scaling: the reduction always runs unscaled (the precise
     // UnpackToDestFp32 path), and the user scalar is applied to the small-magnitude result via
     // SFPU mul_unary_tile inside the compute kernel, gated by the WELFORD_POST_MUL define.
     // Pre-scaling the input (the old do_scale path) read cb_in via the FPU SrcA operand at TF32

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -419,6 +419,13 @@ static Tensor std_var_impl(
 
     auto reduce_math = (reduce_type == reduction_common::ReduceType::Std) ? tt::tt_metal::ReduceOpMath::STD
                                                                           : tt::tt_metal::ReduceOpMath::VAR;
+    // The Welford reduction itself always runs unscaled (precise UnpackToDestFp32 path); the
+    // scalar is applied to the small-magnitude result inside the compute kernel via SFPU
+    // post-multiplication. Pre-scaling the input through mul_tiles_bcast_scalar would read
+    // cb_in via the FPU SrcA operand at TF32 precision (10-bit mantissa), collapsing
+    // large-offset inputs to a constant before the multiply and pinning the variance to ~0
+    // (issue #45222). The kernel derives the post-multiplier from this scalar:
+    //   var(s*x) = s^2 * var(x)      std(s*x) = |s| * std(x)
     ttnn::Tensor output_tensor = ttnn::prim::welford_reduce(
         input_tensor,
         reduce_math,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/generic_reductions.cpp
@@ -419,13 +419,6 @@ static Tensor std_var_impl(
 
     auto reduce_math = (reduce_type == reduction_common::ReduceType::Std) ? tt::tt_metal::ReduceOpMath::STD
                                                                           : tt::tt_metal::ReduceOpMath::VAR;
-    // The Welford reduction itself always runs unscaled (precise UnpackToDestFp32 path); the
-    // scalar is applied to the small-magnitude result inside the compute kernel via SFPU
-    // post-multiplication. Pre-scaling the input through mul_tiles_bcast_scalar would read
-    // cb_in via the FPU SrcA operand at TF32 precision (10-bit mantissa), collapsing
-    // large-offset inputs to a constant before the multiply and pinning the variance to ~0
-    // (issue #45222). The kernel derives the post-multiplier from this scalar:
-    //   var(s*x) = s^2 * var(x)      std(s*x) = |s| * std(x)
     ttnn::Tensor output_tensor = ttnn::prim::welford_reduce(
         input_tensor,
         reduce_math,


### PR DESCRIPTION
## PR Category

Bug fix — `ttnn.std` / `ttnn.var` precision, issue #45222

## Summary

`ttnn.std` / `ttnn.var` returned catastrophically wrong results on biased FP32 inputs with `scalar != 1.0`. That path pre-scaled the input via `mul_tiles_bcast_scalar`, whose FPU SrcA read truncates FP32 → TF32 (10-bit mantissa); at large magnitudes (e.g. offset `1e6`, TF32 ULP ~512) nearby values collapse to a constant before the multiply, pinning variance to ~0.

The fix applies the scalar **after** the reduction, in the compute kernel via SFPU `mul_unary_tile` . The reduction runs unscaled on the precise `UnpackToDestFp32` path, then scales the result: `var(s·x)=s²·var(x)`, `std(s·x)=|s|·std(x)`.

## Changes Made

1. **`generic_reductions.cpp`**: pass `scalar` straight to `welford_reduce` (no host-side scaling).
2. **`welford_reduce_program_factory.cpp`**: removed the `do_scale` pre-scale path + `cb_scaled` CB; compute `post_mul_scaler = is_std ? |scalar| : scalar²`, pass packed bits as a compile arg, set `WELFORD_POST_MUL`; FP32 input CB now always `UnpackToDestFp32`.
3. **`welford_reduce_{w,h,hw}.cpp`**: dropped the `do_scale` branches; under `WELFORD_POST_MUL` apply `mul_unary_tile` on the output DST after the optional `sqrt`.
4. **`test_reduction.py` / `test_reduction_ops.py`**: re-enabled the `xfail`-ing biased / `scalar != 1.0` fp32 cases.

## Notes for Reviewers

Core change is moving the scalar from a per-input-tile FPU pre-multiply to one SFPU post-multiply on the output, keeping the reduction on the full-FP32 path. Verified on Wormhole B0: biased rows flip FAIL→PASS across W/H/HW and both ops; non-biased fp32 relative error improves ~10⁴× (≈2e-3 → ≈3e-7). 

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/45222_std_var_precision_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/45222_std_var_precision_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/45222_std_var_precision_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/45222_std_var_precision_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ign/45222_std_var_precision_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ign/45222_std_var_precision_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/45222_std_var_precision_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/45222_std_var_precision_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/45222_std_var_precision_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/45222_std_var_precision_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/45222_std_var_precision_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/45222_std_var_precision_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/45222_std_var_precision_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/45222_std_var_precision_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/45222_std_var_precision_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/45222_std_var_precision_fix)