### PR TITLE
[Bug fix] concat_bw: use logical_shape instead of padded_shape for slice indices

### DIFF
--- a/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
+++ b/ttnn/cpp/ttnn/operations/eltwise/binary_backward/binary_backward.cpp
@@ -527,10 +527,10 @@ std::vector<std::optional<Tensor>> concat_bw(
     if (are_required_outputs[0]) {
         ttnn::SmallVector<uint32_t> start_index = {0, 0, 0, 0};
         ttnn::SmallVector<uint32_t> end_index = {
-            input_tensor_a_arg.padded_shape()[0],
-            input_tensor_a_arg.padded_shape()[1],
-            input_tensor_a_arg.padded_shape()[2],
-            input_tensor_a_arg.padded_shape()[3]};
+            input_tensor_a_arg.logical_shape()[0],
+            input_tensor_a_arg.logical_shape()[1],
+            input_tensor_a_arg.logical_shape()[2],
+            input_tensor_a_arg.logical_shape()[3]};
         ttnn::SmallVector<uint32_t> step = {1, 1, 1, 1};
         ttnn::slice(grad_tensor_arg, start_index, end_index, step, std::nullopt, input_grad);
         grad_tensor[0] = input_grad;
@@ -539,19 +539,19 @@ std::vector<std::optional<Tensor>> concat_bw(
     if (are_required_outputs[1]) {
         ttnn::SmallVector<uint32_t> start_index_2 = {0, 0, 0, 0};
         if (dim == 0) {
-            start_index_2 = {input_tensor_a_arg.padded_shape()[0], 0, 0, 0};
+            start_index_2 = {input_tensor_a_arg.logical_shape()[0], 0, 0, 0};
         } else if (dim == 1) {
-            start_index_2 = {0, input_tensor_a_arg.padded_shape()[1], 0, 0};
+            start_index_2 = {0, input_tensor_a_arg.logical_shape()[1], 0, 0};
         } else if (dim == 2) {
-            start_index_2 = {0, 0, input_tensor_a_arg.padded_shape()[2], 0};
+            start_index_2 = {0, 0, input_tensor_a_arg.logical_shape()[2], 0};
         } else if (dim == 3) {
-            start_index_2 = {0, 0, 0, input_tensor_a_arg.padded_shape()[3]};
+            start_index_2 = {0, 0, 0, input_tensor_a_arg.logical_shape()[3]};
         }
         ttnn::SmallVector<uint32_t> end_index_2 = {
-            grad_tensor_arg.padded_shape()[0],
-            grad_tensor_arg.padded_shape()[1],
-            grad_tensor_arg.padded_shape()[2],
-            grad_tensor_arg.padded_shape()[3]};
+            grad_tensor_arg.logical_shape()[0],
+            grad_tensor_arg.logical_shape()[1],
+            grad_tensor_arg.logical_shape()[2],
+            grad_tensor_arg.logical_shape()[3]};
         ttnn::SmallVector<uint32_t> step_2 = {1, 1, 1, 1};
         ttnn::slice(grad_tensor_arg, start_index_2, end_index_2, step_2, std::nullopt, other_grad);
         grad_tensor[1] = other_grad;


### PR DESCRIPTION
### Problem
`concat_bw` uses `padded_shape()` to compute slice begin/end indices when splitting the gradient tensor back into the two input gradients. For non-tile-aligned dimensions (e.g. height=30 padded to 32), the slice output has padded dimensions that don't match the preallocated output tensor's logical shape, triggering the copy op's shape validation:
```
TT_FATAL @ copy_device_operation.cpp:109: out_tensor.logical_shape() == input_tensor_a.logical_shape()
```

### Root cause
`ttnn::slice` operates on logical coordinates. Passing `padded_shape()` indices produces:
- Oversized end indices (30→32 for height), creating a slice output bigger than the preallocated tensor
- Incorrect split points on the concat dimension (e.g. dim-0 split at padded index 12 vs logical index 12 — same for dim-0 but wrong for dims 1-3 when those dims aren't tile-aligned)

### Fix
Replace all `padded_shape()` calls with `logical_shape()` in `concat_bw`:
- `end_index` for the first slice (input_grad)
- `start_index_2` for the second slice split point
- `end_index_2` for the second slice (other_grad)

### Repro
```
pytest tests/ttnn/nightly/unit_tests/operations/eltwise/backward/test_backward_concat.py::test_bw_concat_default_example -xvs
```
Shapes `[12,1,30,32]` + `[2,1,30,32]` with dim=0 — height 30 is not tile-aligned.

## Test plan
- [ ] `test_bw_concat_default_example` passes
- [ ] All `test_bw_concat` parametrized cases pass
- [ ] Sanity tests pass

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-concat-bw-padded-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-concat-bw-padded-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-concat-bw-padded-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/fix-concat-bw-padded-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/fix-concat-bw-padded-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/fix-concat-bw-padded-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix-concat-bw-padded-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-concat-bw-padded-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/fix-concat-bw-padded-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/fix-concat-bw-padded-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix-concat-bw-padded-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-concat-bw-padded-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix-concat-bw-padded-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-concat-bw-padded-shape)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix-concat-bw-padded-shape)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-concat-bw-padded-shape)