### PR TITLE
[cleanup] Reduce surface area of Runtime Tensor APIS

### DIFF
--- a/tt-train/sources/ttml/nanobind/nb_util.cpp
+++ b/tt-train/sources/ttml/nanobind/nb_util.cpp
@@ -315,15 +315,11 @@ nb::object make_numpy_tensor(
             return make_numpy_tensor_from_data.template operator()<NumpyType>(vec, composed_spec);
         }
 
-        const auto cpu_tensor_data = tt::tt_metal::host_buffer::get_as<const MetalType>(cpu_tensor);
         const auto cpu_tensor_spec = cpu_tensor.tensor_spec();
-        const auto cpu_tensor_strides = cpu_tensor.strides();
 
-        if (tt::tt_metal::logical_matches_physical(cpu_tensor_spec)) {
-            return make_numpy_tensor_from_data.template operator()<NumpyType>(cpu_tensor_data, cpu_tensor_spec);
-        }
-
-        const auto decoded_data = tt::tt_metal::tensor_impl::decode_tensor_data(cpu_tensor_data, cpu_tensor_spec);
+        // to_vector returns logical, row-major data (decoding padding/tiling as needed), which is
+        // exactly the representation NumPy expects.
+        const auto decoded_data = cpu_tensor.to_vector<MetalType>();
         return make_numpy_tensor_from_data.template operator()<NumpyType>(decoded_data, cpu_tensor_spec);
     };
 

--- a/tt_metal/api/tt-metalium/experimental/tensor/impl/tensor_impl.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/impl/tensor_impl.hpp
@@ -5,82 +5,31 @@
 #pragma once
 
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
-#include <tt-metalium/distributed_host_buffer.hpp>
 #include <tt-metalium/mesh_buffer.hpp>
 #include <tt-metalium/mesh_device.hpp>
 #include <tt-metalium/host_buffer.hpp>
-#include <tt-metalium/tilize_utils.hpp>
+#include <tt-metalium/bfloat16.hpp>
+#include <tt-metalium/float8.hpp>
 
