### PR TITLE
emule: startup barrier for simultaneous multi-core dispatch

### DIFF
--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -2132,9 +2132,22 @@ static void launch_cores(
     std::vector<std::thread> core_threads;
     std::vector<std::exception_ptr> core_exceptions(core_setups.size());
 
+    // Startup barrier modeling silicon's simultaneous multi-core dispatch. emule
+    // spawns kernel threads sequentially, so without it an early thread can run its
+    // whole kernel (including cross-core semaphore increments) before a later peer
+    // has executed its prologue — e.g. racing ahead of an argmax reducer's k=0
+    // done_sem reset. Releasing all threads from one barrier restores "all cores
+    // start together".
+    size_t total_kernel_threads = 0;
+    for (const auto& cs : core_setups) {
+        total_kernel_threads += cs.ki_list->size();
+    }
+    std::atomic<uint32_t> kernel_start_barrier{0};
+
     for (size_t core_idx = 0; core_idx < core_setups.size(); ++core_idx) {
         core_threads.emplace_back(
-            [&cs = core_setups[core_idx], dram_data, core_map_ptr, &core_ep = core_exceptions[core_idx]]() {
+            [&cs = core_setups[core_idx], dram_data, core_map_ptr, &core_ep = core_exceptions[core_idx],
+             &kernel_start_barrier, total_kernel_threads]() {
                 try {
                     auto* core = cs.core;
                     uint8_t* l1_data = core->l1_data();
@@ -2169,6 +2182,8 @@ static void launch_cores(
                                               lx,
                                               ly,
                                               kidx,
+                                              &kernel_start_barrier,
+                                              total_kernel_threads,
                                               &kep = kernel_exceptions[kidx]]() {
                             (void)kidx;
                             auto& ki = *ki_ptr;
@@ -2200,6 +2215,13 @@ static void launch_cores(
                             __emule_trisc_id = 0;
                             __emule_num_threads = ki.num_threads;
                             __emule_my_thread_id = ki.thread_idx;
+
+                            // Startup barrier (declared in launch_cores): all
+                            // kernel threads start together.
+                            kernel_start_barrier.fetch_add(1, std::memory_order_acq_rel);
+                            while (kernel_start_barrier.load(std::memory_order_acquire) < total_kernel_threads) {
+                                std::this_thread::yield();
+                            }
 
                             log_debug(
                                 tt::LogMetal,


### PR DESCRIPTION
### Companion tt-emule PR
`sgholami/argmax-support` https://github.com/tenstorrent/tt-emule/pull/181

### What
Adds a startup barrier to the emule program runner so all kernel threads begin executing together, modeling silicon's simultaneous multi-core dispatch. Scope is emule integration only; no kernel sources or Metal APIs change.

### How
emule spawns one host thread per (core, kernel) sequentially. Without a barrier, an early-spawned thread can run its entire kernel — including cross-core NOC semaphore increments — before a later-spawned peer has executed even its prologue. The motivating case is `ttnn.argmax`'s multi-core reducer, which resets its `done_sem` in an ungated `k=0` prologue and then waits for every worker to increment it: a worker that races ahead increments before the reset, the reset clobbers it, and the exact-match wait hangs (worse with more cores).

The fix counts the program's kernel threads and holds each at a barrier before it runs any kernel body, restoring the "all cores start together" invariant. Cost is a single sync point per program launch.

### Verification (with the companion branch) 
This pairs with the companion emule PR, which adds the first-read latency that orders the reducer's reset ahead of worker increments; both are needed.
argmax passes across repeated WH/BH runs; C++ regressions stay green (WH 39/0, BH 19/0); topk, sort, and matmul are unaffected.

### Visualization
<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/2d0957ec-d10b-4396-8c93-960026c7092c" />

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sgholami/emule-argmax-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sgholami/emule-argmax-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sgholami/emule-argmax-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sgholami/emule-argmax-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sgholami/emule-argmax-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sgholami/emule-argmax-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sgholami/emule-argmax-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sgholami/emule-argmax-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sgholami/emule-argmax-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sgholami/emule-argmax-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sgholami/emule-argmax-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sgholami/emule-argmax-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sgholami/emule-argmax-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sgholami/emule-argmax-support)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sgholami/emule-argmax-support)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sgholami/emule-argmax-support)