### PR TITLE
[Cleanup] Create `from_buffer` factory methods for runtime tensors

### DIFF
--- a/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_host_tensor.cpp
@@ -38,7 +38,7 @@ HostTensor create_simple_host_tensor(const Shape& shape, DataType dtype = DataTy
     auto spec = create_simple_spec(shape, dtype);
     auto buffer = DistributedHostBuffer::create(distributed::MeshShape{1});
     auto topology = TensorTopology();
-    return HostTensor(std::move(buffer), std::move(spec), std::move(topology));
+    return HostTensor::from_buffer(std::move(buffer), std::move(spec), std::move(topology));
 }
 
 // Type trait tests verifying HostTensor's semantic constraints
@@ -80,7 +80,7 @@ TEST(HostTensorTest, ConstructionWithHostBuffer) {
     std::vector<float> data(shape.volume(), 1.0f);
     HostBuffer host_buffer(std::move(data));
 
-    HostTensor tensor(std::move(host_buffer), std::move(spec), std::move(topology));
+    HostTensor tensor = HostTensor::from_buffer(std::move(host_buffer), std::move(spec), std::move(topology));
 
     EXPECT_EQ(tensor.logical_shape(), shape);
     EXPECT_EQ(tensor.dtype(), DataType::FLOAT32);

--- a/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_mesh_tensor.cpp
@@ -80,16 +80,6 @@ TEST(MeshTensorTypeTraitsTest, IsNothrowMoveConstructible) {
 
 TEST(MeshTensorTypeTraitsTest, IsNothrowMoveAssignable) { EXPECT_TRUE(std::is_nothrow_move_assignable_v<MeshTensor>); }
 
-TEST(MeshTensorTest, ConstructionWithNullMeshBufferFails) {
-    auto page_config = PageConfig(Layout::ROW_MAJOR);
-    auto memory_config = MemoryConfig{TensorMemoryLayout::INTERLEAVED, BufferType::DRAM};
-    auto tensor_layout = TensorLayout(DataType::BFLOAT16, page_config, memory_config);
-    auto spec = TensorSpec(Shape{1, 32}, tensor_layout);
-    auto topology = TensorTopology();
-
-    EXPECT_ANY_THROW(MeshTensor(nullptr, std::move(spec), std::move(topology)));
-}
-
 // Device-based tests using GenericMeshDeviceFixture
 using MeshTensorDeviceTest = GenericMeshDeviceFixture;
 
@@ -125,9 +115,10 @@ TEST_F(MeshTensorDeviceTest, ConstructionWithMeshBuffer) {
 
     auto topology = TensorTopology();
 
-    MeshTensor tensor(mesh_buffer, std::move(spec), std::move(topology));
+    auto buffer_address = mesh_buffer->address();
+    MeshTensor tensor = MeshTensor::from_buffer(std::move(*mesh_buffer), std::move(spec), std::move(topology));
 
-    EXPECT_EQ(&tensor.mesh_buffer(), mesh_buffer.get());
+    EXPECT_EQ(tensor.address(), buffer_address);
     EXPECT_EQ(&tensor.device(), mesh_device_.get());
     EXPECT_EQ(tensor.dtype(), DataType::BFLOAT16);
     EXPECT_EQ(tensor.layout(), Layout::ROW_MAJOR);
@@ -143,7 +134,7 @@ TEST_F(MeshTensorDeviceTest, MoveConstructionTransfersOwnership) {
     auto mesh_buffer = create_mesh_buffer(*mesh_device_, spec);
     auto topology = TensorTopology();
 
-    MeshTensor original(mesh_buffer, std::move(spec), std::move(topology));
+    MeshTensor original = MeshTensor::from_buffer(std::move(*mesh_buffer), std::move(spec), std::move(topology));
     const auto* buffer_ptr = &original.mesh_buffer();
 
     MeshTensor moved(std::move(original));
@@ -163,8 +154,8 @@ TEST_F(MeshTensorDeviceTest, MoveAssignmentTransfersOwnership) {
     auto mesh_buffer1 = create_mesh_buffer(*mesh_device_, spec1);
     auto mesh_buffer2 = create_mesh_buffer(*mesh_device_, spec2);
 
-    MeshTensor tensor1(mesh_buffer1, std::move(spec1), TensorTopology());
-    MeshTensor tensor2(mesh_buffer2, std::move(spec2), TensorTopology());
+    MeshTensor tensor1 = MeshTensor::from_buffer(std::move(*mesh_buffer1), std::move(spec1), TensorTopology());
+    MeshTensor tensor2 = MeshTensor::from_buffer(std::move(*mesh_buffer2), std::move(spec2), TensorTopology());
 
     const auto* buffer1_ptr = &tensor1.mesh_buffer();
 
@@ -183,7 +174,7 @@ TEST_F(MeshTensorDeviceTest, TensorProperties) {
     auto mesh_buffer = create_mesh_buffer(*mesh_device_, spec);
     auto topology = TensorTopology();
 
-    MeshTensor tensor(mesh_buffer, std::move(spec), std::move(topology));
+    MeshTensor tensor = MeshTensor::from_buffer(std::move(*mesh_buffer), std::move(spec), std::move(topology));
 
     EXPECT_EQ(tensor.dtype(), DataType::FLOAT32);
     EXPECT_EQ(tensor.layout(), Layout::ROW_MAJOR);
@@ -257,7 +248,7 @@ TEST_F(MeshTensorDeviceTest, ConstructionWithTooSmallBufferFails) {
 
     auto topology = TensorTopology();
 
-    EXPECT_ANY_THROW(MeshTensor(mesh_buffer, std::move(spec), std::move(topology)));
+    EXPECT_ANY_THROW(MeshTensor::from_buffer(std::move(*mesh_buffer), std::move(spec), std::move(topology)));
 }
 
 // ======================================================================================
@@ -303,13 +294,13 @@ HostTensor make_full_coverage_aligned_host_tensor(
         return make_aligned_host_buffer(static_cast<size_t>(shape.volume()), shard_fills.at(idx++));
     });
     auto topology = TensorTopology::create_sharded_tensor_topology(mesh_shape);
-    return HostTensor(std::move(dhb), spec, topology);
+    return HostTensor::from_buffer(std::move(dhb), spec, topology);
 }
 
 // Helper: create a HostTensor with a single shard at [0,0].
 HostTensor make_single_shard_host_tensor(const Shape& shape, uint32_t fill) {
     auto spec = TensorSpec(shape, TensorLayout(DataType::UINT32, Layout::ROW_MAJOR, MemoryConfig{}));
-    return HostTensor(HostBuffer(std::vector<uint32_t>(shape.volume(), fill)), spec, TensorTopology{});
+    return HostTensor::from_buffer(HostBuffer(std::vector<uint32_t>(shape.volume(), fill)), spec, TensorTopology{});
 }
 
 // Helper: create a HostTensor with one shard per coordinate in a mesh.
@@ -324,7 +315,7 @@ HostTensor make_full_coverage_host_tensor(
         return HostBuffer(std::vector<uint32_t>(shape.volume(), shard_fills.at(idx++)));
     });
     auto topology = TensorTopology::create_sharded_tensor_topology(mesh_shape);
-    return HostTensor(std::move(dhb), spec, topology);
+    return HostTensor::from_buffer(std::move(dhb), spec, topology);
 }
 
 // Helper: create a HostTensor with shards at only a subset of mesh coordinates.
@@ -340,7 +331,7 @@ HostTensor make_partial_coverage_host_tensor(
         return HostBuffer(std::vector<uint32_t>(shape.volume(), shard_fills.at(idx++)));
     });
     auto topology = TensorTopology::create_sharded_tensor_topology(distributed::MeshShape(coords.size()));
-    return HostTensor(std::move(dhb), spec, topology);
+    return HostTensor::from_buffer(std::move(dhb), spec, topology);
 }
 
 // Helper: assert that two HostTensors have the same populated coords and identical shard contents.
