### PR TITLE
from_torch(): do tilize on host when input tensor is sharded

### DIFF
--- a/tests/ttnn/unit_tests/gtests/sources.cmake
+++ b/tests/ttnn/unit_tests/gtests/sources.cmake
@@ -38,6 +38,7 @@ set(UNIT_TESTS_TTNN_BASIC_SOURCES
     test_gelu_fw_ulp.cpp
     test_tanh_bw_ulp.cpp
     test_tanh_fw_ulp.cpp
+    test_tilize_width_sharded_dram.cpp
 )
 
 set(UNIT_TESTS_TTNN_CCL_SOURCES

--- a/tests/ttnn/unit_tests/gtests/test_tilize_width_sharded_dram.cpp
+++ b/tests/ttnn/unit_tests/gtests/test_tilize_width_sharded_dram.cpp
@@ -1,0 +1,56 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Regression test for https://github.com/tenstorrent/tt-metal/issues/45331
+//
+// On-device ttnn::tilize crashes with an L1 OOM (statically allocated
+// circular buffers grow well beyond per-core L1) when the destination
+// memory_config is a wide WIDTH_SHARDED DRAM tile-layout target.
+//
+// The original Python reproducer hits this path via
+//   ttnn.from_torch(..., layout=ttnn.TILE_LAYOUT,
+//                   memory_config=<width-sharded DRAM>, device=mesh_device)
+// which lands the torch tensor on device as ROW_MAJOR DRAM interleaved and
+// then runs on-device tilize to convert to the sharded TILE target. This
+// test exercises just that final tilize hop directly.
+
+#include <array>
+
+#include <gtest/gtest.h>
+
+#include <tt-metalium/buffer_types.hpp>
+#include <tt-metalium/core_coord.hpp>
+#include <tt-metalium/shape.hpp>
+
+#include "ttnn/operations/creation/creation.hpp"
+#include "ttnn/operations/data_movement/tilize/tilize.hpp"
+#include "ttnn/tensor/types.hpp"
+#include "ttnn/types.hpp"
+#include "ttnn_test_fixtures.hpp"
+
+namespace ttnn::operations::data_movement::test {
+
+using TilizeWidthShardedDramFixture = ttnn::TTNNFixtureWithDevice;
+
+TEST_F(TilizeWidthShardedDramFixture, WidthShardedDramTargetDoesNotCrash) {
+    auto& device = *device_;
+
+    // Same shape, dtype, and target sharding as the reproducer in #45331:
+    //   2048 x 42752 bfloat16, width-sharded across 12 cores on row 0,
+    //   per-shard shape (2048, 3584), ROW_MAJOR orientation, DRAM, TILE output.
+    const ttnn::Shape shape({2048, 42752});
+
+    auto input_tensor =
+        ttnn::zeros(shape, DataType::BFLOAT16, ttnn::ROW_MAJOR_LAYOUT, std::ref(device), ttnn::DRAM_MEMORY_CONFIG);
+
+    const CoreRangeSet shard_grid(CoreRange(CoreCoord{0, 0}, CoreCoord{11, 0}));
+    const ShardSpec shard_spec(shard_grid, std::array<uint32_t, 2>{2048, 3584}, ShardOrientation::ROW_MAJOR);
+    const MemoryConfig sharded_dram_cfg(TensorMemoryLayout::WIDTH_SHARDED, BufferType::DRAM, shard_spec);
+
+    // The bug manifests as a TT_THROW during tilize program compile (CB sizing),
+    // not as a wrong numerical result. We only assert the call doesn't throw.
+    EXPECT_NO_THROW({ auto out = ttnn::tilize(input_tensor, sharded_dram_cfg); });
+}
+
+}  // namespace ttnn::operations::data_movement::test

--- a/ttnn/core/tensor/py_to_tt_tensor.cpp
+++ b/ttnn/core/tensor/py_to_tt_tensor.cpp
@@ -242,15 +242,21 @@ Tensor create_tt_tensor_from_host_data(
             auto src_tensor_layout =
                 compute_input_tensor_layout(src_dtype, device_shard_shape, memory_config, layout, optional_tile);
 
-            const bool construct_on_mesh_device = construct_on_device && has_sufficient_device_memory(
-                                                                             device,
-                                                                             src_tensor_layout,
-                                                                             device_shard_shape,
-                                                                             src_dtype,
-                                                                             dst_dtype,
-                                                                             layout,
-                                                                             memory_config,
-                                                                             optional_tile);
+            // Mirror can_construct_on_single_device's sharded guard: the on-device tilize/typecast
+            // pipeline's L1 circular-buffer footprint is not modeled by has_sufficient_device_memory
+            // (which only checks the target buffer pool, e.g. DRAM). For wide width-sharded TILE
+            // targets this leads to L1 OOM at program compile time, so force host construction.
+            // See issue #45331 for more details.
+            const bool construct_on_mesh_device = construct_on_device && !memory_config.is_sharded() &&
+                                                  has_sufficient_device_memory(
+                                                      device,
+                                                      src_tensor_layout,
+                                                      device_shard_shape,
+                                                      src_dtype,
+                                                      dst_dtype,
+                                                      layout,
+                                                      memory_config,
+                                                      optional_tile);
 
             return ttnn::distributed::create_distributed_tensor(
                 host_buffer.view_as<T>(),


### PR DESCRIPTION
Temporary patch for the issue #45331

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ichovpan/tilize-patch)