### PR TITLE
[BuildEnvManager] Key build env by (context, chip) so a mock device can't clobber a real device's build env

### DIFF
--- a/tt_metal/distributed/mesh_device.cpp
+++ b/tt_metal/distributed/mesh_device.cpp
@@ -1026,8 +1026,10 @@ const MeshDeviceView& MeshDeviceImpl::get_view() const {
 }
 
 int MeshDeviceImpl::id() const { return mesh_id_; }
-// For a mesh, build id is the same as the device id for the reference device
-ChipId MeshDeviceImpl::build_id() const { return reference_device()->id(); }
+// Build id keys BuildEnvManager's per-device build env (context-encoded, see
+// encode_build_env_id), so delegate to the reference device's build_id() rather
+// than its raw id() — otherwise a non-default-context mesh would miss its entry.
+ChipId MeshDeviceImpl::build_id() const { return reference_device()->build_id(); }
 
 bool MeshDeviceImpl::is_parent_mesh() const { return parent_mesh_ == nullptr; }
 

--- a/tt_metal/impl/context/context_types.hpp
+++ b/tt_metal/impl/context/context_types.hpp
@@ -23,6 +23,14 @@ constexpr ContextId DEFAULT_CONTEXT_ID = ContextId{0};
 // Limit the number of context IDs so they can be stored in an array
 constexpr size_t MAX_CONTEXT_COUNT = 32;
 
+// Build-env identity, unique per (context, chip). BuildEnvManager keys its per-device
+// build envs by this value (via IDevice::build_id()). Keying by ChipId alone lets a
+// mock device in a non-default context clobber a real device's build env for the same
+// ChipId, which can hang on Blackhole. Backward compatible: ctx 0 -> chip. See #38445.
+inline int encode_build_env_id(int context_id, int chip_id) {
+    return (context_id << 16) | (chip_id & 0xFFFF);
+}
+
 // Helper function to extract the context ID from the public API device type by casting it to the impl type.
 // This function may perform a dynamic cast on the IDevice so should not be used in performance critical paths.
 // TODO: Remove these extract_context_id functions once all child objects have MetalEnv and MetalContext references

--- a/tt_metal/impl/context/context_types.hpp
+++ b/tt_metal/impl/context/context_types.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cassert>
 #include <cstddef>
 #include <tt_stl/strong_type.hpp>
 #include <tt-metalium/device.hpp>
@@ -28,6 +29,11 @@ constexpr size_t MAX_CONTEXT_COUNT = 32;
 // mock device in a non-default context clobber a real device's build env for the same
 // ChipId, which can hang on Blackhole. Backward compatible: ctx 0 -> chip. See #38445.
 inline int encode_build_env_id(int context_id, int chip_id) {
+    // 16 bits each: context in the high half, chip in the low half. Far more than
+    // enough today (context < MAX_CONTEXT_COUNT, chips < a few hundred); assert so a
+    // future overflow surfaces instead of silently aliasing build envs.
+    assert(context_id >= 0 && context_id < static_cast<int>(MAX_CONTEXT_COUNT));
+    assert(chip_id >= 0 && chip_id <= 0xFFFF);
     return (context_id << 16) | (chip_id & 0xFFFF);
 }
 

--- a/tt_metal/impl/device/device_impl.hpp
+++ b/tt_metal/impl/device/device_impl.hpp
@@ -67,8 +67,10 @@ public:
     tt::ARCH arch() const override;
 
     ChipId id() const override { return id_; }
