### PR TITLE
fix Kimi chunked-prefill L1 semaphore clash; enable DEVICE_FP32 gate + sharded trace

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/model_variants.py
+++ b/models/demos/deepseek_v3_d_p/tests/model_variants.py
@@ -51,6 +51,7 @@ class TestVariant:
         mla_pcc_threshold: float = 0.999,
         supports_pretrained: bool = True,
         prefill_trace_default: Optional[str] = None,
+        prefill_trace_layout: str = "single_file",
     ) -> None:
         self.name = name
         self.env_var = env_var
@@ -71,6 +72,10 @@ class TestVariant:
         # Golden chunked-prefill trace (metadata.json token_ids + kv_cache/ + hidden_states/) for the
         # chunked block/transformer PCC tests. The PREFILL_TRACE_DIR env overrides this default.
         self.prefill_trace_default = prefill_trace_default
+        # Trace on-disk layout: "single_file" (DeepSeek — one safetensors/layer, all tensors as keys)
+        # or "chunked_group_a_v1" (Kimi — each tensor a directory of row-sharded rows_<s>_<e>.safetensors,
+        # hidden_states/ -> decoder_io/). The chunked trace readers in the tests dispatch on this.
+        self.prefill_trace_layout = prefill_trace_layout
 
 
 DSV3 = TestVariant(
@@ -111,6 +116,7 @@ KIMI_V2_6 = TestVariant(
     # vllm-traced golden: metadata.json + kv_cache nest under a run-hash subdir (resolve_trace_dir
     # descends), and kv_post_transform is row-sharded (the transformer test's loader reassembles it).
     prefill_trace_default="/mnt/models/deepseek-prefill-cache/golden/kimi-26/kimi_longbook_56320",
+    prefill_trace_layout="chunked_group_a_v1",
 )
 
 TEST_VARIANTS = {v.name: v for v in [DSV3, KIMI_V2_6]}

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -100,15 +100,51 @@ def _load_metadata_token_ids(trace_dir: Path, total_len: int) -> torch.Tensor:
     return torch.tensor(md["token_ids"][:total_len], dtype=torch.int64)
 
 
-def _ref_layer_slice(trace_dir: Path, layer: int, start: int, end: int) -> torch.Tensor:
-    """Read decoder_output_layer_{layer}[start:end] from the trace (partial read, natural order)."""
-    path = trace_dir / "hidden_states" / f"layer_{layer}.safetensors"
+# Trace layouts: DeepSeek ("single_file") writes one safetensors file per layer with every tensor
+# as a key; Kimi ("chunked_group_a_v1") writes each tensor as a directory of row-sharded files
+# (rows_<start>_<end>.safetensors, chunk_rows each) and renames hidden_states/ -> decoder_io/. Both
+# capture decoder_output + kv_post_transform (all this test needs), so only the reader differs.
+_LAYOUT_SINGLE_FILE = "single_file"
+_LAYOUT_CHUNKED_GROUP_A = "chunked_group_a_v1"
+
+
+def _read_sharded_rows(tensor_dir: Path, key: str, start: int, end: int) -> torch.Tensor:
+    """Read rows [start:end] of `key` from a chunked_group_a_v1 shard directory, concatenating the
+    rows_<s>_<e>.safetensors shards that overlap the range (partial read, natural order)."""
+    parts = []
+    for shard in sorted(tensor_dir.glob("rows_*.safetensors")):
+        s, e = (int(x) for x in shard.stem.split("_")[1:3])
+        if e <= start or s >= end:
+            continue
+        with safe_open(shard, framework="pt") as f:
+            parts.append(f.get_slice(key)[max(start, s) - s : min(end, e) - s].to(torch.float32))
+    assert parts, f"no shards overlap rows [{start}:{end}] in {tensor_dir}"
+    return torch.cat(parts, dim=0)
+
+
+def _load_layer_rows(
+    trace_dir: Path, layout: str, group: str, layer: int, key: str, start: int, end: int
+) -> torch.Tensor:
+    """Read trace tensor `key` rows [start:end] (float32) for `layer`, handling both layouts. `group`
+    is the logical bucket: "hidden_states" (decoder_io for Kimi) or "kv_cache"."""
+    if layout == _LAYOUT_CHUNKED_GROUP_A:
+        if group == "hidden_states":
+            tensor_dir = trace_dir / "decoder_io" / key
+        else:
+            tensor_dir = trace_dir / "kv_cache" / f"layer_{layer}"
+        return _read_sharded_rows(tensor_dir, key, start, end)
+    path = trace_dir / group / f"layer_{layer}.safetensors"
     with safe_open(path, framework="pt") as f:
-        return f.get_slice(f"decoder_output_layer_{layer}")[start:end].to(torch.float32)
+        return f.get_slice(key)[start:end].to(torch.float32)
+
+
+def _ref_layer_slice(trace_dir: Path, layout: str, layer: int, start: int, end: int) -> torch.Tensor:
+    """Read decoder_output_layer_{layer}[start:end] from the trace (partial read, natural order)."""
+    return _load_layer_rows(trace_dir, layout, "hidden_states", layer, f"decoder_output_layer_{layer}", start, end)
 
 
 def _record_kv_cache_pcc(
-    trace_dir, tt_kvpe_cache, mesh_device, sp, num_layers, seq_len_cache, total_len, kvpe_dim, kv_lora
+    trace_dir, layout, tt_kvpe_cache, mesh_device, sp, num_layers, seq_len_cache, total_len, kvpe_dim, kv_lora
 ):
     """Record-only: gather the device KV cache, un-rotate the block-cyclic layout, and PCC each
     layer's valid region [:total_len] against the golden kv_post_transform trace. nope is compared
@@ -128,9 +164,7 @@ def _record_kv_cache_pcc(
         nat = torch.empty(seq_len_cache, kvpe_dim, dtype=torch.float32)
         nat[p] = cache_full[i, 0]  # un-rotate block-cyclic -> natural order
         dev_cache = nat[:total_len]
-        path = trace_dir / "kv_cache" / f"layer_{i}.safetensors"
-        with safe_open(path, framework="pt") as f:
-            g_post = f.get_slice(f"kv_post_transform_layer_{i}")[:total_len].to(torch.float32)
+        g_post = _load_layer_rows(trace_dir, layout, "kv_cache", i, f"kv_post_transform_layer_{i}", 0, total_len)
         _, pcc_nope = comp_pcc(g_post[:, :kv_lora], dev_cache[:, :kv_lora])
         ref_pe = g_post[:, kv_lora:]
         d = ref_pe.shape[-1]
@@ -142,7 +176,16 @@ def _record_kv_cache_pcc(
 
 
 def run_chunked_transformer_padded(
-    variant, config, mesh_device, weight_cache_path, num_layers, splits, gate_fallback_mode, num_links, topology
+    variant,
+    config,
+    mesh_device,
+    weight_cache_path,
+    num_layers,
+    splits,
+    gate_fallback_mode,
+    num_links,
+    topology,
+    routing_use_l1_small_for_semaphores=False,
 ):
     """Chunked prefill through num_layers with VARIABLE/partial chunks `splits` (each run as a full
     CHUNK-wide tile padded with a pad token). Exercises the rotated + partial MLA path across the full
@@ -153,6 +196,7 @@ def run_chunked_transformer_padded(
     trace_dir = _resolve_trace_dir(variant)
     if not trace_dir.exists():
         pytest.skip(f"golden trace not found: {trace_dir}")
+    layout = variant.prefill_trace_layout
 
     profiler.clear()
     profiler.start("total_test_time")
@@ -217,6 +261,7 @@ def run_chunked_transformer_padded(
         lm_head_is_column_parallel=True,
         is_chunked=True,
         slot_num=1,
+        routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
     )
     ttnn.synchronize_device(mesh_device)
     gc.collect()
@@ -281,7 +326,7 @@ def run_chunked_transformer_padded(
 
             natural = torch.zeros(isl, emb_dim, dtype=torch.float32)
             natural[dst] = out_flat[src]  # un-rotate valid rows -> natural order [kv_actual, valid_end)
-            ref = _ref_layer_slice(trace_dir, i, kv_actual, valid_end)
+            ref = _ref_layer_slice(trace_dir, layout, i, kv_actual, valid_end)
             _, pcc = comp_pcc(ref, natural)
             layer_min_pcc[i] = min(layer_min_pcc[i], pcc)
             # Record-only mode: log every per-layer/per-chunk PCC, do not assert (deep-layer
@@ -303,7 +348,16 @@ def run_chunked_transformer_padded(
         assert overall_min >= LAYER_PCC_THRESHOLD, f"min per-layer PCC {overall_min:.6f} < {LAYER_PCC_THRESHOLD}"
 
     _record_kv_cache_pcc(
-        trace_dir, tt_kvpe_cache, mesh_device, sp, num_layers, seq_len_cache, total_len, kvpe_dim, config.kv_lora_rank
+        trace_dir,
+        layout,
+        tt_kvpe_cache,
+        mesh_device,
+        sp,
+        num_layers,
+        seq_len_cache,
+        total_len,
+        kvpe_dim,
+        config.kv_lora_rank,
     )
 
     profiler.end("total_test_time")
@@ -316,13 +370,23 @@ def run_chunked_transformer_padded(
 
 
 def run_chunked_transformer(
-    variant, config, mesh_device, weight_cache_path, num_layers, n_chunks, gate_fallback_mode, num_links, topology
+    variant,
+    config,
+    mesh_device,
+    weight_cache_path,
+    num_layers,
+    n_chunks,
+    gate_fallback_mode,
+    num_links,
+    topology,
+    routing_use_l1_small_for_semaphores=False,
 ):
     if weight_cache_path is None:
         pytest.skip(f"pretrained weights unavailable (set {variant.ttnn_cache_env} + {variant.env_var})")
     trace_dir = _resolve_trace_dir(variant)
     if not trace_dir.exists():
         pytest.skip(f"golden trace not found: {trace_dir}")
+    layout = variant.prefill_trace_layout
 
     profiler.clear()
     profiler.start("total_test_time")
@@ -378,6 +442,7 @@ def run_chunked_transformer(
         lm_head_is_column_parallel=True,
         is_chunked=True,
         slot_num=1,
+        routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
     )
     ttnn.synchronize_device(mesh_device)
     gc.collect()
@@ -438,7 +503,7 @@ def run_chunked_transformer(
 
             natural = torch.zeros(CHUNK, emb_dim, dtype=torch.float32)
             natural[local_pos] = out_flat  # un-rotate block-cyclic -> natural chunk order
-            ref = _ref_layer_slice(trace_dir, i, kv_actual, kv_actual + CHUNK)
+            ref = _ref_layer_slice(trace_dir, layout, i, kv_actual, kv_actual + CHUNK)
             _, pcc = comp_pcc(ref, natural)
             layer_min_pcc[i] = min(layer_min_pcc[i], pcc)
             # Record-only mode: log every per-layer/per-chunk PCC, do not assert (deep-layer
@@ -460,7 +525,16 @@ def run_chunked_transformer(
         assert overall_min >= LAYER_PCC_THRESHOLD, f"min per-layer PCC {overall_min:.6f} < {LAYER_PCC_THRESHOLD}"
 
     _record_kv_cache_pcc(
-        trace_dir, tt_kvpe_cache, mesh_device, sp, num_layers, SEQ_CACHE, total_len, kvpe_dim, config.kv_lora_rank
+        trace_dir,
+        layout,
+        tt_kvpe_cache,
+        mesh_device,
+        sp,
+        num_layers,
+        SEQ_CACHE,
+        total_len,
+        kvpe_dim,
+        config.kv_lora_rank,
     )
 
     profiler.end("total_test_time")
@@ -572,7 +646,7 @@ def test_ds_prefill_transformer_chunked_padded(
 # Kimi K2.6 variants
 # ---------------------------------------------------------------------------
 # Same chunked-prefill validation as the DeepSeek tests, with the kimi_k2_6 variant and the host gate
-# (GateComputeMode.HOST_ALL — Kimi has a single expert group and is validated only with the host
+# (GateComputeMode.DEVICE_FP32 — Kimi has a single expert group and is validated only with the host
 # gate) + KimiK26Config fabric payload. These skip until the Kimi golden trace lands (set
 # PREFILL_TRACE_DIR; see model_variants.py).
 
@@ -587,6 +661,11 @@ def test_ds_prefill_transformer_chunked_padded(
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
                 "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
+                # Carve a small L1_SMALL region so the MoE routing all-gather can place its global
+                # semaphores there (use_l1_small_for_semaphores) instead of pinning the main-L1 floor.
+                # Kept minimal: L1_SMALL is carved from the top of L1, so a large value would shift the
+                # main-L1 buffer floor down and could re-introduce the clash.
+                "l1_small_size": 512,
             },
             2,
             ttnn.Topology.Linear,
@@ -617,9 +696,10 @@ def test_kimi_prefill_transformer_chunked(
         weight_cache_path,
         num_layers,
         n_chunks,
-        GateComputeMode.HOST_ALL,
+        GateComputeMode.DEVICE_FP32,
         num_links,
         topology,
+        routing_use_l1_small_for_semaphores=True,
     )
 
 
@@ -633,6 +713,11 @@ def test_kimi_prefill_transformer_chunked(
             {
                 "fabric_config": ttnn.FabricConfig.FABRIC_1D,
                 "fabric_router_config": create_fabric_router_config(max_payload_size=KimiK26Config.FABRIC_PAYLOAD_SIZE),
+                # Carve a small L1_SMALL region so the MoE routing all-gather can place its global
+                # semaphores there (use_l1_small_for_semaphores) instead of pinning the main-L1 floor.
+                # Kept minimal: L1_SMALL is carved from the top of L1, so a large value would shift the
+                # main-L1 buffer floor down and could re-introduce the clash.
+                "l1_small_size": 512,
             },
             2,
             ttnn.Topology.Linear,
@@ -663,7 +748,8 @@ def test_kimi_prefill_transformer_chunked_padded(
         weight_cache_path,
         num_layers,
         splits,
-        GateComputeMode.HOST_ALL,
+        GateComputeMode.DEVICE_FP32,
         num_links,
         topology,
+        routing_use_l1_small_for_semaphores=True,
     )

--- a/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
+++ b/models/demos/deepseek_v3_d_p/tests/test_prefill_transformer_chunked.py
@@ -645,9 +645,9 @@ def test_ds_prefill_transformer_chunked_padded(
 # ---------------------------------------------------------------------------
 # Kimi K2.6 variants
 # ---------------------------------------------------------------------------
-# Same chunked-prefill validation as the DeepSeek tests, with the kimi_k2_6 variant and the host gate
-# (GateComputeMode.DEVICE_FP32 — Kimi has a single expert group and is validated only with the host
-# gate) + KimiK26Config fabric payload. These skip until the Kimi golden trace lands (set
+# Same chunked-prefill validation as the DeepSeek tests, with the kimi_k2_6 variant and the on-device
+# gate (GateComputeMode.DEVICE_FP32 — Kimi has a single expert group, so it uses the grouped-topk
+# fp32 device path) + KimiK26Config fabric payload. These skip until the Kimi golden trace lands (set
 # PREFILL_TRACE_DIR; see model_variants.py).
 
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -33,6 +33,7 @@ from models.demos.deepseek_v3_d_p.tt.moe.tt_moe_routing_setup import TtMoERoutin
 from models.demos.deepseek_v3_d_p.tt.moe.tt_reduce import TtReduceModule
 from models.demos.deepseek_v3_d_p.tt.moe.tt_routed_expert import TtRoutedExpert
 from models.demos.deepseek_v3_d_p.tt.moe.tt_shared_expert import TtSharedExpert
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 
 
 class TtMoe(LightweightModule):
@@ -198,8 +199,6 @@ class TtMoe(LightweightModule):
         self.mesh_device = mesh_device
         # Shared per-mesh CCL singleton: persistent global semaphores for the TP all-gather of x,
         # so all_gather_async reuses them instead of leaking fresh L1 semaphores every layer.
-        from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
-
         self.tt_ccl = get_tt_ccl(mesh_device)
         self.dispatch_group_size = dispatch_group_size
         self.num_dispatch_groups = num_dispatch_groups

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe.py
@@ -156,6 +156,7 @@ class TtMoe(LightweightModule):
         weight_cache_path: Optional[Path] = None,
         layer_idx: int = 0,
         overlap_shared_expert_with_dispatch: bool = True,
+        routing_use_l1_small_for_semaphores: bool = False,
     ):
         """
         Initialize TtMoe module.
@@ -195,6 +196,11 @@ class TtMoe(LightweightModule):
         """
         super().__init__()
         self.mesh_device = mesh_device
+        # Shared per-mesh CCL singleton: persistent global semaphores for the TP all-gather of x,
+        # so all_gather_async reuses them instead of leaking fresh L1 semaphores every layer.
+        from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
+
+        self.tt_ccl = get_tt_ccl(mesh_device)
         self.dispatch_group_size = dispatch_group_size
         self.num_dispatch_groups = num_dispatch_groups
         self.experts_per_chip = experts_per_chip
@@ -257,6 +263,7 @@ class TtMoe(LightweightModule):
             expert_dispatch_table,
             num_links=gate_config.ccl_config["NUM_LINKS"],
             experts_per_chip=experts_per_chip,
+            use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
         )
         logger.debug(f"Initializing TtMoe")
         logger.debug(f"  mesh_device.shape={mesh_device.shape}")
@@ -480,10 +487,12 @@ class TtMoe(LightweightModule):
         # Both shared_expert and dispatch need full emb_dim, so all-gather first
         # Only needed if there are multiple devices in TP axis (axis 1)
         if self.mesh_device.shape[1] > 1:
-            x = ttnn.all_gather(
+            x = ttnn.experimental.all_gather_async(
                 x,
                 dim=-1,  # Gather along emb_dim
                 cluster_axis=1,  # Gather across axis 1 (TP axis)
+                multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=1),
+                barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis=1),
                 num_links=self.col_num_links,
                 topology=self.col_topology,
             )

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -18,6 +18,7 @@ from models.common.lightweightmodule import LightweightModule
 from models.common.utility_functions import is_blackhole
 from models.demos.deepseek_v3_d_p.reference.deepseek_v3_config import DeepSeekV3Config
 from models.demos.deepseek_v3_d_p.reference.kimi_k2_6_config import KimiK26Config
+from models.demos.deepseek_v3_d_p.tt.tt_ccl import get_tt_ccl
 
 
 class GateComputeMode(Enum):
@@ -267,6 +268,10 @@ class TtMoEGatePrefill(LightweightModule):
         """
         self.config = config
         self.mesh_device = mesh_device
+        # Shared per-mesh CCL singleton: provides persistent global semaphores for the gate's TP
+        # all-reduce so the op reuses them instead of allocating fresh L1 semaphores every layer
+        # (those leaked, pinning the L1 floor and clashing with the next layer's ring_mla CBs).
+        self.tt_ccl = get_tt_ccl(mesh_device)
         self.fallback_mode = fallback_mode
 
         if weight is not None and bias is not None:
@@ -423,11 +428,19 @@ class TtMoEGatePrefill(LightweightModule):
             program_config=program_config,
             memory_config=ttnn.L1_MEMORY_CONFIG,
         )
-        if self.mesh_device.shape[self.config.ccl_config["TP_AXIS"]] > 1:
+        tp_axis = self.config.ccl_config["TP_AXIS"]
+        if self.mesh_device.shape[tp_axis] > 1:
+            # Pass persistent CCL semaphores (created once in TT_CCL) so all_reduce_async reuses them
+            # instead of internally allocating+leaking global semaphores in main L1 every call. The
+            # composite all-reduce needs barrier_semaphores of size 2 ([0]=reduce-scatter, [1]=all-gather),
+            # plus the reduce-scatter (3) and all-gather (2) semaphore vectors.
             logits = ttnn.experimental.all_reduce_async(
                 logits,
-                cluster_axis=self.config.ccl_config["TP_AXIS"],
+                cluster_axis=tp_axis,
                 mesh_device=self.mesh_device,
+                barrier_semaphores=self.tt_ccl.barrier_semaphore_handles[tp_axis],
+                rs_global_semaphores=self.tt_ccl.get_and_cycle_rs_semaphore_handles(cluster_axis=tp_axis),
+                ag_global_semaphores=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis=tp_axis),
                 num_links=self.config.ccl_config["NUM_LINKS"],
                 math_op=ttnn.ReduceType.Sum,
                 memory_config=ttnn.L1_MEMORY_CONFIG,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_routing_setup.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_routing_setup.py
@@ -120,6 +120,7 @@ class TtMoERoutingSetup(LightweightModule):
         expert_dispatch_table: torch.Tensor,
         num_links: int = 1,
         experts_per_chip: int = 32,
+        use_l1_small_for_semaphores: bool = False,
     ):
         """
         Initialize routing setup with the expert-to-chip mapping.
@@ -140,6 +141,7 @@ class TtMoERoutingSetup(LightweightModule):
         self.mesh_device = mesh_device
         self.num_links = num_links
         self.experts_per_chip = experts_per_chip
+        self.use_l1_small_for_semaphores = use_l1_small_for_semaphores
 
         self.experts_in_dispatch_group = ttnn.from_torch(
             expert_dispatch_table,
@@ -273,6 +275,10 @@ class TtMoERoutingSetup(LightweightModule):
             num_links=self.num_links,
             experts_per_chip=self.experts_per_chip,
             memory_config=ttnn.DRAM_MEMORY_CONFIG,
+            # Route the internal all-gather's global semaphores to L1_SMALL so they don't pin the main-L1
+            # floor and clash with the next layer's MLA static CBs. Off by default; enabled only where the
+            # device is opened with l1_small_size > 0 (e.g. the Kimi chunked test).
+            use_l1_small_for_semaphores=self.use_l1_small_for_semaphores,
         )
         signpost(header="moe_gate_calculate_global_dispatch_offsets")
 

--- a/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/prefill_runner.py
@@ -72,6 +72,11 @@ GATE_FALLBACK_MODE = os.environ.get("PREFILL_GATE_FALLBACK_MODE", VARIANT.defaul
 # cache for migration and skips its Q/SDPA/wo, FFN/MoE, final norm, and LM head.
 KV_ONLY_LAST_LAYER = os.environ.get("PREFILL_KV_ONLY_LAST_LAYER", "1") == "1"
 PREFILL_DEBUG = os.environ.get("PREFILL_DEBUG", "0") == "1"
+# Kimi (single expert group, device gate) routes the MoE routing all-gather's global semaphores to
+# L1_SMALL so they don't pin the main-L1 floor and clash with the next layer's MLA static CBs. This
+# requires opening the mesh with an L1_SMALL region. Off for DeepSeek (semaphores stay in main L1).
+_ROUTING_USE_L1_SMALL_SEMAPHORES = VARIANT.name == "kimi_k2_6"
+_L1_SMALL_SIZE = 512 if _ROUTING_USE_L1_SMALL_SEMAPHORES else 0
 
 _shutdown = False
 
@@ -284,7 +289,7 @@ def main() -> None:
         f"migration={'ON (KV chunk table publish)' if enable_migration else 'OFF'}"
     )
 
-    mesh_device = open_mesh_device(GLOBAL_MESH_SHAPE, MODEL_CFG)
+    mesh_device = open_mesh_device(GLOBAL_MESH_SHAPE, MODEL_CFG, l1_small_size=_L1_SMALL_SIZE)
 
     hf_config = load_hf_config(VARIANT)
     hf_config.max_seq_len = MAX_SEQ_LEN
@@ -302,6 +307,7 @@ def main() -> None:
         weight_cache_path=cache_path,
         model_cfg=MODEL_CFG,
         kv_only_last_layer=KV_ONLY_LAST_LAYER,
+        routing_use_l1_small_for_semaphores=_ROUTING_USE_L1_SMALL_SEMAPHORES,
     )
 
     pipeline = TtDeepSeekPrefillPipeline(

--- a/models/demos/deepseek_v3_d_p/tt/runners/runner_utils.py
+++ b/models/demos/deepseek_v3_d_p/tt/runners/runner_utils.py
@@ -66,7 +66,7 @@ VARIANTS = {
         # /mnt/models/moonshotai/Kimi-K2.6-dequantized dir name).
         hf_model_default="models/demos/deepseek_v3_d_p/reference/kimi_k2_6",
         ttnn_cache_default="/mnt/models/Kimi-K2_6-Cache/Kimi-K2_6-Cache-prefill",
-        default_gate_mode="HOST_ALL",  # Kimi (1 expert group) is validated only with the host gate
+        default_gate_mode="DEVICE_FP32",  # Kimi (1 expert group)
         # vllm-traced golden: metadata.json + kv_cache live under a single run-hash subdir, and the
         # per-layer KV is row-sharded into layer_N/rows_*.safetensors. resolve_trace_dir descends to
         # the subdir; kv_cache_pcc_check reassembles the shards.
@@ -116,8 +116,10 @@ def load_hf_config(variant: RunnerVariant):
 # ---------------------------------------------------------------------------
 # Device / weight-cache / H2D-service setup
 # ---------------------------------------------------------------------------
-def open_mesh_device(mesh_shape: tuple, model_cfg: type) -> ttnn.MeshDevice:
-    """Configure fabric (1D for sp<=8, else 2D) and open the mesh device."""
+def open_mesh_device(mesh_shape: tuple, model_cfg: type, l1_small_size: int = 0) -> ttnn.MeshDevice:
+    """Configure fabric (1D for sp<=8, else 2D) and open the mesh device. `l1_small_size` > 0 carves an
+    L1_SMALL region (needed when an op routes its semaphores there, e.g. the Kimi MoE routing all-gather
+    with use_l1_small_for_semaphores)."""
     sp = mesh_shape[0]
     fabric_config = ttnn.FabricConfig.FABRIC_1D if sp <= 8 else ttnn.FabricConfig.FABRIC_2D
 
@@ -134,7 +136,7 @@ def open_mesh_device(mesh_shape: tuple, model_cfg: type) -> ttnn.MeshDevice:
         ttnn.FabricManagerMode.DEFAULT,
         fabric_router_config,
     )
-    return ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(*mesh_shape))
+    return ttnn.open_mesh_device(mesh_shape=ttnn.MeshShape(*mesh_shape), l1_small_size=l1_small_size)
 
 
 def resolve_weight_cache_path(variant: RunnerVariant, mesh_shape: tuple) -> Optional[Path]:

--- a/models/demos/deepseek_v3_d_p/tt/tt_deepseek_prefill_pipeline.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_deepseek_prefill_pipeline.py
@@ -38,6 +38,10 @@ class TtPrefillPipelineConfig:
     shared_expert_activations_dtype: ttnn.DataType = ttnn.bfloat16
     shared_expert_weights_dtype: ttnn.DataType = ttnn.bfloat8_b
     weight_cache_path: Optional[Path] = None
+    # Route the MoE routing all-gather's global semaphores to L1_SMALL (instead of pinning the main-L1
+    # floor and clashing with the next layer's MLA static CBs). Requires the mesh opened with
+    # l1_small_size > 0. Enable for Kimi (single expert group, device gate). See TtMoERoutingSetup.
+    routing_use_l1_small_for_semaphores: bool = False
     # Static model-dimension constants for the variant being built
     # (DeepSeekV3Config | KimiK26Config). Drives expert counts, dense-layer
     # count, route groups, etc. in the TT layer code.
@@ -128,6 +132,7 @@ class TtDeepSeekPrefillPipeline:
             is_chunked=True,
             slot_num=self.config.num_users,
             kv_only_last_layer=self.config.kv_only_last_layer,
+            routing_use_l1_small_for_semaphores=self.config.routing_use_l1_small_for_semaphores,
         )
         self.model_built = True
 

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_block.py
@@ -197,8 +197,10 @@ class TtPrefillBlock(LightweightModule):
         layer_num: Optional[int] = None,
         max_seq_len: Optional[int] = None,
         kv_only: bool = False,
+        routing_use_l1_small_for_semaphores: bool = False,
     ):
         super().__init__()
+        self.routing_use_l1_small_for_semaphores = routing_use_l1_small_for_semaphores
         # In chunked prefill the flat KV-cache slot is cache_user_id * layer_num + cache_layer_idx, so
         # layer_num must be the model's actual layer count — there is no safe default to fall back to.
         assert not is_chunked or layer_num is not None, "chunked prefill requires layer_num (model layer count)"
@@ -284,6 +286,7 @@ class TtPrefillBlock(LightweightModule):
                 weight_cache_path=weight_cache_path,
                 layer_idx=layer_idx,
                 dispatch_buffer_capacity_factor=dispatch_buffer_capacity_factor,
+                routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
             )
         else:
             self.ffn = TtFfn(
@@ -313,6 +316,7 @@ class TtPrefillBlock(LightweightModule):
         dispatch_buffer_capacity_factor,
         weight_cache_path=None,
         layer_idx=0,
+        routing_use_l1_small_for_semaphores=False,
     ):
         mesh_config = extract_mesh_config(mesh_device)
         sp_factor = mesh_device.shape[sp_axis]
@@ -361,6 +365,7 @@ class TtPrefillBlock(LightweightModule):
             weight_cache_path=weight_cache_path,
             layer_idx=layer_idx,
             overlap_shared_expert_with_dispatch=True,
+            routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
         )
 
     def forward(

--- a/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
+++ b/models/demos/deepseek_v3_d_p/tt/tt_prefill_transformer.py
@@ -119,6 +119,7 @@ class TtPrefillTransformer(LightweightModule):
         slot_num: int = 1,
         max_seq_len: Optional[int] = None,
         kv_only_last_layer: bool = False,
+        routing_use_l1_small_for_semaphores: bool = False,
     ):
         super().__init__()
         self.mesh_device = mesh_device
@@ -179,6 +180,7 @@ class TtPrefillTransformer(LightweightModule):
                 layer_num=num_layers,
                 max_seq_len=max_seq_len,
                 kv_only=kv_only_last_layer and is_last,
+                routing_use_l1_small_for_semaphores=routing_use_l1_small_for_semaphores,
             )
             self.layers.append(layer)
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.cpp
@@ -16,7 +16,8 @@ std::array<ttnn::Tensor, 3> offset_cumsum(
     uint32_t cluster_axis,
     uint32_t num_links,
     uint32_t experts_per_chip,
-    const ttnn::MemoryConfig& memory_config) {
+    const ttnn::MemoryConfig& memory_config,
+    bool use_l1_small_for_semaphores) {
     const auto& shape = input_tensor.logical_shape();
     uint32_t n_routed_experts = shape[-1];
 
@@ -29,7 +30,13 @@ std::array<ttnn::Tensor, 3> offset_cumsum(
         /*subdevice_id=*/std::nullopt,
         /*memory_config=*/memory_config,
         /*optional_output_tensor=*/std::nullopt,
-        /*num_links=*/num_links);
+        /*num_links=*/num_links,
+        /*topology=*/std::nullopt,
+        /*chunks_per_sync=*/std::nullopt,
+        /*num_workers_per_link=*/std::nullopt,
+        /*num_buffers_per_channel=*/std::nullopt,
+        /*sub_core_grid=*/std::nullopt,
+        /*use_l1_small_for_semaphores=*/use_l1_small_for_semaphores);
 
     auto row_major = ttnn::to_layout(gathered, tt::tt_metal::Layout::ROW_MAJOR, std::nullopt, std::nullopt);
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum.hpp
@@ -11,12 +11,17 @@
 
 namespace ttnn::operations::experimental::deepseek_prefill::offset_cumsum {
 
+// `use_l1_small_for_semaphores`: route the internal cross-device all-gather's global semaphores to the
+// L1_SMALL region instead of main L1. The all-gather creates its sync semaphores internally and keeps
+// them resident; in main L1 they pin the L1 floor and clash with the next layer's MLA static CBs. Routing
+// them to L1_SMALL keeps them off the main-L1 floor. Requires the device opened with l1_small_size > 0.
 std::array<ttnn::Tensor, 3> offset_cumsum(
     const ttnn::Tensor& input_tensor,
     uint32_t cluster_axis,
     uint32_t num_links,
     uint32_t experts_per_chip,
-    const ttnn::MemoryConfig& memory_config);
+    const ttnn::MemoryConfig& memory_config,
+    bool use_l1_small_for_semaphores = false);
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::offset_cumsum
 

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.cpp
@@ -48,7 +48,8 @@ void bind_experimental_offset_cumsum_operation(nb::module_& mod) {
         nb::arg("cluster_axis"),
         nb::arg("num_links"),
         nb::arg("experts_per_chip"),
-        nb::arg("memory_config"));
+        nb::arg("memory_config"),
+        nb::arg("use_l1_small_for_semaphores") = false);
 }
 
 }  // namespace ttnn::operations::experimental::deepseek_prefill::offset_cumsum::detail