@@ -427,7 +418,7 @@ TEST_F(MeshTensorDataMovementTest, IsUniformWrite_EmptyDistributedHostBuffer) {
     const Shape shape{1, 1, 32, 32};
     auto spec = TensorSpec(shape, TensorLayout(DataType::UINT32, Layout::ROW_MAJOR, MemoryConfig{}));
     auto dhb = DistributedHostBuffer::create(mesh_device_->shape());
-    HostTensor host_tensor(std::move(dhb), spec, TensorTopology{});
+    auto host_tensor = HostTensor::from_buffer(std::move(dhb), spec, TensorTopology{});
     EXPECT_FALSE(is_uniform_write(host_tensor, *mesh_device_));
     auto& cq = mesh_device_->mesh_command_queue();
     EXPECT_ANY_THROW(enqueue_write_tensor(cq, host_tensor, *mesh_device_));
@@ -467,7 +458,7 @@ TEST_F(MeshTensorDataMovementTest, UniformCopyToDevice_CopyToHost_Roundtrip) {
     for (const auto& coord : distributed::MeshCoordinateRange(mesh_device_->shape())) {
         result_dhb.emplace_shard(coord, [&]() { return tensor_impl::allocate_host_buffer(spec); });
     }
-    HostTensor result(std::move(result_dhb), spec, TensorTopology{});
+    auto result = HostTensor::from_buffer(std::move(result_dhb), spec, TensorTopology{});
     enqueue_read_tensor(cq, device_tensor, result);
 
     expect_host_tensors_eq(host_tensor, result);
@@ -526,7 +517,7 @@ TEST_F(MeshTensorPinnedMemoryBudgetTest, LargeHostWriteOverHardwarePinBudgetFall
             tt::stl::Span<uint32_t>(reinterpret_cast<uint32_t*>(mapping_owner.get()), num_words),
             tt::tt_metal::MemoryPin(std::static_pointer_cast<void>(mapping_owner)));
     });
-    HostTensor large_host_tensor(
+    auto large_host_tensor = HostTensor::from_buffer(
         std::move(large_dhb), large_spec, TensorTopology::create_sharded_tensor_topology(mesh_device_->shape()));
 
     auto& cq = mesh_device_->mesh_command_queue();
@@ -673,7 +664,7 @@ TEST_F(MeshTensorDeviceTest, UniformCopyToHost_ReusesPinnedMemoryCacheEntries) {
     for (const auto& coord : distributed::MeshCoordinateRange(mesh_device_->shape())) {
         result_dhb.emplace_shard(coord, [&]() { return tensor_impl::allocate_host_buffer(spec); });
     }
-    HostTensor result(std::move(result_dhb), spec, TensorTopology{});
+    auto result = HostTensor::from_buffer(std::move(result_dhb), spec, TensorTopology{});
 
     const size_t entries_before = cache.num_entries();
     enqueue_read_tensor(cq, device_tensor, result);
@@ -760,7 +751,7 @@ TEST_F(MeshTensorDataMovementTest, EnqueueWriteTensor_FilterEmpty_Noop) {
     for (const auto& coord : distributed::MeshCoordinateRange(mesh_device_->shape())) {
         result_dhb.emplace_shard(coord, [&]() { return tensor_impl::allocate_host_buffer(spec); });
     }
-    HostTensor result(std::move(result_dhb), spec, TensorTopology{});
+    auto result = HostTensor::from_buffer(std::move(result_dhb), spec, TensorTopology{});
     enqueue_read_tensor(cq, device_tensor, result);
     expect_host_tensors_eq(host_sentinel, result);
 }
@@ -820,7 +811,7 @@ TEST_F(MeshTensorDataMovementTest, NonUniformCopyToDevice_CopyToHost_Roundtrip) 
     for (const auto& coord : written_coords) {
         result_dhb.emplace_shard(coord, [&]() { return tensor_impl::allocate_host_buffer(spec); });
     }
-    HostTensor result(std::move(result_dhb), spec, TensorTopology{});
+    auto result = HostTensor::from_buffer(std::move(result_dhb), spec, TensorTopology{});
     non_uniform_data_movement::enqueue_read_tensor(cq, device_tensor, result, written_coords);
     expect_host_tensors_eq(host_tensor, result);
 }
@@ -914,7 +905,7 @@ TEST_F(MeshTensorDeviceTest, LargeWriteRoundtrip_PinnedMemoryPath) {
         return HostBuffer(std::move(data));
     });
     auto topology = TensorTopology::create_sharded_tensor_topology(mesh_device_->shape());
-    HostTensor host_tensor(std::move(dhb), spec, topology);
+    auto host_tensor = HostTensor::from_buffer(std::move(dhb), spec, topology);
 
     auto& cq = mesh_device_->mesh_command_queue();
     MeshTensor device_tensor = enqueue_write_tensor(cq, host_tensor, *mesh_device_);
@@ -953,7 +944,7 @@ TEST_F(MeshTensorDeviceTest, LargeWriteRoundtrip_HeightShardedDeviceRequiringSha
         return HostBuffer(std::move(data));
     });
     auto topology = TensorTopology::create_sharded_tensor_topology(mesh_device_->shape());
