### PR TITLE
Restore y-dim reset in WH tilize uninit (fix Qwen3-32B Galaxy 0% accuracy)

### DIFF
--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_tilize.h
@@ -546,11 +546,14 @@ inline void _llk_unpack_tilize_uninit_(const std::uint32_t unpack_dst_format, co
     // Stalling SETDMAREG done by THCON until UNPACK finishes
     TTI_STALLWAIT(p_stall::STALL_THCON, p_stall::UNPACK);
 
-    // Restore Z dim to the default operand state set by _llk_unpack_init_:
+    // Restore Z and Y dim to the default operand state set by _llk_unpack_init_:
     // THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1 - word 1 of the same-named register
     // z-dim sits in upper 16 bits and is set to unpA_num_faces by _llk_unpack_init_
-    // (y-dim sits in the lower 16 bits and is left untouched by tilize, so we don't restore it)
     cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(num_faces);
+    // y-dim sits in the lower 16 bits and must be restored to its default of 1. #45179
+    // dropped this restore (assuming tilize leaves y-dim untouched); that leaves the tile
+    // descriptor corrupted for subsequent unpack ops -> Qwen3-32B Galaxy Top-1 0%. Restore it.
+    cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 0, 0x0000ffff>(1);
 
     unpack_config_u config   = {0};
     config.f.out_data_format = unpack_dst_format;


### PR DESCRIPTION
## Problem

`Qwen3-32B e2e tests (Galaxy) [wh_galaxy_perf]` (`test_qwen_model_acc`) has been failing with **Top-1 accuracy 0.0%** on every scheduled run since **2026-06-09**. Tracked in #47049.

## Root cause (bisected)

Bisected the regression to **#45179 "Fix y-dim and z-dim for tilize"** (`bb78d08fb43`), via clean adjacent verdicts on Galaxy:
- parent `a01cf929674` (docs) → ✅ **GOOD, Top-1 92%**
- `bb78d08fb43` (#45179) → ❌ **BAD, Top-1 0%**

#45179 **removed the y-dim restore** in `_llk_unpack_tilize_uninit_`, on the assumption that *"y-dim is left untouched by tilize, so we don't restore it."* That assumption is wrong: the tile descriptor's y-dim (lower 16 bits of `THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1`) is left dirty after tilize, corrupting subsequent unpack ops → garbage activations → total accuracy loss on Qwen3-32B Galaxy.

## Fix

Restore the pre-#45179 y-dim reset (set the tile-descriptor y-dim back to its default of 1), while **keeping #45179's legitimate z-dim=`num_faces` change**:

```c
cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1, 16, 0xffff0000>(num_faces);  // z-dim (kept from #45179)
cfg_reg_rmw_tensix<THCON_SEC0_REG0_TileDescriptor_ADDR32 + 1,  0, 0x0000ffff>(1);          // y-dim (restored)
```

Body-only change — no signature change, so no metal-API/Compute-API propagation needed.

**Scope:** Wormhole only. #45179 did not touch the Blackhole llk_lib, so BH is intentionally untouched.

> Note: a literal `git revert` of #45179 does **not** build on current `main` — `_llk_unpack_tilize_uninit_`'s signature changed 2→3→2 params across later commits — so this is the targeted reversal of the specific behavioral regression rather than a whole-commit revert.

## Validation — accuracy

⏳ 3 redundant `qwen3-32b-galaxy / wh_galaxy_perf` accuracy runs dispatched on this branch (`a2a5bf9`), expecting Top-1 to return to ~90%+:

- https://github.com/tenstorrent/tt-metal/actions/runs/27640429944
- https://github.com/tenstorrent/tt-metal/actions/runs/27640445207
- https://github.com/tenstorrent/tt-metal/actions/runs/27640458947

(3× for redundancy — the `wh_galaxy_perf` runner has been flaky; we need one clean completion.)

## Validation — LLK tilize/unpack regression coverage

This touches `_llk_unpack_tilize_uninit_`, so the LLK tilize/unpack suite is the relevant regression guard:
- **`test_tilize_uninit.py`** — the regression test #45179 itself added. It asserts only that the **z-dim** is restored to `num_faces`; this fix preserves that, so it stays green. ✅ (it does not check y-dim)
- `test_unpack_tilize_sweep.py`, `test_zzz_unpack_tilize.py`, `test_fast_tilize*.py`, `test_matmul_unpack_tilize.py`, `test_unpack_A.py`, `test_unpack_matmul.py`, and the fuser tilize cases (`tilize_a`, `tilize_only_num_faces_2`, `fpu_tilize_a_then_unpack_a`).

⚠️ Tried to dispatch the dedicated **LLK e2e** workflow on this branch but it `startup_failure`s — **the `llk-e2e.yaml` workflow is currently broken on `main` too** (every scheduled run since at least Jun 13 is `startup_failure`; unrelated to this change). LLK coverage should run via merge-gate / the LLK pipeline once that workflow is fixed.

## Cross-check — author's fix PR #47036

The author of #45179 has an alternative fix in #47036 (`ldjurovic/fix_47016`). Dispatched the same 3 redundant `qwen3-32b-galaxy / wh_galaxy_perf` accuracy runs on it for comparison:

- https://github.com/tenstorrent/tt-metal/actions/runs/27641367569
- https://github.com/tenstorrent/tt-metal/actions/runs/27641381663
- https://github.com/tenstorrent/tt-metal/actions/runs/27641395782

If #47036 also restores accuracy, it likely supersedes this PR (this one can then be closed in its favor).

cc @ldjurovic (author of #45179) — please sanity-check the y-dim restore is the intended behavior.

Relates to #47049.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/fix-45179-tilize-ydim)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/fix-45179-tilize-ydim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/fix-45179-tilize-ydim)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/fix-45179-tilize-ydim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/fix-45179-tilize-ydim)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/fix-45179-tilize-ydim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/fix-45179-tilize-ydim)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/fix-45179-tilize-ydim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/fix-45179-tilize-ydim)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/fix-45179-tilize-ydim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/fix-45179-tilize-ydim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/fix-45179-tilize-ydim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/fix-45179-tilize-ydim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/fix-45179-tilize-ydim)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/fix-45179-tilize-ydim)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/fix-45179-tilize-ydim)