### PR TITLE
Restore greedy_only warmup API after #45355 merge.

### DIFF
--- a/models/common/warmup/warmup_utils.py
+++ b/models/common/warmup/warmup_utils.py
@@ -87,14 +87,10 @@ class WarmupForwardMixin:
         can_sample_on_device,
         read_from_device=True,
         greedy_only: bool = False,
-        non_greedy_decoding_on_device: bool | None = None,
     ):
         """
         This function is called by vLLM
         """
-        if non_greedy_decoding_on_device is not None:
-            greedy_only = not non_greedy_decoding_on_device
-
         sampling_params = self._create_sampling_params(can_sample_on_device, max_batch_size, greedy_only=greedy_only)
 
         tokens, start_pos, page_table = self._create_decode_warmup_inputs(max_batch_size, num_blocks)

--- a/models/demos/gemma4/tt/attention/prefill.py
+++ b/models/demos/gemma4/tt/attention/prefill.py
@@ -158,6 +158,7 @@ def prefill_forward(
     shared_kv=None,
     keep_kv=False,
     batch_size=1,
+    valid_seq_len=None,
 ):
     """
     Multi-token prefill attention, fully on device.
@@ -180,6 +181,7 @@ def prefill_forward(
             ccl_manager=ccl_manager,
             shared_kv=shared_kv,
             keep_kv=keep_kv,
+            valid_seq_len=valid_seq_len,
         )
 
     tp = mesh_config.tp if mesh_config else 1

--- a/models/demos/gemma4/tt/generator.py
+++ b/models/demos/gemma4/tt/generator.py
@@ -139,13 +139,13 @@ class Gemma4Generator(Generator):
             for m in self.model:
                 m._prefill_trace_mode = False
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device=False):
+    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, greedy_only: bool = False):
         warmup_gemma4_model_prefill(
             self,
             kv_cache,
             enable_trace=enable_trace,
             can_sample_on_device=can_sample_on_device,
-            non_greedy_decoding_on_device=non_greedy_decoding_on_device,
+            greedy_only=greedy_only,
         )
 
     def prefill_forward_text(

--- a/models/demos/gemma4/tt/generator_trace.py
+++ b/models/demos/gemma4/tt/generator_trace.py
@@ -178,7 +178,7 @@ def warmup_gemma4_batched_prefill_traces(
     *,
     enable_trace: bool,
     can_sample_on_device,
-    non_greedy_decoding_on_device,
+    greedy_only: bool = False,
 ) -> None:
     """Capture prefill traces for MoE models across batch sizes and trace ISLs.
 
@@ -240,7 +240,7 @@ def warmup_gemma4_batched_prefill_traces(
                 if not sampling_parameters_sweeped:
                     sampling_params = generator._create_sampling_params(
                         can_sample_on_device=can_sample_on_device,
-                        greedy_only=not non_greedy_decoding_on_device,
+                        greedy_only=greedy_only,
                         batch_size=batch_size,
                     )
                 else:
@@ -312,7 +312,7 @@ def warmup_gemma4_model_prefill(
     *,
     enable_trace,
     can_sample_on_device,
-    non_greedy_decoding_on_device,
+    greedy_only: bool = False,
 ) -> None:
     """Shared prefill warmup for standalone and vLLM Gemma4 generators."""
     enable_trace = maybe_disable_pli_prefill_trace(enable_trace, generator.model[0])
@@ -322,7 +322,7 @@ def warmup_gemma4_model_prefill(
             kv_cache,
             enable_trace=enable_trace,
             can_sample_on_device=can_sample_on_device,
-            non_greedy_decoding_on_device=non_greedy_decoding_on_device,
+            greedy_only=greedy_only,
         )
         return
     from models.tt_transformers.tt.generator import Generator
@@ -332,5 +332,5 @@ def warmup_gemma4_model_prefill(
         kv_cache=kv_cache,
         enable_trace=enable_trace,
         can_sample_on_device=can_sample_on_device,
-        greedy_only=not non_greedy_decoding_on_device,
+        greedy_only=greedy_only,
     )

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -65,13 +65,13 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
     def _maybe_disable_pli_prefill_trace(self, enable_trace: bool, batch_size: int = 1) -> bool:
         return maybe_disable_pli_prefill_trace(enable_trace, self.model[0], batch_size=batch_size)
 
-    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, non_greedy_decoding_on_device=False):
+    def warmup_model_prefill(self, kv_cache, enable_trace, can_sample_on_device, greedy_only: bool = False):
         warmup_gemma4_model_prefill(
             self,
             kv_cache,
             enable_trace=enable_trace,
             can_sample_on_device=can_sample_on_device,
-            non_greedy_decoding_on_device=non_greedy_decoding_on_device,
+            greedy_only=greedy_only,
         )
 
     def prefill_forward_text(self, *args, enable_trace=True, **kwargs):