-    HostTensor host_tensor(
+    auto host_tensor = HostTensor::from_buffer(
         std::move(dhb), TensorSpec(shape, TensorLayout(DataType::UINT32, Layout::ROW_MAJOR, MemoryConfig{})), topology);
 
     const size_t entries_before = cache.num_entries();

--- a/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
+++ b/tests/tt_metal/tt_metal/api/tensor/test_vector_conversion.cpp
@@ -181,7 +181,7 @@ TYPED_TEST(BorrowedStorageVectorConversionTest, Roundtrip) {
         EXPECT_EQ(ctor_count, 1);
         EXPECT_EQ(dtor_count, 0);
         {
-            HostTensor copy(tensor.buffer(), tensor.tensor_spec(), tensor.tensor_topology());
+            auto copy = HostTensor::from_buffer(tensor.buffer(), tensor.tensor_spec(), tensor.tensor_topology());
             EXPECT_EQ(ctor_count, 2);
             EXPECT_EQ(dtor_count, 0);
         }
@@ -214,7 +214,7 @@ TYPED_TEST(BorrowedStorageVectorConversionTest, Callbacks) {
     EXPECT_EQ(ctor_count, 1);
     EXPECT_EQ(dtor_count, 0);
     {
-        HostTensor copy(tensor.buffer(), tensor.tensor_spec(), tensor.tensor_topology());
+        auto copy = HostTensor::from_buffer(tensor.buffer(), tensor.tensor_spec(), tensor.tensor_topology());
         EXPECT_EQ(ctor_count, 2);
         EXPECT_EQ(dtor_count, 0);
     }

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -53,17 +53,6 @@ public:
 
     HostTensor() = delete;
 
-    /**
-     * Constructs a host tensor from a distributed host buffer.
-     */
-    explicit HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology);
-
-    /**
-     * Constructs a host tensor from a single device host storage.
-     * The buffer is occupies the 0x0 shard of the distributed host buffer.
-     */
-    explicit HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topology);
-
     ~HostTensor();
 
     /**
@@ -103,6 +92,17 @@ public:
     // End special member functions
 
     // Factory methods for creating an Engaged HostTensor.
+
+    /**
+     * Constructs a host tensor from a distributed host buffer.
+     */
+    static HostTensor from_buffer(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology);
+
+    /**
+     * Constructs a host tensor from a single device host buffer.
+     * The buffer occupies the 0x0 shard of the distributed host buffer.
+     */
+    static HostTensor from_buffer(HostBuffer buffer, TensorSpec spec, TensorTopology topology);
 
     /**
      * Converts a buffer of elements of type `T` to a `Tensor`.
@@ -208,6 +208,19 @@ public:
     const HostTensorImpl& impl() const;
 
 private:
+    // Internal constructors. Use the from_buffer factories to build a HostTensor from a backing buffer.
+
+    /**
+     * Constructs a host tensor from a distributed host buffer.
+     */
+    explicit HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology);
+
+    /**
+     * Constructs a host tensor from a single device host buffer.
+     * The buffer occupies the 0x0 shard of the distributed host buffer.
+     */
+    explicit HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topology);
+
     // impl_ could be a nullptr if HostTensor is in a moved-from state.
     // Avoid using impl_ pointer directly, use the impl() accessor instead.
     // Otherwise, please add manual TT_FATAL checks for nullptr.

--- a/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/host_tensor.hpp
@@ -209,17 +209,7 @@ public:
 
 private:
     // Internal constructors. Use the from_buffer factories to build a HostTensor from a backing buffer.
-
-    /**
-     * Constructs a host tensor from a distributed host buffer.
-     */
     explicit HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology);
-
-    /**
-     * Constructs a host tensor from a single device host buffer.
-     * The buffer occupies the 0x0 shard of the distributed host buffer.
-     */
-    explicit HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topology);
 
     // impl_ could be a nullptr if HostTensor is in a moved-from state.
     // Avoid using impl_ pointer directly, use the impl() accessor instead.

--- a/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
+++ b/tt_metal/api/tt-metalium/experimental/tensor/mesh_tensor.hpp
@@ -25,6 +25,7 @@ struct DeviceStorage;
 
 namespace distributed {
 class MeshDevice;
+class MeshBuffer;
 }
 
 /**
@@ -62,8 +63,10 @@ public:
     static MeshTensor allocate_on_device(
         distributed::MeshDevice& mesh_device, const TensorSpec& spec, const TensorTopology& topology);
 
-    // Internal Constructor for transition.
-    explicit MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology);
+    /**
+     * Construct a MeshTensor that takes ownership of an already-allocated MeshBuffer.
+     */
+    static MeshTensor from_buffer(distributed::MeshBuffer mesh_buffer, TensorSpec spec, TensorTopology topology);
 
     /**
      * Release ownership of the underlying device memory.
@@ -178,6 +181,10 @@ public:
     const MeshTensorImpl& impl() const;
 
 private:
+    // Internal constructor for transition. Use the from_buffer factory or allocate_on_device
+    // to build a MeshTensor.
+    explicit MeshTensor(std::shared_ptr<distributed::MeshBuffer> mesh_buffer, TensorSpec spec, TensorTopology topology);
+
     // TODO(#43693): Remove once DeviceStorage no longer keeps a shared_ptr<MeshBuffer>
     // in its DeallocatedTombStone state.
     // DeviceStorage is the sole caller — it uses mesh_buffer_invariant_breaking() to

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -12,34 +12,18 @@ namespace tt::tt_metal {
 HostTensor::HostTensor(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) :
     impl_(std::make_unique<HostTensorImpl>(std::move(buffer), std::move(spec), std::move(topology))) {}
 
-namespace {
-namespace CMAKE_UNIQUE_NAMESPACE {
-// Uses the nullptr-context overload so it never touches MetalContext/Cluster and works in
-// processes that haven't opened a device.
-DistributedHostBuffer create_unit_distributed_host_buffer(HostBuffer buffer) {
+HostTensor HostTensor::from_buffer(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) {
+    return HostTensor(std::move(buffer), std::move(spec), std::move(topology));
+}
+
+HostTensor HostTensor::from_buffer(HostBuffer buffer, TensorSpec spec, TensorTopology topology) {
     auto distributed_buffer = DistributedHostBuffer::create(
         distributed::MeshShape(1, 1),
         distributed::MeshShape(1, 1),
         distributed::MeshCoordinate(0, 0),
         /*context=*/nullptr);
     distributed_buffer.emplace_shard(distributed::MeshCoordinate(0, 0), [&buffer]() { return std::move(buffer); });
