### PR TITLE
[DM] Remove duplicate architecture entry in data movement CSVs

### DIFF
--- a/tests/tt_metal/tt_metal/data_movement/python/stats_reporter.py
+++ b/tests/tt_metal/tt_metal/data_movement/python/stats_reporter.py
@@ -194,7 +194,7 @@ class StatsReporter:
                             # Standard metadata fields in specific order
                             standard_fields = ["architecture", "mechanism", "memory_type", "pattern"]
                             for field in standard_fields:
-                                if field in test_metadata:
+                                if field in test_metadata and field != "architecture":
                                     row.append(test_metadata[field])
 
                             # Add any additional optional fields in alphabetical order


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
Bug fix

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->
Issue: https://github.com/tenstorrent/tt-metal/issues/47277

When running data movement tests with the metadata attributes (memory_type, mechanism, pattern) appended in `test_information.yaml`, such as One to One Packet Sizes or One to All Packet Sizes, with the `--report` flag, the CSV is generated incorrectly, with the architecture data value being inserted twice, resulting in a duplicated column, and the column headers are not duplicated.

Fixes this by removing the duplicated value.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ryanzhu/dm-report-arch-dupe)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ryanzhu/dm-report-arch-dupe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ryanzhu/dm-report-arch-dupe)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ryanzhu/dm-report-arch-dupe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ryanzhu/dm-report-arch-dupe)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ryanzhu/dm-report-arch-dupe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ryanzhu/dm-report-arch-dupe)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ryanzhu/dm-report-arch-dupe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ryanzhu/dm-report-arch-dupe)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ryanzhu/dm-report-arch-dupe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ryanzhu/dm-report-arch-dupe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ryanzhu/dm-report-arch-dupe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ryanzhu/dm-report-arch-dupe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ryanzhu/dm-report-arch-dupe)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ryanzhu/dm-report-arch-dupe)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ryanzhu/dm-report-arch-dupe)