### PR TITLE
experimental: add indexer_score op (DSA lightning indexer for GLM5.1 + DeepSeek-V3.2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -294,6 +294,9 @@ ttnn/cpp/ttnn/operations/experimental/cnn/**/CMakeLists.txt @tenstorrent/metaliu
 ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/ @tenstorrent/metalium-developers-ds-prefill @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/**/CMakeLists.txt @tenstorrent/metalium-developers-ds-prefill @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 tests/ttnn/nightly/unit_tests/operations/experimental/deepseek_prefill/ @tenstorrent/metalium-developers-ds-prefill @tenstorrent/codeowner-bypass
+ttnn/cpp/ttnn/operations/experimental/indexer_score/ @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
+ttnn/cpp/ttnn/operations/experimental/indexer_score/**/CMakeLists.txt @tenstorrent/metalium-developers-sdpa @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
+tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py @tenstorrent/metalium-developers-sdpa @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/matmul/ @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/matmul/**/CMakeLists.txt @tenstorrent/metalium-developers-mmfusedreduce @tenstorrent/metalium-developers-infra @tenstorrent/codeowner-bypass
 ttnn/cpp/ttnn/operations/experimental/minimal_matmul/ @cglagovichTT @jonathansuTT @tenstorrent/codeowner-bypass

--- a/.github/workflows/perf-device-models-impl.yaml
+++ b/.github/workflows/perf-device-models-impl.yaml
@@ -409,6 +409,7 @@ jobs:
           commands: |
             pytest tests/ttnn/perf_tests/operations/conv -m models_device_performance_bare_metal --timeout=300
             ${{ matrix.test-info.arch == 'blackhole' && 'SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_scaled_dot_product_attention_sprint.py::test_sdpa_perf_check -svv' || '' }}
+            ${{ matrix.test-info.arch == 'blackhole' && 'INDEXER_SCORE_PERF_CHECKS=1 pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::test_indexer_score_perf_check -svv' || '' }}
         if: ${{ !cancelled() && matrix.test-info.civ2-compatible && (!matrix.test-info.job-set1 || matrix.test-info.job-blackhole-set1) && fromJSON(needs.define-models.outputs.models-to-run)['ops-perf-tests'] }}
         timeout-minutes: ${{ matrix.test-info.timeout }}
 

--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -483,6 +483,7 @@ Transformer
    ttnn.transformer.scaled_dot_product_attention_decode
    ttnn.transformer.split_query_key_value_and_split_heads
    ttnn.transformer.windowed_scaled_dot_product_attention
+   ttnn.experimental.indexer_score
 
 CCL
 ===

--- a/tests/pipeline_reorg/ttnn-tests.yaml
+++ b/tests/pipeline_reorg/ttnn-tests.yaml
@@ -201,6 +201,20 @@
   owner_id: U085GDCAZTN # Pavle Josipovic
   merge_gate: false
 
+# indexer_score is Blackhole-only (the nightly suite has the full coverage); this reuses the accuracy
+# test's sp_rank-7 GLM5.1/DSv32 deployment cases (8h/16h, bf16 + bfp8 q, deployed bfp8 k) so post-commit/
+# sanity catches deployment regressions and the op gets watcher coverage, without re-running them nightly.
+- name: "ttnn indexer_score group"
+  cmd: 'pytest --timeout 300 tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py -k "accuracy and rank7" -xv'
+  skus:
+    bh_p100:
+      timeout: 10
+    bh_p150b_civ2:
+      timeout: 10
+  team: ttnn
+  owner_id: U085GDCAZTN # Pavle Josipovic
+  merge_gate: false
+
 - name: "ttnn reduce group"
   cmd: 'pytest --timeout 300 tests/ttnn/unit_tests/operations/reduce -xv -m "not disable_fast_runtime_mode"'
   skus:

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -1,0 +1,353 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Tests for the DeepSeek-V3.2 DSA ``indexer_score`` op (GLM5 and DSv32 deployments).
+
+    score[b, s, t] = sum_h relu(q[b, h, s, :] . k[b, t, :]) * w[b, h, s]
+
+Causality from scalar ``chunk_start``: key ``t`` visible to query ``s`` iff
+``t <= chunk_start + s``; future columns are -inf.
+
+Two deployments, both Galaxy chunked prefill (50K history + 5K chunk =
+55K all-gathered keys; the 5K-query chunk is sharded SP=8 -> 640 queries/device):
+
+    GLM5   -  8 heads (per-device indexer)
+    DSv32  - 16 heads (64-head indexer split across TP=4; the op sums only its
+             heads and the -inf mask is head-independent, so -inf survives the
+             cross-TP sum)
+
+SP enters only via ``chunk_start``, so this is single-chip with ``sp_rank``
+selecting the ring position. This file is deliberately narrow (GLM5/DSv32 shapes
+only); broader knob/corner/validation coverage will be migrated in separately.
+"""
+
+import os
+import time
+from unittest import mock
+
+import pytest
+import torch
+from loguru import logger
+
+import ttnn
+
+pytestmark = pytest.mark.skipif(not ttnn.device.is_blackhole(), reason="indexer_score is Blackhole-only")
+
+GLX_DIM = 128  # indexer head dim
+GLX_SQ = 640  # queries per device (5120 chunk / SP=8)
+GLX_T = 56320  # all-gathered keys: 50K history + 5K chunk = 55K, tile-aligned
+GLX_HISTORY = GLX_T - 8 * GLX_SQ  # 51200 keys visible to every query
+
+# The two indexer deployments, by (id, head count).
+GLX_CASES = [("glm5", 8), ("dsv32", 16)]
+GLX_IDS = [c[0] for c in GLX_CASES]
+
+
+def indexer_score_ref(q, k, w, chunk_start):
+    """Per-head fp32 accumulation (a full [Hi,Sq,T] tensor is many GB at GLX sizes)."""
+    b, hi, sq, _ = q.shape
+    t = k.shape[2]
+    q, k, w = q.float(), k.float(), w.float()
+    score = torch.zeros(b, sq, t)
+    for h in range(hi):
+        score += torch.relu(q[:, h] @ k[:, 0].transpose(-2, -1)) * w[:, h]
+    future = torch.arange(t).unsqueeze(0) > chunk_start + torch.arange(sq).unsqueeze(1)
+    return score.masked_fill(future, float("-inf")).unsqueeze(1)
+
+
+def make_inputs(heads, dim, sq, t, seed=42):
+    """q [1,Hi,Sq,D], k [1,1,T,D], weights [1,Hi,Sq,1], all bf16.
+
+    Weights are random so some gates are negative: -inf padding must stay distinguishable from
+    low-but-valid (negative) scores by topk.
+    """
+    g = torch.Generator().manual_seed(seed)
+    q = torch.randn(1, heads, sq, dim, generator=g, dtype=torch.bfloat16)
+    k = torch.randn(1, 1, t, dim, generator=g, dtype=torch.bfloat16)
+    w = torch.randn(1, heads, sq, 1, generator=g, dtype=torch.bfloat16)
+    return q, k, w
+
+
+def to_device(t, device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT):
+    return ttnn.from_torch(t, device=device, layout=layout, dtype=dtype)
+
+
+def run_indexer(q, k, w, chunk_start, device, program_config=None, q_dtype=ttnn.bfloat16, k_dtype=ttnn.bfloat16):
+    """Run the device op and return the row-major bf16 score as a torch tensor.
+
+    q (srcB) and k (srcA) may be bfp8_b; weights stay bf16.
+    """
+    kwargs = {} if program_config is None else {"program_config": program_config}
+    out = ttnn.experimental.indexer_score(
+        to_device(q, device, dtype=q_dtype),
+        to_device(k, device, dtype=k_dtype),
+        to_device(w, device),
+        chunk_start_idx=chunk_start,
+        **kwargs,
+    )
+    return ttnn.to_torch(out)
+
+
+def assert_indexer_match(out, ref, sq, t, check_neg=False):
+    """Check the -inf map is exact and the visible scores match the reference by PCC."""
+    assert out.shape == (1, 1, sq, t)
+    # -inf maps must agree exactly (<= bf16 lowest counts as masked)
+    masked = ref == float("-inf")
+    assert torch.equal(out <= torch.finfo(torch.bfloat16).min, masked)
+    # visible values by PCC (0.999 floor for the bf16 device op)
+    a, b = out[~masked].flatten().float(), ref[~masked].flatten().float()
+    pcc = torch.corrcoef(torch.stack([a, b]))[0, 1].item()
+    assert pcc >= 0.999, f"PCC {pcc} < 0.999"
+    if check_neg:
+        # negative gates -> a zero-filled column can't masquerade as valid
+        assert (ref[~masked] < 0).any()
+
+
+def glx_config(heads):
+    """GLX chunked-prefill knobs for the two deployments (GLM5 8h, DSv32 16h).
+
+    - head_group_size=0 keeps all heads resident; head streaming re-reads q per output tile and is
+      ~24x slower, so never used here.
+    - QC=2 (q_chunk_size=64) reuses each resident K chunk across 2 q-rows, ~2x fewer redundant K
+      reads (heads8 sp7 bfp8 0.73 -> 0.48 ms). Fits L1 for both 8 and 16 heads.
+    - k_chunk: GLM5 (8h) uses KC=16 (k_chunk=512), the compute-ceiling optimum at 8 heads; DSv32
+      (16h) is matmul-bound and stays KC=8 (k_chunk=256).
+    """
+    return ttnn.IndexerScoreProgramConfig(
+        q_chunk_size=64,
+        k_chunk_size=512 if heads <= 8 else 256,
+        head_group_size=0,
+    )
+
+
+@pytest.mark.parametrize("case_id, heads", GLX_CASES, ids=GLX_IDS)
+@pytest.mark.parametrize("q_dtype", [ttnn.bfloat16, ttnn.bfloat8_b], ids=["q_bf16", "q_bfp8"])
+@pytest.mark.parametrize("sp_rank", [0, 7], ids=["rank0", "rank7"])
+def test_indexer_score_accuracy(device, sp_rank, q_dtype, case_id, heads):
+    """GLX chunked prefill with the GLX knobs, boundary SP ranks, bfp8 k (the deployed dtype).
+
+    bfp8 k (matmul srcA) halves k BW; PCC stays >= 0.999 (bfp8 quantization of well-conditioned k is
+    below the bf16 sum's noise). Negative gates keep -inf padding distinguishable from low scores.
+    """
+    chunk_start = GLX_HISTORY + sp_rank * GLX_SQ
+    q, k, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
+    out = run_indexer(
+        q, k, w, chunk_start, device, program_config=glx_config(heads), q_dtype=q_dtype, k_dtype=ttnn.bfloat8_b
+    )
+    ref = indexer_score_ref(q, k, w, chunk_start)
+    assert_indexer_match(out, ref, GLX_SQ, GLX_T, check_neg=True)
+
+
+# ---------------------------------------------------------------------------
+# Mechanism coverage: small bf16 shapes that exercise every kernel path, checked the same way as the
+# deployments (exact -inf map + PCC >= 0.999 + a negative gate present). Two axes -- config knobs on a
+# fixed shape, and shape/geometry corners.
+# ---------------------------------------------------------------------------
+MINI = dict(heads=64, dim=128, sq=64, t=256)  # 64 heads, D=128, Sq=2 tiles, T=8 tiles
+
+
+def _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group):
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=q_chunk, k_chunk_size=k_chunk, head_group_size=head_group)
+    q, k, w = make_inputs(heads, dim, sq, t)
+    out = run_indexer(q, k, w, chunk_start, device, program_config=cfg)
+    ref = indexer_score_ref(q, k, w, chunk_start)
+    assert_indexer_match(out, ref, sq, t, check_neg=True)
+
+
+@pytest.mark.parametrize(
+    "q_chunk, k_chunk, head_group, chunk_start",
+    [
+        (32, 32, 1, 128),  # default: 1 head resident, streamed per output tile
+        (32, 32, 8, 128),  # head streaming, groups of 8
+        (32, 32, 32, 128),  # head streaming, 2 groups
+        (32, 32, 0, 128),  # all heads resident, single-tile chunks
+        (64, 32, 16, 128),  # QC=2 multi-row group (HB=16 of 64 to fit L1)
+        (32, 128, 0, 128),  # KC=4 chunked k, partial edge chunks
+        (64, 128, 16, 128),  # QC=2 and KC=4 together
+        (64, 128, 16, 160),  # chunk_start not a k_chunk multiple (diagonal mid-group)
+    ],
+    ids=["hb1", "hb8", "hb32", "hb_all", "qc2", "kc4", "qc2_kc4", "diag_unaligned"],
+)
+def test_indexer_score_knobs(device, q_chunk, k_chunk, head_group, chunk_start):
+    """QC/KC/head_group sweep on a fixed 64-head shape: head streaming vs all-resident, single vs
+    batched k chunks, multi-row q groups, and a diagonal that lands mid-chunk (chunk_start % KC != 0)."""
+    _run_and_check(device, MINI["heads"], MINI["dim"], MINI["sq"], MINI["t"], chunk_start, q_chunk, k_chunk, head_group)
+
+
+@pytest.mark.parametrize(
+    "heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group",
+    [
+        (64, 128, 128, 128, 0, 32, 32, 0),  # prefill square: no history, fully-causal triangle from tile 0
+        (64, 128, 32, 32, 0, 32, 32, 0),  # single k-tile (Tt=1): in-tile diagonal only
+        (64, 128, 32, 256, 0, 32, 32, 1),  # row-0 long tail: 1 valid k-tile, long -inf suffix
+        (64, 128, 64, 256, 192, 32, 32, 0),  # fully-causal corner (chunk_start near T)
+        (32, 64, 64, 256, 128, 32, 32, 0),  # narrow head dim (D=64, Dt=2)
+        (16, 256, 64, 256, 128, 32, 32, 0),  # wide head dim (D=256, Dt=8)
+        (64, 128, 64, 192, 128, 32, 128, 0),  # KC does not divide Tt (Tt=6, KC=4 -> 2-tile last unit)
+        (64, 128, 64, 160, 96, 32, 128, 0),  # KC does not divide Tt (Tt=5, KC=4 -> 1-tile last unit)
+        (64, 128, 64, 160, 96, 32, 64, 0),  # KC does not divide Tt (Tt=5, KC=2 -> 1-tile last unit)
+        (16, 128, 128, 2048, 512, 64, 32, 0),  # multicore: QC=2 group split across cores (writer tail fill)
+    ],
+    ids=[
+        "prefill_square",
+        "single_ktile",
+        "row0_long_tail",
+        "fully_causal",
+        "dim64",
+        "dim256",
+        "kc_partial_tt6",
+        "kc_partial_tt5_kc4",
+        "kc_partial_tt5_kc2",
+        "multicore_qc2",
+    ],
+)
+def test_indexer_score_shapes(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group):
+    """Shape/geometry coverage: prefill corners, single/partial k-tiles, narrow/wide head dims, KC not
+    dividing Tt (partial last unit clipped by the writer), and a multicore QC=2 split that exercises the
+    writer's group -inf tail fill across cores."""
+    _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)
+
+
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally")
+@pytest.mark.parametrize("case_id, heads", GLX_CASES, ids=GLX_IDS)
+def test_indexer_score_perf(device, case_id, heads):
+    """Wall-clock latency per op for the GLX shape at the fullest causal rank (sp7), bfp8 k.
+
+    Inputs placed on device once (host transfer excluded), run program-cache-warm with a device sync
+    around a fixed iteration count. Host-dispatched single-op latency (includes enqueue overhead, not
+    pure device-kernel time -- use tracy for that). Logged ms is the signal; the assert is only a
+    coarse hang / gross-regression guard (thresholds are board-dependent).
+    """
+    warmup_iters, measured_iters = 3, 20
+    chunk_start = GLX_HISTORY + 7 * GLX_SQ
+    cfg = glx_config(heads)
+    q, k, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
+    q_dev = to_device(q, device)
+    k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
+    w_dev = to_device(w, device)
+
+    def run_once():
+        return ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, program_config=cfg)
+
+    for _ in range(warmup_iters):  # compile + program-cache warm
+        run_once().deallocate()
+    ttnn.synchronize_device(device)
+
+    start = time.perf_counter()
+    for _ in range(measured_iters):
+        run_once().deallocate()
+    ttnn.synchronize_device(device)
+    ms_per_op = (time.perf_counter() - start) / measured_iters * 1e3
+
+    logger.info(
+        f"indexer_score {case_id} rank7 heads={heads} k=bfp8: "
+        f"{ms_per_op:.3f} ms/op (mean of {measured_iters} iters)"
+    )
+    assert ms_per_op < 50.0, f"{case_id} rank7 k=bfp8: {ms_per_op:.3f} ms/op exceeds 50 ms guard (regression or hang)"
+
+
+# ---------------------------------------------------------------------------
+# sp_rank 7 math-utilization perf check (tracy device profiler; no accuracy check)
+# math_util = matmul FLOPs / (cores x device cycles x matmul peak); duration from tracy, FLOPs from
+# shape. Run locally with the profiler build (default):
+#   pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::test_indexer_score_sp7_math_util
+# ---------------------------------------------------------------------------
+SP7_CHUNK_START = GLX_HISTORY + 7 * GLX_SQ  # fullest causal case (99.5% valid)
+
+# Blackhole matmul peak (tests/nightly/sdpa_perf_utils.py): 4096 mm FLOP/cycle/core at LoFi,
+# halved per extra math-fidelity phase. The `fidelity` param below must match the factory's
+# choice for the measured q/k dtypes (LoFi when both bfp8, else HiFi2).
+_BH_CLOCK_GHZ = 1.35
+_MM_FLOPS_PER_CYCLE_PER_CORE = {"LoFi": 4096, "HiFi2": 2048, "HiFi3": 1365, "HiFi4": 1024}
+
+
+def sp7_valid_tiles():
+    """Causal-valid output tiles V at sp_rank 7 = sum_s min(Tt, chunk_t + s + 1) over q-tile-rows."""
+    chunk_t = SP7_CHUNK_START // 32
+    tt_tiles = GLX_T // 32
+    sqt = GLX_SQ // 32
+    return sum(min(tt_tiles, chunk_t + s + 1) for s in range(sqt))
+
+
+def indexer_mm_flops(valid_tiles, heads):
+    """Matmul FLOPs the kernel performs: each valid 32x32 output tile is, per head, a 32x32xD
+    matmul = (32*32) elements x (2*D) FLOPs; summed over heads and valid tiles."""
+    return valid_tiles * heads * (32 * 32) * (2 * GLX_DIM)
+
+
+# (heads, q_id, k_id, fidelity) cases for the sp7 profiler tests. fidelity must match the factory:
+# q and k both bfp8 -> LoFi (1 phase), any bf16 input -> HiFi2. id is shared by perf_impl and math_util
+# (which spawns it by id), so they must stay in lockstep. Both deployments run bfp8 k; the q_bfp8 rows
+# add the LoFi path (bfp8 q halves the dominant q read and doubles matmul peak).
+_SP7_PERF_CASES = [
+    (8, "q_bf16", "k_bfp8", "HiFi2"),  # GLM5
+    (16, "q_bf16", "k_bfp8", "HiFi2"),  # DSv32
+    (8, "q_bfp8", "k_bfp8", "LoFi"),  # GLM5, bfp8 q -> LoFi
+    (16, "q_bfp8", "k_bfp8", "LoFi"),  # DSv32, bfp8 q -> LoFi
+]
+_SP7_PERF_IDS = [f"heads{h}_{q}_{k}" for h, q, k, _ in _SP7_PERF_CASES]
+
+
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally with tracy")
+@pytest.mark.parametrize("heads, q_id, k_id", [(h, q, k) for h, q, k, _ in _SP7_PERF_CASES], ids=_SP7_PERF_IDS)
+def test_indexer_score_sp7_perf_impl(device, heads, q_id, k_id):
+    """Inner test profiled by tracy: a few indexer_score ops at GLX sp_rank 7. No accuracy check."""
+    q_dtype = ttnn.bfloat16 if q_id == "q_bf16" else ttnn.bfloat8_b
+    k_dtype = ttnn.bfloat16 if k_id == "k_bf16" else ttnn.bfloat8_b
+    q, k, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
+    q_dev = to_device(q, device, dtype=q_dtype)
+    k_dev = to_device(k, device, dtype=k_dtype)
+    w_dev = to_device(w, device)
+    cfg = glx_config(heads)
+    for _ in range(5):  # tracy logs each op's device duration; the outer test takes the min
+        ttnn.experimental.indexer_score(
+            q_dev, k_dev, w_dev, chunk_start_idx=SP7_CHUNK_START, program_config=cfg
+        ).deallocate()
+    ttnn.synchronize_device(device)
+
+
+@pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally with tracy")
+@pytest.mark.parametrize("heads, q_id, k_id, fidelity", _SP7_PERF_CASES, ids=_SP7_PERF_IDS)
+def test_indexer_score_sp7_math_util(heads, q_id, k_id, fidelity):
+    """sp_rank 7 matmul math utilization from a tracy device-kernel-duration measurement.
+
+    Spawns the inner perf_impl test under the device profiler, reads the minimum
+    DEVICE KERNEL DURATION, and reports math_util = mm_flops / (cores * cycles * peak).
+    No accuracy check.
+    """
+    from tracy.process_model_log import run_device_profiler
+    from tests.nightly.sdpa_perf_utils import post_process_ops_log
+
+    subdir = "ttnn_indexer_score_sp7"
+    perf_id = f"heads{heads}_{q_id}_{k_id}"
+    command = (
+        "pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::"
+        f"test_indexer_score_sp7_perf_impl[{perf_id}]"
+    )
+    with mock.patch.dict(os.environ, {"CI": "false"}):
+        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+    r = post_process_ops_log(
+        subdir,
+        float_columns=["CORE COUNT", "DEVICE KERNEL DURATION [ns]"],
+        columns=["ATTRIBUTES"],
+        sum_vals=False,
+        has_signposts=False,
+    )
+    assert len(r["DEVICE KERNEL DURATION [ns]"]) > 0, "profiler returned no indexer_score ops"
+
+    core_count = int(r["CORE COUNT"][0])
+    duration_ns = float(r["DEVICE KERNEL DURATION [ns]"].min())
+
+    valid_tiles = sp7_valid_tiles()
+    mm_flops = indexer_mm_flops(valid_tiles, heads)
+    peak = _MM_FLOPS_PER_CYCLE_PER_CORE[fidelity]
+    cycles = duration_ns * _BH_CLOCK_GHZ
+    theoretical_flops = core_count * cycles * peak
+    math_util = (mm_flops / theoretical_flops) * 100 if theoretical_flops > 0 else 0.0
+
+    logger.info(
+        f"indexer_score sp7 heads={heads} {q_id} {k_id} ({fidelity}): device={duration_ns / 1e6:.3f} ms, "
+        f"cores={core_count}, V={valid_tiles} tiles, mm={mm_flops / 1e9:.1f} GFLOP, "
+        f"peak={peak} FLOP/cyc/core @ {_BH_CLOCK_GHZ} GHz -> math_util={math_util:.1f}%"
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -199,7 +199,12 @@ def test_indexer_score_knobs(device, q_chunk, k_chunk, head_group, chunk_start):
         (64, 128, 64, 192, 128, 32, 128, 0),  # KC does not divide Tt (Tt=6, KC=4 -> 2-tile last unit)
         (64, 128, 64, 160, 96, 32, 128, 0),  # KC does not divide Tt (Tt=5, KC=4 -> 1-tile last unit)
         (64, 128, 64, 160, 96, 32, 64, 0),  # KC does not divide Tt (Tt=5, KC=2 -> 1-tile last unit)
-        (16, 128, 128, 2048, 512, 64, 32, 0),  # multicore: QC=2 group split across cores (writer tail fill)
+        # head streaming (HB<Hi) AND KC not dividing Tt together: the reader must push a q block for
+        # every padded column compute walks, else compute hangs on the partial last unit (regression
+        # guard for the streaming/partial-KC deadlock).
+        (64, 128, 64, 192, 128, 32, 128, 8),  # stream HB=8 + Tt=6, KC=4 -> 2-tile last unit
+        (64, 128, 64, 160, 96, 32, 64, 8),  # stream HB=8 + Tt=5, KC=2 -> 1-tile last unit
+        (16, 128, 128, 2048, 512, 64, 32, 0),  # multicore: QC=2 group split across cores (per-core strip writes)
     ],
     ids=[
         "prefill_square",
@@ -211,14 +216,62 @@ def test_indexer_score_knobs(device, q_chunk, k_chunk, head_group, chunk_start):
         "kc_partial_tt6",
         "kc_partial_tt5_kc4",
         "kc_partial_tt5_kc2",
+        "stream_kc_partial_tt6",
+        "stream_kc_partial_tt5",
         "multicore_qc2",
     ],
 )
 def test_indexer_score_shapes(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group):
     """Shape/geometry coverage: prefill corners, single/partial k-tiles, narrow/wide head dims, KC not
-    dividing Tt (partial last unit clipped by the writer), and a multicore QC=2 split that exercises the
-    writer's group -inf tail fill across cores."""
+    dividing Tt (partial last unit clipped by the writer), and a multicore QC=2 split where a single
+    q-row-group is dealt across cores."""
     _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)
+
+
+@pytest.mark.parametrize("case_id, heads", GLX_CASES, ids=GLX_IDS)
+def test_indexer_score_determinism(device, case_id, heads):
+    """Determinism on the production deployments (GLM5.1 8h, DSv32 16h, GLX chunked-prefill knobs at
+    sp_rank 7, deployed bf16 q + bfp8 k). The op feeds a downstream top-k key selection, so any
+    nondeterminism (reduction order, an unstable -inf boundary) would silently change which keys are kept.
+
+    Follows the ring-joint-SDPA determinism rule: upload the device inputs once and reuse them for every
+    iteration (this tests device-side determinism, not host re-generation), then require each output to be
+    bit-identical to the first run.
+    """
+    num_iterations = 10
+    chunk_start = GLX_HISTORY + 7 * GLX_SQ  # sp_rank 7: fullest causal case
+    cfg = glx_config(heads)
+    q, k, w = make_inputs(heads, GLX_DIM, GLX_SQ, GLX_T)
+    # Upload once; the same device tensors are reused across all iterations.
+    q_dev = to_device(q, device, dtype=ttnn.bfloat16)
+    k_dev = to_device(k, device, dtype=ttnn.bfloat8_b)
+    w_dev = to_device(w, device)
+
+    reference = None
+    for i in range(num_iterations):
+        out = ttnn.to_torch(
+            ttnn.experimental.indexer_score(q_dev, k_dev, w_dev, chunk_start_idx=chunk_start, program_config=cfg)
+        )
+        if reference is None:
+            reference = out
+        elif not torch.equal(reference, out):
+            diff_mask = reference != out
+            num_diffs = int(diff_mask.sum().item())
+            both_finite = torch.isfinite(reference) & torch.isfinite(out)
+            max_diff = (
+                (reference[both_finite] - out[both_finite]).abs().max().item() if both_finite.any() else float("nan")
+            )
+            pytest.fail(
+                f"indexer_score {case_id} output at iteration {i} differs from iteration 0: "
+                f"{num_diffs} differing elements, max finite diff = {max_diff}"
+            )
+    logger.info(f"indexer_score {case_id} determinism verified: all {num_iterations} outputs identical")
+
+
+# Blackhole post-commit / sanity coverage reuses test_indexer_score_accuracy above: the CI entry in
+# tests/pipeline_reorg/ttnn-tests.yaml selects its sp_rank-7 GLM5.1/DSv32 cases via `-k "accuracy and
+# rank7"`. No separate post-commit test (that would re-run the same cases under nightly); post-commit just
+# runs a subset of the nightly accuracy parametrization.
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -73,12 +73,24 @@ def to_device(t, device, dtype=ttnn.bfloat16, layout=ttnn.TILE_LAYOUT):
     return ttnn.from_torch(t, device=device, layout=layout, dtype=dtype)
 
 
-def run_indexer(q, k, w, chunk_start, device, program_config=None, q_dtype=ttnn.bfloat16, k_dtype=ttnn.bfloat16):
+def run_indexer(
+    q,
+    k,
+    w,
+    chunk_start,
+    device,
+    program_config=None,
+    q_dtype=ttnn.bfloat16,
+    k_dtype=ttnn.bfloat16,
+    compute_kernel_config=None,
+):
     """Run the device op and return the row-major bf16 score as a torch tensor.
 
     q (srcB) and k (srcA) may be bfp8_b; weights stay bf16.
     """
     kwargs = {} if program_config is None else {"program_config": program_config}
+    if compute_kernel_config is not None:
+        kwargs["compute_kernel_config"] = compute_kernel_config
     out = ttnn.experimental.indexer_score(
         to_device(q, device, dtype=q_dtype),
         to_device(k, device, dtype=k_dtype),
@@ -207,6 +219,32 @@ def test_indexer_score_shapes(device, heads, dim, sq, t, chunk_start, q_chunk, k
     dividing Tt (partial last unit clipped by the writer), and a multicore QC=2 split that exercises the
     writer's group -inf tail fill across cores."""
     _run_and_check(device, heads, dim, sq, t, chunk_start, q_chunk, k_chunk, head_group)
+
+
+# ---------------------------------------------------------------------------
+# compute_kernel_config: math_fidelity is the one honored knob (default dtype-derived); the bf16-DEST
+# half-sync modes are required, so fp32_dest_acc_en / dst_full_sync_en are rejected by validate.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize("math_fidelity", [ttnn.MathFidelity.HiFi4, ttnn.MathFidelity.HiFi2, ttnn.MathFidelity.LoFi])
+def test_indexer_score_compute_kernel_config(device, math_fidelity):
+    """An explicit compute_kernel_config overrides math_fidelity; accuracy holds across fidelities."""
+    heads, dim, sq, t, chunk_start = MINI["heads"], MINI["dim"], MINI["sq"], MINI["t"], 128
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
+    ckc = ttnn.init_device_compute_kernel_config(device.arch(), math_fidelity=math_fidelity)
+    q, k, w = make_inputs(heads, dim, sq, t)
+    out = run_indexer(q, k, w, chunk_start, device, program_config=cfg, compute_kernel_config=ckc)
+    ref = indexer_score_ref(q, k, w, chunk_start)
+    assert_indexer_match(out, ref, sq, t, check_neg=True)
+
+
+def test_indexer_score_rejects_fp32_dest_acc(device):
+    """fp32_dest_acc_en=True is not supported by the custom LLK -> validate must reject it."""
+    heads, dim, sq, t = MINI["heads"], MINI["dim"], MINI["sq"], MINI["t"]
+    cfg = ttnn.IndexerScoreProgramConfig(q_chunk_size=32, k_chunk_size=32, head_group_size=0)
+    ckc = ttnn.init_device_compute_kernel_config(device.arch(), fp32_dest_acc_en=True)
+    q, k, w = make_inputs(heads, dim, sq, t)
+    with pytest.raises(RuntimeError, match="fp32_dest_acc_en=false"):
+        run_indexer(q, k, w, 128, device, program_config=cfg, compute_kernel_config=ckc)
 
 
 @pytest.mark.skipif(os.environ.get("CI") == "true", reason="perf test - run locally")

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py
@@ -442,3 +442,69 @@ def test_indexer_score_sp7_math_util(heads, q_id, k_id, fidelity):
         f"cores={core_count}, V={valid_tiles} tiles, mm={mm_flops / 1e9:.1f} GFLOP, "
         f"peak={peak} FLOP/cyc/core @ {_BH_CLOCK_GHZ} GHz -> math_util={math_util:.1f}%"
     )
