### PR TITLE
[tt-transformers] Qwen3-32B p300x2: disable batched prefill for seeded-sampling determinism (workaround for tt-inference-server#4004)

### DIFF
--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -596,7 +596,7 @@ class ModelArgs:
 
         # Set the max number of tokens for each prefill chunk based on the model and device
         self.max_prefill_chunk_size = self.get_max_prefill_chunk_size()
-
+        # TODO: Enable batched_prefill once this is fixed: https://github.com/tenstorrent/tt-metal/issues/47238
         # Qwen3-32B prefill logits are batch-variant on multi-chip Blackhole: the
         # float-reduction order in the prefill matmul/attention depends on the
         # batched-token count, so identical same-seed requests that land in

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -597,6 +597,16 @@ class ModelArgs:
         # Set the max number of tokens for each prefill chunk based on the model and device
         self.max_prefill_chunk_size = self.get_max_prefill_chunk_size()
 
+        # Qwen3-32B prefill logits are batch-variant on multi-chip Blackhole: the
+        # float-reduction order in the prefill matmul/attention depends on the
+        # batched-token count, so identical same-seed requests that land in
+        # different-sized prefill batches get slightly different logits. Seeded
+        # sampling under concurrency then diverges (tt-inference-server#4004,
+        # test_non_uniform_seeding). Forcing per-user batch-1 prefill removes the
+        # variance. Workaround until the prefill kernels are batch-invariant;
+        # mirrors the existing Llama-3.1-8B P300/P150x8 handling.
+        self.disable_batched_prefill = self.base_model_name == "Qwen3-32B" and self.device_name == "P150x4"
+
         if (
             self.base_model_name
             in ["Llama-3.1-8B", "Llama-3.2-11B", "Mistral-7B", "gemma-3-27b", "gemma-3-4b", "Phi-4"]


### PR DESCRIPTION
## What
Disable batched prefill for **Qwen3-32B on P150x4 (p300x2)** so each request prefills at batch-1.

## Why it's failing (tt-inference-server#4004)
Ref: https://github.com/tenstorrent/tt-inference-server/issues/4004 — `test_non_uniform_seeding` fails (two `seed=0` requests return different text).

Root cause, confirmed on hardware (Qwen3-32B, p300x2):
- The model's **prefill logits are not batch-invariant**. Float reductions in the prefill matmul/attention are non-associative, and their order depends on the batched-token count (the prefill matmul program config — grid / `in0_block_w` — is a function of `seq_len`/batch).
- So identical, same-seed requests that get scheduled into **different-sized prefill batches** receive slightly different logits. Measured directly: position-0 top-k logprobs differ (e.g. `</think>` −16.75 vs −16.5) between a batch-1 request and an 8-way batched one, same input.
- **Greedy/argmax is robust** to these sub-LSB differences (top token unchanged) → `temperature=0`/`top_k=1`/`top_p=0.01` pass. **Seeded categorical sampling is sensitive** (the shifted distribution + fixed RNG draw eventually selects a different token) → `test_non_uniform_seeding` fails, flakily, under concurrency.
- Sampling mode (host vs on-device) is irrelevant: both consume the same batch-variant logits.

## The change
`generator.py`'s `use_batched_prefill` gate already honors `disable_batched_prefill`; this only adds the model/device condition in `ModelConfig`. Forcing per-user batch-1 prefill removes the batched-prefill variance. Mirrors the existing **Llama-3.1-8B P300/P150x8** handling.

## This is a WORKAROUND
The prefill kernels remain batch-variant; this just avoids the batched path (decode batching is already invariant). The real fix is **batch-invariant prefill** (fixed reduction order / pinned matmul grid + `in0_block_w` independent of batch). Tracking that separately.

## Verification (Qwen3-32B p300x2, host **and** on-device sampling)
The tt-inference-server determinism suite passes, including the previously-failing `test_non_uniform_seeding`:
```
test_seed_reproducibility ................. PASSED
test_non_uniform_seeding .................. PASSED
test_determinism_parameters[temperature-0.0] PASSED
test_determinism_parameters[top_k-1] ...... PASSED
test_determinism_parameters[top_p-0.01] ... PASSED
```
Plus a focused repro (8-concurrent `seed=0`, 5 trials): all deterministic (was 7-vs-1 every trial before).

## Tradeoff
Batched prefill is a throughput optimization; disabling it serializes prefills (higher TTFT / lower prefill throughput under concurrent load) — the same tradeoff already accepted for Llama-3.1-8B on P300/P150x8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
✅  Models CI: https://github.com/tenstorrent/tt-shield/actions/runs/27621047919/job/81686844194