### PR TITLE
Dgomez/fix hash collision 45821 operations

### DIFF
--- a/tt-train/sources/ttml/metal/ops/moe_group/device/moe_group_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/moe_group/device/moe_group_device_operation.cpp
@@ -132,12 +132,6 @@ tensor_return_value_t MoeGroupDeviceOperation::create_output_tensors(
     };
 }
 
-ttsl::hash::hash_t MoeGroupDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& args) {
-    return tt::tt_metal::operation::hash_operation<MoeGroupDeviceOperation>(
-        attrs, args.dispatched.dtype(), args.dispatched.logical_shape());
-}
-
 }  // namespace ttml::metal::ops::moe_group::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/moe_group/device/moe_group_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/moe_group/device/moe_group_device_operation.hpp
@@ -24,8 +24,6 @@ struct MoeGroupDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::moe_group::device

--- a/tt-train/sources/ttml/metal/ops/polynorm_bw/device/polynorm_bw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/polynorm_bw/device/polynorm_bw_device_operation.cpp
@@ -142,13 +142,6 @@ PolyNorm3BWTensorReturn PolyNorm3BackwardDeviceOperation::create_output_tensors(
     return output_tensors;
 }
 
-ttsl::hash::hash_t PolyNorm3BackwardDeviceOperation::compute_program_hash(
-    const PolyNorm3BWAttributes& args, const PolyNorm3BWTensorArgs& tensor_args) {
-    const auto& input = tensor_args.input;
-    return tt::tt_metal::operation::hash_operation<PolyNorm3BackwardDeviceOperation>(
-        args.epsilon, input.dtype(), input.logical_shape());
-}
-
 }  // namespace ttml::metal::ops::polynorm3_bw::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/polynorm_bw/device/polynorm_bw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/polynorm_bw/device/polynorm_bw_device_operation.hpp
@@ -20,7 +20,6 @@ struct PolyNorm3BackwardDeviceOperation {
     static void validate_on_program_cache_miss(const PolyNorm3BWAttributes&, const PolyNorm3BWTensorArgs&);
     static PolyNorm3BWSpecReturn compute_output_specs(const PolyNorm3BWAttributes&, const PolyNorm3BWTensorArgs&);
     static PolyNorm3BWTensorReturn create_output_tensors(const PolyNorm3BWAttributes&, const PolyNorm3BWTensorArgs&);
-    static ttsl::hash::hash_t compute_program_hash(const PolyNorm3BWAttributes&, const PolyNorm3BWTensorArgs&);
 };
 
 }  // namespace ttml::metal::ops::polynorm3_bw::device

--- a/tt-train/sources/ttml/metal/ops/polynorm_fw/device/polynorm_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/polynorm_fw/device/polynorm_fw_device_operation.cpp
@@ -68,13 +68,6 @@ PolyNorm3FWTensorReturn PolyNorm3ForwardDeviceOperation::create_output_tensors(
     return create_device_tensor(specs[0], tensor_args.input.device());
 }
 
-ttsl::hash::hash_t PolyNorm3ForwardDeviceOperation::compute_program_hash(
-    const PolyNorm3FWAttributes& args, const PolyNorm3FWTensorArgs& tensor_args) {
-    const auto& input = tensor_args.input;
-    return tt::tt_metal::operation::hash_operation<PolyNorm3ForwardDeviceOperation>(
-        args, input.dtype(), input.logical_shape());
-}
-
 }  // namespace ttml::metal::ops::polynorm3_fw::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/polynorm_fw/device/polynorm_fw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/polynorm_fw/device/polynorm_fw_device_operation.hpp
@@ -22,7 +22,6 @@ struct PolyNorm3ForwardDeviceOperation {
     static void validate_on_program_cache_miss(const PolyNorm3FWAttributes&, const PolyNorm3FWTensorArgs&);
     static PolyNorm3FWSpecReturn compute_output_specs(const PolyNorm3FWAttributes&, const PolyNorm3FWTensorArgs&);
     static PolyNorm3FWTensorReturn create_output_tensors(const PolyNorm3FWAttributes&, const PolyNorm3FWTensorArgs&);
-    static ttsl::hash::hash_t compute_program_hash(const PolyNorm3FWAttributes&, const PolyNorm3FWTensorArgs&);
 };
 
 }  // namespace ttml::metal::ops::polynorm3_fw::device

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_kv_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_kv_device_operation.cpp
@@ -62,21 +62,6 @@ RingSDPABwKVDeviceOperation::tensor_return_value_t RingSDPABwKVDeviceOperation::
     return {grad_key, grad_value};
 }
 
-ttsl::hash::hash_t RingSDPABwKVDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    // Hash based on operation configuration - buffer addresses are updated via override_runtime_arguments
-    return ttsl::hash::hash_objects(
-        1,  // KV marker (different from Q)
-        attrs.ring_size,
-        attrs.ring_axis,
-        attrs.step,
-        static_cast<int>(attrs.mask_type),
-        static_cast<int>(attrs.ring_direction),
-        tensor_args.query.tensor_spec().logical_shape(),
-        tensor_args.query.dtype(),
-        tensor_args.key.tensor_spec().logical_shape());
-}
-
 }  // namespace ttml::metal::ops::ring_sdpa_bw::kv
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_kv_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_kv_device_operation.hpp
@@ -29,8 +29,6 @@ struct RingSDPABwKVDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::ring_sdpa_bw::kv

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_q_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_q_device_operation.cpp
@@ -59,20 +59,6 @@ RingSDPABwQDeviceOperation::tensor_return_value_t RingSDPABwQDeviceOperation::cr
     return {grad_query, u_scaler};
 }
 
-ttsl::hash::hash_t RingSDPABwQDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    return ttsl::hash::hash_objects(
-        0,  // Q marker (different from KV)
-        attrs.ring_size,
-        attrs.ring_axis,
-        attrs.step,
-        static_cast<int>(attrs.mask_type),
-        static_cast<int>(attrs.ring_direction),
-        tensor_args.query.logical_shape(),
-        tensor_args.query.dtype(),
-        tensor_args.key.logical_shape());
-}
-
 }  // namespace ttml::metal::ops::ring_sdpa_bw::q
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_q_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/ring_sdpa_bw/device/ring_sdpa_bw_q_device_operation.hpp
@@ -29,8 +29,6 @@ struct RingSDPABwQDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::ring_sdpa_bw::q

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation.cpp
@@ -184,20 +184,6 @@ SDPABackwardKVDeviceOperation::tensor_return_value_t SDPABackwardKVDeviceOperati
     return {grad_key, grad_value};
 }
 
