### PR TITLE
#40182: Avoid implicit vInt<->vUInt conversions

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -52,24 +52,17 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
 
     // Compute correction for approximation error: correction = |r| / b
     sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
-    sfpi::vInt correction = sfpi::convert<sfpi::vUInt16>(r_f * inv_b_f, sfpi::RoundMode::Nearest);
+    sfpi::vMag correction = sfpi::convert<sfpi::vUInt16>(r_f * inv_b_f, sfpi::RoundMode::Nearest);
 
     // Compute correction * b (full 32-bit result from 24-bit multiplies)
     sfpi::vInt tmp_lo = sfpi::fractional_mul(correction, b);
     sfpi::vInt tmp_hi = sfpi::fractional_mul(correction, b, sfpi::FractionalHalf::High);
-    sfpi::vInt b_hi = b >> 23;
-    b_hi = sfpi::fractional_mul(correction, b_hi);
+    sfpi::vInt b_hi = sfpi::fractional_mul(correction, b >> 23);
     sfpi::vInt tmp = tmp_lo + ((tmp_hi + b_hi) << 23);
 
-    // Extract sign mask of r
-    // r_sign = 0 if r >= 0, -1 if r < 0
-    sfpi::vInt r_sign = r >> 31;
-
-    // Apply correction with sign of r
-    // If r < 0  -> r += tmp
-    // Else      -> r -= tmp
-    sfpi::vInt signed_tmp = (tmp ^ r_sign) - r_sign;
-    r -= signed_tmp;
+    v_if(r < 0) { tmp = -tmp; }
+    v_endif;
+    r -= tmp;
 
     // Final adjustment to ensure r is in [0, b)
     v_if(r < 0 && (r - 1) < 0) { r += b; }
