### PR TITLE
[Bug fix] On-device sampling: gather logits in the model forward (fixes concurrency corruption)

### DIFF
--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -250,7 +250,7 @@ jobs:
               "runner-label": "BH-Quietbox-2",
               "arch": "arch-blackhole",
               "mesh-device": "P150x4",
-              "tt-config": "{\"trace_region_size\": 76000000}",
+              "tt-config": "{\"trace_region_size\": 150000000}",
               "tt-llama-text-ver": "tt_transformers",
               "additional-server-args": "--async-scheduling",
               "structured-output": true,

--- a/models/common/sampling/tt_penalties.py
+++ b/models/common/sampling/tt_penalties.py
@@ -163,11 +163,19 @@ class TTPenalties(LightweightModule):
         self.per_row_batch_size = per_row_batch
         self._shard_dims_gathered = shard_dims_gathered
 
-        self.prompt_mask = self._alloc_int_buffer(shard_dims=shard_dims)
-        self.output_mask = self._alloc_int_buffer(shard_dims=shard_dims)
+        # Gather-in-forward: the sampling op operates on the FULL (replicated) vocab,
+        # so the per-token penalty buffers (prompt/output masks + output counts) must
+        # be full-vocab replicated too (instead of vocab-sharded). The per-device
+        # slice that normally derives the sharded mask from the gathered counts is
+        # then skipped (see token_bin_counts_and_mask). Enabled via model_config.
+        self._gather_in_forward = getattr(args, "gather_logits_in_forward", False)
+        mask_shard_dims = shard_dims_gathered if self._gather_in_forward else shard_dims
+
+        self.prompt_mask = self._alloc_int_buffer(shard_dims=mask_shard_dims)
+        self.output_mask = self._alloc_int_buffer(shard_dims=mask_shard_dims)
         self.output_counts_gathered = self._alloc_int_buffer(shard_dims=shard_dims_gathered)
-        self.output_counts = self._alloc_int_buffer(shard_dims=shard_dims)
-        self._shard_dims_mask = shard_dims
+        self.output_counts = self._alloc_int_buffer(shard_dims=mask_shard_dims)
+        self._shard_dims_mask = mask_shard_dims
         self.decode_src = self._alloc_int_buffer(
             host=torch.ones(self._total_batch, 1), shard_dims=shard_dims_gathered, layout=ttnn.ROW_MAJOR_LAYOUT
         )
@@ -357,15 +365,21 @@ class TTPenalties(LightweightModule):
             counts = ttnn.add(counts, counts_new, output_tensor=counts, **self._op_kwargs)
         else:
             counts = counts_new
-        counts_sliced = ttnn.slice(
-            counts,
-            self.slice_start,
-            self.slice_end,
-            output_tensor=counts_sliced,
-            slice_dim=1,
-            num_devices=self.num_devices,
-            **self._op_kwargs,
-        )
+        if self._gather_in_forward:
+            # Full-vocab path: output_counts spans the whole vocab (matches the
+            # forward-gathered logits), so copy the gathered counts in directly
+            # instead of slicing out a per-device shard.
+            counts_sliced = ttnn.add(counts, 0, output_tensor=counts_sliced, **self._op_kwargs)
+        else:
+            counts_sliced = ttnn.slice(
+                counts,
+                self.slice_start,
+                self.slice_end,
+                output_tensor=counts_sliced,
+                slice_dim=1,
+                num_devices=self.num_devices,
+                **self._op_kwargs,
+            )
 
         mask = ttnn.gt(counts_sliced, 0, output_tensor=mask, **self._op_kwargs)
         return counts, mask