-ttsl::hash::hash_t SDPABackwardKVDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto hash = tt::tt_metal::operation::hash_operation<SDPABackwardKVDeviceOperation>(
-        operation_attributes,
-        operation_attributes.mask_type,
-        tensor_args.query.logical_shape(),
-        tensor_args.key.logical_shape(),
-        tensor_args.value.logical_shape(),
-        tensor_args.intermediates.logical_shape(),
-        tensor_args.query.dtype());
-
-    return hash;
-}
-
 }  // namespace ttml::metal::ops::sdpa_bw::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_kv_device_operation.hpp
@@ -23,8 +23,6 @@ struct SDPABackwardKVDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::sdpa_bw::device

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation.cpp
@@ -178,20 +178,6 @@ SDPABackwardQDeviceOperation::tensor_return_value_t SDPABackwardQDeviceOperation
     return {grad_query, u_scaler};
 }
 
-ttsl::hash::hash_t SDPABackwardQDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto hash = tt::tt_metal::operation::hash_operation<SDPABackwardQDeviceOperation>(
-        operation_attributes,
-        tensor_args.query.logical_shape(),
-        tensor_args.key.logical_shape(),
-        tensor_args.value.logical_shape(),
-        tensor_args.intermediates.logical_shape(),
-        tensor_args.query.dtype(),
-        operation_attributes.mask_type);
-
-    return hash;
-}
-
 }  // namespace ttml::metal::ops::sdpa_bw::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_bw/device/sdpa_bw_q_device_operation.hpp
@@ -23,8 +23,6 @@ struct SDPABackwardQDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::sdpa_bw::device

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.cpp
@@ -248,20 +248,6 @@ tensor_return_value_t SDPAForwardDeviceOperation::create_output_tensors(
     return output_tensors;
 }
 
-ttsl::hash::hash_t SDPAForwardDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& query_tensor = tensor_args.query;
-    const auto& query_logical_shape = query_tensor.logical_shape();
-    const auto& key_tensor = tensor_args.key;
-    const auto& key_logical_shape = key_tensor.logical_shape();
-    const auto& value_tensor = tensor_args.value;
-    const auto& value_logical_shape = value_tensor.logical_shape();
-    tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<SDPAForwardDeviceOperation>(
-        args, query_tensor.dtype(), query_logical_shape, key_logical_shape, value_logical_shape);
-
-    return hash;
-}
-
 }  // namespace ttml::metal::ops::sdpa_fw::device
 
 namespace ttnn::prim {

--- a/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.hpp
+++ b/tt-train/sources/ttml/metal/ops/sdpa_fw/device/sdpa_fw_device_operation.hpp
@@ -23,8 +23,6 @@ struct SDPAForwardDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttml::metal::ops::sdpa_fw::device

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.cpp
@@ -96,24 +96,6 @@ std::vector<tt::tt_metal::TensorTopology> AllBroadcastDeviceOperation::compute_o
     return topologies;
 }
 
-ttsl::hash::hash_t AllBroadcastDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "AllBroadcastDeviceOperation::compute_program_hash is called");
-
-    auto subdevice_id = operation_attributes.sub_device_id;
-    auto* mesh_device = tensor_args.device();
-    auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
-    return tt::tt_metal::operation::hash_operation<AllBroadcastDeviceOperation>(
-        operation_attributes.num_links,
-        operation_attributes.ring_size,
-        operation_attributes.output_mem_config,
-        operation_attributes.topology,
-        operation_attributes.cluster_axis,
-        subdevice_core_range_set,
-        tensor_args);
-}
-
 std::vector<ttnn::Tensor> all_broadcast(
     const ttnn::Tensor& input_tensor,
     std::optional<uint32_t> cluster_axis,

--- a/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_broadcast/device/all_broadcast_device_operation.hpp
@@ -30,7 +30,6 @@ struct AllBroadcastDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static topology_return_value_t compute_output_topologies(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 std::vector<ttnn::Tensor> all_broadcast(

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.cpp
@@ -138,31 +138,6 @@ AllGatherDeviceOperation::topology_return_value_t AllGatherDeviceOperation::comp
         input_topology.distribution_shape(), output_placements, input_topology.mesh_coords())};
 }
 