-    return distributed_buffer;
-}
-};  // namespace CMAKE_UNIQUE_NAMESPACE
-};  // namespace
-
-HostTensor::HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topology) :
-    impl_(std::make_unique<HostTensorImpl>(
-        CMAKE_UNIQUE_NAMESPACE::create_unit_distributed_host_buffer(std::move(buffer)),
-        std::move(spec),
-        std::move(topology))) {}
-
-HostTensor HostTensor::from_buffer(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) {
-    return HostTensor(std::move(buffer), std::move(spec), std::move(topology));
-}
-
-HostTensor HostTensor::from_buffer(HostBuffer buffer, TensorSpec spec, TensorTopology topology) {
-    return HostTensor(std::move(buffer), std::move(spec), std::move(topology));
+    return HostTensor(std::move(distributed_buffer), std::move(spec), std::move(topology));
 }
 
 HostTensor::HostTensor(const HostTensor& other) :

--- a/tt_metal/impl/tensor/host_tensor.cpp
+++ b/tt_metal/impl/tensor/host_tensor.cpp
@@ -34,6 +34,14 @@ HostTensor::HostTensor(HostBuffer buffer, TensorSpec spec, TensorTopology topolo
         std::move(spec),
         std::move(topology))) {}
 
+HostTensor HostTensor::from_buffer(DistributedHostBuffer buffer, TensorSpec spec, TensorTopology topology) {
+    return HostTensor(std::move(buffer), std::move(spec), std::move(topology));
+}
+
+HostTensor HostTensor::from_buffer(HostBuffer buffer, TensorSpec spec, TensorTopology topology) {
+    return HostTensor(std::move(buffer), std::move(spec), std::move(topology));
+}
+
 HostTensor::HostTensor(const HostTensor& other) :
     impl_(other.impl_ ? std::make_unique<HostTensorImpl>(*other.impl_) : nullptr) {}
 

--- a/tt_metal/impl/tensor/host_tensor_factory.cpp
+++ b/tt_metal/impl/tensor/host_tensor_factory.cpp
@@ -45,7 +45,7 @@ HostTensor from_span_impl(std::span<const T> buffer, const TensorSpec& spec, T p
 
     auto host_buffer = HostBuffer(tensor_impl::encode_tensor_data(tt::stl::make_const_span(buffer), spec, pad_value));
 
-    auto res = HostTensor(std::move(host_buffer), buffer_spec, TensorTopology{});
+    auto res = HostTensor::from_buffer(std::move(host_buffer), buffer_spec, TensorTopology{});
     return to_dtype(res, spec.data_type());
 }
 

--- a/tt_metal/impl/tensor/host_tensor_factory.cpp
+++ b/tt_metal/impl/tensor/host_tensor_factory.cpp
@@ -73,7 +73,7 @@ HostTensor HostTensor::from_borrowed_data(
     auto buffer_dtype = convert_to_data_type<T>();
     TensorSpec tensor_spec(shape, TensorLayout(buffer_dtype, PageConfig(Layout::ROW_MAJOR, tile), MemoryConfig{}));
 
-    return HostTensor(std::move(host_buffer), std::move(tensor_spec), TensorTopology{});
+    return HostTensor::from_buffer(std::move(host_buffer), std::move(tensor_spec), TensorTopology{});
 }
 
 template <typename T>
@@ -99,7 +99,7 @@ HostTensor HostTensor::from_vector(std::vector<T>&& buffer, const TensorSpec& sp
             ? HostBuffer(std::move(buffer))
             : HostBuffer(tensor_impl::encode_tensor_data(ttsl::make_const_span(buffer), spec, pad_value));
 
-    auto res = HostTensor(std::move(host_buffer), buffer_spec, TensorTopology{});
+    auto res = HostTensor::from_buffer(std::move(host_buffer), buffer_spec, TensorTopology{});
     return to_dtype(res, spec.data_type());
 }
 

--- a/tt_metal/impl/tensor/mesh_tensor.cpp
+++ b/tt_metal/impl/tensor/mesh_tensor.cpp
@@ -101,7 +101,12 @@ MeshTensor MeshTensor::allocate_on_device(
             mesh_device.arch());
     }
     auto mesh_buffer = tensor_impl::allocate_device_buffer(&mesh_device, spec);
-    return MeshTensor(std::move(mesh_buffer), spec, topology);
+    return MeshTensor::from_buffer(std::move(*mesh_buffer), spec, topology);
+}
+
+MeshTensor MeshTensor::from_buffer(distributed::MeshBuffer mesh_buffer, TensorSpec spec, TensorTopology topology) {
+    return MeshTensor(
+        std::make_shared<distributed::MeshBuffer>(std::move(mesh_buffer)), std::move(spec), std::move(topology));
 }
 
 }  // namespace tt::tt_metal

--- a/tt_metal/impl/tensor/mesh_tensor_impl.hpp
+++ b/tt_metal/impl/tensor/mesh_tensor_impl.hpp
@@ -38,6 +38,12 @@ public:
     const TensorSpec& spec() const { return spec_; }
     const TensorTopology& topology() const { return topology_; }
     void update_topology(TensorTopology topology) { topology_ = std::move(topology); }