-#include <tt_stl/span.hpp>
-#include <vector>
+#include <tt_stl/assert.hpp>
+
+#include <memory>
 
 /**
- * Functions in this file are internal utilities for Runtime Tensors.
- * They are exported out in the public API area as a transiet state,
- * many of them are used by ttnn python binding.
- * We should disperse these functions as public APIs in tensor_apis.hpp or make them private to tt_metal.
+ * Buffer allocation and DataType dispatch utilities for Runtime Tensors.
+ *
+ * These remain exported in the public API area as a transient state, pending dispersal into the
+ * public Runtime Tensor APIs (see tensor_apis.hpp / host_tensor.hpp) or relocation to tt_metal
+ * internals. The data-conversion helpers that previously lived here are now private to tt_metal
+ * (tt_metal/impl/tensor/tensor_impl_private.hpp).
  */
 
 namespace tt::tt_metal::tensor_impl {
-
-// ======================================================================================
-//                           Data reader, writer, and initializers
-// ======================================================================================
 
 std::shared_ptr<distributed::MeshBuffer> allocate_device_buffer(
     distributed::MeshDevice* mesh_device, const TensorSpec& tensor_spec);
 
 HostBuffer allocate_host_buffer(const TensorSpec& tensor_spec);
-
-// Converts logical data into physical data based on tensor spec
-// - Logical data: Flat container of row major data corresponding to some ND logical shape
-// - Physical data: Flat container of physical data corresponding to tensor spec. It takes into account:
-//   * Sharding: Each shard will be padded to nearest page (if needed)
-//     ** This is mostly for logical sharding, since logical shards may not be aligned to page in general
-//     ** For interleaved, it will be handled as a "logically sharded" tensor with same shard shard height/width
-//        as the original tensor dims at -2 and -1. In the future, interleaved may be generalized as sharded.
-//     ** This means padding may be inserted in the middle of logical data (if needed)
-//   * Layout: Each aligned shard will be tilized (if needed)
-//     ** Tilization happens after first inserting padding to align shards (if needed)
-//     ** For the last shard, we only align to nearest page instead of full shard size for partial shards
-//   * After conversion, size of physical data will match 2D physical size indicated by tensor_spec.physical_shape()
-template <typename T>
-std::vector<T> encode_tensor_data(ttsl::Span<const T> logical_data, const TensorSpec& tensor_spec, T pad_value = 0);
-
-// Converts physical data into logical data based on tensor spec (see encode_tensor_data for details)
-// - Physical data: Flat container of physical data corresponding to tensor spec
-//   * Assumes that the physical data already matches tensor spec
-//   * There is a bare minimum check that size of physical data matches size indicated by tensor_spec.physical_shape()
-// - Logical data: Flat container of row major data corresponding to some ND logical shape
-//   * To get logical data, perform the exact inverse process of encode_tensor_data
-//   * Resulting data is safe to be converted to python tensors or general consumption with just a ND logical shape
-template <typename T>
-std::vector<T> decode_tensor_data(ttsl::Span<const T> physical_data, const TensorSpec& tensor_spec);
-
-// ======================================================================================
-//                                  Layout converters
-// ======================================================================================
-
-template <typename T>
-std::vector<T> to_row_major_layout(const Shape2D& shape, const Tile& tile, ttsl::Span<const T> data_to_convert) {
-    auto tile_shape = tile.get_tile_shape();
-    auto face_shape = tile.get_face_shape();
-    auto transpose_within_face = tile.get_transpose_within_face();
-    auto transpose_of_faces = tile.get_transpose_of_faces();
-
-    return convert_layout(
-        data_to_convert,
-        shape,
-        TensorLayoutType::TILED_NFACES,
-        TensorLayoutType::LIN_ROW_MAJOR,
-        tile_shape,
-        face_shape,
-        transpose_within_face,
-        transpose_of_faces);
-}
-
-template <typename T>
-std::vector<T> to_tile_major_layout(const Shape2D& shape, const Tile& tile, ttsl::Span<const T> data_to_convert);
 
 // Empty structs to facilitate Tensor template logic.
 struct bfloat4_b {};

--- a/tt_metal/impl/tensor/host_tensor_factory.cpp
+++ b/tt_metal/impl/tensor/host_tensor_factory.cpp
@@ -13,7 +13,8 @@
 #include <tt-metalium/mesh_coord.hpp>
 #include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
 #include <tt-metalium/experimental/tensor/topology/tensor_topology.hpp>
-#include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
+
+#include "tensor_impl_private.hpp"
 
 #include <tt_stl/span.hpp>
 #include <tt_stl/fmt.hpp>

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -12,6 +12,7 @@
 
 #include <tt-metalium/experimental/tensor/tensor_apis.hpp>
 #include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
+#include "tensor_impl_private.hpp"
 
 #include <tt-metalium/constants.hpp>
 #include <tt-metalium/math.hpp>

--- a/tt_metal/impl/tensor/tensor_impl.cpp
+++ b/tt_metal/impl/tensor/tensor_impl.cpp
@@ -8,6 +8,7 @@
 #include <tt-metalium/float8.hpp>
 
 #include <tt-metalium/experimental/tensor/impl/tensor_impl.hpp>
+#include "tensor_impl_private.hpp"
 
 #include <vector>
 

--- a/tt_metal/impl/tensor/tensor_impl_private.hpp
+++ b/tt_metal/impl/tensor/tensor_impl_private.hpp
@@ -1,0 +1,74 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <tt-metalium/experimental/tensor/spec/tensor_spec.hpp>
+#include <tt-metalium/tilize_utils.hpp>
+
+#include <tt_stl/span.hpp>
+#include <vector>
+
+/**
+ * Internal data-conversion utilities for Runtime Tensors.
+ *
+ * These convert tensor data between its logical (row-major, ND) and physical (padded, tiled, sharded)
+ * representations. They are implementation details of tt_metal's tensor layer: only translation units
+ * under tt_metal/impl/tensor should include this header. Callers outside tt_metal should use the
+ * public Runtime Tensor APIs (HostTensor::from_vector / to_vector, tensor_apis.hpp::to_layout, ...).
+ */
+
+namespace tt::tt_metal::tensor_impl {
+
+// Converts logical data into physical data based on tensor spec
+// - Logical data: Flat container of row major data corresponding to some ND logical shape
+// - Physical data: Flat container of physical data corresponding to tensor spec. It takes into account:
+//   * Sharding: Each shard will be padded to nearest page (if needed)
+//     ** This is mostly for logical sharding, since logical shards may not be aligned to page in general
+//     ** For interleaved, it will be handled as a "logically sharded" tensor with same shard shard height/width
+//        as the original tensor dims at -2 and -1. In the future, interleaved may be generalized as sharded.
+//     ** This means padding may be inserted in the middle of logical data (if needed)
+//   * Layout: Each aligned shard will be tilized (if needed)
+//     ** Tilization happens after first inserting padding to align shards (if needed)
+//     ** For the last shard, we only align to nearest page instead of full shard size for partial shards
+//   * After conversion, size of physical data will match 2D physical size indicated by tensor_spec.physical_shape()
+template <typename T>
+std::vector<T> encode_tensor_data(ttsl::Span<const T> logical_data, const TensorSpec& tensor_spec, T pad_value = 0);
+
+// Converts physical data into logical data based on tensor spec (see encode_tensor_data for details)
+// - Physical data: Flat container of physical data corresponding to tensor spec
+//   * Assumes that the physical data already matches tensor spec
+//   * There is a bare minimum check that size of physical data matches size indicated by tensor_spec.physical_shape()
+// - Logical data: Flat container of row major data corresponding to some ND logical shape
+//   * To get logical data, perform the exact inverse process of encode_tensor_data
+//   * Resulting data is safe to be converted to python tensors or general consumption with just a ND logical shape
+template <typename T>
+std::vector<T> decode_tensor_data(ttsl::Span<const T> physical_data, const TensorSpec& tensor_spec);
+
+// ======================================================================================
+//                                  Layout converters
+// ======================================================================================
+
+template <typename T>
+std::vector<T> to_row_major_layout(const Shape2D& shape, const Tile& tile, ttsl::Span<const T> data_to_convert) {
+    auto tile_shape = tile.get_tile_shape();
+    auto face_shape = tile.get_face_shape();
+    auto transpose_within_face = tile.get_transpose_within_face();
+    auto transpose_of_faces = tile.get_transpose_of_faces();
+
+    return convert_layout(
+        data_to_convert,
+        shape,
+        TensorLayoutType::TILED_NFACES,
+        TensorLayoutType::LIN_ROW_MAJOR,
+        tile_shape,
+        face_shape,
+        transpose_within_face,
+        transpose_of_faces);
+}
+
+template <typename T>
+std::vector<T> to_tile_major_layout(const Shape2D& shape, const Tile& tile, ttsl::Span<const T> data_to_convert);
+
+}  // namespace tt::tt_metal::tensor_impl

--- a/ttnn/cpp/ttnn-nanobind/bfloat_dtype_traits.hpp
+++ b/ttnn/cpp/ttnn-nanobind/bfloat_dtype_traits.hpp
@@ -25,25 +25,5 @@ struct dtype_traits<::bfloat16> {
     static constexpr auto name = const_name("bfloat16");
 };
 
-template <>
-struct dtype_traits<tt::tt_metal::tensor_impl::bfloat8_b> {
-    static constexpr dlpack::dtype value{
-        static_cast<std::uint8_t>(nanobind::dlpack::dtype_code::Bfloat),  // type code
-        8,                                                                // size in bits
-        1                                                                 // lanes (simd), usually set to 1
-    };
-    static constexpr auto name = const_name("bfloat8_b");
-};
-
-template <>
-struct dtype_traits<tt::tt_metal::tensor_impl::bfloat4_b> {
-    static constexpr dlpack::dtype value{
-        static_cast<std::uint8_t>(nanobind::dlpack::dtype_code::Bfloat),  // type code
-        4,                                                                // size in bits
-        1                                                                 // lanes (simd), usually set to 1
-    };
-    static constexpr auto name = const_name("bfloat4_b");
-};
-
 NAMESPACE_END(detail)
 NAMESPACE_END(NB_NAMESPACE)

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -32,6 +32,10 @@
 #include "ttnn-nanobind/bfloat_dtype_traits.hpp"
 #include "ttnn-nanobind/small_vector_caster.hpp"
 #include "ttnn-nanobind/ttnn_dtype_traits.hpp"
+
+#include <tt-metalium/experimental/tensor/host_tensor.hpp>
+#include <tt-metalium/experimental/tensor/tensor_apis.hpp>
+
 #include "ttnn/common/queue_id.hpp"
 #include "ttnn/core.hpp"
 #include "ttnn/distributed/api.hpp"
@@ -202,23 +206,30 @@ RowMajorHostBuffer convert_to_row_major_host_buffer(const Tensor& tt_tensor, con
 
     const auto& tensor_spec = tt_tensor.tensor_spec();
 
-    // Performs logical data conversion on the concrete data type.
+    // Performs logical data conversion on the concrete data type, routing through the public Runtime
+    // Tensor APIs. The buffer holds elements of type T (block-float inputs are pre-unpacked to float
+    // by the caller), so it is described with a matching-dtype spec.
     auto dispatch_to_concrete = [&tensor_spec, padded_output]<typename T>(HostBuffer host_buffer) {
+        const tt::tt_metal::TensorSpec elem_spec(
+            tensor_spec.logical_shape(),
+            tt::tt_metal::TensorLayout(
+                tt::tt_metal::convert_to_data_type<T>(), tensor_spec.page_config(), tensor_spec.memory_config()));
+
         if (padded_output) {
             if (tensor_spec.layout() == Layout::TILE) {
-                auto row_major_data = tensor_impl::to_row_major_layout(
-                    tensor_spec.physical_shape(), tensor_spec.tile(), host_buffer.view_as<const T>());
-                return RowMajorHostBuffer::create_padded(HostBuffer(std::move(row_major_data)), tensor_spec);
+                const tt::tt_metal::HostTensor host_tensor(
+                    std::move(host_buffer), elem_spec, tt::tt_metal::TensorTopology{});
+                const tt::tt_metal::HostTensor row_major = tt::tt_metal::to_layout(host_tensor, Layout::ROW_MAJOR);
+                const auto row_major_view = tt::tt_metal::host_buffer::get_as<const T>(row_major);
+                return RowMajorHostBuffer::create_padded(
+                    HostBuffer(std::vector<T>(row_major_view.begin(), row_major_view.end())), tensor_spec);
             }
             return RowMajorHostBuffer::create_padded(std::move(host_buffer), tensor_spec);
         }
 
-        // Previous impl only copied if data needed transformation. Instead *always* copy
-        // because the HostBuffer will be returned directly to the other python frameworks
-        // wrapped in an ndarray
-
-        auto logical_data = tensor_impl::decode_tensor_data(host_buffer.view_as<const T>(), tensor_spec);
-        return RowMajorHostBuffer::create_logical(HostBuffer(std::move(logical_data)), tensor_spec);
+        // Always copy: the HostBuffer is handed directly to other python frameworks wrapped in an ndarray.
+        const tt::tt_metal::HostTensor host_tensor(std::move(host_buffer), elem_spec, tt::tt_metal::TensorTopology{});
+        return RowMajorHostBuffer::create_logical(HostBuffer(host_tensor.to_vector<T>()), tensor_spec);
     };
 
     auto convert_to_logical = [&tensor_spec, &dispatch_to_concrete](const HostBuffer& buffer) {


### PR DESCRIPTION
Reduce the public API surface of experimental/tensor/impl/tensor_impl.hpp. The data-conversion templates (encode_tensor_data, decode_tensor_data, to_tile_major_layout, to_row_major_layout) are internal-only and move to a new private header tt_metal/impl/tensor/tensor_impl_private.hpp. The public header retains only the buffer allocators (allocate_device_buffer, allocate_host_buffer) and the shared DataType dispatch toolkit (dispatch + bfloat4_b/bfloat8_b tag structs), which ttnn still uses.

External callers are migrated to existing public Runtime Tensor APIs: pytensor.cpp to_torch/to_numpy use HostTensor::to_vector and tt::tt_metal::to_layout + host_buffer::get_as; tt-train nb_util.cpp uses Tensor::to_vector; bfloat_dtype_traits.hpp drops the dead bfloat8_b/bfloat4_b dtype_traits specializations (block-float data is unpacked to float32 before any ndarray is built).

Privatizing the two allocate_* functions is deferred (needs a public uninitialized-allocation API plus ttnn/test migration).

### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/runtime-tensor-surface-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/runtime-tensor-surface-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/runtime-tensor-surface-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/runtime-tensor-surface-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/runtime-tensor-surface-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/runtime-tensor-surface-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/runtime-tensor-surface-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/runtime-tensor-surface-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/runtime-tensor-surface-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/runtime-tensor-surface-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/runtime-tensor-surface-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/runtime-tensor-surface-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/runtime-tensor-surface-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/runtime-tensor-surface-reduction)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/runtime-tensor-surface-reduction)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/runtime-tensor-surface-reduction)