-ttsl::hash::hash_t AllGatherDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "AllGatherDeviceOperation::compute_program_hash is called");
-
-    auto subdevice_id = operation_attributes.subdevice_id;
-    auto* mesh_device = tensor_args.input_tensor.device();
-    auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
-    if (operation_attributes.sub_core_grid.has_value()) {
-        subdevice_core_range_set = subdevice_core_range_set.intersection(operation_attributes.sub_core_grid.value());
-    }
-    return tt::tt_metal::operation::hash_operation<AllGatherDeviceOperation>(
-        operation_attributes.dim,
-        operation_attributes.num_links,
-        operation_attributes.cluster_axis,
-        operation_attributes.memory_config,
-        operation_attributes.topology,
-        operation_attributes.chunks_per_sync,
-        operation_attributes.num_workers_per_link,
-        operation_attributes.num_buffers_per_channel,
-        operation_attributes.use_l1_small_for_semaphores,
-        subdevice_core_range_set,
-        tensor_args);
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<AllGatherDeviceOperation::tensor_return_value_t>
 AllGatherDeviceOperation::create_op_performance_model(
     const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {

--- a/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/all_gather/device/all_gather_device_operation.hpp
@@ -82,7 +82,6 @@ struct AllGatherDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static topology_return_value_t compute_output_topologies(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
 };

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.cpp
@@ -97,30 +97,6 @@ ReduceScatterDeviceOperation::tensor_return_value_t ReduceScatterDeviceOperation
     return {intermediate_tensor, output_tensor};
 }
 
-ttsl::hash::hash_t ReduceScatterDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "ReduceScatterDeviceOperation::compute_program_hash is called");
-
-    auto subdevice_id = operation_attributes.subdevice_id;
-    auto* mesh_device = tensor_args.input_tensor.device();
-    auto sd_id = subdevice_id.value_or(mesh_device->get_sub_device_ids().at(0));
-    auto subdevice_core_range_set = mesh_device->worker_cores(tt::tt_metal::HalProgrammableCoreType::TENSIX, sd_id);
-    return tt::tt_metal::operation::hash_operation<ReduceScatterDeviceOperation>(
-        operation_attributes.dim,
-        operation_attributes.num_links,
-        operation_attributes.cluster_axis,
-        operation_attributes.memory_config,
-        operation_attributes.optional_intermediate_mem_config,
-        operation_attributes.topology,
-        operation_attributes.chunks_per_sync,
-        operation_attributes.num_workers_per_link,
-        operation_attributes.num_buffers_per_channel,
-        operation_attributes.compute_kernel_config,
-        operation_attributes.use_l1_small_for_semaphores,
-        subdevice_core_range_set,
-        tensor_args);
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<ReduceScatterDeviceOperation::tensor_return_value_t>
 ReduceScatterDeviceOperation::create_op_performance_model(
     const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensors) {

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_scatter/device/reduce_scatter_device_operation.hpp
@@ -81,7 +81,6 @@ struct ReduceScatterDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
 };

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.cpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.cpp
@@ -153,36 +153,6 @@ Tensor TypecastDeviceOperation::create_output_tensors(const TypecastParams& args
     return tt::tt_metal::create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t TypecastDeviceOperation::compute_program_hash(
-    const TypecastParams& args, const TypecastInputs& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& input_shape = input_tensor.padded_shape();
-
-    auto program_factory = select_program_factory(args, tensor_args);
-
-    operation::Hash hash;
-
-    // For tile layout, only volume matters. For row-major, actual shape dimensions matter.
-    if (input_tensor.layout() == Layout::TILE) {
-        hash = operation::hash_operation<TypecastDeviceOperation>(
-            args,
-            program_factory.index(),
-            input_tensor.dtype(),
-            input_tensor.memory_config(),
-            input_shape.volume(),
-            input_tensor.layout());
-    } else {
-        hash = operation::hash_operation<TypecastDeviceOperation>(
-            args,
-            program_factory.index(),
-            input_tensor.dtype(),
-            input_tensor.memory_config(),
-            input_shape,
-            input_tensor.layout());
-    }
-    return hash;
-}
-
 bool TypecastDeviceOperation::skip_launch(
     const operation_attributes_t& /*attributes*/,
     const tensor_args_t& /*tensor_args*/,

--- a/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.hpp
+++ b/ttnn/cpp/ttnn/operations/copy/typecast/device/typecast_device_op.hpp
@@ -35,8 +35,6 @@ struct TypecastDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     static bool skip_launch(const operation_attributes_t&, const tensor_args_t&, const tensor_return_value_t&);
 };
 

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.cpp
@@ -54,16 +54,6 @@ Tensor ConvertToCHWDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.device());
 }
 
-ttsl::hash::hash_t ConvertToCHWDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args;
-    const auto& input_shape = input_tensor.padded_shape();
-    operation::Hash hash = operation::hash_operation<ConvertToCHWDeviceOperation>(
-        args, input_tensor.dtype(), input_tensor.memory_config(), input_shape.volume());
-
-    return hash;
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_chw/device/convert_to_chw_device_operation.hpp
@@ -23,7 +23,6 @@ struct ConvertToCHWDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.cpp
@@ -56,12 +56,6 @@ Tensor ConvertToHWCDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t ConvertToHWCDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    return ttsl::hash::hash_objects_with_default_seed(
-        ttsl::hash::type_hash<ConvertToHWCDeviceOperation>, args, tensor_args);
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/cnn/convert_to_hwc/device/convert_to_hwc_device_operation.hpp
@@ -28,8 +28,6 @@ struct ConvertToHWCDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.cpp
@@ -247,24 +247,6 @@ Tensor Conv3dDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
 }
 
-ttsl::hash::hash_t Conv3dDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input_tensor;
-    const auto& weight_tensor = tensor_args.weight_tensor;
-    const auto& bias_tensor = tensor_args.bias_tensor;
-    operation::Hash hash = operation::hash_operation<Conv3dDeviceOperation>(
-        args,
-        input_tensor.dtype(),
-        input_tensor.memory_config(),
-        input_tensor.logical_shape(),
-        weight_tensor.dtype(),
-        weight_tensor.memory_config(),
-        weight_tensor.logical_shape(),
-        bias_tensor.has_value());
-
-    return hash;
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor> Conv3dDeviceOperation::create_op_performance_model(
     const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor) {
     const auto& input_shape = tensor_args.input_tensor.logical_shape();

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/device/conv3d_device_operation.hpp
@@ -28,7 +28,6 @@ struct Conv3dDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
 };

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/deepseek_moe_gate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/deepseek_moe_gate_device_operation.cpp
@@ -116,12 +116,6 @@ DeepseekMoeGateDeviceOperation::tensor_return_value_t DeepseekMoeGateDeviceOpera
     return {tensor_args.output_tensor, tensor_args.output_indices_tensor};
 }
 
-std::uint64_t DeepseekMoeGateDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& tensor_args) {
-    auto program_descriptor = build_moe_gate_program_descriptor(tensor_args, attrs);
-    return hash_moe_gate_program_structure(program_descriptor);
-}
-
 std::tuple<DeepseekMoeGateDeviceOperation::operation_attributes_t, DeepseekMoeGateDeviceOperation::tensor_args_t>
 DeepseekMoeGateDeviceOperation::invoke(
     const Tensor& input_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/deepseek_moe_gate_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek/moe/deepseek_moe_gate/device/deepseek_moe_gate_device_operation.hpp
@@ -32,8 +32,6 @@ struct DeepseekMoeGateDeviceOperation {
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 
-    static std::uint64_t compute_program_hash(const operation_attributes_t& attrs, const tensor_args_t& tensor_args);
-
     static std::tuple<operation_attributes_t, tensor_args_t> invoke(
         const Tensor& input_tensor,
         const Tensor& bias_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.cpp
@@ -52,14 +52,6 @@ MaskedBincountDeviceOperation::spec_return_value_t MaskedBincountDeviceOperation
             tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM}));
 }
 
-tt::stl::hash::hash_t MaskedBincountDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_shape = tensor_args.input_tensor.padded_shape();
-    tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<MaskedBincountDeviceOperation>(
-        args, tensor_args.input_tensor.dtype(), tensor_args.input_tensor.memory_config(), input_shape);
-    return hash;
-}
-
 MaskedBincountDeviceOperation::tensor_return_value_t MaskedBincountDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/masked_bincount/device/masked_bincount_device_operation.hpp
