### PR TITLE
[LLK test] MatmulGolden: apply fidelity masks in source-register order

### DIFF
--- a/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/golden_generators.py
@@ -1212,8 +1212,15 @@ class MatmulGolden(FidelityMasking):
         t1 = to_tensor(operand1, fidelity_format)
         t2 = to_tensor(operand2, fidelity_format)
         if fidelity_iter is not None:
-            t1, t2 = self._apply_fidelity_masking(
-                fidelity_format, t1, t2, fidelity_iter
+            # The Tensix matmul swaps its operands through the source registers:
+            # the lhs is unpacked into SrcB and the rhs into SrcA. The fidelity
+            # masks are per-source (mask_a -> SrcA, mask_b -> SrcB) and asymmetric
+            # (e.g. LoFi keeps the top 4 of SrcA's mantissa but the top 6 of
+            # SrcB's), so the lhs must take the SrcB mask and the rhs the SrcA mask.
+            # Feed (rhs, lhs) into the masking and unswap the result so each operand
+            # is masked as the source register it actually lands in.
+            t2, t1 = self._apply_fidelity_masking(
+                fidelity_format, t2, t1, fidelity_iter
             )
         return t1, t2
 


### PR DESCRIPTION
## Problem

`MatmulGolden`'s LoFi/HiFi fidelity masking is applied to the wrong operands. The masks are per **source register** — `mask_a → SrcA`, `mask_b → SrcB` — and asymmetric (LoFi keeps the top **4** of SrcA's 7 mantissa bits but the top **6** of SrcB's). But the Tensix matmul **swaps its operands through the source registers**: the lhs is unpacked into **SrcB** and the rhs into **SrcA**.

`_prepare_fidelity_operands` masked `operand1` (lhs) with `mask_a` and `operand2` (rhs) with `mask_b` — i.e. the inverse of what the hardware does.

## Fix

Apply the masks in source-register order: lhs → SrcB mask, rhs → SrcA mask (feed `(rhs, lhs)` into `_apply_fidelity_masking` and unswap the result). `HiFi4` is unmasked (`fidelity_iter is None`) and is unaffected.

## Why it wasn't caught before

For symmetric inputs and the tolerances used by the existing matmul tests the inversion is absorbed. It only becomes visible on a narrow, tight-tolerance bf16/bfp8 matmul, where the inverted masks produce ~0.3–0.9 abs error vs silicon, dropping to ~0.02 (≈bf16 rounding) with the fix. The correct (keep-6-on-lhs / keep-4-on-rhs) order was confirmed by sweeping mantissa-truncation widths against captured silicon results.

## Verification (Blackhole)

- `test_matmul.py` LoFi: **1696 passed**
- `test_matmul.py` HiFi2 / HiFi3: **3392 passed**
- A narrow compressed-matmul test now matches silicon to ~bf16 rounding (was ~0.3–0.9 off)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=lpremovic/matmul-golden-fidelity-operand-swap)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:lpremovic/matmul-golden-fidelity-operand-swap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=lpremovic/matmul-golden-fidelity-operand-swap)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:lpremovic/matmul-golden-fidelity-operand-swap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=lpremovic/matmul-golden-fidelity-operand-swap)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:lpremovic/matmul-golden-fidelity-operand-swap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=lpremovic/matmul-golden-fidelity-operand-swap)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:lpremovic/matmul-golden-fidelity-operand-swap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=lpremovic/matmul-golden-fidelity-operand-swap)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:lpremovic/matmul-golden-fidelity-operand-swap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=lpremovic/matmul-golden-fidelity-operand-swap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:lpremovic/matmul-golden-fidelity-operand-swap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=lpremovic/matmul-golden-fidelity-operand-swap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:lpremovic/matmul-golden-fidelity-operand-swap)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=lpremovic/matmul-golden-fidelity-operand-swap)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:lpremovic/matmul-golden-fidelity-operand-swap)