### PR TITLE
Fix #47150: L1 OOM on bh-lb

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/unified_routed_expert_ffn/device/unified_routed_expert_ffn_program_factory.cpp
@@ -292,24 +292,29 @@ UnifiedRoutedExpertFfnProgramFactory::cached_program_t UnifiedRoutedExpertFfnPro
 
     // Scratch CBs for the device-side count lookup. The reader does a single
     // noc_async_read_page(page=0, ...) of each tensor and then indexes
-    // counts[global_expert_id] for global_expert_id in
-    // [0, num_global_experts). The scratch must therefore be large enough to
-    // both (a) land the tensor's page and (b) hold up to MAX_GLOBAL_EXPERTS
-    // UINT32 entries so indexing the largest global id stays in-bounds.
+    // counts[global_expert_id] / idx[local_expert_id]. Both indices stay within
+    // the tensor's own length (counts: [0, num_global_experts); idx:
+    // [0, idx_len)), and the reader's page-0 read contract requires the entire
+    // vector to live in page 0 — i.e. aligned_page_size already covers every
+    // index the reader can produce. So aligned_page_size is the exact capacity
+    // the scratch needs; we keep a num_entries*4B floor purely as a defensive
+    // guard in case a future layout reports a sub-row page.
     //
-    // Size to max(aligned_page_size, MAX_GLOBAL_EXPERTS * 4B). For the
-    // supported range (<= MAX_GLOBAL_EXPERTS experts) the page never exceeds
-    // MAX_GLOBAL_EXPERTS * 4B, so this fixes the scratch at 4 KB ("4 tiles" of
-    // 1 KB) — enough for DeepSeek V3 (256), Kimi (384) and up to 1024 routed
-    // experts. Decoupling the capacity from the incidental input page size
-    // (which scales with num_experts) keeps the buffer correct for the design
-    // maximum regardless of how few experts a given call passes. ~4 KB/core of
-    // the ~250 KB L1 headroom — negligible.
-    constexpr uint32_t kScratchMinBytes = MAX_GLOBAL_EXPERTS * static_cast<uint32_t>(sizeof(uint32_t));
-    const uint32_t counts_scratch_bytes =
-        std::max<uint32_t>(static_cast<uint32_t>(counts_buffer->aligned_page_size()), kScratchMinBytes);
-    const uint32_t idx_scratch_bytes =
-        std::max<uint32_t>(static_cast<uint32_t>(idx_buffer->aligned_page_size()), kScratchMinBytes);
+    // Previously this floored to MAX_GLOBAL_EXPERTS * 4B (a fixed 4 KB), which
+    // over-allocated ~3 KB/core for the 256-expert DS-V3 path and ~2.5 KB for
+    // Kimi (384). That slack is what tipped the mesh-4x2 perf-256 program over
+    // the L1 ceiling once MEM_MAILBOX_SIZE grew 256 B (#46526). Sizing to the
+    // real per-call requirement reclaims it (~6 KB/core across both scratches)
+    // — far more than the 192 B overlap — and still scales correctly up to the
+    // host-side-validated MAX_GLOBAL_EXPERTS limit.
+    const uint32_t counts_num_entries = static_cast<uint32_t>(t.counts.logical_shape()[-1]);
+    const uint32_t idx_num_entries = static_cast<uint32_t>(t.global_expert_idx_table.logical_shape()[-1]);
+    const uint32_t counts_scratch_bytes = std::max<uint32_t>(
+        static_cast<uint32_t>(counts_buffer->aligned_page_size()),
+        counts_num_entries * static_cast<uint32_t>(sizeof(uint32_t)));
+    const uint32_t idx_scratch_bytes = std::max<uint32_t>(
+        static_cast<uint32_t>(idx_buffer->aligned_page_size()),
+        idx_num_entries * static_cast<uint32_t>(sizeof(uint32_t)));
     tt::tt_metal::CircularBufferConfig counts_cb_cfg =
         tt::tt_metal::CircularBufferConfig(counts_scratch_bytes, {{CB_COUNTS_SCRATCH, tt::DataFormat::UInt32}})
             .set_page_size(CB_COUNTS_SCRATCH, counts_scratch_bytes);


### PR DESCRIPTION
The unified_routed_expert_ffn program factory sized CB_COUNTS_SCRATCH and CB_IDX_SCRATCH to max(aligned_page_size, MAX_GLOBAL_EXPERTS*4) — a fixed 4 KB floor (1024 entries). The reader only ever indexes within each tensor's own length (counts[global_expert_id], idx[local_expert_id]), and its page-0 read contract already requires the whole vector to live in page 0, so aligned_page_size is the exact capacity needed. The 4 KB floor over-allocated ~3 KB/core per scratch (~6 KB/core total) for the 256-expert DeepSeek-V3 path.

That slack pushed the mesh-4x2 perf-256 program over the L1 ceiling after MEM_MAILBOX_SIZE grew 256 B (#46526), causing a static-CB / L1-buffer clash at program.cpp:1544 (192 B overlap). Sizing each scratch to its real per-call requirement reclaims the headroom and still scales correctly up to the host-validated MAX_GLOBAL_EXPERTS limit.

Verified on LoudBox 8xP150 (mesh-4x2): test_ds_moe perf-device-256 (previously crashing) and pcc-device-256 now pass.

### CIs
- [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=kgrujcic%2Ffix_47150)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml) - fixed bh-lb issue
- [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=kgrujcic%2Ffix_47150)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml) - no regression

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=kgrujcic/fix_47150)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:kgrujcic/fix_47150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=kgrujcic/fix_47150)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:kgrujcic/fix_47150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=kgrujcic/fix_47150)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:kgrujcic/fix_47150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=kgrujcic/fix_47150)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:kgrujcic/fix_47150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=kgrujcic/fix_47150)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:kgrujcic/fix_47150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=kgrujcic/fix_47150)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:kgrujcic/fix_47150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=kgrujcic/fix_47150)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:kgrujcic/fix_47150)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=kgrujcic/fix_47150)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:kgrujcic/fix_47150)