@@ -21,7 +21,6 @@ struct MaskedBincountDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_device_operation.cpp
@@ -65,14 +65,6 @@ OffsetCumsumDeviceOperation::topology_return_value_t OffsetCumsumDeviceOperation
     return {offsets_topology, totals_topology, expert_region_topology};
 }
 
-tt::stl::hash::hash_t OffsetCumsumDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& input_tensor) {
-    const auto& input_shape = input_tensor.padded_shape();
-    tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<OffsetCumsumDeviceOperation>(
-        args, input_tensor.dtype(), input_tensor.memory_config(), input_shape);
-    return hash;
-}
-
 OffsetCumsumDeviceOperation::tensor_return_value_t OffsetCumsumDeviceOperation::create_output_tensors(
     const operation_attributes_t& args, const tensor_args_t& input_tensor) {
     auto output_specs = compute_output_specs(args, input_tensor);

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/device/offset_cumsum_device_operation.hpp
@@ -26,7 +26,6 @@ struct OffsetCumsumDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static topology_return_value_t compute_output_topologies(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/isin/device/isin_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/isin/device/isin_device_operation.cpp
@@ -53,26 +53,6 @@ IsInDeviceOperation::tensor_return_value_t IsInDeviceOperation::create_output_te
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.elements_tensor.device());
 }
 
-ttsl::hash::hash_t IsInDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_memory_layout = tensor_args.elements_tensor.layout();
-    const auto& input_dtype = tensor_args.elements_tensor.dtype();
-    const auto& input_logical_volume = tensor_args.elements_tensor.logical_volume();
-    const auto& test_elements_memory_layout = tensor_args.test_elements_tensor.layout();
-    const auto& test_elements_dtype = tensor_args.test_elements_tensor.dtype();
-    const auto& test_elements_logical_volume = tensor_args.test_elements_tensor.logical_volume();
-
-    return tt::tt_metal::operation::hash_operation<IsInDeviceOperation>(
-        args.invert,
-        args.single_fetch_subchunk_size,
-        input_dtype,
-        input_memory_layout,
-        input_logical_volume,
-        test_elements_dtype,
-        test_elements_memory_layout,
-        test_elements_logical_volume);
-}
-
 Tensor isin(
     const Tensor& elements,
     const Tensor& test_elements,

--- a/ttnn/cpp/ttnn/operations/experimental/isin/device/isin_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/isin/device/isin_device_operation.hpp
@@ -20,8 +20,6 @@ struct IsInDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 Tensor isin(

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.cpp
@@ -103,29 +103,6 @@ AttnMatmulDeviceOperation::tensor_return_value_t AttnMatmulDeviceOperation::crea
     return create_device_tensor(output_spec, tensor_args.input_tensor_a.device());
 }
 
-ttsl::hash::hash_t AttnMatmulDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    TT_FATAL(
-        is_device_tensor(tensor_args.input_tensor_a),
-        "Unexpected Tensor type {}",
-        tensor_args.input_tensor_a.storage_type());
-    TT_FATAL(
-        is_device_tensor(tensor_args.input_tensor_b),
-        "Unexpected Tensor type {}",
-        tensor_args.input_tensor_b.storage_type());
-    return operation::hash_operation<AttnMatmulDeviceOperation>(
-        args,
-        args.transpose_hw,
-        args.output_mem_config,
-        args.output_dtype,
-        tensor_args.input_tensor_a.dtype(),
-        tensor_args.input_tensor_a.memory_config(),
-        tensor_args.input_tensor_a.padded_shape(),  // drives CB total_size (Kt = padded_shape[-1] / TILE_WIDTH)
-        tensor_args.input_tensor_b.dtype(),
-        tensor_args.input_tensor_b.memory_config(),
-        tensor_args.input_tensor_b.padded_shape());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/attn_matmul/device/attn_matmul_device_operation.hpp
@@ -28,8 +28,6 @@ struct AttnMatmulDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.cpp
@@ -205,35 +205,6 @@ GroupAttnMatmulDeviceOperation::tensor_return_value_t GroupAttnMatmulDeviceOpera
         compute_output_specs(operation_attributes, tensor_args), tensor_args.input_tensor_a.device());
 }
 
-ttsl::hash::hash_t GroupAttnMatmulDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    const auto& input_tensor_a = tensor_args.input_tensor_a;
-    const auto& input_tensor_b = tensor_args.input_tensor_b;
-
-    TT_FATAL(is_device_tensor(input_tensor_a), "Unexpected Tensor type {}", input_tensor_a.storage_type());
-    TT_FATAL(is_device_tensor(input_tensor_b), "Unexpected Tensor type {}", input_tensor_b.storage_type());
-    return operation::hash_operation<GroupAttnMatmulDeviceOperation>(
-        operation_attributes.transpose_hw,
-        operation_attributes.out_subblock_w,
-        operation_attributes.compute_with_storage_grid_size.str(),
-        operation_attributes.output_mem_config.memory_layout(),
-        operation_attributes.output_mem_config.buffer_type(),
-        operation_attributes.output_dtype,
-        operation_attributes.row_major,
-        operation_attributes.compute_kernel_config,  // Affects math_fidelity and fp32_dest_acc_en in ComputeConfig
-        input_tensor_a.memory_config().memory_layout(),
-        input_tensor_a.memory_config().buffer_type(),
-        input_tensor_a.dtype(),
-        input_tensor_a.padded_shape(),  // drives CB total_size (Kt, Mt) — must be in hash since CB sizing is not
-                                        // patched on cache hit
-        input_tensor_a.device()->id(),
-        input_tensor_b.memory_config().memory_layout(),
-        input_tensor_b.memory_config().buffer_type(),
-        input_tensor_b.dtype(),
-        input_tensor_b.padded_shape(),  // drives CB total_size (KV_HEADS, Kt)
-        input_tensor_b.device()->id());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/matmul/group_attn_matmul/device/group_attn_matmul_device_operation.hpp
@@ -30,9 +30,6 @@ struct GroupAttnMatmulDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.cpp
@@ -105,18 +105,6 @@ Tensor PaddedSliceDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t PaddedSliceDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "PaddedSliceDeviceOperation::compute_program_hash is called");
-
-    auto program_factory = select_program_factory(args, tensor_args);
-
-    // Include input shape last dimension as it affects pad_output_row decision (RM factory)
-    // and max_num_tiles_per_row calculation (Tile factory), which affect kernel selection and CB configs
-    return tt::tt_metal::operation::hash_operation<PaddedSliceDeviceOperation>(
-        args, tensor_args, program_factory.index());
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/padded_slice/device/padded_slice_device_operation.hpp
@@ -30,8 +30,6 @@ struct PaddedSliceDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_device_operation.cpp
@@ -23,21 +23,6 @@ PlusOneDeviceOperation::spec_return_value_t PlusOneDeviceOperation::compute_outp
     return input_tensor.tensor_spec();
 }
 