--- a/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/deepseek_prefill/offset_cumsum/offset_cumsum_nanobind.cpp
@@ -41,6 +41,9 @@ void bind_experimental_offset_cumsum_operation(nb::module_& mod) {
                 * :attr:`num_links`: Number of links for all_gather.
                 * :attr:`experts_per_chip`: Number of experts per chip (for expert region grouping).
                 * :attr:`memory_config`: Memory configuration for intermediate and output tensors.
+                * :attr:`use_l1_small_for_semaphores`: If True, route the internal all_gather's
+                  global semaphores to the reserved L1_SMALL region instead of the main L1 floor.
+                  Defaults to False.
 
         )doc",
         &offset_cumsum,


### PR DESCRIPTION
Running the Kimi K2.6 chunked-prefill transformer with the on-device MoE gate (GateComputeMode.DEVICE_FP32) crashed inside MLA with a static circular-buffer / L1-buffer clash:

  TT_THROW @ tt_metal/impl/program/program.cpp:1545
  Statically allocated circular buffers in program N clash with L1 buffers on core
  range [0-0 - 10-9]. L1 buffer allocated at 1559104 and static circular buffer
  region ends at 1562896

Root cause
----------
Several MoE collective ops create global semaphores in the MAIN L1 region and keep them resident for the lifetime of their cached program. These ~4-byte buffers pile up at the bottom of L1 and pin the L1-buffer floor below where the next layer's ring_mla static circular-buffer region ends, so program validation rejects the layout. The clash surfaces in MLA (ring_mla) but the offending buffers are leaked by the MoE path of the previous layer. Three contributors, found via the device allocator report (ttnn._ttnn.reports.get_buffers):

  1. gate all_reduce_async  (router matmul TP all-reduce, tt_moe_gate_prefill)
  2. MoE input all_gather   (TP gather of x before dispatch, tt_moe)
  3. routing offset_cumsum  (its internal cross-device all-gather, deepseek_prefill)

