### PR TITLE
[Conv3D] Fix near-zero PCC from inconsistent C_in_block defaults (#47316)

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
+++ b/tests/ttnn/nightly/unit_tests/operations/conv/test_conv3d.py
@@ -965,3 +965,104 @@ def test_conv3d_program_cache_batch_size(device):
             padding_mode,
             grid_size=grid_size,
         )
+
+
+# C_in=64 (aligns to 64 > 32): the old fixed prepare default (32) split the weight into 2 blocks
+# while the conv default (0 = full) used 1, so the matmul contracted mismatched rows. C_in=32 hid it.
+@pytest.mark.parametrize(
+    "input_shape, out_channels, kernel_size, stride, padding",
+    [[(1, 64, 8, 10, 9), 64, (3, 3, 3), (1, 1, 1), (0, 1, 1)]],
+    ids=["c64_k333"],
+)
+def test_conv3d_prepare_default_blocking(device, input_shape, out_channels, kernel_size, stride, padding):
+    """prepare_conv3d_weights and conv3d must agree on C_in_block when both use defaults (issue #47316)."""
+    tt_input, conv3d_module, gt_output, kernel_config, output_dims = setup_conv3d_test(
+        input_shape, out_channels, kernel_size, stride, 1, padding, "zeros", device
+    )
+    N, D_out, H_out, W_out = output_dims
+
+    # Default config (C_in_block unset == 0) and default prepare blocking (C_in_block omitted).
+    config = create_conv3d_config(compute_with_storage_grid_size=device.compute_with_storage_grid_size())
+
+    w = conv3d_module.weight.data
+    tt_weight = ttnn.from_torch(w, dtype=ttnn.DataType.BFLOAT16, pad_value=0)
+    tt_weight = ttnn.experimental.prepare_conv3d_weights(
+        weight_tensor=tt_weight, groups=1, alignment=ALIGNMENT, device=device
+    )
+    tt_bias = ttnn.from_torch(
+        conv3d_module.bias.data.reshape(1, -1),
+        device=device,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        pad_value=0,
+    )
+
+    tt_output = ttnn.experimental.conv3d(
+        input_tensor=tt_input,
+        weight_tensor=tt_weight,
+        device=device,
+        bias_tensor=tt_bias,
+        dtype=ttnn.bfloat16,
+        output_channels=out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        padding_mode="zeros",
+        groups=1,
+        config=config,
+        compute_kernel_config=kernel_config,
+    )
+
+    tt_output = reshape_output(tt_output, N, D_out, H_out, W_out, out_channels, device)
+
+    assert tt_output.shape == gt_output.shape
+    pcc_passed, pcc_message = check_with_pcc(gt_output, tt_output, pcc=0.999)
+    logger.info(f"Compare conv3d (default blocking) torch vs ttnn: {pcc_message}")
+    assert pcc_passed, pcc_message
+
+
+def test_conv3d_preprepared_weight_no_config(device):
+    """Pre-prepared (rank-2) weight + no config: conv3d's fallback C_in_block must match
+    prepare's default (0 = full), since it does not re-block the weight (issue #47316). C_in=64."""
+    input_shape, out_channels, kernel_size, stride, padding = (1, 64, 8, 10, 9), 64, (3, 3, 3), (1, 1, 1), (0, 1, 1)
+    tt_input, conv3d_module, gt_output, kernel_config, output_dims = setup_conv3d_test(
+        input_shape, out_channels, kernel_size, stride, 1, padding, "zeros", device
+    )
+    N, D_out, H_out, W_out = output_dims
+
+    # Prepare the weight separately with default blocking, yielding a rank-2 tensor.
+    w = conv3d_module.weight.data
+    tt_weight = ttnn.from_torch(w, dtype=ttnn.DataType.BFLOAT16, pad_value=0)
+    tt_weight = ttnn.experimental.prepare_conv3d_weights(
+        weight_tensor=tt_weight, groups=1, alignment=ALIGNMENT, device=device
+    )
+    assert len(tt_weight.shape) == 2
+    tt_bias = ttnn.from_torch(
+        conv3d_module.bias.data.reshape(1, -1),
+        device=device,
+        dtype=ttnn.DataType.BFLOAT16,
+        layout=ttnn.TILE_LAYOUT,
+        pad_value=0,
+    )
+
+    # No config -> the op's fallback default blocking must match the prepared weight.
+    tt_output = ttnn.experimental.conv3d(
+        input_tensor=tt_input,
+        weight_tensor=tt_weight,
+        device=device,
+        bias_tensor=tt_bias,
+        dtype=ttnn.bfloat16,
+        output_channels=out_channels,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        padding_mode="zeros",
+        groups=1,
+        compute_kernel_config=kernel_config,
+    )
+
+    tt_output = reshape_output(tt_output, N, D_out, H_out, W_out, out_channels, device)
+    assert tt_output.shape == gt_output.shape
+    pcc_passed, pcc_message = check_with_pcc(gt_output, tt_output, pcc=0.999)
+    logger.info(f"Compare conv3d (pre-prepared weight, no config) torch vs ttnn: {pcc_message}")
+    assert pcc_passed, pcc_message

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d.cpp
@@ -64,6 +64,13 @@ ttnn::Tensor conv3d(
     uint32_t l1_alignment = tt::tt_metal::hal::get_l1_alignment();
     uint32_t min_c_in_block = std::lcm(l1_alignment, tile_align_factor);
 
+    // Default C_in_block must match the weight's blocking or the matmul contracts mismatched rows
+    // -> near-zero PCC (issue #47316). rank-5 (unprepared): blocked + computed here, so
+    // min_c_in_block keeps large kernels in L1. rank-2 (pre-prepared): not re-blocked, so match
+    // prepare_conv3d_weights' own default of 0 (full block).
+    const bool weight_already_prepared = weight_tensor.logical_shape().rank() == 2;
+    const uint32_t default_c_in_block = weight_already_prepared ? 0u : min_c_in_block;
+
     auto config = config_opt.value_or(ttnn::experimental::prim::Conv3dConfig(
         tt::tt_metal::DataType::BFLOAT16,                        // weights_dtype
         tt::tt_metal::Layout::ROW_MAJOR,                         // output_layout
@@ -71,7 +78,7 @@ ttnn::Tensor conv3d(
         1,                                                       // W_out_block
         1,                                                       // H_out_block
         tt::constants::TILE_WIDTH,                               // C_out_block (one tile width)
-        min_c_in_block,                                          // C_in_block (min valid for this kernel)
+        default_c_in_block,                                      // C_in_block (match weight blocking)
         dilation_,                                               // dilation (match the op's dilation)
         32,                                                      // alignment
         input_tensor.device()->compute_with_storage_grid_size()  // use full device grid

--- a/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/conv3d/conv3d_nanobind.cpp
@@ -72,7 +72,9 @@ void bind_conv3d(nb::module_& mod) {
         nb::kw_only(),
         nb::arg("weight_tensor"),
         nb::arg("groups") = 1u,
-        nb::arg("C_in_block") = tt::constants::TILE_WIDTH,
+        // 0 == single full-channel block; must match Conv3dConfig's default so the prepared weight
+        // and conv compute agree on K-row blocking. A mismatch silently reorders rows (issue #47316).
+        nb::arg("C_in_block") = 0u,
         nb::arg("alignment") = 32u,
         nb::arg("device") = nb::none());
 


### PR DESCRIPTION
## Problem

Resolves #47316.

`ttnn.experimental.conv3d` returned **near-zero PCC** for a non-overlapping low-channel patchify — the Qwen2.5-VL vision patch embedding (`C_in=3`, `stride == kernel_size`). Because this is the first op in the model, full-model Qwen2.5-VL-3B PCC collapsed from ~0.90 to ~0.24.

## Root cause

`prepare_conv3d_weights` lays out the weight **K (row) dimension** as `(c_in_block_idx, kD, kH, kW, channel_within_block)` — the interleaving depends on `C_in_block`. The conv compute splits its matmul into `C_in_num_blocks` using `config.C_in_block`. When the two `C_in_block` values disagree, the matmul contracts mismatched activation/weight rows → uncorrelated output.

The defaults disagreed across three surfaces:
- `prepare_conv3d_weights` (nanobind): `TILE_WIDTH` (32)
- `Conv3dConfig`: `0`
- high-level `conv3d` fallback config: `min_c_in_block`

Validation can't catch it: the total K dimension is `kD·kH·kW·C_in_aligned` regardless of blocking, so a shape check passes for any `C_in_block`. (`C_in=32` coincidentally hid the bug since `32/32 == 1` block matched.)

## Fix

Align the `C_in_block` defaults so `0 == single full-channel block` consistently:
- **`conv3d_nanobind.cpp`** — `prepare_conv3d_weights` default `TILE_WIDTH` → `0`, matching the C++ header and `Conv3dConfig`.
- **`conv3d.cpp`** — make the op's fallback `C_in_block` rank-aware: a rank-5 (unprepared) weight is blocked *and* computed here, so keep `min_c_in_block` to keep large kernels within L1; a rank-2 (pre-prepared) weight is not re-blocked, so default to `0` to match `prepare`'s default.

Audited the other config defaults — `alignment` (consumed only by `prepare`), `dilation` (reconciled + `TT_FATAL`-guarded), and `C_out_block` (`prepare` never blocks `C_out`) — no further mismatches.

## Tests

Added two regression tests (nightly) with `C_in=64` (aligns to 64 > 32), where the old defaults split the blocking differently:
- `test_conv3d_prepare_default_blocking` — default config + default prepare.
- `test_conv3d_preprepared_weight_no_config` — pre-prepared rank-2 weight + no config (the fallback path).

Unit suite: 27 passed, 1 skipped. Both new tests pass from the nightly location.

## Known limitation (out of scope)

This fixes default-vs-default. A caller that *explicitly* passes a mismatched `C_in_block` to `prepare` vs `config` still silently corrupts, because the flat weight carries no blocking metadata for validation. Fully closing that needs the prepared weight to encode its blocking (e.g. rank-3 `[num_C_in_blocks, K_per_block, C_out]`) + a device-op guard — a breaking change to `prepare`'s output contract (affects tt-mlir), deliberately deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/conv3d-cin-block-defaults-47316)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/conv3d-cin-block-defaults-47316)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/conv3d-cin-block-defaults-47316)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/conv3d-cin-block-defaults-47316)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/conv3d-cin-block-defaults-47316)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/conv3d-cin-block-defaults-47316)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/conv3d-cin-block-defaults-47316)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/conv3d-cin-block-defaults-47316)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/conv3d-cin-block-defaults-47316)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/conv3d-cin-block-defaults-47316)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/conv3d-cin-block-defaults-47316)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/conv3d-cin-block-defaults-47316)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/conv3d-cin-block-defaults-47316)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/conv3d-cin-block-defaults-47316)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/conv3d-cin-block-defaults-47316)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/conv3d-cin-block-defaults-47316)