-ttsl::hash::hash_t PlusOneDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& input_tensor) {
-    const auto& input_shape = input_tensor.padded_shape();
-    // Hash operation attributes (both sub_core_grids and skip_negative_entries affect program structure)
-    // and specific tensor properties that affect program structure (dtype, memory_config, shape)
-    // rather than the whole tensor to avoid including runtime-only properties like buffer addresses
-    tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<PlusOneDeviceOperation>(
-        args,                          // Includes sub_core_grids and skip_negative_entries
-        input_tensor.dtype(),          // Affects CB data format and element size
-        input_tensor.memory_config(),  // Affects buffer type (DRAM/L1) and sharding
-        input_shape);                  // Affects W, H, aligned_input_page_size, core groups
-
-    return hash;
-}
-
 PlusOneDeviceOperation::tensor_return_value_t PlusOneDeviceOperation::create_output_tensors(
     const operation_attributes_t&, const tensor_args_t& input_tensor) {
     return input_tensor;

--- a/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/plusone/device/plusone_device_operation.hpp
@@ -24,7 +24,6 @@ struct PlusOneDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.cpp
@@ -89,16 +89,6 @@ TensorSpec SliceWriteDeviceOperation::compute_output_specs(
     return tensor_args.output.tensor_spec();
 }
 
-ttsl::hash::hash_t SliceWriteDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    log_trace(tt::LogOp, "SliceWriteDeviceOperation::compute_program_hash is called");
-
-    auto program_factory = select_program_factory(args, tensor_args);
-
-    return tt::tt_metal::operation::hash_operation<SliceWriteDeviceOperation>(
-        args, tensor_args, program_factory.index());
-}
-
 Tensor SliceWriteDeviceOperation::create_output_tensors(
     const operation_attributes_t&, const tensor_args_t& tensor_args) {
     return tensor_args.output;

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/slice_write_device_operation.hpp
@@ -33,9 +33,6 @@ struct SliceWriteDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& args, const tensor_args_t& tensor_args);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.cpp
@@ -67,16 +67,6 @@ Tensor ConcatenateHeadsDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t ConcatenateHeadsDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& input_shape = input_tensor.padded_shape();
-    operation::Hash hash = operation::hash_operation<ConcatenateHeadsDeviceOperation>(
-        args.output_mem_config, input_tensor.dtype(), input_tensor.memory_config(), input_shape.volume());
-
-    return hash;
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/concatenate_heads/device/concatenate_heads_device_operation.hpp
@@ -26,8 +26,6 @@ struct ConcatenateHeadsDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.cpp
@@ -225,16 +225,6 @@ CreateQKVHeadsSeparateTensorsDeviceOperation::create_output_tensors(
         create_device_tensor(std::get<1>(output_specs), tensor_args.input_tensor.device()),
         create_device_tensor(std::get<2>(output_specs), tensor_args.input_tensor.device()));
 }
-    ttsl::hash::hash_t
-    CreateQKVHeadsSeparateTensorsDeviceOperation::compute_program_hash(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return tt::tt_metal::operation::hash_operation<CreateQKVHeadsSeparateTensorsDeviceOperation>(
-        operation_attributes.num_q_heads,
-        operation_attributes.num_kv_heads,
-        operation_attributes.head_dim,
-        operation_attributes.transpose_k_heads,
-        tensor_args);
-}
 
 }  // namespace ttnn::experimental::prim
 

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/create_qkv_heads_from_separate_tensors/device/create_qkv_heads_from_separate_tensors_device_operation.hpp
@@ -27,8 +27,6 @@ struct CreateQKVHeadsSeparateTensorsDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.cpp
@@ -143,20 +143,6 @@ tt::tt_metal::Tensor RotaryEmbeddingHfDeviceOperation::create_output_tensors(
         compute_output_specs(args, tensor_args), tensor_args.input_tensor.device());
 }
 
-tt::stl::hash::hash_t RotaryEmbeddingHfDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    auto program_factory = select_program_factory(args, tensor_args);
-    tt::tt_metal::operation::Hash hash = tt::tt_metal::operation::hash_operation<RotaryEmbeddingHfDeviceOperation>(
-        args.is_decode_mode,
-        args.output_mem_config,
-        args.compute_kernel_config,
-        program_factory.index(),
-        tensor_args.input_tensor,
-        tensor_args.cos_cache,
-        tensor_args.sin_cache);
-    return hash;
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_hf/device/rotary_embedding_hf_device_operation.hpp
@@ -22,7 +22,6 @@ struct RotaryEmbeddingHfDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static tt::stl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.cpp
@@ -225,12 +225,6 @@ RotaryEmbeddingLlamaDeviceOperation::tensor_return_value_t RotaryEmbeddingLlamaD
         compute_output_specs(operation_attributes, tensor_args)[0], tensor_args.input_tensor.device());
 }
 
-ttsl::hash::hash_t RotaryEmbeddingLlamaDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return tt::tt_metal::operation::hash_operation<RotaryEmbeddingLlamaDeviceOperation>(
-        operation_attributes, tensor_args);
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/rotary_embedding_llama/device/rotary_embedding_llama_device_operation.hpp
@@ -26,7 +26,6 @@ struct RotaryEmbeddingLlamaDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.cpp
@@ -127,22 +127,6 @@ Tensor GeluBackwardDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t GeluBackwardDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& grad_output = tensor_args.grad_output;
-    const auto& input_shape = input_tensor.padded_shape();
-    operation::Hash hash = operation::hash_operation<GeluBackwardDeviceOperation>(
-        args,
-        input_tensor.dtype(),
-        input_tensor.memory_config(),
-        grad_output.dtype(),
-        grad_output.memory_config(),
-        input_shape.volume());
-
-    return hash;
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/unary_backward/gelu_backward/device/gelu_backward_device_operation.hpp
@@ -28,8 +28,6 @@ struct GeluBackwardDeviceOperation {
 
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& args, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::experimental::prim

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.cpp
@@ -144,36 +144,6 @@ MorehGroupNormOperation::tensor_return_value_t MorehGroupNormOperation::create_o
     }
     return result;
 }
