### PR TITLE
Fix BF8 non-determinism: restore set_packer_l1_offset in _llk_pack_init_

### DIFF
--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -401,7 +401,10 @@ inline void _llk_pack_init_(
         _llk_pack_configure_addrmod_<pack_mode>();
     }
     _llk_pack_mop_config_<pack_mode, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
-    set_packer_l1_offset(pack_dst_format, face_r_dim);
+    if constexpr (!skip_packer_strides)
+    {
+        set_packer_l1_offset(pack_dst_format, face_r_dim);
+    }
 
     // Program the packer X (datum) counter. This value is pack_mode-dependent (Untilize packs a single
     // face row, Default packs a full face), so it is per-op state that must be (re)established by init

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -401,6 +401,7 @@ inline void _llk_pack_init_(
         _llk_pack_configure_addrmod_<pack_mode>();
     }
     _llk_pack_mop_config_<pack_mode, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
+    set_packer_l1_offset(pack_dst_format, face_r_dim);
 
     // Program the packer X (datum) counter. This value is pack_mode-dependent (Untilize packs a single
     // face row, Default packs a full face), so it is per-op state that must be (re)established by init


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
Restores `set_packer_l1_offset(pack_dst_format, face_r_dim)` in `_llk_pack_init_` on Wormhole B0.

PR #46482 removed this call, moving L1 face-offset ownership to `configure_pack`/`reconfig_packer_data_format`. However, `reconfig_packer_data_format` only reprograms strides when the data format actually *changes*. When a core transitions from a prior BF16 kernel (L1 face offset = 32) to a BF8 kernel that reconfigures between two same-format BF8 CBs, the stale BF16 offset persists and corrupts BF8 tile packing (shared exponent uses 16B face stride, not 512B).

This manifests as **non-deterministic output** in multi-core BF8 `row_col_bcast` operations — only cores that happened to run a BF16 program previously produce corrupted tiles.

**Root cause:** `pack_reconfig_data_format(cb_out, cb_llk_post)` in the row_col_bcast kernel switches BF8 → BF8 (no format change), so `set_packer_strides` (which includes `set_packer_l1_offset`) is never called.

**Fix:** Add `set_packer_l1_offset` back to `_llk_pack_init_` so every kernel start establishes the correct L1 face offset for its format, regardless of prior core state.

**Note:** Blackhole's `pack_init_apply` already calls `set_packer_strides` (which includes L1 offset) via the `skip_packer_strides` template parameter — this bug is WH-only.

### Validation
- WH N300: **50/50 deterministic** runs of BF8 row_col_bcast (mul + eq)
- **72/72 pytest pass** for `test_opt_output_bf8b` (all bcast modes, all binary ops)
- PCC = 1.0, 0 element mismatches

### Notes for reviewers
Single-line change in `_llk_pack_init_`. The call is placed after `_llk_pack_mop_config_` and before the existing `TT_SETADCXX` (packer X counter), matching the init sequence order in BH's `pack_init_apply`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-bf8-pack-l1-offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:Aswinmcw/fix-bf8-pack-l1-offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=Aswinmcw/fix-bf8-pack-l1-offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:Aswinmcw/fix-bf8-pack-l1-offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=Aswinmcw/fix-bf8-pack-l1-offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:Aswinmcw/fix-bf8-pack-l1-offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=Aswinmcw/fix-bf8-pack-l1-offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:Aswinmcw/fix-bf8-pack-l1-offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=Aswinmcw/fix-bf8-pack-l1-offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:Aswinmcw/fix-bf8-pack-l1-offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=Aswinmcw/fix-bf8-pack-l1-offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:Aswinmcw/fix-bf8-pack-l1-offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=Aswinmcw/fix-bf8-pack-l1-offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:Aswinmcw/fix-bf8-pack-l1-offset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=Aswinmcw/fix-bf8-pack-l1-offset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:Aswinmcw/fix-bf8-pack-l1-offset)