### PR TITLE
Flush negative-zero BFP mantissa to +0 in LLK test packers

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/pack.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/pack.py
@@ -183,7 +183,11 @@ def float_to_bfp8_block(block):
         else:
             mantissa = mantissas_explicit[i]
         mantissa = mantissa & 0x7F
-        mantissa = (signs[i] << 7) | mantissa
+        # Flush negative-zero to +0: when the magnitude rounds/shifts to 0, drop
+        # the sign bit. The tt-metal host quantizer (convert_u32_to_bfp) does the
+        # same, and the hardware unpacker decodes a sign-only mantissa (0x80) to
+        # -inf, so no valid producer should ever emit it.
+        mantissa = ((signs[i] << 7) | mantissa) if mantissa != 0 else 0
         bfp8_mantissas.append(mantissa)
 
     return shared_exponent, bfp8_mantissas
@@ -232,10 +236,16 @@ def truncate_bfp8(bfp8_mantissas, magnitude_bits):
     """
     shift = 7 - magnitude_bits
     mag_mask = (1 << magnitude_bits) - 1
-    return [
-        (((bfp8 >> 7) & 0x1) << magnitude_bits) | ((bfp8 >> shift) & mag_mask)
-        for bfp8 in bfp8_mantissas
-    ]
+    out = []
+    for bfp8 in bfp8_mantissas:
+        magnitude = (bfp8 >> shift) & mag_mask
+        sign = (bfp8 >> 7) & 0x1
+        # Flush negative-zero to +0: truncation can drop a small BFP8 magnitude to
+        # 0 while leaving the sign bit set. Emit +0 so the hardware unpacker never
+        # sees a sign-only mantissa (which it decodes to -inf), matching the host
+        # quantizer's behavior.
+        out.append(((sign << magnitude_bits) | magnitude) if magnitude != 0 else 0)
+    return out
 
 
 def float_to_bfp4_block(block):


### PR DESCRIPTION
## Problem
The LLK test BFP packers (`tests/python_tests/helpers/pack.py`) emit a sign-only
mantissa (e.g. BFP8 `0x80` = sign set, magnitude 0) when a negative value's
magnitude rounds/truncates to zero within its block. The hardware unpacker
decodes such a sign-only mantissa to `-inf`, injecting spurious infinities into
test results (one such B datum poisons a whole matmul output column).

## Root cause
The tt-metal host quantizer already normalizes this away — `convert_u32_to_bfp`
(`tt_metal/impl/data_format/blockfloat_common.cpp`):
`if (0 == mantissa) { sign = 0; }`. So no valid producer emits `0x80`; the test
packers simply didn't match the host (they OR'd in the sign bit unconditionally).

## Fix
- `float_to_bfp8_block` — drop the sign bit when magnitude is 0 (BFP8).
- `truncate_bfp8` — drop the sign bit when truncation leaves magnitude 0
  (BFP4/BFP2); the sign is still preserved when a magnitude survives.

## Verification
- BFP8 negative-underflow datum now packs to `0x00` (was `0x80`).
- `truncate_bfp8([0x81], 3) == [0]`; `truncate_bfp8([0xC0], 3) == 0b1100` (sign kept).
- Golden round-trip unaffected (dequant gives `-0.0 == 0.0`), so existing tests'
  PCC/tolerance is unchanged — only the L1 byte flips `0x80 -> 0x00`, removing the `-inf`.

Found while debugging a compressed-matmul test that hit `-inf` at a single output
element; isolated to a lone negative-zero BFP8 datum.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lpremovic/llk-bfp-flush-negative-zero)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lpremovic/llk-bfp-flush-negative-zero)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lpremovic/llk-bfp-flush-negative-zero)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lpremovic/llk-bfp-flush-negative-zero)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lpremovic/llk-bfp-flush-negative-zero)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lpremovic/llk-bfp-flush-negative-zero)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lpremovic/llk-bfp-flush-negative-zero)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lpremovic/llk-bfp-flush-negative-zero)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lpremovic/llk-bfp-flush-negative-zero)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lpremovic/llk-bfp-flush-negative-zero)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lpremovic/llk-bfp-flush-negative-zero)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lpremovic/llk-bfp-flush-negative-zero)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lpremovic/llk-bfp-flush-negative-zero)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lpremovic/llk-bfp-flush-negative-zero)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lpremovic/llk-bfp-flush-negative-zero)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lpremovic/llk-bfp-flush-negative-zero)