### PR TITLE
[models][ci] Global --skip-model-load auto-detection via MLPERF_READ_ONLY env var

### DIFF
--- a/models/conftest.py
+++ b/models/conftest.py
@@ -4,20 +4,28 @@
 
 import ast
 import gc
+import os
 
 import pytest
 import torchvision.transforms as transforms
 from PIL import Image
+
+
+def pytest_addoption(parser):
+    # Auto-enable when MLPERF_READ_ONLY=true (set by CI impl workflows).
+    # Locally (env var unset) defaults to False so weights load normally.
+    default_skip = os.getenv("MLPERF_READ_ONLY", "false").lower() == "true"
+    parser.addoption(
+        "--skip-model-load",
+        action="store_true",
+        default=default_skip,
+        help="Skip loading the model state dict (auto-enabled when MLPERF_READ_ONLY=true)",
+    )
 
 
 @pytest.fixture(autouse=True)
 def ensure_gc():
     gc.collect()
-
-
-import pytest
-import torchvision.transforms as transforms
-from PIL import Image
 
 
 @pytest.fixture

--- a/models/demos/gemma4/conftest.py
+++ b/models/demos/gemma4/conftest.py
@@ -11,7 +11,6 @@ _DEFAULT_MAX_PREFILL = 8192
 
 
 def pytest_addoption(parser):
