### PR TITLE
[Bug fix] Fix inconsistent CB usage in matmul kernels

### DIFF
--- a/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
+++ b/tests/ttnn/unit_tests/operations/matmul/test_matmul_deepseek.py
@@ -1437,3 +1437,104 @@ def test_lm_head_decode_linear(device):
     passed, pcc = comp_pcc(pt_out, output_tensor, 0.999)
     logger.info(f"PCC: {pcc}")
     assert passed, f"LM head decode linear test failed with PCC {pcc} < 0.999"
+
+
+@pytest.mark.parametrize("num_iters", [1])
+def test_matmul_dram_sharded_single_kblock(device, num_iters):
+    """
+    DRAM-sharded matmul whose activations live on a single in0 core, so in0_block_w
+    spans the full contraction dimension and the reader processes K in a single block
+    (num_blocks == 1). With one K-block the in1 circular buffer is single-buffered
+    rather than triple-buffered, so the reader's initial cb_in1.reserve_back must
+    request no more pages than the single-slot CB holds. Reserving a wider window
+    exceeds the CB capacity and deadlocks the reader, so this case guards the
+    single-buffered reservation path on any DRAM-sharded matmul.
+    """
+    torch.manual_seed(0)
+
+    m, k, n = 32, 512, 384
+    tile = 32
+    in0_dtype, in1_dtype, out_dtype = ttnn.bfloat16, ttnn.bfloat8_b, ttnn.bfloat16
+
+    # in1 is DRAM width-sharded across every bank; bank count is arch-dependent
+    # (8 on Blackhole, 12 on Wormhole), so derive it from the device.
+    num_dram_banks = device.dram_grid_size().x
+    n_padded = pad_to_dram_banks(n, tile, tile * num_dram_banks)
+
+    in0_shape = [1, 1, m, k]
+    in1_shape = [1, 1, k, n]
+    in1_shard_shape = [k, n_padded // num_dram_banks]
+
+    # A single in0 core makes in0_block_w cover all of K, which yields num_blocks == 1.
+    in0_core_grid = ttnn.CoreGrid(y=1, x=1)
+    in0_block_w = k // tile
+    per_core_M = m // tile
+    per_core_N = (n_padded // tile) // num_dram_banks
+
+    in0 = torch.randn(in0_shape, dtype=torch.bfloat16)
+    in1 = torch.randn(in1_shape, dtype=torch.bfloat16)
+
+    in0_memory_config = ttnn.create_sharded_memory_config(
+        in0_shape,
+        core_grid=in0_core_grid,
+        strategy=ttnn.ShardStrategy.WIDTH,
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    in0_t = ttnn.from_torch(
+        in0,
+        dtype=in0_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=in0_memory_config,
+    )
+
+    in1_shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_dram_banks - 1, 0))})
+    in1_shard_spec = ttnn.ShardSpec(in1_shard_grid, in1_shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    in1_memory_config = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.DRAM, in1_shard_spec)
+    in1_t = ttnn.from_torch(
+        in1,
+        dtype=in1_dtype,
+        layout=ttnn.TILE_LAYOUT,
+        device=device,
+        memory_config=in1_memory_config,
+    )
+
+    program_config = ttnn.MatmulMultiCoreReuseMultiCastDRAMShardedProgramConfig(
+        in0_block_w=in0_block_w,
+        per_core_M=per_core_M,
+        per_core_N=per_core_N,
+        fused_activation=None,
+    )
+
+    compute_kernel_config = ttnn.init_device_compute_kernel_config(
+        device.arch(),
+        math_fidelity=ttnn.MathFidelity.LoFi,
+        math_approx_mode=True,
+        fp32_dest_acc_en=True,
+        packer_l1_acc=True,
+    )
+
+    for itr in range(num_iters):
+        output_t = ttnn.matmul(
+            in0_t,
+            in1_t,
+            program_config=program_config,
+            memory_config=ttnn.L1_WIDTH_SHARDED_MEMORY_CONFIG,
+            dtype=out_dtype,
+            compute_kernel_config=compute_kernel_config,
+        )
+        if itr != num_iters - 1:
+            output_t.deallocate()
+
+    output_tensor = ttnn.to_torch(output_t)[:, :, :m, :n]
+    pt_out = in0 @ in1
+
+    assert_numeric_metrics(
+        pt_out,
+        output_tensor,
+        atol=0.0028 * k,
+        rtol=1.5 * k,
+        frobenius_threshold=0.0001 * k,
+        pcc_threshold=0.99,
+        check_ulp=False,
+    )

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp
@@ -194,7 +194,6 @@ void kernel_main() {
 
     CircularBuffer in0_cb(in0_cb_id);
     CircularBuffer in1_cb(in1_cb_id);
-    CircularBuffer out_cb(out_cb_id);
     CircularBuffer mm_partials_cb(mm_partials_cb_id);
     CircularBuffer untilize_mode_out_cb(untilize_mode_out_cb_id);
 
@@ -301,10 +300,6 @@ void kernel_main() {
 
                     in0_cb.wait_front(in0_block_num_tiles);
                     in1_cb.wait_front(in1_block_num_tiles);
-
-                    if (block == 0 && !last_out) {
-                        out_cb.reserve_back(out_block_num_tiles);
-                    }
 
                     int in0_index_subblock_offset = 0;
                     for (uint32_t in0_subblock = 0; in0_subblock < in0_num_subblocks; in0_subblock++) {

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -106,6 +106,10 @@ void kernel_main() {
     uint32_t curr_block_trid = 1;
     uint32_t block_trid_to_wait = 1;
 
+    // Reserve 2 blocks up front when num_blocks > 1: the loop's reserve_back at line 133
+    // only fires after block 1's writes complete, so the initial reservation must cover
+    // both block 0 and block 1 to avoid writing outside the reserved CB window.
+    // When num_blocks == 1 the CB is single-buffered, so reserve only 1 block.
     constexpr uint32_t initial_reserved_blocks = (num_blocks > 1) ? 2 : 1;
     cb_in1.reserve_back(in1_block_num_tiles * initial_reserved_blocks);
     uint32_t l1_write_addr_in1_offset = 0;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -106,7 +106,8 @@ void kernel_main() {
     uint32_t curr_block_trid = 1;
     uint32_t block_trid_to_wait = 1;
 
-    cb_in1.reserve_back(in1_block_num_tiles);
+    constexpr uint32_t initial_reserved_blocks = (num_blocks > 1) ? 2 : 1;
+    cb_in1.reserve_back(in1_block_num_tiles * initial_reserved_blocks);
     uint32_t l1_write_addr_in1_offset = 0;
     uint32_t l1_write_addr_in1_start = cb_in1.get_write_ptr();
     l1_write_addr_in1 = l1_write_addr_in1_start;

--- a/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp
@@ -212,6 +212,8 @@ void kernel_main() {
     noc.async_write_barrier();
 #endif
 
+    cb_out.pop_front(out_block_num_tiles);
+
     // Restore NCRISC_RD_CMD_BUF NOC_CTRL to the firmware default (VC=1, set in
     // noc_init). set_async_read_state<NocOptions::CUSTOM_VC> writes a per-bank VC into NOC_CTRL
     // and this hardware register persists across kernel launches. Kernels that


### PR DESCRIPTION
### Summary
New CB chacks in tt-emule flagged writing to unreserved area of CB in DRAM sharded reader. Fixing this issue then uncovered two other incorrect CB usages. This PR addresses all three. Specifically:
1. Removed unneeded `reserve_back` statements on `out_cb` in `ttnn/cpp/ttnn/operations/matmul/device/kernels/compute/bmm_large_block_zm_fused_bias_activation.cpp` since nothing was ever pushed to that CB.
2. Adjusted `reserve_back` statement on `cb_in1` in `ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp` to account for writes in the first iteration.
   Also added a unit test to detect a hang which would have resulted from an incorrect naive fix
3. Added obviously missing `cb_out.pop_front` in `ttnn/cpp/ttnn/operations/matmul/device/kernels/dataflow/reader_bmm_tile_layout_in1_sender_dram_sharded.cpp`

Closes #46843

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=fplavec_46843_cb_emule_assert_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:fplavec_46843_cb_emule_assert_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=fplavec_46843_cb_emule_assert_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:fplavec_46843_cb_emule_assert_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=fplavec_46843_cb_emule_assert_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:fplavec_46843_cb_emule_assert_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=fplavec_46843_cb_emule_assert_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:fplavec_46843_cb_emule_assert_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=fplavec_46843_cb_emule_assert_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:fplavec_46843_cb_emule_assert_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=fplavec_46843_cb_emule_assert_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:fplavec_46843_cb_emule_assert_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=fplavec_46843_cb_emule_assert_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:fplavec_46843_cb_emule_assert_fixes)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=fplavec_46843_cb_emule_assert_fixes)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:fplavec_46843_cb_emule_assert_fixes)