-
-ttsl::hash::hash_t MorehGroupNormOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    // Hash everything that affects the program: shape/dtype/layout of every tensor + all
-    // operation_attributes. This is more conservative than the framework's default
-    // (which only hashes the descriptor's compile_time_args / CB sizes / kernel paths)
-    // and ensures eps is part of the cache key — required for the BufferBinding fast
-    // cache-hit path to be correctness-safe (cache hit guarantees identical attrs).
-    const auto& input = tensor_args.input;
-    return ttsl::hash::hash_objects_with_default_seed(
-        // Shape/dtype/layout of input — frame these as a tuple for the hasher
-        input.padded_shape(),
-        input.logical_shape(),
-        input.dtype(),
-        input.layout(),
-        input.memory_config(),
-        // Optional inputs — has_value flags + (if present) shape/dtype/layout
-        tensor_args.gamma.has_value(),
-        tensor_args.gamma.has_value() ? tensor_args.gamma->dtype() : tt::tt_metal::DataType::INVALID,
-        tensor_args.beta.has_value(),
-        tensor_args.beta.has_value() ? tensor_args.beta->dtype() : tt::tt_metal::DataType::INVALID,
-        // Attribute knobs
-        operation_attributes.num_groups,
-        operation_attributes.eps,
-        operation_attributes.are_required_outputs,
-        operation_attributes.memory_config,
-        operation_attributes.mean_memory_config,
-        operation_attributes.rstd_memory_config,
-        operation_attributes.compute_kernel_config);
-}
 }  // namespace ttnn::operations::moreh::moreh_group_norm
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/moreh/moreh_group_norm/device/moreh_group_norm_device_operation.hpp
@@ -37,12 +37,6 @@ struct MorehGroupNormOperation {
         const tensor_args_t& tensor_args,
         tensor_return_value_t& outputs);
 
-    // Custom program-cache hash: include eps (the only attribute that doesn't flow
-    // through compile_time_args). Without this, different eps values would hit the
-    // same cache entry, breaking the BufferBinding fast cache-hit path. With it, a
-    // cache hit guarantees identical attrs, so BufferBinding can be safely adopted.
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     static void validate_tensors(const operation_attributes_t&, const tensor_args_t&);
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.cpp
@@ -118,32 +118,6 @@ BatchNormOperation::tensor_return_value_t BatchNormOperation::create_output_tens
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t BatchNormOperation::compute_program_hash(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    const auto& [input, batch_mean, batch_var, weight, bias, output] = tensor_args;
-
-    TT_FATAL(is_device_tensor(input), "Unexpected type {}", input.storage_type());
-
-    auto hash_optional_tensor = [](const std::optional<Tensor>& t) -> ttsl::hash::hash_t {
-        if (!t.has_value()) {
-            return ttsl::hash::hash_objects_with_default_seed(false);
-        }
-        return ttsl::hash::hash_objects_with_default_seed(true, t->tensor_spec(), t->padded_shape());
-    };
-
-    return operation::hash_operation<BatchNormOperation>(
-        attributes,
-        input.tensor_spec(),
-        input.padded_shape(),
-        batch_mean.tensor_spec(),
-        batch_mean.padded_shape(),
-        batch_var.tensor_spec(),
-        batch_var.padded_shape(),
-        hash_optional_tensor(weight),
-        hash_optional_tensor(bias),
-        hash_optional_tensor(output));
-}
-
 ttsl::hash::hash_t BatchNormOperation::operation_attributes_t::to_hash() const {
     return ttsl::hash::hash_objects_with_default_seed(eps, memory_config, get_dtype(), compute_kernel_config);
 }

--- a/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/batch_norm/device/batch_norm_device_operation.hpp
@@ -48,7 +48,6 @@ struct BatchNormOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 }  // namespace ttnn::operations::normalization
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.cpp
@@ -366,44 +366,6 @@ SoftmaxDeviceOperation::tensor_return_value_t SoftmaxDeviceOperation::create_out
     return {create_device_tensor(compute_output_specs(attributes, tensor_args), tensor_args.input_tensor.device())};
 }
 
-tt::tt_metal::operation::Hash SoftmaxDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attributes, const tensor_args_t& tensor_args) {
-    // When a mask is present, its dtype and memory_config influence the compiled program:
-    //   - mask dtype        → mask_cb_data_format → CB c_in4/c_in5 data format (compile-time)
-    //   - mask memory_config → TensorAccessorArgs IsDram flag (compile-time arg)
-    //
-    // mask padded_shape is NOT included, even though num_tiles_causal_mask (compile-time arg,
-    // is_causal_mask=True only) is derived from it. It is provably redundant: scale_mask_softmax
-    // enforces mask.padded_shape()[-1] == input.padded_shape()[-1] and mask.padded_shape()[-2]
-    // is always the tile height at the device op level (either already equal to the tile height or
-    // padded to it by tilize_with_val_padding). Therefore, using tile_height and tile_width from
-    // input_tensor.tensor_spec().tile():
-    //   num_tiles_causal_mask = input.padded_shape()[-1] * tile_height / (tile_height * tile_width) = Wt_of_input
-    // which is fully determined by input.logical_shape()[-1] already present in the hash.
-    std::optional<MemoryConfig> default_memory_config =
-        !tensor_args.mask.has_value() ? std::make_optional<MemoryConfig>() : std::nullopt;
-    const auto& mask_memory_config =
-        tensor_args.mask.has_value() ? tensor_args.mask->memory_config() : *default_memory_config;
-    return operation::hash_operation<SoftmaxDeviceOperation>(
-        select_program_factory(attributes, tensor_args).index(),
-        attributes.softmax_type,
-        attributes.dim,
-        attributes.scale,
-        attributes.inplace,
-        attributes.output_mem_config,
-        attributes.program_config,
-        attributes.is_causal_mask,
-        attributes.compute_kernel_config,
-        attributes.is_scale_causal_mask_hw_dims_softmax,
-        attributes.numeric_stable,
-        tensor_args.input_tensor.logical_shape(),
-        tensor_args.input_tensor.dtype(),
-        tensor_args.input_tensor.memory_config(),
-        tensor_args.input_tensor.layout(),
-        tensor_args.mask.has_value() ? tensor_args.mask->dtype() : DataType::INVALID,
-        mask_memory_config);
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<SoftmaxDeviceOperation::tensor_return_value_t>
 SoftmaxDeviceOperation::create_op_performance_model(
     const operation_attributes_t& /*attributes*/, const tensor_args_t& tensor_args, const Tensor& output_tensor) {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/softmax_device_operation.hpp
@@ -72,7 +72,6 @@ struct SoftmaxDeviceOperation {
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static tt::tt_metal::operation::Hash compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, const Tensor&);
 };

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.cpp
@@ -126,15 +126,6 @@ RotateDeviceOperation::tensor_return_value_t RotateDeviceOperation::create_outpu
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t RotateDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    return ttsl::hash::hash_objects_with_default_seed(
-        operation_attributes.memory_config,
-        operation_attributes.interpolation_mode,
-        tensor_args.input.logical_shape(),
-        tensor_args.input.dtype());
-}
-
 }  // namespace ttnn::operations::rotate
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/pool/rotate/device/rotate_device_operation.hpp
@@ -50,8 +50,6 @@ struct RotateDeviceOperation {
     static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
     static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
-
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
 };
 
 }  // namespace ttnn::operations::rotate

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.cpp
@@ -207,29 +207,6 @@ ReduceDeviceOperation::tensor_return_value_t ReduceDeviceOperation::create_outpu
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.device());
 }
 
