### PR TITLE
[Cleanup] Shrink DRAM-backed command queue region from 256 MB to 16 MB

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -994,7 +994,7 @@ protected:
             GTEST_SKIP();
         }
         if (is_quasar_sim()) {
-            GTEST_SKIP() << "FD unsupported on Quasar simulator: 256 MB DRAM-backed CQ overflows the 64 MB window";
+            GTEST_SKIP();
         }
         tt_metal::GenericMeshDeviceFixture::SetUp();
 

--- a/tt_metal/impl/dispatch/util/dispatch_settings.cpp
+++ b/tt_metal/impl/dispatch/util/dispatch_settings.cpp
@@ -60,7 +60,7 @@ void DispatchSettings::init_worker_defaults(
     uint32_t num_hw_cqs, bool is_galaxy_cluster, bool are_cqs_dram_backed, uint32_t l1_alignment) {
     uint32_t prefetch_q_entries;
     if (are_cqs_dram_backed) {
-        prefetch_q_entries = 256;
+        prefetch_q_entries = 64;
     } else if (is_galaxy_cluster) {
         prefetch_q_entries = 1532 / num_hw_cqs;
     } else {

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal.cpp
@@ -70,7 +70,7 @@ constexpr static std::uint32_t get_dram_backed_command_queues_base(std::uint32_t
 }
 
 constexpr static std::uint32_t get_dram_backed_command_queues_size(bool enable_dram_backed_cq) {
-    return enable_dram_backed_cq ? (1 << 28)  // 256 MB
+    return enable_dram_backed_cq ? (16u << 20)  // 16 MB
                                  : 0;
 }
 

--- a/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/wormhole/wh_hal.cpp
@@ -67,7 +67,7 @@ constexpr static std::uint32_t get_dram_backed_command_queues_base(std::uint32_t
     return get_dram_device_print_dispatch_base(dram_profiler_size) + DRAM_DEVICE_PRINT_DISPATCH_SIZE;
 }
 constexpr static std::uint32_t get_dram_backed_command_queues_size(bool enable_dram_backed_cq) {
-    return enable_dram_backed_cq ? (1 << 28)  // 256 MB
+    return enable_dram_backed_cq ? (16u << 20)  // 16 MB
                                  : 0;
 }
 constexpr static std::uint32_t get_dram_unreserved_base(std::uint32_t dram_profiler_size, bool enable_dram_backed_cq) {

--- a/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
+++ b/tt_metal/llrt/hal/tt-2xx/quasar/qa_hal.cpp
@@ -68,7 +68,7 @@ constexpr static std::uint32_t get_dram_backed_command_queues_base(std::uint32_t
 }
 
 constexpr static std::uint32_t get_dram_backed_command_queues_size(bool enable_dram_backed_cq) {
-    return enable_dram_backed_cq ? (1 << 28)  // 256 MB
+    return enable_dram_backed_cq ? (16u << 20)  // 16 MB
                                  : 0;
 }
 


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
DRAM-backed command queues were originally implemented to support Quasar simulation, which lacks host hugepages. This change reduces the reserved region from 256 MB down to 16 MB so that it fits within the Quasar simulator's 64 MB physical DRAM window. The original 256 MB reservation was larger than necessary; 16 MB is sufficient for fast dispatch, freeing up the excess DRAM for other uses. Wormhole and Blackhole are lowered to match since the DRAM-backed CQ path is an opt-in niche feature on those architectures, and unifying the size keeps the `prefetch_q_entries` reduction arch-agnostic.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/dram_backed_cq_lower_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/dram_backed_cq_lower_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/dram_backed_cq_lower_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/dram_backed_cq_lower_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/dram_backed_cq_lower_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/dram_backed_cq_lower_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/dram_backed_cq_lower_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/dram_backed_cq_lower_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/dram_backed_cq_lower_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/dram_backed_cq_lower_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/dram_backed_cq_lower_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/dram_backed_cq_lower_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/dram_backed_cq_lower_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/dram_backed_cq_lower_size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/dram_backed_cq_lower_size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/dram_backed_cq_lower_size)