### PR TITLE
[Bug fix] Batched prefill: fall back to regular matmul for the Blackhole minimal-matmul race

### DIFF
--- a/models/demos/multimodal/gemma3/tt/model_config.py
+++ b/models/demos/multimodal/gemma3/tt/model_config.py
@@ -187,7 +187,9 @@ class ModelArgs(TTModelArgs):
             return model_overrides[model_name][device_name] * 1024
         return super().get_max_prefill_chunk_size()
 
-    def get_attn_qkv_program_config(self, mode: Mode, seq_len: int = 1, prefetcher: Prefetcher = None):
+    def get_attn_qkv_program_config(
+        self, mode: Mode, seq_len: int = 1, prefetcher: Prefetcher = None, batched: bool = False
+    ):
         """Smaller MinimalMatmul blocks for traced long prefill (default 8³ overflows static CB vs L1)."""
         if self._enable_program_trace and mode == Mode.PREFILL and seq_len > 128:
             return ttnn.MinimalMatmulConfig(
@@ -196,7 +198,7 @@ class ModelArgs(TTModelArgs):
                 N_block_size=4,
                 compute_with_storage_grid_size=ttnn.CoreCoord(8, 10) if is_blackhole() else ttnn.CoreCoord(8, 8),
             )
-        return super().get_attn_qkv_program_config(mode, seq_len, prefetcher)
+        return super().get_attn_qkv_program_config(mode, seq_len, prefetcher, batched=batched)
 
     def get_attn_sdpa_decode_program_config(self, prefetcher: Prefetcher = None):
         force_fixed_k_chunk = getattr(self, "force_fixed_decode_k_chunk", False)

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -904,12 +904,14 @@ class Attention(LightweightModule):
         if seq_len > self.MAX_QKV_MM_SEQ_LEN:
             x_11SH = ttnn.reshape(x_11SH, [1, seq_len // self.MAX_QKV_MM_SEQ_LEN, self.MAX_QKV_MM_SEQ_LEN, -1])
 
-        if self.args.use_minimal_qkv_prefill_matmul(seq_len):
+        # batch_size > 1 ⇒ batched prefill; minimal_matmul races on Blackhole there.
+        batched_prefill = batch_size > 1
+        if self.args.use_minimal_qkv_prefill_matmul(seq_len, batched=batched_prefill):
             xqkv_fused = ttnn.experimental.minimal_matmul(
                 x_11SH,
                 self.wqkv,
                 compute_kernel_config=self.li_qkv_prefill_compute_kernel_cfg,
-                config=self.args.get_attn_qkv_program_config(Mode.PREFILL, seq_len, None),
+                config=self.args.get_attn_qkv_program_config(Mode.PREFILL, seq_len, None, batched=batched_prefill),
             )
         else:
             xqkv_fused = ttnn.linear(
@@ -918,7 +920,7 @@ class Attention(LightweightModule):
                 dtype=self.ccl_dtype if self.TG else self.activation_dtype or ttnn.bfloat16,
                 memory_config=self.args.get_attn_qkv_mm_mem_config(Mode.PREFILL, None),
                 compute_kernel_config=self.li_qkv_prefill_compute_kernel_cfg,
-                program_config=self.args.get_attn_qkv_program_config(Mode.PREFILL, seq_len, None),
+                program_config=self.args.get_attn_qkv_program_config(Mode.PREFILL, seq_len, None, batched=batched_prefill),
             )
 
         # FIXME: surely ttnn.linear bias should work?

--- a/models/tt_transformers/tt/attention.py
+++ b/models/tt_transformers/tt/attention.py
@@ -920,7 +920,9 @@ class Attention(LightweightModule):
                 dtype=self.ccl_dtype if self.TG else self.activation_dtype or ttnn.bfloat16,
                 memory_config=self.args.get_attn_qkv_mm_mem_config(Mode.PREFILL, None),
                 compute_kernel_config=self.li_qkv_prefill_compute_kernel_cfg,
-                program_config=self.args.get_attn_qkv_program_config(Mode.PREFILL, seq_len, None, batched=batched_prefill),
+                program_config=self.args.get_attn_qkv_program_config(
+                    Mode.PREFILL, seq_len, None, batched=batched_prefill
+                ),
             )
 
         # FIXME: surely ttnn.linear bias should work?

--- a/models/tt_transformers/tt/decoder.py
+++ b/models/tt_transformers/tt/decoder.py
@@ -309,7 +309,7 @@ class TransformerBlock(LightweightModule):
             hidden_states = ttnn.to_memory_config(hidden_states, memory_config=self.args.get_mlp_act_mem_config(mode))
         # MLP takes replicated inputs and produces fractured outputs
 
-        hidden_states = self.feed_forward.forward(hidden_states, mode)
+        hidden_states = self.feed_forward.forward(hidden_states, mode, batch_size=batch_size)
 
         activation_dtype = self.args.decoders_optimizations.get_tensor_dtype(
             decoder_id=self.layer_num, tensor=TensorGroup.ACTIVATION

--- a/models/tt_transformers/tt/mixtral_moe.py
+++ b/models/tt_transformers/tt/mixtral_moe.py
@@ -91,7 +91,7 @@ class TtMoeLayer(LightweightModule):
             mesh_mapper=ReplicateTensorToMesh(mesh_device),
         )
 
-    def forward(self, inputs, mode: Mode):
+    def forward(self, inputs, mode: Mode, batch_size: int = 1):
         """
         Tensors are postfixed with 4 characters that represent their 4-D shape:
         B : batch_size (32)

--- a/models/tt_transformers/tt/mlp.py
+++ b/models/tt_transformers/tt/mlp.py
@@ -6,6 +6,7 @@ import torch
 
 import ttnn
 from models.common.lightweightmodule import LightweightModule
+from models.common.utility_functions import is_blackhole
 from models.tt_transformers.tt.ccl import tt_all_reduce
 from models.tt_transformers.tt.common import Mode, pad_to_size
 from models.tt_transformers.tt.model_config import OpGroup, TensorGroup
@@ -115,7 +116,7 @@ class MLP(LightweightModule):
 
             self.prefetcher.register_callback(register_weights)
 
-    def forward(self, x: ttnn.Tensor, mode: Mode) -> ttnn.Tensor:
+    def forward(self, x: ttnn.Tensor, mode: Mode, batch_size: int = 1) -> ttnn.Tensor:
         """
         w1 -> gate_proj
         w2 -> down_proj
@@ -123,6 +124,8 @@ class MLP(LightweightModule):
         HF reference: self.down_proj(self.act_fn(self.gate_proj(x)) * self.up_proj(x))
         """
         seq_len = x.shape[-2]
+        # batch_size > 1 ⇒ batched prefill; minimal_matmul races on Blackhole there.
+        batched_prefill = batch_size > 1
         TG = self.args.is_galaxy
         layer_num = max(self.layer_num, 0)  # cross_block uses the configuration of the first decoder
         activation_dtype = self.decoders_optimizations.get_tensor_dtype(
@@ -139,7 +142,7 @@ class MLP(LightweightModule):
         # In decode mode (seqlen <= 32) do DRAM sharded matmuls
         # These use HiFi2; this drops 1 bit of the activations but would be FLOP-bound on 12 cores with HiFi4
         pc_1 = self.args.get_mlp_ff1_3_prg_config(mode, seq_len, self.prefetcher)
-        pc_2 = self.args.get_mlp_ff2_prg_config(mode, seq_len, self.prefetcher)
+        pc_2 = self.args.get_mlp_ff2_prg_config(mode, seq_len, self.prefetcher, batched=batched_prefill)
         pc_3 = self.args.get_mlp_ff1_3_prg_config(mode, seq_len, self.prefetcher)
 
         w1_out = ttnn.linear(
@@ -272,7 +275,7 @@ class MLP(LightweightModule):
             decoder_id=layer_num, op=OpGroup.LI_FF2, configuration=self.args
         )
 
-        if seq_len > 128 and mode != Mode.DECODE:
+        if seq_len > 128 and mode != Mode.DECODE and not (batched_prefill and is_blackhole()):
             w2_out = ttnn.experimental.minimal_matmul(
                 w2_in,
                 self.w2,

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -603,9 +603,21 @@ class ModelArgs:
         # different-sized prefill batches get slightly different logits. Seeded
         # sampling under concurrency then diverges (tt-inference-server#4004,
         # test_non_uniform_seeding). Forcing per-user batch-1 prefill removes the
-        # variance. Workaround until the prefill kernels are batch-invariant;
-        # mirrors the existing Llama-3.1-8B P300/P150x8 handling.
-        self.disable_batched_prefill = self.base_model_name == "Qwen3-32B" and self.device_name == "P150x4"
+        # variance. Workaround until the prefill kernels are batch-invariant.
+        #
+        # Batched prefill on Blackhole previously produced non-deterministic
+        # garbage for Llama 3.1 8B because ttnn.experimental.minimal_matmul races
+        # at the batched-prefill shapes (see use_minimal_qkv_prefill_matmul /
+        # get_mlp_ff2_prg_config, which now fall back to the regular matmul for
+        # batched prefill on Blackhole). With that gate, batched prefill on the
+        # 4-chip P300x2 system (reported as device_name "P150x4") is deterministic
+        # and bit-identical to the per-user prefill path, so it is re-enabled
+        # there. P300 (2-chip) and P150x8 (8-chip) stay on the per-user path
+        # until batched prefill is validated on those device counts (different
+        # CCL / fused all-gather-matmul paths).
+        self.disable_batched_prefill = (
+            self.base_model_name == "Qwen3-32B" and self.device_name == "P150x4"
+        ) or (self.base_model_name == "Llama-3.1-8B" and self.device_name in ("P300", "P150x8"))
 
         if (
             self.base_model_name
@@ -1286,7 +1298,7 @@ class ModelArgs:
             )
 
     @lru_cache(maxsize=None)
-    def get_mlp_ff2_prg_config(self, mode: Mode, seq_len: int = 1, prefetcher: Prefetcher = None):
+    def get_mlp_ff2_prg_config(self, mode: Mode, seq_len: int = 1, prefetcher: Prefetcher = None, batched: bool = False):
         if mode == Mode.DECODE:
             if self.dim >= 4096 and self.is_galaxy:
                 return self.matmul_1d_config_from_tensor_shapes(
@@ -1324,7 +1336,9 @@ class ModelArgs:
                         num_cores=self.mlp2_core_grid.num_cores,
                     )
         elif mode == Mode.PREFILL:
-            if seq_len > 128:
+            # minimal_matmul races on Blackhole for batched prefill (see
+            # use_minimal_qkv_prefill_matmul); use the regular matmul there.
+            if seq_len > 128 and not (batched and is_blackhole()):
                 grid = self.mlp2_grid(seq_len)
                 return ttnn.MinimalMatmulConfig(
                     M_block_size=8,
@@ -1601,7 +1615,9 @@ class ModelArgs:
     # QKV, WO, All-Reduce, All-Gather configs
     # =========================================================================
     @lru_cache(maxsize=None)
-    def get_attn_qkv_program_config(self, mode: Mode, seq_len: int = 1, prefetcher: Prefetcher = None):
+    def get_attn_qkv_program_config(
+        self, mode: Mode, seq_len: int = 1, prefetcher: Prefetcher = None, batched: bool = False
+    ):
         """Get the program config for the QKV matmul in attention."""
         if mode == Mode.DECODE:
             if prefetcher is not None:
@@ -1623,7 +1639,7 @@ class ModelArgs:
                 )
         elif mode == Mode.PREFILL:
             self.MAX_QKV_MM_SEQ_LEN = 2048
-            if self.use_minimal_qkv_prefill_matmul(seq_len):
+            if self.use_minimal_qkv_prefill_matmul(seq_len, batched=batched):
                 return ttnn.MinimalMatmulConfig(
                     M_block_size=8,
                     K_block_size=8,
@@ -1656,7 +1672,15 @@ class ModelArgs:
         else:
             raise ValueError(f"Invalid mode: {mode}")
 
-    def use_minimal_qkv_prefill_matmul(self, seq_len: int) -> bool:
+    def use_minimal_qkv_prefill_matmul(self, seq_len: int, batched: bool = False) -> bool:
+        # ttnn.experimental.minimal_matmul races non-deterministically on Blackhole
+        # at the batched-prefill shapes (concatenated multi-user seq), producing
+        # run-to-run garbage / occasional repetition loops. Fall back to the
+        # regular matmul for batched prefill on Blackhole (proven deterministic
+        # and bit-identical to the per-user prefill path). See tenstorrent/tt-metal#46181
+        # for the analogous gpt-oss fused-op race. Single-user prefill is unaffected.
+        if batched and is_blackhole():
+            return False
         if seq_len > 128:
             return True
 

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1298,7 +1298,9 @@ class ModelArgs:
             )
 
     @lru_cache(maxsize=None)
-    def get_mlp_ff2_prg_config(self, mode: Mode, seq_len: int = 1, prefetcher: Prefetcher = None, batched: bool = False):
+    def get_mlp_ff2_prg_config(
+        self, mode: Mode, seq_len: int = 1, prefetcher: Prefetcher = None, batched: bool = False
+    ):
         if mode == Mode.DECODE:
             if self.dim >= 4096 and self.is_galaxy:
                 return self.matmul_1d_config_from_tensor_shapes(


### PR DESCRIPTION
### Summary
Threads a batched flag through the prefill matmul program-config helpers so batched (concatenated multi-user) prefill on Blackhole avoids ttnn.experimental.minimal_matmul, which races non-deterministically at the batched-prefill shapes (run-to-run garbage / occasional repetition loops). Single-user prefill is unchanged.

### Changes
Add batched param to use_minimal_qkv_prefill_matmul, get_attn_qkv_program_config, and get_mlp_ff2_prg_config; fall back to the regular matmul when batched and is_blackhole().
Thread batched/batched_prefill through attention.py, decoder.py, mlp.py, mixtral_moe.py.
gemma3 ModelArgs.get_attn_qkv_program_config override accepts and forwards batched (otherwise it raises TypeError on the batched path).
disable_batched_prefill: combined with main's existing Qwen3-32B/P150x4 case so the Llama-3.1-8B (P300, P150x8) handling and the Qwen3 handling coexist; batched prefill stays enabled on P150x4 for Llama-3.1-8B (deterministic with the gate above).

### Why
Without the fall-back, batched prefill on Blackhole produced non-deterministic logits -> seeded sampling diverged under concurrency. The regular-matmul path is proven bit-identical to per-user prefill.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ctr-ifabijanic/batched-prefill-qkv-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ctr-ifabijanic/batched-prefill-qkv-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ctr-ifabijanic/batched-prefill-qkv-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ctr-ifabijanic/batched-prefill-qkv-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ctr-ifabijanic/batched-prefill-qkv-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ctr-ifabijanic/batched-prefill-qkv-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-ifabijanic/batched-prefill-qkv-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-ifabijanic/batched-prefill-qkv-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ctr-ifabijanic/batched-prefill-qkv-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ctr-ifabijanic/batched-prefill-qkv-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-ifabijanic/batched-prefill-qkv-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-ifabijanic/batched-prefill-qkv-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-ifabijanic/batched-prefill-qkv-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-ifabijanic/batched-prefill-qkv-race)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-ifabijanic/batched-prefill-qkv-race)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-ifabijanic/batched-prefill-qkv-race)