-    parser.addoption("--skip-model-load", action="store_true", default=False, help="Skip loading the model state dict")
     parser.addoption(
         "--speculative",
         action="store_true",

--- a/models/demos/gpt_oss/conftest.py
+++ b/models/demos/gpt_oss/conftest.py
@@ -10,10 +10,6 @@ import pytest
 from models.demos.gpt_oss.tt.model_config import ModelArgs
 
 
-def pytest_addoption(parser):
-    parser.addoption("--skip-model-load", action="store_true", default=False, help="Skip loading the model state dict")
-
-
 @pytest.fixture(scope="session")
 def state_dict(request):
     load_model = not request.config.getoption("--skip-model-load")

--- a/models/demos/gpt_oss/tt/common.py
+++ b/models/demos/gpt_oss/tt/common.py
@@ -6,6 +6,8 @@
 GPT-OSS specific implementation of create_tt_model that's compatible with tt_transformers
 """
 
+import os
+
 import ttnn
 from models.tt_transformers.tt.common import PagedAttentionConfig
 
@@ -53,11 +55,14 @@ def create_tt_model(
     # Avoid loading state_dict for every DP model. An empty dict is intentional
     # when --skip-model-load is used.
     if state_dict is None:
-        state_dict = gpt_oss_model_args.load_state_dict(
-            weights_path=gpt_oss_model_args.model_path,
-            dummy_weights=gpt_oss_model_args.dummy_weights,
-            convert_to_meta_format=True,
-        )
+        if os.getenv("MLPERF_READ_ONLY", "false").lower() == "true":
+            state_dict = {}
+        else:
+            state_dict = gpt_oss_model_args.load_state_dict(
+                weights_path=gpt_oss_model_args.model_path,
+                dummy_weights=gpt_oss_model_args.dummy_weights,
+                convert_to_meta_format=True,
+            )
 
     # Create GPT-OSS model using transformer-compatible constructor
     model = Model.create_transformer_compatible(

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -836,8 +836,9 @@ def create_tt_model(
     if prefetcher is not None:
         prefetcher.num_layers = tt_model_args.n_layers
 
-    # Avoid loading state_dict for every DP model
-    if not state_dict:
+    # Avoid loading state_dict for every DP model. An empty dict is intentional
+    # when --skip-model-load is used.
+    if state_dict is None:
         state_dict = tt_model_args.load_state_dict()
 
     model = Transformer(

--- a/models/tt_transformers/tt/common.py
+++ b/models/tt_transformers/tt/common.py
@@ -839,7 +839,10 @@ def create_tt_model(
     # Avoid loading state_dict for every DP model. An empty dict is intentional
     # when --skip-model-load is used.
     if state_dict is None:
-        state_dict = tt_model_args.load_state_dict()
+        if os.getenv("MLPERF_READ_ONLY", "false").lower() == "true":
+            state_dict = {}
+        else:
+            state_dict = tt_model_args.load_state_dict()
 
     model = Transformer(
         args=tt_model_args,

--- a/tests/pipeline_reorg/models_e2e_tests.yaml
+++ b/tests/pipeline_reorg/models_e2e_tests.yaml
@@ -525,11 +525,7 @@
   cmd: |
     uv pip install -r models/demos/gpt_oss/requirements.txt
     export HF_MODEL=openai/gpt-oss-120b TT_CACHE_PATH=/mnt/MLPerf/huggingface/tt_cache/openai--gpt-oss-120b/ TT_MM_THROTTLE_PERF=2
-    # Tensor cache is pre-built on the NAS — skip loading model weights by default.
-    # Check mlperf-write-access in the workflow to load weights and regenerate the cache.
-    SKIP_MODEL_LOAD="--skip-model-load"
-    [ "${MLPERF_READ_ONLY:-true}" = "false" ] && SKIP_MODEL_LOAD=""
-    pytest models/demos/gpt_oss/demo/text_demo.py --timeout 1500 $SKIP_MODEL_LOAD
+    pytest models/demos/gpt_oss/demo/text_demo.py --timeout 1500
   model: gpt-oss-120b
   skus:
     wh_galaxy_perf:

--- a/tests/pipeline_reorg/models_unit_tests.yaml
+++ b/tests/pipeline_reorg/models_unit_tests.yaml
@@ -412,11 +412,7 @@
   cmd: |
     uv pip install -r models/demos/gpt_oss/requirements.txt
     export HF_MODEL=models/demos/gpt_oss/configs/gpt-oss-120b TT_MM_THROTTLE_PERF=2
-    # Tensor cache is pre-built on the NAS — skip loading model weights by default.
-    # Check mlperf-write-access in the workflow to load weights and regenerate the cache.
-    SKIP_MODEL_LOAD="--skip-model-load"
-    [ "${MLPERF_READ_ONLY:-true}" = "false" ] && SKIP_MODEL_LOAD=""
-    pytest --timeout 1500 models/demos/gpt_oss/tests/unit $SKIP_MODEL_LOAD
+    pytest --timeout 1500 models/demos/gpt_oss/tests/unit
   model: gpt-oss-120b
   skus:
     # Wormhole


### PR DESCRIPTION
### Summary

Centralizes the `--skip-model-load` pytest option in `models/conftest.py` so it applies to **all** model e2e and unit tests across tiers 1, 2, and 3 — not just GPT-OSS 120B. The option auto-detects the `MLPERF_READ_ONLY` environment variable (already set by all CI impl workflows) and defaults accordingly:

- **CI (MLPERF_READ_ONLY=true):** `--skip-model-load` is enabled by default — tests use pre-built tensor caches, skipping expensive weight loading.
- **Local dev (env var unset):** `--skip-model-load` is disabled — weights load normally.

No per-test YAML boilerplate required. Zero changes to test matrix files (except removing the now-redundant GPT-OSS 120B shell conditionals).

### Changes

| File | What |
|------|------|
| `models/conftest.py` | Register `--skip-model-load` globally with `MLPERF_READ_ONLY` env auto-detect |
| `models/demos/gpt_oss/conftest.py` | Remove duplicate `--skip-model-load` registration (inherited from parent) |
| `models/demos/gemma4/conftest.py` | Remove duplicate `--skip-model-load` registration (inherited from parent) |
| `models/tt_transformers/tt/common.py` | `if not state_dict:` → `if state_dict is None:` + skip weight loading when `MLPERF_READ_ONLY=true` |
| `models/tt_transformers/tt/embedding.py` | Guard `state_dict[key]` with `if state_dict else None` for tensor cache fallback |
| `models/tt_transformers/tt/mlp.py` | Same guard on weight lambda |
| `models/tt_transformers/tt/attention.py` | Guard QKV bias, QKV weights, wo weight, q_norm/k_norm state_dict accesses |
| `models/tt_transformers/tt/lm_head.py` | Guard output weight extraction and padding |
| `models/tt_transformers/tt/mixtral_mlp.py` | Guard expert weight concat lambda |
| `models/tt_transformers/tt/mixtral_moe.py` | Guard gate tensor construction |
| `models/demos/gpt_oss/tt/common.py` | Skip weight loading when `MLPERF_READ_ONLY=true` |
| `tests/pipeline_reorg/models_e2e_tests.yaml` | Remove GPT-OSS 120B shell conditional (now handled by conftest) |
| `tests/pipeline_reorg/models_unit_tests.yaml` | Remove GPT-OSS 120B shell conditional (now handled by conftest) |

### Why

PR #45301 added `--skip-model-load` for GPT-OSS 120B only, using per-test shell boilerplate in the YAML cmd blocks. Extending this to all models with the same approach would require duplicating 4 lines of bash into 40+ test entries. Instead, this PR:

1. Moves the skip logic into `models/conftest.py` (auto-detects `MLPERF_READ_ONLY` env var)
2. Adds the `MLPERF_READ_ONLY` check directly in `create_tt_model` so it works even for models that don't use a `state_dict` fixture
3. Guards all direct `state_dict[key]` accesses in tt_transformers layer code so an empty dict (`{}`) doesn't crash — instead `None` is passed to `ttnn.as_tensor(cache_file_name=...)` which loads from the pre-built tensor cache on NAS

### Model coverage

All models that go through `create_tt_model` skip weight loading automatically in CI. This includes every model in both YAML test matrices across tiers 1, 2, and 3: Llama (all variants), Qwen (all variants), Mistral, Mixtral, Falcon, GPT-OSS (20B, 120B), Gemma-3, Gemma-4 (all variants), Whisper, Phi, Mamba, UNet.
