### PR TITLE
Add TXQ resent count and RXQ packet drop count to BH mem map

### DIFF
--- a/tt_metal/api/tt-metalium/hal_types.hpp
+++ b/tt_metal/api/tt-metalium/hal_types.hpp
@@ -39,10 +39,16 @@ enum class HalL1MemAddrType : uint8_t {
     APP_ROUTING_INFO,
     RETRAIN_COUNT,
     RETRAIN_FORCE,
-    CRC_ERR,    // Link status - CRC error count
-    CORR_CW,    // Link status - Corrected Codewords count
-    UNCORR_CW,  // Link status - Uncorrected Codewords count
-    LINK_UP,    // Link status - Link up status
+    CRC_ERR,          // Link status - CRC error count
+    CORR_CW,          // Link status - Corrected Codewords count
+    UNCORR_CW,        // Link status - Uncorrected Codewords count
+    TXQ0_RESEND_CNT,  // Link status - TX queue 0 packet resend count (Blackhole only)
+    TXQ1_RESEND_CNT,  // Link status - TX queue 1 packet resend count (Blackhole only)
+    TXQ2_RESEND_CNT,  // Link status - TX queue 2 packet resend count (Blackhole only)
+    RXQ0_PKT_DROP,    // Link status - RX queue 0 packet drop count (Blackhole only)
+    RXQ1_PKT_DROP,    // Link status - RX queue 1 packet drop count (Blackhole only)
+    RXQ2_PKT_DROP,    // Link status - RX queue 2 packet drop count (Blackhole only)
+    LINK_UP,          // Link status - Link up status
     FABRIC_TELEMETRY,
     ROUTING_TABLE,
     ROUTER_STATE,

--- a/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
+++ b/tt_metal/llrt/hal/tt-1xx/blackhole/bh_hal_active_eth.cpp
@@ -106,6 +106,26 @@ HalCoreInfoType create_active_eth_mem_map(bool enable_2_erisc_mode) {
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::RETRAIN_FORCE)] = MEM_RETRAIN_FORCE_ADDR;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::CORR_CW)] = MEM_CORR_CW_ADDR;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::UNCORR_CW)] = MEM_UNCORR_CW_ADDR;
+    // TX/RX queue counters live in boot_results.eth_live_status (see eth_fw_api.h). They have no
+    // fixed MEM_*_ADDR macro, so derive their addresses from the struct layout.
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::TXQ0_RESEND_CNT)] =
+        MEM_SYSENG_BOOT_RESULTS_BASE + offsetof(boot_results_t, eth_live_status) +
+        offsetof(eth_live_status_t, txq0_resend_cnt);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::TXQ1_RESEND_CNT)] =
+        MEM_SYSENG_BOOT_RESULTS_BASE + offsetof(boot_results_t, eth_live_status) +
+        offsetof(eth_live_status_t, txq1_resend_cnt);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::TXQ2_RESEND_CNT)] =
+        MEM_SYSENG_BOOT_RESULTS_BASE + offsetof(boot_results_t, eth_live_status) +
+        offsetof(eth_live_status_t, txq2_resend_cnt);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::RXQ0_PKT_DROP)] =
+        MEM_SYSENG_BOOT_RESULTS_BASE + offsetof(boot_results_t, eth_live_status) +
+        offsetof(eth_live_status_t, rxq0_pkt_drop);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::RXQ1_PKT_DROP)] =
+        MEM_SYSENG_BOOT_RESULTS_BASE + offsetof(boot_results_t, eth_live_status) +
+        offsetof(eth_live_status_t, rxq1_pkt_drop);
+    mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::RXQ2_PKT_DROP)] =
+        MEM_SYSENG_BOOT_RESULTS_BASE + offsetof(boot_results_t, eth_live_status) +
+        offsetof(eth_live_status_t, rxq2_pkt_drop);
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::FABRIC_TELEMETRY)] = MEM_AERISC_FABRIC_TELEMETRY_BASE;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::ROUTING_TABLE)] = MEM_AERISC_ROUTING_TABLE_BASE;
     mem_map_bases[static_cast<std::size_t>(HalL1MemAddrType::ROUTER_STATE)] = MEM_AERISC_FABRIC_ROUTER_STATE_BASE;


### PR DESCRIPTION
### PR Category
Feature

### Summary
We needed to expose these Eth firmware L1 values for telemetry.

### Notes for reviewers
In particular, are the addresses for queue 2 correct?

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=bart/eth-bh-metrics)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:bart/eth-bh-metrics)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=bart/eth-bh-metrics)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:bart/eth-bh-metrics)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=bart/eth-bh-metrics)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:bart/eth-bh-metrics)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=bart/eth-bh-metrics)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:bart/eth-bh-metrics)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=bart/eth-bh-metrics)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:bart/eth-bh-metrics)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=bart/eth-bh-metrics)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:bart/eth-bh-metrics)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=bart/eth-bh-metrics)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:bart/eth-bh-metrics)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=bart/eth-bh-metrics)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:bart/eth-bh-metrics)