--- a/models/demos/gemma4/tt/generator_vllm.py
+++ b/models/demos/gemma4/tt/generator_vllm.py
@@ -119,6 +119,7 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
         use_batched_prefill=False,
         user_id=None,
         padded_batch_size=None,
+        use_full_prompt_len=False,
     ):
         """Override the shared Generator helper to size/slice the
         per-user page table to the *smallest* effective block_size in
@@ -154,6 +155,7 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
                 use_batched_prefill=use_batched_prefill,
                 user_id=user_id,
                 padded_batch_size=padded_batch_size,
+                use_full_prompt_len=use_full_prompt_len,
             )
 
         # Per-user (non-batched) path: replicate the base behavior but
@@ -171,7 +173,14 @@ class Gemma4ForCausalLM(HybridAttentionForCausalLM):
         max_head_dim = max(head_dims)
         effective_block_size = cache_block_size * cache_head_dim // max_head_dim
 
-        target_prefill_len = prefill_seq_len if prefill_seq_len is not None else prefill_len
+        # Mirror the base Generator semantics: when ``use_full_prompt_len`` is
+        # set (vLLM warmup runs prefill kernels on the padded prompt length, e.g.
+        # a 32-token prompt becomes a 128-token kernel), size the page table to
+        # the full ``prefill_len`` so it exposes blocks for the padded length.
+        if use_full_prompt_len:
+            target_prefill_len = prefill_len
+        else:
+            target_prefill_len = prefill_seq_len if prefill_seq_len is not None else prefill_len
         num_blocks = num_blocks_in_seq(target_prefill_len, effective_block_size)
         # Bounded sliding-window cache: ``paged_fill_cache`` /
         # ``paged_update_cache`` with ``cache_position_modulo`` set require


### PR DESCRIPTION
Remove reintroduced `non_greedy_decoding_on_device` shim, align Gemma4 prefill warmup with #45747, and fix `valid_seq_len` forwarding in `prefill_forward` after #45355/#46508 merge.

### PR Category
Bug Fix

## Summary

Fixes post-merge regressions from #45355 that reintroduced `non_greedy_decoding_on_device` and undid the warmup API cleanup from #45747, plus a `valid_seq_len` kwarg drop in `prefill_forward` from the same merge.

- Remove `non_greedy_decoding_on_device` compat shim from `warmup_model_decode` in `warmup_utils.py`
- Switch Gemma4 prefill warmup to `greedy_only` in `generator.py`, `generator_vllm.py`, and `generator_trace.py`
- Pass `greedy_only` through `warmup_gemma4_model_prefill` and `warmup_gemma4_batched_prefill_traces` instead of inverted `non_greedy_decoding_on_device`
- Add `valid_seq_len=None` to `prefill_forward()` in `attention/prefill.py` and forward it to `_prefill_forward_single()` (logic added in #46508 but not wired through the wrapper)

## Why

Reviewer feedback on #45355: use the standardized `greedy_only` parameter (from #45747) and do not bring back `non_greedy_decoding_on_device`.

Separately, callers (`attention/__init__.py`, `layer.py`, `model.py`) still pass `valid_seq_len` into `prefill_forward`, but the #45355 wrapper did not accept it — causing `TypeError` in `test_prefill_trace_perf` and any prefill path that passes `prefill_valid_len`.

## API note

Default is now `greedy_only=False` (full on-device sampling warmup when the model declares support), matching `tt_transformers` and other generators. Call sites that need greedy-only warmup (e.g. `text_demo_v2.py`, vLLM parity tests) already pass `greedy_only=True` explicitly.

## Test plan

- [x] `git grep 'non_greedy_decoding_on_device'` returns no matches
- [x] `python3 -m py_compile` on touched files
- [x] Gemma4 demo smoke: `text_demo_v2.py` (uses `greedy_only=True`)
- [x] `test_prefill_trace_perf` (no `valid_seq_len` TypeError)
- [x] Gemma4 31B unit suite with `CI=true` and config-only `HF_MODEL=models/demos/gemma4/configs/gemma-4-31B-it`

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fix/gemma4-greedy-only-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fix/gemma4-greedy-only-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fix/gemma4-greedy-only-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fix/gemma4-greedy-only-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fix/gemma4-greedy-only-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fix/gemma4-greedy-only-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fix/gemma4-greedy-only-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fix/gemma4-greedy-only-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fix/gemma4-greedy-only-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fix/gemma4-greedy-only-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fix/gemma4-greedy-only-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fix/gemma4-greedy-only-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fix/gemma4-greedy-only-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fix/gemma4-greedy-only-warmup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fix/gemma4-greedy-only-warmup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fix/gemma4-greedy-only-warmup)