Fix
---
- gate all_reduce_async and the MoE all_gather now reuse the model's persistent TT_CCL global semaphores (created once, at high addresses) instead of letting the op allocate fresh per-call semaphores on the L1 floor.
- offset_cumsum's gather is a tiny tensor that routes through composite_all_gather, which self-allocates its semaphores and honors only use_l1_small_for_semaphores (persistent external semaphores do not suppress the composite path). Expose that flag through ttnn.experimental.deepseek_prefill.offset_cumsum and route those semaphores to the reserved L1_SMALL region so they no longer sit on the main-L1 floor. A routing_use_l1_small_for_semaphores flag is threaded transformer -> block -> TtMoe -> TtMoERoutingSetup (default False); it is enabled only for Kimi, and the Kimi mesh is opened with a small l1_small_size.

Also enables the Kimi chunked-prefill transformer test on main:
- model_variants: add prefill_trace_layout and a chunked_group_a_v1 row-sharded golden-trace reader (Kimi vllm trace), alongside the existing single_file reader.
- Switch the Kimi chunked block/transformer tests and the prefill runner default to the DEVICE_FP32 gate (single expert group -> grouped-topk fp32 path).

Runner: prefill_runner opens the Kimi mesh with l1_small_size > 0 and builds the transformer with routing_use_l1_small_for_semaphores=True (gated on the kimi_k2_6 variant). DeepSeek and all other variants/tests are unaffected: every new flag defaults to off and no L1_SMALL region is carved for them.

Validation
----------
- test_kimi_prefill_transformer_chunked (L10, 11 chunks) passes: min per-layer PCC 0.9957, KV-cache min PCC 0.9937.
- Standalone runner (kimi_k2_6, 61 layers, 11x5120 longbook, DEVICE_FP32 gate): no L1 clash, full forward, KV-cache min PCC 0.9661 across 61 layers (matches the pre-existing baseline; the fix does not perturb accuracy).

Refs #47330
Refs #47331

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppopovic/device_fp32_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppopovic/device_fp32_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppopovic/device_fp32_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppopovic/device_fp32_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ppopovic/device_fp32_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ppopovic/device_fp32_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppopovic/device_fp32_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppopovic/device_fp32_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppopovic/device_fp32_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppopovic/device_fp32_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppopovic/device_fp32_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppopovic/device_fp32_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppopovic/device_fp32_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppopovic/device_fp32_gate)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppopovic/device_fp32_gate)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppopovic/device_fp32_gate)