--- a/models/common/sampling/tt_sampling.py
+++ b/models/common/sampling/tt_sampling.py
@@ -129,6 +129,13 @@ class TTSampling(LightweightModule):
         self.max_batch_size = max(32, ((raw_batch + 31) // 32) * 32)
         self.max_top_k = getattr(args, "max_top_k", 32)
         self.cluster_shape = args.cluster_shape
+        # Gather-in-forward: logits are all-gathered inside the forward, so the
+        # sampling op sees the FULL (replicated) vocab. The top-k path then splits
+        # the full vocab back into per-device shards, top-ks each locally, and
+        # reuses the existing local index tensor + device offsets -- avoiding the
+        # corrupting sampling-context all-gather while producing identical global
+        # candidates. Enabled via model_config.gather_logits_in_forward.
+        self._gather_in_forward = getattr(args, "gather_logits_in_forward", False)
 
         self.sampling_all_gather_axis = getattr(args, "sampling_all_gather_axis", 0)
         self.sub_core_grids = getattr(args, "sub_core_grids", None)
@@ -276,6 +283,10 @@ class TTSampling(LightweightModule):
         )
         # padded_per_device: tile-aligned width matching actual logit tensors (for indices tensor)
         padded_per_device = self.padded_vocab_size // num_devices_in_mesh
+        # Stored for the gather-in-forward path (chunk the full gathered vocab back
+        # into these per-device shards and reuse the local index tensor + offsets).
+        self._num_sampling_devices = num_devices_in_mesh
+        self._padded_per_device = padded_per_device
 
         for device_id in range(num_devices_in_mesh):
             indices_device_offsets[:, :, :, device_id * self.max_top_k : (device_id + 1) * self.max_top_k] = (
@@ -462,7 +473,10 @@ class TTSampling(LightweightModule):
             logger.info("Forcing argmax sampling")
             # Gather the output across all devices and untilize the tensor (for argmax)
             num_devices = self.mesh_device.get_num_devices()
-            if num_devices > 1:
+            # Gather-in-forward: logits were already all-gathered inside the forward
+            # (still tiled), so skip the sampling-context gather and only untilize +
+            # argmax below.
+            if num_devices > 1 and not self._gather_in_forward:
                 cluster_axis = self._get_sampling_cluster_axis()
                 num_links, topology = self._get_force_argmax_all_gather_config(cluster_axis)
                 logger.debug(
@@ -499,7 +513,60 @@ class TTSampling(LightweightModule):
         # Convert to bfloat16 for top-k operations (typecast is no-op if already bfloat16)
         x_bf16 = ttnn.typecast(x, dtype=ttnn.bfloat16, sub_core_grids=self.sub_core_grids)
 
-        if self.multi_step_reduction:
+        if self._gather_in_forward:
+            # The forward-gathered logits are the concatenation of the per-device
+            # vocab shards (padded_vocab = num_devices * padded_per_device). Split
+            # them back into those shards, pad each to pow2 exactly like the sharded
+            # path pads a shard, top-k each locally with the SAME local index tensor,
+            # and concat in device order. This reproduces the sharded path's
+            # (num_devices * k) LOCAL top-k results WITHOUT the corrupting
+            # sampling-context all-gather, so the existing device-offset add below
+            # converts them to global indices identically.
+            per_device_width = self._padded_per_device
+            x_chunks = ttnn.split(x_bf16, per_device_width, dim=3)
+            topk_values_list = []
+            topk_indices_list = []
+            for ci in range(len(x_chunks)):
+                xc_in = x_chunks[ci]
+                xc = xc_in
+                if self.pad_to_power_of_2 and not is_power_of_2(xc.shape[-1]):
+                    padded_value = upper_power_of_2(xc.shape[-1])
+                    xc = ttnn.pad(
+                        xc_in,
+                        [(0, 0), (0, 0), (0, 0), (0, padded_value - xc_in.shape[-1])],
+                        value=-sys.float_info.max,
+                        sub_core_grids=self.sub_core_grids,
+                    )
+                cv, cidx = ttnn.topk(
+                    xc,
+                    k=self.max_top_k,
+                    dim=-1,
+                    sub_core_grids=self.sub_core_grid_topk,
+                    indices_tensor=self.tt_indices_tensor,
+                )
+                topk_values_list.append(cv)
+                topk_indices_list.append(cidx)
+                ttnn.deallocate(xc)
+                if xc is not xc_in:
+                    ttnn.deallocate(xc_in)
+            topk_values_gathered = ttnn.concat(topk_values_list, dim=3)
+            topk_indices_gathered = ttnn.concat(topk_indices_list, dim=3)
+            for ci in range(len(topk_values_list)):
+                ttnn.deallocate(topk_values_list[ci])
+                ttnn.deallocate(topk_indices_list[ci])
+            if self.sampling_memory_config != ttnn.DRAM_MEMORY_CONFIG:
+                topk_values_gathered_bf16 = ttnn.to_memory_config(
+                    topk_values_gathered, memory_config=self.sampling_memory_config, dtype=ttnn.bfloat16
+                )
+                topk_values_gathered_bf16_interleaved = ttnn.to_memory_config(
+                    topk_values_gathered_bf16, memory_config=ttnn.DRAM_MEMORY_CONFIG
+                )
+                ttnn.deallocate(topk_values_gathered_bf16)
+                ttnn.deallocate(topk_values_gathered)
+            else:
+                topk_values_gathered_bf16_interleaved = topk_values_gathered
+
+        elif self.multi_step_reduction:
             x_bf16_list = ttnn.split(x_bf16, x_bf16.shape[-1] // 2, dim=3)
             indices_tensor_list = ttnn.split(self.tt_indices_tensor, self.tt_indices_tensor.shape[-1] // 2, dim=3)
             topk_values_list = []
@@ -602,7 +669,9 @@ class TTSampling(LightweightModule):
         else:
             topk_indices_gathered_int32_sharded = topk_indices_gathered_int32
 
-        # Add device offsets to get global vocabulary indices
+        # Add device offsets to get global vocabulary indices. For gather-in-forward
+        # the per-shard chunks were top-k'd with the same local index tensor, so the
+        # same offsets apply (device_id * padded_per_device) -- identical to sharded.
         topk_global_indices = ttnn.add(
             self.tt_indices_device_offsets,
             topk_indices_gathered_int32_sharded,

--- a/models/tt_transformers/tt/model.py
+++ b/models/tt_transformers/tt/model.py
@@ -252,6 +252,37 @@ class Transformer(LightweightModule):
         )
         return self._apply_norm_and_lm_head(user_tokens)
 
+    def _all_gather_logits_full_vocab(self, tt_logits):
+        """All-gather vocab-sharded logits to full (replicated) vocab for on-device sampling.
+
+        No-op unless ``gather_logits_in_forward`` is enabled on a multi-device mesh.
+        Mirrors the decode ``on_device_logits`` gather (see ttnn_decode_forward): when
+        ``gather_logits_in_forward`` is on, the penalty/sampling buffers are sized for the
+        FULL vocab, but prefill lm_head leaves logits vocab-sharded -- so prefill
+        device-sampling would subtract mismatched vocab widths (binary_ng "Invalid subtile
+        broadcast type"). Gather here so prefill matches decode. Keep logits TILED:
+        penalties' binary_ng op requires tiled layout.
+        """
+        if not (getattr(self.args, "gather_logits_in_forward", False) and self.args.num_devices > 1):
+            return tt_logits
+        cluster_axis = 0 if self.args.is_galaxy else None
+        num_links = 2 if self.args.is_galaxy else 1
+        return ttnn.experimental.all_gather_async(
+            tt_logits,
+            persistent_output_buffer=None,
+            dim=3,
+            multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis),
+            num_links=num_links,
+            memory_config=tt_logits.memory_config() if self.prefetcher is None else ttnn.DRAM_MEMORY_CONFIG,
+            cluster_axis=cluster_axis,
+            topology=self.args.ccl_topology(),
+            barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+            chunks_per_sync=10,
+            num_workers_per_link=2,
+            num_buffers_per_channel=2,
+            subdevice_id=self.prefetcher.worker_sub_device_id if self.prefetcher is not None else None,
+        )
+
     def _apply_norm_and_lm_head(self, x):
         """Shared norm + lm_head for prefill logit processing. Input: [1, 1, 32, hidden_dim]."""
         x = self.norm(
@@ -262,6 +293,9 @@ class Transformer(LightweightModule):
             x = ttnn.interleaved_to_sharded(x, lm_head_input_mem_cfg)
         logits = self.lm_head(x)
         logits = ttnn.to_memory_config(logits, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+        # Match decode: gather to full vocab when gather_logits_in_forward is on so
+        # device-sampling penalties/sampling see full-vocab logits (no-op otherwise).
+        logits = self._all_gather_logits_full_vocab(logits)
         return logits
 
     def process_hidden_states_after_prefill_trace(self, hidden_states, last_token_idx):
@@ -813,6 +847,32 @@ class Transformer(LightweightModule):
                 "module exists (self.sampling is None)."
             )
             self._increment_decode_positions_device(current_pos, rot_mat_idxs)
+            # Gather-in-forward: all-gather the logits HERE, inside the forward (the
+            # exact CCL call/context host sampling uses correctly), instead of
+            # leaving them sharded for the on-device sampling op to gather later in
+            # the sampling context (which corrupts on-device sampling under
+            # concurrent batch condense/slot_remap). Keep them TILED (do NOT untilize
+            # here — penalties' binary_ng requires tiled layout); force_argmax
+            # untilizes as usual. Enabled via model_config.gather_logits_in_forward
+            # (default on for non-Galaxy multi-device models with a force-argmax config).
+            if getattr(self.args, "gather_logits_in_forward", False) and self.args.num_devices > 1:
+                cluster_axis = 0 if self.args.is_galaxy else None
+                num_links = 2 if self.args.is_galaxy else 1
+                tt_logits = ttnn.experimental.all_gather_async(
+                    tt_logits,
+                    persistent_output_buffer=None,
+                    dim=3,
+                    multi_device_global_semaphore=self.tt_ccl.get_and_cycle_ag_semaphore_handles(cluster_axis),
+                    num_links=num_links,
+                    memory_config=tt_logits.memory_config() if self.prefetcher is None else ttnn.DRAM_MEMORY_CONFIG,
+                    cluster_axis=cluster_axis,
+                    topology=self.args.ccl_topology(),
+                    barrier_semaphore=self.tt_ccl.get_and_cycle_barrier_semaphore_handle(cluster_axis),
+                    chunks_per_sync=10,
+                    num_workers_per_link=2,
+                    num_buffers_per_channel=2,
+                    subdevice_id=self.prefetcher.worker_sub_device_id if self.prefetcher is not None else None,
+                )
             return tt_logits
 
         # Gather the output across all devices and untilize the tensor (for argmax)
@@ -945,5 +1005,8 @@ class Transformer(LightweightModule):
         x = self.lm_head(x)
         if mode == Mode.PREFILL:
             x = ttnn.to_memory_config(x, memory_config=ttnn.DRAM_MEMORY_CONFIG)
+            # Match decode: gather to full vocab when gather_logits_in_forward is on so
+            # device-sampling penalties/sampling see full-vocab logits (no-op otherwise).
+            x = self._all_gather_logits_full_vocab(x)
 
         return x

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -1092,6 +1092,28 @@ class ModelArgs:
                 self.model_config["MLP_RS_CONFIG"] = default_mlp_rs
                 self.model_config["SAMPLING_AG_CONFIG"] = default_sampling_force_argmax
 
+            # Gather-in-forward decode sampling: move the decode-logits all-gather
+            # into the forward (the CCL context host sampling uses correctly) instead
+            # of the on-device sampling op, which corrupts on-device sampling under
+            # concurrent batch condense/slot_remap. Enabled BY DEFAULT for the models
+            # that have a force-argmax sampling config, on non-Galaxy multi-device
+            # meshes (where the corruption occurs and the fix is validated). The env
+            # var TT_GATHER_IN_FORWARD, if set, overrides the default (1=on, 0=off)
+            # for A/B testing; CI/serving need not set it.
+            _gif_default = (
+                (not executed_on_galaxy)
+                and (self.base_model_name in model_specific_ccl_configs)
+                and (self.num_devices > 1)
+            )
+            _gif_env = os.environ.get("TT_GATHER_IN_FORWARD")
+            self.gather_logits_in_forward = (_gif_env == "1") if _gif_env is not None else _gif_default
+            if self.gather_logits_in_forward:
+                # Greedy uses the on-device argmax path on the forward-gathered logits.
+                self.model_config["SAMPLING_AG_CONFIG"] = model_specific_ccl_configs[self.base_model_name][
+                    "sampling_force_argmax"
+                ]
+            logger.info(f"gather_logits_in_forward = {self.gather_logits_in_forward}")
+
             logger.info(f"Attention grid: {self.attn_input_grid}")
             logger.info(f"MLP grid: {self.mlp_core_grid}")
             logger.info(f"MLP prefill grids @ 32: w1/w3: {self.mlp1_3_grid(32)}, w2: {self.mlp2_grid(32)}")


### PR DESCRIPTION
### Summary
Moves the decode-logits all-gather into the model forward - the CCL call/context host sampling already uses correctly - instead of leaving logits sharded for the on-device sampling op to gather in its own context, which corrupts sampling under concurrent batch condense / slot_remap. Gated by model_config.gather_logits_in_forward (default on for non-Galaxy multi-device force-argmax models; TT_GATHER_IN_FORWARD=1/0 overrides). No-op when off.

### Changes
model_config.py: add gather_logits_in_forward (default + env override) and point SAMPLING_AG_CONFIG at the force-argmax config when enabled.
model.py: all-gather decode logits inside ttnn_decode_forward (kept tiled); add _all_gather_logits_full_vocab and call it from both prefill lm_head paths so prefill device-sampling logits are full-vocab too — otherwise prefill subtracts sharded-vs-full-vocab penalty tensors and hits binary_ng "Invalid subtile broadcast type".
tt_penalties.py / tt_sampling.py: size penalty/sampling buffers for the full (replicated) vocab and split back into per-device shards for top-k when gather_logits_in_forward is set.
CI: bump vllm-nightly BH-Quietbox-2 (P150x4) trace_region_size to 150M (the added gather ops grow the prefill/decode traces).

### Why
On-device sampling produced corrupted results under concurrency because the sampling-context all-gather interacts badly with batch condense/slot_remap. Gathering in the forward removes that, and the prefill-side gather keeps prefill consistent with decode.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ctr-ifabijanic/sampling-gather-in-forward)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ctr-ifabijanic/sampling-gather-in-forward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ctr-ifabijanic/sampling-gather-in-forward)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ctr-ifabijanic/sampling-gather-in-forward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ctr-ifabijanic/sampling-gather-in-forward)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ctr-ifabijanic/sampling-gather-in-forward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-ifabijanic/sampling-gather-in-forward)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-ifabijanic/sampling-gather-in-forward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ctr-ifabijanic/sampling-gather-in-forward)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ctr-ifabijanic/sampling-gather-in-forward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-ifabijanic/sampling-gather-in-forward)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-ifabijanic/sampling-gather-in-forward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-ifabijanic/sampling-gather-in-forward)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-ifabijanic/sampling-gather-in-forward)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-ifabijanic/sampling-gather-in-forward)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-ifabijanic/sampling-gather-in-forward)