-ttsl::hash::hash_t ReduceDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto program_factory = select_program_factory(operation_attributes, tensor_args);
-
-    return tt::tt_metal::operation::hash_operation<ReduceDeviceOperation>(
-        operation_attributes.math_op,
-        operation_attributes.dim,
-        operation_attributes.scaler,
-        operation_attributes.output_mem_config,
-        operation_attributes.output_dtype,
-        operation_attributes.compute_kernel_config,
-        operation_attributes.sub_core_grids,
-        operation_attributes.negate,
-        operation_attributes.post_mul_scaler,
-        operation_attributes.row_major_w_dense_path,
-        operation_attributes.row_major_h_dense_path,
-        program_factory.index(),
-        tensor_args.dtype(),
-        tensor_args.memory_config(),
-        tensor_args.padded_shape(),
-        tensor_args.tensor_spec().tile());
-}
-
 ttnn::Tensor reduce(
     const Tensor& input_tensor,
     tt::tt_metal::ReduceOpMath reduce_math,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/reduce_op_device_operation.hpp
@@ -56,9 +56,6 @@ struct ReduceDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 
 ttnn::Tensor reduce(

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.cpp
@@ -80,28 +80,6 @@ WelfordReduceDeviceOperation::tensor_return_value_t WelfordReduceDeviceOperation
     return create_device_tensor(compute_output_specs(operation_attributes, tensor_args), tensor_args.device());
 }
 
-ttsl::hash::hash_t WelfordReduceDeviceOperation::compute_program_hash(
-    const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args) {
-    auto program_factory = select_program_factory(operation_attributes, tensor_args);
-
-    return tt::tt_metal::operation::hash_operation<WelfordReduceDeviceOperation>(
-        operation_attributes.math_op,
-        operation_attributes.reduce_dim,
-        operation_attributes.scalar,
-        operation_attributes.output_mem_config,
-        operation_attributes.output_dtype,
-        operation_attributes.compute_kernel_config,
-        operation_attributes.sub_core_grids,
-        operation_attributes.correction,
-        operation_attributes.reduce_batch_size,
-        program_factory.index(),
-        tensor_args.dtype(),
-        tensor_args.memory_config(),
-        tensor_args.padded_shape(),
-        tensor_args.logical_shape(),
-        tensor_args.tensor_spec().tile());
-}
-
 ttnn::Tensor welford_reduce(
     const Tensor& input_tensor,
     tt::tt_metal::ReduceOpMath reduce_math,

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/welford_reduce_device_operation.hpp
@@ -40,9 +40,6 @@ struct WelfordReduceDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(
         const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
-
-    static ttsl::hash::hash_t compute_program_hash(
-        const operation_attributes_t& operation_attributes, const tensor_args_t& tensor_args);
 };
 
 ttnn::Tensor welford_reduce(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.cpp
@@ -388,37 +388,6 @@ SDPAOperation::tensor_return_value_t SDPAOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(attrs, tensors), tensors.q.device());
 }
 
-ttsl::hash::hash_t SDPAOperation::compute_program_hash(const SDPAParams& attrs, const SDPAInputs& tensors) {
-    bool is_chunked_prefill = attrs.chunk_start_idx.has_value() || attrs.chunk_start_idx_tensor.has_value();
-    bool flexible_chunked = attrs.chunk_start_idx_tensor.has_value();
-
-    const Tensor& q = tensors.q;
-    const Tensor& k = tensors.k;
-    const Tensor& v = tensors.v.value_or(tensors.k);
-
-    const std::optional<Tensor> page_table_for_hash = flexible_chunked ? std::nullopt : tensors.page_table;
-    const std::optional<int64_t> chunk_start_idx_for_hash = flexible_chunked ? std::nullopt : attrs.chunk_start_idx;
-    operation::Hash hash = operation::hash_operation<SDPAOperation>(
-        attrs.head_dim_v,
-        attrs.scale,
-        attrs.sliding_window_size,
-        attrs.output_mem_config,
-        attrs.program_config,
-        attrs.is_causal,
-        is_chunked_prefill,
-        flexible_chunked,
-        chunk_start_idx_for_hash,
-        attrs.compute_kernel_config,
-        q,
-        k,
-        v,
-        tensors.attn_mask,
-        page_table_for_hash,
-        tensors.attention_sink,
-        attrs.use_mla);
-    return hash;
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<SDPAOperation::tensor_return_value_t>
 SDPAOperation::create_op_performance_model(
     const SDPAParams& args, const SDPAInputs& tensor_args, Tensor& output_tensor) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sdpa_device_operation.hpp
@@ -36,7 +36,6 @@ struct SDPAOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t& attrs, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t& args, const tensor_args_t& tensor_args, tensor_return_value_t& output_tensor);
 };

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.cpp
@@ -139,20 +139,6 @@ Tensor WindowedScaledDotProductAttentionDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(attrs, tensors), tensors.q.device());
 }
 
