### PR TITLE
[Cleanup] Remove `mesh_buffer_invariant_breaking`

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -400,8 +400,6 @@ TEST_F(MeshTensorTest, DefaultConstructedDeviceStorageGetters) {
     EXPECT_THAT(([&]() { storage.get_tensor_spec(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
     EXPECT_THAT(
         ([&]() { storage.get_tensor_topology(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
-    EXPECT_THAT(
-        ([&]() { storage.get_mesh_buffer_leak_ownership(); }),
         ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
     EXPECT_THAT(
         ([&]() { storage.get_device_bypass_deallocate_check(); }),

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -400,7 +400,7 @@ TEST_F(MeshTensorTest, DefaultConstructedDeviceStorageGetters) {
     EXPECT_THAT(([&]() { storage.get_tensor_spec(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
     EXPECT_THAT(
         ([&]() { storage.get_tensor_topology(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
-        ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
+        ThrowsMessage<std::runtime_error>(HasSubstr("not allocated"));
     EXPECT_THAT(
         ([&]() { storage.get_device_bypass_deallocate_check(); }),
         ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -400,6 +400,9 @@ TEST_F(MeshTensorTest, DefaultConstructedDeviceStorageGetters) {
     EXPECT_THAT(([&]() { storage.get_tensor_spec(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
     EXPECT_THAT(
         ([&]() { storage.get_tensor_topology(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
+    EXPECT_THAT(
+        ([&]() { storage.get_device_bypass_deallocate_check(); }),
+        ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
 
     EXPECT_FALSE(storage.is_allocated());
     EXPECT_TRUE(storage.is_uniform_storage());

--- a/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_mesh_tensor.cpp
@@ -400,10 +400,6 @@ TEST_F(MeshTensorTest, DefaultConstructedDeviceStorageGetters) {
     EXPECT_THAT(([&]() { storage.get_tensor_spec(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
     EXPECT_THAT(
         ([&]() { storage.get_tensor_topology(); }), ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
-        ThrowsMessage<std::runtime_error>(HasSubstr("not allocated"));
-    EXPECT_THAT(
-        ([&]() { storage.get_device_bypass_deallocate_check(); }),
-        ThrowsMessage<std::runtime_error>(HasSubstr("not allocated")));
 
     EXPECT_FALSE(storage.is_allocated());
     EXPECT_TRUE(storage.is_uniform_storage());

--- a/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_tensor_deallocation.cpp
@@ -133,17 +133,6 @@ TEST_F(DeallocateTest, MeshTensorGetterThrowsWhenDeallocated) {
 // Tombstone state (DeallocatedTombStone): MeshTensor is gone but spec/topology and a shared MeshBuffer are kept
 // so device-facing workarounds still work (https://github.com/tenstorrent/tt-metal/issues/40716).
 
-TEST_F(DeallocateTest, DeallocatedTombStoneMeshBufferLeakOwnershipNonNull) {
-    Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
-    DeviceStorage storage = tensor.device_storage();
-
-    storage.deallocate();
-    ASSERT_FALSE(storage.is_allocated());
-
-    auto mesh_buffer = storage.get_mesh_buffer_leak_ownership();
-    EXPECT_NE(mesh_buffer, nullptr) << "Tombstone should preserve MeshBuffer shared_ptr for leak-ownership access";
-}
-
 TEST_F(DeallocateTest, DeallocatedTombStoneDeviceBypassDeallocateCheckNonNull) {
     Tensor tensor = create_device_tensor(make_test_tensor_spec(), mesh_device_.get());
     DeviceStorage storage = tensor.device_storage();
@@ -160,12 +149,6 @@ TEST_F(DeallocateTest, DefaultConstructedThrowsForDeviceBypassDeallocateCheck) {
     DeviceStorage storage;
 
     EXPECT_THROW(storage.get_device_bypass_deallocate_check(), std::exception);
-}
-
-TEST_F(DeallocateTest, DefaultConstructedThrowsForMeshBufferLeakOwnership) {
-    DeviceStorage storage;
-
-    EXPECT_THROW(storage.get_mesh_buffer_leak_ownership(), std::exception);
 }
 
 }  // namespace CMAKE_UNIQUE_NAMESPACE

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -153,13 +153,6 @@ struct DeviceStorage {
     ////////////////////////////////////////////////////////////////////////////////////////////////////////////
     // Begin internal functions:
 
-    // Returns the MeshBuffer associated with the underlying device memory.
-    // This function should be removed in-favor of `get_mesh_tensor()`.
-    // The function also leaks the ownership of the underlying device memory out.
-    // This is meant to be transitional and is to be removed.
-    // Throws if the DeviceStorage is not constructed from a MeshTensor.
-    std::shared_ptr<distributed::MeshBuffer> get_mesh_buffer_leak_ownership() const;
-
     // There are situations where we want to "reinterpret" an existing Tensor without modifying its underlying memory.
     // For example, select slice ops can be done in-place, as can select reshapes. This DeviceStorage constructor
     // addresses such cases.

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -196,19 +196,6 @@ MeshTensor& DeviceStorage::get_mesh_tensor() {
         mesh_tensor_holder_->state_);
 }
 
-std::shared_ptr<distributed::MeshBuffer> DeviceStorage::get_mesh_buffer_leak_ownership() const {
-    return std::visit(
-        ttsl::overloaded{
-            [](const MeshTensorHolder::Allocated& allocated) -> std::shared_ptr<distributed::MeshBuffer> {
-                return allocated.mesh_tensor_.mesh_buffer_invariant_breaking();
-            },
-            [](const MeshTensorHolder::DeallocatedTombStone& tombstone) -> std::shared_ptr<distributed::MeshBuffer> {
-                return tombstone.mesh_buffer_;
-            },
-            [](const auto&) -> std::shared_ptr<distributed::MeshBuffer> { TT_THROW("Tensor is not allocated"); }},
-        mesh_tensor_holder_->state_);
-}
-
 const std::shared_ptr<DeviceStorage::MeshTensorHolder>& DeviceStorage::get_root_mesh_tensor() const {
     return root_mesh_tensor_holder_ ? root_mesh_tensor_holder_ : mesh_tensor_holder_;
 }


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #44640

Removes `DeviceStorage::get_mesh_buffer_leak_ownership`, which leaks the ownership semantics of MeshTensor to allow co-owners of the underlying buffer. 

One of the core invariant of `MeshTensor` is it must retain the sole ownership of it's underlying `MeshBuffer`.
This was a change from prior ownership model in `ttnn::Tensor`, and thus this  method was created as a transitional period utility to move MeshBuffer into MeshTensor from `ttnn::Tensor`.

Now that we have cleaned up sufficient areas within `ttnn::Tensor`, we can remove this invariant leakage.

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

ops code can still obtain the underlying `MeshBuffer` via `DeviceStorage.get_mesh_tensor().mesh_buffer()`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/rm-get-mesh-buffer-invariant-breaking)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/rm-get-mesh-buffer-invariant-breaking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/rm-get-mesh-buffer-invariant-breaking)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/rm-get-mesh-buffer-invariant-breaking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/rm-get-mesh-buffer-invariant-breaking)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/rm-get-mesh-buffer-invariant-breaking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/rm-get-mesh-buffer-invariant-breaking)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/rm-get-mesh-buffer-invariant-breaking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/rm-get-mesh-buffer-invariant-breaking)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/rm-get-mesh-buffer-invariant-breaking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/rm-get-mesh-buffer-invariant-breaking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/rm-get-mesh-buffer-invariant-breaking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/rm-get-mesh-buffer-invariant-breaking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/rm-get-mesh-buffer-invariant-breaking)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/rm-get-mesh-buffer-invariant-breaking)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/rm-get-mesh-buffer-invariant-breaking)