### PR TITLE
Bug fix: clear NoC packet tags at idle-erisc startup

### DIFF
--- a/tt_metal/hw/firmware/src/tt-1xx/idle_erisc.cc
+++ b/tt_metal/hw/firmware/src/tt-1xx/idle_erisc.cc
@@ -136,6 +136,7 @@ int main() {
     for (uint32_t n = 0; n < NUM_NOCS; n++) {
         noc_local_state_init(n);
     }
+    noc_clear_all_packet_tags();
 
     DEVICE_PRINT_INITIALIZE_LOCK();
     deassert_all_reset();  // Bring all riscs on eth cores out of reset


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
PR #44425 added the `ncrisc_noc_packet_tags_cleared` between-kernel assert to `idle_erisck.cc` but omitted the paired `noc_clear_all_packet_tags()` firmware startup clear that every other RISC (`brisc`/`drisc`/`active_erisc`/`erisc`) received. On cores running idle-erisc dispatch kernels a stale write-command-buffer transaction ID is therefore never cleared, so the handoff assert trips on the stale tag. This adds the missing startup clear, matching the sibling firmware placement right after the `noc_local_state_init` loop.