+
+
+# ---------------------------------------------------------------------------
+# Device-perf op-test band check (CI-gated by INDEXER_SCORE_PERF_CHECKS=1; runs in the "ops perf tests"
+# job of perf-device-models). Mirrors SDPA's test_sdpa_perf_check: measure sp_rank-7 HiFi2 math
+# utilization (the deployed bf16 q + bfp8 k path) via tracy and assert it stays within a symmetric +/-
+# band, catching both regressions and unexpected speedups. Expected values were measured on a Blackhole
+# dev board; the band is wider than SDPA's 1% while the op's cross-board perf is still being characterized.
+# ---------------------------------------------------------------------------
+INDEXER_PERF_MARGIN = 0.02  # symmetric +/- 2%
+
+_INDEXER_PERF_CHECK_CONFIGS = [
+    # (case_id, heads, expected_util) at HiFi2 (bf16 q, bfp8 k), sp_rank 7
+    ("glm5", 8, 70.1),
+    ("dsv32", 16, 76.1),
+]
+
+
+@pytest.mark.skipif(
+    os.environ.get("INDEXER_SCORE_PERF_CHECKS") != "1",
+    reason="Set INDEXER_SCORE_PERF_CHECKS=1 to run (CI: ops perf tests job)",
+)
+@pytest.mark.parametrize(
+    "case_id, heads, expected_util",
+    _INDEXER_PERF_CHECK_CONFIGS,
+    ids=[f"{case_id}_heads{heads}" for case_id, heads, _ in _INDEXER_PERF_CHECK_CONFIGS],
+)
+def test_indexer_score_perf_check(case_id, heads, expected_util):
+    """GLM5.1 / DSv32 sp_rank-7 HiFi2 math utilization via tracy, asserted within +/- INDEXER_PERF_MARGIN."""
+    from tracy.process_model_log import run_device_profiler
+    from tests.nightly.sdpa_perf_utils import post_process_ops_log
+
+    subdir = "ttnn_indexer_score_perf_check"
+    perf_id = f"heads{heads}_q_bf16_k_bfp8"  # HiFi2 (bf16 q, bfp8 k)
+    command = (
+        "pytest tests/ttnn/nightly/unit_tests/operations/experimental/test_indexer_score.py::"
+        f"test_indexer_score_sp7_perf_impl[{perf_id}]"
+    )
+    with mock.patch.dict(os.environ, {"CI": "false"}):
+        run_device_profiler(command, subdir, device_analysis_types=["device_kernel_duration"])
+    r = post_process_ops_log(
+        subdir,
+        float_columns=["CORE COUNT", "DEVICE KERNEL DURATION [ns]"],
+        columns=["ATTRIBUTES"],
+        sum_vals=False,
+        has_signposts=False,
+    )
+    assert len(r["DEVICE KERNEL DURATION [ns]"]) > 0, "profiler returned no indexer_score ops"
+
+    core_count = int(r["CORE COUNT"][0])
+    duration_ns = float(r["DEVICE KERNEL DURATION [ns]"].min())
+    mm_flops = indexer_mm_flops(sp7_valid_tiles(), heads)
+    peak = _MM_FLOPS_PER_CYCLE_PER_CORE["HiFi2"]
+    cycles = duration_ns * _BH_CLOCK_GHZ
+    utilization = (mm_flops / (core_count * cycles * peak)) * 100 if core_count > 0 else 0.0
+
+    lower = expected_util * (1 - INDEXER_PERF_MARGIN)
+    upper = expected_util * (1 + INDEXER_PERF_MARGIN)
+    logger.info(
+        f"indexer_score perf check {case_id} heads={heads} (HiFi2): duration={duration_ns / 1e6:.3f} ms, "
+        f"math_util={utilization:.2f}% (expected {expected_util:.2f}%, band [{lower:.2f}, {upper:.2f}])"
+    )
+    assert lower <= utilization <= upper, (
+        f"Math utilization {utilization:.2f}% outside band [{lower:.2f}, {upper:.2f}] "
+        f"(expected {expected_util:.2f}%, margin +/- {INDEXER_PERF_MARGIN * 100:.1f}%)"
+    )

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
@@ -13,6 +13,14 @@
  *   SUB: SDPA   |   MUL: indexer_score gate reduction
  *************************************************************************/
 
+/**
+ * @brief Init the math (FPU) thread for the SDPA blocked bcast-col SUB path.
+ *
+ * @tparam math_fidelity: FPU fidelity phase, values = <LoFi/HiFi2/HiFi3/HiFi4>
+ * @param operandA: CB id of srcA; its num_faces drives the addr-mod setup.
+ * @param operandB: CB id of srcB (the bcast-col operand).
+ * @note Run before @ref llk_math_eltwise_binary_sub_bcast_cols_custom on this thread.
+ */
 template <MathFidelity math_fidelity>
 inline void llk_math_eltwise_binary_sub_bcast_cols_init_custom(
     const std::uint32_t operandA, const std::uint32_t operandB) {
@@ -22,18 +30,33 @@ inline void llk_math_eltwise_binary_sub_bcast_cols_init_custom(
     _llk_math_eltwise_binary_init_custom_<EltwiseBinaryType::ELWSUB, BroadcastType::COL>(num_faces);
 }
 
+/**
+ * @brief SDPA blocked bcast-col SUB over ct_dim column tiles starting at dst_index.
+ *
+ * @tparam is_fp32_dest_acc_en: Whether dest accumulates in fp32 (selects the dest tile budget).
+ * @param dst_index: First destination tile index.
+ * @param ct_dim: Number of column tiles written, into dest range [dst_index, dst_index + ct_dim).
+ * @note Run @ref llk_math_eltwise_binary_sub_bcast_cols_init_custom first.
+ */
 template <bool is_fp32_dest_acc_en = false>
 inline void llk_math_eltwise_binary_sub_bcast_cols_custom(const std::uint32_t dst_index, const std::uint32_t ct_dim = 1) {
     LLK_ASSERT(
-        (dst_index < get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
-        "dst_index out of range");
+        (dst_index + ct_dim <= get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
+        "dst range out of bounds");
 
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
     _llk_math_sub_bcast_cols_reuse_custom_(ct_dim);
     math::clear_dst_reg_addr();
 }
 
-// No fidelity template arg (unlike the SUB init above): the COL bcast init doesn't take one.
+/**
+ * @brief Init the math (FPU) thread for the indexer_score blocked bcast-col MUL path.
+ *
+ * @param operandA: CB id of srcA; its num_faces drives the addr-mod setup.
+ * @param operandB: CB id of srcB (the bcast-col operand).
+ * @note No fidelity template arg (unlike the SUB init): the COL bcast init doesn't take one. Run before
+ *       @ref llk_math_eltwise_binary_mul_bcast_cols_custom on this thread.
+ */
 inline void llk_math_eltwise_binary_mul_bcast_cols_init_custom(
     const std::uint32_t operandA, const std::uint32_t operandB) {
     const std::uint32_t operand_id = get_operand_id(operandA);
@@ -42,8 +65,16 @@ inline void llk_math_eltwise_binary_mul_bcast_cols_init_custom(
     _llk_math_eltwise_binary_init_custom_<EltwiseBinaryType::ELWMUL, BroadcastType::COL>(num_faces);
 }
 
-// Dest-MAC head reduction (see _llk_math_bcast_cols_reuse_custom_): column j MACs onto
-// dest[dst_index + j], so calling once per head into the same dst_index reduces heads in place.
+/**
+ * @brief indexer_score blocked bcast-col MUL with dest-MAC head reduction over ct_dim column tiles.
+ *
+ * Column j MACs onto dest[dst_index + j], so calling once per head into the same dst_index reduces
+ * heads in place (see @ref _llk_math_bcast_cols_reuse_custom_).
+ *
+ * @param dst_index: First destination tile index.
+ * @param ct_dim: Number of column tiles written, into dest range [dst_index, dst_index + ct_dim).
+ * @note Run @ref llk_math_eltwise_binary_mul_bcast_cols_init_custom first.
+ */
 inline void llk_math_eltwise_binary_mul_bcast_cols_custom(
     const std::uint32_t dst_index, const std::uint32_t ct_dim = 1) {
     LLK_ASSERT(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_math_eltwise_binary_custom_api.h
@@ -9,7 +9,8 @@
 #include "experimental/llk_math_eltwise_binary_custom.h"
 
 /*************************************************************************
- * LLK MATH ELTWISE BINARY CUSTOM - SDPA specialized blocked sub path
+ * LLK MATH ELTWISE BINARY CUSTOM - blocked bcast-col paths
+ *   SUB: SDPA   |   MUL: indexer_score gate reduction
  *************************************************************************/
 
 template <MathFidelity math_fidelity>
@@ -29,5 +30,27 @@ inline void llk_math_eltwise_binary_sub_bcast_cols_custom(const std::uint32_t ds
 
     math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
     _llk_math_sub_bcast_cols_reuse_custom_(ct_dim);
+    math::clear_dst_reg_addr();
+}
+
+// No fidelity template arg (unlike the SUB init above): the COL bcast init doesn't take one.
+inline void llk_math_eltwise_binary_mul_bcast_cols_init_custom(
+    const std::uint32_t operandA, const std::uint32_t operandB) {
+    const std::uint32_t operand_id = get_operand_id(operandA);
+    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+
+    _llk_math_eltwise_binary_init_custom_<EltwiseBinaryType::ELWMUL, BroadcastType::COL>(num_faces);
+}
+
+// Dest-MAC head reduction (see _llk_math_bcast_cols_reuse_custom_): column j MACs onto
+// dest[dst_index + j], so calling once per head into the same dst_index reduces heads in place.
+inline void llk_math_eltwise_binary_mul_bcast_cols_custom(
+    const std::uint32_t dst_index, const std::uint32_t ct_dim = 1) {
+    LLK_ASSERT(
+        (dst_index + ct_dim <= get_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE, DstTileShape::Tile32x32>()),
+        "dst range out of bounds");
+
+    math::set_dst_write_addr<DstTileShape::Tile32x32, UnpackDestination::SrcRegs>(dst_index);
+    _llk_math_bcast_cols_reuse_custom_<EltwiseBinaryType::ELWMUL>(ct_dim);
     math::clear_dst_reg_addr();
 }

--- a/tt_metal/hw/inc/api/compute/experimental/indexer_mul_custom.h
+++ b/tt_metal/hw/inc/api/compute/experimental/indexer_mul_custom.h
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "api/compute/common.h"
+
+// Blackhole-only: the math LLK lives only in the Blackhole llk_lib and indexer_score is a BH op.
+#if defined(TRISC_MATH) && defined(ARCH_BLACKHOLE)
+#include "experimental/llk_math_eltwise_binary_custom_api.h"
+#endif
+
+#if defined(TRISC_UNPACK) && defined(ARCH_BLACKHOLE)
+#include "experimental/llk_unpack_AB_sub_bcast_col_custom_api.h"
+#endif
+
+namespace ckernel {
+
+#if defined(ARCH_BLACKHOLE)
+
+// Blocked bcast-col MUL with dest-MAC head reduction (indexer_score gate-mul). Mechanism documented
+// canonically in _llk_math_bcast_cols_reuse_custom_ (llk_math_eltwise_binary_custom.h). Here: one
+// unpack context loads ONE SrcB (gate w[h]) + ct_dim SrcA tiles (qk for ct_dim consecutive cols of
+// head h, so cb_qk must be head-major). Reuses the SDPA blocked-sub unpack (op-agnostic). Pair with
+// mul_bcast_cols_init_short_custom.
+
+ALWI void mul_bcast_cols_init_short_custom(uint32_t icb0, uint32_t icb1, uint32_t call_line = __builtin_LINE()) {
+    state_configure(icb0, icb1, call_line);
+    MATH((llk_math_eltwise_binary_mul_bcast_cols_init_custom(icb0, icb1)));
+    UNPACK((llk_unpack_AB_sub_bcast_col_init_custom(icb0)));
+}
+
+// itile0 = base SrcA (qk) tile of head h's column run (ct_dim consecutive tiles); itile1 = w[h].
+ALWI void mul_tiles_bcast_cols_custom(
+    uint32_t icb0, uint32_t icb1, uint32_t itile0, uint32_t itile1, uint32_t idst, uint32_t ct_dim) {
+    MATH((llk_math_eltwise_binary_mul_bcast_cols_custom(idst, ct_dim)));
+    UNPACK((llk_unpack_AB_sub_bcast_col_custom(icb0, icb1, itile0, itile1, ct_dim)));
+}
+
+#endif
+
+}  // namespace ckernel

--- a/tt_metal/tt-llk/tests/python_tests/test_eltwise_bcast_col_custom.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_eltwise_bcast_col_custom.py
@@ -6,6 +6,7 @@ from dataclasses import dataclass
 
 import pytest
 import torch
+from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
 from helpers.format_config import DataFormat
 from helpers.golden_generators import (
     BroadcastGolden,
@@ -54,7 +55,7 @@ class CT_DIM(TemplateParameter):
             DataFormat.Float16_b,
         ]
     ),
-    mathop=[MathOperation.Elwsub],
+    mathop=[MathOperation.Elwsub, MathOperation.Elwmul],
     dest_acc=[DestAccumulation.No],
     math_fidelity=[
         MathFidelity.LoFi,
@@ -78,6 +79,13 @@ def test_eltwise_bcast_col_custom(
 ):
     if mathop != MathOperation.Elwmul and math_fidelity != MathFidelity.LoFi:
         pytest.skip("Fidelity does not affect Elwadd and Elwsub operations")
+    # The MUL instantiation of the blocked bcast-col reuse scaffold exists only on Blackhole
+    # (Wormhole has just the SUB-named wrapper).
+    if (
+        mathop == MathOperation.Elwmul
+        and get_chip_architecture() != ChipArchitecture.BLACKHOLE
+    ):
+        pytest.skip("MUL bcast-col reuse scaffold is Blackhole-only")
 
     ct_dim = input_dimensions_A[1] // 32
     logger.info(
@@ -160,7 +168,7 @@ def test_eltwise_bcast_col_custom(
     torch_format = format_dict[formats.output_format]
     res_tensor = torch.tensor(res_from_L1, dtype=torch_format)
 
-    # Spot-check: log a few elements per tile to verify srcA - bcast(srcB)
+    # Spot-check: log a few elements per tile to verify srcA <op> bcast(srcB)
     for t in range(ct_dim):
         tile_start = t * 32 * 32
         a_sample = src_A[tile_start : tile_start + 4].tolist()

--- a/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/multiple_tiles_eltwise_custom_test.cpp
@@ -50,8 +50,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
 
-    // call custom LLK
+    // call custom LLK. The templated MUL/SUB scaffold is Blackhole-only; Wormhole has only the
+    // SUB-named wrapper, so MUL is exercised on BH alone (the test skips the MUL variant on non-BH).
+#ifdef ARCH_BLACKHOLE
+    _llk_math_bcast_cols_reuse_custom_<ELTWISE_BINARY_OP>(CT_DIM);
+#else
     _llk_math_sub_bcast_cols_reuse_custom_(CT_DIM);
+#endif
 
     _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_binary_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_binary_custom.h
@@ -54,8 +54,36 @@ inline void _llk_math_eltwise_binary_uninit_custom_()
     // No state to restore - all states are transient or default
 }
 
-inline void _llk_math_sub_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
+// CANONICAL mechanism note (other files refer here). Blocked bcast-col scaffold shared by the SDPA SUB
+// path and the indexer_score MUL path; they differ only in the FPU op (selected at compile time), so
+// addr-mod setup, srcB face-reuse addressing, and per-tile counter resets are single-sourced here. The
+// name tracks the shared mechanism (srcB face reuse), matching the WH _llk_math_sub_bcast_cols_reuse_custom_.
+// MUL path = dest-MAC head reduction: ELWMUL's dest_accum_en opcode field is 0 (MAC, not overwrite),
+// and dest is cleared only by tile_regs_acquire's ZEROACC. So the caller does ONE acquire per ct_dim-
+// column batch and calls once per head into the SAME dest -> dest[col] = sum_h qk[col,h]*w[h], one pack
+// per column instead of per (column, head). cb_qk must be head-major.
+template <EltwiseBinaryType eltwise_binary_type>
+inline void _llk_math_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
 {
+    static_assert(
+        eltwise_binary_type == EltwiseBinaryType::ELWMUL || eltwise_binary_type == EltwiseBinaryType::ELWSUB,
+        "blocked bcast-col reuse scaffold supports ELWMUL and ELWSUB only");
+
+    // One FPU bcast-col op (mul or sub) advancing srcA/srcB/dest per `addr_mod`; op fixed at compile
+    // time -> branch resolves to a single emitted instruction.
+#define BCAST_COLS_OP(addr_mod)                                                       \
+    do                                                                                \
+    {                                                                                 \
+        if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWMUL)               \
+        {                                                                             \
+            TTI_ELWMUL(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, addr_mod, 0); \
+        }                                                                             \
+        else                                                                          \
+        {                                                                             \
+            TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, addr_mod, 0); \
+        }                                                                             \
+    } while (0)
+
     addr_mod_t {
         .srca = {.incr = 8},
         .srcb = {.incr = 8},
@@ -79,28 +107,41 @@ inline void _llk_math_sub_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 
 
     TTI_SETRWC(p_setrwc::CLR_NONE, 0, 0, 0, 0, p_setrwc::SET_AB); // reset both src counters to 0
 
+    // Per tile: walk srcA/dest across 4 faces while srcB reuses one face per pair (F0/F1 -> srcB face
+    // 0, F2/F3 -> srcB face 2). Comments are dest/srcA counter values. ADDR_MOD_5 rewinds srcB -8 so
+    // the pair's 2nd op rereads the same srcB face; ADDR_MOD_6 then jumps srcB +24 to the next pair.
     for (std::uint32_t i = 0; i < ct_dim; i++)
     {
-        // F0 - F0
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_7, 0); // 0 -> 8
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_5, 0); // 8 -> 0
+        // face F0 (srcB face 0)
+        BCAST_COLS_OP(ADDR_MOD_7); // 0 -> 8
+        BCAST_COLS_OP(ADDR_MOD_5); // 8 -> 0
 
-        // F1 - F0
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_7, 0); // 0 -> 8
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_6, 0); // 8 -> 32
+        // face F1 (srcB face 0, reused)
+        BCAST_COLS_OP(ADDR_MOD_7); // 0 -> 8
+        BCAST_COLS_OP(ADDR_MOD_6); // 8 -> 32
 
-        // F2 - F2
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_7, 0); // 32 -> 40
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_5, 0); // 40 -> 32
+        // face F2 (srcB face 2)
+        BCAST_COLS_OP(ADDR_MOD_7); // 32 -> 40
+        BCAST_COLS_OP(ADDR_MOD_5); // 40 -> 32
 
-        // F3 - F2
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_7, 0); // 32 -> 40
-        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, ADDR_MOD_6, 0); // 40 -> 64, no CLR_A
+        // face F3 (srcB face 2, reused)
+        BCAST_COLS_OP(ADDR_MOD_7); // 32 -> 40
+        BCAST_COLS_OP(ADDR_MOD_6); // 40 -> 64, no CLR_A
 
-        // Reset srcB to 0 for next tile, but keep srcA advancing
-        TTI_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_AB); // reset only srcB counter to 0
+        // Rewind srcB to 0 for the next srcA tile (CLR_A clears srcA's dvalid); srcA keeps advancing.
+        TTI_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_AB);
     }
 
-    // Final cleanup: reset both counters
+    // Clear srcB dvalid on the way out.
     TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_AB);
+
+#undef BCAST_COLS_OP
+}
+
+// SDPA's SUB path keeps this op-named wrapper: its name is referenced directly by external callers
+// (WH arch + the tt-llk eltwise_bcast_col tests), so it can't be folded away. The MUL
+// path has no such external caller -- its API calls _llk_math_bcast_cols_reuse_custom_<ELWMUL> directly.
+inline void _llk_math_sub_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
+{
+    _llk_math_bcast_cols_reuse_custom_<EltwiseBinaryType::ELWSUB>(ct_dim);
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_binary_custom.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_math_eltwise_binary_custom.h
@@ -54,35 +54,49 @@ inline void _llk_math_eltwise_binary_uninit_custom_()
     // No state to restore - all states are transient or default
 }
 