-ttsl::hash::hash_t WindowedScaledDotProductAttentionDeviceOperation::compute_program_hash(
-    const operation_attributes_t& attrs, const tensor_args_t& tensors) {
-    operation::Hash hash = operation::hash_operation<WindowedScaledDotProductAttentionDeviceOperation>(
-        attrs.scale,
-        attrs.output_mem_config,
-        attrs.program_config,
-        attrs.compute_kernel_config,
-        tensors.q,
-        tensors.k,
-        tensors.v,
-        tensors.cu_window_seqlens);
-    return hash;
-}
-
 tt::tt_metal::operation::OpPerformanceModelGeneral<Tensor>
 WindowedScaledDotProductAttentionDeviceOperation::create_op_performance_model(
     const operation_attributes_t& attrs, const tensor_args_t& tensors, tensor_return_value_t& output_tensor) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/sdpa_windowed_device_operation.hpp
@@ -45,7 +45,6 @@ struct WindowedScaledDotProductAttentionDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
     static tt::tt_metal::operation::OpPerformanceModelGeneral<tensor_return_value_t> create_op_performance_model(
         const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t& output_tensor);
 };


### PR DESCRIPTION
### PR Category
This PR must be merged only after #46385 ([fix program-cache hash collisions — strong mixer + exact-key collision resolution](https://github.com/tenstorrent/tt-metal/pull/46385)). It builds directly on the canonical-key machinery introduced there and is meaningless without it. Please do not merge or rebase-to-main ahead of #46385.

### Summary
#46385 gave the program cache two layers of protection: a strong splitmix64 mixer, and an exact canonical-key comparison that makes a hash collision resolve to a (correct) rebuild instead of a wrong cache hit. That structural guarantee only applies to operations that take the default reflection hash path. Any op with a custom DeviceOperation::compute_program_hash opts out automatically — the framework only sees its opaque 64-bit output, so it cannot build a canonical key and falls back to hash-only behavior (~10⁻¹³ residual collision risk).

This is the first migration batch toward removing the custom-hash opt-out branches in ttnn/api/ttnn/mesh_device_operation_adapter.hpp entirely (the 78-operation follow-up azaytsev-epam called out on #46385).

For every operation that still defines compute_program_hash, here selected only the ones where the custom hash is redundant with the default — i.e. it hashes the full operation_attributes_t (plus a curated subset of tensor properties that the default already covers as a superset) and excludes no runtime-only/volatile field. For these, simply deleting the custom hash:

produces an equal-or-stricter hash (no wrong reuse — at worst a few extra cache misses, never a wrong hit), and
earns each op the canonical-key collision guarantee for free, with zero behavioral change.
Operations whose custom hash legitimately excludes volatile/runtime-only state (RNG seed, raw MeshDevice*/IDevice* pointers, GlobalSemaphores, per-step decode indices, memory_used, etc.), or whose tensor_args_t isn't reflection-hashable, or that must keep a custom hash (e.g. GenericOp, FusionDispatchOp) are not in this batch — they need attribute-level work and will follow in later PRs.

**What changed**
For each operation below, removed the compute_program_hash declaration (header) and definition (.cpp), and cleaned up comments that existed solely to justify the custom hash (no dangling references left; e.g. updated a stale "…in compute_program_hash above…" note in moreh_group_norm_program_factory.cpp). No other behavior touched.

Affected operations (37)
Reduction / normalization / copy (6)

ReduceDeviceOperation, WelfordReduceDeviceOperation, TypecastDeviceOperation, SoftmaxDeviceOperation, BatchNormOperation, MorehGroupNormOperation
Transformer / attention / matmul (8)

SDPAOperation, WindowedScaledDotProductAttentionDeviceOperation, RotaryEmbeddingLlamaDeviceOperation, RotaryEmbeddingHfDeviceOperation, ConcatenateHeadsDeviceOperation, CreateQKVHeadsSeparateTensorsDeviceOperation, AttnMatmulDeviceOperation, GroupAttnMatmulDeviceOperation
Pool / CCL (4)

RotateDeviceOperation, AllGatherDeviceOperation, ReduceScatterDeviceOperation, AllBroadcastDeviceOperation
Experimental (11)

Conv3dDeviceOperation, DeepseekMoeGateDeviceOperation, OffsetCumsumDeviceOperation, MaskedBincountDeviceOperation, GeluBackwardDeviceOperation, SliceWriteDeviceOperation, PlusOneDeviceOperation, PaddedSliceDeviceOperation, IsInDeviceOperation, ConvertToCHWDeviceOperation, ConvertToHWCDeviceOperation
tt-train (8)

MoeGroupDeviceOperation, PolyNorm3ForwardDeviceOperation, PolyNorm3BackwardDeviceOperation, SDPAForwardDeviceOperation, SDPABackwardKVDeviceOperation, SDPABackwardQDeviceOperation, RingSDPABwKVDeviceOperation, RingSDPABwQDeviceOperation
Reviewer notes / things to double-check
A couple of removals are worth an extra look because their custom hash derived values rather than passing attrs straight through — all verified safe (per-device program cache makes the derived values constant within a cache):
CCL AllGather / ReduceScatter / AllBroadcast: custom hash derived a subdevice_core_range_set from sub_device_id; the default now hashes sub_device_id directly (strictly more conservative).
DeepseekMoeGateDeviceOperation: custom hash built a program descriptor and hashed its structure; its helper hash_moe_gate_program_structure is header-declared (non-static) so leaving it now-unused is not a -Werror=unused-function hazard.
Confirmed no direct (non-framework) callers of any removed compute_program_hash exist in tests or other code.

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821_operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-hash-collision-45821_operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821_operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-hash-collision-45821_operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821_operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/fix-hash-collision-45821_operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821_operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-hash-collision-45821_operations)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821_operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/fix-hash-collision-45821_operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821_operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/fix-hash-collision-45821_operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821_operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/fix-hash-collision-45821_operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821_operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/fix-hash-collision-45821_operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821_operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/fix-hash-collision-45821_operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821_operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/fix-hash-collision-45821_operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821_operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/fix-hash-collision-45821_operations)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/fix-hash-collision-45821_operations)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/fix-hash-collision-45821_operations)