### PR TITLE
[Bug fix] Skip Blackhole DEVICE_PULL host IO loopback to unblock CI hang

### DIFF
--- a/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
+++ b/models/demos/deepseek_v3_b1/tests/unit_tests/test_host_io.py
@@ -55,6 +55,13 @@ def test_host_io_loopback(mesh_device, tensor_size_bytes, fifo_size, num_iterati
     if not is_slow_dispatch():
         pytest.skip("Skipping test in fast dispatch mode")
 
+    # TODO(#43079): Blackhole DEVICE_PULL host IO loopback hangs under viommu.
+    if is_blackhole() and h2d_mode == ttnn.H2DMode.DEVICE_PULL:
+        pytest.skip(
+            "[SKIP REASON]: Blackhole HostIO DEVICE_PULL loopback hangs in the data-transfer loop "
+            "(device PCIe pull from host-pinned memory) under viommu. Issue: #43079"
+        )
+
     ttnn.enable_asynchronous_slow_dispatch(mesh_device)
 
     tensor_size_datums = tensor_size_bytes // 4


### PR DESCRIPTION
 The `(Blackhole) e2e tests` job `Host IO fast unit test (viommu only) [bh_p300]`
  hangs on `test_host_io_loopback[blackhole-H2DMode.DEVICE_PULL-64-128-512]` and
  times out after 10 minutes on every run. This PR skips the `DEVICE_PULL`
  parametrizations of `test_host_io_loopback` on Blackhole to unblock CI, matching
  the existing skips already tracked under #43079.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bzhang/fix-host-io-device-pull-blackhole-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bzhang/fix-host-io-device-pull-blackhole-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bzhang/fix-host-io-device-pull-blackhole-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bzhang/fix-host-io-device-pull-blackhole-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bzhang/fix-host-io-device-pull-blackhole-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bzhang/fix-host-io-device-pull-blackhole-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bzhang/fix-host-io-device-pull-blackhole-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bzhang/fix-host-io-device-pull-blackhole-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bzhang/fix-host-io-device-pull-blackhole-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bzhang/fix-host-io-device-pull-blackhole-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bzhang/fix-host-io-device-pull-blackhole-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bzhang/fix-host-io-device-pull-blackhole-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bzhang/fix-host-io-device-pull-blackhole-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bzhang/fix-host-io-device-pull-blackhole-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bzhang/fix-host-io-device-pull-blackhole-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bzhang/fix-host-io-device-pull-blackhole-hang)