### PR TITLE
Cleanup: MoE: Auto-detect `moe_compute` matmul core count

### DIFF
--- a/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
+++ b/tests/nightly/tg/ccl/moe/test_moe_compute_6U.py
@@ -105,7 +105,6 @@ class MoEModelConfig:
     num_iterations: int = 3
     tokens_per_device: int = 32
     output_height_shard_dim: int = 4
-    bh_ring_size_values: tuple = (12,)
     marks: tuple = ()
 
 
@@ -163,7 +162,7 @@ def _expand_model_configs(
     test_modes_fn=_test_modes_for_model,
     trace_values_fn=_trace_values_for_case,
 ):
-    """Expand model configs into pytest.param entries (test_mode, has_bias, epd, act, enable_trace, bh_ring_size)."""
+    """Expand model configs into pytest.param entries (test_mode, has_bias, epd, act, enable_trace)."""
     expanded = []
     for cfg in configs:
         for test_mode in test_modes_fn(cfg):
@@ -172,28 +171,24 @@ def _expand_model_configs(
                     for act in cfg.activation_types:
                         # enable_trace innermost so a shape's trace variants run back-to-back and the
                         # second hits the _build_moe_host_data lru_cache (maxsize=1, evicted on every
-                        # new shape). bh_ring_size is part of that cache key (it changes the prepped
-                        # weight layout), so it must sit outside enable_trace or the trace pair — which
-                        # shares a ring size — would never be adjacent and every call would evict.
-                        for bh_ring_size in cfg.bh_ring_size_values:
-                            for enable_trace in trace_values_fn(cfg, test_mode):
-                                bias_tag = "bias" if has_bias else "no_bias"
-                                act_tag = act.name.lower()
-                                trace_tag = "enable_trace" if enable_trace else "disable_trace"
-                                ring_tag = f"bh_ring_size{bh_ring_size}"
-                                expanded.append(
-                                    pytest.param(
-                                        cfg,
-                                        test_mode,
-                                        has_bias,
-                                        epd,
-                                        act,
-                                        enable_trace,
-                                        bh_ring_size,
-                                        id=f"{cfg.name}-{test_mode}-{bias_tag}-{epd}experts_per_device-{act_tag}-{trace_tag}-{ring_tag}",
-                                        marks=cfg.marks,
-                                    )
+                        # new shape). The matmul ring size is auto-detected from the arch by the op
+                        # (8 on BH, 12 on WH) and is no longer a sweep dimension.
+                        for enable_trace in trace_values_fn(cfg, test_mode):
+                            bias_tag = "bias" if has_bias else "no_bias"
+                            act_tag = act.name.lower()
+                            trace_tag = "enable_trace" if enable_trace else "disable_trace"
+                            expanded.append(
+                                pytest.param(
+                                    cfg,
+                                    test_mode,
+                                    has_bias,
+                                    epd,
+                                    act,
+                                    enable_trace,
+                                    id=f"{cfg.name}-{test_mode}-{bias_tag}-{epd}experts_per_device-{act_tag}-{trace_tag}",
+                                    marks=cfg.marks,
                                 )
+                            )
     return expanded
 
 
@@ -269,7 +264,7 @@ _MODELS_BH_LB_1x8 = [
     MoEModelConfig("qwen3_omni_thinker", N=768,  hidden_size=2048, selected_experts_k=8),
     MoEModelConfig("qwen35_35b",         N=512,  hidden_size=2048, selected_experts_k=8),
     MoEModelConfig("gemma_4_26b",        N=704,  hidden_size=2816, selected_experts_k=8, activation_types=(MoEActivationFunction.GELU,)),
-    MoEModelConfig("gpt_oss",            N=2880, hidden_size=2880, selected_experts_k=4, experts_per_device_values=(4,), has_bias_values=(True,), test_modes=("perf", "correctness"), activation_types=(MoEActivationFunction.SWIGLU,), bh_ring_size_values=(8, 12, 16)),
+    MoEModelConfig("gpt_oss",            N=2880, hidden_size=2880, selected_experts_k=4, experts_per_device_values=(4,), has_bias_values=(True,), test_modes=("perf", "correctness"), activation_types=(MoEActivationFunction.SWIGLU,)),
     MoEModelConfig("qwen3_235b",         N=1536, hidden_size=4096, selected_experts_k=8),
     MoEModelConfig("qwen35_397b",        N=1024, hidden_size=4096, selected_experts_k=10),
     MoEModelConfig("glm_47",             N=1536, hidden_size=5120, selected_experts_k=8),
@@ -301,7 +296,6 @@ def _run_model_test(
     activation_type,
     num_links,
     topology=None,
-    bh_ring_size=12,
 ):
     if test_mode == "perf":
         selected_experts_k = 1
@@ -311,6 +305,10 @@ def _run_model_test(
         selected_experts_k = model_cfg.selected_experts_k
         num_layers = model_cfg.num_layers
         num_iterations = model_cfg.num_iterations
+
+    # Matmul ring size the op (and the weight-prep helpers) auto-detect from the arch
+    # (8 on BH, 12 on WH); used here for the ring-aware width-parallel derivation.
+    ring_n = effective_matmul_ring_size(mesh_device)
 
     _run_moe_compute_impl(
         mesh_device=mesh_device,
@@ -326,7 +324,7 @@ def _run_model_test(
         output_height_shard_dim=model_cfg.output_height_shard_dim,
         output_width_shard_dim=auto_output_width_shard_dim(
             model_cfg.hidden_size,
-            matmul_ring_size=effective_matmul_ring_size(mesh_device, bh_ring_size),
+            matmul_ring_size=ring_n,
         ),
         dtype=ttnn.bfloat16,
         enable_trace=enable_trace,
@@ -334,7 +332,6 @@ def _run_model_test(
         has_bias=has_bias,
         topology=topology,
         num_links=num_links,
-        bh_ring_size=bh_ring_size,
     )
 
 
@@ -1530,7 +1527,6 @@ def _build_moe_host_data(
     dtype,
     activation_type,
     has_bias,
-    bh_ring_size,
 ):
     """Build all device-independent inputs and golden references for the test.
 
@@ -1541,10 +1537,8 @@ def _build_moe_host_data(
     same shape share an entry. ``maxsize=1`` keeps at most one (large) shape's artifacts
     alive: a new shape evicts the previous one.
 
-    ``bh_ring_size`` is a parameter (the goldens don't use it) purely so it participates
-    in the lru_cache key: the quantized bfloat4_b weight host tensors attached to the
-    returned object in ``_run_moe_compute_impl`` DO depend on it (prepare/interleave
-    layout), so two ring sizes of the same shape must not share a cached object.
+    The matmul ring size is auto-detected from the arch (8 on BH, 12 on WH) by the
+    weight-prep helpers, so it is fixed per device and not part of the cache key.
     """
     torch.manual_seed(2003)
     random.seed(2003)
@@ -1701,7 +1695,7 @@ def _build_moe_host_data(
 
 
 def _build_quantized_weight_host_tensors(
-    mesh_device, weight_inputs, num_layers, experts_per_device, hidden_size, N, has_bias, bh_ring_size
+    mesh_device, weight_inputs, num_layers, experts_per_device, hidden_size, N, has_bias
 ):
     """Upload raw weights, run the on-device prepare/interleave, then quantize to
     ``bfloat4_b`` via host — returning the result as **host** tensors (memory_config
@@ -1739,7 +1733,6 @@ def _build_quantized_weight_host_tensors(
             E=experts_per_device,
             K=hidden_size,
             N=N,
-            bh_ring_size=bh_ring_size,
         )
         ttnn.deallocate(tt_b0_raw)
         ttnn.deallocate(tt_b1_raw)
@@ -1751,7 +1744,6 @@ def _build_quantized_weight_host_tensors(
             E=experts_per_device,
             K=hidden_size,
             N=N,
-            bh_ring_size=bh_ring_size,
         )
     ttnn.deallocate(tt_w0_raw)
     ttnn.deallocate(tt_w1_raw)
@@ -1770,7 +1762,6 @@ def _build_quantized_weight_host_tensors(
             E=experts_per_device,
             N=N,
             K=hidden_size,
-            bh_ring_size=bh_ring_size,
         )
         ttnn.deallocate(tt_b2_raw)
     else:
@@ -1780,7 +1771,6 @@ def _build_quantized_weight_host_tensors(
             E=experts_per_device,
             N=N,
             K=hidden_size,
-            bh_ring_size=bh_ring_size,
         )
     ttnn.deallocate(tt_w2_raw)
 
@@ -1810,7 +1800,6 @@ def _run_moe_compute_impl(
     has_bias,
     num_links,
     topology=None,
-    bh_ring_size=12,
 ):
     """Run MoE compute E2E validation. Called from test_moe_compute via _run_model_test."""
     experts = experts_per_device * mesh_shape[cluster_axis]
@@ -1865,13 +1854,11 @@ def _run_moe_compute_impl(
         dtype,
         activation_type,
         has_bias,
-        bh_ring_size,
     )
     cache_hit = _build_moe_host_data.cache_info().hits > _hits_before
     shape_desc = (
         f"mesh={tuple(mesh_shape)} EP={experts_per_device} T/dev={tokens_per_device} "
-        f"k={selected_experts_k} L={num_layers} N={N} H={hidden_size} act={activation_type} bias={has_bias} "
-        f"bh_ring_size={bh_ring_size}"
+        f"k={selected_experts_k} L={num_layers} N={N} H={hidden_size} act={activation_type} bias={has_bias}"
     )
     if host.w0_w1_host is None:
         # Quantization needs a live device, so it can't run inside the pure (cached)
@@ -1882,7 +1869,7 @@ def _run_moe_compute_impl(
         # re-quantizing. w0_w1_host is None only on a genuine miss (fresh or evicted
         # shape), which is exactly when we want to (re)build them.
         host.w0_w1_host, host.w2_host = _build_quantized_weight_host_tensors(
-            mesh_device, weight_inputs, num_layers, experts_per_device, hidden_size, N, has_bias, bh_ring_size
+            mesh_device, weight_inputs, num_layers, experts_per_device, hidden_size, N, has_bias
         )
     # cache_hit (lru_cache) and "w0_w1_host was None" (quantization) always agree: a
     # goldens hit returns the already-quantized object; a miss rebuilds it with None.
@@ -1999,7 +1986,6 @@ def _run_moe_compute_impl(
         hidden_size=hidden_size,
         intermediate_size=N,
         has_bias=has_bias,
-        bh_ring_size=bh_ring_size,
     )
     tt_w0_w1 = ttnn.to_device(host.w0_w1_host, mesh_device, memory_config=weight_mem_configs.w0_w1)
     tt_w2 = ttnn.to_device(host.w2_host, mesh_device, memory_config=weight_mem_configs.w2)
@@ -2092,7 +2078,6 @@ def _run_moe_compute_impl(
             optional_output_tensor=tt_combine_output_tensors[layer_id],
             optional_cross_device_semaphore=combine_barrier_semaphore,
             activation_type=activation_type,
-            bh_ring_size=bh_ring_size,
         )
 
     #########################################
@@ -2168,7 +2153,11 @@ def _run_moe_compute_impl(
         mesh_device, output_height_shard_dim, output_width_shard_dim
     )
     worker_mcast_bbox = ttnn.experimental.get_moe_worker_mcast_bounding_box(
-        mesh_device, output_height_shard_dim, output_width_shard_dim, hidden_size, bh_ring_size
+        mesh_device,
+        output_height_shard_dim,
+        output_width_shard_dim,
+        hidden_size,
+        effective_matmul_ring_size(mesh_device),
     )
     per_expert_tokens_all_passed = True
     activation_all_passed = True
@@ -2308,7 +2297,7 @@ def _run_moe_compute_impl(
 #   MOE_COMPUTE_FULL=1             — all models x all meshes (1x8/1x16 x torus/linear); tier rules unchanged.
 # ---------------------------------------------------------------------------
 @pytest.mark.parametrize(
-    "device_params, mesh_cfg, mesh_shape, mesh_device, model_cfg, test_mode, has_bias, experts_per_device, activation_type, enable_trace, bh_ring_size",
+    "device_params, mesh_cfg, mesh_shape, mesh_device, model_cfg, test_mode, has_bias, experts_per_device, activation_type, enable_trace",
     MOE_COMPUTE_MODEL_TEST_CASES,
     indirect=["device_params", "mesh_device"],
 )
@@ -2322,7 +2311,6 @@ def test_moe_compute(
     has_bias,
     experts_per_device,
     activation_type,
-    bh_ring_size,
 ):
     from ttnn.operations.ccl import Topology
 
@@ -2338,7 +2326,6 @@ def test_moe_compute(
         activation_type,
         topology=topology,
         num_links=mesh_cfg.num_links,
-        bh_ring_size=bh_ring_size,
     )
 
 

--- a/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
+++ b/tests/ttnn/nightly/unit_tests/operations/experimental/test_moe_compute_single_card.py
@@ -82,15 +82,14 @@ def _run_moe_compute_single_card_test(
     dtype,
     activation_type,
     has_bias=False,
-    bh_ring_size=None,
 ):
     """
     Single-card MoE compute test body. cluster_axis is fixed to None
     (no dispatch axis on 1x1 mesh) and compute_only is fixed to True.
 
-    `bh_ring_size`: pinned BH matmul ring size. None defaults to 12. Pass the same value to
-    ``auto_output_width_shard_dim(..., matmul_ring_size=effective_matmul_ring_size(...))`` so
-    host tensor layout matches the op's ring-aware width-parallel auto-derivation.
+    The matmul ring size is auto-detected from the arch (8 on BH, 12 on WH) — the same
+    ``effective_matmul_ring_size(mesh_device)`` the public op uses — and is used to pack the
+    weights so host tensor layout matches the op's ring-aware width-parallel auto-derivation.
     """
     # The MoE op uses tilize cores keyed off the per-arch layout table in the program
     # factory's `get_layout()` (see #41827) and matmul cores from
@@ -243,9 +242,11 @@ def _run_moe_compute_single_card_test(
     # CREATE MATMUL INPUT TENSORS
     #########################################
 
-    w0_w1_shard_map, w2_shard_map, dram_core_range_set = get_weight_core_shard_maps(
-        mesh_device, hidden_size, N, bh_ring_size=bh_ring_size
-    )
+    # Ring size the op (and the weight-prep helpers) auto-detect from the arch (8 on BH,
+    # 12 on WH); used here for the ring-aware width-parallel derivation and the mcast bbox.
+    ring_n = effective_matmul_ring_size(mesh_device)
+
+    w0_w1_shard_map, w2_shard_map, dram_core_range_set = get_weight_core_shard_maps(mesh_device, hidden_size, N)
 
     torch_w0 = create_torch_w0(num_layers, experts_per_device, hidden_size, N)
     torch_w1 = create_torch_w1(num_layers, experts_per_device, hidden_size, N)
@@ -350,7 +351,6 @@ def _run_moe_compute_single_card_test(
         optional_cross_device_semaphore=None,
         activation_type=activation_type,
         compute_only=True,
-        bh_ring_size=bh_ring_size,
     )
 
     # ===================================================================
@@ -403,7 +403,7 @@ def _run_moe_compute_single_card_test(
         mesh_device, output_height_shard_dim, output_width_shard_dim
     )
     worker_mcast_bbox = ttnn.experimental.get_moe_worker_mcast_bounding_box(
-        mesh_device, output_height_shard_dim, output_width_shard_dim, hidden_size, bh_ring_size or 12
+        mesh_device, output_height_shard_dim, output_width_shard_dim, hidden_size, ring_n
     )
 
     base_pcc_threshold = _get_base_pcc_threshold(activation_type, has_bias)
@@ -486,13 +486,6 @@ def _run_moe_compute_single_card_test(
 #     harvested n150_L), and (6,9)/(5,9) fall out of range. COL-axis matches the 6U
 #     test setup and keeps all 10 functional rows (logical y=0..9) available.
 #
-# bh_ring_size sweep: N=12 always runs (the default on both WH and BH); N=8 and N=16
-# add BH-specific coverage of the kBhMatmulExtras padding paths (N=8: no extras;
-# N=16: full 8 extras). On WH the op only supports N=12, so N=8/16 are skipped there.
-_DS_BH_RING_SIZES = [12]
-_DS_BH_RING_SIZES += [8, 16]  # comment this line to skip N=8 and N=16 sweep
-
-
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -503,17 +496,14 @@ _DS_BH_RING_SIZES += [8, 16]  # comment this line to skip N=8 and N=16 sweep
     ],
     indirect=True,
 )
-@pytest.mark.parametrize("bh_ring_size", _DS_BH_RING_SIZES)
 @pytest.mark.parametrize("has_bias", [False, True], ids=["no_bias", "with_bias"])
 @pytest.mark.parametrize("mesh_shape, mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
-def test_moe_compute_single_card_deepseek(mesh_device, mesh_shape, has_bias, bh_ring_size):
-    """compute_only=True on a 1x1 WH mesh, DeepSeek-shaped workload (hidden=7168).
+def test_moe_compute_single_card_deepseek(mesh_device, mesh_shape, has_bias):
+    """compute_only=True on a 1x1 mesh, DeepSeek-shaped workload (hidden=7168).
 
-    Parametrized over has_bias and bh_ring_size. WH always uses N=12 (DRAM banks);
-    N=8/16 only run on BH.
+    The matmul ring size is auto-detected from the arch (12 on WH, 8 on BH); the op no longer
+    exposes a bh_ring_size knob.
     """
-    if bh_ring_size != 12 and mesh_device.arch() != ttnn.device.Arch.BLACKHOLE:
-        pytest.skip(f"bh_ring_size={bh_ring_size} is BH-only; WH always uses N=12")
     _run_moe_compute_single_card_test(
         mesh_device=mesh_device,
         mesh_shape=mesh_shape,
@@ -527,16 +517,12 @@ def test_moe_compute_single_card_deepseek(mesh_device, mesh_shape, has_bias, bh_
         dtype=ttnn.bfloat16,
         activation_type=MoEActivationFunction.SILU,
         has_bias=has_bias,
-        bh_ring_size=bh_ring_size,
     )
 
 
 # GPT-OSS canonical config from the GPT-OSS entry in `_MODELS_1x8` (test_moe_compute_6U.py):
 #   experts_per_device=4, has_bias=True, activation=SWIGLU.
-# Ring-aware width dim: N=12 → width=3; N=8/16 → width=2 (90%3==0 but 8%3≠0).
-_GPT_BH_RING_SIZES = [12, 8, 16]  # remove 8, 16 to limit sweep to ring_n=12
-
-
+# Ring-aware width dim: N=12 (WH) → width=3; N=8 (BH) → width=2 (90%3==0 but 8%3≠0).
 @pytest.mark.parametrize(
     "device_params",
     [
@@ -547,16 +533,14 @@ _GPT_BH_RING_SIZES = [12, 8, 16]  # remove 8, 16 to limit sweep to ring_n=12
     ],
     indirect=True,
 )
-@pytest.mark.parametrize("bh_ring_size", _GPT_BH_RING_SIZES)
 @pytest.mark.parametrize("mesh_shape, mesh_device", [((1, 1), (1, 1))], indirect=["mesh_device"])
-def test_moe_compute_single_card_gpt_oss(mesh_device, mesh_shape, bh_ring_size):
+def test_moe_compute_single_card_gpt_oss(mesh_device, mesh_shape):
     """compute_only=True on a 1x1 mesh, GPT-OSS-shaped workload (hidden=N=2880, SWIGLU+bias).
 
-    Parametrized over bh_ring_size. WH always uses N=12; N=8/16 only run on BH.
+    The matmul ring size is auto-detected from the arch (12 on WH, 8 on BH); the op no longer
+    exposes a bh_ring_size knob.
     """
-    if bh_ring_size != 12 and mesh_device.arch() != ttnn.device.Arch.BLACKHOLE:
-        pytest.skip(f"bh_ring_size={bh_ring_size} is BH-only; WH always uses N=12")
-    ring_n = effective_matmul_ring_size(mesh_device, bh_ring_size)
+    ring_n = effective_matmul_ring_size(mesh_device)
     _run_moe_compute_single_card_test(
         mesh_device=mesh_device,
         mesh_shape=mesh_shape,
@@ -570,7 +554,6 @@ def test_moe_compute_single_card_gpt_oss(mesh_device, mesh_shape, bh_ring_size):
         dtype=ttnn.bfloat16,
         activation_type=MoEActivationFunction.SWIGLU,
         has_bias=True,
-        bh_ring_size=bh_ring_size,
     )
 
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute.cpp
@@ -5,6 +5,8 @@
 #include <cstdint>
 #include <optional>
 
+#include <umd/device/types/arch.hpp>
+
 #include "moe_compute.hpp"
 #include "device/moe_compute_device_operation.hpp"
 
@@ -30,8 +32,11 @@ std::vector<ttnn::Tensor> moe_compute(
     const std::optional<ttnn::GlobalSemaphore>& optional_cross_device_semaphore,
     const std::optional<ttnn::experimental::prim::detail::MoEActivationFunction>& activation_type,
     const bool compute_only,
-    const std::optional<uint32_t>& bh_ring_size,
     const std::optional<uint32_t>& num_shared_experts_per_device) {
+    // bh_ring_size is intentionally not exposed on the public API. The matmul ring size is
+    // auto-detected from the architecture: 8 on Blackhole, 12 on Wormhole (one per DRAM bank).
+    // It remains a tunable knob on the ttnn::prim::moe_compute entry point.
+    const std::optional<uint32_t> bh_ring_size = (tilize_input_tensor.device()->arch() == tt::ARCH::BLACKHOLE) ? 8 : 12;
     return ttnn::prim::moe_compute(
         tilize_input_tensor,
         tilize_expert_indices_tensor,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute.hpp
@@ -35,7 +35,6 @@ std::vector<ttnn::Tensor> moe_compute(
     const std::optional<ttnn::GlobalSemaphore>& optional_cross_device_semaphore,
     const std::optional<ttnn::experimental::prim::detail::MoEActivationFunction>& activation_type = std::nullopt,
     bool compute_only = false,
-    const std::optional<uint32_t>& bh_ring_size = std::nullopt,
     const std::optional<uint32_t>& num_shared_experts_per_device = std::nullopt);
 
 std::vector<ttnn::CoreCoord> get_moe_combine_cores(

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_nanobind.cpp
@@ -34,10 +34,10 @@ void bind_moe_compute(nb::module_& mod) {
 
         This operation performs the expert matmuls (gate/up projection via W0/W1, down
         projection via W2) and activation (SILU, SwiGLU, or GELU) in a fused compute kernel.
-        Tile distribution across the matmul ring (12 cores on Wormhole; ``bh_ring_size``
-        cores — 8/12/16 — on Blackhole) is derived at compile time from ``hidden_size`` and
-        ``intermediate_size`` using Euclidean-rhythm (Bresenham) shard formulas — no
-        model-specific configuration tables are needed.
+        Tile distribution across the matmul ring (12 cores on Wormhole; 8 cores on
+        Blackhole — auto-detected from the architecture) is derived at compile time from
+        ``hidden_size`` and ``intermediate_size`` using Euclidean-rhythm (Bresenham) shard
+        formulas — no model-specific configuration tables are needed.
 
         Note: This is the **compute** portion of the MoE pipeline. The A2A dispatch
         (producing the sparse buffer consumed by this op) and the A2A combine (reducing
@@ -114,10 +114,10 @@ void bind_moe_compute(nb::module_& mod) {
           matmul output is the final output, slot 4) instead of 6, and all combine-path
           arguments below must be left unset (notably ``cluster_axis`` must be ``None``).
 
-        - ``bh_ring_size`` (optional, default ``None`` ≡ ``12``): Matmul ring size on
-          Blackhole; must be one of ``{8, 12, 16}``. Ignored on Wormhole, which always
-          uses 12 (one per DRAM bank). Must match the value passed to the ``prepare_*`` /
-          ``get_weight_mem_configs`` helpers that packed the weights.
+        The matmul ring size is **auto-detected** from the architecture — 8 on Blackhole,
+        12 on Wormhole (one per DRAM bank) — and is not exposed on this API. The
+        ``prepare_*`` / ``get_weight_mem_configs`` helpers that pack the weights must be
+        called with the matching ring size (see ``effective_matmul_ring_size``).
 
         **Bias support (optional)**
 
@@ -190,7 +190,8 @@ void bind_moe_compute(nb::module_& mod) {
         nb::arg("has_bias") = false,
         // cluster_axis is required when compute_only=False; pass None for compute_only=True paths.
         // (Two breaking changes vs prior versions: (1) intermediate_size is now required positional
-        // from PR #43932; (2) cluster_axis became optional, new compute_only/bh_ring_size knobs.)
+        // from PR #43932; (2) cluster_axis became optional, new compute_only knob. The matmul ring
+        // size is auto-detected from the arch (8 BH / 12 WH); bh_ring_size remains only on prim.)
         nb::arg("cluster_axis") = nb::none(),
         nb::arg("topology") = nb::none(),
         nb::arg("num_links") = nb::none(),
@@ -200,7 +201,6 @@ void bind_moe_compute(nb::module_& mod) {
         nb::arg("optional_cross_device_semaphore") = nb::none(),
         nb::arg("activation_type") = nb::none(),
         nb::arg("compute_only") = false,
-        nb::arg("bh_ring_size") = nb::none(),
         nb::arg("num_shared_experts_per_device") = nb::none());
 }
 
@@ -249,14 +249,17 @@ void bind_moe_compute_utils(nb::module_& mod) {
         (complementary when ``Nt%n_cores + Ht%n_cores == n_cores``) for W2. Ring
         ordering: DRAM bank logical coords sorted by ``(y, x)`` descending.
 
+        The matmul ring size is auto-detected from the architecture — 8 on Blackhole,
+        12 on Wormhole (the DRAM-bank count) — matching ``ttnn.experimental.moe_compute``,
+        so the packed weights always line up with the op.
+
         Returns an object with ``w0_w1_shard_map``, ``w2_shard_map``, and
         ``dram_core_range_set`` attributes.
         )doc",
         &ttnn::experimental::get_weight_core_shard_maps,
         nb::arg("mesh_device"),
         nb::arg("hidden_size"),
-        nb::arg("intermediate_size"),
-        nb::arg("bh_ring_size") = 12);
+        nb::arg("intermediate_size"));
 
     nb::class_<ttnn::experimental::WeightMemoryConfigs>(mod, "WeightMemoryConfigs")
         .def_ro("w0_w1", &ttnn::experimental::WeightMemoryConfigs::w0_w1)
@@ -281,8 +284,7 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("experts_per_device"),
         nb::arg("hidden_size"),
         nb::arg("intermediate_size"),
-        nb::arg("has_bias") = false,
-        nb::arg("bh_ring_size") = 12);
+        nb::arg("has_bias") = false);
 
     ttnn::bind_function<"add_shared_expert_weights", "ttnn.experimental.">(
         mod,
@@ -303,8 +305,8 @@ void bind_moe_compute_utils(nb::module_& mod) {
         dim) so real columns stay paired with their real W2 rows. This keeps the
         downstream prep + DRAM layout uniform (full-Nt per-expert stride) while
         letting the kernel walk only the per-core prefixes as a balanced TpNt ring.
-        ``bh_ring_size`` selects the ring size for the shard-map generator (must
-        match the value used for ``prepare_*`` / ``get_weight_mem_configs``).
+        The shard-map generator auto-detects the ring size from the arch (8 on Blackhole,
+        12 on Wormhole), matching ``prepare_*`` / ``get_weight_mem_configs`` and the op.
 
         Returns ``(output_w0, output_w1, output_w2)``, each the result of
         concatenating routed + shared along dim 1.
@@ -316,8 +318,7 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("shared_w0").noconvert(),
         nb::arg("shared_w1").noconvert(),
         nb::arg("shared_w2").noconvert(),
-        nb::arg("cluster_axis"),
-        nb::arg("bh_ring_size") = 12);
+        nb::arg("cluster_axis"));
 
     ttnn::bind_function<"prepare_w0_w1_tensor_for_moe_compute", "ttnn.experimental.">(
         mod,
@@ -337,8 +338,7 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("L"),
         nb::arg("E"),
         nb::arg("K"),
-        nb::arg("N"),
-        nb::arg("bh_ring_size") = 12);
+        nb::arg("N"));
 
     ttnn::bind_function<"prepare_w2_tensor_for_moe_compute", "ttnn.experimental.">(
         mod,
@@ -356,8 +356,7 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("L"),
         nb::arg("E"),
         nb::arg("N"),
-        nb::arg("K"),
-        nb::arg("bh_ring_size") = 12);
+        nb::arg("K"));
 
     ttnn::bind_function<"prepare_w0_w1_tensor_with_bias", "ttnn.experimental.">(
         mod,
@@ -378,8 +377,7 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("L"),
         nb::arg("E"),
         nb::arg("K"),
-        nb::arg("N"),
-        nb::arg("bh_ring_size") = 12);
+        nb::arg("N"));
 
     ttnn::bind_function<"prepare_w2_tensor_with_bias", "ttnn.experimental.">(
         mod,
@@ -398,8 +396,7 @@ void bind_moe_compute_utils(nb::module_& mod) {
         nb::arg("L"),
         nb::arg("E"),
         nb::arg("N"),
-        nb::arg("K"),
-        nb::arg("bh_ring_size") = 12);
+        nb::arg("K"));
 
     ttnn::bind_function<"quantize_weights_via_host", "ttnn.experimental.">(
         mod,

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.cpp
@@ -18,7 +18,6 @@
 #include <tt-metalium/kernel_types.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt_stl/assert.hpp>
-#include <umd/device/types/arch.hpp>
 #include <tt_stl/small_vector.hpp>
 #include <tt_stl/span.hpp>
 
@@ -280,19 +279,13 @@ ttnn::Tensor prepare_w2_no_n_pad(
 }  // namespace
 
 WeightCoreShardMaps get_weight_core_shard_maps(
-    ttnn::MeshDevice* mesh_device, uint32_t hidden_size, uint32_t intermediate_size, uint32_t bh_ring_size) {
+    ttnn::MeshDevice* mesh_device, uint32_t hidden_size, uint32_t intermediate_size) {
     const auto in0_core_coords =
         mesh_device->get_optimal_dram_bank_to_logical_worker_assignment(tt::tt_metal::NOC::RISCV_0_default);
+    // Matmul ring size = the DRAM-bank count, which auto-detects the ring per arch (8 on
+    // Blackhole, 12 on Wormhole) to match ttnn.experimental.moe_compute.
     const uint32_t n_dram_banks = static_cast<uint32_t>(in0_core_coords.size());
-
-    const bool is_blackhole = mesh_device->arch() == tt::ARCH::BLACKHOLE;
-    if (is_blackhole) {
-        TT_FATAL(
-            bh_ring_size == 8 || bh_ring_size == 12 || bh_ring_size == 16,
-            "bh_ring_size ({}) must be 8, 12, or 16 on BLACKHOLE",
-            bh_ring_size);
-    }
-    const uint32_t target_ring_size = is_blackhole ? bh_ring_size : n_dram_banks;
+    const uint32_t target_ring_size = n_dram_banks;
 
     // Ring ordering: sort the DRAM-bank logical core coords by (y, x) descending.
     std::vector<uint32_t> ring_to_dram_bank(n_dram_banks);
@@ -346,8 +339,7 @@ WeightMemoryConfigs get_weight_mem_configs(
     uint32_t experts_per_device,
     uint32_t hidden_size,
     uint32_t intermediate_size,
-    bool has_bias,
-    uint32_t bh_ring_size) {
+    bool has_bias) {
     TT_FATAL(
         hidden_size % TILE_SIZE == 0, "hidden_size ({}) must be divisible by TILE_SIZE ({})", hidden_size, TILE_SIZE);
     TT_FATAL(
@@ -356,7 +348,7 @@ WeightMemoryConfigs get_weight_mem_configs(
         intermediate_size,
         TILE_SIZE);
 
-    const auto shard_maps = get_weight_core_shard_maps(mesh_device, hidden_size, intermediate_size, bh_ring_size);
+    const auto shard_maps = get_weight_core_shard_maps(mesh_device, hidden_size, intermediate_size);
     const auto& w0_w1_shard_map = shard_maps.w0_w1_shard_map;
     const auto& w2_shard_map = shard_maps.w2_shard_map;
 
@@ -427,8 +419,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
     const ttnn::Tensor& shared_w0,
     const ttnn::Tensor& shared_w1,
     const ttnn::Tensor& shared_w2,
-    const uint32_t cluster_axis,
-    const uint32_t bh_ring_size) {
+    const uint32_t cluster_axis) {
     const auto intermediate_dim = static_cast<uint32_t>(routed_w0.logical_shape()[-1]);
     const auto hidden_dim = static_cast<uint32_t>(routed_w0.logical_shape()[-2]);
     const auto tp_axis = 1 - cluster_axis;
@@ -442,8 +433,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
     // (zeros after), applying the same mapping to W0/W1 and W2. This keeps the whole
     // downstream prep + DRAM layout uniform (full-Nt per-expert stride) while letting
     // the kernel walk only the real per-core prefixes as a balanced TpNt ring.
-    const auto full_map =
-        get_weight_core_shard_maps(device, hidden_dim, intermediate_dim, bh_ring_size).w0_w1_shard_map;
+    const auto full_map = get_weight_core_shard_maps(device, hidden_dim, intermediate_dim).w0_w1_shard_map;
 
     auto mp_w0 = ttnn::mesh_partition(shared_w0, -1, tp_axis);
     const auto tp_intermediate = static_cast<uint32_t>(mp_w0.logical_shape()[-1]);
@@ -452,7 +442,7 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
         "TP-split intermediate ({}) must be tile-aligned (TILE_SIZE={})",
         tp_intermediate,
         TILE_SIZE);
-    const auto tp_map = get_weight_core_shard_maps(device, hidden_dim, tp_intermediate, bh_ring_size).w0_w1_shard_map;
+    const auto tp_map = get_weight_core_shard_maps(device, hidden_dim, tp_intermediate).w0_w1_shard_map;
 
     auto working_shared_w0 = front_pack_per_core(mp_w0, /*axis=*/-1, full_map, tp_map);
     mp_w0.deallocate(/*force=*/false);
@@ -477,19 +467,12 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
 }
 
 ttnn::Tensor prepare_w0_w1_tensor_for_moe_compute(
-    const ttnn::Tensor& tt_w0,
-    const ttnn::Tensor& tt_w1,
-    uint32_t L,
-    uint32_t E,
-    uint32_t K,
-    uint32_t N,
-    uint32_t bh_ring_size) {
+    const ttnn::Tensor& tt_w0, const ttnn::Tensor& tt_w1, uint32_t L, uint32_t E, uint32_t K, uint32_t N) {
     TT_FATAL(K % TILE_SIZE == 0, "K dimension ({}) must be divisible by TILE_SIZE ({})", K, TILE_SIZE);
     TT_FATAL(N % TILE_SIZE == 0, "N dimension ({}) must be divisible by TILE_SIZE ({})", N, TILE_SIZE);
 
     const auto shard_map =
-        get_weight_core_shard_maps(tt_w0.device(), /*hidden_size=*/K, /*intermediate_size=*/N, bh_ring_size)
-            .w0_w1_shard_map;
+        get_weight_core_shard_maps(tt_w0.device(), /*hidden_size=*/K, /*intermediate_size=*/N).w0_w1_shard_map;
     const uint32_t Nt = N / TILE_SIZE;
     // Pad K up to a multiple of (TILE_SIZE * BLOCK_TILES_H) — matches the DRAM read transaction.
     const uint32_t Kp = ceil_div(K / TILE_SIZE, BLOCK_TILES_H) * TILE_SIZE * BLOCK_TILES_H;
@@ -624,12 +607,11 @@ ttnn::Tensor prepare_w0_w1_tensor_for_moe_compute(
 }
 
 ttnn::Tensor prepare_w2_tensor_for_moe_compute(
-    const ttnn::Tensor& tt_w2, uint32_t L, uint32_t E, uint32_t N, uint32_t K, uint32_t bh_ring_size) {
+    const ttnn::Tensor& tt_w2, uint32_t L, uint32_t E, uint32_t N, uint32_t K) {
     TT_FATAL(N % TILE_SIZE == 0, "N dimension ({}) must be divisible by TILE_SIZE ({})", N, TILE_SIZE);
     TT_FATAL(K % TILE_SIZE == 0, "K dimension ({}) must be divisible by TILE_SIZE ({})", K, TILE_SIZE);
 
-    const auto shard_maps =
-        get_weight_core_shard_maps(tt_w2.device(), /*hidden_size=*/K, /*intermediate_size=*/N, bh_ring_size);
+    const auto shard_maps = get_weight_core_shard_maps(tt_w2.device(), /*hidden_size=*/K, /*intermediate_size=*/N);
     const auto& w0_w1_shard_map = shard_maps.w0_w1_shard_map;
     const auto& w2_shard_map = shard_maps.w2_shard_map;
 
@@ -666,8 +648,7 @@ ttnn::Tensor prepare_w0_w1_tensor_with_bias(
     uint32_t L,
     uint32_t E,
     uint32_t K,
-    uint32_t N,
-    uint32_t bh_ring_size) {
+    uint32_t N) {
     TT_FATAL(K % TILE_SIZE == 0, "K dimension ({}) must be divisible by TILE_SIZE ({})", K, TILE_SIZE);
     TT_FATAL(N % TILE_SIZE == 0, "N dimension ({}) must be divisible by TILE_SIZE ({})", N, TILE_SIZE);
 
@@ -688,25 +669,18 @@ ttnn::Tensor prepare_w0_w1_tensor_with_bias(
     b0_tiled.deallocate(/*force=*/true);
     b1_tiled.deallocate(/*force=*/true);
 
-    auto result = prepare_w0_w1_tensor_for_moe_compute(w0_b0, w1_b1, L, E, K_with_bias, N, bh_ring_size);
+    auto result = prepare_w0_w1_tensor_for_moe_compute(w0_b0, w1_b1, L, E, K_with_bias, N);
     w0_b0.deallocate(/*force=*/true);
     w1_b1.deallocate(/*force=*/true);
     return result;
 }
 
 ttnn::Tensor prepare_w2_tensor_with_bias(
-    const ttnn::Tensor& tt_w2,
-    const ttnn::Tensor& tt_b2,
-    uint32_t L,
-    uint32_t E,
-    uint32_t N,
-    uint32_t K,
-    uint32_t bh_ring_size) {
+    const ttnn::Tensor& tt_w2, const ttnn::Tensor& tt_b2, uint32_t L, uint32_t E, uint32_t N, uint32_t K) {
     TT_FATAL(N % TILE_SIZE == 0, "N dimension ({}) must be divisible by TILE_SIZE ({})", N, TILE_SIZE);
     TT_FATAL(K % TILE_SIZE == 0, "K dimension ({}) must be divisible by TILE_SIZE ({})", K, TILE_SIZE);
 
-    const auto shard_maps =
-        get_weight_core_shard_maps(tt_w2.device(), /*hidden_size=*/K, /*intermediate_size=*/N, bh_ring_size);
+    const auto shard_maps = get_weight_core_shard_maps(tt_w2.device(), /*hidden_size=*/K, /*intermediate_size=*/N);
     const auto& w0_w1_shard_map = shard_maps.w0_w1_shard_map;
     const auto& w2_shard_map = shard_maps.w2_shard_map;
 

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/moe_compute/moe_compute_utils.hpp
@@ -39,8 +39,10 @@ struct WeightCoreShardMaps {
 // compute op expects. Uses ``shard_tiles`` (Euclidean rhythm) for W0/W1 and
 // ``w2_shard_tiles`` (complementary when ``Nt%n_cores + Ht%n_cores == n_cores``)
 // for W2. Ring ordering: DRAM bank logical coords sorted by ``(y, x)`` descending.
+// The matmul ring size is auto-detected from the device arch (8 on Blackhole,
+// 12 — the DRAM-bank count — on Wormhole), matching ``ttnn.experimental.moe_compute``.
 WeightCoreShardMaps get_weight_core_shard_maps(
-    ttnn::MeshDevice* mesh_device, uint32_t hidden_size, uint32_t intermediate_size, uint32_t bh_ring_size = 12);
+    ttnn::MeshDevice* mesh_device, uint32_t hidden_size, uint32_t intermediate_size);
 
 // DRAM-sharded memory configs for the packed W0/W1 and W2 weight tensors. The
 // shard maps and DRAM-bank CoreRangeSet are computed internally to match
@@ -59,8 +61,7 @@ WeightMemoryConfigs get_weight_mem_configs(
     uint32_t experts_per_device,
     uint32_t hidden_size,
     uint32_t intermediate_size,
-    bool has_bias = false,
-    uint32_t bh_ring_size = 12);
+    bool has_bias = false);
 
 // Append per-device shared experts after routed experts along the experts dim.
 //
@@ -76,28 +77,21 @@ std::tuple<ttnn::Tensor, ttnn::Tensor, ttnn::Tensor> add_shared_expert_weights(
     const ttnn::Tensor& shared_w0,
     const ttnn::Tensor& shared_w1,
     const ttnn::Tensor& shared_w2,
-    uint32_t cluster_axis,
-    uint32_t bh_ring_size = 12);
+    uint32_t cluster_axis);
 
 // Pack W0/W1 into the interleaved, padded, per-core layout the MoE kernel reads.
 // Output local shape: ``(num_cores, L, E, groups_per_core, K_padded, 4*TILE)``.
 // The per-core shard map is derived internally from ``K`` (hidden_size) and
 // ``N`` (intermediate_size) via ``get_weight_core_shard_maps``.
 ttnn::Tensor prepare_w0_w1_tensor_for_moe_compute(
-    const ttnn::Tensor& tt_w0,
-    const ttnn::Tensor& tt_w1,
-    uint32_t L,
-    uint32_t E,
-    uint32_t K,
-    uint32_t N,
-    uint32_t bh_ring_size = 12);
+    const ttnn::Tensor& tt_w0, const ttnn::Tensor& tt_w1, uint32_t L, uint32_t E, uint32_t K, uint32_t N);
 
 // Pack W2 into the ring-rotated per-core layout the MoE kernel reads.
 // Output local shape: ``(num_cores, L, E, w2_groups_per_core, N_padded, 4*TILE)``.
 // The per-core shard maps are derived internally from ``K`` (hidden_size) and
 // ``N`` (intermediate_size) via ``get_weight_core_shard_maps``.
 ttnn::Tensor prepare_w2_tensor_for_moe_compute(
-    const ttnn::Tensor& tt_w2, uint32_t L, uint32_t E, uint32_t N, uint32_t K, uint32_t bh_ring_size = 12);
+    const ttnn::Tensor& tt_w2, uint32_t L, uint32_t E, uint32_t N, uint32_t K);
 
 // Bias-aware W0/W1 packer: appends bias tiles along K, then delegates to the
 // no-bias packer. Bias inputs are PyTorch-format ``(L, E, N)``; output matches
@@ -110,20 +104,13 @@ ttnn::Tensor prepare_w0_w1_tensor_with_bias(
     uint32_t L,
     uint32_t E,
     uint32_t K,
-    uint32_t N,
-    uint32_t bh_ring_size = 12);
+    uint32_t N);
 
 // Bias-aware W2 packer: weight tiles get ring-rotated as usual; bias tile row
 // is column-sharded and concatenated along N **without** rotation, then N is
 // padded to a multiple of BLOCK_TILES_H tiles.
 ttnn::Tensor prepare_w2_tensor_with_bias(
-    const ttnn::Tensor& tt_w2,
-    const ttnn::Tensor& tt_b2,
-    uint32_t L,
-    uint32_t E,
-    uint32_t N,
-    uint32_t K,
-    uint32_t bh_ring_size = 12);
+    const ttnn::Tensor& tt_w2, const ttnn::Tensor& tt_b2, uint32_t L, uint32_t E, uint32_t N, uint32_t K);
 
 // Round-trip a device tensor through host to change its dtype and optionally re-upload
 // it under the supplied memory config. Used to quantize the packed weight

--- a/ttnn/ttnn/_experimental/moe_compute_utils.py
+++ b/ttnn/ttnn/_experimental/moe_compute_utils.py
@@ -66,7 +66,7 @@ memory configs, or see ``test_moe_compute_6U.py`` for the full flow.
 
 - Shard formulas: ``_shard_tiles``, ``_w2_shard_tiles``, ``auto_output_width_shard_dim``,
   ``effective_matmul_ring_size``
-- Shard maps: ``get_weight_core_shard_maps(mesh_device, hidden_size, intermediate_size, bh_ring_size=12)``
+- Shard maps: ``get_weight_core_shard_maps(mesh_device, hidden_size, intermediate_size)``
 - Memory configs: ``get_weight_mem_configs(...)``
 - Non-bias: ``prepare_w0_w1_tensor_for_moe_compute``, ``prepare_w2_tensor_for_moe_compute``
 - With bias: ``prepare_w0_w1_tensor_with_bias``, ``prepare_w2_tensor_with_bias``
@@ -385,8 +385,14 @@ def _w2_shard_tiles(Ht: int, core_id: int, Nt: int, n_cores: int) -> int:
     return _shard_tiles(Ht, core_id, n_cores)
 
 
-def effective_matmul_ring_size(mesh_device, bh_ring_size: int = 12) -> int:
-    """Matmul ring N used by ``moe_compute`` on this device (12 on WH; ``bh_ring_size`` on BH)."""
+def effective_matmul_ring_size(mesh_device, bh_ring_size: int = 8) -> int:
+    """Matmul ring N used by ``moe_compute`` on this device (12 on WH; ``bh_ring_size`` on BH).
+
+    ``ttnn.experimental.moe_compute`` auto-detects the ring from the arch (8 on BH, 12 on WH)
+    and no longer exposes a ``bh_ring_size`` knob, so the default here matches that auto-detection.
+    Call with no ``bh_ring_size`` to get the ring the public op will actually use, and pass the
+    result to the ``prepare_*`` / ``get_weight_*`` helpers so host weight layout matches the op.
+    """
     if mesh_device.arch() == ttnn.Arch.BLACKHOLE:
         if bh_ring_size not in _BH_SUPPORTED_RING_SIZES:
             raise ValueError(
@@ -841,42 +847,21 @@ def prepare_w2_tensor_with_bias(
     return N_with_bias
 
 
-def get_weight_core_shard_maps(mesh_device, hidden_size: int, intermediate_size: int, bh_ring_size: int = 12):
+def get_weight_core_shard_maps(mesh_device, hidden_size: int, intermediate_size: int):
     """Compute per-ring-position shard maps for W0/W1 and W2 weight tensors.
 
     Uses _shard_tiles() (Euclidean rhythm) for W0/W1 and _w2_shard_tiles()
     (complementary when Nt%n_cores + Ht%n_cores == n_cores) for W2.
     Ring ordering: DRAM bank logical coords sorted by (y, x) descending.
 
-    Ring length:
-    - WH: target_ring_size = num_dram_banks = 12 (1:1 ring-to-bank).
-    - BH: target_ring_size = bh_ring_size (default 12; supported {8, 12, 16}).
-          When target_ring_size > num_dram_banks (=8), the shard_map has extra entries
-          for the synthetic ring positions that the C++ program_factory appends via
-          kBhMatmulExtras. The prepare functions emit a matching target_ring_size-slot
-          logical tensor; HEIGHT_SHARDED regroups it onto num_banks physical shards,
-          and the kernel's dm0.cpp bank-run loop walks each ring core's contiguous
-          slice across the bank(s) it covers.
-
-    dram_core_range_set always has exactly num_dram_banks entries (the placement target),
-    regardless of target_ring_size.
-
-    `bh_ring_size`: if you pass this kwarg to ttnn.experimental.moe_compute, pass the same
-    value here. The default (12) matches the op's default, so a fully-default call site
-    stays consistent. On WH this kwarg is ignored (ring is fixed at num_dram_banks).
+    The matmul ring size is the DRAM-bank count, which auto-detects the ring per arch
+    (8 on Blackhole, 12 on Wormhole) to match ``ttnn.experimental.moe_compute``, so the
+    packed weights always line up with the op. dram_core_range_set has exactly that many
+    entries.
     """
     in0_core_coords = ttnn.device.get_optimal_dram_bank_to_logical_worker_assignment(mesh_device, 0)
     n_dram_banks = len(in0_core_coords)
-
-    is_blackhole = mesh_device.arch() == ttnn.Arch.BLACKHOLE
-    if is_blackhole:
-        if bh_ring_size not in _BH_SUPPORTED_RING_SIZES:
-            raise ValueError(
-                f"bh_ring_size={bh_ring_size} is not supported (must be one of {_BH_SUPPORTED_RING_SIZES})"
-            )
-        target_ring_size = bh_ring_size
-    else:
-        target_ring_size = n_dram_banks
+    target_ring_size = n_dram_banks
 
     core2dram = {cc: dram_bank_id for dram_bank_id, cc in enumerate(in0_core_coords)}
     in0_core_coords_sorted = sorted(in0_core_coords, key=lambda x: (x.y, x.x), reverse=True)


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=amorrison/moe-auto-detect-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:amorrison/moe-auto-detect-ring-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=amorrison/moe-auto-detect-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:amorrison/moe-auto-detect-ring-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=amorrison/moe-auto-detect-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:amorrison/moe-auto-detect-ring-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=amorrison/moe-auto-detect-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:amorrison/moe-auto-detect-ring-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=amorrison/moe-auto-detect-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:amorrison/moe-auto-detect-ring-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=amorrison/moe-auto-detect-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:amorrison/moe-auto-detect-ring-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=amorrison/moe-auto-detect-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:amorrison/moe-auto-detect-ring-size)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=amorrison/moe-auto-detect-ring-size)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:amorrison/moe-auto-detect-ring-size)