### PR TITLE
[skip ci] BHPC: fix p100 nightly

### DIFF
--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -383,7 +383,7 @@ jobs:
       enable-watcher: ${{ inputs.enable-watcher || false }}
       enable-llk-asserts: ${{ inputs.enable-llk-asserts || false }}
   ttnn-unit-tests:
-    needs: [resolve-docker-pull-refs, resolve-artifacts, generate-matrix]
+    needs: [resolve-docker-pull-refs, resolve-artifacts, generate-matrix, check-harbor]
     if: ${{ always() && !cancelled() && (inputs.run-ttnn-unit-tests == true || (github.event_name == 'schedule' && needs.resolve-artifacts.outputs.schedule-runs-all-tests-effective == 'true')) }}
     secrets: inherit
     uses: ./.github/workflows/ttnn-post-commit.yaml

--- a/.github/workflows/blackhole-post-commit.yaml
+++ b/.github/workflows/blackhole-post-commit.yaml
@@ -376,7 +376,7 @@ jobs:
     with:
       arch: blackhole
       runner-label: ${{ matrix.test-group }}
-      timeout: 20
+      timeout: 30
       # CIv1 runners: cannot use harbor-prefix (resolve-docker-pull-refs)
       docker-image: ${{ needs.resolve-artifacts.outputs.dev-docker-image }}
       wheel-artifact-name: ${{ needs.resolve-artifacts.outputs.wheel-artifact-name }}
@@ -393,7 +393,8 @@ jobs:
         test-group: ${{ fromJson(needs.generate-matrix.outputs.civ2-matrix) }}
     with:
       enabled-skus: ${{ (matrix.test-group == 'P100' || matrix.test-group == 'P100a') && 'bh_p100' || 'bh_p150b_civ2' }}
-      docker-image: ${{ needs.resolve-docker-pull-refs.outputs.ci-test-docker-image }}
+      docker-image: ${{ needs.resolve-artifacts.outputs.ci-test-docker-image }}
+      harbor-prefix: ${{ needs.check-harbor.outputs.harbor-prefix }}
       wheel-artifact-name: ${{ needs.resolve-artifacts.outputs.wheel-artifact-name }}
       enable-watcher: ${{ inputs.enable-watcher || false }}
       timeout-minutes-override: ${{ inputs.enable-watcher && 120 || 0 }}

--- a/.github/workflows/umd-unit-tests.yaml
+++ b/.github/workflows/umd-unit-tests.yaml
@@ -34,8 +34,7 @@ jobs:
     name: UMD tests ${{ inputs.arch }} ${{ inputs.runner-label }}
     runs-on: >-
       ${{
-        (inputs.runner-label == 'P100a') && fromJSON(format('["in-service", "cloud-virtual-machine", "P100"]'))
-        || format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label)
+        format('tt-ubuntu-2204-{0}-viommu-stable', inputs.runner-label)
       }}
     container:
       image: ${{ inputs.docker-image }}


### PR DESCRIPTION
### PR Category
Bug fix / cleanup

### Summary
BHPC P100 jobs were using harbor docker paths while still running on CIv1.
Changes:

- CIv1 P100 uses non-harbor docker image path
- UMD test jobs fully migrated to CIv2 runners

### Notes for reviewers
Issues:
- fixes https://github.com/tenstorrent/tt-metal/issues/47141
- fixes https://github.com/tenstorrent/tt-metal/issues/47143
- fixes https://github.com/tenstorrent/tt-metal/issues/47154
- fixes https://github.com/tenstorrent/tt-metal/issues/47155
- fixes https://github.com/tenstorrent/tt-metal/issues/46988
- fixes https://github.com/tenstorrent/tt-metal/issues/46989
- fixes https://github.com/tenstorrent/tt-metal/issues/46990
- fixes https://github.com/tenstorrent/tt-metal/issues/46991
- fixes https://github.com/tenstorrent/tt-metal/issues/46992
- fixes https://github.com/tenstorrent/tt-metal/issues/46993
- fixes https://github.com/tenstorrent/tt-metal/issues/46994
- fixes https://github.com/tenstorrent/tt-metal/issues/46995
- fixes https://github.com/tenstorrent/tt-metal/issues/47145
- fixes https://github.com/tenstorrent/tt-metal/issues/47144
- fixes https://github.com/tenstorrent/tt-metal/issues/47139
- fixes https://github.com/tenstorrent/tt-metal/issues/47142
- fixes https://github.com/tenstorrent/tt-metal/issues/47130
- fixes https://github.com/tenstorrent/tt-metal/issues/47146
- fixes https://github.com/tenstorrent/tt-metal/issues/47131
- fixes https://github.com/tenstorrent/tt-metal/issues/47140
- fixes https://github.com/tenstorrent/tt-metal/issues/47147
- fixes https://github.com/tenstorrent/tt-metal/issues/47113
- fixes https://github.com/tenstorrent/tt-metal/issues/47156

BHPC runs:
P100: https://github.com/tenstorrent/tt-metal/actions/runs/27623807220
P150: https://github.com/tenstorrent/tt-metal/actions/runs/27623778835

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=williamly/p100-nightly-no-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:williamly/p100-nightly-no-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=williamly/p100-nightly-no-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:williamly/p100-nightly-no-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=williamly/p100-nightly-no-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:williamly/p100-nightly-no-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=williamly/p100-nightly-no-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:williamly/p100-nightly-no-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=williamly/p100-nightly-no-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:williamly/p100-nightly-no-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=williamly/p100-nightly-no-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:williamly/p100-nightly-no-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=williamly/p100-nightly-no-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:williamly/p100-nightly-no-harbor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=williamly/p100-nightly-no-harbor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:williamly/p100-nightly-no-harbor)