### PR TITLE
Alexey zaytsev epam/fix hash collision 45821 dropout

### DIFF
--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.cpp
@@ -106,23 +106,6 @@ Tensor DropoutDeviceOperation::create_output_tensors(
     return create_device_tensor(compute_output_specs(args, tensor_args), tensor_args.input.device());
 }
 
-ttsl::hash::hash_t DropoutDeviceOperation::compute_program_hash(
-    const operation_attributes_t& args, const tensor_args_t& tensor_args) {
-    const auto& input_tensor = tensor_args.input;
-    const auto& input_shape = input_tensor.padded_shape();
-    auto args_without_seed = args;
-    args_without_seed.seed = 0;
-    auto program_factory = select_program_factory(args, tensor_args);
-    operation::Hash hash = operation::hash_operation<DropoutDeviceOperation>(
-        args_without_seed,
-        program_factory.index(),
-        input_tensor.dtype(),
-        input_tensor.memory_config(),
-        input_shape.volume());
-
-    return hash;
-}
-
 }  // namespace ttnn::experimental::prim
 
 namespace ttnn::prim {

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation.hpp
@@ -33,12 +33,6 @@ struct DropoutDeviceOperation {
 
     static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
 
-    // Kept (not attribute_names): the hash coarsens the input to its VOLUME, since dropout is
-    // elementwise (program depends on tile count, not shape). attribute_names can't express that —
-    // it only controls the attrs struct, while the input shape is hashed from tensor_args. The seed
-    // it excludes is re-applied via get_dynamic_runtime_args below.
-    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
-
     // seed is excluded from the program hash (so calls differing only in seed cache-hit); it is
     // DYNAMIC and re-applied to the cached program on every dispatch (per-device offset applied when
     // use_per_device_seed). Must mirror the compute-kernel seed runtime arg in the factory.

--- a/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/experimental/dropout/device/dropout_device_operation_types.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <tuple>
+
 #include "ttnn/tensor/tensor.hpp"
 
 namespace ttnn::experimental::prim {
@@ -19,8 +21,22 @@ struct DropoutParams {
 
     const float prob = 0.0f;
     const float scale = 1.0f;
+
+    // `seed` is re-applied via get_dynamic_runtime_args, so it is excluded from the program hash
+    // (calls differing only in seed cache-hit). `prob`/`scale` are baked as compile-time args and
+    // `use_per_device_seed` selects the program factory, so all three are structural and kept.
+    static constexpr auto attribute_names =
+        std::forward_as_tuple("output_dtype", "output_memory_config", "use_per_device_seed", "prob", "scale");
+    auto attribute_values() const {
+        return std::forward_as_tuple(output_dtype, output_memory_config, use_per_device_seed, prob, scale);
+    }
 };
 
+// tensor_args must stay a plain reflectable aggregate: the device-operation framework walks it
+// structurally to discover the Tensor leaves (output-spec counting, buffer extraction). Compile-time
+// attributes here would both be ambiguous against the Reflectable visitor and hide the Tensors, so
+// the input is hashed in full via its TensorSpec (correct and stricter than the old volume-only
+// hash; the seed is still excluded via DropoutParams + get_dynamic_runtime_args).
 struct DropoutInputs {
     const Tensor& input;
     std::optional<Tensor> preallocated_output;


### PR DESCRIPTION
### PR Category
hash calculation unification for operation DropoutDeviceOperation

### Summary
It was decided to unificate hash calculations for operations
after raising an issue [#45821](https://github.com/tenstorrent/tt-metal/issues/45821)
Hash collision in Shape hashing

PR contains changes for DropoutDeviceOperation

### Notes for reviewers
NA

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:AlexeyZaytsev-epam/fix-hash-collision-45821_uniform_bernoulli_dropout)
