### PR TITLE
docs: add Dead Code review rule to tt-llk CLAUDE.md

### DIFF
--- a/tt_metal/tt-llk/.claude/CLAUDE.md
+++ b/tt_metal/tt-llk/.claude/CLAUDE.md
@@ -59,6 +59,11 @@ We use lightweight Doxygen docstrings — high-signal, low-noise (`@brief`, `@pa
 
 **When writing or updating docstrings**, follow `.claude/references/doxygen-style.md`.
 
+### Dead Code
+
+- **Commented-out code must have an explanation.** Any commented-out instruction or function call (e.g. `// TTI_*`, `// llk_*`, `// _llk_*`, `// _gmg_*`, `// MATH(`, `// UNPACK(`, `// PACK(`, `// sfpi::`) requires an inline comment on the same line or immediately above it explaining *why* it is disabled. Acceptable reasons: known HW bug workaround, arch-specific divergence (e.g. WH vs BH), pending re-evaluation.
+- **During code review, always scan for commented-out code without explanation and flag it.** Check every `//` line whose content looks like a function call or instruction using the prefixes above. Commented-out code with a clear explanation is acceptable — the explanation is what matters, not the presence of commented-out code itself.
+
 ## Test Infrastructure
 
 ### Two-Phase Test Flow


### PR DESCRIPTION
## Summary

- Adds a `### Dead Code` subsection under `## Coding Style` in `tt_metal/tt-llk/.claude/CLAUDE.md`
- Requires commented-out instructions/function calls (`TTI_*`, `llk_*`, `_llk_*`, `_gmg_*`, `MATH(`, etc.) to have an explanation
- Mandates that code reviewers always scan for unexplained commented-out code and flag it

## Motivation

Caught during review of #46633: `TTI_SETC16(CLR_DVALID_SrcA_Disable_ADDR32, 0)` was commented out in `_llk_math_generalized_moe_gate_transpose_dest_single_face_step0_init_()` in both WH and BH files with no explanation. This rule ensures such cases are caught automatically in future reviews without requiring a manual prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nvelickovic/claude-md-dead-code-review-rule)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nvelickovic/claude-md-dead-code-review-rule)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nvelickovic/claude-md-dead-code-review-rule)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nvelickovic/claude-md-dead-code-review-rule)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nvelickovic/claude-md-dead-code-review-rule)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nvelickovic/claude-md-dead-code-review-rule)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nvelickovic/claude-md-dead-code-review-rule)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nvelickovic/claude-md-dead-code-review-rule)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nvelickovic/claude-md-dead-code-review-rule)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nvelickovic/claude-md-dead-code-review-rule)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nvelickovic/claude-md-dead-code-review-rule)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nvelickovic/claude-md-dead-code-review-rule)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nvelickovic/claude-md-dead-code-review-rule)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nvelickovic/claude-md-dead-code-review-rule)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nvelickovic/claude-md-dead-code-review-rule)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nvelickovic/claude-md-dead-code-review-rule)