@@ -128,8 +121,8 @@ sfpi_inline sfpi::vFloat _sfpu_binary_remainder_(sfpi::vFloat in0, sfpi::vFloat 
     // Sign correction: remainder must match the sign of b (or be zero).
     // XOR of the float bit-patterns detects sign mismatch via the MSB,
     // avoiding a compound conditional with four comparisons and an OR.
-    v_if(result != sfpi::vFloat(0.0f)) {
-        sfpi::vInt signs = sfpi::reinterpret<sfpi::vUInt>(result) ^ sfpi::reinterpret<sfpi::vUInt>(b);
+    v_if(result != 0.0f) {
+        sfpi::vInt signs = sfpi::as<sfpi::vInt>(result) ^ sfpi::as<sfpi::vInt>(b);
         v_and(signs < 0);
         result += b;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
@@ -21,7 +21,7 @@ sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
         sfpi::vInt man = exman(in, sfpi::MantissaMode::ImplicitOne);
         // shift the mantissa by (23-exponent) to the right
         sfpi::vInt shift = exp - 23;  // 23 is number of mantissa bits in float32
-        man = sfpi::reinterpret<sfpi::vInt>(shft(sfpi::reinterpret<sfpi::vUInt>(man), shift));
+        man = shft(man, shift, sfpi::ShiftMode::Logical);
 
         result = man;
     }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -52,7 +52,7 @@ sfpi_inline void calculate_div_int32_body(
     // the mantissa so that we extract the top 22 bits of the result.
     sfpi::vFloat q_f = a_f * inv_b_f + vConstFloatPrgm0;
     sfpi::vInt sign = a_orig ^ b_orig;
-    sfpi::vUInt q = sfpi::exman(q_f);
+    sfpi::vMag q_m = sfpi::exman(q_f);
 
     // Compute qb = q * b.  This tells us how close our approximation `q` is to
     // the target `a`.  We split into 23-bit chunks.
@@ -60,10 +60,8 @@ sfpi_inline void calculate_div_int32_body(
     // 22 bits, so we can compute qb = (q1<<10 + 0) * (b1<<22 + b0)
     //                               = (q1<<10) * b0
 
-    sfpi::vInt qb = sfpi::fractional_mul(q, b);
-
-    q <<= 10;
-    qb <<= 10;
+    sfpi::vInt qb{sfpi::fractional_mul(q_m, b) << 10};
+    sfpi::vInt q{q_m << 10};
 
     // Compute remainder.
     sfpi::vInt r = a - qb;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -36,7 +36,7 @@ sfpi_inline sfpi::vInt _float_to_int32_for_exp_21f_(sfpi::vFloat val) {
     sfpi::vInt exp = sfpi::exexp(val);
     sfpi::vInt man =
         sfpi::exman(val, sfpi::MantissaMode::ImplicitOne);  // get mantissa with implicit bit (man in [1; 2])
-    man = sfpi::reinterpret<sfpi::vInt>(sfpi::shft(sfpi::reinterpret<sfpi::vUInt>(man), exp));
+    man = sfpi::shft(man, exp, sfpi::ShiftMode::Logical);
     return man;
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_binary_remainder.h
@@ -30,7 +30,7 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
     v_endif;
 
     // Compute reciprocal of b
-    sfpi::vFloat neg_b_f = sfpi::setman(sfpi::vConstNeg1, b_f);
+    sfpi::vFloat neg_b_f = sfpi::copyman(-1.0f, b_f);
 
     sfpi::vFloat inv_b_f = sfpi::vConstFloatPrgm2 + sfpi::vConstFloatPrgm1 * neg_b_f;
 
@@ -76,12 +76,12 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
     sfpi::vFloat lo = q1 * b0 + MANTISSA_ALIGNMENT_OFFSET;
     hi = q1 * b1 + hi;
 
-    sfpi::vInt qb = sfpi::exman(lo) << 11;
+    sfpi::vUInt qb = sfpi::exman(lo) << 11;
     qb += sfpi::exman(hi) << 22;
 
     // Compute remainder - recompute abs(a_signed)
     a = sfpi::abs(a_signed);
-    sfpi::vInt r = a - qb;
+    sfpi::vInt r{a - qb};
 
     // Use abs(r) for correction computation
     sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
@@ -102,20 +102,10 @@ sfpi_inline sfpi::vInt compute_unsigned_remainder_int32(const sfpi::vInt& a_sign
     sfpi::vFloat mid = correction_f * b1 + MANTISSA_ALIGNMENT_OFFSET;
     sfpi::vFloat top = correction_f * b2 + MANTISSA_ALIGNMENT_OFFSET;
 
-    sfpi::vInt tmp = sfpi::exman(low);
-    tmp += sfpi::exman(mid) << 11;
-    tmp += sfpi::exman(top) << 22;
-
-    // Extract sign mask of r
-    // r_sign = 0 if r >= 0, -1 if r < 0
-    sfpi::vInt r_sign = sfpi::reinterpret<sfpi::vInt>(sfpi::reinterpret<sfpi::vUInt>(r) >> 31);
-    r_sign = -r_sign;
-
-    // Apply correction with sign of r
-    // If r < 0  -> r += tmp
-    // Else      -> r -= tmp
-    sfpi::vInt signed_tmp = (tmp ^ r_sign) - r_sign;
-    r -= signed_tmp;
+    sfpi::vInt tmp{sfpi::exman(low) + (sfpi::exman(mid) << 11) + (sfpi::exman(top) << 22)};
+    v_if(r < 0) { tmp = -tmp; }
+    v_endif;
+    r -= tmp;
 
     // Final adjustment - recompute b to reduce register pressure
     b = sfpi::abs(b_signed);
@@ -176,7 +166,7 @@ sfpi_inline sfpi::vFloat _sfpu_binary_remainder_(sfpi::vFloat in0, sfpi::vFloat 
     // XOR of the float bit-patterns detects sign mismatch via the MSB,
     // avoiding a compound conditional with four comparisons and an OR.
     v_if(result != sfpi::vFloat(0.0f)) {
-        sfpi::vInt signs = sfpi::reinterpret<sfpi::vUInt>(result) ^ sfpi::reinterpret<sfpi::vUInt>(b);
+        sfpi::vInt signs = sfpi::as<sfpi::vInt>(result) ^ sfpi::as<sfpi::vInt>(b);
         v_and(signs < 0);
         result += b;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_conversions.h
@@ -21,7 +21,7 @@ sfpi_inline sfpi::vInt _float_to_int32_positive_(sfpi::vFloat in) {
         sfpi::vInt man = exman(in, sfpi::MantissaMode::ImplicitOne);
         // shift the mantissa by (23-exponent) to the right
         sfpi::vInt shift = exp - 23;  // 23 is number of mantissa bits in float32
-        man = sfpi::reinterpret<sfpi::vInt>(shft(sfpi::reinterpret<sfpi::vUInt>(man), shift));
+        man = sfpi::shft(man, shift, sfpi::ShiftMode::Logical);
 
         result = man;
     }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_div_int32_floor.h
@@ -24,15 +24,14 @@ sfpi_inline void calculate_div_int32_body(
     // want to use MOD0_FMT_INT32=4, which gives us the original two's
     // complement integers.
 
-    // Equivalent to: sfpi::vUInt b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-    sfpi::vUInt b_u = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
+    sfpi::vInt b_s = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
 
     // When converting to float, integers are treated as sign-magnitude.
     // Convert inputs to positive values to avoid conversion problems; the
     // original inputs are two's complement integers.  Note that
     // sfpi::abs(-2**31) will return -2**31, which will give -0.0 when
     // converted to float via sfpi::convert
-    sfpi::vMag b = sfpi::abs(b_u);
+    sfpi::vMag b = sfpi::abs(b_s);
 
     // Convert to floats, but check for the edge case mentioned above.
     sfpi::vFloat b_f = sfpi::convert<sfpi::vFloat>(b, sfpi::RoundMode::Nearest);
@@ -48,7 +47,7 @@ sfpi_inline void calculate_div_int32_body(
 
     // Combines the sign and exponent of -1.0 with the mantissa of `b_f`.
     // Scale the input value to the range [1.0, 2.0), and make it negative.
-    sfpi::vFloat neg_b_f = sfpi::setman(sfpi::vConstNeg1, b_f);
+    sfpi::vFloat neg_b_f = sfpi::copyman(-1.0f, b_f);
     // Linear approximation.
     sfpi::vFloat inv_b_f = sfpi::vConstFloatPrgm2 + sfpi::vConstFloatPrgm1 * neg_b_f;
     sfpi::vFloat scale = sfpi::setman(b_f, 0);
@@ -61,14 +60,14 @@ sfpi_inline void calculate_div_int32_body(
     // Halley's Method
     sfpi::vFloat e = inv_b_f * neg_b_f + sfpi::vConst1;
 
-    sfpi::vUInt a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
+    sfpi::vInt a_s = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
 
     // Continue Halley's Method
     e = e * e + e;
 
     // Final step of Halley's Method
     inv_b_f = e * inv_b_f + inv_b_f;
-    sfpi::vFloat a_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(a), sfpi::RoundMode::Nearest);
+    sfpi::vFloat a_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(a_s), sfpi::RoundMode::Nearest);
 
     // Apply scale
     inv_b_f = inv_b_f * scale;
@@ -93,20 +92,20 @@ sfpi_inline void calculate_div_int32_body(
     sfpi::vFloat q2 = sfpi::convert<sfpi::vFloat>(q_m >> 11, sfpi::RoundMode::Nearest);
     sfpi::vFloat b1 = sfpi::convert<sfpi::vFloat>((b >> 11) & MASK_11, sfpi::RoundMode::Nearest);
     sfpi::vFloat b0 = sfpi::convert<sfpi::vFloat>(b & MASK_11, sfpi::RoundMode::Nearest);
-    auto q = sfpi::vUInt(q_m) << 11;
+    sfpi::vUInt q = q_m << 11;
 
     sfpi::vFloat MANTISSA_ALIGNMENT_OFFSET = 8388608.0f;
     sfpi::vFloat hi = q2 * b0 + MANTISSA_ALIGNMENT_OFFSET;
     sfpi::vFloat lo = q1 * b0 + MANTISSA_ALIGNMENT_OFFSET;
     hi = q1 * b1 + hi;
 
-    sfpi::vInt qb = sfpi::exman(lo) << 11;
-    qb += sfpi::exman(hi) << 22;
+    sfpi::vInt qb = sfpi::vInt(sfpi::exman(lo)) << 11;
+    qb += sfpi::vInt(sfpi::exman(hi)) << 22;
 
     // Compute remainder.
-    a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-    a = sfpi::abs(a);
-    sfpi::vInt r = a - qb;
+    a_s = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+    a_s = sfpi::abs(a_s);
+    sfpi::vInt r = a_s - qb;
     sfpi::vFloat r_f = sfpi::convert<sfpi::vFloat>(sfpi::abs(r), sfpi::RoundMode::Nearest);
 
     // Compute correction value in float32.
@@ -122,19 +121,15 @@ sfpi_inline void calculate_div_int32_body(
     sfpi::vFloat mid = correction_f * b1 + MANTISSA_ALIGNMENT_OFFSET;
     sfpi::vFloat top = correction_f * b2 + MANTISSA_ALIGNMENT_OFFSET;
 
-    sfpi::vInt tmp = sfpi::exman(low);
-    tmp += sfpi::exman(mid) << 11;
-    tmp += sfpi::exman(top) << 22;
-
-    v_if(r < 0) {
-        q -= correction;
-        r += tmp;
-    }
-    v_else {
-        q += correction;
-        r -= tmp;
+    sfpi::vInt tmp{sfpi::exman(low) + (sfpi::exman(mid) << 11) + (sfpi::exman(top) << 22)};
+    sfpi::vUInt cor = correction;
+    v_if(r >= 0) {
+        tmp = -tmp;
+        cor = -cor;
     }
     v_endif;
+    q -= cor;
+    r += tmp;
 
     // Since the correction might have been rounded, we may need to correct one
     // additional bit.  The (r - 1) < 0 check is required to handle r=INT_MIN.
@@ -148,17 +143,14 @@ sfpi_inline void calculate_div_int32_body(
     }
     v_endif;
 
-    sfpi::vInt result = q;
+    auto result = sfpi::vInt(q);
 
-    // If a ^ b >= 0, then the result will be positive, otherwise negative.
+    // If a_s ^ b_s >= 0, then the result will be positive, otherwise negative.
     // Reload signed values here due to register pressure.
-    // a = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-    // b = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-    sfpi::vUInt a_s = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi];
-    sfpi::vUInt b_s = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi];
-    sfpi::vInt sign = a_s ^ b_s;
+    a_s = sfpi::dst_reg[dst_index_in0 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
+    b_s = sfpi::dst_reg[dst_index_in1 * dst_tile_size_sfpi].mode<sfpi::DataLayout::I32>();
     // Finally, if we expect a negative result, negate the value (two's complement).
-    v_if(sign < 0) {
+    v_if((a_s ^ b_s) < 0) {
         result = -result;
 
         // Optionally, if we want "floor" rounding, check for a remainder

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_exp.h
@@ -34,7 +34,7 @@ sfpi_inline sfpi::vInt _float_to_int32_for_exp_21f_(sfpi::vFloat val) {
     sfpi::vInt exp = sfpi::exexp(val);
     sfpi::vInt man =
         sfpi::exman(val, sfpi::MantissaMode::ImplicitOne);  // get mantissa with implicit bit (man in [1; 2])
-    man = sfpi::reinterpret<sfpi::vInt>(sfpi::shft(sfpi::reinterpret<sfpi::vUInt>(man), exp));
+    man = sfpi::shft(man, exp, sfpi::ShiftMode::Logical);
     return man;
 }
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_sfpu/ckernel_sfpu_trigonometry.h
@@ -48,7 +48,7 @@ sfpi_inline sfpi::vFloat sfpu_tan<true>(sfpi::vFloat a, sfpi::vInt i) {
         // Compensated residual for the reciprocal-correction branch.
         // This preserves precision when tan(x) is near its poles.
         s = sfpi::vConstNeg1 * r + a;
-        sfpi::vFloat negative_x = sfpi::setman(sfpi::vConstNeg1, r);
+        sfpi::vFloat negative_x = sfpi::copyman(-1.0f, r);
         s = t * a + s;
 
         // Approximate reciprocal of -r using quadratic initial estimate.
@@ -56,7 +56,7 @@ sfpi_inline sfpi::vFloat sfpu_tan<true>(sfpi::vFloat a, sfpi::vInt i) {
         const float k1 = 1.4545459747314453125f;
         const float k2 = 2.121212482452392578125f;
 
-        sfpi::vInt scale_bits = ~sfpi::reinterpret<sfpi::vUInt>(r);
+        sfpi::vInt scale_bits = ~sfpi::reinterpret<sfpi::vInt>(r);
         t = k1 + k0 * negative_x;
         sfpi::vFloat scale = sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(scale_bits), 0);
         t = k2 + t * negative_x;
@@ -95,9 +95,9 @@ sfpi_inline sfpi::vFloat sfpu_tan<false>(sfpi::vFloat a, sfpi::vInt i) {
         const float k1 = 1.4545459747314453125f;
         const float k2 = 2.121212482452392578125f;
 
-        sfpi::vFloat negative_x = sfpi::setman(sfpi::vConstNeg1, r);
+        sfpi::vFloat negative_x = sfpi::copyman(-1.0f, r);
         t = k1 + k0 * negative_x;
-        sfpi::vInt scale_bits = ~sfpi::reinterpret<sfpi::vUInt>(r);
+        sfpi::vInt scale_bits = ~sfpi::reinterpret<sfpi::vInt>(r);
         t = k2 + t * negative_x;
         sfpi::vFloat scale = sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(scale_bits), 0);
 

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/common/inc/sfpu/ckernel_sfpu_recip.h
@@ -27,7 +27,7 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
     // If in ≠ ±0 and in ≠ ±inf, then x = in * 2**(127-in.Exp).
     // If in = ±0 or in = ±inf, then x = ±1.
     // Then negative_x = -x.
-    sfpi::vFloat negative_x = sfpi::setman(sfpi::vConstNeg1, in);
+    sfpi::vFloat negative_x = sfpi::copyman(-1.0f, in);
 
     // Quadratic initial estimate: y = k2 - k1*x + k0*x**2.
     sfpi::vFloat y = sfpi::vConstFloatPrgm1 + sfpi::vConstFloatPrgm0 * negative_x;
@@ -41,13 +41,13 @@ sfpi_inline sfpi::vFloat _sfpu_reciprocal_(const sfpi::vFloat in)
     // Not only is 255-in.Exp more efficient via SFPNOT, but it also ensures
     // that in.Exp == 0 results in ±inf, and in.Exp == 255 results in ±0.
     // See the scale factor adjustment via scale*0.5 below for further details.
-    sfpi::vInt scale_bits = ~sfpi::reinterpret<sfpi::vUInt>(in);
+    sfpi::vInt scale_bits = ~sfpi::as<sfpi::vInt>(in);
 
     // Continue with quadratic estimate.
     y = sfpi::vConstFloatPrgm2 + y * negative_x;
 
     // Scale factor: set mantissa to zero.
-    sfpi::vFloat scale = sfpi::setman(sfpi::reinterpret<sfpi::vFloat>(scale_bits), 0);
+    sfpi::vFloat scale = sfpi::setman(sfpi::as<sfpi::vFloat>(scale_bits), 0);
 
     // First iteration of Newton-Raphson: t = 1.0 - x*y.
     sfpi::vFloat t = sfpi::vConst1 + negative_x * y;


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Uses the new sfpi types to remove implicit conversions between vInt<->vUInt types.  Tested with a release that removed the implicit conversions (so compile fail if used).  The current SFPI merely deprecates the implicit conversions, so one gets moaned at (in the midst of all the other moaning though :( )

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/conv-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/conv-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/conv-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/conv-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/conv-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/conv-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/conv-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/conv-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/conv-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/conv-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/conv-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/conv-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/conv-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/conv-40182)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/conv-40182)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/conv-40182)