+    void update_spec(TensorSpec spec) {
+        TT_FATAL(
+            mesh_buffer_->size() >= spec.compute_packed_buffer_size_bytes(),
+            "MeshBuffer must be large enough to hold the tensor.");
+        spec_ = std::move(spec);
+    }
 
 private:
     // Invariant:

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -78,7 +78,8 @@ HostTensor enqueue_read_tensor(distributed::MeshCommandQueue& cq, const MeshTens
 
     cq.enqueue_read(mesh_buffer, distributed_host_buffer, /*shards=*/std::nullopt, blocking);
 
-    return HostTensor(std::move(distributed_host_buffer), device_tensor.tensor_spec(), device_tensor.tensor_topology());
+    return HostTensor::from_buffer(
+        std::move(distributed_host_buffer), device_tensor.tensor_spec(), device_tensor.tensor_topology());
 }
 
 MeshTensor enqueue_write_tensor(
@@ -215,8 +216,8 @@ void enqueue_write_tensor(distributed::MeshCommandQueue& cq, const HostTensor& h
         cq.enqueue_write(mesh_buffer, distributed_host_buffer, /*blocking=*/false);
     }
 
-    device_tensor = MeshTensor(
-        mesh_buffer,
+    device_tensor = MeshTensor::from_buffer(
+        std::move(*mesh_buffer),
         TensorSpec(
             host_tensor.tensor_spec().logical_shape(),
             host_tensor.tensor_spec().tensor_layout().with_memory_config(device_tensor.memory_config())),
@@ -273,7 +274,8 @@ HostTensor enqueue_read_tensor(
         },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
 
-    HostTensor result(std::move(distributed_host_buffer), device_tensor.tensor_spec(), device_tensor.tensor_topology());
+    auto result = HostTensor::from_buffer(
+        std::move(distributed_host_buffer), device_tensor.tensor_spec(), device_tensor.tensor_topology());
     enqueue_read_tensor(cq, device_tensor, result, coords, blocking);
     return result;
 }
@@ -317,7 +319,7 @@ void enqueue_read_tensor(
     std::unordered_set<distributed::MeshCoordinate> shard_set(coords.begin(), coords.end());
     cq.enqueue_read(device_tensor.impl().raw_mesh_buffer(), dst_distributed_host_buffer, shard_set, blocking);
 
-    host_tensor = HostTensor(
+    host_tensor = HostTensor::from_buffer(
         std::move(dst_distributed_host_buffer), device_tensor.tensor_spec(), device_tensor.tensor_topology());
 }
 
@@ -403,8 +405,8 @@ void h2d_as_replicate_tensor_on_1x1_mesh(
     const auto& mesh_device_shape = mesh_buffer->device()->shape();
     auto topology = TensorTopology::create_fully_replicated_tensor_topology(mesh_device_shape);
     const auto& old_spec = host_tensor.tensor_spec();
-    device_tensor = MeshTensor(
-        mesh_buffer,
+    device_tensor = MeshTensor::from_buffer(
+        std::move(*mesh_buffer),
         TensorSpec(
             old_spec.logical_shape(), old_spec.tensor_layout().with_memory_config(device_tensor.memory_config())),
         topology);
@@ -502,8 +504,8 @@ std::vector<distributed::MeshCoordinate> enqueue_write_tensor(
     std::copy(shard_coords.begin(), shard_coords.end(), std::back_inserter(coords));
 
     const auto& old_spec = host_tensor.tensor_spec();
-    device_tensor = MeshTensor(
-        mesh_buffer,
+    device_tensor = MeshTensor::from_buffer(
+        std::move(*mesh_buffer),
         TensorSpec(
             old_spec.logical_shape(), old_spec.tensor_layout().with_memory_config(device_tensor.memory_config())),
         host_tensor.tensor_topology());
@@ -550,7 +552,7 @@ HostTensor to_layout_impl(const HostTensor& tensor, Layout target_layout) {
     auto transformed_buffer = tensor.buffer().transform(
         [&](const HostBuffer& buffer) { return HostBuffer(convert(buffer)); },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-    return HostTensor(
+    return HostTensor::from_buffer(
         std::move(transformed_buffer),
         TensorSpec(
             tensor.logical_shape(),
@@ -633,7 +635,7 @@ HostTensor pad_bfloat8_b(
         unpack_bfp8_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
 
     auto input_float_buffer = HostBuffer(std::move(input_float_data));
-    auto intermediate = HostTensor(
+    auto intermediate = HostTensor::from_buffer(
         std::move(input_float_buffer),
         TensorSpec(
             tensor.logical_shape(),
@@ -659,7 +661,7 @@ HostTensor pad_bfloat8_b(
             MemoryConfig{},
             float_tensor.logical_shape(),
             float_tensor.padded_shape()));
-    return HostTensor(std::move(output_uint32_buffer), output_spec, tensor.tensor_topology());
+    return HostTensor::from_buffer(std::move(output_uint32_buffer), output_spec, tensor.tensor_topology());
 }
 
 HostTensor unpad_bfloat8_b(
@@ -675,7 +677,7 @@ HostTensor unpad_bfloat8_b(
         unpack_bfp8_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
     auto input_float_buffer = HostBuffer(std::move(input_float_data));
 
-    HostTensor intermediate(
+    auto intermediate = HostTensor::from_buffer(
         std::move(input_float_buffer),
         TensorSpec(
             tensor.logical_shape(),
@@ -693,7 +695,7 @@ HostTensor unpad_bfloat8_b(
     auto output_packed_data =
         pack_as_bfp8_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
     auto output_uint32_buffer = HostBuffer(std::move(output_packed_data));
-    return HostTensor(
+    return HostTensor::from_buffer(
         std::move(output_uint32_buffer),
         TensorSpec(
             float_tensor.logical_shape(),
@@ -719,7 +721,7 @@ HostTensor pad_bfloat4_b(
     auto input_float_data =
         unpack_bfp4_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
     auto input_float_buffer = HostBuffer(std::move(input_float_data));
-    auto intermediate = HostTensor(
+    auto intermediate = HostTensor::from_buffer(
         std::move(input_float_buffer),
         TensorSpec(
             tensor.logical_shape(),
@@ -745,7 +747,7 @@ HostTensor pad_bfloat4_b(
             MemoryConfig{},
             float_tensor.logical_shape(),
             float_tensor.padded_shape()));
-    return HostTensor(std::move(output_uint32_buffer), output_spec, tensor.tensor_topology());
+    return HostTensor::from_buffer(std::move(output_uint32_buffer), output_spec, tensor.tensor_topology());
 }
 
 HostTensor unpad_bfloat4_b(
@@ -760,7 +762,7 @@ HostTensor unpad_bfloat4_b(
     auto input_float_data =
         unpack_bfp4_tiles_into_float_vec(input_packed_data, /*row_major_output=*/false, /*is_exp_a=*/false, tile);
     auto input_float_buffer = HostBuffer(std::move(input_float_data));
-    auto intermediate = HostTensor(
+    auto intermediate = HostTensor::from_buffer(
         std::move(input_float_buffer),
         TensorSpec(
             tensor.logical_shape(),
@@ -778,7 +780,7 @@ HostTensor unpad_bfloat4_b(
     auto output_packed_data =
         pack_as_bfp4_tiles(output_float_data, /*row_major_input=*/false, /*is_exp_a=*/false, tile);
     auto output_uint32_buffer = HostBuffer(std::move(output_packed_data));
-    return HostTensor(
+    return HostTensor::from_buffer(
         std::move(output_uint32_buffer),
         TensorSpec(
             float_tensor.logical_shape(),
@@ -877,7 +879,7 @@ HostTensor pad_impl(
         tile = tensor.tensor_spec().tile();
     }
 
-    return HostTensor(
+    return HostTensor::from_buffer(
         std::move(transformed_buffer),
         TensorSpec(
             tensor.logical_shape(),
@@ -963,7 +965,7 @@ HostTensor unpad_impl(
     auto transformed_buffer = tensor.buffer().transform(
         [&](const HostBuffer& buffer) { return HostBuffer(unpad(buffer)); },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-    return HostTensor(
+    return HostTensor::from_buffer(
         std::move(transformed_buffer),
         TensorSpec(
             tt::tt_metal::Shape(output_shape),
@@ -1233,7 +1235,7 @@ HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype) {
             input_tensor.logical_shape(),
             input_tensor.padded_shape()));
 
-    return HostTensor(std::move(output_storage), output_spec, input_tensor.tensor_topology());
+    return HostTensor::from_buffer(std::move(output_storage), output_spec, input_tensor.tensor_topology());
 }
 
 // ======================================================================================

--- a/ttnn/core/distributed/api.cpp
+++ b/ttnn/core/distributed/api.cpp
@@ -104,7 +104,8 @@ Tensor from_host_shards(const std::vector<Tensor>& tensor_shards, const MeshShap
     }
 
     TensorTopology topology = TensorTopology::create_sharded_tensor_topology(mesh_shape, shard_dim);
-    return Tensor(HostTensor(std::move(distributed_host_buffer), reference_shard.tensor_spec(), std::move(topology)));
+    return Tensor(HostTensor::from_buffer(
+        std::move(distributed_host_buffer), reference_shard.tensor_spec(), std::move(topology)));
 }
 
 Tensor combine_device_tensors(const std::vector<Tensor>& tensor_shards, int shard_dim) {

--- a/ttnn/core/distributed/distributed_tensor.cpp
+++ b/ttnn/core/distributed/distributed_tensor.cpp
@@ -223,7 +223,8 @@ public:
             const auto tensor_topology =
                 tt::tt_metal::TensorTopology(distribution_shape_, config_.placements, buffer_coords);
 
-            return Tensor(tt::tt_metal::HostTensor(std::move(distributed_buffer), tensor_spec, tensor_topology));
+            return Tensor(
+                tt::tt_metal::HostTensor::from_buffer(std::move(distributed_buffer), tensor_spec, tensor_topology));
         }
 
         // Otherwise, use xtensor to chunk the data into shards.
@@ -395,7 +396,8 @@ private:
         const auto tensor_topology =
             tt::tt_metal::TensorTopology(actual_distribution_shape, config_.placements, buffer_coords);
 
-        return Tensor(tt::tt_metal::HostTensor(std::move(distributed_buffer), shard_spec, tensor_topology));
+        return Tensor(
+            tt::tt_metal::HostTensor::from_buffer(std::move(distributed_buffer), shard_spec, tensor_topology));
     }
 
     // Mesh parameters. `mesh_device_view_` is empty when constructed from a `MeshShape` only.

--- a/ttnn/core/distributed/host_ccl.cpp
+++ b/ttnn/core/distributed/host_ccl.cpp
@@ -104,7 +104,7 @@ Tensor all_gather(const Tensor& tensor) {
         }
     }
 
-    return Tensor(
-        tt::tt_metal::HostTensor(std::move(all_gather_buffer), tensor.tensor_spec(), tensor.tensor_topology()));
+    return Tensor(tt::tt_metal::HostTensor::from_buffer(
+        std::move(all_gather_buffer), tensor.tensor_spec(), tensor.tensor_topology()));
 }
 }  // namespace ttnn::distributed::host_ccl

--- a/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
+++ b/ttnn/core/tensor/flatbuffer/tensor_flatbuffer.cpp
@@ -286,7 +286,7 @@ Tensor from_flatbuffer(
         fb_topology != nullptr ? from_flatbuffer(fb_topology)
                                : tt::tt_metal::TensorTopology::create_fully_replicated_tensor_topology(ttnn_mesh_shape);
 
-    return Tensor(tt::tt_metal::HostTensor(std::move(distributed_buffer), spec, std::move(topology)));
+    return Tensor(tt::tt_metal::HostTensor::from_buffer(std::move(distributed_buffer), spec, std::move(topology)));
 }
 
 }  // namespace ttnn

--- a/ttnn/core/tensor/tensor.cpp
+++ b/ttnn/core/tensor/tensor.cpp
@@ -78,7 +78,7 @@ Tensor::Tensor(
 }
 
 Tensor::Tensor(HostBuffer buffer, TensorSpec tensor_spec) :
-    Tensor(HostTensor(std::move(buffer), std::move(tensor_spec), TensorTopology{})) {}
+    Tensor(HostTensor::from_buffer(std::move(buffer), std::move(tensor_spec), TensorTopology{})) {}
 
 Tensor::Tensor(HostTensor tensor) :
     tensor_id(Tensor::next_tensor_id()),

--- a/ttnn/core/tensor/tensor_impl.cpp
+++ b/ttnn/core/tensor/tensor_impl.cpp
@@ -431,7 +431,7 @@ HostTensor view(
 
     // TODO (#25340): Review tensor topology logic for reshape
     const auto& buffer = tensor.buffer();
-    return HostTensor(buffer, new_spec, tensor.tensor_topology());
+    return HostTensor::from_buffer(buffer, new_spec, tensor.tensor_topology());
 }
 
 // ======================================================================================

--- a/ttnn/core/tensor/tensor_ops.cpp
+++ b/ttnn/core/tensor/tensor_ops.cpp
@@ -40,7 +40,7 @@ Tensor allocate_tensor_on_host(const TensorSpec& tensor_spec, distributed::MeshD
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
 
     // TODO (#25340): Implement correct logic and add test for this
-    return Tensor(HostTensor(std::move(distributed_host_buffer), tensor_spec, TensorTopology{}));
+    return Tensor(HostTensor::from_buffer(std::move(distributed_host_buffer), tensor_spec, TensorTopology{}));
 }
 
 Tensor create_device_tensor(
@@ -345,7 +345,8 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
             input_buffer.device(),
             input_buffer.address());
 
-        MeshTensor view_mesh_tensor(std::move(view_mesh_buffer), new_spec, input_tensor.tensor_topology());
+        MeshTensor view_mesh_tensor =
+            MeshTensor::from_buffer(std::move(*view_mesh_buffer), new_spec, input_tensor.tensor_topology());
         DeviceStorage view_storage(input_tensor.device_storage(), std::move(view_mesh_tensor));
         return Tensor(std::move(view_storage));
     }
@@ -358,7 +359,8 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
         auto view_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
             input_buffer.global_config(), new_device_config, input_buffer.device(), input_buffer.address());
 
-        MeshTensor view_mesh_tensor(std::move(view_mesh_buffer), new_spec, input_tensor.tensor_topology());
+        MeshTensor view_mesh_tensor =
+            MeshTensor::from_buffer(std::move(*view_mesh_buffer), new_spec, input_tensor.tensor_topology());
         DeviceStorage view_storage(input_tensor.device_storage(), std::move(view_mesh_tensor));
         return Tensor(std::move(view_storage));
     }
@@ -394,7 +396,8 @@ Tensor view_device(const Tensor& input_tensor, const Shape& new_logical_shape, c
         input_tensor.mesh_buffer().address());
 
     tt::tt_metal::DeviceStorage view_storage(
-        input_tensor.device_storage(), MeshTensor(view_mesh_buffer, new_spec, input_tensor.tensor_topology()));
+        input_tensor.device_storage(),
+        MeshTensor::from_buffer(std::move(*view_mesh_buffer), new_spec, input_tensor.tensor_topology()));
     return Tensor(std::move(view_storage));
 }
 
@@ -426,7 +429,7 @@ Tensor unchecked_reinterpret_layout(const Tensor& input_tensor, Layout target_la
     const auto& topology = input_tensor.tensor_topology();
 
     if (is_cpu_tensor(input_tensor)) {
-        return Tensor(HostTensor(input_tensor.host_tensor().buffer(), new_spec, topology));
+        return Tensor(HostTensor::from_buffer(input_tensor.host_tensor().buffer(), new_spec, topology));
     }
 
     const auto& input_buffer = input_tensor.device_storage().get_mesh_buffer();
@@ -436,7 +439,7 @@ Tensor unchecked_reinterpret_layout(const Tensor& input_tensor, Layout target_la
         input_buffer.device(),
         input_buffer.address());
 
-    MeshTensor reinterpreted(std::move(new_mesh_buffer), new_spec, topology);
+    MeshTensor reinterpreted = MeshTensor::from_buffer(std::move(*new_mesh_buffer), new_spec, topology);
     DeviceStorage reinterpreted_storage(input_tensor.device_storage(), std::move(reinterpreted));
     return Tensor(std::move(reinterpreted_storage));
 }

--- a/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
+++ b/ttnn/core/tensor/unit_mesh/unit_mesh_utils.cpp
@@ -95,7 +95,7 @@ Tensor aggregate(const std::vector<tt::tt_metal::Tensor>& tensors) {
     auto topology = tt::tt_metal::TensorTopology::create_sharded_tensor_topology(
         tt::tt_metal::distributed::MeshShape(parent_mesh->shape().mesh_size()), /*shard_dim=*/0);
 
-    MeshTensor mesh_tensor(mesh_buffer, reference_spec, topology);
+    MeshTensor mesh_tensor = MeshTensor::from_buffer(std::move(*mesh_buffer), reference_spec, topology);
 
     auto result = Tensor(tt::tt_metal::DeviceStorage(std::move(mesh_tensor), std::move(coords)));
     return result;
@@ -138,7 +138,8 @@ std::vector<tt::tt_metal::Tensor> disaggregate(const tt::tt_metal::Tensor& tenso
         auto mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
             input_mesh_buffer.global_config(), input_mesh_buffer.device_local_config(), submesh.get(), input_address);
 
-        Tensor unit_tensor(tt::tt_metal::MeshTensor(mesh_buffer, reference_spec, TensorTopology{}));
+        Tensor unit_tensor(
+            tt::tt_metal::MeshTensor::from_buffer(std::move(*mesh_buffer), reference_spec, TensorTopology{}));
         TT_FATAL(
             unit_tensor.device_storage().get_coords().size() == 1 &&
                 unit_tensor.device_storage().get_coords()[0] == tt::tt_metal::distributed::MeshCoordinate(0, 0),

--- a/ttnn/cpp/ttnn-nanobind/pytensor.cpp
+++ b/ttnn/cpp/ttnn-nanobind/pytensor.cpp
@@ -1675,7 +1675,8 @@ void pytensor_module(nb::module_& mod) {
                 tt::tt_metal::distributed::MeshShape(1, 1),
                 {tt::tt_metal::distributed::MeshMapperConfig::Replicate{}},
                 {coord});
-            DeviceStorage device_storage(MeshTensor(std::move(mesh_buffer), tensor_spec, std::move(topology)), {coord});
+            DeviceStorage device_storage(
+                MeshTensor::from_buffer(std::move(*mesh_buffer), tensor_spec, std::move(topology)), {coord});
             return Tensor(std::move(device_storage));
         },
         nb::arg("host_tensor"),

--- a/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv2d/prepare_conv2d_weights.cpp
@@ -149,7 +149,8 @@ Tensor convert_tensor(const Tensor& input_tensor, const Fn& compute, const Tenso
     TT_FATAL(is_cpu_tensor(input_tensor), "convert_tensor only supports cpu tensors");
     auto transformed_buffer = input_tensor.host_storage().buffer().transform(
         compute, tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-    return Tensor(tt::tt_metal::HostTensor(std::move(transformed_buffer), output_spec, input_tensor.tensor_topology()));
+    return Tensor(tt::tt_metal::HostTensor::from_buffer(
+        std::move(transformed_buffer), output_spec, input_tensor.tensor_topology()));
 }
 
 template <typename Func, typename... Args>
@@ -1023,7 +1024,7 @@ static Tensor to_folded_weight_layout(const Tensor& conv_weight_tensor, std::arr
                 return tt::tt_metal::HostBuffer(std::move(output_buffer));
             },
             tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-        return Tensor(tt::tt_metal::HostTensor(
+        return Tensor(tt::tt_metal::HostTensor::from_buffer(
             std::move(folded_buffer),
             TensorSpec(
                 output_shape,

--- a/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/conv/conv_transpose2d/prepare_conv_transpose2d_weights.cpp
@@ -135,8 +135,8 @@ ttnn::Tensor _transform_weights_for_conv_transpose2d(const Tensor& conv_weight_t
 
     auto transformed_buffer = conv_weight_tensor.host_storage().buffer().transform(
         compute, tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-    return Tensor(
-        tt::tt_metal::HostTensor(std::move(transformed_buffer), output_spec, conv_weight_tensor.tensor_topology()));
+    return Tensor(tt::tt_metal::HostTensor::from_buffer(
+        std::move(transformed_buffer), output_spec, conv_weight_tensor.tensor_topology()));
 }
 
 Tensor transform_weights_for_conv_transpose2d(const Tensor& conv_weight_tensor, bool mirror_kernel) {

--- a/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/move/move.cpp
@@ -28,7 +28,8 @@ Tensor create_ghost_tensor(const Tensor& input_tensor) {
     const auto& mesh_buffer = input_tensor.mesh_buffer();
     auto ghost_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
         mesh_buffer.global_config(), mesh_buffer.device_local_config(), mesh_buffer.device(), mesh_buffer.address());
-    return Tensor(MeshTensor(ghost_mesh_buffer, input_tensor.tensor_spec(), input_tensor.tensor_topology()));
+    return Tensor(MeshTensor::from_buffer(
+        std::move(*ghost_mesh_buffer), input_tensor.tensor_spec(), input_tensor.tensor_topology()));
 }
 
 inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {

--- a/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/narrow/narrow.cpp
@@ -133,7 +133,9 @@ ttnn::Tensor narrow(
                 input_tensor.tensor_spec().memory_config()));
 
         tt::tt_metal::DeviceStorage subtensor_storage(
-            storage, tt::tt_metal::MeshTensor(subtensor_mesh, subtensor_spec, input_tensor.tensor_topology()));
+            storage,
+            tt::tt_metal::MeshTensor::from_buffer(
+                std::move(*subtensor_mesh), subtensor_spec, input_tensor.tensor_topology()));
         return Tensor(std::move(subtensor_storage));
     }
 
@@ -292,7 +294,9 @@ ttnn::Tensor narrow(
                 input_tensor.dtype(), input_tensor.tensor_spec().page_config(), narrowed_memory_config));
 
         tt::tt_metal::DeviceStorage subtensor_storage(
-            storage, tt::tt_metal::MeshTensor(subtensor_mesh, subtensor_spec, input_tensor.tensor_topology()));
+            storage,
+            tt::tt_metal::MeshTensor::from_buffer(
+                std::move(*subtensor_mesh), subtensor_spec, input_tensor.tensor_topology()));
         return Tensor(std::move(subtensor_storage));
     }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/reshape_on_device/reshape.cpp
@@ -34,7 +34,7 @@ static Tensor manual_insertion(
         logical_shape,
         TensorLayout::fromPaddedShape(
             DataType::BFLOAT16, PageConfig(Layout::ROW_MAJOR), MemoryConfig{}, logical_shape, padded_shape));
-    auto output = Tensor(tt::tt_metal::HostTensor(
+    auto output = Tensor(tt::tt_metal::HostTensor::from_buffer(
                              cpu_tensor.host_storage().buffer(), std::move(output_spec), cpu_tensor.tensor_topology()))
                       .to_layout(Layout::ROW_MAJOR);
     if (device != nullptr) {

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/prepare_conv3d_weights.cpp
@@ -25,7 +25,8 @@ Tensor convert_tensor(const Tensor& input_tensor, const Fn& compute, const Tenso
     TT_FATAL(is_cpu_tensor(input_tensor), "convert_tensor only supports cpu tensors");
     auto transformed_buffer = input_tensor.host_storage().buffer().transform(
         compute, tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-    return Tensor(tt::tt_metal::HostTensor(std::move(transformed_buffer), output_spec, input_tensor.tensor_topology()));
+    return Tensor(tt::tt_metal::HostTensor::from_buffer(
+        std::move(transformed_buffer), output_spec, input_tensor.tensor_topology()));
 }
 
 template <typename Func, typename... Args>

--- a/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/quasar/move/move.cpp
@@ -28,7 +28,7 @@ Tensor create_ghost_tensor(const Tensor& input_tensor) {
     const auto& mesh_buffer = input_tensor.mesh_buffer();
     auto ghost_mesh_buffer = tt::tt_metal::distributed::MeshBuffer::create(
         mesh_buffer.global_config(), mesh_buffer.device_local_config(), mesh_buffer.device(), mesh_buffer.address());
-    return Tensor(MeshTensor(ghost_mesh_buffer, input_tensor.tensor_spec(), input_tensor.tensor_topology()));
+    return Tensor(MeshTensor::from_buffer(std::move(*ghost_mesh_buffer), input_tensor.tensor_spec(), input_tensor.tensor_topology()));
 }
 
 inline Tensor move_impl(const Tensor& input_tensor, const std::optional<MemoryConfig>& mem_config) {

--- a/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
+++ b/ttnn/cpp/ttnn/operations/pool/grid_sample/grid_sample_prepare_grid.cpp
@@ -198,7 +198,8 @@ Tensor convert_grid_tensor(
 
     auto transformed_buffer = input_tensor.host_storage().buffer().transform(
         compute, tt::tt_metal::DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
-    return Tensor(tt::tt_metal::HostTensor(std::move(transformed_buffer), output_spec, input_tensor.tensor_topology()));
+    return Tensor(tt::tt_metal::HostTensor::from_buffer(
+        std::move(transformed_buffer), output_spec, input_tensor.tensor_topology()));
 }
 
 }  // anonymous namespace


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes https://github.com/tenstorrent/tt-metal/issues/43928

Runtime Tensor contains heavy usages of factory functions with the only exception of `buffer` based constructors.
This PR converts the `buffer` based constructor to a factory function to allow a more uniform api surface.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

It is intentional for `MeshTensor::from_buffer` to take `MeshBuffer` as value instead of as `shared_ptr`. This is because one of the core invariant for `MeshTensor` is it holds the sole ownership of it's underlying device handle. Allow passing in of `shared_ptr` implies that some other owners can jointly own the device handle before and potentially along the `MeshTensor`.

It is currently very ugly that the general practice of passing a `MeshBuffer` is through a `shared_ptr`, this is mostly because `MeshBuffer::create` returns `shared_ptr<MeshBuffer>`, these will be ironed out in #38691 .

Similarly, internals of the MeshTensor will also move away from using a `shared_ptr<MeshBuffer>` after other cleanups, notably #47291

Sanity Run: https://github.com/tenstorrent/tt-metal/actions/runs/27716502817

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/tensor-from-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/tensor-from-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/tensor-from-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/tensor-from-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/tensor-from-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/tensor-from-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/tensor-from-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/tensor-from-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/tensor-from-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/tensor-from-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/tensor-from-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/tensor-from-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/tensor-from-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/tensor-from-buffer)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/tensor-from-buffer)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/tensor-from-buffer)