-// CANONICAL mechanism note (other files refer here). Blocked bcast-col scaffold shared by the SDPA SUB
-// path and the indexer_score MUL path; they differ only in the FPU op (selected at compile time), so
-// addr-mod setup, srcB face-reuse addressing, and per-tile counter resets are single-sourced here. The
-// name tracks the shared mechanism (srcB face reuse), matching the WH _llk_math_sub_bcast_cols_reuse_custom_.
-// MUL path = dest-MAC head reduction: ELWMUL's dest_accum_en opcode field is 0 (MAC, not overwrite),
-// and dest is cleared only by tile_regs_acquire's ZEROACC. So the caller does ONE acquire per ct_dim-
-// column batch and calls once per head into the SAME dest -> dest[col] = sum_h qk[col,h]*w[h], one pack
-// per column instead of per (column, head). cb_qk must be head-major.
+/**
+ * @brief Emit one bcast-col FPU op (ELWMUL or ELWSUB) advancing srcA/srcB/dest per addr_mod.
+ *
+ * The op is fixed at compile time, so the constexpr branch resolves to a single emitted instruction.
+ *
+ * @tparam eltwise_binary_type: FPU op, values = <ELWSUB/ELWMUL>
+ * @tparam addr_mod: addr-mod slot selecting the srcA/srcB/dest strides for this op.
+ */
+template <EltwiseBinaryType eltwise_binary_type, std::uint8_t addr_mod>
+inline void _bcast_cols_op_()
+{
+    if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWMUL)
+    {
+        TTI_ELWMUL(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, addr_mod, 0);
+    }
+    else
+    {
+        TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, addr_mod, 0);
+    }
+}
+
+/**
+ * @brief Blocked bcast-col FPU scaffold shared by the SDPA SUB and indexer_score MUL paths.
+ *
+ * Single-sources the addr-mod setup, srcB face-reuse addressing, and per-tile counter resets; the two
+ * paths differ only in the FPU op (selected at compile time). The name tracks the shared mechanism
+ * (srcB face reuse), matching WH's _llk_math_sub_bcast_cols_reuse_custom_.
+ *
+ * The MUL path is a dest-MAC head reduction: ELWMUL's dest_accum_en field is 0 (MAC, not overwrite) and
+ * dest is cleared only by tile_regs_acquire's ZEROACC, so the caller does ONE acquire per ct_dim-column
+ * batch and calls once per head into the SAME dest -> dest[col] = sum_h qk[col,h]*w[h], one pack per
+ * column instead of per (column, head). cb_qk must be head-major.
+ *
+ * @tparam eltwise_binary_type: FPU op, values = <ELWSUB/ELWMUL>
+ * @param ct_dim: Number of srcA column tiles processed in the block.
+ * @note Canonical description of the shared blocked bcast-col mechanism; other files reference this one.
+ */
 template <EltwiseBinaryType eltwise_binary_type>
 inline void _llk_math_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
 {
     static_assert(
         eltwise_binary_type == EltwiseBinaryType::ELWMUL || eltwise_binary_type == EltwiseBinaryType::ELWSUB,
         "blocked bcast-col reuse scaffold supports ELWMUL and ELWSUB only");
-
-    // One FPU bcast-col op (mul or sub) advancing srcA/srcB/dest per `addr_mod`; op fixed at compile
-    // time -> branch resolves to a single emitted instruction.
-#define BCAST_COLS_OP(addr_mod)                                                       \
-    do                                                                                \
-    {                                                                                 \
-        if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWMUL)               \
-        {                                                                             \
-            TTI_ELWMUL(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, addr_mod, 0); \
-        }                                                                             \
-        else                                                                          \
-        {                                                                             \
-            TTI_ELWSUB(p_setrwc::CLR_NONE, 0, p_elwise::SRCB_BCAST_COL, addr_mod, 0); \
-        }                                                                             \
-    } while (0)
 
     addr_mod_t {
         .srca = {.incr = 8},
@@ -113,20 +127,20 @@ inline void _llk_math_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
     for (std::uint32_t i = 0; i < ct_dim; i++)
     {
         // face F0 (srcB face 0)
-        BCAST_COLS_OP(ADDR_MOD_7); // 0 -> 8
-        BCAST_COLS_OP(ADDR_MOD_5); // 8 -> 0
+        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_7>(); // 0 -> 8
+        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_5>(); // 8 -> 0
 
         // face F1 (srcB face 0, reused)
-        BCAST_COLS_OP(ADDR_MOD_7); // 0 -> 8
-        BCAST_COLS_OP(ADDR_MOD_6); // 8 -> 32
+        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_7>(); // 0 -> 8
+        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_6>(); // 8 -> 32
 
         // face F2 (srcB face 2)
-        BCAST_COLS_OP(ADDR_MOD_7); // 32 -> 40
-        BCAST_COLS_OP(ADDR_MOD_5); // 40 -> 32
+        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_7>(); // 32 -> 40
+        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_5>(); // 40 -> 32
 
         // face F3 (srcB face 2, reused)
-        BCAST_COLS_OP(ADDR_MOD_7); // 32 -> 40
-        BCAST_COLS_OP(ADDR_MOD_6); // 40 -> 64, no CLR_A
+        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_7>(); // 32 -> 40
+        _bcast_cols_op_<eltwise_binary_type, ADDR_MOD_6>(); // 40 -> 64, no CLR_A
 
         // Rewind srcB to 0 for the next srcA tile (CLR_A clears srcA's dvalid); srcA keeps advancing.
         TTI_SETRWC(p_setrwc::CLR_A, 0, 0, 0, 0, p_setrwc::SET_AB);
@@ -134,13 +148,17 @@ inline void _llk_math_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
 
     // Clear srcB dvalid on the way out.
     TTI_SETRWC(p_setrwc::CLR_B, 0, 0, 0, 0, p_setrwc::SET_AB);
-
-#undef BCAST_COLS_OP
 }
 
-// SDPA's SUB path keeps this op-named wrapper: its name is referenced directly by external callers
-// (WH arch + the tt-llk eltwise_bcast_col tests), so it can't be folded away. The MUL
-// path has no such external caller -- its API calls _llk_math_bcast_cols_reuse_custom_<ELWMUL> directly.
+/**
+ * @brief SDPA's SUB entry point into the shared blocked bcast-col scaffold.
+ *
+ * Kept as an op-named wrapper because external callers reference this name directly (WH arch + the
+ * tt-llk eltwise_bcast_col tests), so it can't be folded away. The MUL path has no such external caller
+ * and calls @ref _llk_math_bcast_cols_reuse_custom_ <ELWMUL> directly.
+ *
+ * @param ct_dim: Number of srcA column tiles processed in the block.
+ */
 inline void _llk_math_sub_bcast_cols_reuse_custom_(const std::uint32_t ct_dim = 1)
 {
     _llk_math_bcast_cols_reuse_custom_<EltwiseBinaryType::ELWSUB>(ct_dim);

--- a/ttnn/CMakeLists.txt
+++ b/ttnn/CMakeLists.txt
@@ -279,6 +279,7 @@ target_link_libraries(
         TTNN::Ops::Experimental::TopkLargeIndices
         TTNN::Ops::Experimental::TopkRouterGpt
         TTNN::Ops::Experimental::Deepseek::MLA::Matmul_WO
+        TTNN::Ops::Experimental::IndexerScore
         TTNN::Ops::Experimental::MoEGPT
         TTNN::Ops::Experimental::DeepSeekPrefill::Dispatch
         TTNN::Ops::Experimental::DeepSeekPrefill::Combine
@@ -542,6 +543,7 @@ add_subdirectory(cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate
 add_subdirectory(cpp/ttnn/operations/experimental/topk_large_indices)
 add_subdirectory(cpp/ttnn/operations/experimental/topk_router_gpt)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek/mla/matmul_wo)
+add_subdirectory(cpp/ttnn/operations/experimental/indexer_score)
 add_subdirectory(cpp/ttnn/operations/experimental/ccl/moe_gpt)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/dispatch)
 add_subdirectory(cpp/ttnn/operations/experimental/deepseek_prefill/combine)

--- a/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/experimental_nanobind.cpp
@@ -66,6 +66,7 @@
 #include "ttnn/operations/experimental/topk_router_gpt/topk_router_gpt_nanobind.hpp"
 #include "ttnn/operations/experimental/topk_large_indices/topk_large_indices_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek/mla/matmul_wo/matmul_wo_nanobind.hpp"
+#include "ttnn/operations/experimental/indexer_score/indexer_score_nanobind.hpp"
 #include "ttnn/operations/experimental/ccl/moe_gpt/moe_gpt_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.hpp"
 #include "ttnn/operations/experimental/deepseek_prefill/combine/combine_nanobind.hpp"
@@ -176,6 +177,7 @@ void py_module(nb::module_& mod) {
     topk_large_indices::detail::bind_topk_large_indices(mod);
     topk_router_gpt::detail::bind_topk_router_gpt(mod);
     deepseek::mla::detail::bind_matmul_wo(mod);
+    indexer_score::detail::bind_indexer_score(mod);
     moe_gpt::detail::bind_moe_gpt(mod);
 
     // DeepSeek prefill MoE operations

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/CMakeLists.txt
@@ -1,0 +1,29 @@
+include(sources.cmake)
+
+add_library(ttnn_op_experimental_indexer_score ${LIB_TYPE})
+add_library(TTNN::Ops::Experimental::IndexerScore ALIAS ttnn_op_experimental_indexer_score)
+
+tt_reuse_precompile_headers(ttnn_op_experimental_indexer_score TT::CommonPCH)
+TT_ENABLE_UNITY_BUILD(ttnn_op_experimental_indexer_score)
+
+set_target_properties(
+    ttnn_op_experimental_indexer_score
+    PROPERTIES
+        INTERFACE_HEADER_SETS_TO_VERIFY
+            api
+)
+
+target_sources(
+    ttnn_op_experimental_indexer_score
+    PUBLIC
+        FILE_SET api
+        TYPE HEADERS
+        BASE_DIRS ${FixmeOpAPIDir}
+        FILES ${TTNN_OP_EXPERIMENTAL_INDEXER_SCORE_API_HEADERS}
+    PRIVATE
+        ${TTNN_OP_EXPERIMENTAL_INDEXER_SCORE_SRCS}
+)
+
+target_link_libraries(ttnn_op_experimental_indexer_score PRIVATE TT::Metalium PUBLIC TTNN::Core)
+
+install(TARGETS ttnn_op_experimental_indexer_score FILE_SET api COMPONENT ttnn-dev LIBRARY COMPONENT tar)

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -1,0 +1,153 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "indexer_score_device_operation.hpp"
+
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+
+namespace ttnn::operations::experimental::indexer_score {
+
+IndexerScoreDeviceOperation::program_factory_t IndexerScoreDeviceOperation::select_program_factory(
+    const operation_attributes_t&, const tensor_args_t&) {
+    return program::IndexerScoreProgramFactory{};
+}
+
+void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
+    using tt::constants::TILE_HEIGHT;
+    using tt::constants::TILE_WIDTH;
+
+    const auto& q = tensor_args.q;
+    const auto& k = tensor_args.k;
+    const auto& w = tensor_args.weights;
+
+    const auto& q_shape = q.logical_shape();
+    const auto& k_shape = k.logical_shape();
+    const auto& w_shape = w.logical_shape();
+
+    // Blackhole-only: the compute kernel relies on BH fast-untilize + custom BH LLK paths. Enforce in
+    // C++ (not just the pytest skip) so a Wormhole caller fails cleanly instead of hanging at launch.
+    const tt::ARCH arch = tt::tt_metal::hal::get_arch();
+    TT_FATAL(arch == tt::ARCH::BLACKHOLE, "indexer_score is only supported on Blackhole, got {}", arch);
+
+    // On-device, allocated, interleaved, same-device: the factory dereferences each buffer's address
+    // in q's device address space and the kernels assume interleaved DRAM/L1 (mcast deal + TensorAccessor).
+    for (const auto& [t, name] : {std::pair{&q, "q"}, std::pair{&k, "k"}, std::pair{&w, "weights"}}) {
+        TT_FATAL(t->storage_type() == StorageType::DEVICE, "indexer_score {} must be on device", name);
+        TT_FATAL(t->buffer() != nullptr, "indexer_score {} must have an allocated buffer", name);
+        TT_FATAL(!t->is_sharded(), "indexer_score {} must use interleaved memory", name);
+    }
+    TT_FATAL(
+        q.device() == k.device() && q.device() == w.device(), "indexer_score q, k, weights must be on the same device");
+
+    // Shapes: q [B, Hi, Sq, D], k [B, 1, T, D] (single shared head), weights [B, Hi, Sq, 1].
+    TT_FATAL(q_shape.rank() == 4 && k_shape.rank() == 4 && w_shape.rank() == 4, "q, k, weights must be rank 4");
+    TT_FATAL(k_shape[1] == 1, "k must be single-head [B, 1, T, D], got {} heads", k_shape[1]);
+    TT_FATAL(q_shape[3] == k_shape[3], "q head dim {} != k head dim {}", q_shape[3], k_shape[3]);
+    TT_FATAL(
+        w_shape[1] == q_shape[1] && w_shape[2] == q_shape[2] && w_shape[3] == 1,
+        "weights must be [B, Hi, Sq, 1] matching q [B, Hi, Sq, D]");
+    TT_FATAL(q_shape[0] == k_shape[0] && q_shape[0] == w_shape[0], "batch mismatch");
+    TT_FATAL(q_shape[0] == 1, "batch 1 only, got {}", q_shape[0]);
+
+    // weights are bf16 tiles. q and k are matmul inputs (q is srcB, k is srcA), neither is ever
+    // packed, so each may be bfp8_b (halves its BW). q+k both bfp8 drops the matmul to LoFi (1 phase);
+    // any bf16 input keeps HiFi2. Mismatched dtype/layout corrupts or hangs.
+    TT_FATAL(w.dtype() == DataType::BFLOAT16, "weights must be bfloat16 (got {})", w.dtype());
+    TT_FATAL(
+        q.dtype() == DataType::BFLOAT16 || q.dtype() == DataType::BFLOAT8_B,
+        "q must be bfloat16 or bfloat8_b (got {})",
+        q.dtype());
+    TT_FATAL(
+        k.dtype() == DataType::BFLOAT16 || k.dtype() == DataType::BFLOAT8_B,
+        "k must be bfloat16 or bfloat8_b (got {})",
+        k.dtype());
+    TT_FATAL(
+        q.layout() == Layout::TILE && k.layout() == Layout::TILE && w.layout() == Layout::TILE,
+        "q, k, weights must be TILE layout");
+
+    // Tile alignment and the causal chunk window.
+    const uint32_t Hi = q_shape[1];
+    const uint32_t Sq = q_shape[2];
+    const uint32_t D = q_shape[3];
+    const uint32_t T = k_shape[2];
+    TT_FATAL(
+        Sq % TILE_HEIGHT == 0 && T % TILE_WIDTH == 0 && D % TILE_WIDTH == 0,
+        "Sq {}, T {}, D {} must be tile-aligned",
+        Sq,
+        T,
+        D);
+    TT_FATAL(attrs.chunk_start_idx % TILE_WIDTH == 0, "chunk_start_idx {} must be tile-aligned", attrs.chunk_start_idx);
+    TT_FATAL(
+        attrs.chunk_start_idx + Sq <= T,
+        "chunk window [{}, {}+{}) exceeds T={}",
+        attrs.chunk_start_idx,
+        attrs.chunk_start_idx,
+        Sq,
+        T);
+
+    // Work-unit knobs (elements, tile-aligned); see IndexerScoreProgramConfig.
+    const auto& cfg = attrs.program_config;
+    TT_FATAL(
+        cfg.q_chunk_size % TILE_HEIGHT == 0 && cfg.k_chunk_size % TILE_WIDTH == 0,
+        "q_chunk_size {} / k_chunk_size {} must be tile-aligned",
+        cfg.q_chunk_size,
+        cfg.k_chunk_size);
+    const uint32_t QC = cfg.q_chunk_size / TILE_HEIGHT;
+    const uint32_t KC = cfg.k_chunk_size / TILE_WIDTH;
+    const uint32_t HB = resolve_head_group(cfg, Hi);
+    TT_FATAL(QC > 0 && (Sq / TILE_HEIGHT) % QC == 0, "q_chunk_size {} must divide Sq {}", cfg.q_chunk_size, Sq);
+    TT_FATAL(KC > 0 && KC <= T / TILE_WIDTH, "k_chunk_size {} out of range (T={})", cfg.k_chunk_size, T);
+    // KC need not divide Tt: the last unit is then partial. Compute still runs a full KC-wide strip
+    // (pad cols matmul stale k, overwritten with full -inf) and the writer clips to the valid width.
+    TT_FATAL(HB > 0 && Hi % HB == 0, "head_group_size {} must divide Hi {}", HB, Hi);
+}
+
+IndexerScoreDeviceOperation::spec_return_value_t IndexerScoreDeviceOperation::compute_output_specs(
+    const operation_attributes_t&, const tensor_args_t& tensor_args) {
+    const auto& q_shape = tensor_args.q.logical_shape();
+    const auto& k_shape = tensor_args.k.logical_shape();
+    // score [B, 1, Sq, T], row-major bf16 (consumed by the row-major topk)
+    ttnn::Shape out_shape({q_shape[0], 1, q_shape[2], k_shape[2]});
+    return TensorSpec(
+        out_shape,
+        tt::tt_metal::TensorLayout(
+            DataType::BFLOAT16, tt::tt_metal::PageConfig(Layout::ROW_MAJOR), tensor_args.q.memory_config()));
+}
+
+IndexerScoreDeviceOperation::tensor_return_value_t IndexerScoreDeviceOperation::create_output_tensors(
+    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
+    return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.q.device());
+}
+
+std::tuple<IndexerScoreDeviceOperation::operation_attributes_t, IndexerScoreDeviceOperation::tensor_args_t>
+IndexerScoreDeviceOperation::invoke(
+    const Tensor& q,
+    const Tensor& k,
+    const Tensor& weights,
+    uint32_t chunk_start_idx,
+    const IndexerScoreProgramConfig& program_config) {
+    return {
+        operation_attributes_t{.chunk_start_idx = chunk_start_idx, .program_config = program_config},
+        tensor_args_t{.q = q, .k = k, .weights = weights}};
+}
+
+}  // namespace ttnn::operations::experimental::indexer_score
+
+namespace ttnn::experimental {
+
+ttnn::Tensor indexer_score(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& k,
+    const ttnn::Tensor& weights,
+    uint32_t chunk_start_idx,
+    const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config) {
+    using OperationType = ttnn::operations::experimental::indexer_score::IndexerScoreDeviceOperation;
+    // Reuse invoke() so attribute/tensor packing lives in one place.
+    auto [operation_attributes, tensor_args] = OperationType::invoke(q, k, weights, chunk_start_idx, program_config);
+    return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
+}
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -19,9 +19,6 @@ IndexerScoreDeviceOperation::program_factory_t IndexerScoreDeviceOperation::sele
 
 void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    using tt::constants::TILE_HEIGHT;
-    using tt::constants::TILE_WIDTH;
-
     const auto& q = tensor_args.q;
     const auto& k = tensor_args.k;
     const auto& w = tensor_args.weights;
@@ -87,12 +84,16 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     const uint32_t D = q_shape[3];
     const uint32_t T = k_shape[2];
     TT_FATAL(
-        Sq % TILE_HEIGHT == 0 && T % TILE_WIDTH == 0 && D % TILE_WIDTH == 0,
+        Sq % tt::constants::TILE_HEIGHT == 0 && T % tt::constants::TILE_WIDTH == 0 &&
+            D % tt::constants::TILE_WIDTH == 0,
         "Sq {}, T {}, D {} must be tile-aligned",
         Sq,
         T,
         D);
-    TT_FATAL(attrs.chunk_start_idx % TILE_WIDTH == 0, "chunk_start_idx {} must be tile-aligned", attrs.chunk_start_idx);
+    TT_FATAL(
+        attrs.chunk_start_idx % tt::constants::TILE_WIDTH == 0,
+        "chunk_start_idx {} must be tile-aligned",
+        attrs.chunk_start_idx);
     TT_FATAL(
         attrs.chunk_start_idx + Sq <= T,
         "chunk window [{}, {}+{}) exceeds T={}",
@@ -104,15 +105,19 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     // Work-unit knobs (elements, tile-aligned); see IndexerScoreProgramConfig.
     const auto& cfg = attrs.program_config;
     TT_FATAL(
-        cfg.q_chunk_size % TILE_HEIGHT == 0 && cfg.k_chunk_size % TILE_WIDTH == 0,
+        cfg.q_chunk_size % tt::constants::TILE_HEIGHT == 0 && cfg.k_chunk_size % tt::constants::TILE_WIDTH == 0,
         "q_chunk_size {} / k_chunk_size {} must be tile-aligned",
         cfg.q_chunk_size,
         cfg.k_chunk_size);
-    const uint32_t QC = cfg.q_chunk_size / TILE_HEIGHT;
-    const uint32_t KC = cfg.k_chunk_size / TILE_WIDTH;
+    const uint32_t QC = cfg.q_chunk_size / tt::constants::TILE_HEIGHT;
+    const uint32_t KC = cfg.k_chunk_size / tt::constants::TILE_WIDTH;
     const uint32_t HB = resolve_head_group(cfg, Hi);
-    TT_FATAL(QC > 0 && (Sq / TILE_HEIGHT) % QC == 0, "q_chunk_size {} must divide Sq {}", cfg.q_chunk_size, Sq);
-    TT_FATAL(KC > 0 && KC <= T / TILE_WIDTH, "k_chunk_size {} out of range (T={})", cfg.k_chunk_size, T);
+    TT_FATAL(
+        QC > 0 && (Sq / tt::constants::TILE_HEIGHT) % QC == 0,
+        "q_chunk_size {} must divide Sq {}",
+        cfg.q_chunk_size,
+        Sq);
+    TT_FATAL(KC > 0 && KC <= T / tt::constants::TILE_WIDTH, "k_chunk_size {} out of range (T={})", cfg.k_chunk_size, T);
     // KC need not divide Tt: the last unit is then partial. Compute still runs a full KC-wide strip
     // (pad cols matmul stale k, overwritten with full -inf) and the writer clips to the valid width.
     TT_FATAL(HB > 0 && Hi % HB == 0, "head_group_size {} must divide Hi {}", HB, Hi);
@@ -143,9 +148,6 @@ IndexerScoreDeviceOperation::tensor_return_value_t IndexerScoreDeviceOperation::
 tt::tt_metal::operation::OpPerformanceModelGeneral<IndexerScoreDeviceOperation::tensor_return_value_t>
 IndexerScoreDeviceOperation::create_op_performance_model(
     const operation_attributes_t& attrs, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
-    using tt::constants::TILE_HEIGHT;
-    using tt::constants::TILE_WIDTH;
-
     const auto& q = tensor_args.q;
     const auto& k = tensor_args.k;
     const tt::tt_metal::operation::Tensors input_tensors = {q, k, tensor_args.weights};
@@ -161,9 +163,9 @@ IndexerScoreDeviceOperation::create_op_performance_model(
     const uint32_t B = q_shape[0];
     const uint32_t Hi = q_shape[1];
     const uint32_t D = q_shape[3];
-    const uint32_t Sqt = q_shape[2] / TILE_HEIGHT;
-    const uint32_t Tt = k_shape[2] / TILE_WIDTH;
-    const uint32_t chunk_t = attrs.chunk_start_idx / TILE_WIDTH;
+    const uint32_t Sqt = q_shape[2] / tt::constants::TILE_HEIGHT;
+    const uint32_t Tt = k_shape[2] / tt::constants::TILE_WIDTH;
+    const uint32_t chunk_t = attrs.chunk_start_idx / tt::constants::TILE_WIDTH;
 
     // Causal-valid output tiles V = sum over q-tile-rows of min(Tt, chunk_t + row + 1) -- the useful
     // matmul work, masked future tiles excluded (matches the test's sp7_valid_tiles()).
@@ -174,12 +176,13 @@ IndexerScoreDeviceOperation::create_op_performance_model(
 
     // Per valid 32x32 output tile, per head: a 32x32 x D matmul = (32*32) outputs x 2*D FLOPs (2/FMA);
     // summed over heads, valid tiles, and batch (matches the test's indexer_mm_flops()).
-    const uint64_t num_mul_adds = 2ull * valid_tiles * Hi * B * static_cast<uint64_t>(TILE_HEIGHT * TILE_WIDTH) * D;
+    const uint64_t num_mul_adds =
+        2ull * valid_tiles * Hi * B * static_cast<uint64_t>(tt::constants::TILE_HEIGHT * tt::constants::TILE_WIDTH) * D;
 
     // Actual cores used: total_units = groups x ceil(Tt/KC), clamped to the grid (matches the factory),
     // so the perf model's core count equals tracy's CORE COUNT and the utilization ratio lines up.
-    const uint32_t QC = attrs.program_config.q_chunk_size / TILE_HEIGHT;
-    const uint32_t KC = attrs.program_config.k_chunk_size / TILE_WIDTH;
+    const uint32_t QC = attrs.program_config.q_chunk_size / tt::constants::TILE_HEIGHT;
+    const uint32_t KC = attrs.program_config.k_chunk_size / tt::constants::TILE_WIDTH;
     const uint64_t total_units = static_cast<uint64_t>(Sqt / QC) * ((Tt + KC - 1) / KC);
     const auto grid = q.device()->compute_with_storage_grid_size();
     const uint64_t num_cores = std::min<uint64_t>(total_units, static_cast<uint64_t>(grid.x) * grid.y);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -4,6 +4,9 @@
 
 #include "indexer_score_device_operation.hpp"
 
+#include <algorithm>
+#include <cmath>
+
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/hal.hpp>
 
@@ -130,6 +133,67 @@ IndexerScoreDeviceOperation::spec_return_value_t IndexerScoreDeviceOperation::co
 IndexerScoreDeviceOperation::tensor_return_value_t IndexerScoreDeviceOperation::create_output_tensors(
     const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.q.device());
+}
+
+// Matmul-FLOP performance model. Mirrors SDPAOperation::create_op_performance_model: report ideal
+// matmul cycles = num_mul_adds / (cores * peak), and the profiler's ideal/actual ratio is then exactly
+// the math-util test's math_util = mm_flops / (cores * device_cycles * peak). Every term is matched to
+// the test (test_indexer_score_sp7_math_util): causal-valid output tiles only, actual cores, and the
+// fidelity-scaled Blackhole matmul peak.
+tt::tt_metal::operation::OpPerformanceModelGeneral<IndexerScoreDeviceOperation::tensor_return_value_t>
+IndexerScoreDeviceOperation::create_op_performance_model(
+    const operation_attributes_t& attrs, const tensor_args_t& tensor_args, tensor_return_value_t& output) {
+    using tt::constants::TILE_HEIGHT;
+    using tt::constants::TILE_WIDTH;
+
+    const auto& q = tensor_args.q;
+    const auto& k = tensor_args.k;
+    const tt::tt_metal::operation::Tensors input_tensors = {q, k, tensor_args.weights};
+
+    // Matmul throughput model is Blackhole-specific (the only validated arch). q is always on device.
+    const tt::ARCH arch = q.device()->arch();
+    if (arch != tt::ARCH::BLACKHOLE) {
+        return tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t>(input_tensors, output, 0);
+    }
+
+    const auto& q_shape = q.logical_shape();
+    const auto& k_shape = k.logical_shape();
+    const uint32_t B = q_shape[0];
+    const uint32_t Hi = q_shape[1];
+    const uint32_t D = q_shape[3];
+    const uint32_t Sqt = q_shape[2] / TILE_HEIGHT;
+    const uint32_t Tt = k_shape[2] / TILE_WIDTH;
+    const uint32_t chunk_t = attrs.chunk_start_idx / TILE_WIDTH;
+
+    // Causal-valid output tiles V = sum over q-tile-rows of min(Tt, chunk_t + row + 1) -- the useful
+    // matmul work, masked future tiles excluded (matches the test's sp7_valid_tiles()).
+    uint64_t valid_tiles = 0;
+    for (uint32_t s = 0; s < Sqt; ++s) {
+        valid_tiles += std::min<uint64_t>(Tt, (uint64_t)chunk_t + s + 1);
+    }
+
+    // Per valid 32x32 output tile, per head: a 32x32 x D matmul = (32*32) outputs x 2*D FLOPs (2/FMA);
+    // summed over heads, valid tiles, and batch (matches the test's indexer_mm_flops()).
+    const uint64_t num_mul_adds = 2ull * valid_tiles * Hi * B * static_cast<uint64_t>(TILE_HEIGHT * TILE_WIDTH) * D;
+
+    // Actual cores used: total_units = groups x ceil(Tt/KC), clamped to the grid (matches the factory),
+    // so the perf model's core count equals tracy's CORE COUNT and the utilization ratio lines up.
+    const uint32_t QC = attrs.program_config.q_chunk_size / TILE_HEIGHT;
+    const uint32_t KC = attrs.program_config.k_chunk_size / TILE_WIDTH;
+    const uint64_t total_units = static_cast<uint64_t>(Sqt / QC) * ((Tt + KC - 1) / KC);
+    const auto grid = q.device()->compute_with_storage_grid_size();
+    const uint64_t num_cores = std::min<uint64_t>(total_units, static_cast<uint64_t>(grid.x) * grid.y);
+
+    // Blackhole matmul peak: 4096 mul-adds/cycle/core at LoFi, scaled by the fidelity multiplier (the
+    // test's peak table is 4096 / multiplier). Fidelity comes from the resolved compute config.
+    const auto math_fidelity = std::get<0>(ttnn::get_compute_kernel_config_args(arch, attrs.compute_kernel_config));
+    constexpr uint64_t tensix_mul_adds_per_cycle_lofi = 4096;
+    const int ideal_compute_cycles = static_cast<int>(std::ceil(
+        (static_cast<double>(num_mul_adds) / static_cast<double>(num_cores * tensix_mul_adds_per_cycle_lofi)) *
+        static_cast<double>(tt::tt_metal::operation::OpPerformanceModel::fidelity_multiplier(math_fidelity))));
+
+    return tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t>(
+        input_tensors, output, ideal_compute_cycles);
 }
 
 std::tuple<IndexerScoreDeviceOperation::operation_attributes_t, IndexerScoreDeviceOperation::tensor_args_t>

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.cpp
@@ -32,6 +32,16 @@ void IndexerScoreDeviceOperation::validate_on_program_cache_miss(
     const tt::ARCH arch = tt::tt_metal::hal::get_arch();
     TT_FATAL(arch == tt::ARCH::BLACKHOLE, "indexer_score is only supported on Blackhole, got {}", arch);
 
+    // The compute kernel honors the config's math_fidelity (default: dtype-derived), but its custom
+    // blocked bcast-col LLK + half-sync 8-head subblock are validated only for bf16 DEST in half-sync.
+    // Reject the unvalidated knobs loudly instead of silently building a path that can drop the -inf mask.
+    const auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        ttnn::get_compute_kernel_config_args(arch, attrs.compute_kernel_config);
+    TT_FATAL(
+        !fp32_dest_acc_en,
+        "indexer_score requires fp32_dest_acc_en=false (bf16 DEST; the custom LLK is not validated for fp32 DEST)");
+    TT_FATAL(!dst_full_sync_en, "indexer_score requires dst_full_sync_en=false (the kernel is built half-sync)");
+
     // On-device, allocated, interleaved, same-device: the factory dereferences each buffer's address
     // in q's device address space and the kernels assume interleaved DRAM/L1 (mcast deal + TensorAccessor).
     for (const auto& [t, name] : {std::pair{&q, "q"}, std::pair{&k, "k"}, std::pair{&w, "weights"}}) {
@@ -128,9 +138,13 @@ IndexerScoreDeviceOperation::invoke(
     const Tensor& k,
     const Tensor& weights,
     uint32_t chunk_start_idx,
-    const IndexerScoreProgramConfig& program_config) {
+    const IndexerScoreProgramConfig& program_config,
+    const DeviceComputeKernelConfig& compute_kernel_config) {
     return {
-        operation_attributes_t{.chunk_start_idx = chunk_start_idx, .program_config = program_config},
+        operation_attributes_t{
+            .chunk_start_idx = chunk_start_idx,
+            .program_config = program_config,
+            .compute_kernel_config = compute_kernel_config},
         tensor_args_t{.q = q, .k = k, .weights = weights}};
 }
 
@@ -143,10 +157,24 @@ ttnn::Tensor indexer_score(
     const ttnn::Tensor& k,
     const ttnn::Tensor& weights,
     uint32_t chunk_start_idx,
-    const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config) {
+    const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config,
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config) {
     using OperationType = ttnn::operations::experimental::indexer_score::IndexerScoreDeviceOperation;
+    // Default math_fidelity follows the matmul-input dtypes (both bfp8 -> LoFi for the 2x peak, else
+    // HiFi2 to keep the bf16 mantissa); a caller-supplied config overrides per field. fp32-dest acc and
+    // full-sync default off -- the only modes this op's custom LLK is validated for (see validate).
+    const bool both_bfp8 = q.dtype() == DataType::BFLOAT8_B && k.dtype() == DataType::BFLOAT8_B;
+    const auto resolved = ttnn::init_device_compute_kernel_config(
+        q.device()->arch(),
+        compute_kernel_config,
+        /*default_fidelity=*/both_bfp8 ? tt::tt_metal::MathFidelity::LoFi : tt::tt_metal::MathFidelity::HiFi2,
+        /*default_approx_mode=*/false,
+        /*default_fp32_acc=*/false,
+        /*default_l1_acc=*/false,
+        /*default_dst_full_sync_en=*/false);
     // Reuse invoke() so attribute/tensor packing lives in one place.
-    auto [operation_attributes, tensor_args] = OperationType::invoke(q, k, weights, chunk_start_idx, program_config);
+    auto [operation_attributes, tensor_args] =
+        OperationType::invoke(q, k, weights, chunk_start_idx, program_config, resolved);
     return ttnn::device_operation::launch<OperationType>(operation_attributes, tensor_args);
 }
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -8,6 +8,7 @@
 #include <variant>
 
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operation.hpp"
 #include "indexer_score_device_operation_types.hpp"
 #include "indexer_score_program_factory.hpp"
 
@@ -28,6 +29,12 @@ struct IndexerScoreDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    // Matmul-FLOP performance model (mirrors SDPAOperation::create_op_performance_model): reports ideal
+    // matmul cycles so tracy's ideal/actual utilization equals the math-util test's mm_flops/(cores x
+    // cycles x peak). FLOPs count causal-valid tiles only; cores/fidelity match the factory.
+    static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
+        const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
 
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& q,

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <optional>
 #include <variant>
 
 #include "ttnn/tensor/tensor.hpp"
@@ -33,7 +34,8 @@ struct IndexerScoreDeviceOperation {
         const Tensor& k,
         const Tensor& weights,
         uint32_t chunk_start_idx,
-        const IndexerScoreProgramConfig& program_config);
+        const IndexerScoreProgramConfig& program_config,
+        const DeviceComputeKernelConfig& compute_kernel_config);
 };
 
 }  // namespace ttnn::operations::experimental::indexer_score
@@ -49,6 +51,7 @@ ttnn::Tensor indexer_score(
     const ttnn::Tensor& k,
     const ttnn::Tensor& weights,
     uint32_t chunk_start_idx = 0,
-    const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config = {});
+    const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config = {},
+    const std::optional<ttnn::DeviceComputeKernelConfig>& compute_kernel_config = std::nullopt);
 
 }  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -1,0 +1,54 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <variant>
+
+#include "ttnn/tensor/tensor.hpp"
+#include "indexer_score_device_operation_types.hpp"
+#include "indexer_score_program_factory.hpp"
+
+namespace ttnn::operations::experimental::indexer_score {
+
+struct IndexerScoreDeviceOperation {
+    using operation_attributes_t = indexer_score::operation_attributes_t;
+    using tensor_args_t = indexer_score::tensor_args_t;
+    using spec_return_value_t = indexer_score::spec_return_value_t;
+    using tensor_return_value_t = indexer_score::tensor_return_value_t;
+    using program_factory_t = std::variant<program::IndexerScoreProgramFactory>;
+
+    // No custom compute_program_hash: operation_attributes_t (chunk_start_idx + every config field)
+    // is a reflectable aggregate, so the default reflection hash already keys distinct programs on all
+    // fields. Do not add a hand-rolled hash that drops fields.
+    static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+
+    static std::tuple<operation_attributes_t, tensor_args_t> invoke(
+        const Tensor& q,
+        const Tensor& k,
+        const Tensor& weights,
+        uint32_t chunk_start_idx,
+        const IndexerScoreProgramConfig& program_config);
+};
+
+}  // namespace ttnn::operations::experimental::indexer_score
+
+namespace ttnn::experimental {
+
+// DeepSeek-V3.2 DSA lightning-indexer scorer (the public callable, ttnn.experimental.indexer_score):
+//   score[b, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
+// q [B, Hi, Sq, D], k [B, 1, T, D], weights [B, Hi, Sq, 1] -> score [B, 1, Sq, T] (row-major bf16).
+// Causality from chunk_start_idx: key t visible to query s iff t <= chunk_start_idx + s.
+ttnn::Tensor indexer_score(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& k,
+    const ttnn::Tensor& weights,
+    uint32_t chunk_start_idx = 0,
+    const ttnn::operations::experimental::indexer_score::IndexerScoreProgramConfig& program_config = {});
+
+}  // namespace ttnn::experimental

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation.hpp
@@ -5,6 +5,7 @@
 #pragma once
 
 #include <optional>
+#include <tuple>
 #include <variant>
 
 #include "ttnn/tensor/tensor.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -7,6 +7,7 @@
 #include <cstddef>
 
 #include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
 #include <tt-metalium/base_types.hpp>
 
 namespace ttnn::operations::experimental::indexer_score {
@@ -28,6 +29,9 @@ inline uint32_t resolve_head_group(const IndexerScoreProgramConfig& cfg, uint32_
 struct operation_attributes_t {
     uint32_t chunk_start_idx{0};
     IndexerScoreProgramConfig program_config{};
+    // Resolved (not optional) so it is part of the reflected program-cache key; the public callable
+    // fills it from the user's optional config, defaulting math_fidelity to the dtype-derived choice.
+    DeviceComputeKernelConfig compute_kernel_config{};
 };
 
 struct tensor_args_t {

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_device_operation_types.hpp
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <cstddef>
+
+#include "ttnn/tensor/tensor.hpp"
+#include <tt-metalium/base_types.hpp>
+
+namespace ttnn::operations::experimental::indexer_score {
+
+// Work-unit knobs (elements, tile-aligned; SDPAProgramConfig analogue).
+// One unit = q_chunk rows x k_chunk keys; heads stream in head_group blocks.
+struct IndexerScoreProgramConfig {
+    std::size_t q_chunk_size = 32;
+    std::size_t k_chunk_size = 32;
+    std::size_t head_group_size = 1;  // heads resident at once; 1 always fits L1, raise for perf (0 = all)
+};
+
+// Resolve head_group_size to a concrete head count (0 = all Hi). Single-sourced so validate and the
+// factory can't drift on the "0 = all" contract.
+inline uint32_t resolve_head_group(const IndexerScoreProgramConfig& cfg, uint32_t Hi) {
+    return cfg.head_group_size == 0 ? Hi : static_cast<uint32_t>(cfg.head_group_size);
+}
+
+struct operation_attributes_t {
+    uint32_t chunk_start_idx{0};
+    IndexerScoreProgramConfig program_config{};
+};
+
+struct tensor_args_t {
+    const Tensor& q;
+    const Tensor& k;
+    const Tensor& weights;
+};
+
+using tensor_return_value_t = Tensor;
+
+using spec_return_value_t = TensorSpec;
+
+}  // namespace ttnn::operations::experimental::indexer_score

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -212,7 +212,15 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
     const uint32_t q_tile = tt::tile_size(q_fmt);
     const uint32_t k_tile = tt::tile_size(k_fmt);
 
-    auto make_cb = [&](uint32_t idx, uint32_t ntiles, tt::DataFormat fmt, uint32_t tile_bytes) {
+    // Continuous CB indices, allocated on demand: each make_cb claims the next free index (c_0, c_1, ...)
+    // and records it under its CbArg slot. The whole array is forwarded to the kernels as compile-time
+    // args (CbArg is the shared slot order; see indexer_score_cb.hpp), so every buffer is resolved through
+    // this one allocation and indices can never drift host<->device.
+    std::array<uint32_t, num_cb_args> cb_id{};
+    uint32_t next_cb_index = tt::CBIndex::c_0;
+    auto make_cb = [&](uint32_t slot, uint32_t ntiles, tt::DataFormat fmt, uint32_t tile_bytes) {
+        const uint32_t idx = next_cb_index++;
+        cb_id[slot] = idx;
         tt::tt_metal::CreateCircularBuffer(
             program,
             core_ranges,
@@ -221,24 +229,11 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
 
     const bool stream_heads = HB < Hi;
 
-    // Continuous CB indices c_0..c_7, allocated here and forwarded to the kernels as compile-time args
-    // (CbArg is the shared slot order; see indexer_score_cb.hpp). Indexed by CbArg so the make_cb
-    // sizing below and the kernels resolve every buffer through this one allocation.
-    constexpr std::array<uint32_t, num_cb_args> cb_id = {
-        tt::CBIndex::c_0,
-        tt::CBIndex::c_1,
-        tt::CBIndex::c_2,
-        tt::CBIndex::c_3,
-        tt::CBIndex::c_4,
-        tt::CBIndex::c_5,
-        tt::CBIndex::c_6,
-        tt::CBIndex::c_7};
-
-    // Sizes are set here; the indices come from cb_id above.
-    make_cb(cb_id[cb_q_arg], (stream_heads ? 2 : 1) * HB * QC * Dt, q_fmt, q_tile);
-    make_cb(cb_id[cb_k_arg], 2 * KC * Dt, k_fmt, k_tile);
-    make_cb(cb_id[cb_w_arg], Hi * QC, tt::DataFormat::Float16_b, bf16_tile);
-    make_cb(cb_id[cb_mask_arg], num_mask_tiles, tt::DataFormat::Float16_b, bf16_tile);
+    // Allocate each CB by its CbArg slot; make_cb assigns the next continuous index.
+    make_cb(cb_q_arg, (stream_heads ? 2 : 1) * HB * QC * Dt, q_fmt, q_tile);
+    make_cb(cb_k_arg, 2 * KC * Dt, k_fmt, k_tile);
+    make_cb(cb_w_arg, Hi * QC, tt::DataFormat::Float16_b, bf16_tile);
+    make_cb(cb_mask_arg, num_mask_tiles, tt::DataFormat::Float16_b, bf16_tile);
     const tt::DataFormat acc_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     const uint32_t acc_tile = fp32_dest_acc_en ? fp32_tile : bf16_tile;
     // cb_qk buffers a batch of the group's relu(q.kT) tiles so compute runs that batch's matmuls then
@@ -261,15 +256,14 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
     // caller's k_chunk_size is too large for L1 (the caller owns the knob trade-off).
     const bool single_chunk = (qk_batch_heads == Hi) && !stream_heads;
     const uint32_t qk_col_batch = (KC >= 2 && single_chunk) ? KC : 1u;
-    make_cb(cb_id[cb_qk_arg], qk_col_batch * qk_batch_heads, acc_fmt, acc_tile);
-    make_cb(cb_id[cb_scratch_arg], 1, tt::DataFormat::Float16_b, bf16_tile);
+    make_cb(cb_qk_arg, qk_col_batch * qk_batch_heads, acc_fmt, acc_tile);
     // cb_out_strip holds a unit's untilized output. Uniform KC push/pop keeps the packer's KC-tile
     // reads contiguous (a non-uniform push would wrap the ring mid-strip).
-    make_cb(cb_id[cb_out_strip_arg], 2 * KC, tt::DataFormat::Float16_b, bf16_tile);
+    make_cb(cb_out_strip_arg, 2 * KC, tt::DataFormat::Float16_b, bf16_tile);
     // cb_acc_strip accumulates a whole unit's QC*KC strip, then all QC strips untilize under ONE
     // pack_untilize bracket (per-strip cost amortizes over QC*KC, not KC). max(2*KC, .) keeps the
     // QC<=2 double buffer and a whole multiple of the QC*KC batch so a uniform push never wraps mid-unit.
-    make_cb(cb_id[cb_acc_strip_arg], std::max(2u * KC, QC * KC), acc_fmt, acc_tile);
+    make_cb(cb_acc_strip_arg, std::max(2u * KC, QC * KC), acc_fmt, acc_tile);
 
     // No up-front L1-fit guard: an oversized QC/KC/head_group config fails at CB allocation. The caller
     // owns the knob trade-off (see glx_config() in the test).
@@ -329,8 +323,8 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
         const uint32_t count = base + (i < rem ? 1 : 0);
         std::vector<uint32_t> reader_rt = {
             q.buffer()->address(), k.buffer()->address(), w.buffer()->address(), flat, count};
-        // Per-core mcast args: K column (8) then Q/W row (8). role 0=none(DRAM read), 1=sender,
-        // 2=receiver. rect (xs,ys,xe,ye) + sender (sx,sy) are physical NoC; ndst=#receivers.
+        // Per-core mcast args: K column (8) then Q/W row (8). role is a McastRole (none = per-core DRAM
+        // read); rect (xs,ys,xe,ye) + sender (sx,sy) are physical NoC; ndst = #receivers.
         const auto u32 = [](auto v) { return static_cast<uint32_t>(v); };
         const auto push_mcast_dir =
             [&](uint32_t role, uint32_t xs, uint32_t ys, uint32_t xe, uint32_t ye, const CoreCoord& s, uint32_t ndst) {
@@ -345,30 +339,33 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
             };
         if (grid_aligned) {
             const uint32_t x = i % grid.x, y = i / grid.x;
-            // K column x: sender (x,0), receivers (x,1..); vertical rect spanning the column.
+            // K column x: sender on row 0, receivers down the column; vertical rect spanning the column.
             const auto [kys, kye] = phys_col_y_range(x);
             push_mcast_dir(
-                k_mcast_on ? (y == 0 ? 1u : 2u) : 0u,
+                k_mcast_on ? (y == 0 ? mcast_role_sender : mcast_role_receiver) : mcast_role_none,
                 u32(phys[cidx(x, 0)].x),
                 kys,
                 u32(phys[cidx(x, 0)].x),
                 kye,
                 phys[cidx(x, 0)],
                 u32(grid.y) - 1);
-            // Q/W row y: ONE sender per row on the grid DIAGONAL (logical x == y), mcasting the WHOLE
-            // row in one rect (its bbox [min x, max x] x py). Any core in the row can send (all share
-            // q-rows + w); the diagonal fans senders across distinct columns vs stacking in column 0.
-            // Receivers = rest of the row (ndst = grid.x - 1); hardware excludes the in-rect source.
-            // Guard the diagonal lookup phys[cidx(y, y)] behind q_mcast_on: it is only a valid index
-            // when q_rows_ok held (which requires grid.x >= grid.y). With q-mcast off every core just
-            // DRAM-reads q/w (role 0), so the rect/sender fields are unused -- push a zeroed tuple.
-            if (q_mcast_on) {
-                const auto [qxs, qxe] = phys_row_x_range(y);
-                const uint32_t py = u32(phys[cidx(y, y)].y);  // diagonal sender's row (== every core's py)
-                push_mcast_dir(x == y ? 1u : 2u, qxs, py, qxe, py, phys[cidx(y, y)], u32(grid.x) - 1);
-            } else {
-                push_mcast_dir(0u, 0, 0, 0, 0, phys[i], 0);
-            }
+            // Q/W row y: same shape as the K column; the ONLY difference is the sender sits on the grid
+            // DIAGONAL (logical x == y) instead of row 0 -- any core in the row can send (all share q/w),
+            // and the diagonal fans senders across distinct columns rather than stacking in one. The
+            // diagonal lookup phys[cidx(y, y)] is in-bounds only when q_mcast_on held (q_rows_ok requires
+            // grid.x >= grid.y); with q-mcast off the role is none and the rect/sender are unused, so fall
+            // back to this core's own coord to keep the index valid.
+            const auto [qxs, qxe] = phys_row_x_range(y);
+            const CoreCoord q_sender = q_mcast_on ? phys[cidx(y, y)] : phys[i];
+            const uint32_t qpy = u32(q_sender.y);  // sender's row == every core's py in this grid row
+            push_mcast_dir(
+                q_mcast_on ? (x == y ? mcast_role_sender : mcast_role_receiver) : mcast_role_none,
+                qxs,
+                qpy,
+                qxe,
+                qpy,
+                q_sender,
+                u32(grid.x) - 1);
         } else {
             for (uint32_t z = 0; z < reader_mcast_args; ++z) {
                 reader_rt.push_back(0);

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -1,0 +1,403 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "indexer_score_program_factory.hpp"
+
+#include <algorithm>
+#include <utility>
+#include <vector>
+
+#include <tt-metalium/host_api.hpp>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <tt-metalium/work_split.hpp>
+
+#include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
+#include "kernels/indexer_score_cb.hpp"          // shared host/device circular-buffer indices
+#include "kernels/indexer_score_work_split.hpp"  // shared host/device causal work-split formula
+
+namespace ttnn::operations::experimental::indexer_score::program {
+
+using namespace tt;
+using namespace tt::tt_metal;
+using namespace tt::constants;
+
+// Runtime-arg slots, shared by create()/override_runtime_arguments() and matched positionally
+// by the kernels. Reader: q,k,w addrs; writer: out addr.
+namespace rt_arg {
+constexpr uint32_t reader_q_addr = 0;
+constexpr uint32_t reader_k_addr = 1;
+constexpr uint32_t reader_w_addr = 2;
+constexpr uint32_t writer_out_addr = 0;
+}  // namespace rt_arg
+
+// Patch one runtime-arg slot on a program-cache hit, asserting the slot exists.
+inline void patch_arg(RuntimeArgsData& args, uint32_t index, uint32_t value, const char* name) {
+    TT_FATAL(index < args.size(), "indexer_score override: {} index {} >= args size {}", name, index, args.size());
+    args[index] = value;
+}
+
+// Dense deal landed exactly on the grid (q/w mcast along rows, k down columns) and each direction's
+// lines form contiguous NoC rects. 0 = direction off (per-core DRAM read); see call-site block.
+struct McastPlan {
+    bool grid_aligned = false;
+    uint32_t k_mcast_on = 0;  // K columns are vertical NoC rects
+    uint32_t q_mcast_on = 0;  // Q/W rows are single horizontal NoC rects (covers q and w)
+};
+
+// Pure analysis of the physical core coords: grid alignment + per-line NoC-rect contiguity for the
+// two mcast directions. phys is indexed row-major (y * grid.x + x).
+inline McastPlan compute_mcast_plan(
+    CoreCoord grid,
+    const std::vector<CoreCoord>& phys,
+    uint32_t groups,
+    uint32_t num_cores,
+    uint32_t base,
+    uint32_t rem,
+    uint64_t total_units,
+    uint32_t HB,
+    uint32_t Hi) {
+    const auto cidx = [&](uint32_t x, uint32_t y) { return y * grid.x + x; };
+    // grid-aligned iff group g == grid row y and the row's grid_x cores evenly split its k-chunks
+    // (units_per_group == grid.x * base, no remainder, full grid).
+    const uint32_t units_per_group = groups > 0 ? (uint32_t)(total_units / groups) : 0;
+    const bool grid_aligned = ttnn::operations::experimental::indexer_score::dense_schedule && groups == grid.y &&
+                              num_cores == (uint32_t)(grid.x * grid.y) && rem == 0 && units_per_group == grid.x * base;
+
+    // K columns must be vertical NoC rects: shared x down the column, contiguous y spanning the grid.
+    bool k_cols_ok = grid_aligned;
+    for (uint32_t x = 0; x < grid.x && k_cols_ok; ++x) {
+        const uint32_t px = phys[cidx(x, 0)].x;
+        uint32_t ymin = phys[cidx(x, 0)].y, ymax = ymin;
+        for (uint32_t y = 0; y < grid.y; ++y) {
+            const auto& p = phys[cidx(x, y)];
+            if (p.x != px) {
+                k_cols_ok = false;
+            }
+            ymin = std::min<uint32_t>(ymin, p.y);
+            ymax = std::max<uint32_t>(ymax, p.y);
+        }
+        if (ymax - ymin + 1 != grid.y) {
+            k_cols_ok = false;
+        }
+    }
+    // Q/W row-mcast needs every core in a logical row on ONE physical NoC row (mcast = the row's
+    // horizontal bounding-box rect) and all heads resident (one q block). x-contiguity not required
+    // (the NoC routes the bbox rect); only a row spanning multiple physical NoC rows disables it.
+    bool q_rows_ok = grid_aligned && HB == Hi;
+    for (uint32_t y = 0; y < grid.y && q_rows_ok; ++y) {
+        const uint32_t py = phys[cidx(0, y)].y;
+        for (uint32_t x = 0; x < grid.x; ++x) {
+            if (phys[cidx(x, y)].y != py) {
+                q_rows_ok = false;
+            }
+        }
+    }
+    return {grid_aligned, k_cols_ok ? 1u : 0u, q_rows_ok ? 1u : 0u};
+}
+
+// Output-stationary flat deal of causal-valid work units. One unit = QC q-tile-rows x up-to-KC
+// k-tiles, dealt evenly across cores row-major (kernels invert the flat index). Heads stream in
+// HB-head groups; fully-future tiles get the full -inf mask, row tails -inf-filled by the writer
+// (zeros unsafe: gates can be negative).
+IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
+    const operation_attributes_t& args, const tensor_args_t& tensors, tensor_return_value_t& out) {
+    Program program = CreateProgram();
+
+    const auto& q = tensors.q;
+    const auto& k = tensors.k;
+    const auto& w = tensors.weights;
+
+    // Inputs and knobs are validated in IndexerScoreDeviceOperation::validate_on_program_cache_miss;
+    // here we only derive tile dims and the one build-specific (subblock) constraint.
+    const uint32_t Hi = q.logical_shape()[1];
+    const uint32_t Sq = q.logical_shape()[2];
+    const uint32_t D = q.logical_shape()[3];
+    const uint32_t T = k.logical_shape()[2];
+
+    const uint32_t Sqt = Sq / TILE_HEIGHT;
+    const uint32_t Tt = T / TILE_WIDTH;
+    const uint32_t Dt = D / TILE_WIDTH;
+    const uint32_t chunk_t = args.chunk_start_idx / TILE_WIDTH;
+
+    // Work-unit knobs, converted from elements to tiles / heads.
+    const auto& cfg = args.program_config;
+    const uint32_t QC = cfg.q_chunk_size / TILE_HEIGHT;
+    const uint32_t KC = cfg.k_chunk_size / TILE_WIDTH;
+    const uint32_t HB = resolve_head_group(cfg, Hi);
+
+    // qk matmul subblock: heads are output rows, k column is 1 tile wide (SDPA-style), so only the
+    // subblock height (head rows) is needed.
+    constexpr bool fp32_dest_acc_en = false;                 // bf16 DEST: 8-head subblocks in half-sync
+    constexpr uint32_t dst_size = fp32_dest_acc_en ? 4 : 8;  // half-sync, as in sdpa_program_factory
+    const uint32_t qk_subblock_h = ttnn::prim::detail::determine_largest_subblock_size(HB, 1, dst_size).first;
+    TT_FATAL(HB % qk_subblock_h == 0, "head group {} must be divisible by qk_subblock_h={}", HB, qk_subblock_h);
+
+    // QC/KC/HB are verbatim from the config -- no auto-tune; the caller owns the perf trade-off (see
+    // glx_config() in the test). Oversized configs hit the L1-fit check below, not a silent clamp.
+
+    // total valid work units V (groups exact: validate guarantees QC divides Sqt). units_in_group is
+    // the shared formula the kernels' WorkUnitSpan inverts.
+    const uint32_t groups = Sqt / QC;
+    uint64_t total_units = 0;
+    for (uint32_t g = 0; g < groups; ++g) {
+        total_units += units_in_group(g, QC, KC, chunk_t, Tt);
+    }
+
+    const auto grid = q.device()->compute_with_storage_grid_size();
+    const uint32_t num_cores = std::min<uint64_t>(total_units, (uint64_t)grid.x * grid.y);
+    const auto core_ranges = num_cores_to_corerangeset(num_cores, grid, true);
+    const auto cores = corerange_to_cores(core_ranges, num_cores, true);
+
+    const uint32_t base = total_units / num_cores;
+    const uint32_t rem = total_units % num_cores;
+
+    // ---- grid-aligned multicast (decoupled Q/W along rows, K down columns) -------------------
+    // When the dense deal lands exactly on the grid, a grid ROW shares identical q/w and a grid COLUMN
+    // shares the identical k-band: one core per row mcasts q/w along it, one per column mcasts k down
+    // it, killing ~grid_x q/w re-reads + ~grid_y k re-reads. Each direction is independent, enabled only
+    // if its lines are contiguous NoC rects; else that input falls back to per-core DRAM reads.
+    std::vector<CoreCoord> phys(num_cores);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        phys[i] = q.device()->worker_core_from_logical_core(cores[i]);
+    }
+    const McastPlan plan = compute_mcast_plan(grid, phys, groups, num_cores, base, rem, total_units, HB, Hi);
+    const bool grid_aligned = plan.grid_aligned;
+    const uint32_t k_mcast_on = plan.k_mcast_on;
+    const uint32_t q_mcast_on = plan.q_mcast_on;
+
+    auto cidx = [&](uint32_t x, uint32_t y) { return y * grid.x + x; };
+    // Physical NoC bounding box of one grid column / row, used to build the multicast rects below.
+    auto phys_col_y_range = [&](uint32_t x) {  // [min y, max y] down grid column x
+        uint32_t lo = static_cast<uint32_t>(phys[cidx(x, 0)].y), hi = lo;
+        for (uint32_t y = 0; y < grid.y; ++y) {
+            lo = std::min<uint32_t>(lo, static_cast<uint32_t>(phys[cidx(x, y)].y));
+            hi = std::max<uint32_t>(hi, static_cast<uint32_t>(phys[cidx(x, y)].y));
+        }
+        return std::pair<uint32_t, uint32_t>{lo, hi};
+    };
+    auto phys_row_x_range = [&](uint32_t y) {  // [min x, max x] across grid row y
+        uint32_t lo = static_cast<uint32_t>(phys[cidx(0, y)].x), hi = lo;
+        for (uint32_t x = 0; x < grid.x; ++x) {
+            lo = std::min<uint32_t>(lo, static_cast<uint32_t>(phys[cidx(x, y)].x));
+            hi = std::max<uint32_t>(hi, static_cast<uint32_t>(phys[cidx(x, y)].x));
+        }
+        return std::pair<uint32_t, uint32_t>{lo, hi};
+    };
+
+    // 3 semaphores per active direction: send (receivers ready), recv (sender relays valid in), valid
+    // (constant 1, relay source). Mirrors SDPA chain_link's handshake.
+    const uint32_t k_send_sem = k_mcast_on ? CreateSemaphore(program, core_ranges, 0) : 0;
+    const uint32_t k_recv_sem = k_mcast_on ? CreateSemaphore(program, core_ranges, 0) : 0;
+    const uint32_t k_valid_sem = k_mcast_on ? CreateSemaphore(program, core_ranges, 1) : 0;
+    const uint32_t q_send_sem = q_mcast_on ? CreateSemaphore(program, core_ranges, 0) : 0;
+    const uint32_t q_recv_sem = q_mcast_on ? CreateSemaphore(program, core_ranges, 0) : 0;
+    const uint32_t q_valid_sem = q_mcast_on ? CreateSemaphore(program, core_ranges, 1) : 0;
+
+    const uint32_t bf16_tile = tile_size(DataFormat::Float16_b);
+    const uint32_t fp32_tile = tile_size(DataFormat::Float32);
+
+    // q (srcB) and k (srcA) are matmul inputs; either may be bfp8_b to halve its DRAM/L1 footprint
+    // (w stays bf16). The format flows into the CB; the compute kernel needs no change.
+    const bool q_is_bfp8 = q.dtype() == DataType::BFLOAT8_B;
+    const bool k_is_bfp8 = k.dtype() == DataType::BFLOAT8_B;
+    const DataFormat q_fmt = q_is_bfp8 ? DataFormat::Bfp8_b : DataFormat::Float16_b;
+    const DataFormat k_fmt = k_is_bfp8 ? DataFormat::Bfp8_b : DataFormat::Float16_b;
+    const uint32_t q_tile = tile_size(q_fmt);
+    const uint32_t k_tile = tile_size(k_fmt);
+    // Both matmul inputs bfp8 -> LoFi (a single fidelity phase, 2x matmul peak). Any bf16 input keeps
+    // HiFi2 so the bf16 mantissa is not thrown away by a 1-phase pass.
+    const MathFidelity math_fidelity = (q_is_bfp8 && k_is_bfp8) ? MathFidelity::LoFi : MathFidelity::HiFi2;
+
+    uint64_t l1_used = 0;
+    auto make_cb = [&](uint32_t idx, uint32_t ntiles, DataFormat fmt, uint32_t tile_bytes) {
+        l1_used += (uint64_t)ntiles * tile_bytes;
+        CreateCircularBuffer(
+            program,
+            core_ranges,
+            CircularBufferConfig(ntiles * tile_bytes, {{idx, fmt}}).set_page_size(idx, tile_bytes));
+    };
+
+    const bool stream_heads = HB < Hi;
+
+    // CB indices come from shared kernels/indexer_score_cb.hpp (factory and kernels can't disagree
+    // on which index is which buffer); sizes are set here.
+    make_cb(cb_q, (stream_heads ? 2 : 1) * HB * QC * Dt, q_fmt, q_tile);
+    make_cb(cb_k, 2 * KC * Dt, k_fmt, k_tile);
+    make_cb(cb_w, Hi * QC, DataFormat::Float16_b, bf16_tile);
+    make_cb(cb_mask, num_mask_tiles, DataFormat::Float16_b, bf16_tile);
+    const DataFormat acc_fmt = fp32_dest_acc_en ? DataFormat::Float32 : DataFormat::Float16_b;
+    const uint32_t acc_tile = fp32_dest_acc_en ? fp32_tile : bf16_tile;
+    // cb_qk buffers a batch of the group's relu(q.kT) tiles so compute runs that batch's matmuls then
+    // its mul+accumulates, hoisting the matmul<->eltwise reinit out of the per-head-pass loop.
+    // QC==1 has spare L1 -> batch the whole group; QC>1 doubles cb_q/cb_w, so cap at 32.
+    const uint32_t qk_batch_cap = (QC == 1) ? HB : 32u;
+    const uint32_t qk_batch_heads = std::min<uint32_t>(HB, qk_batch_cap);  // multiple of qk_subblock_h
+    // The compute kernel walks HB in qk_batch_heads-sized chunks (chunk += qk_batch_heads), so HB must
+    // be a whole multiple or the last chunk over-reads past the resident head group. Only reachable when
+    // the 32-cap engages (HB > 32 && QC > 1); the deployed cases never hit it, but guard loudly.
+    TT_FATAL(
+        HB % qk_batch_heads == 0,
+        "head_group {} not divisible by qk_batch_heads {} (QC>1 with HB>32); reduce head_group_size or q_chunk_size",
+        HB,
+        qk_batch_heads);
+    // Full-strip path batches qk_col_batch k-columns per matmul<->mul mode switch (one switch per batch,
+    // not per output tile): w is column-independent and the whole k chunk is resident, so a row's columns
+    // share one switch. Only when the group is a single chunk (qk_batch_heads == Hi) and the fast strip
+    // is used (KC >= 2); cb_qk then holds qk_col_batch * qk_batch_heads tiles, capped to an L1 budget.
+    // Tile budget for cb_qk (the batched matmul outputs). This is really an L1-fit proxy: cb_qk holds
+    // qk_col_batch * qk_batch_heads tiles, and 128 is ~the L1 left over once cb_q/cb_k/cb_w (large at
+    // high head counts) are resident. It self-tunes to ~that ceiling: heads8
+    // (8 heads, KC=16) lands at the full chunk 8*16=128; heads64 (64 heads) throttles to qk_col_batch=2
+    // (2*64=128) -- without the cap it would pick KC and overflow L1. 128 tiles == 256 KB at bf16
+    // acc_fmt (the only mode today); if fp32-dest acc is ever enabled this would be 512 KB, so prefer
+    // deriving the byte budget from acc_tile if that path is added.
+    constexpr uint32_t qk_col_tile_cap = 128;
+    const bool single_chunk = (qk_batch_heads == Hi) && !stream_heads;
+    const uint32_t qk_col_batch = (KC >= 2 && single_chunk)
+                                      ? std::min<uint32_t>(KC, std::max<uint32_t>(1u, qk_col_tile_cap / qk_batch_heads))
+                                      : 1u;
+    make_cb(cb_qk, qk_col_batch * qk_batch_heads, acc_fmt, acc_tile);
+    make_cb(cb_scratch, 1, DataFormat::Float16_b, bf16_tile);
+    // cb_out_strip holds a unit's untilized output. Uniform KC push/pop keeps the packer's KC-tile
+    // reads contiguous (a non-uniform push would wrap the ring mid-strip).
+    make_cb(cb_out_strip, 2 * KC, DataFormat::Float16_b, bf16_tile);
+    // cb_acc_strip accumulates a whole unit's QC*KC strip, then all QC strips untilize under ONE
+    // pack_untilize bracket (per-strip cost amortizes over QC*KC, not KC). max(2*KC, .) keeps the
+    // QC<=2 double buffer and a whole multiple of the QC*KC batch so a uniform push never wraps mid-unit.
+    make_cb(cb_acc_strip, std::max(2u * KC, QC * KC), acc_fmt, acc_tile);
+
+    // Reject an oversized config up front instead of a cryptic CB-alloc failure. Reserve covers kernel
+    // binaries/stack/semaphores and (under tracy) the per-RISC profiler L1 buffers.
+    constexpr uint64_t l1_reserve = 320 * 1024;
+    const uint64_t l1_budget = (uint64_t)q.device()->l1_size_per_core() - l1_reserve;
+    TT_FATAL(
+        l1_used <= l1_budget,
+        "indexer_score CBs need {} B but only {} B fit L1 (per-core {} B minus {} B reserve); "
+        "reduce q_chunk_size, k_chunk_size, or head_group_size",
+        l1_used,
+        l1_budget,
+        q.device()->l1_size_per_core(),
+        l1_reserve);
+
+    const std::vector<uint32_t> common_ct = {Hi, Sqt, Tt, Dt, chunk_t, QC, KC, HB};
+
+    std::vector<uint32_t> reader_ct = common_ct;
+    TensorAccessorArgs(*q.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(*k.buffer()).append_to(reader_ct);
+    TensorAccessorArgs(*w.buffer()).append_to(reader_ct);
+    // multicast: on/off per direction (q_mcast_on covers q and w) then the 6 semaphore ids, at fixed
+    // offsets right after the three TensorAccessors.
+    reader_ct.push_back(k_mcast_on);
+    reader_ct.push_back(q_mcast_on);
+    reader_ct.push_back(k_send_sem);
+    reader_ct.push_back(k_recv_sem);
+    reader_ct.push_back(k_valid_sem);
+    reader_ct.push_back(q_send_sem);
+    reader_ct.push_back(q_recv_sem);
+    reader_ct.push_back(q_valid_sem);
+
+    std::vector<uint32_t> writer_ct = common_ct;
+    constexpr uint32_t out_elem_bytes = 2;    // bf16 output (compute_output_specs)
+    writer_ct.push_back(T * out_elem_bytes);  // row-major page = one full row of T scores
+    TensorAccessorArgs(*out.buffer()).append_to(writer_ct);
+
+    std::vector<uint32_t> compute_ct = common_ct;
+    compute_ct.push_back(qk_subblock_h);
+    compute_ct.push_back(qk_batch_heads);  // head tiles per matmul/mul phase chunk
+    compute_ct.push_back(qk_col_batch);    // k-columns batched per mode switch in the full-strip path
+
+    const std::string kdir = "ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/";
+    auto reader_id =
+        CreateKernel(program, kdir + "reader_indexer_score.cpp", core_ranges, ReaderDataMovementConfig(reader_ct));
+    auto writer_id =
+        CreateKernel(program, kdir + "writer_indexer_score.cpp", core_ranges, WriterDataMovementConfig(writer_ct));
+    auto compute_id = CreateKernel(
+        program,
+        kdir + "compute_indexer_score.cpp",
+        core_ranges,
+        ComputeConfig{
+            .math_fidelity = math_fidelity,
+            .fp32_dest_acc_en = fp32_dest_acc_en,
+            .dst_full_sync_en = false,
+            .compile_args = compute_ct});
+
+    // Per-core multicast runtime args: K column then Q/W row, each an 8-tuple (push8 below); the two
+    // together are what the non-grid-aligned fallback zero-fills.
+    constexpr uint32_t mcast_args_per_dir = 8;
+    constexpr uint32_t reader_mcast_args = 2 * mcast_args_per_dir;
+
+    uint32_t flat = 0;
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const uint32_t count = base + (i < rem ? 1 : 0);
+        std::vector<uint32_t> reader_rt = {
+            q.buffer()->address(), k.buffer()->address(), w.buffer()->address(), flat, count};
+        // Per-core mcast args: K column (8) then Q/W row (8). role 0=none(DRAM read), 1=sender,
+        // 2=receiver. rect (xs,ys,xe,ye) + sender (sx,sy) are physical NoC; ndst=#receivers.
+        const auto u32 = [](auto v) { return static_cast<uint32_t>(v); };
+        const auto push8 =
+            [&](uint32_t role, uint32_t xs, uint32_t ys, uint32_t xe, uint32_t ye, const CoreCoord& s, uint32_t ndst) {
+                reader_rt.push_back(role);
+                reader_rt.push_back(xs);
+                reader_rt.push_back(ys);
+                reader_rt.push_back(xe);
+                reader_rt.push_back(ye);
+                reader_rt.push_back(u32(s.x));
+                reader_rt.push_back(u32(s.y));
+                reader_rt.push_back(ndst);
+            };
+        if (grid_aligned) {
+            const uint32_t x = i % grid.x, y = i / grid.x;
+            // K column x: sender (x,0), receivers (x,1..); vertical rect spanning the column.
+            const auto [kys, kye] = phys_col_y_range(x);
+            push8(
+                k_mcast_on ? (y == 0 ? 1u : 2u) : 0u,
+                u32(phys[cidx(x, 0)].x),
+                kys,
+                u32(phys[cidx(x, 0)].x),
+                kye,
+                phys[cidx(x, 0)],
+                u32(grid.y) - 1);
+            // Q/W row y: ONE sender per row on the grid DIAGONAL (logical x == y), mcasting the WHOLE
+            // row in one rect (its bbox [min x, max x] x py). Any core in the row can send (all share
+            // q-rows + w); the diagonal fans senders across distinct columns vs stacking in column 0.
+            // Receivers = rest of the row (ndst = grid.x - 1); hardware excludes the in-rect source.
+            const auto [qxs, qxe] = phys_row_x_range(y);
+            const uint32_t py = u32(phys[cidx(y, y)].y);  // diagonal sender's row (== every core's py)
+            push8(q_mcast_on ? (x == y ? 1u : 2u) : 0u, qxs, py, qxe, py, phys[cidx(y, y)], u32(grid.x) - 1);
+        } else {
+            for (uint32_t z = 0; z < reader_mcast_args; ++z) {
+                reader_rt.push_back(0);
+            }
+        }
+        SetRuntimeArgs(program, reader_id, cores[i], reader_rt);
+        SetRuntimeArgs(program, compute_id, cores[i], {flat, count});
+        SetRuntimeArgs(program, writer_id, cores[i], {out.buffer()->address(), flat, count});
+        flat += count;
+    }
+
+    return {
+        std::move(program),
+        IndexerScoreSharedVariables{
+            .reader_kernel = reader_id,
+            .compute_kernel = compute_id,
+            .writer_kernel = writer_id,
+            .worker_cores = cores}};
+}
+
+void IndexerScoreProgramFactory::override_runtime_arguments(
+    cached_program_t& cached, const operation_attributes_t&, const tensor_args_t& tensors, tensor_return_value_t& out) {
+    auto& shared = cached.shared_variables;
+    auto& reader_args = GetRuntimeArgs(cached.program, shared.reader_kernel);
+    auto& writer_args = GetRuntimeArgs(cached.program, shared.writer_kernel);
+    for (const auto& core : shared.worker_cores) {
+        auto& reader_rt = reader_args[core.x][core.y];
+        patch_arg(reader_rt, rt_arg::reader_q_addr, tensors.q.buffer()->address(), "reader.q_addr");
+        patch_arg(reader_rt, rt_arg::reader_k_addr, tensors.k.buffer()->address(), "reader.k_addr");
+        patch_arg(reader_rt, rt_arg::reader_w_addr, tensors.weights.buffer()->address(), "reader.w_addr");
+        patch_arg(writer_args[core.x][core.y], rt_arg::writer_out_addr, out.buffer()->address(), "writer.out_addr");
+    }
+}
+
+}  // namespace ttnn::operations::experimental::indexer_score::program

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.cpp
@@ -5,6 +5,7 @@
 #include "indexer_score_program_factory.hpp"
 
 #include <algorithm>
+#include <array>
 #include <utility>
 #include <vector>
 
@@ -12,16 +13,13 @@
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
 #include <tt-metalium/work_split.hpp>
+#include "hostdevcommon/kernel_structs.h"  // tt::CBIndex
 
 #include "ttnn/operations/transformer/sdpa/device/sdpa_subblock_utils.hpp"
-#include "kernels/indexer_score_cb.hpp"          // shared host/device circular-buffer indices
+#include "kernels/indexer_score_cb.hpp"          // shared host/device CB-index argument layout (CbArg)
 #include "kernels/indexer_score_work_split.hpp"  // shared host/device causal work-split formula
 
 namespace ttnn::operations::experimental::indexer_score::program {
-
-using namespace tt;
-using namespace tt::tt_metal;
-using namespace tt::constants;
 
 // Runtime-arg slots, shared by create()/override_runtime_arguments() and matched positionally
 // by the kernels. Reader: q,k,w addrs; writer: out addr.
@@ -33,7 +31,7 @@ constexpr uint32_t writer_out_addr = 0;
 }  // namespace rt_arg
 
 // Patch one runtime-arg slot on a program-cache hit, asserting the slot exists.
-inline void patch_arg(RuntimeArgsData& args, uint32_t index, uint32_t value, const char* name) {
+inline void patch_arg(tt::tt_metal::RuntimeArgsData& args, uint32_t index, uint32_t value, const char* name) {
     TT_FATAL(index < args.size(), "indexer_score override: {} index {} >= args size {}", name, index, args.size());
     args[index] = value;
 }
@@ -62,8 +60,8 @@ inline McastPlan compute_mcast_plan(
     // grid-aligned iff group g == grid row y and the row's grid_x cores evenly split its k-chunks
     // (units_per_group == grid.x * base, no remainder, full grid).
     const uint32_t units_per_group = groups > 0 ? (uint32_t)(total_units / groups) : 0;
-    const bool grid_aligned = ttnn::operations::experimental::indexer_score::dense_schedule && groups == grid.y &&
-                              num_cores == (uint32_t)(grid.x * grid.y) && rem == 0 && units_per_group == grid.x * base;
+    const bool grid_aligned =
+        groups == grid.y && num_cores == (uint32_t)(grid.x * grid.y) && rem == 0 && units_per_group == grid.x * base;
 
     // K columns must be vertical NoC rects: shared x down the column, contiguous y spanning the grid.
     bool k_cols_ok = grid_aligned;
@@ -85,7 +83,10 @@ inline McastPlan compute_mcast_plan(
     // Q/W row-mcast needs every core in a logical row on ONE physical NoC row (mcast = the row's
     // horizontal bounding-box rect) and all heads resident (one q block). x-contiguity not required
     // (the NoC routes the bbox rect); only a row spanning multiple physical NoC rows disables it.
-    bool q_rows_ok = grid_aligned && HB == Hi;
+    // grid.x >= grid.y guards the diagonal sender lookup phys[cidx(y, y)] at the call site: cidx(y, y)
+    // is in-bounds only while y < grid.x, which holds for every row iff the grid is at least as wide as
+    // tall (always true on Blackhole's 14x10 grid; the guard keeps a narrower grid safe).
+    bool q_rows_ok = grid_aligned && HB == Hi && grid.x >= grid.y;
     for (uint32_t y = 0; y < grid.y && q_rows_ok; ++y) {
         const uint32_t py = phys[cidx(0, y)].y;
         for (uint32_t x = 0; x < grid.x; ++x) {
@@ -103,7 +104,7 @@ inline McastPlan compute_mcast_plan(
 // (zeros unsafe: gates can be negative).
 IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
     const operation_attributes_t& args, const tensor_args_t& tensors, tensor_return_value_t& out) {
-    Program program = CreateProgram();
+    tt::tt_metal::Program program = tt::tt_metal::CreateProgram();
 
     const auto& q = tensors.q;
     const auto& k = tensors.k;
@@ -116,39 +117,43 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
     const uint32_t D = q.logical_shape()[3];
     const uint32_t T = k.logical_shape()[2];
 
-    const uint32_t Sqt = Sq / TILE_HEIGHT;
-    const uint32_t Tt = T / TILE_WIDTH;
-    const uint32_t Dt = D / TILE_WIDTH;
-    const uint32_t chunk_t = args.chunk_start_idx / TILE_WIDTH;
+    const uint32_t Sqt = Sq / tt::constants::TILE_HEIGHT;
+    const uint32_t Tt = T / tt::constants::TILE_WIDTH;
+    const uint32_t Dt = D / tt::constants::TILE_WIDTH;
+    const uint32_t chunk_t = args.chunk_start_idx / tt::constants::TILE_WIDTH;
 
     // Work-unit knobs, converted from elements to tiles / heads.
     const auto& cfg = args.program_config;
-    const uint32_t QC = cfg.q_chunk_size / TILE_HEIGHT;
-    const uint32_t KC = cfg.k_chunk_size / TILE_WIDTH;
+    const uint32_t QC = cfg.q_chunk_size / tt::constants::TILE_HEIGHT;
+    const uint32_t KC = cfg.k_chunk_size / tt::constants::TILE_WIDTH;
     const uint32_t HB = resolve_head_group(cfg, Hi);
+
+    // Compute knobs from the resolved compute config. math_fidelity defaults to the dtype-derived
+    // choice (bf16 -> HiFi2, both bfp8 -> LoFi) but a caller can override it; validate guarantees
+    // fp32_dest_acc_en==false / dst_full_sync_en==false (the bf16-DEST half-sync layout the custom
+    // blocked bcast-col MUL LLK + packer path are validated for).
+    const auto [math_fidelity, math_approx_mode, fp32_dest_acc_en, packer_l1_acc, dst_full_sync_en] =
+        ttnn::get_compute_kernel_config_args(q.device()->arch(), args.compute_kernel_config);
 
     // qk matmul subblock: heads are output rows, k column is 1 tile wide (SDPA-style), so only the
     // subblock height (head rows) is needed.
-    constexpr bool fp32_dest_acc_en = false;                 // bf16 DEST: 8-head subblocks in half-sync
-    constexpr uint32_t dst_size = fp32_dest_acc_en ? 4 : 8;  // half-sync, as in sdpa_program_factory
+    const uint32_t dst_size = fp32_dest_acc_en ? 4 : 8;  // half-sync, as in sdpa_program_factory
     const uint32_t qk_subblock_h = ttnn::prim::detail::determine_largest_subblock_size(HB, 1, dst_size).first;
     TT_FATAL(HB % qk_subblock_h == 0, "head group {} must be divisible by qk_subblock_h={}", HB, qk_subblock_h);
 
     // QC/KC/HB are verbatim from the config -- no auto-tune; the caller owns the perf trade-off (see
-    // glx_config() in the test). Oversized configs hit the L1-fit check below, not a silent clamp.
+    // glx_config() in the test). An oversized config is not clamped; it fails at CB allocation.
 
-    // total valid work units V (groups exact: validate guarantees QC divides Sqt). units_in_group is
-    // the shared formula the kernels' WorkUnitSpan inverts.
+    // total work units V = groups x the per-group unit count (uniform under the dense schedule; groups
+    // exact since validate guarantees QC divides Sqt). units_in_group is the shared formula the kernels'
+    // WorkUnitSpan inverts.
     const uint32_t groups = Sqt / QC;
-    uint64_t total_units = 0;
-    for (uint32_t g = 0; g < groups; ++g) {
-        total_units += units_in_group(g, QC, KC, chunk_t, Tt);
-    }
+    const uint64_t total_units = (uint64_t)groups * units_in_group(KC, Tt);
 
     const auto grid = q.device()->compute_with_storage_grid_size();
     const uint32_t num_cores = std::min<uint64_t>(total_units, (uint64_t)grid.x * grid.y);
-    const auto core_ranges = num_cores_to_corerangeset(num_cores, grid, true);
-    const auto cores = corerange_to_cores(core_ranges, num_cores, true);
+    const auto core_ranges = tt::tt_metal::num_cores_to_corerangeset(num_cores, grid, true);
+    const auto cores = tt::tt_metal::corerange_to_cores(core_ranges, num_cores, true);
 
     const uint32_t base = total_units / num_cores;
     const uint32_t rem = total_units % num_cores;
@@ -188,46 +193,53 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
 
     // 3 semaphores per active direction: send (receivers ready), recv (sender relays valid in), valid
     // (constant 1, relay source). Mirrors SDPA chain_link's handshake.
-    const uint32_t k_send_sem = k_mcast_on ? CreateSemaphore(program, core_ranges, 0) : 0;
-    const uint32_t k_recv_sem = k_mcast_on ? CreateSemaphore(program, core_ranges, 0) : 0;
-    const uint32_t k_valid_sem = k_mcast_on ? CreateSemaphore(program, core_ranges, 1) : 0;
-    const uint32_t q_send_sem = q_mcast_on ? CreateSemaphore(program, core_ranges, 0) : 0;
-    const uint32_t q_recv_sem = q_mcast_on ? CreateSemaphore(program, core_ranges, 0) : 0;
-    const uint32_t q_valid_sem = q_mcast_on ? CreateSemaphore(program, core_ranges, 1) : 0;
+    const uint32_t k_send_sem = k_mcast_on ? tt::tt_metal::CreateSemaphore(program, core_ranges, 0) : 0;
+    const uint32_t k_recv_sem = k_mcast_on ? tt::tt_metal::CreateSemaphore(program, core_ranges, 0) : 0;
+    const uint32_t k_valid_sem = k_mcast_on ? tt::tt_metal::CreateSemaphore(program, core_ranges, 1) : 0;
+    const uint32_t q_send_sem = q_mcast_on ? tt::tt_metal::CreateSemaphore(program, core_ranges, 0) : 0;
+    const uint32_t q_recv_sem = q_mcast_on ? tt::tt_metal::CreateSemaphore(program, core_ranges, 0) : 0;
+    const uint32_t q_valid_sem = q_mcast_on ? tt::tt_metal::CreateSemaphore(program, core_ranges, 1) : 0;
 
-    const uint32_t bf16_tile = tile_size(DataFormat::Float16_b);
-    const uint32_t fp32_tile = tile_size(DataFormat::Float32);
+    const uint32_t bf16_tile = tt::tile_size(tt::DataFormat::Float16_b);
+    const uint32_t fp32_tile = tt::tile_size(tt::DataFormat::Float32);
 
     // q (srcB) and k (srcA) are matmul inputs; either may be bfp8_b to halve its DRAM/L1 footprint
     // (w stays bf16). The format flows into the CB; the compute kernel needs no change.
-    const bool q_is_bfp8 = q.dtype() == DataType::BFLOAT8_B;
-    const bool k_is_bfp8 = k.dtype() == DataType::BFLOAT8_B;
-    const DataFormat q_fmt = q_is_bfp8 ? DataFormat::Bfp8_b : DataFormat::Float16_b;
-    const DataFormat k_fmt = k_is_bfp8 ? DataFormat::Bfp8_b : DataFormat::Float16_b;
-    const uint32_t q_tile = tile_size(q_fmt);
-    const uint32_t k_tile = tile_size(k_fmt);
-    // Both matmul inputs bfp8 -> LoFi (a single fidelity phase, 2x matmul peak). Any bf16 input keeps
-    // HiFi2 so the bf16 mantissa is not thrown away by a 1-phase pass.
-    const MathFidelity math_fidelity = (q_is_bfp8 && k_is_bfp8) ? MathFidelity::LoFi : MathFidelity::HiFi2;
+    const bool q_is_bfp8 = q.dtype() == tt::tt_metal::DataType::BFLOAT8_B;
+    const bool k_is_bfp8 = k.dtype() == tt::tt_metal::DataType::BFLOAT8_B;
+    const tt::DataFormat q_fmt = q_is_bfp8 ? tt::DataFormat::Bfp8_b : tt::DataFormat::Float16_b;
+    const tt::DataFormat k_fmt = k_is_bfp8 ? tt::DataFormat::Bfp8_b : tt::DataFormat::Float16_b;
+    const uint32_t q_tile = tt::tile_size(q_fmt);
+    const uint32_t k_tile = tt::tile_size(k_fmt);
 
-    uint64_t l1_used = 0;
-    auto make_cb = [&](uint32_t idx, uint32_t ntiles, DataFormat fmt, uint32_t tile_bytes) {
-        l1_used += (uint64_t)ntiles * tile_bytes;
-        CreateCircularBuffer(
+    auto make_cb = [&](uint32_t idx, uint32_t ntiles, tt::DataFormat fmt, uint32_t tile_bytes) {
+        tt::tt_metal::CreateCircularBuffer(
             program,
             core_ranges,
-            CircularBufferConfig(ntiles * tile_bytes, {{idx, fmt}}).set_page_size(idx, tile_bytes));
+            tt::tt_metal::CircularBufferConfig(ntiles * tile_bytes, {{idx, fmt}}).set_page_size(idx, tile_bytes));
     };
 
     const bool stream_heads = HB < Hi;
 
-    // CB indices come from shared kernels/indexer_score_cb.hpp (factory and kernels can't disagree
-    // on which index is which buffer); sizes are set here.
-    make_cb(cb_q, (stream_heads ? 2 : 1) * HB * QC * Dt, q_fmt, q_tile);
-    make_cb(cb_k, 2 * KC * Dt, k_fmt, k_tile);
-    make_cb(cb_w, Hi * QC, DataFormat::Float16_b, bf16_tile);
-    make_cb(cb_mask, num_mask_tiles, DataFormat::Float16_b, bf16_tile);
-    const DataFormat acc_fmt = fp32_dest_acc_en ? DataFormat::Float32 : DataFormat::Float16_b;
+    // Continuous CB indices c_0..c_7, allocated here and forwarded to the kernels as compile-time args
+    // (CbArg is the shared slot order; see indexer_score_cb.hpp). Indexed by CbArg so the make_cb
+    // sizing below and the kernels resolve every buffer through this one allocation.
+    constexpr std::array<uint32_t, num_cb_args> cb_id = {
+        tt::CBIndex::c_0,
+        tt::CBIndex::c_1,
+        tt::CBIndex::c_2,
+        tt::CBIndex::c_3,
+        tt::CBIndex::c_4,
+        tt::CBIndex::c_5,
+        tt::CBIndex::c_6,
+        tt::CBIndex::c_7};
+
+    // Sizes are set here; the indices come from cb_id above.
+    make_cb(cb_id[cb_q_arg], (stream_heads ? 2 : 1) * HB * QC * Dt, q_fmt, q_tile);
+    make_cb(cb_id[cb_k_arg], 2 * KC * Dt, k_fmt, k_tile);
+    make_cb(cb_id[cb_w_arg], Hi * QC, tt::DataFormat::Float16_b, bf16_tile);
+    make_cb(cb_id[cb_mask_arg], num_mask_tiles, tt::DataFormat::Float16_b, bf16_tile);
+    const tt::DataFormat acc_fmt = fp32_dest_acc_en ? tt::DataFormat::Float32 : tt::DataFormat::Float16_b;
     const uint32_t acc_tile = fp32_dest_acc_en ? fp32_tile : bf16_tile;
     // cb_qk buffers a batch of the group's relu(q.kT) tiles so compute runs that batch's matmuls then
     // its mul+accumulates, hoisting the matmul<->eltwise reinit out of the per-head-pass loop.
@@ -242,51 +254,34 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
         "head_group {} not divisible by qk_batch_heads {} (QC>1 with HB>32); reduce head_group_size or q_chunk_size",
         HB,
         qk_batch_heads);
-    // Full-strip path batches qk_col_batch k-columns per matmul<->mul mode switch (one switch per batch,
-    // not per output tile): w is column-independent and the whole k chunk is resident, so a row's columns
-    // share one switch. Only when the group is a single chunk (qk_batch_heads == Hi) and the fast strip
-    // is used (KC >= 2); cb_qk then holds qk_col_batch * qk_batch_heads tiles, capped to an L1 budget.
-    // Tile budget for cb_qk (the batched matmul outputs). This is really an L1-fit proxy: cb_qk holds
-    // qk_col_batch * qk_batch_heads tiles, and 128 is ~the L1 left over once cb_q/cb_k/cb_w (large at
-    // high head counts) are resident. It self-tunes to ~that ceiling: heads8
-    // (8 heads, KC=16) lands at the full chunk 8*16=128; heads64 (64 heads) throttles to qk_col_batch=2
-    // (2*64=128) -- without the cap it would pick KC and overflow L1. 128 tiles == 256 KB at bf16
-    // acc_fmt (the only mode today); if fp32-dest acc is ever enabled this would be 512 KB, so prefer
-    // deriving the byte budget from acc_tile if that path is added.
-    constexpr uint32_t qk_col_tile_cap = 128;
+    // Full-strip path batches the whole k chunk's columns per matmul<->mul mode switch (one switch per
+    // batch, not per output tile): w is column-independent and the whole k chunk is resident, so a row's
+    // columns share one switch. Only when the group is a single chunk (qk_batch_heads == Hi) and the fast
+    // strip is used (KC >= 2); cb_qk then holds KC * qk_batch_heads tiles and fails at allocation if the
+    // caller's k_chunk_size is too large for L1 (the caller owns the knob trade-off).
     const bool single_chunk = (qk_batch_heads == Hi) && !stream_heads;
-    const uint32_t qk_col_batch = (KC >= 2 && single_chunk)
-                                      ? std::min<uint32_t>(KC, std::max<uint32_t>(1u, qk_col_tile_cap / qk_batch_heads))
-                                      : 1u;
-    make_cb(cb_qk, qk_col_batch * qk_batch_heads, acc_fmt, acc_tile);
-    make_cb(cb_scratch, 1, DataFormat::Float16_b, bf16_tile);
+    const uint32_t qk_col_batch = (KC >= 2 && single_chunk) ? KC : 1u;
+    make_cb(cb_id[cb_qk_arg], qk_col_batch * qk_batch_heads, acc_fmt, acc_tile);
+    make_cb(cb_id[cb_scratch_arg], 1, tt::DataFormat::Float16_b, bf16_tile);
     // cb_out_strip holds a unit's untilized output. Uniform KC push/pop keeps the packer's KC-tile
     // reads contiguous (a non-uniform push would wrap the ring mid-strip).
-    make_cb(cb_out_strip, 2 * KC, DataFormat::Float16_b, bf16_tile);
+    make_cb(cb_id[cb_out_strip_arg], 2 * KC, tt::DataFormat::Float16_b, bf16_tile);
     // cb_acc_strip accumulates a whole unit's QC*KC strip, then all QC strips untilize under ONE
     // pack_untilize bracket (per-strip cost amortizes over QC*KC, not KC). max(2*KC, .) keeps the
     // QC<=2 double buffer and a whole multiple of the QC*KC batch so a uniform push never wraps mid-unit.
-    make_cb(cb_acc_strip, std::max(2u * KC, QC * KC), acc_fmt, acc_tile);
+    make_cb(cb_id[cb_acc_strip_arg], std::max(2u * KC, QC * KC), acc_fmt, acc_tile);
 
-    // Reject an oversized config up front instead of a cryptic CB-alloc failure. Reserve covers kernel
-    // binaries/stack/semaphores and (under tracy) the per-RISC profiler L1 buffers.
-    constexpr uint64_t l1_reserve = 320 * 1024;
-    const uint64_t l1_budget = (uint64_t)q.device()->l1_size_per_core() - l1_reserve;
-    TT_FATAL(
-        l1_used <= l1_budget,
-        "indexer_score CBs need {} B but only {} B fit L1 (per-core {} B minus {} B reserve); "
-        "reduce q_chunk_size, k_chunk_size, or head_group_size",
-        l1_used,
-        l1_budget,
-        q.device()->l1_size_per_core(),
-        l1_reserve);
+    // No up-front L1-fit guard: an oversized QC/KC/head_group config fails at CB allocation. The caller
+    // owns the knob trade-off (see glx_config() in the test).
 
-    const std::vector<uint32_t> common_ct = {Hi, Sqt, Tt, Dt, chunk_t, QC, KC, HB};
+    // Common args: 8 dims then the CB indices in CbArg order (kernels read both from this shared base).
+    std::vector<uint32_t> common_ct = {Hi, Sqt, Tt, Dt, chunk_t, QC, KC, HB};
+    common_ct.insert(common_ct.end(), cb_id.begin(), cb_id.end());
 
     std::vector<uint32_t> reader_ct = common_ct;
-    TensorAccessorArgs(*q.buffer()).append_to(reader_ct);
-    TensorAccessorArgs(*k.buffer()).append_to(reader_ct);
-    TensorAccessorArgs(*w.buffer()).append_to(reader_ct);
+    tt::tt_metal::TensorAccessorArgs(*q.buffer()).append_to(reader_ct);
+    tt::tt_metal::TensorAccessorArgs(*k.buffer()).append_to(reader_ct);
+    tt::tt_metal::TensorAccessorArgs(*w.buffer()).append_to(reader_ct);
     // multicast: on/off per direction (q_mcast_on covers q and w) then the 6 semaphore ids, at fixed
     // offsets right after the three TensorAccessors.
     reader_ct.push_back(k_mcast_on);
@@ -299,9 +294,9 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
     reader_ct.push_back(q_valid_sem);
 
     std::vector<uint32_t> writer_ct = common_ct;
-    constexpr uint32_t out_elem_bytes = 2;    // bf16 output (compute_output_specs)
-    writer_ct.push_back(T * out_elem_bytes);  // row-major page = one full row of T scores
-    TensorAccessorArgs(*out.buffer()).append_to(writer_ct);
+    const uint32_t out_elem_bytes = out.element_size();  // from the output tensor's dtype (bf16 today)
+    writer_ct.push_back(T * out_elem_bytes);             // row-major page = one full row of T scores
+    tt::tt_metal::TensorAccessorArgs(*out.buffer()).append_to(writer_ct);
 
     std::vector<uint32_t> compute_ct = common_ct;
     compute_ct.push_back(qk_subblock_h);
@@ -309,21 +304,22 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
     compute_ct.push_back(qk_col_batch);    // k-columns batched per mode switch in the full-strip path
 
     const std::string kdir = "ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/";
-    auto reader_id =
-        CreateKernel(program, kdir + "reader_indexer_score.cpp", core_ranges, ReaderDataMovementConfig(reader_ct));
-    auto writer_id =
-        CreateKernel(program, kdir + "writer_indexer_score.cpp", core_ranges, WriterDataMovementConfig(writer_ct));
-    auto compute_id = CreateKernel(
+    auto reader_id = tt::tt_metal::CreateKernel(
+        program, kdir + "reader_indexer_score.cpp", core_ranges, tt::tt_metal::ReaderDataMovementConfig(reader_ct));
+    auto writer_id = tt::tt_metal::CreateKernel(
+        program, kdir + "writer_indexer_score.cpp", core_ranges, tt::tt_metal::WriterDataMovementConfig(writer_ct));
+    auto compute_id = tt::tt_metal::CreateKernel(
         program,
         kdir + "compute_indexer_score.cpp",
         core_ranges,
-        ComputeConfig{
+        tt::tt_metal::ComputeConfig{
             .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
-            .dst_full_sync_en = false,
+            .dst_full_sync_en = dst_full_sync_en,
+            .math_approx_mode = math_approx_mode,
             .compile_args = compute_ct});
 
-    // Per-core multicast runtime args: K column then Q/W row, each an 8-tuple (push8 below); the two
+    // Per-core multicast runtime args: K column then Q/W row, each an 8-tuple (push_mcast_dir below); the two
     // together are what the non-grid-aligned fallback zero-fills.
     constexpr uint32_t mcast_args_per_dir = 8;
     constexpr uint32_t reader_mcast_args = 2 * mcast_args_per_dir;
@@ -336,7 +332,7 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
         // Per-core mcast args: K column (8) then Q/W row (8). role 0=none(DRAM read), 1=sender,
         // 2=receiver. rect (xs,ys,xe,ye) + sender (sx,sy) are physical NoC; ndst=#receivers.
         const auto u32 = [](auto v) { return static_cast<uint32_t>(v); };
-        const auto push8 =
+        const auto push_mcast_dir =
             [&](uint32_t role, uint32_t xs, uint32_t ys, uint32_t xe, uint32_t ye, const CoreCoord& s, uint32_t ndst) {
                 reader_rt.push_back(role);
                 reader_rt.push_back(xs);
@@ -351,7 +347,7 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
             const uint32_t x = i % grid.x, y = i / grid.x;
             // K column x: sender (x,0), receivers (x,1..); vertical rect spanning the column.
             const auto [kys, kye] = phys_col_y_range(x);
-            push8(
+            push_mcast_dir(
                 k_mcast_on ? (y == 0 ? 1u : 2u) : 0u,
                 u32(phys[cidx(x, 0)].x),
                 kys,
@@ -363,17 +359,24 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
             // row in one rect (its bbox [min x, max x] x py). Any core in the row can send (all share
             // q-rows + w); the diagonal fans senders across distinct columns vs stacking in column 0.
             // Receivers = rest of the row (ndst = grid.x - 1); hardware excludes the in-rect source.
-            const auto [qxs, qxe] = phys_row_x_range(y);
-            const uint32_t py = u32(phys[cidx(y, y)].y);  // diagonal sender's row (== every core's py)
-            push8(q_mcast_on ? (x == y ? 1u : 2u) : 0u, qxs, py, qxe, py, phys[cidx(y, y)], u32(grid.x) - 1);
+            // Guard the diagonal lookup phys[cidx(y, y)] behind q_mcast_on: it is only a valid index
+            // when q_rows_ok held (which requires grid.x >= grid.y). With q-mcast off every core just
+            // DRAM-reads q/w (role 0), so the rect/sender fields are unused -- push a zeroed tuple.
+            if (q_mcast_on) {
+                const auto [qxs, qxe] = phys_row_x_range(y);
+                const uint32_t py = u32(phys[cidx(y, y)].y);  // diagonal sender's row (== every core's py)
+                push_mcast_dir(x == y ? 1u : 2u, qxs, py, qxe, py, phys[cidx(y, y)], u32(grid.x) - 1);
+            } else {
+                push_mcast_dir(0u, 0, 0, 0, 0, phys[i], 0);
+            }
         } else {
             for (uint32_t z = 0; z < reader_mcast_args; ++z) {
                 reader_rt.push_back(0);
             }
         }
-        SetRuntimeArgs(program, reader_id, cores[i], reader_rt);
-        SetRuntimeArgs(program, compute_id, cores[i], {flat, count});
-        SetRuntimeArgs(program, writer_id, cores[i], {out.buffer()->address(), flat, count});
+        tt::tt_metal::SetRuntimeArgs(program, reader_id, cores[i], reader_rt);
+        tt::tt_metal::SetRuntimeArgs(program, compute_id, cores[i], {flat, count});
+        tt::tt_metal::SetRuntimeArgs(program, writer_id, cores[i], {out.buffer()->address(), flat, count});
         flat += count;
     }
 
@@ -389,8 +392,8 @@ IndexerScoreProgramFactory::cached_program_t IndexerScoreProgramFactory::create(
 void IndexerScoreProgramFactory::override_runtime_arguments(
     cached_program_t& cached, const operation_attributes_t&, const tensor_args_t& tensors, tensor_return_value_t& out) {
     auto& shared = cached.shared_variables;
-    auto& reader_args = GetRuntimeArgs(cached.program, shared.reader_kernel);
-    auto& writer_args = GetRuntimeArgs(cached.program, shared.writer_kernel);
+    auto& reader_args = tt::tt_metal::GetRuntimeArgs(cached.program, shared.reader_kernel);
+    auto& writer_args = tt::tt_metal::GetRuntimeArgs(cached.program, shared.writer_kernel);
     for (const auto& core : shared.worker_cores) {
         auto& reader_rt = reader_args[core.x][core.y];
         patch_arg(reader_rt, rt_arg::reader_q_addr, tensors.q.buffer()->address(), "reader.q_addr");

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.hpp
@@ -1,0 +1,35 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "indexer_score_device_operation_types.hpp"
+#include "ttnn/device_operation.hpp"
+
+namespace ttnn::operations::experimental::indexer_score::program {
+
+struct IndexerScoreSharedVariables {
+    tt::tt_metal::KernelHandle reader_kernel;
+    tt::tt_metal::KernelHandle compute_kernel;
+    tt::tt_metal::KernelHandle writer_kernel;
+    std::vector<CoreCoord> worker_cores;
+};
+
+struct IndexerScoreProgramFactory {
+    using shared_variables_t = IndexerScoreSharedVariables;
+    using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
+
+    static cached_program_t create(
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+
+    static void override_runtime_arguments(
+        cached_program_t& cached_program,
+        const operation_attributes_t& operation_attributes,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& tensor_return_value);
+};
+
+}  // namespace ttnn::operations::experimental::indexer_score::program

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.hpp
@@ -21,15 +21,13 @@ struct IndexerScoreProgramFactory {
     using cached_program_t = ttnn::device_operation::CachedProgram<shared_variables_t>;
 
     static cached_program_t create(
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        const operation_attributes_t& args, const tensor_args_t& tensors, tensor_return_value_t& out);
 
     static void override_runtime_arguments(
-        cached_program_t& cached_program,
-        const operation_attributes_t& operation_attributes,
-        const tensor_args_t& tensor_args,
-        tensor_return_value_t& tensor_return_value);
+        cached_program_t& cached,
+        const operation_attributes_t& args,
+        const tensor_args_t& tensors,
+        tensor_return_value_t& out);
 };
 
 }  // namespace ttnn::operations::experimental::indexer_score::program

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/indexer_score_program_factory.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "indexer_score_device_operation_types.hpp"
 #include "ttnn/device_operation.hpp"
 

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
@@ -1,0 +1,338 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Compute for indexer_score. Per work unit (QC q-rows x KC k-cols):
+//   acc[r,c] = sum_h relu(q[h,row] @ k[col]^T) * w[h,row], then causal -inf mask,
+//   then pack_untilize -> bf16 row-major out.
+// Heads stream in groups (heads_per_dest_pass rows per DEST pass, half-sync bf16 DEST);
+// q/w stay resident when all heads fit.
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/matmul.h"
+#include "api/compute/bcast.h"
+#include "api/compute/eltwise_binary.h"
+#include "api/compute/pack.h"
+#include "api/compute/reconfig_data_format.h"
+#include "api/compute/cb_api.h"
+#include "api/compute/tile_move_copy.h"
+
+#include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+#include "indexer_score_common.hpp"  // shared CB indices, compile-time dims, work-unit walk
+#include "api/compute/experimental/indexer_mul_custom.h"
+
+// qk subblock height (head rows per DEST pass); first per-kernel compile-time arg.
+constexpr uint32_t heads_per_dest_pass = get_compile_time_arg_val(num_common_ct_args);
+// heads buffered in cb_qk per matmul/mul phase chunk (multiple of HP).
+constexpr uint32_t qk_batch_heads = get_compile_time_arg_val(num_common_ct_args + 1);
+// k-columns batched per matmul<->mul mode switch in the full-strip path (1 = per-column, no batching).
+constexpr uint32_t qk_col_batch = get_compile_time_arg_val(num_common_ct_args + 2);
+
+// k-cols sharing ONE dest acquire in the blocked-custom mul; bounded by the dest budget. One unpack
+// context per head loads w[h] + ct_dim qk cols, so unpack-context sync is paid 1/ct_dim as often as
+// the per-tile bcast-mul (the mul-phase bottleneck).
+constexpr uint32_t mul_ct_dim = (k_tiles_per_unit < heads_per_dest_pass) ? k_tiles_per_unit : heads_per_dest_pass;
+
+// Head reduction splits into a matmul phase (fill cb_qk with relu(q.kT)) and a mul phase (gate +
+// head-reduce into the accumulator) so the matmul<->eltwise reconfig happens once per batch, not per
+// head pass. Two implementations of that split live below: the head-major path
+// (matmul_phase + mul_phase, blocked-custom MUL, qk_col_batch > 1) and the per-column streaming
+// FALLBACK (accumulate_heads, qk_col_batch == 1). The set_*/set_mul_* helpers are shared by both.
+
+/** srcA<-k, srcB<-q, matmul mode for the matmul phase. Reconfig order matters: matmul maps
+ *  in1->srcA, in0->srcB, so swapping the reconfig misreads bfp8 k (bf16 k is unaffected). */
+template <uint32_t q_cb, uint32_t k_cb, uint32_t qk_cb>
+inline void set_matmul_mode() {
+    // guarded reconfig: srcA qk->k changes format (fires); srcB w->q is bf16->bf16 (skipped).
+    reconfig_data_format(qk_cb, k_cb, cb_w, q_cb);
+    // guarded: no-op in the bf16 path; only the fp32-dest fallback (qk=fp32, out=bf16) reconfigs.
+    pack_reconfig_data_format(cb_out_strip, qk_cb);
+    pack_reconfig_l1_acc(0);  // cb_qk packs overwrite (mul phase turns L1-acc on for cb_acc_strip)
+    mm_block_init_short(
+        q_cb, k_cb, 1 /*transpose k*/, 1 /*ct_dim*/, heads_per_dest_pass /*rt_dim*/, head_dim_tiles /*kt_dim*/);
+    pack_relu_config(ReluConfig::zero());  // relu in the packer for the whole matmul phase
+}
+
+/** Matmul one DEST pass of relu(q.kT): HP head-rows of q row r vs k col c, left in DEST (caller packs).
+ *  q blocks are [QC][HG][Dt] so head rows stride head_dim_tiles. Assumes set_matmul_mode() ran. */
+template <uint32_t q_cb, uint32_t k_cb>
+inline void emit_qk_matmul_block(uint32_t head_in_group, uint32_t r, uint32_t c) {
+    tile_regs_acquire();
+    const uint32_t q_base = (r * heads_per_group + head_in_group) * head_dim_tiles;
+    for (uint32_t d = 0; d < head_dim_tiles; ++d) {
+        matmul_block(
+            q_cb,
+            k_cb,
+            q_base + d,
+            c * head_dim_tiles + d,
+            0,
+            1 /*transpose k*/,
+            1,
+            heads_per_dest_pass,
+            head_dim_tiles);
+    }
+    tile_regs_commit();
+}
+
+/** One matmul-phase DEST pass: relu(q row r @ k col c^T) block-packed into cb_qk front (tile-major). */
+template <uint32_t q_cb, uint32_t k_cb, uint32_t qk_cb>
+void matmul_relu_pass(uint32_t head_in_group, uint32_t r, uint32_t c) {
+    emit_qk_matmul_block<q_cb, k_cb>(head_in_group, r, c);
+    cb_reserve_back(qk_cb, heads_per_dest_pass);
+    tile_regs_wait();
+    pack_tile_block(0, qk_cb, heads_per_dest_pass);
+    tile_regs_release();
+    cb_push_back(qk_cb, heads_per_dest_pass);
+}
+
+/** srcA<-qk, srcB<-w + pack format for a mul+accumulate phase (shared by the standard and
+ *  blocked-custom mul; only the following bcast-mul init differs). */
+template <uint32_t qk_cb, uint32_t w_cb, uint32_t acc_cb>
+inline void set_mul_reconfig() {
+    pack_relu_config(ReluConfig::none());  // accumulator packs stay linear (negative gates)
+    // guarded reconfig: srcA k->qk changes format (fires); srcB q->w is bf16->bf16 (skipped).
+    reconfig_data_format(cb_k, qk_cb, cb_q, w_cb);
+    pack_reconfig_data_format(qk_cb, acc_cb);  // guarded: qk and acc share acc_fmt -> no-op.
+}
+
+/** srcA<-qk, srcB<-w + bcast-mul mode for the mul+accumulate phase. */
+template <uint32_t qk_cb, uint32_t w_cb, uint32_t acc_cb>
+inline void set_mul_mode() {
+    set_mul_reconfig<qk_cb, w_cb, acc_cb>();
+    mul_bcast_cols_init_short(qk_cb, w_cb);
+    // acc_to_dest=1: each mul MACs onto the same DEST tile (tile_regs_acquire zeroes it, head 0
+    // seeds), so the chunk's head reduction needs one pack, not a per-head packer-L1-acc RMW.
+    MATH((llk_math_eltwise_binary_init<ckernel::EltwiseBinaryType::ELWMUL, ckernel::BroadcastType::COL, MATH_FIDELITY>(
+        qk_cb, w_cb, 1 /*acc_to_dest*/)));
+}
+
+/** Mul+accumulate `chunk_heads` resident heads onto the output tile via hw MAC:
+ *  dst0 += sum_h relu(qk[h]) * w[w_base+h], packed once to acc_cb[acc_slot]. `first` overwrites the
+ *  slot (l1_acc off); later chunks L1-accumulate. Caller owns acc_cb and the l1_acc reset. */
+template <uint32_t qk_cb, uint32_t w_cb, uint32_t acc_cb>
+void mul_accum_chunk(uint32_t w_base, uint32_t chunk_heads, bool first, uint32_t acc_slot) {
+    cb_wait_front(qk_cb, chunk_heads);
+    tile_regs_acquire();
+    for (uint32_t h = 0; h < chunk_heads; ++h) {
+        mul_tiles_bcast_cols(qk_cb, w_cb, h, w_base + h, 0);
+    }
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_reconfig_l1_acc(first ? 0 : 1);  // first chunk seeds (overwrite), later chunks accumulate
+    pack_tile<true>(0, acc_cb, acc_slot);
+    tile_regs_release();
+    cb_pop_front(qk_cb, chunk_heads);
+}
+
+/** Matmul DEST pass packed HEAD-MAJOR: head h's `cols` columns land contiguous in cb_qk (slot
+ *  (head+d)*cols + col_in_batch), the layout the blocked mul streams as SrcA. Uses llk_matmul_pack
+ *  out_of_order (generic pack misreads the matmul DEST layout). Caller reserves cols*num_heads once. */
+template <uint32_t q_cb, uint32_t k_cb, uint32_t qk_cb>
+void matmul_relu_pass_headmajor(uint32_t head_in_group, uint32_t r, uint32_t c, uint32_t col_in_batch, uint32_t cols) {
+    emit_qk_matmul_block<q_cb, k_cb>(head_in_group, r, c);
+    tile_regs_wait();
+    for (uint32_t d = 0; d < heads_per_dest_pass; ++d) {
+        PACK((llk_matmul_pack<DST_ACCUM_MODE, true /*out_of_order*/, PackMode::Default>(
+            d, qk_cb, 1 /*ntiles*/, (head_in_group + d) * cols + col_in_batch)));  // relu(q.kT), head-major slot
+    }
+    tile_regs_release();
+}
+
+/** Like set_mul_mode but with the blocked-custom bcast-col MUL (one unpack context per head: w[h]
+ *  loaded once + ct_dim qk cols, MAC-reduced in dest). Same reconfig. */
+template <uint32_t qk_cb, uint32_t w_cb, uint32_t acc_cb>
+inline void set_mul_mode_custom() {
+    set_mul_reconfig<qk_cb, w_cb, acc_cb>();
+    mul_bcast_cols_init_short_custom(qk_cb, w_cb);
+}
+
+/** Per-column (qk_col_batch==1) head reduction for output tile (r,c): acc_cb[acc_slot] =
+ *  sum_h relu(q[h,r].k[c]^T)*w[h,r], MAC'd in DEST per chunk, L1-acc only across chunks. Caller
+ *  owns acc_cb. */
+template <uint32_t acc_cb>
+inline void accumulate_heads(uint32_t r, uint32_t c, uint32_t acc_slot) {
+    bool first = true;
+    for (uint32_t group_start = 0; group_start < num_heads; group_start += heads_per_group) {
+        if constexpr (stream_heads) {
+            cb_wait_front(cb_q, q_group_tiles);
+        }
+        // per chunk (cb_qk capacity): run its matmuls, then MAC the chunk's head sum into DEST once,
+        // so the matmul<->eltwise reinit and the acc pack happen per chunk, not per head
+        for (uint32_t chunk = 0; chunk < heads_per_group; chunk += qk_batch_heads) {
+            const uint32_t chunk_end = chunk + qk_batch_heads;
+            set_matmul_mode<cb_q, cb_k, cb_qk>();
+            for (uint32_t head = chunk; head < chunk_end; head += heads_per_dest_pass) {
+                matmul_relu_pass<cb_q, cb_k, cb_qk>(head, r, c);
+            }
+            set_mul_mode<cb_qk, cb_w, acc_cb>();
+            // w is laid out [q_tiles_per_unit][num_heads] (see reader read_w_group)
+            const uint32_t w_base = r * num_heads + group_start + chunk;
+            mul_accum_chunk<cb_qk, cb_w, acc_cb>(w_base, qk_batch_heads, first, acc_slot);
+            first = false;
+        }
+        if constexpr (stream_heads) {
+            cb_pop_front(cb_q, q_group_tiles);
+        }
+    }
+    pack_reconfig_l1_acc(0);  // done accumulating; downstream packs (mask, untilize) overwrite
+}
+
+/** Stamp the causal mask for absolute column `k_tile` onto acc write slot `slot` (before
+ *  cb_push_back, no repush). Two cases:
+ *   - diagonal (k_tile == diag_tile): L1-ACCUMULATE the strict-upper -inf tile, keeping the lower tri.
+ *   - past diagonal (incl. pad cols >= Tt): OVERWRITE with -inf, so stale-k garbage in a pad column is
+ *     discarded rather than turned to nan by `garbage + -inf`. */
+template <uint32_t acc_cb, uint32_t mask_cb>
+inline void stamp_mask_tile(uint32_t slot, uint32_t k_tile, uint32_t diag_tile) {
+    const bool is_diag = (k_tile == diag_tile);
+    const uint32_t midx = is_diag ? 0u : 1u;  // 0 = diag strict-upper -inf, 1 = full -inf
+    copy_tile_to_dst_init_short(mask_cb);
+    pack_reconfig_l1_acc(is_diag ? 1 : 0);  // diag accumulates (keeps score); full -inf overwrites
+    tile_regs_acquire();
+    copy_tile(mask_cb, midx, 0);
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile<true>(0, acc_cb, slot);
+    tile_regs_release();
+    pack_reconfig_l1_acc(0);
+}
+
+// ---------------------------------------------------------------------------------------------------
+// The three per-unit phases, called in order from kernel_main:
+//   PHASE 1 matmul_phase  -- fill cb_qk with relu(q.kT) for a batch of a row's k-columns
+//   PHASE 2 mul_phase     -- gate-scale + head-reduce that batch into the unit accumulator
+//   PHASE 3 (inline)      -- untilize the whole accumulated QC x KC unit in one pack_untilize bracket
+// Phases 1/2 run per k-column batch: cb_qk holds one batch, so they alternate. When the batch is the
+// whole row (qk_col_batch == KC, heads8/16) that's one matmul + one mul per row; heads64
+// (qk_col_batch=2 < KC) interleaves per 2-column batch.
+// ---------------------------------------------------------------------------------------------------
+
+/** PHASE 1 -- fill cb_qk HEAD-MAJOR with relu(q[:,r].k[col_base..]^T) for one k-col batch of row r.
+ *  One set_matmul_mode for the batch (reinit hoisted out of the col loop), one cb_qk reserve/push. */
+inline void matmul_phase(uint32_t r, uint32_t col_base, uint32_t cols) {
+    const uint32_t batch_tiles = cols * num_heads;
+    set_matmul_mode<cb_q, cb_k, cb_qk>();
+    cb_reserve_back(cb_qk, batch_tiles);
+    for (uint32_t col_in_batch = 0; col_in_batch < cols; ++col_in_batch) {
+        for (uint32_t head = 0; head < num_heads; head += heads_per_dest_pass) {
+            matmul_relu_pass_headmajor<cb_q, cb_k, cb_qk>(head, r, col_base + col_in_batch, col_in_batch, cols);
+        }
+    }
+    cb_push_back(cb_qk, batch_tiles);
+}
+
+/** PHASE 2 -- gate-multiply the batch's cb_qk by w and head-reduce into cb_acc_strip via the blocked
+ *  bcast-col MUL. Per ct_dim-col sub-batch, one dest acquire holds the column accumulators; each head
+ *  is one unpack context (w[h] once + ct_dim cols) that MACs onto dest[0..n_cols), so unpack-context
+ *  sync is per head, not per (col, head). ELWMUL accumulates in dest -> one pack per column. cb_qk is
+ *  head-major (head h's cols contiguous); whole batch shares one set_mul_mode (w is column-independent). */
+inline void mul_phase(uint32_t r, uint32_t slot_base, uint32_t col_base, uint32_t cols) {
+    const uint32_t batch_tiles = cols * num_heads;
+    const uint32_t w_base = r * num_heads;  // single chunk (group_start = 0); gate per (head, row)
+    // gates consumed only here: wait now (after this batch's matmuls) so the reader reads w behind the
+    // latency-critical q/k. Cumulative wait -> no-op once the resident group is in.
+    cb_wait_front(cb_w, w_group_tiles);
+    set_mul_mode_custom<cb_qk, cb_w, cb_acc_strip>();
+    cb_wait_front(cb_qk, batch_tiles);
+    for (uint32_t sub_base = 0; sub_base < cols; sub_base += mul_ct_dim) {
+        const uint32_t n_cols = (sub_base + mul_ct_dim <= cols) ? mul_ct_dim : (cols - sub_base);
+        tile_regs_acquire();
+        for (uint32_t h = 0; h < num_heads; ++h) {
+            mul_tiles_bcast_cols_custom(cb_qk, cb_w, h * cols + sub_base, w_base + h, 0, n_cols);
+        }
+        tile_regs_commit();
+        tile_regs_wait();
+        for (uint32_t j = 0; j < n_cols; ++j) {
+            pack_tile(j, cb_acc_strip, slot_base + col_base + sub_base + j);
+        }
+        tile_regs_release();
+    }
+    cb_pop_front(cb_qk, batch_tiles);
+}
+
+/** PHASE 1+2 fallback for head-streaming / KC==1 (qk_col_batch == 1): each k-col runs accumulate_heads
+ *  (matmul + STANDARD bcast-mul interleaved per head group). It reads cb_w by index, so wait the gates
+ *  here (k already waited in kernel_main). */
+inline void accumulate_row_streaming(uint32_t r, uint32_t slot_base) {
+    cb_wait_front(cb_w, w_group_tiles);
+    for (uint32_t c = 0; c < k_tiles_per_unit; ++c) {
+        accumulate_heads<cb_acc_strip>(r, c, slot_base + c);  // head reduction -> cb_acc_strip slot
+    }
+}
+
+/** Stamp the causal -inf mask onto row r's masked suffix [valid, KC) in place, so the strip still
+ *  untilizes via the fast W=KC path (empty loop when the row is fully valid). */
+inline void stamp_masked_suffix(const WorkUnitSpan& span, uint32_t r, uint32_t slot_base, uint32_t k_tiles_in_unit) {
+    const uint32_t k_tile0 = span.k_tile_start();
+    const uint32_t diag_tile = chunk_start_tiles + span.q_tile_start() + r;
+    const uint32_t valid = row_valid_prefix(span.q_tile_start() + r, k_tile0, k_tiles_in_unit);
+    for (uint32_t c = valid; c < k_tiles_per_unit; ++c) {
+        stamp_mask_tile<cb_acc_strip, cb_mask>(slot_base + c, k_tile0 + c, diag_tile);
+    }
+}
+
+void kernel_main() {
+    const uint32_t flat_start = get_arg_val<uint32_t>(0);
+    const uint32_t flat_count = get_arg_val<uint32_t>(1);
+    if (flat_count == 0) {
+        return;
+    }
+
+    mm_block_init(
+        cb_q, cb_k, cb_qk, 1 /*transpose k*/, 1 /*ct_dim*/, heads_per_dest_pass /*rt_dim*/, head_dim_tiles /*kt_dim*/);
+    cb_wait_front(cb_mask, num_mask_tiles);
+
+    WorkUnitSpan span;
+    span.start(flat_start);
+
+    constexpr uint32_t unit_strip = q_tiles_per_unit * k_tiles_per_unit;  // QC x KC accumulator slots
+    constexpr uint32_t q_row_tiles = q_group_tiles / q_tiles_per_unit;    // heads_per_group * head_dim_tiles
+
+    // One QC x KC unit per iteration. Every unit spans KC k-tiles; the dense schedule may leave a
+    // partial last unit (valid < KC), masked in stamp_masked_suffix.
+    //
+    // No whole-block q/w wait here: resident q is waited PER ROW below (reader pushes a row at a time, so
+    // row 0 runs while row 1 drains); w is waited in the mul phase. Only k is waited up front.
+    for (uint32_t i = 0; i < flat_count; ++i) {
+        cb_wait_front(cb_k, k_chunk_tiles);
+        const uint32_t k_tiles_in_unit = span.k_tiles();
+
+        cb_reserve_back(cb_acc_strip, unit_strip);
+        for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
+            // wait q rows 0..r only (reader pushes per row): row r reads only its row, so row 0 runs
+            // while row 1 arrives. Cumulative + non-consuming -> immediate once q is resident.
+            if constexpr (!stream_heads) {
+                cb_wait_front(cb_q, (r + 1) * q_row_tiles);
+            }
+            const uint32_t slot_base = r * k_tiles_per_unit;
+
+            // PHASE 1 (matmul) + PHASE 2 (mul) per k-col batch. cb_qk holds one batch, so they
+            // alternate; GLM5/DSv32 (heads8/16) = one of each per row.
+            if constexpr (qk_col_batch > 1) {
+                for (uint32_t col_base = 0; col_base < k_tiles_per_unit; col_base += qk_col_batch) {
+                    const uint32_t cols =
+                        (col_base + qk_col_batch <= k_tiles_per_unit) ? qk_col_batch : (k_tiles_per_unit - col_base);
+                    matmul_phase(r, col_base, cols);          // PHASE 1: relu(q.kT) -> cb_qk (head-major)
+                    mul_phase(r, slot_base, col_base, cols);  // PHASE 2: gate-mul + head-reduce -> cb_acc_strip
+                }
+            } else {
+                accumulate_row_streaming(r, slot_base);  // PHASE 1+2 head-streaming / KC==1 fallback
+            }
+
+            stamp_masked_suffix(span, r, slot_base, k_tiles_in_unit);  // causal -inf on the row's masked suffix
+        }
+        cb_push_back(cb_acc_strip, unit_strip);
+
+        // PHASE 3 -- untilize all QC strips in ONE pack_untilize bracket (cost amortizes over QC*KC).
+        compute_kernel_lib::untilize<k_tiles_per_unit, cb_acc_strip, cb_out_strip>(q_tiles_per_unit);
+
+        cb_pop_front(cb_k, k_chunk_tiles);
+        if (span.advance()) {
+            cb_pop_front(cb_w, w_group_tiles);
+            if constexpr (!stream_heads) {
+                cb_pop_front(cb_q, q_group_tiles);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
@@ -17,6 +17,7 @@
 #include "api/compute/reconfig_data_format.h"
 #include "api/compute/cb_api.h"
 #include "api/compute/tile_move_copy.h"
+#include "api/dataflow/circular_buffer.h"  // Device 2.0 CircularBuffer wrapper (cb ops)
 
 #include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
 #include "indexer_score_common.hpp"  // shared CB indices, compile-time dims, work-unit walk
@@ -78,12 +79,13 @@ inline void emit_qk_matmul_block(uint32_t head_in_group, uint32_t r, uint32_t c)
 /** One matmul-phase DEST pass: relu(q row r @ k col c^T) block-packed into cb_qk front (tile-major). */
 template <uint32_t q_cb, uint32_t k_cb, uint32_t qk_cb>
 void matmul_relu_pass(uint32_t head_in_group, uint32_t r, uint32_t c) {
+    CircularBuffer qk(qk_cb);
     emit_qk_matmul_block<q_cb, k_cb>(head_in_group, r, c);
-    cb_reserve_back(qk_cb, heads_per_dest_pass);
+    qk.reserve_back(heads_per_dest_pass);
     tile_regs_wait();
     pack_tile_block(0, qk_cb, heads_per_dest_pass);
     tile_regs_release();
-    cb_push_back(qk_cb, heads_per_dest_pass);
+    qk.push_back(heads_per_dest_pass);
 }
 
 /** srcA<-qk, srcB<-w + pack format for a mul+accumulate phase (shared by the standard and
@@ -112,7 +114,8 @@ inline void set_mul_mode() {
  *  slot (l1_acc off); later chunks L1-accumulate. Caller owns acc_cb and the l1_acc reset. */
 template <uint32_t qk_cb, uint32_t w_cb, uint32_t acc_cb>
 void mul_accum_chunk(uint32_t w_base, uint32_t chunk_heads, bool first, uint32_t acc_slot) {
-    cb_wait_front(qk_cb, chunk_heads);
+    CircularBuffer qk(qk_cb);
+    qk.wait_front(chunk_heads);
     tile_regs_acquire();
     for (uint32_t h = 0; h < chunk_heads; ++h) {
         mul_tiles_bcast_cols(qk_cb, w_cb, h, w_base + h, 0);
@@ -122,7 +125,7 @@ void mul_accum_chunk(uint32_t w_base, uint32_t chunk_heads, bool first, uint32_t
     pack_reconfig_l1_acc(first ? 0 : 1);  // first chunk seeds (overwrite), later chunks accumulate
     pack_tile<true>(0, acc_cb, acc_slot);
     tile_regs_release();
-    cb_pop_front(qk_cb, chunk_heads);
+    qk.pop_front(chunk_heads);
 }
 
 /** Matmul DEST pass packed HEAD-MAJOR: head h's `cols` columns land contiguous in cb_qk (slot
@@ -152,10 +155,11 @@ inline void set_mul_mode_custom() {
  *  owns acc_cb. */
 template <uint32_t acc_cb>
 inline void accumulate_heads(uint32_t r, uint32_t c, uint32_t acc_slot) {
+    CircularBuffer q(cb_q);
     bool first = true;
     for (uint32_t group_start = 0; group_start < num_heads; group_start += heads_per_group) {
         if constexpr (stream_heads) {
-            cb_wait_front(cb_q, q_group_tiles);
+            q.wait_front(q_group_tiles);
         }
         // per chunk (cb_qk capacity): run its matmuls, then MAC the chunk's head sum into DEST once,
         // so the matmul<->eltwise reinit and the acc pack happen per chunk, not per head
@@ -172,7 +176,7 @@ inline void accumulate_heads(uint32_t r, uint32_t c, uint32_t acc_slot) {
             first = false;
         }
         if constexpr (stream_heads) {
-            cb_pop_front(cb_q, q_group_tiles);
+            q.pop_front(q_group_tiles);
         }
     }
     pack_reconfig_l1_acc(0);  // done accumulating; downstream packs (mask, untilize) overwrite
@@ -212,14 +216,15 @@ inline void stamp_mask_tile(uint32_t slot, uint32_t k_tile, uint32_t diag_tile) 
  *  One set_matmul_mode for the batch (reinit hoisted out of the col loop), one cb_qk reserve/push. */
 inline void matmul_phase(uint32_t r, uint32_t col_base, uint32_t cols) {
     const uint32_t batch_tiles = cols * num_heads;
+    CircularBuffer qk(cb_qk);
     set_matmul_mode<cb_q, cb_k, cb_qk>();
-    cb_reserve_back(cb_qk, batch_tiles);
+    qk.reserve_back(batch_tiles);
     for (uint32_t col_in_batch = 0; col_in_batch < cols; ++col_in_batch) {
         for (uint32_t head = 0; head < num_heads; head += heads_per_dest_pass) {
             matmul_relu_pass_headmajor<cb_q, cb_k, cb_qk>(head, r, col_base + col_in_batch, col_in_batch, cols);
         }
     }
-    cb_push_back(cb_qk, batch_tiles);
+    qk.push_back(batch_tiles);
 }
 
 /** PHASE 2 -- gate-multiply the batch's cb_qk by w and head-reduce into cb_acc_strip via the blocked
@@ -232,9 +237,10 @@ inline void mul_phase(uint32_t r, uint32_t slot_base, uint32_t col_base, uint32_
     const uint32_t w_base = r * num_heads;  // single chunk (group_start = 0); gate per (head, row)
     // gates consumed only here: wait now (after this batch's matmuls) so the reader reads w behind the
     // latency-critical q/k. Cumulative wait -> no-op once the resident group is in.
-    cb_wait_front(cb_w, w_group_tiles);
+    CircularBuffer qk(cb_qk);
+    CircularBuffer(cb_w).wait_front(w_group_tiles);  // single use here; gates popped in kernel_main
     set_mul_mode_custom<cb_qk, cb_w, cb_acc_strip>();
-    cb_wait_front(cb_qk, batch_tiles);
+    qk.wait_front(batch_tiles);
     for (uint32_t sub_base = 0; sub_base < cols; sub_base += mul_ct_dim) {
         const uint32_t n_cols = (sub_base + mul_ct_dim <= cols) ? mul_ct_dim : (cols - sub_base);
         tile_regs_acquire();
@@ -248,14 +254,14 @@ inline void mul_phase(uint32_t r, uint32_t slot_base, uint32_t col_base, uint32_
         }
         tile_regs_release();
     }
-    cb_pop_front(cb_qk, batch_tiles);
+    qk.pop_front(batch_tiles);
 }
 
 /** PHASE 1+2 fallback for head-streaming / KC==1 (qk_col_batch == 1): each k-col runs accumulate_heads
  *  (matmul + STANDARD bcast-mul interleaved per head group). It reads cb_w by index, so wait the gates
  *  here (k already waited in kernel_main). */
 inline void accumulate_row_streaming(uint32_t r, uint32_t slot_base) {
-    cb_wait_front(cb_w, w_group_tiles);
+    CircularBuffer(cb_w).wait_front(w_group_tiles);
     for (uint32_t c = 0; c < k_tiles_per_unit; ++c) {
         accumulate_heads<cb_acc_strip>(r, c, slot_base + c);  // head reduction -> cb_acc_strip slot
     }
@@ -281,7 +287,12 @@ void kernel_main() {
 
     mm_block_init(
         cb_q, cb_k, cb_qk, 1 /*transpose k*/, 1 /*ct_dim*/, heads_per_dest_pass /*rt_dim*/, head_dim_tiles /*kt_dim*/);
-    cb_wait_front(cb_mask, num_mask_tiles);
+    CircularBuffer(cb_mask).wait_front(num_mask_tiles);  // single use; the mask CB is never popped
+
+    // CBs touched twice below (wait/pop, reserve/push) get one instance each.
+    CircularBuffer k(cb_k);
+    CircularBuffer acc(cb_acc_strip);
+    CircularBuffer q(cb_q);
 
     WorkUnitSpan span;
     span.start(flat_start);
@@ -295,15 +306,15 @@ void kernel_main() {
     // No whole-block q/w wait here: resident q is waited PER ROW below (reader pushes a row at a time, so
     // row 0 runs while row 1 drains); w is waited in the mul phase. Only k is waited up front.
     for (uint32_t i = 0; i < flat_count; ++i) {
-        cb_wait_front(cb_k, k_chunk_tiles);
+        k.wait_front(k_chunk_tiles);
         const uint32_t k_tiles_in_unit = span.k_tiles();
 
-        cb_reserve_back(cb_acc_strip, unit_strip);
+        acc.reserve_back(unit_strip);
         for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
             // wait q rows 0..r only (reader pushes per row): row r reads only its row, so row 0 runs
             // while row 1 arrives. Cumulative + non-consuming -> immediate once q is resident.
             if constexpr (!stream_heads) {
-                cb_wait_front(cb_q, (r + 1) * q_row_tiles);
+                q.wait_front((r + 1) * q_row_tiles);
             }
             const uint32_t slot_base = r * k_tiles_per_unit;
 
@@ -322,16 +333,16 @@ void kernel_main() {
 
             stamp_masked_suffix(span, r, slot_base, k_tiles_in_unit);  // causal -inf on the row's masked suffix
         }
-        cb_push_back(cb_acc_strip, unit_strip);
+        acc.push_back(unit_strip);
 
         // PHASE 3 -- untilize all QC strips in ONE pack_untilize bracket (cost amortizes over QC*KC).
         compute_kernel_lib::untilize<k_tiles_per_unit, cb_acc_strip, cb_out_strip>(q_tiles_per_unit);
 
-        cb_pop_front(cb_k, k_chunk_tiles);
+        k.pop_front(k_chunk_tiles);
         if (span.advance()) {
-            cb_pop_front(cb_w, w_group_tiles);
+            CircularBuffer(cb_w).pop_front(w_group_tiles);  // single use; gates waited in the mul phase
             if constexpr (!stream_heads) {
-                cb_pop_front(cb_q, q_group_tiles);
+                q.pop_front(q_group_tiles);
             }
         }
     }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/compute_indexer_score.cpp
@@ -182,8 +182,8 @@ inline void accumulate_heads(uint32_t r, uint32_t c, uint32_t acc_slot) {
     pack_reconfig_l1_acc(0);  // done accumulating; downstream packs (mask, untilize) overwrite
 }
 
-/** Stamp the causal mask for absolute column `k_tile` onto acc write slot `slot` (before
- *  cb_push_back, no repush). Two cases:
+/** Stamp the causal mask for absolute column `k_tile` onto acc write slot `slot` (written into the
+ *  already-reserved acc_cb slot before its push_back, no repush). Two cases:
  *   - diagonal (k_tile == diag_tile): L1-ACCUMULATE the strict-upper -inf tile, keeping the lower tri.
  *   - past diagonal (incl. pad cols >= Tt): OVERWRITE with -inf, so stale-k garbage in a pad column is
  *     discarded rather than turned to nan by `garbage + -inf`. */

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_cb.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_cb.hpp
@@ -23,11 +23,18 @@ enum CbArg : uint32_t {
     cb_qk_arg,         // relu(q.kT) for a whole head group
     cb_acc_strip_arg,  // unit accumulator: QC x KC strip (untilize input)
     cb_out_strip_arg,  // untilized row-major strip output
-    cb_scratch_arg,    // writer-only -inf scratch tile
     num_cb_args
 };
 
 // Two mask tiles in cb_mask: index 0 = diagonal strict-upper -inf, index 1 = full -inf.
 constexpr uint32_t num_mask_tiles = 2;
+
+// Per-direction multicast role, written by the factory into the reader's runtime args and switched on by
+// the reader. Single-sourced here so the host writer and device reader can't drift on the encoding.
+enum McastRole : uint32_t {
+    mcast_role_none = 0,      // no multicast: plain per-core DRAM read
+    mcast_role_sender = 1,    // reads DRAM, then multicasts the block to the rect
+    mcast_role_receiver = 2,  // waits for the sender's multicast into its slot
+};
 
 }  // namespace ttnn::operations::experimental::indexer_score

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_cb.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_cb.hpp
@@ -1,0 +1,34 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// CB indices for indexer_score, single-sourced for the host factory and the kernels:
+// both reference these same indices, so defining them once prevents corrupt/hang from
+// index drift. Host+device safe (tt::CBIndex is in the shared hostdevcommon header).
+
+#pragma once
+
+#include <cstdint>
+
+#include "hostdevcommon/kernel_structs.h"
+
+namespace ttnn::operations::experimental::indexer_score {
+
+// Inputs (reader -> compute) and the persistent mask.
+constexpr uint32_t cb_q = tt::CBIndex::c_0;     // q head-group block: heads_per_group * QC * Dt tiles
+constexpr uint32_t cb_k = tt::CBIndex::c_1;     // k chunk, double buffered
+constexpr uint32_t cb_w = tt::CBIndex::c_2;     // resident gate (w) group: Hi * QC tiles
+constexpr uint32_t cb_mask = tt::CBIndex::c_3;  // [diag strict-upper -inf, full -inf], built once
+
+// Compute intermediates.
+constexpr uint32_t cb_qk = tt::CBIndex::c_24;         // relu(q.kT) for a whole head group
+constexpr uint32_t cb_acc_strip = tt::CBIndex::c_27;  // unit accumulator: QC x KC strip (untilize input)
+
+// Compute -> writer outputs.
+constexpr uint32_t cb_out_strip = tt::CBIndex::c_18;  // untilized row-major strip output
+constexpr uint32_t cb_scratch = tt::CBIndex::c_17;    // writer-only -inf scratch tile
+
+// Two mask tiles in cb_mask: index 0 = diagonal strict-upper -inf, index 1 = full -inf.
+constexpr uint32_t num_mask_tiles = 2;
+
+}  // namespace ttnn::operations::experimental::indexer_score

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_cb.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_cb.hpp
@@ -2,31 +2,30 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// CB indices for indexer_score, single-sourced for the host factory and the kernels:
-// both reference these same indices, so defining them once prevents corrupt/hang from
-// index drift. Host+device safe (tt::CBIndex is in the shared hostdevcommon header).
+// CB-index argument layout for indexer_score. The factory allocates the concrete (continuous)
+// circular-buffer indices and forwards them to the reader / compute / writer kernels as compile-time
+// args; this enum is the single-sourced slot order both sides agree on (host push-order ==
+// device read-order), so the index of any buffer can never drift between host and device.
 
 #pragma once
 
 #include <cstdint>
 
-#include "hostdevcommon/kernel_structs.h"
-
 namespace ttnn::operations::experimental::indexer_score {
 
-// Inputs (reader -> compute) and the persistent mask.
-constexpr uint32_t cb_q = tt::CBIndex::c_0;     // q head-group block: heads_per_group * QC * Dt tiles
-constexpr uint32_t cb_k = tt::CBIndex::c_1;     // k chunk, double buffered
-constexpr uint32_t cb_w = tt::CBIndex::c_2;     // resident gate (w) group: Hi * QC tiles
-constexpr uint32_t cb_mask = tt::CBIndex::c_3;  // [diag strict-upper -inf, full -inf], built once
-
-// Compute intermediates.
-constexpr uint32_t cb_qk = tt::CBIndex::c_24;         // relu(q.kT) for a whole head group
-constexpr uint32_t cb_acc_strip = tt::CBIndex::c_27;  // unit accumulator: QC x KC strip (untilize input)
-
-// Compute -> writer outputs.
-constexpr uint32_t cb_out_strip = tt::CBIndex::c_18;  // untilized row-major strip output
-constexpr uint32_t cb_scratch = tt::CBIndex::c_17;    // writer-only -inf scratch tile
+// One slot per circular buffer, in the order the factory appends the CB indices to the common
+// compile-time args. Kernels read each back at (num common dim args) + the matching slot.
+enum CbArg : uint32_t {
+    cb_q_arg,          // q head-group block: heads_per_group * QC * Dt tiles
+    cb_k_arg,          // k chunk, double buffered
+    cb_w_arg,          // resident gate (w) group: Hi * QC tiles
+    cb_mask_arg,       // [diag strict-upper -inf, full -inf], built once
+    cb_qk_arg,         // relu(q.kT) for a whole head group
+    cb_acc_strip_arg,  // unit accumulator: QC x KC strip (untilize input)
+    cb_out_strip_arg,  // untilized row-major strip output
+    cb_scratch_arg,    // writer-only -inf scratch tile
+    num_cb_args
+};
 
 // Two mask tiles in cb_mask: index 0 = diagonal strict-upper -inf, index 1 = full -inf.
 constexpr uint32_t num_mask_tiles = 2;

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
@@ -13,7 +13,6 @@
 #include "indexer_score_cb.hpp"          // shared host/device CB-index argument layout (CbArg)
 #include "indexer_score_work_split.hpp"  // shared host/device causal work-split formula
 
-using ttnn::operations::experimental::indexer_score::num_mask_tiles;
 namespace iscore = ttnn::operations::experimental::indexer_score;
 
 // Common dim args 0..7 (same in every kernel).
@@ -36,10 +35,12 @@ constexpr uint32_t cb_mask = get_compile_time_arg_val(num_dim_args + iscore::cb_
 constexpr uint32_t cb_qk = get_compile_time_arg_val(num_dim_args + iscore::cb_qk_arg);
 constexpr uint32_t cb_acc_strip = get_compile_time_arg_val(num_dim_args + iscore::cb_acc_strip_arg);
 constexpr uint32_t cb_out_strip = get_compile_time_arg_val(num_dim_args + iscore::cb_out_strip_arg);
-constexpr uint32_t cb_scratch = get_compile_time_arg_val(num_dim_args + iscore::cb_scratch_arg);
 
 // Dim args + CB indices are common to all kernels; per-kernel compile-time args start here.
 constexpr uint32_t num_common_ct_args = num_dim_args + iscore::num_cb_args;
+
+// Mask tile count, as a bare name for the kernels (defined in indexer_score_cb.hpp).
+constexpr uint32_t num_mask_tiles = iscore::num_mask_tiles;
 
 // True when heads don't all fit L1 resident, so they stream in groups.
 constexpr bool stream_heads = heads_per_group < num_heads;
@@ -88,7 +89,4 @@ struct WorkUnitSpan {
         uint32_t left = k_len_tiles - k_tile_start();
         return left < k_tiles_per_unit ? left : k_tiles_per_unit;
     }
-    // compute fills [0, this) for every group row -- the whole k rectangle under the dense schedule
-    uint32_t valid_k_tiles() const { return k_len_tiles; }
-    bool last_in_group() const { return unit == units_per_group - 1; }
 };

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
@@ -1,0 +1,100 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Shared by indexer_score reader / compute / writer: common compile-time dims (args
+// 0..7), CB indices, derived group/chunk tile counts, and WorkUnitSpan (this core's
+// walk over its flat span of units). One unit = QC q-tile-rows x up-to-KC k-tiles.
+
+#pragma once
+
+#include <cstdint>
+
+#include "indexer_score_cb.hpp"          // shared host/device circular-buffer indices
+#include "indexer_score_work_split.hpp"  // shared host/device causal work-split formula
+
+// Re-export shared CB indices to global scope so kernels use bare names.
+using ttnn::operations::experimental::indexer_score::cb_acc_strip;
+using ttnn::operations::experimental::indexer_score::cb_k;
+using ttnn::operations::experimental::indexer_score::cb_mask;
+using ttnn::operations::experimental::indexer_score::cb_out_strip;
+using ttnn::operations::experimental::indexer_score::cb_q;
+using ttnn::operations::experimental::indexer_score::cb_qk;
+using ttnn::operations::experimental::indexer_score::cb_scratch;
+using ttnn::operations::experimental::indexer_score::cb_w;
+using ttnn::operations::experimental::indexer_score::num_mask_tiles;
+
+constexpr uint32_t num_heads = get_compile_time_arg_val(0);          // indexer heads
+constexpr uint32_t q_len_tiles = get_compile_time_arg_val(1);        // q chunk rows, in tiles
+constexpr uint32_t k_len_tiles = get_compile_time_arg_val(2);        // total k positions, in tiles
+constexpr uint32_t head_dim_tiles = get_compile_time_arg_val(3);     // head dim, in tiles
+constexpr uint32_t chunk_start_tiles = get_compile_time_arg_val(4);  // q chunk start offset, in tiles
+constexpr uint32_t q_tiles_per_unit = get_compile_time_arg_val(5);   // q-tile-rows per work unit (q_chunk knob)
+constexpr uint32_t k_tiles_per_unit = get_compile_time_arg_val(6);   // k tiles per work unit (k_chunk knob)
+constexpr uint32_t heads_per_group = get_compile_time_arg_val(7);    // heads resident at once (head_group knob)
+
+// Args 0..7 are common to all kernels; per-kernel compile-time args start here.
+constexpr uint32_t num_common_ct_args = 8;
+
+// True when heads don't all fit L1 resident, so they stream in groups.
+constexpr bool stream_heads = heads_per_group < num_heads;
+
+// Derived tile counts for the per-unit circular-buffer blocks.
+constexpr uint32_t q_group_tiles = heads_per_group * q_tiles_per_unit * head_dim_tiles;  // [QC][HB][Dt]
+constexpr uint32_t w_group_tiles = num_heads * q_tiles_per_unit;                         // [QC][Hi]
+constexpr uint32_t k_chunk_tiles = k_tiles_per_unit * head_dim_tiles;                    // [KC][Dt]
+
+// Thin wrappers binding the shared work-split formula to this kernel's CT dims.
+namespace ws = ttnn::operations::experimental::indexer_score;
+
+/** Valid k-tiles of q-row-group `group` = causal-valid k-tiles of its (widest) last row. */
+inline uint32_t group_valid_k_tiles(uint32_t group) {
+    return ws::valid_k_tiles_in_group(group, q_tiles_per_unit, chunk_start_tiles, k_len_tiles);
+}
+
+/** Unmasked prefix k-tiles of absolute q-tile-row q_row_abs in a unit (bound to this kernel's
+ *  chunk_start_tiles). */
+inline uint32_t row_valid_prefix(uint32_t q_row_abs, uint32_t k_tile_start, uint32_t k_tiles_in_unit) {
+    return ws::valid_prefix_tiles(q_row_abs, k_tile_start, k_tiles_in_unit, chunk_start_tiles);
+}
+
+/** Number of k-chunk units in q-row-group `group`. */
+inline uint32_t units_in_group(uint32_t group) {
+    return ws::units_in_group(group, q_tiles_per_unit, k_tiles_per_unit, chunk_start_tiles, k_len_tiles);
+}
+
+/** (group, unit) cursor over causal-valid work units, starting at a flat index. */
+struct WorkUnitSpan {
+    uint32_t group = 0;
+    uint32_t unit = 0;
+
+    void start(uint32_t flat) {
+        uint32_t rowsum = 0;
+        while (flat >= rowsum + units_in_group(group)) {
+            rowsum += units_in_group(group);
+            ++group;
+        }
+        unit = flat - rowsum;
+    }
+
+    /** Advance one unit; true when a new q-row-group begins. */
+    bool advance() {
+        if (++unit == units_in_group(group)) {
+            ++group;
+            unit = 0;
+            return true;
+        }
+        return false;
+    }
+
+    uint32_t q_tile_start() const { return group * q_tiles_per_unit; }  // first q-tile-row of this unit
+    uint32_t k_tile_start() const { return unit * k_tiles_per_unit; }   // first k-tile of this unit
+    uint32_t k_tiles() const {                                          // valid k-tiles in this unit (< full on edge)
+        uint32_t left = group_valid_k_tiles(group) - k_tile_start();
+        return left < k_tiles_per_unit ? left : k_tiles_per_unit;
+    }
+    uint32_t valid_k_tiles() const {
+        return group_valid_k_tiles(group);
+    }  // compute fills [0, this) for every group row
+    bool last_in_group() const { return unit == units_in_group(group) - 1; }
+};

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_common.hpp
@@ -10,20 +10,13 @@
 
 #include <cstdint>
 
-#include "indexer_score_cb.hpp"          // shared host/device circular-buffer indices
+#include "indexer_score_cb.hpp"          // shared host/device CB-index argument layout (CbArg)
 #include "indexer_score_work_split.hpp"  // shared host/device causal work-split formula
 
-// Re-export shared CB indices to global scope so kernels use bare names.
-using ttnn::operations::experimental::indexer_score::cb_acc_strip;
-using ttnn::operations::experimental::indexer_score::cb_k;
-using ttnn::operations::experimental::indexer_score::cb_mask;
-using ttnn::operations::experimental::indexer_score::cb_out_strip;
-using ttnn::operations::experimental::indexer_score::cb_q;
-using ttnn::operations::experimental::indexer_score::cb_qk;
-using ttnn::operations::experimental::indexer_score::cb_scratch;
-using ttnn::operations::experimental::indexer_score::cb_w;
 using ttnn::operations::experimental::indexer_score::num_mask_tiles;
+namespace iscore = ttnn::operations::experimental::indexer_score;
 
+// Common dim args 0..7 (same in every kernel).
 constexpr uint32_t num_heads = get_compile_time_arg_val(0);          // indexer heads
 constexpr uint32_t q_len_tiles = get_compile_time_arg_val(1);        // q chunk rows, in tiles
 constexpr uint32_t k_len_tiles = get_compile_time_arg_val(2);        // total k positions, in tiles
@@ -32,9 +25,21 @@ constexpr uint32_t chunk_start_tiles = get_compile_time_arg_val(4);  // q chunk 
 constexpr uint32_t q_tiles_per_unit = get_compile_time_arg_val(5);   // q-tile-rows per work unit (q_chunk knob)
 constexpr uint32_t k_tiles_per_unit = get_compile_time_arg_val(6);   // k tiles per work unit (k_chunk knob)
 constexpr uint32_t heads_per_group = get_compile_time_arg_val(7);    // heads resident at once (head_group knob)
+constexpr uint32_t num_dim_args = 8;
 
-// Args 0..7 are common to all kernels; per-kernel compile-time args start here.
-constexpr uint32_t num_common_ct_args = 8;
+// CB indices, forwarded from the factory in CbArg order right after the dim args. Bare names so
+// kernels (and their template-arg uses) read like the host-side constants did.
+constexpr uint32_t cb_q = get_compile_time_arg_val(num_dim_args + iscore::cb_q_arg);
+constexpr uint32_t cb_k = get_compile_time_arg_val(num_dim_args + iscore::cb_k_arg);
+constexpr uint32_t cb_w = get_compile_time_arg_val(num_dim_args + iscore::cb_w_arg);
+constexpr uint32_t cb_mask = get_compile_time_arg_val(num_dim_args + iscore::cb_mask_arg);
+constexpr uint32_t cb_qk = get_compile_time_arg_val(num_dim_args + iscore::cb_qk_arg);
+constexpr uint32_t cb_acc_strip = get_compile_time_arg_val(num_dim_args + iscore::cb_acc_strip_arg);
+constexpr uint32_t cb_out_strip = get_compile_time_arg_val(num_dim_args + iscore::cb_out_strip_arg);
+constexpr uint32_t cb_scratch = get_compile_time_arg_val(num_dim_args + iscore::cb_scratch_arg);
+
+// Dim args + CB indices are common to all kernels; per-kernel compile-time args start here.
+constexpr uint32_t num_common_ct_args = num_dim_args + iscore::num_cb_args;
 
 // True when heads don't all fit L1 resident, so they stream in groups.
 constexpr bool stream_heads = heads_per_group < num_heads;
@@ -47,39 +52,29 @@ constexpr uint32_t k_chunk_tiles = k_tiles_per_unit * head_dim_tiles;           
 // Thin wrappers binding the shared work-split formula to this kernel's CT dims.
 namespace ws = ttnn::operations::experimental::indexer_score;
 
-/** Valid k-tiles of q-row-group `group` = causal-valid k-tiles of its (widest) last row. */
-inline uint32_t group_valid_k_tiles(uint32_t group) {
-    return ws::valid_k_tiles_in_group(group, q_tiles_per_unit, chunk_start_tiles, k_len_tiles);
-}
-
 /** Unmasked prefix k-tiles of absolute q-tile-row q_row_abs in a unit (bound to this kernel's
  *  chunk_start_tiles). */
 inline uint32_t row_valid_prefix(uint32_t q_row_abs, uint32_t k_tile_start, uint32_t k_tiles_in_unit) {
     return ws::valid_prefix_tiles(q_row_abs, k_tile_start, k_tiles_in_unit, chunk_start_tiles);
 }
 
-/** Number of k-chunk units in q-row-group `group`. */
-inline uint32_t units_in_group(uint32_t group) {
-    return ws::units_in_group(group, q_tiles_per_unit, k_tiles_per_unit, chunk_start_tiles, k_len_tiles);
-}
+// Work units per q-row-group: the full k rectangle over the k chunk, uniform across groups (dense
+// schedule), so the flat<->(group, unit) map is a plain divide/modulo.
+constexpr uint32_t units_per_group = ws::units_in_group(k_tiles_per_unit, k_len_tiles);
 
-/** (group, unit) cursor over causal-valid work units, starting at a flat index. */
+/** (group, unit) cursor over work units, starting at a flat index. */
 struct WorkUnitSpan {
     uint32_t group = 0;
     uint32_t unit = 0;
 
     void start(uint32_t flat) {
-        uint32_t rowsum = 0;
-        while (flat >= rowsum + units_in_group(group)) {
-            rowsum += units_in_group(group);
-            ++group;
-        }
-        unit = flat - rowsum;
+        group = flat / units_per_group;
+        unit = flat % units_per_group;
     }
 
     /** Advance one unit; true when a new q-row-group begins. */
     bool advance() {
-        if (++unit == units_in_group(group)) {
+        if (++unit == units_per_group) {
             ++group;
             unit = 0;
             return true;
@@ -90,11 +85,10 @@ struct WorkUnitSpan {
     uint32_t q_tile_start() const { return group * q_tiles_per_unit; }  // first q-tile-row of this unit
     uint32_t k_tile_start() const { return unit * k_tiles_per_unit; }   // first k-tile of this unit
     uint32_t k_tiles() const {                                          // valid k-tiles in this unit (< full on edge)
-        uint32_t left = group_valid_k_tiles(group) - k_tile_start();
+        uint32_t left = k_len_tiles - k_tile_start();
         return left < k_tiles_per_unit ? left : k_tiles_per_unit;
     }
-    uint32_t valid_k_tiles() const {
-        return group_valid_k_tiles(group);
-    }  // compute fills [0, this) for every group row
-    bool last_in_group() const { return unit == units_in_group(group) - 1; }
+    // compute fills [0, this) for every group row -- the whole k rectangle under the dense schedule
+    uint32_t valid_k_tiles() const { return k_len_tiles; }
+    bool last_in_group() const { return unit == units_per_group - 1; }
 };

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_work_split.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_work_split.hpp
@@ -1,0 +1,59 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Causal work-split arithmetic for indexer_score, shared by the host factory (deals
+// units across cores) and the kernels (WorkUnitSpan inverts a flat index to group/unit).
+// Single-sourcing stops host/device desync (else cores overlap or miss output tiles).
+// Pure uint32_t math (no std::, no CT args) so it includes cleanly on both sides.
+
+#pragma once
+
+#include <cstdint>
+
+namespace ttnn::operations::experimental::indexer_score {
+
+// Dense schedule: deal the full [0, k_len_tiles) rectangle for every group (not just its causal
+// prefix), so every group has the same unit count and the flat deal is perfectly uniform. Future
+// tiles are computed + masked to -inf in-band. Negligible cost at high sp_rank, ~2x at sp~0 -- so
+// the causal split (false) is kept for early chunks. Shared constexpr (not a CT arg) so host and
+// device read the SAME value and can never desync the unit count.
+constexpr bool dense_schedule = true;
+
+/** Causal-valid output k-tiles in q-tile-row q_row: columns [0, this) are causally visible. */
+constexpr uint32_t valid_k_tiles_in_row(uint32_t q_row, uint32_t chunk_start_tiles, uint32_t k_len_tiles) {
+    const uint32_t v = chunk_start_tiles + q_row + 1;
+    return v < k_len_tiles ? v : k_len_tiles;
+}
+
+/** k-tiles scheduled for a q-row-group. Dense: full rectangle; causal: valid k-tiles of its last
+ *  (widest) row. The ONE place the schedule shape is decided; host and device derive the rest. */
+constexpr uint32_t valid_k_tiles_in_group(
+    uint32_t group, uint32_t q_tiles_per_unit, uint32_t chunk_start_tiles, uint32_t k_len_tiles) {
+    if (dense_schedule) {
+        return k_len_tiles;
+    }
+    return valid_k_tiles_in_row((group + 1) * q_tiles_per_unit - 1, chunk_start_tiles, k_len_tiles);
+}
+
+/** Unmasked prefix k-tiles of q-tile-row q_row_abs in a unit (start k_tile_start, k_tiles_in_unit
+ *  valid). Tiles [0, this) are below the diagonal (no mask); diagonal and beyond are masked. */
+constexpr uint32_t valid_prefix_tiles(
+    uint32_t q_row_abs, uint32_t k_tile_start, uint32_t k_tiles_in_unit, uint32_t chunk_start_tiles) {
+    const uint32_t diag_tile = chunk_start_tiles + q_row_abs;
+    const uint32_t v = diag_tile > k_tile_start ? diag_tile - k_tile_start : 0;
+    return v < k_tiles_in_unit ? v : k_tiles_in_unit;
+}
+
+/** Number of k-chunk work units in a q-row-group (ceil of its valid width over the k chunk). */
+constexpr uint32_t units_in_group(
+    uint32_t group,
+    uint32_t q_tiles_per_unit,
+    uint32_t k_tiles_per_unit,
+    uint32_t chunk_start_tiles,
+    uint32_t k_len_tiles) {
+    const uint32_t valid = valid_k_tiles_in_group(group, q_tiles_per_unit, chunk_start_tiles, k_len_tiles);
+    return (valid + k_tiles_per_unit - 1) / k_tiles_per_unit;
+}
+
+}  // namespace ttnn::operations::experimental::indexer_score

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_work_split.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/indexer_score_work_split.hpp
@@ -2,8 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-// Causal work-split arithmetic for indexer_score, shared by the host factory (deals
-// units across cores) and the kernels (WorkUnitSpan inverts a flat index to group/unit).
+// Work-split arithmetic for indexer_score, shared by the host factory (deals units across
+// cores) and the kernels (WorkUnitSpan inverts a flat index to group/unit).
 // Single-sourcing stops host/device desync (else cores overlap or miss output tiles).
 // Pure uint32_t math (no std::, no CT args) so it includes cleanly on both sides.
 
@@ -13,28 +13,10 @@
 
 namespace ttnn::operations::experimental::indexer_score {
 
-// Dense schedule: deal the full [0, k_len_tiles) rectangle for every group (not just its causal
-// prefix), so every group has the same unit count and the flat deal is perfectly uniform. Future
-// tiles are computed + masked to -inf in-band. Negligible cost at high sp_rank, ~2x at sp~0 -- so
-// the causal split (false) is kept for early chunks. Shared constexpr (not a CT arg) so host and
-// device read the SAME value and can never desync the unit count.
-constexpr bool dense_schedule = true;
-
-/** Causal-valid output k-tiles in q-tile-row q_row: columns [0, this) are causally visible. */
-constexpr uint32_t valid_k_tiles_in_row(uint32_t q_row, uint32_t chunk_start_tiles, uint32_t k_len_tiles) {
-    const uint32_t v = chunk_start_tiles + q_row + 1;
-    return v < k_len_tiles ? v : k_len_tiles;
-}
-
-/** k-tiles scheduled for a q-row-group. Dense: full rectangle; causal: valid k-tiles of its last
- *  (widest) row. The ONE place the schedule shape is decided; host and device derive the rest. */
-constexpr uint32_t valid_k_tiles_in_group(
-    uint32_t group, uint32_t q_tiles_per_unit, uint32_t chunk_start_tiles, uint32_t k_len_tiles) {
-    if (dense_schedule) {
-        return k_len_tiles;
-    }
-    return valid_k_tiles_in_row((group + 1) * q_tiles_per_unit - 1, chunk_start_tiles, k_len_tiles);
-}
+// Schedule: every q-row-group is dealt the full [0, k_len_tiles) k rectangle (not just its causal
+// prefix), so the flat deal is perfectly uniform across groups -- which is what lets the grid-aligned
+// multicast path apply. Future/diagonal tiles are computed and masked to -inf in-band (see
+// valid_prefix_tiles); cost is negligible at high sp_rank (~2x only near sp~0).
 
 /** Unmasked prefix k-tiles of q-tile-row q_row_abs in a unit (start k_tile_start, k_tiles_in_unit
  *  valid). Tiles [0, this) are below the diagonal (no mask); diagonal and beyond are masked. */
@@ -45,15 +27,10 @@ constexpr uint32_t valid_prefix_tiles(
     return v < k_tiles_in_unit ? v : k_tiles_in_unit;
 }
 
-/** Number of k-chunk work units in a q-row-group (ceil of its valid width over the k chunk). */
-constexpr uint32_t units_in_group(
-    uint32_t group,
-    uint32_t q_tiles_per_unit,
-    uint32_t k_tiles_per_unit,
-    uint32_t chunk_start_tiles,
-    uint32_t k_len_tiles) {
-    const uint32_t valid = valid_k_tiles_in_group(group, q_tiles_per_unit, chunk_start_tiles, k_len_tiles);
-    return (valid + k_tiles_per_unit - 1) / k_tiles_per_unit;
+/** Work units per q-row-group: ceil of the full k rectangle over the k chunk. Uniform across groups
+ *  under the dense schedule. */
+constexpr uint32_t units_in_group(uint32_t k_tiles_per_unit, uint32_t k_len_tiles) {
+    return (k_len_tiles + k_tiles_per_unit - 1) / k_tiles_per_unit;
 }
 
 }  // namespace ttnn::operations::experimental::indexer_score

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -1,0 +1,279 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Reader for indexer_score (DMA bottleneck). Walks this core's flat span of work units
+// (QC q-rows x up-to-KC k-tiles): per group pushes resident w + (if all heads fit) q,
+// per unit pushes the k chunk. Builds the [diag, full] -inf mask tiles once.
+//
+// Grid-aligned multicast: grid ROW shares q/w, grid COLUMN shares the k-band. role 1
+// (sender) reads DRAM + mcasts; role 2 (receiver) takes the L1->L1 copy; role 0 plain
+// DRAM read. Q/W (row) and K (column) mcast are independent; either may be off (role 0).
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/noc_semaphore.h"
+#include "api/dataflow/endpoints.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include "ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp"
+
+#include "indexer_score_common.hpp"  // shared CB indices, compile-time dims, work-unit walk
+
+constexpr uint32_t q_tile_bytes = get_tile_size(cb_q);     // q: bf16 or bfp8_b (smaller tile)
+constexpr uint32_t bf16_tile_bytes = get_tile_size(cb_w);  // w / mask: always bf16
+constexpr uint32_t k_tile_bytes = get_tile_size(cb_k);     // k: bf16 or bfp8_b (smaller tile)
+
+// CT arg layout after the common args: q/k/w TensorAccessors, then 8 multicast args.
+// File-scope so the semaphore ids work as template parameters.
+constexpr auto q_args = TensorAccessorArgs<num_common_ct_args>();
+constexpr auto k_args = TensorAccessorArgs<q_args.next_compile_time_args_offset()>();
+constexpr auto w_args = TensorAccessorArgs<k_args.next_compile_time_args_offset()>();
+
+// ---- multicast CT config (semaphore ids; on/off per direction) -------------------
+constexpr uint32_t mc_ct_base = w_args.next_compile_time_args_offset();
+constexpr uint32_t k_mcast_on = get_compile_time_arg_val(mc_ct_base + 0);
+constexpr uint32_t q_mcast_on = get_compile_time_arg_val(mc_ct_base + 1);  // covers q and w (shared row mcast)
+constexpr uint32_t k_send_sem = get_compile_time_arg_val(mc_ct_base + 2);
+constexpr uint32_t k_recv_sem = get_compile_time_arg_val(mc_ct_base + 3);
+constexpr uint32_t k_valid_sem = get_compile_time_arg_val(mc_ct_base + 4);
+constexpr uint32_t q_send_sem = get_compile_time_arg_val(mc_ct_base + 5);
+constexpr uint32_t q_recv_sem = get_compile_time_arg_val(mc_ct_base + 6);
+constexpr uint32_t q_valid_sem = get_compile_time_arg_val(mc_ct_base + 7);
+
+// Receiver rectangle / sender coords for one mcast direction (physical NoC), set per core on host.
+struct McastDir {
+    uint32_t role;            // 0 none (DRAM read), 1 sender (read + mcast), 2 receiver (wait for mcast)
+    uint32_t xs, ys, xe, ye;  // receiver rectangle (sender excluded by default mcast opts)
+    uint32_t sx, sy;          // sender physical coord (receivers signal it ready)
+    uint32_t ndst;            // number of receivers
+};
+
+/** Unpack a McastDir from runtime args [base, base+8) in the host's push order. */
+inline McastDir read_mcast_dir(uint32_t base) {
+    return McastDir{
+        get_arg_val<uint32_t>(base + 0),
+        get_arg_val<uint32_t>(base + 1),
+        get_arg_val<uint32_t>(base + 2),
+        get_arg_val<uint32_t>(base + 3),
+        get_arg_val<uint32_t>(base + 4),
+        get_arg_val<uint32_t>(base + 5),
+        get_arg_val<uint32_t>(base + 6),
+        get_arg_val<uint32_t>(base + 7)};
+}
+
+/** Sender: data already at `addr` from DRAM; wait all receivers ready, mcast the block,
+ *  then relay the valid flag into their recv semaphore. Mirrors chain_link. */
+template <uint32_t send_sem, uint32_t recv_sem, uint32_t valid_sem>
+inline void mcast_send(Noc noc, const McastDir& d, uint32_t addr, uint32_t bytes) {
+    Semaphore<> s(send_sem);
+    s.wait(d.ndst);  // all receivers reserved their slot and signaled ready
+    s.set(0);
+    noc.async_write_multicast(
+        CoreLocalMem<uint32_t>(addr),
+        MulticastEndpoint{},
+        bytes,
+        d.ndst,
+        {},
+        {.noc_x_start = d.xs, .noc_y_start = d.ys, .noc_x_end = d.xe, .noc_y_end = d.ye, .addr = addr},
+        /*linked=*/true);
+    // back-to-back after the linked data write (a flush/barrier between would deadlock)
+    Semaphore<>(valid_sem).relay_multicast(
+        noc, Semaphore<>(recv_sem), d.xs, d.ys, d.xe, d.ye, d.ndst, /*linked=*/false);
+    noc.async_writes_flushed();
+}
+
+/** Receiver: slot already reserved at `addr`; set recv=INVALID, signal sender ready, wait VALID. */
+template <uint32_t send_sem, uint32_t recv_sem>
+inline void mcast_recv(Noc noc, const McastDir& d) {
+    Semaphore<> r(recv_sem);
+    r.set(0);
+    Semaphore<>(send_sem).up(noc, d.sx, d.sy, 1);
+    r.wait(1);
+}
+
+/** Role-aware block read shared by the q-block, w-group and k-chunk readers. Reserve `ntiles` of cb_id;
+ *  receiver waits the sender's mcast and returns; everyone else runs `read_into(addr)` (DRAM read loop),
+ *  barriers, and (sender only) broadcasts `bytes`. read_q_rows has its own per-row variant. */
+template <uint32_t cb_id, uint32_t mcast_on, uint32_t send_sem, uint32_t recv_sem, uint32_t valid_sem, typename ReadFn>
+inline void read_block_or_mcast(Noc noc, uint32_t ntiles, uint32_t bytes, const McastDir& dir, ReadFn&& read_into) {
+    CircularBuffer cb(cb_id);
+    cb.reserve_back(ntiles);
+    const uint32_t addr = cb.get_write_ptr();
+    if constexpr (mcast_on) {
+        if (dir.role == 2) {  // receiver: wait the sender's mcast into this slot
+            mcast_recv<send_sem, recv_sem>(noc, dir);
+            cb.push_back(ntiles);
+            return;
+        }
+    }
+    read_into(addr);
+    noc.async_read_barrier();
+    if constexpr (mcast_on) {
+        if (dir.role == 1) {  // sender: broadcast the block to the rest of the rect
+            mcast_send<send_sem, recv_sem, valid_sem>(noc, dir, addr, bytes);
+        }
+    }
+    cb.push_back(ntiles);
+}
+
+inline void build_mask_tiles(Noc noc) {
+    CircularBuffer cb(cb_mask);
+    cb.reserve_back(num_mask_tiles);
+    fill_causal_diagonal_tile_bf16<bf16_tile_bytes>(noc, cb_mask, /*tile_id=*/0);  // diagonal strict-upper -inf
+    fill_neginf_tile<bf16_tile_bytes>(cb_mask, /*tile_id=*/1);                     // full -inf
+    cb.push_back(num_mask_tiles);
+}
+
+/** Read ONE q-row (heads_per_group heads x head_dim_tiles tiles, heads starting at first_head) from
+ *  DRAM into L1 at `ptr`; returns the advanced write pointer. Shared inner loop of the resident
+ *  (read_q_rows, first_head=0) and head-streaming (read_q_block, varying first_head) paths -- the q
+ *  page layout is [Hi][q_len_tiles][head_dim_tiles]. */
+template <typename QAcc>
+inline uint32_t read_q_row_into(Noc noc, const QAcc& q_acc, uint32_t ptr, uint32_t q_row_abs, uint32_t first_head) {
+    for (uint32_t h = first_head; h < first_head + heads_per_group; ++h) {
+        const uint32_t base = h * q_len_tiles * head_dim_tiles + q_row_abs * head_dim_tiles;
+        for (uint32_t d = 0; d < head_dim_tiles; ++d) {
+            noc.async_read(q_acc, CoreLocalMem<uint32_t>(ptr), q_tile_bytes, {.page_id = base + d}, {});
+            ptr += q_tile_bytes;
+        }
+    }
+    return ptr;
+}
+
+/** q head-group block [QC][heads_per_group][head_dim_tiles], role-aware (q row mcast).
+ *  ONE block / ONE mcast handshake: unit-0 startup is bound by the COUNT of mcast rendezvous,
+ *  so one handshake beats per-row streaming (which multiplies the count). */
+template <typename QAcc>
+inline void read_q_block(Noc noc, const QAcc& q_acc, uint32_t q_row_start, uint32_t first_head, const McastDir& q_dir) {
+    read_block_or_mcast<cb_q, q_mcast_on, q_send_sem, q_recv_sem, q_valid_sem>(
+        noc, q_group_tiles, q_group_tiles * q_tile_bytes, q_dir, [&](uint32_t addr) {
+            uint32_t ptr = addr;
+            for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
+                ptr = read_q_row_into(noc, q_acc, ptr, q_row_start + r, first_head);
+            }
+        });
+}
+
+/** Resident-heads q, read/mcast ONE q-row at a time (QC pushes) so compute starts row-0 matmuls while
+ *  row 1 still drains. Costs one mcast rendezvous PER ROW (QC) vs the block's one, still near the startup
+ *  optimum. QC==1 is byte-identical to read_q_block. first_head always 0 (resident). */
+template <typename QAcc>
+inline void read_q_rows(Noc noc, const QAcc& q_acc, uint32_t q_row_start, const McastDir& q_dir) {
+    constexpr uint32_t row_tiles = heads_per_group * head_dim_tiles;  // one q-row across all resident heads
+    CircularBuffer cb(cb_q);
+    cb.reserve_back(q_group_tiles);
+    const uint32_t base = cb.get_write_ptr();
+    for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
+        const uint32_t row_addr = base + r * row_tiles * q_tile_bytes;
+        if constexpr (q_mcast_on) {
+            if (q_dir.role == 2) {  // receiver: one mcast handshake per row -> row_addr
+                mcast_recv<q_send_sem, q_recv_sem>(noc, q_dir);
+                cb.push_back(row_tiles);
+                continue;
+            }
+        }
+        read_q_row_into(noc, q_acc, row_addr, q_row_start + r, /*first_head=*/0);
+        noc.async_read_barrier();
+        if constexpr (q_mcast_on) {
+            if (q_dir.role == 1) {  // sender: broadcast this row to the rest of the grid row
+                mcast_send<q_send_sem, q_recv_sem, q_valid_sem>(noc, q_dir, row_addr, row_tiles * q_tile_bytes);
+            }
+        }
+        cb.push_back(row_tiles);
+    }
+}
+
+/** resident w (gates) group [q_tiles_per_unit][num_heads], role-aware (q row mcast). */
+template <typename WAcc>
+inline void read_w_group(Noc noc, const WAcc& w_acc, uint32_t q_row_start, const McastDir& q_dir) {
+    read_block_or_mcast<cb_w, q_mcast_on, q_send_sem, q_recv_sem, q_valid_sem>(
+        noc, w_group_tiles, w_group_tiles * bf16_tile_bytes, q_dir, [&](uint32_t addr) {
+            uint32_t ptr = addr;
+            for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
+                for (uint32_t h = 0; h < num_heads; ++h) {
+                    noc.async_read(
+                        w_acc,
+                        CoreLocalMem<uint32_t>(ptr),
+                        bf16_tile_bytes,
+                        {.page_id = h * q_len_tiles + q_row_start + r},
+                        {});
+                    ptr += bf16_tile_bytes;
+                }
+            }
+        });
+}
+
+/** k chunk [k_tiles_in_unit][head_dim_tiles], role-aware (k col mcast). ONE chunk / ONE mcast
+ *  handshake to minimize startup rendezvous. */
+template <typename KAcc>
+inline void read_k_chunk(
+    Noc noc, const KAcc& k_acc, uint32_t k_tile_start, uint32_t k_tiles_in_unit, const McastDir& k_dir) {
+    // Reserves/pushes the full k_chunk_tiles to keep the 2-chunk ring half-aligned, but reads only the
+    // k_tiles_in_unit valid columns (pad slots stay stale; compute masks them).
+    read_block_or_mcast<cb_k, k_mcast_on, k_send_sem, k_recv_sem, k_valid_sem>(
+        noc, k_chunk_tiles, k_chunk_tiles * k_tile_bytes, k_dir, [&](uint32_t addr) {
+            uint32_t ptr = addr;
+            for (uint32_t c = 0; c < k_tiles_in_unit; ++c) {
+                for (uint32_t d = 0; d < head_dim_tiles; ++d) {
+                    noc.async_read(
+                        k_acc,
+                        CoreLocalMem<uint32_t>(ptr),
+                        k_tile_bytes,
+                        {.page_id = (k_tile_start + c) * head_dim_tiles + d},
+                        {});
+                    ptr += k_tile_bytes;
+                }
+            }
+        });
+}
+
+void kernel_main() {
+    const uint32_t q_addr = get_arg_val<uint32_t>(0);
+    const uint32_t k_addr = get_arg_val<uint32_t>(1);
+    const uint32_t w_addr = get_arg_val<uint32_t>(2);
+    const uint32_t flat_start = get_arg_val<uint32_t>(3);
+    const uint32_t flat_count = get_arg_val<uint32_t>(4);
+    const McastDir k_dir = read_mcast_dir(5);   // K column mcast: args [5, 13)
+    const McastDir q_dir = read_mcast_dir(13);  // Q/W row mcast: args [13, 21)
+
+    const auto q_acc = TensorAccessor(q_args, q_addr, q_tile_bytes);
+    const auto k_acc = TensorAccessor(k_args, k_addr, k_tile_bytes);
+    const auto w_acc = TensorAccessor(w_args, w_addr, bf16_tile_bytes);
+
+    Noc noc;
+
+    build_mask_tiles(noc);
+
+    WorkUnitSpan span;
+    span.start(flat_start);
+
+    // Resident-heads path order: k -> q -> w. w (gates) is consumed only in the mul phase, so read it
+    // LAST behind the latency-critical q/k. Streaming path reads w FIRST: compute's mul drains streamed
+    // q, so w must be present or compute blocks on w while the reader blocks on the full q CB => deadlock.
+    bool need_group = true;
+    for (uint32_t i = 0; i < flat_count; ++i) {
+        const bool group_start = need_group;
+        if (group_start && stream_heads) {
+            read_w_group(noc, w_acc, span.q_tile_start(), q_dir);  // gates before the streamed q
+        }
+        // k FIRST: compute waits the whole k chunk before any row, so reading k ahead of q lets the
+        // split q-row0 push unblock the first matmul (else the k wait re-serializes it).
+        read_k_chunk(noc, k_acc, span.k_tile_start(), span.k_tiles(), k_dir);
+        if (group_start && !stream_heads) {
+            read_q_rows(noc, q_acc, span.q_tile_start(), q_dir);  // per-row: compute starts on row 0
+        }
+        if constexpr (stream_heads) {
+            // one q-block per (r, c) output tile per head group; must match compute's tile order
+            for (uint32_t tile_idx = 0; tile_idx < q_tiles_per_unit * span.k_tiles(); ++tile_idx) {
+                for (uint32_t first_head = 0; first_head < num_heads; first_head += heads_per_group) {
+                    read_q_block(noc, q_acc, span.q_tile_start(), first_head, q_dir);
+                }
+            }
+        }
+        if (group_start && !stream_heads) {
+            read_w_group(noc, w_acc, span.q_tile_start(), q_dir);  // gates deferred behind q/k
+        }
+        need_group = span.advance();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/reader_indexer_score.cpp
@@ -43,7 +43,7 @@ constexpr uint32_t q_valid_sem = get_compile_time_arg_val(mc_ct_base + 7);
 
 // Receiver rectangle / sender coords for one mcast direction (physical NoC), set per core on host.
 struct McastDir {
-    uint32_t role;            // 0 none (DRAM read), 1 sender (read + mcast), 2 receiver (wait for mcast)
+    uint32_t role;            // McastRole: none (DRAM read), sender (read + mcast), receiver (wait for mcast)
     uint32_t xs, ys, xe, ye;  // receiver rectangle (sender excluded by default mcast opts)
     uint32_t sx, sy;          // sender physical coord (receivers signal it ready)
     uint32_t ndst;            // number of receivers
@@ -101,7 +101,7 @@ inline void read_block_or_mcast(Noc noc, uint32_t ntiles, uint32_t bytes, const 
     cb.reserve_back(ntiles);
     const uint32_t addr = cb.get_write_ptr();
     if constexpr (mcast_on) {
-        if (dir.role == 2) {  // receiver: wait the sender's mcast into this slot
+        if (dir.role == iscore::mcast_role_receiver) {  // wait the sender's mcast into this slot
             mcast_recv<send_sem, recv_sem>(noc, dir);
             cb.push_back(ntiles);
             return;
@@ -110,7 +110,7 @@ inline void read_block_or_mcast(Noc noc, uint32_t ntiles, uint32_t bytes, const 
     read_into(addr);
     noc.async_read_barrier();
     if constexpr (mcast_on) {
-        if (dir.role == 1) {  // sender: broadcast the block to the rest of the rect
+        if (dir.role == iscore::mcast_role_sender) {  // broadcast the block to the rest of the rect
             mcast_send<send_sem, recv_sem, valid_sem>(noc, dir, addr, bytes);
         }
     }
@@ -167,7 +167,7 @@ inline void read_q_rows(Noc noc, const QAcc& q_acc, uint32_t q_row_start, const 
     for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
         const uint32_t row_addr = base + r * row_tiles * q_tile_bytes;
         if constexpr (q_mcast_on) {
-            if (q_dir.role == 2) {  // receiver: one mcast handshake per row -> row_addr
+            if (q_dir.role == iscore::mcast_role_receiver) {  // one mcast handshake per row -> row_addr
                 mcast_recv<q_send_sem, q_recv_sem>(noc, q_dir);
                 cb.push_back(row_tiles);
                 continue;
@@ -176,7 +176,7 @@ inline void read_q_rows(Noc noc, const QAcc& q_acc, uint32_t q_row_start, const 
         read_q_row_into(noc, q_acc, row_addr, q_row_start + r, /*first_head=*/0);
         noc.async_read_barrier();
         if constexpr (q_mcast_on) {
-            if (q_dir.role == 1) {  // sender: broadcast this row to the rest of the grid row
+            if (q_dir.role == iscore::mcast_role_sender) {  // broadcast this row to the rest of the grid row
                 mcast_send<q_send_sem, q_recv_sem, q_valid_sem>(noc, q_dir, row_addr, row_tiles * q_tile_bytes);
             }
         }
@@ -264,8 +264,11 @@ void kernel_main() {
             read_q_rows(noc, q_acc, span.q_tile_start(), q_dir);  // per-row: compute starts on row 0
         }
         if constexpr (stream_heads) {
-            // one q-block per (r, c) output tile per head group; must match compute's tile order
-            for (uint32_t tile_idx = 0; tile_idx < q_tiles_per_unit * span.k_tiles(); ++tile_idx) {
+            // one q-block per (r, c) output tile per head group; must match compute's tile order, which
+            // walks the FULL k_tiles_per_unit columns (compute masks the padded tail of a partial last
+            // unit). Using span.k_tiles() here would under-produce q blocks on a partial unit and hang
+            // compute, which still waits/pops a q block for every padded column.
+            for (uint32_t tile_idx = 0; tile_idx < q_tiles_per_unit * k_tiles_per_unit; ++tile_idx) {
                 for (uint32_t first_head = 0; first_head < num_heads; first_head += heads_per_group) {
                     read_q_block(noc, q_acc, span.q_tile_start(), first_head, q_dir);
                 }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
@@ -3,29 +3,21 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Writer for indexer_score. Pops untilized bf16 strips and scatters each strip's
-// 32 rows into the row-major output (page = row, one contiguous run per row).
-// The owner of a group's last unit fills row tails [valid_k_tiles*32, T)
-// with -inf; compute already covers [0, valid_k_tiles) for every row.
+// 32 rows into the row-major output (page = row, one contiguous run per row). Under the dense schedule
+// compute covers every column of every row (future keys already stamped to -inf), so the writer just
+// scatters each unit's strip -- there is no separate row-tail fill.
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include <tt-metalium/constants.hpp>
-#include "ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp"
 
 #include "indexer_score_common.hpp"  // shared CB indices, compile-time dims, work-unit walk
 
 constexpr uint32_t page_bytes = get_compile_time_arg_val(num_common_ct_args);  // row-major page = T*2 bytes
 
 constexpr uint32_t frag_bytes = tt::constants::TILE_WIDTH * sizeof(uint16_t);  // one bf16 tile row
-constexpr uint32_t scratch_bytes = tt::constants::TILE_HW * sizeof(uint16_t);
-
-/** Stamp the -inf scratch tile (plain L1 stores) and return its L1 address for reuse as a fill source. */
-inline uint32_t fill_inf_scratch_and_get_addr() {
-    fill_neginf_tile<scratch_bytes>(cb_scratch, /*tile_id=*/0);
-    return CircularBuffer(cb_scratch).get_write_ptr();
-}
 
 /** Scatter one strip into the 32 output rows of q-tile-row q_row at column tile k_tile_start. Strip is
  *  always KC tiles wide; each row written as ONE contiguous run (1 async_write/row, not KC fragments).
@@ -51,40 +43,6 @@ inline void write_strip(Noc noc, const OutAcc& out_acc, uint32_t q_row, uint32_t
     cb.pop_front(k_tiles_per_unit);
 }
 
-/** Fill the group's row tails [tail_start_tiles*32, T) with -inf from the L1 scratch tile.
- *  Tail starts at the group's valid width (same column for every row), NOT each row's own valid
- *  length -- this keeps the fill disjoint from compute's output, so cores sharing a group never
- *  double-write the same bytes. */
-template <typename OutAcc>
-inline void fill_group_tails(
-    Noc noc, const OutAcc& out_acc, uint32_t scratch, uint32_t q_tile_start, uint32_t tail_start_tiles) {
-    if (tail_start_tiles >= k_len_tiles) {
-        return;  // group is fully causal-valid, no tail
-    }
-    const uint32_t tail_bytes_total = (k_len_tiles - tail_start_tiles) * frag_bytes;
-    const uint32_t base_off = tail_start_tiles * frag_bytes;
-    for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
-        for (uint32_t rr = 0; rr < tt::constants::TILE_HEIGHT; ++rr) {
-            uint32_t off = base_off;
-            uint32_t left = tail_bytes_total;
-            while (left > 0) {
-                // chunk == scratch tile size: the -inf source is exactly one tile, so each write
-                // copies at most a tile-worth of bytes before reusing the same source.
-                const uint32_t n = left < scratch_bytes ? left : scratch_bytes;
-                noc.async_write(
-                    CoreLocalMem<uint32_t>(scratch),
-                    out_acc,
-                    n,
-                    {},
-                    {.page_id = (q_tile_start + r) * tt::constants::TILE_HEIGHT + rr, .offset_bytes = off});
-                off += n;
-                left -= n;
-            }
-        }
-    }
-    noc.async_write_barrier();
-}
-
 void kernel_main() {
     const uint32_t out_addr = get_arg_val<uint32_t>(0);
     const uint32_t flat_start = get_arg_val<uint32_t>(1);
@@ -95,8 +53,6 @@ void kernel_main() {
 
     Noc noc;
 
-    const uint32_t scratch = fill_inf_scratch_and_get_addr();
-
     WorkUnitSpan span;
     span.start(flat_start);
 
@@ -106,9 +62,6 @@ void kernel_main() {
         // One KC-wide strip per row; masked suffix already stamped by compute. Write only valid_w columns.
         for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
             write_strip(noc, out_acc, span.q_tile_start() + r, k_tile0, valid_w);
-        }
-        if (span.last_in_group()) {
-            fill_group_tails(noc, out_acc, scratch, span.q_tile_start(), span.valid_k_tiles());
         }
         span.advance();
     }

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
@@ -4,8 +4,8 @@
 
 // Writer for indexer_score. Pops untilized bf16 strips and scatters each strip's
 // 32 rows into the row-major output (page = row, one contiguous run per row).
-// The owner of a group's last unit fills row tails [group_valid_k_tiles*32, T)
-// with -inf; compute already covers [0, group_valid_k_tiles) for every row.
+// The owner of a group's last unit fills row tails [valid_k_tiles*32, T)
+// with -inf; compute already covers [0, valid_k_tiles) for every row.
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/device/kernels/writer_indexer_score.cpp
@@ -1,0 +1,115 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Writer for indexer_score. Pops untilized bf16 strips and scatters each strip's
+// 32 rows into the row-major output (page = row, one contiguous run per row).
+// The owner of a group's last unit fills row tails [group_valid_k_tiles*32, T)
+// with -inf; compute already covers [0, group_valid_k_tiles) for every row.
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/core_local_mem.h"
+#include <tt-metalium/constants.hpp>
+#include "ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp"
+
+#include "indexer_score_common.hpp"  // shared CB indices, compile-time dims, work-unit walk
+
+constexpr uint32_t page_bytes = get_compile_time_arg_val(num_common_ct_args);  // row-major page = T*2 bytes
+
+constexpr uint32_t frag_bytes = tt::constants::TILE_WIDTH * sizeof(uint16_t);  // one bf16 tile row
+constexpr uint32_t scratch_bytes = tt::constants::TILE_HW * sizeof(uint16_t);
+
+/** Stamp the -inf scratch tile (plain L1 stores) and return its L1 address for reuse as a fill source. */
+inline uint32_t fill_inf_scratch_and_get_addr() {
+    fill_neginf_tile<scratch_bytes>(cb_scratch, /*tile_id=*/0);
+    return CircularBuffer(cb_scratch).get_write_ptr();
+}
+
+/** Scatter one strip into the 32 output rows of q-tile-row q_row at column tile k_tile_start. Strip is
+ *  always KC tiles wide; each row written as ONE contiguous run (1 async_write/row, not KC fragments).
+ *  `valid_w` = KC tiles inside T (< KC on a partial last unit; KC need not divide Tt). CB always pops
+ *  full KC; only the in-bounds prefix is written. */
+template <typename OutAcc>
+inline void write_strip(Noc noc, const OutAcc& out_acc, uint32_t q_row, uint32_t k_tile_start, uint32_t valid_w) {
+    CircularBuffer cb(cb_out_strip);
+    cb.wait_front(k_tiles_per_unit);
+    uint32_t src = cb.get_read_ptr();
+    const uint32_t row_pitch = k_tiles_per_unit * frag_bytes;  // strip row stride (full KC)
+    const uint32_t write_bytes = valid_w * frag_bytes;         // only the in-bounds columns
+    for (uint32_t rr = 0; rr < tt::constants::TILE_HEIGHT; ++rr) {
+        noc.async_write(
+            CoreLocalMem<uint32_t>(src),
+            out_acc,
+            write_bytes,
+            {},
+            {.page_id = q_row * tt::constants::TILE_HEIGHT + rr, .offset_bytes = k_tile_start * frag_bytes});
+        src += row_pitch;
+    }
+    noc.async_write_barrier();
+    cb.pop_front(k_tiles_per_unit);
+}
+
+/** Fill the group's row tails [tail_start_tiles*32, T) with -inf from the L1 scratch tile.
+ *  Tail starts at the group's valid width (same column for every row), NOT each row's own valid
+ *  length -- this keeps the fill disjoint from compute's output, so cores sharing a group never
+ *  double-write the same bytes. */
+template <typename OutAcc>
+inline void fill_group_tails(
+    Noc noc, const OutAcc& out_acc, uint32_t scratch, uint32_t q_tile_start, uint32_t tail_start_tiles) {
+    if (tail_start_tiles >= k_len_tiles) {
+        return;  // group is fully causal-valid, no tail
+    }
+    const uint32_t tail_bytes_total = (k_len_tiles - tail_start_tiles) * frag_bytes;
+    const uint32_t base_off = tail_start_tiles * frag_bytes;
+    for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
+        for (uint32_t rr = 0; rr < tt::constants::TILE_HEIGHT; ++rr) {
+            uint32_t off = base_off;
+            uint32_t left = tail_bytes_total;
+            while (left > 0) {
+                // chunk == scratch tile size: the -inf source is exactly one tile, so each write
+                // copies at most a tile-worth of bytes before reusing the same source.
+                const uint32_t n = left < scratch_bytes ? left : scratch_bytes;
+                noc.async_write(
+                    CoreLocalMem<uint32_t>(scratch),
+                    out_acc,
+                    n,
+                    {},
+                    {.page_id = (q_tile_start + r) * tt::constants::TILE_HEIGHT + rr, .offset_bytes = off});
+                off += n;
+                left -= n;
+            }
+        }
+    }
+    noc.async_write_barrier();
+}
+
+void kernel_main() {
+    const uint32_t out_addr = get_arg_val<uint32_t>(0);
+    const uint32_t flat_start = get_arg_val<uint32_t>(1);
+    const uint32_t flat_count = get_arg_val<uint32_t>(2);
+
+    constexpr auto out_args = TensorAccessorArgs<num_common_ct_args + 1>();
+    const auto out_acc = TensorAccessor(out_args, out_addr, page_bytes);
+
+    Noc noc;
+
+    const uint32_t scratch = fill_inf_scratch_and_get_addr();
+
+    WorkUnitSpan span;
+    span.start(flat_start);
+
+    for (uint32_t i = 0; i < flat_count; ++i) {
+        const uint32_t k_tile0 = span.k_tile_start();
+        const uint32_t valid_w = span.k_tiles();  // == KC for interior units, < KC for a partial last unit
+        // One KC-wide strip per row; masked suffix already stamped by compute. Write only valid_w columns.
+        for (uint32_t r = 0; r < q_tiles_per_unit; ++r) {
+            write_strip(noc, out_acc, span.q_tile_start() + r, k_tile0, valid_w);
+        }
+        if (span.last_in_group()) {
+            fill_group_tails(noc, out_acc, scratch, span.q_tile_start(), span.valid_k_tiles());
+        }
+        span.advance();
+    }
+}

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score.hpp
@@ -1,0 +1,9 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Public op surface: the ttnn.experimental.indexer_score callable and the
+// IndexerScoreProgramConfig knobs are declared by the device operation header.
+#include "device/indexer_score_device_operation.hpp"

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -29,14 +29,18 @@ void bind_indexer_score(nb::module_& mod) {
         score[b, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
 
         Args:
-            q: [B, Hi, Sq, D] bf16 tiled (post non-interleaved RoPE)
-            k: [B, 1, T, D] bf16 tiled, single shared head
+            q: [B, Hi, Sq, D] bf16 or bfp8_b tiled (post non-interleaved RoPE)
+            k: [B, 1, T, D] bf16 or bfp8_b tiled, single shared head
             weights: [B, Hi, Sq, 1] bf16 tiled, scales pre-folded
             chunk_start_idx: global position of query row 0 (causality: key t
                 visible to query s iff t <= chunk_start_idx + s)
             program_config: work-unit knobs (q_chunk_size, k_chunk_size,
                 head_group_size; elements, tile-aligned). Defaults always fit
                 L1; raise head_group_size (0 = all resident) for performance.
+            compute_kernel_config: optional DeviceComputeKernelConfig. Only
+                math_fidelity is honored (default: HiFi2, or LoFi when q and k
+                are both bfloat8_b); fp32_dest_acc_en / dst_full_sync_en must
+                stay false (the custom LLK is validated for bf16 DEST half-sync).
 
         Returns: score [B, 1, Sq, T] bf16 row-major; future/pad columns -inf.
         )doc",
@@ -46,7 +50,8 @@ void bind_indexer_score(nb::module_& mod) {
         nb::arg("weights"),
         nb::kw_only(),
         nb::arg("chunk_start_idx") = 0,
-        nb::arg("program_config") = IndexerScoreProgramConfig{});
+        nb::arg("program_config") = IndexerScoreProgramConfig{},
+        nb::arg("compute_kernel_config") = std::nullopt);
 }
 
 }  // namespace ttnn::operations::experimental::indexer_score::detail

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "indexer_score_nanobind.hpp"
+
+#include "ttnn-nanobind/bind_function.hpp"
+#include "indexer_score.hpp"
+
+namespace ttnn::operations::experimental::indexer_score::detail {
+
+void bind_indexer_score(nb::module_& mod) {
+    nb::class_<IndexerScoreProgramConfig>(mod, "IndexerScoreProgramConfig")
+        .def(
+            nb::init<std::size_t, std::size_t, std::size_t>(),
+            nb::kw_only(),
+            nb::arg("q_chunk_size") = 32,
+            nb::arg("k_chunk_size") = 32,
+            nb::arg("head_group_size") = 1)
+        .def_rw("q_chunk_size", &IndexerScoreProgramConfig::q_chunk_size)
+        .def_rw("k_chunk_size", &IndexerScoreProgramConfig::k_chunk_size)
+        .def_rw("head_group_size", &IndexerScoreProgramConfig::head_group_size);
+
+    ttnn::bind_function<"indexer_score", "ttnn.experimental.">(
+        mod,
+        R"doc(
+        DeepSeek-V3.2 DSA lightning-indexer scorer.
+
+        score[b, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]
+
+        Args:
+            q: [B, Hi, Sq, D] bf16 tiled (post non-interleaved RoPE)
+            k: [B, 1, T, D] bf16 tiled, single shared head
+            weights: [B, Hi, Sq, 1] bf16 tiled, scales pre-folded
+            chunk_start_idx: global position of query row 0 (causality: key t
+                visible to query s iff t <= chunk_start_idx + s)
+            program_config: work-unit knobs (q_chunk_size, k_chunk_size,
+                head_group_size; elements, tile-aligned). Defaults always fit
+                L1; raise head_group_size (0 = all resident) for performance.
+
+        Returns: score [B, 1, Sq, T] bf16 row-major; future/pad columns -inf.
+        )doc",
+        &ttnn::experimental::indexer_score,
+        nb::arg("q"),
+        nb::arg("k"),
+        nb::arg("weights"),
+        nb::kw_only(),
+        nb::arg("chunk_start_idx") = 0,
+        nb::arg("program_config") = IndexerScoreProgramConfig{});
+}
+
+}  // namespace ttnn::operations::experimental::indexer_score::detail

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.hpp
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn-nanobind/nanobind_fwd.hpp"
+
+namespace ttnn::operations::experimental::indexer_score::detail {
+
+namespace nb = nanobind;
+void bind_indexer_score(nb::module_& mod);
+
+}  // namespace ttnn::operations::experimental::indexer_score::detail

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/sources.cmake
@@ -1,0 +1,9 @@
+# Source files for ttnn_op_experimental_indexer_score.
+# Module owners should update this file when adding/removing/renaming source files.
+
+set(TTNN_OP_EXPERIMENTAL_INDEXER_SCORE_API_HEADERS indexer_score.hpp)
+
+set(TTNN_OP_EXPERIMENTAL_INDEXER_SCORE_SRCS
+    device/indexer_score_device_operation.cpp
+    device/indexer_score_program_factory.cpp
+)

--- a/ttnn/cpp/ttnn/operations/experimental/indexer_score/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/experimental/indexer_score/sources.cmake
@@ -1,7 +1,14 @@
 # Source files for ttnn_op_experimental_indexer_score.
 # Module owners should update this file when adding/removing/renaming source files.
 
-set(TTNN_OP_EXPERIMENTAL_INDEXER_SCORE_API_HEADERS indexer_score.hpp)
+# Install the full public-header chain (indexer_score.hpp pulls in the device headers transitively),
+# mirroring topk_large_indices, so external ttnn-dev consumers can include the op.
+set(TTNN_OP_EXPERIMENTAL_INDEXER_SCORE_API_HEADERS
+    indexer_score.hpp
+    device/indexer_score_device_operation.hpp
+    device/indexer_score_device_operation_types.hpp
+    device/indexer_score_program_factory.hpp
+)
 
 set(TTNN_OP_EXPERIMENTAL_INDEXER_SCORE_SRCS
     device/indexer_score_device_operation.cpp

--- a/ttnn/sources.cmake
+++ b/ttnn/sources.cmake
@@ -173,6 +173,7 @@ set(TTNN_SRC_PYBIND
     cpp/ttnn/operations/experimental/topk_large_indices/topk_large_indices_nanobind.cpp
     cpp/ttnn/operations/experimental/topk_router_gpt/topk_router_gpt_nanobind.cpp
     cpp/ttnn/operations/experimental/deepseek/mla/matmul_wo/matmul_wo_nanobind.cpp
+    cpp/ttnn/operations/experimental/indexer_score/indexer_score_nanobind.cpp
     cpp/ttnn/operations/experimental/ccl/moe_gpt/moe_gpt_nanobind.cpp
     cpp/ttnn/operations/experimental/deepseek_prefill/dispatch/dispatch_nanobind.cpp
     cpp/ttnn/operations/experimental/deepseek_prefill/combine/combine_nanobind.cpp

--- a/ttnn/ttnn/__init__.py
+++ b/ttnn/ttnn/__init__.py
@@ -547,6 +547,8 @@ Conv1dConfig = ttnn._ttnn.operations.conv.Conv2dConfig
 
 from ttnn.operations.transformer import SDPAProgramConfig
 
+IndexerScoreProgramConfig = ttnn._ttnn.operations.experimental.IndexerScoreProgramConfig
+
 import ttnn.graph
 
 if importlib.util.find_spec("torch") is not None:


### PR DESCRIPTION
## Summary

Adds `ttnn.experimental.indexer_score`, the DeepSeek-style DSA **lightning-indexer** scorer for Blackhole:

```
score[b, s, t] = sum_h relu(q[b,h,s,:] . k[b,t,:]) * weights[b,h,s]

q [B, Hi, Sq, D], k [B, 1, T, D], weights [B, Hi, Sq, 1]  ->  score [B, 1, Sq, T]  (row-major bf16)
```

Causality is driven by a scalar `chunk_start_idx`: key `t` is visible to query `s` iff `t <= chunk_start_idx + s`.

## What it is / how it's used

The lightning indexer is the cheap pre-filter of DeepSeek-style sparse attention: for each query it scores every key, and a downstream row-major top-k selects the few keys that the full attention then attends to. This op produces those per-key scores — a gated, ReLU'd, head-summed q·kᵀ — during chunked prefill. It backs two deployments: **GLM5.1** (8-head indexer) and **DeepSeek-V3.2** (16-head, the 64-head indexer sharded across TP=4). Sequence-parallelism enters only through `chunk_start_idx`, so each rank runs single-chip and the op feeds straight into the sibling `topk_large_indices` op.

## Implementation

- **Work split / data movement:** output-stationary flat work-unit deal with grid-aligned multicast (q/w along grid rows, k down columns; SDPA-style 3-semaphore chain-link handshake), with a per-core DRAM-read fallback.
- **Compute (3 phases):** matmul `relu(q·kᵀ)` into a head-major buffer → blocked bcast-col gate-multiply with dest-MAC head reduction → fast `pack_untilize`.
- **Custom Blackhole LLK:** blocked bcast-col MUL with per-head dest-MAC reduction, single-sourced with SDPA's blocked-sub scaffold (`_llk_math_bcast_cols_reuse_custom_`).
- **Flexible precision:** q (srcB) and k (srcA) may each be bf16 or bfp8_b (weights bf16); both bfp8 drops the matmul to LoFi. PCC ≥ 0.999 across all dtype combos.
- **Tuning + validation:** `IndexerScoreProgramConfig` (QC/KC/head_group) with per-deployment presets; host-side guards reject ill-formed/oversized configs before launch. Nightly Blackhole tests cover GLM5.1/DSv3.2 accuracy plus a config-knob sweep, shape/corner coverage, and a tracy math-util check.

## Performance (sp_rank 7, Blackhole, fp16 q + bfp8 k, HiFi2)

| Deployment | Heads | Math util | Device time |
|---|---|---|---|
| GLM5.1 | 8 | 70.1% | 0.345 ms |
| DeepSeek-V3.2 | 16 | 76.1% | 0.634 ms |

## Test plan

CI pipelines dispatched on this branch — badges show the latest run on `skrstic/indexer_score_op`:

[![Nightly tt-metal L2 tests](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/indexer_score_op)](https://github.com/tenstorrent/tt-metal/actions/runs/27619427597)
[![Blackhole post-commit tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/indexer_score_op)](https://github.com/tenstorrent/tt-metal/actions/runs/27618713907)
[![Sanity tests](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/indexer_score_op)](https://github.com/tenstorrent/tt-metal/actions/runs/27618716052)

- **Nightly tt-metal L2 (Blackhole)** — runs the op's `experimental` nightly suite (where `test_indexer_score.py` lives).
- **Blackhole post-commit** — Blackhole build + unit/sanity.
- **Sanity tests** — general build + TTNN unit-test sanity.

Local Blackhole validation (rebased onto `main`, rebuilt): accuracy **26/26** (GLM5.1/DSv3.2 deployments + config-knob sweep + shape/corner coverage), math-util **GLM5.1 70.1% / DSv3.2 76.1%**, and an SDPA `test_sdpa_noncausal` smoke test confirming the shared-LLK rename does not regress SDPA.

## For reviewers

An illustrated, interactive walkthrough of the op — the work-split + grid-aligned multicast, the three compute phases, the custom blocked bcast-col LLK, and the writer's masked-tail fill — is available as a self-contained page (it is **not** part of the diff; review aid only):

- **▶️ Rendered (interactive):** https://htmlpreview.github.io/?https://gist.githubusercontent.com/skrsticTT/9c5376af1ed8adeb0a169f91538069bd/raw/291bfbf8dc1f5334adee0fa2a9b2bd2232bb035b/indexer.html
- **Source gist:** https://gist.github.com/skrsticTT/9c5376af1ed8adeb0a169f91538069bd

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=skrstic/indexer_score_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:skrstic/indexer_score_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=skrstic/indexer_score_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:skrstic/indexer_score_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/indexer_score_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:skrstic/indexer_score_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=skrstic/indexer_score_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:skrstic/indexer_score_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=skrstic/indexer_score_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:skrstic/indexer_score_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=skrstic/indexer_score_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:skrstic/indexer_score_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=skrstic/indexer_score_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:skrstic/indexer_score_op)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=skrstic/indexer_score_op)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:skrstic/indexer_score_op)