-    // For a single device, build id is the same as device id
-    ChipId build_id() const override { return id_; }
+    // Build id keys BuildEnvManager's per-device build env; unique per (context, chip)
+    // so a mock device in another context can't clobber this device's build env (see
+    // encode_build_env_id). Default context (0) -> id_, unchanged.
+    ChipId build_id() const override { return encode_build_env_id(get_context_id().get(), id_); }
 
     uint8_t num_hw_cqs() const override { return num_hw_cqs_; }
 

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -182,7 +182,9 @@ void RiscFirmwareInitializer::run_async_build_phase(const std::set<tt::ChipId>& 
                                        (cluster_.get_target_device_type() == tt::TargetDevice::Mock &&
                                         !mock_firmware_sources_available_for(cluster_.arch()));
             if (!skip_fw_build) {
-                BuildEnvManager::get_instance().build_firmware(device_id);
+                // Match the (context, chip) build-env id add_build_env keyed by above.
+                BuildEnvManager::get_instance().build_firmware(
+                    encode_build_env_id(descriptor_->metal_context().get_context_id().get(), device_id));
             }
             if (!cluster_.is_mock_or_emulated()) {
                 // Clear the entire launch message ring buffer on ethernet cores before application firmware is

--- a/tt_metal/jit_build/build_env_manager.cpp
+++ b/tt_metal/jit_build/build_env_manager.cpp
@@ -207,7 +207,10 @@ std::vector<JitBuildState> create_build_state(JitBuildEnv& build_env, const JitD
 void BuildEnvManager::add_build_env(ChipId device_id, uint8_t num_hw_cqs, ContextId context_id) {
     const std::lock_guard<std::mutex> lock(this->lock);
     auto dev_config = create_jit_device_config(device_id, num_hw_cqs, context_id);
-    add_build_env_locked(device_id, dev_config, MetalContext::instance(context_id).rtoptions());
+    // Key by (context, chip) so a mock device in a non-default context can't clobber a
+    // real device's build env for the same ChipId. Raw device_id above is the HW config.
+    add_build_env_locked(
+        encode_build_env_id(context_id.get(), device_id), dev_config, MetalContext::instance(context_id).rtoptions());
 }
 
 void BuildEnvManager::add_build_env(


### PR DESCRIPTION
### Problem

`BuildEnvManager` keys its per-device build environments by `ChipId` alone, ignoring the `ContextId` that `add_build_env(...)` is given. When a mock device (its own `MetalEnv`/`ContextId`) is opened alongside a real device with the same `ChipId`, the mock's `add_build_env` (run during device bring-up in `risc_firmware_initializer.cpp`) overwrites the real device's build-env entry.

The mock and real devices produce different `build_key`s, so the real device's cached `Program` later fails the per-program `device_hash` check:

```
TT_FATAL @ tt_metal/impl/program/program.cpp:1927: *get_cached() == device_hash
Enqueueing a Program across devices with different cores harvested is not supported, ...
```

In threaded host pipelines this surfaces as a hang. (The assert's message is misleading here: coordinate virtualization is enabled on Blackhole and harvesting is excluded from `build_key`; the assert fires on any `device_hash` mismatch.)

Confirmed on Blackhole — real and mock both report `build_id() == 0` but get different build keys (`10204058954120230223` vs `1046994038935364362`), so the mock clobbers the real device's chip-0 entry.

### Fix

Key the build env by `(context, chip)`. `IDevice::build_id()` now encodes the context (`(ctx << 16) | chip`; default ctx 0 -> `chip`, unchanged); `add_build_env` and `build_firmware` key by it. Backward compatible. `build_id()` is only ever used as a `BuildEnvManager` key, never as a hardware index, so encoding the context is safe. Minimal variant of the per-`ContextId` `BuildEnvManager` refactor noted in the `get_instance(ContextId)` comment (#38445).

### Test

Verified on Blackhole: a standalone repro (real device + mock device + a program run on the real device) that deterministically hit the `TT_FATAL`, and model perf tests that previously hung, now pass.

Closes #47213

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rpavlovic/buildenv-per-context-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rpavlovic/buildenv-per-context-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rpavlovic/buildenv-per-context-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rpavlovic/buildenv-per-context-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rpavlovic/buildenv-per-context-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rpavlovic/buildenv-per-context-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rpavlovic/buildenv-per-context-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rpavlovic/buildenv-per-context-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rpavlovic/buildenv-per-context-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rpavlovic/buildenv-per-context-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rpavlovic/buildenv-per-context-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rpavlovic/buildenv-per-context-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rpavlovic/buildenv-per-context-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rpavlovic/buildenv-per-context-key)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rpavlovic/buildenv-per-context-key)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rpavlovic/buildenv-per-context-key)