### PR TITLE
[Feature] Bring up fast dispatch end-to-end on Quasar with a single CQ

### DIFF
--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -982,6 +982,14 @@ inline bool is_quasar_sim() {
            tt::tt_metal::MetalContext::instance().hal().get_arch() == tt::ARCH::QUASAR;
 }
 
+// Wrapper template that marks any base fixture as the Quasar-simulator-only variant; the constructor
+// sets quasar_simulator_variant_ before gtest's SetUp() reads it.
+template <class FDFixture>
+class QuasarSimulatorVariant : public FDFixture {
+public:
+    QuasarSimulatorVariant() { this->quasar_simulator_variant_ = true; }
+};
+
 // BaseTestFixture forms the basis for prefetch and dispatcher tests.
 // Inherits from GenericMeshDeviceFixture which determines the mesh device type automatically
 class BaseTestFixture : public tt_metal::GenericMeshDeviceFixture {
@@ -1009,6 +1017,10 @@ protected:
     // Knobs
     uint32_t dispatch_buffer_page_size_ = 0;
     bool send_to_all_ = false;
+    // Set to true by QuasarSimulatorVariant<> subclasses. The gate in SetUp skips this fixture
+    // when is_quasar_sim() != quasar_simulator_variant_, so the Quasar simulator runs only its
+    // variant and WH/BH run only the default fixture.
+    bool quasar_simulator_variant_ = false;
 
     // Test Config defaults
     DispatchTestConfig cfg_;
@@ -1048,18 +1060,30 @@ protected:
         // Initialize common HW properties
         host_alignment_ = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
         max_fetch_bytes_ = tt_metal::MetalContext::instance().dispatch_mem_map().max_prefetch_command_size();
+
+        // Arch selection gate: on Quasar only the QuasarSimulatorVariant runs; on WH/BH only the default fixture runs.
+        if (Common::is_quasar_sim() != quasar_simulator_variant_) {
+            GTEST_SKIP()
+                << (quasar_simulator_variant_ ? "Quasar-only variant; skipped on non-Quasar"
+                                              : "FD default variant; skipped on Quasar (use QuasarSimulatorVariant)");
+        }
     }
 
     bool validate_dispatch_mode() {
-        auto* slow_dispatch = getenv("TT_METAL_SLOW_DISPATCH_MODE");
-        if (slow_dispatch) {
+        if (!tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
             log_info(tt::LogTest, "This suite can only be run with fast dispatch or TT_METAL_SLOW_DISPATCH_MODE unset");
             return false;
         }
         return true;
     }
 
-    CoreCoord worker_start() const { return Common::is_quasar_sim() ? CoreCoord{1, 0} : default_worker_start; }
+    CoreCoord worker_start() const {
+        if (!Common::is_quasar_sim()) {
+            return default_worker_start;
+        }
+        const bool fast_dispatch = tt::tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch();
+        return fast_dispatch ? CoreCoord{0, 0} : CoreCoord{1, 0};
+    }
 
     CoreRange worker_range(const CoreCoord& first_worker, bool multi_core = true) const {
         if (Common::is_quasar_sim()) {
@@ -1070,11 +1094,11 @@ protected:
     }
 
     // SD (slow dispatch) issue + completion queue sizes. Must fit in one device's hugepage slot
-    // (MAX_DEV_CHANNEL_SIZE = 256 MB) on WH/BH; an even 50/50 split gives 128 MB each. On Quasar simulation, command
-    // queues must be stored in DRAM due to limitations, and only 64 MB of physical DRAM space
+    // (MAX_DEV_CHANNEL_SIZE = 256 MB) on WH/BH; an even 50/50 split gives 128 MB each. On Quasar simulation host
+    // hugepages are not available, so command queues must be stored in DRAM, and only 64 MB of physical DRAM space
     // (QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE) is available even though the bank size is 1 GB. The remaining addresses
     // alias this physical space. The SD command queue must therefore fit in a single 64-MB window, so each half is
-    // capped at 8 MB on Quasar.
+    // capped at 8 MB on the Quasar simulator.
     uint32_t sd_issue_queue_size() const {
         return Common::is_quasar_sim() ? QUASAR_SIMULATION_ISSUE_QUEUE_SIZE
                                        : DispatchSettings::MAX_DEV_CHANNEL_SIZE / 2;
@@ -1086,6 +1110,7 @@ protected:
 
     // Helper function that polls completion queue until expected data is written into by dispatcher
     // Without this, we can fail validation as there can a be an occasional race condition
+    // Timeout check is disabled if timeout_ms=0 or if running on the Quasar simulator
     // TODO: Alternatively, could we use tt_driver_atomics::mfence before validation?
     void wait_for_completion_queue_bytes(uint32_t total_expected_cq_payload, uint32_t timeout_ms = 0) {
         std::atomic<bool> exit_condition{false};
@@ -1108,16 +1133,19 @@ protected:
                 avail = (limit - completion_q_read_ptr) + completion_q_write_ptr;
             }
 
-            const auto elapsed =
-                std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start).count();
-            if (elapsed > timeout_ms) {
-                exit_condition.store(true);
-                TT_FATAL(
-                    false,
-                    "CQ wait timed out after {} ms (needed {} bytes, had {})",
-                    elapsed,
-                    total_expected_cq_payload,
-                    avail);
+            if (timeout_ms > 0 && !Common::is_quasar_sim()) {
+                const auto elapsed =
+                    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::steady_clock::now() - start)
+                        .count();
+                if (elapsed > timeout_ms) {
+                    exit_condition.store(true);
+                    TT_FATAL(
+                        false,
+                        "CQ wait timed out after {} ms (needed {} bytes, had {})",
+                        elapsed,
+                        total_expected_cq_payload,
+                        avail);
+                }
             }
         }
 
@@ -1143,6 +1171,13 @@ protected:
             num_iterations,
             num_cores_to_log);
     }
+
+    // Called after the dispatcher has written host completion data and before device_data.validate().
+    // On the Quasar simulator host hugepages are unavailable, so the completion queue lives in DRAM and
+    // the host pointer is a staging mirror that must be re-synced from DRAM before validation. Default
+    // no-op (WH/BH completion queue is PCIe-mapped host memory, already visible; non-host tests don't
+    // validate completion data).
+    virtual void refresh_completion_data() {}
 
     // Helper function to execute generated commands
     // Orchestrates the command buffer reservation, writing, and submission
@@ -1236,6 +1271,9 @@ protected:
 
         const std::chrono::duration<double> elapsed = end - start;
         log_info(tt::LogTest, "Ran in {:f} ms (for {} iterations)", elapsed.count() * 1000.0, num_iterations);
+
+        // On the Quasar simulator the completion queue is DRAM-backed; sync the host staging mirror before validating.
+        this->refresh_completion_data();
 
         // Validate results
         const bool pass = device_data.validate(device_);

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -61,13 +61,25 @@ struct one_core_data_t {
     std::vector<uint32_t> data;
 };
 
+struct CoreDataKey {
+    tt::CoreType core_type{tt::CoreType::WORKER};
+    CoreCoord core;
+    bool operator==(const CoreDataKey& other) const { return core_type == other.core_type && core == other.core; }
+};
+
+struct CoreDataKeyHash {
+    size_t operator()(const CoreDataKey& key) const {
+        return std::hash<CoreCoord>{}(key.core) ^ (std::hash<int>{}(static_cast<int>(key.core_type)) << 1);
+    }
+};
+
 class DeviceData {
 private:
     int amt_written{0};
     // 10 is a hack...bigger than any core_type
     uint64_t base_data_addr[static_cast<size_t>(tt::CoreType::COUNT)]{};
     uint64_t base_result_data_addr[static_cast<size_t>(tt::CoreType::COUNT)]{};
-    std::unordered_map<CoreCoord, std::unordered_map<uint32_t, one_core_data_t>> all_data;
+    std::unordered_map<CoreDataKey, std::unordered_map<uint32_t, one_core_data_t>, CoreDataKeyHash> all_data;
     CoreCoord host_core;
     size_t host_data_index = 0;
 
@@ -98,12 +110,12 @@ public:
         const DispatchTestConfig& cfg);
 
     // Add expected data to a core
-    void push_one(CoreCoord core, int bank, uint32_t datum);
-    void push_one(CoreCoord core, uint32_t datum);
+    void push_one(CoreCoord core, int bank, uint32_t datum, tt::CoreType core_type = tt::CoreType::WORKER);
+    void push_one(CoreCoord core, uint32_t datum, tt::CoreType core_type = tt::CoreType::WORKER);
     void push_range(const CoreRange& cores, uint32_t datum, bool is_mcast);
 
     // Add invalid data
-    void pad(CoreCoord core, int bank, uint32_t alignment);
+    void pad(CoreCoord core, int bank, uint32_t alignment, tt::CoreType core_type = tt::CoreType::WORKER);
 
     // Some tests write to the same address across multiple cores
     // This takes those core types and pads any that are "behind" with invalid data
@@ -113,21 +125,27 @@ public:
     // Clear data between tests
     void reset();
     uint32_t get_base_result_addr(tt::CoreType core_type);
-    uint32_t get_result_data_addr(CoreCoord core, int bank_id = 0);
+    uint32_t get_result_data_addr(CoreCoord core, int bank_id = 0, tt::CoreType core_type = tt::CoreType::WORKER);
 
     bool validate(distributed::MeshDevice::IDevice* device);
     void overflow_check(distributed::MeshDevice::IDevice* device);
 
     int size() const { return amt_written; }
-    int size(CoreCoord core, int bank_id = 0) { return this->all_data[core][bank_id].data.size(); }
+    int size(CoreCoord core, int bank_id = 0, tt::CoreType core_type = tt::CoreType::WORKER) {
+        return this->all_data[{core_type, core}][bank_id].data.size();
+    }
 
-    std::unordered_map<CoreCoord, std::unordered_map<uint32_t, one_core_data_t>>& get_data() { return this->all_data; }
+    std::unordered_map<CoreDataKey, std::unordered_map<uint32_t, one_core_data_t>, CoreDataKeyHash>& get_data() {
+        return this->all_data;
+    }
 
-    tt::CoreType get_core_type(CoreCoord core) { return this->all_data[core][0].core_type; }
-    uint32_t size_at(CoreCoord core, int bank_id);
-    uint32_t at(CoreCoord core, int bank_id, uint32_t offset);
+    tt::CoreType get_core_type(CoreCoord core, tt::CoreType core_type = tt::CoreType::WORKER) {
+        return this->all_data[{core_type, core}][0].core_type;
+    }
+    uint32_t size_at(CoreCoord core, int bank_id, tt::CoreType core_type = tt::CoreType::WORKER);
+    uint32_t at(CoreCoord core, int bank_id, uint32_t offset, tt::CoreType core_type = tt::CoreType::WORKER);
     CoreCoord get_host_core() { return this->host_core; }
-    bool core_and_bank_present(CoreCoord core, uint32_t bank);
+    bool core_and_bank_present(CoreCoord core, uint32_t bank, tt::CoreType core_type = tt::CoreType::WORKER);
 };
 
 inline DeviceData::DeviceData(
@@ -148,32 +166,31 @@ inline DeviceData::DeviceData(
     this->base_result_data_addr[static_cast<int>(tt::CoreType::PCIE)] = (uint64_t)pcie_data_addr;
     this->base_result_data_addr[static_cast<int>(tt::CoreType::DRAM)] = dram_data_addr;
 
-    // TODO: make this all work w/ phys coords
-    // this is really annoying
-    // the PCIE phys core conflicts w/ worker logical cores
-    // so we hack the physical core for tracking, blech
-    // no simple way to handle this, need to use phys cores
+    // Host (PCIE) data is tracked at an arbitrary reserved coordinate; the core type in the key keeps
+    // it distinct from any worker entry.
     CoreCoord core = {100, 100};
-    this->all_data[core][0] = one_core_data_t();
-    this->all_data[core][0].logical_core = core;
-    this->all_data[core][0].phys_core = core;
-    this->all_data[core][0].core_type = tt::CoreType::PCIE;
-    this->all_data[core][0].bank_id = 20;
-    this->all_data[core][0].bank_offset = 0;
+    one_core_data_t& host_entry = this->all_data[{tt::CoreType::PCIE, core}][0];
+    host_entry = one_core_data_t();
+    host_entry.logical_core = core;
+    host_entry.phys_core = core;
+    host_entry.core_type = tt::CoreType::PCIE;
+    host_entry.bank_id = 20;
+    host_entry.bank_offset = 0;
     this->host_core = core;
 
     // Always populate DRAM
     auto num_banks = device->allocator()->get_num_banks(BufferType::DRAM);
     for (int bank_id = 0; bank_id < num_banks; bank_id++) {
         auto dram_channel = device->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
-        CoreCoord phys_core = device->logical_core_from_dram_channel(dram_channel);
+        CoreCoord dram_core = device->logical_core_from_dram_channel(dram_channel);
         int32_t bank_offset = device->allocator()->get_bank_offset(BufferType::DRAM, bank_id);
-        this->all_data[phys_core][bank_id] = one_core_data_t();
-        this->all_data[phys_core][bank_id].logical_core = phys_core;
-        this->all_data[phys_core][bank_id].phys_core = phys_core;
-        this->all_data[phys_core][bank_id].core_type = tt::CoreType::DRAM;
-        this->all_data[phys_core][bank_id].bank_id = bank_id;
-        this->all_data[phys_core][bank_id].bank_offset = bank_offset;
+        one_core_data_t& entry = this->all_data[{tt::CoreType::DRAM, dram_core}][bank_id];
+        entry = one_core_data_t();
+        entry.logical_core = dram_core;
+        entry.phys_core = dram_core;
+        entry.core_type = tt::CoreType::DRAM;
+        entry.bank_id = bank_id;
+        entry.bank_offset = bank_offset;
     }
 
     // TODO: make banked L1 tests play nicely w/ non-banked L1 tests
@@ -183,24 +200,26 @@ inline DeviceData::DeviceData(
             CoreCoord core = device->allocator()->get_logical_core_from_bank_id(bank_id);
             CoreCoord phys_core = device->worker_core_from_logical_core(core);
             int32_t bank_offset = device->allocator()->get_bank_offset(BufferType::L1, bank_id);
-            this->all_data[core][bank_id] = one_core_data_t();
-            this->all_data[core][bank_id].logical_core = core;
-            this->all_data[core][bank_id].phys_core = phys_core;
-            this->all_data[core][bank_id].core_type = tt::CoreType::WORKER;
-            this->all_data[core][bank_id].bank_id = bank_id;
-            this->all_data[core][bank_id].bank_offset = bank_offset;
+            one_core_data_t& entry = this->all_data[{tt::CoreType::WORKER, core}][bank_id];
+            entry = one_core_data_t();
+            entry.logical_core = core;
+            entry.phys_core = phys_core;
+            entry.core_type = tt::CoreType::WORKER;
+            entry.bank_id = bank_id;
+            entry.bank_offset = bank_offset;
         }
     } else {
         for (uint32_t y = workers.start_coord.y; y <= workers.end_coord.y; y++) {
             for (uint32_t x = workers.start_coord.x; x <= workers.end_coord.x; x++) {
                 CoreCoord core = {x, y};
                 CoreCoord phys_core = device->worker_core_from_logical_core(core);
-                this->all_data[core][0] = one_core_data_t();
-                this->all_data[core][0].logical_core = core;
-                this->all_data[core][0].phys_core = phys_core;
-                this->all_data[core][0].core_type = tt::CoreType::WORKER;
-                this->all_data[core][0].bank_id = 0;
-                this->all_data[core][0].bank_offset = 0;
+                one_core_data_t& entry = this->all_data[{tt::CoreType::WORKER, core}][0];
+                entry = one_core_data_t();
+                entry.logical_core = core;
+                entry.phys_core = phys_core;
+                entry.core_type = tt::CoreType::WORKER;
+                entry.bank_id = 0;
+                entry.bank_offset = 0;
             }
         }
     }
@@ -216,7 +235,7 @@ inline void DeviceData::prepopulate_dram(distributed::MeshDevice::IDevice* devic
         [[maybe_unused]] auto offset = device->allocator()->get_bank_offset(BufferType::DRAM, bank_id);
         auto dram_channel = device->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
         auto bank_core = device->logical_core_from_dram_channel(dram_channel);
-        one_core_data_t& data = this->all_data[bank_core][bank_id];
+        one_core_data_t& data = this->all_data[{tt::CoreType::DRAM, bank_core}][bank_id];
 
         // Generate random or coherent data per bank of specific size.
         for (uint32_t i = 0; i < size_words; i++) {
@@ -248,9 +267,10 @@ inline void DeviceData::prepopulate_dram(distributed::MeshDevice::IDevice* devic
     }
 }
 
-inline bool DeviceData::core_and_bank_present(CoreCoord core, uint32_t bank) {
-    if (this->all_data.contains(core)) {
-        std::unordered_map<uint32_t, one_core_data_t>& core_data = this->all_data.find(core)->second;
+inline bool DeviceData::core_and_bank_present(CoreCoord core, uint32_t bank, tt::CoreType core_type) {
+    const CoreDataKey key{core_type, core};
+    if (this->all_data.contains(key)) {
+        std::unordered_map<uint32_t, one_core_data_t>& core_data = this->all_data.find(key)->second;
         if (core_data.contains(bank)) {
             return true;
         }
@@ -258,19 +278,19 @@ inline bool DeviceData::core_and_bank_present(CoreCoord core, uint32_t bank) {
     return false;
 }
 
-inline void DeviceData::push_one(CoreCoord core, int bank, uint32_t datum) {
-    if (core_and_bank_present(core, bank)) {
+inline void DeviceData::push_one(CoreCoord core, int bank, uint32_t datum, tt::CoreType core_type) {
+    if (core_and_bank_present(core, bank, core_type)) {
         this->amt_written++;
-        this->all_data[core][bank].data.push_back(datum);
-        this->all_data[core][bank].valid.push_back(true);
+        this->all_data[{core_type, core}][bank].data.push_back(datum);
+        this->all_data[{core_type, core}][bank].valid.push_back(true);
     }
 }
 
-inline void DeviceData::push_one(CoreCoord core, uint32_t datum) {
-    if (core_and_bank_present(core, 0)) {
+inline void DeviceData::push_one(CoreCoord core, uint32_t datum, tt::CoreType core_type) {
+    if (core_and_bank_present(core, 0, core_type)) {
         this->amt_written++;
-        this->all_data[core][0].data.push_back(datum);
-        this->all_data[core][0].valid.push_back(true);
+        this->all_data[{core_type, core}][0].data.push_back(datum);
+        this->all_data[{core_type, core}][0].valid.push_back(true);
     }
 }
 
@@ -279,15 +299,16 @@ inline void DeviceData::push_range(const CoreRange& cores, uint32_t datum, bool 
     for (auto y = cores.start_coord.y; y <= cores.end_coord.y; y++) {
         for (auto x = cores.start_coord.x; x <= cores.end_coord.x; x++) {
             CoreCoord core = {x, y};
-            if (core_and_bank_present(core, 0)) {
+            const CoreDataKey key{tt::CoreType::WORKER, core};
+            if (core_and_bank_present(core, 0, tt::CoreType::WORKER)) {
                 if (not counted || not is_mcast) {
                     this->amt_written++;
                     counted = true;
                 }
 
-                TT_FATAL(this->all_data.contains(core), "Core {} not found in all_data", core);
-                this->all_data[core][0].data.push_back(datum);
-                this->all_data[core][0].valid.push_back(true);
+                TT_FATAL(this->all_data.contains(key), "Core {} not found in all_data", core);
+                this->all_data[key][0].data.push_back(datum);
+                this->all_data[key][0].valid.push_back(true);
             }
         }
     }
@@ -297,11 +318,12 @@ inline uint32_t padded_size(uint32_t size, uint32_t alignment) {
     return (size + alignment - 1) / alignment * alignment;
 }
 
-inline void DeviceData::pad(CoreCoord core, int bank, uint32_t alignment) {
-    if (core_and_bank_present(core, bank)) {
-        uint32_t padded = padded_size(this->all_data[core][bank].data.size(), alignment / sizeof(uint32_t));
-        this->all_data[core][bank].data.resize(padded);
-        this->all_data[core][bank].valid.resize(padded);  // pushes false
+inline void DeviceData::pad(CoreCoord core, int bank, uint32_t alignment, tt::CoreType core_type) {
+    if (core_and_bank_present(core, bank, core_type)) {
+        const CoreDataKey key{core_type, core};
+        uint32_t padded = padded_size(this->all_data[key][bank].data.size(), alignment / sizeof(uint32_t));
+        this->all_data[key][bank].data.resize(padded);
+        this->all_data[key][bank].valid.resize(padded);  // pushes false
     }
 }
 
@@ -332,16 +354,16 @@ inline void DeviceData::relevel(CoreRange range) {
     constexpr uint32_t bank = 0;
     for (uint32_t y = range.start_coord.y; y <= range.end_coord.y; y++) {
         for (uint32_t x = range.start_coord.x; x <= range.end_coord.x; x++) {
-            CoreCoord core = {x, y};
-            max = std::max(this->all_data[core][bank].data.size(), max);
+            const CoreDataKey key{tt::CoreType::WORKER, CoreCoord{x, y}};
+            max = std::max(this->all_data[key][bank].data.size(), max);
         }
     }
 
     for (uint32_t y = range.start_coord.y; y <= range.end_coord.y; y++) {
         for (uint32_t x = range.start_coord.x; x <= range.end_coord.x; x++) {
-            CoreCoord core = {x, y};
-            this->all_data[core][bank].data.resize(max);
-            this->all_data[core][bank].valid.resize(max);
+            const CoreDataKey key{tt::CoreType::WORKER, CoreCoord{x, y}};
+            this->all_data[key][bank].data.resize(max);
+            this->all_data[key][bank].valid.resize(max);
         }
     }
 }
@@ -365,15 +387,18 @@ inline uint32_t DeviceData::get_base_result_addr(tt::CoreType core_type) {
     return this->base_result_data_addr[static_cast<int>(core_type)];
 }
 
-inline uint32_t DeviceData::get_result_data_addr(CoreCoord core, int bank_id) {
-    uint32_t base_addr = this->base_result_data_addr[static_cast<int>(this->all_data[core][bank_id].core_type)];
-    return base_addr + (this->all_data[core][bank_id].data.size() * sizeof(uint32_t));
+inline uint32_t DeviceData::get_result_data_addr(CoreCoord core, int bank_id, tt::CoreType core_type) {
+    const CoreDataKey key{core_type, core};
+    uint32_t base_addr = this->base_result_data_addr[static_cast<int>(this->all_data[key][bank_id].core_type)];
+    return base_addr + (this->all_data[key][bank_id].data.size() * sizeof(uint32_t));
 }
 
-inline uint32_t DeviceData::size_at(CoreCoord core, int bank_id) { return this->all_data[core][bank_id].data.size(); }
+inline uint32_t DeviceData::size_at(CoreCoord core, int bank_id, tt::CoreType core_type) {
+    return this->all_data[{core_type, core}][bank_id].data.size();
+}
 
-inline uint32_t DeviceData::at(CoreCoord core, int bank_id, uint32_t offset) {
-    return this->all_data[core][bank_id].data[offset];
+inline uint32_t DeviceData::at(CoreCoord core, int bank_id, uint32_t offset, tt::CoreType core_type) {
+    return this->all_data[{core_type, core}][bank_id].data[offset];
 }
 
 inline bool DeviceData::validate_one_core(
@@ -590,11 +615,12 @@ inline void update_paged_write(
     DeviceData& device_data,
     const CoreCoord& bank_core,
     uint32_t bank_id,
-    uint32_t page_alignment) {
+    uint32_t page_alignment,
+    tt::CoreType core_type) {
     for (const uint32_t datum : payload) {
-        device_data.push_one(bank_core, bank_id, datum);
+        device_data.push_one(bank_core, bank_id, datum, core_type);
     }
-    device_data.pad(bank_core, bank_id, page_alignment);
+    device_data.pad(bank_core, bank_id, page_alignment, core_type);
 }
 
 // Update DeviceData for packed write
@@ -991,9 +1017,6 @@ protected:
 
     void SetUp() override {
         if (!validate_dispatch_mode()) {
-            GTEST_SKIP();
-        }
-        if (is_quasar_sim()) {
             GTEST_SKIP();
         }
         tt_metal::GenericMeshDeviceFixture::SetUp();

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/common.h
@@ -268,29 +268,25 @@ inline void DeviceData::prepopulate_dram(distributed::MeshDevice::IDevice* devic
 }
 
 inline bool DeviceData::core_and_bank_present(CoreCoord core, uint32_t bank, tt::CoreType core_type) {
-    const CoreDataKey key{core_type, core};
-    if (this->all_data.contains(key)) {
-        std::unordered_map<uint32_t, one_core_data_t>& core_data = this->all_data.find(key)->second;
-        if (core_data.contains(bank)) {
-            return true;
-        }
-    }
-    return false;
+    const auto core_it = this->all_data.find(CoreDataKey{core_type, core});
+    return core_it != this->all_data.end() && core_it->second.contains(bank);
 }
 
 inline void DeviceData::push_one(CoreCoord core, int bank, uint32_t datum, tt::CoreType core_type) {
     if (core_and_bank_present(core, bank, core_type)) {
         this->amt_written++;
-        this->all_data[{core_type, core}][bank].data.push_back(datum);
-        this->all_data[{core_type, core}][bank].valid.push_back(true);
+        one_core_data_t& entry = this->all_data[{core_type, core}][bank];
+        entry.data.push_back(datum);
+        entry.valid.push_back(true);
     }
 }
 
 inline void DeviceData::push_one(CoreCoord core, uint32_t datum, tt::CoreType core_type) {
     if (core_and_bank_present(core, 0, core_type)) {
         this->amt_written++;
-        this->all_data[{core_type, core}][0].data.push_back(datum);
-        this->all_data[{core_type, core}][0].valid.push_back(true);
+        one_core_data_t& entry = this->all_data[{core_type, core}][0];
+        entry.data.push_back(datum);
+        entry.valid.push_back(true);
     }
 }
 
@@ -307,8 +303,9 @@ inline void DeviceData::push_range(const CoreRange& cores, uint32_t datum, bool 
                 }
 
                 TT_FATAL(this->all_data.contains(key), "Core {} not found in all_data", core);
-                this->all_data[key][0].data.push_back(datum);
-                this->all_data[key][0].valid.push_back(true);
+                one_core_data_t& entry = this->all_data[key][0];
+                entry.data.push_back(datum);
+                entry.valid.push_back(true);
             }
         }
     }
@@ -320,10 +317,10 @@ inline uint32_t padded_size(uint32_t size, uint32_t alignment) {
 
 inline void DeviceData::pad(CoreCoord core, int bank, uint32_t alignment, tt::CoreType core_type) {
     if (core_and_bank_present(core, bank, core_type)) {
-        const CoreDataKey key{core_type, core};
-        uint32_t padded = padded_size(this->all_data[key][bank].data.size(), alignment / sizeof(uint32_t));
-        this->all_data[key][bank].data.resize(padded);
-        this->all_data[key][bank].valid.resize(padded);  // pushes false
+        one_core_data_t& entry = this->all_data[{core_type, core}][bank];
+        uint32_t padded = padded_size(entry.data.size(), alignment / sizeof(uint32_t));
+        entry.data.resize(padded);
+        entry.valid.resize(padded);  // pushes false
     }
 }
 
@@ -362,8 +359,9 @@ inline void DeviceData::relevel(CoreRange range) {
     for (uint32_t y = range.start_coord.y; y <= range.end_coord.y; y++) {
         for (uint32_t x = range.start_coord.x; x <= range.end_coord.x; x++) {
             const CoreDataKey key{tt::CoreType::WORKER, CoreCoord{x, y}};
-            this->all_data[key][bank].data.resize(max);
-            this->all_data[key][bank].valid.resize(max);
+            one_core_data_t& entry = this->all_data[key][bank];
+            entry.data.resize(max);
+            entry.valid.resize(max);
         }
     }
 }
@@ -388,9 +386,9 @@ inline uint32_t DeviceData::get_base_result_addr(tt::CoreType core_type) {
 }
 
 inline uint32_t DeviceData::get_result_data_addr(CoreCoord core, int bank_id, tt::CoreType core_type) {
-    const CoreDataKey key{core_type, core};
-    uint32_t base_addr = this->base_result_data_addr[static_cast<int>(this->all_data[key][bank_id].core_type)];
-    return base_addr + (this->all_data[key][bank_id].data.size() * sizeof(uint32_t));
+    const one_core_data_t& entry = this->all_data[{core_type, core}][bank_id];
+    uint32_t base_addr = this->base_result_data_addr[static_cast<int>(entry.core_type)];
+    return base_addr + (entry.data.size() * sizeof(uint32_t));
 }
 
 inline uint32_t DeviceData::size_at(CoreCoord core, int bank_id, tt::CoreType core_type) {

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -416,7 +416,12 @@ public:
 
                 // Update Common::DeviceData for paged write
                 Common::DeviceDataUpdater::update_paged_write(
-                    page_payload, device_data, bank_core, bank_id, page_size_alignment_bytes);
+                    page_payload,
+                    device_data,
+                    bank_core,
+                    bank_id,
+                    page_size_alignment_bytes,
+                    is_dram_ ? tt::CoreType::DRAM : tt::CoreType::WORKER);
 
                 // Append page payload to chunk payload
                 chunk_payload.insert(chunk_payload.end(), page_payload.begin(), page_payload.end());

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -1047,7 +1047,7 @@ template <typename FDFixture>
 class SDDispatchTestBase : public FDFixture {
 public:
     void SetUp() override {
-        if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+        if (tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
             GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE";
         }
         this->device_ = tt_metal::CreateDevice(0);
@@ -1257,6 +1257,19 @@ class DispatchPackedWriteLargeSDTestFixture : public SDDispatchTestBase<Dispatch
 class DispatchPackedWriteLargeUnicastSDTestFixture
     : public SDDispatchTestBase<DispatchPackedWriteLargeUnicastTestFixture> {};
 
+// Quasar FD fixtures. QuasarSimulatorVariant<> sets quasar_simulator_variant_=true so the gate in
+// BaseTestFixture::SetUp skips the default FD fixture on Quasar and these on WH/BH.
+class DispatchLinearWriteQuasarSimulatorTestFixture
+    : public Common::QuasarSimulatorVariant<DispatchLinearWriteTestFixture> {};
+class DispatchPagedWriteQuasarSimulatorTestFixture
+    : public Common::QuasarSimulatorVariant<DispatchPagedWriteTestFixture> {};
+class DispatchPackedWriteQuasarSimulatorTestFixture
+    : public Common::QuasarSimulatorVariant<DispatchPackedWriteTestFixture> {};
+class DispatchPackedWriteLargeQuasarSimulatorTestFixture
+    : public Common::QuasarSimulatorVariant<DispatchPackedWriteLargeTestFixture> {};
+class DispatchPackedWriteLargeUnicastQuasarSimulatorTestFixture
+    : public Common::QuasarSimulatorVariant<DispatchPackedWriteLargeUnicastTestFixture> {};
+
 // Linear Write Unicast/Multicast
 TEST_P(DispatchLinearWriteTestFixture, LinearWrite) {
     log_info(tt::LogTest, "DispatchLinearWriteTestFixture - LinearWrite (Fast Dispatch) - Test Start");
@@ -1322,6 +1335,42 @@ TEST_P(DispatchPackedWriteLargeUnicastSDTestFixture, WriteLargePackedUnicast) {
     log_info(
         tt::LogTest,
         "DispatchPackedWriteLargeUnicastSDTestFixture - WriteLargePackedUnicast (Slow Dispatch) - Test Start");
+    run_packed_large_unicast_write_test();
+}
+
+// Quasar simulator FD tests — The default FD fixtures skip on Quasar simulator and these skip on WH/BH.
+TEST_P(DispatchLinearWriteQuasarSimulatorTestFixture, LinearWrite) {
+    log_info(
+        tt::LogTest, "DispatchLinearWriteQuasarSimulatorTestFixture - LinearWrite (Quasar simulator FD) - Test Start");
+    run_linear_write_test();
+}
+
+TEST_P(DispatchPagedWriteQuasarSimulatorTestFixture, PagedWrite) {
+    log_info(
+        tt::LogTest, "DispatchPagedWriteQuasarSimulatorTestFixture - PagedWrite (Quasar simulator FD) - Test Start");
+    run_paged_write_test();
+}
+
+TEST_P(DispatchPackedWriteQuasarSimulatorTestFixture, WritePackedUnicast) {
+    log_info(
+        tt::LogTest,
+        "DispatchPackedWriteQuasarSimulatorTestFixture - WritePackedUnicast (Quasar simulator FD) - Test Start");
+    run_packed_write_test();
+}
+
+TEST_P(DispatchPackedWriteLargeQuasarSimulatorTestFixture, WriteLargePackedMulticast) {
+    log_info(
+        tt::LogTest,
+        "DispatchPackedWriteLargeQuasarSimulatorTestFixture - WriteLargePackedMulticast (Quasar simulator FD) - Test "
+        "Start");
+    run_packed_large_write_test();
+}
+
+TEST_P(DispatchPackedWriteLargeUnicastQuasarSimulatorTestFixture, WriteLargePackedUnicast) {
+    log_info(
+        tt::LogTest,
+        "DispatchPackedWriteLargeUnicastQuasarSimulatorTestFixture - WriteLargePackedUnicast (Quasar simulator FD) - "
+        "Test Start");
     run_packed_large_unicast_write_test();
 }
 
@@ -1404,6 +1453,97 @@ INSTANTIATE_TEST_SUITE_P(
         PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
         // Testcase: 409600 bytes
         PackedWriteParams{409600, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS}),
+    [](const testing::TestParamInfo<PackedWriteParams>& info) {
+        return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
+               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorDispatcherTests,
+    DispatchLinearWriteQuasarSimulatorTestFixture,
+    ::testing::Values(
+        // Testcase: 49152 bytes (Unicast)
+        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        // Testcase: 196608 bytes (Unicast)
+        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        // Testcase: 49152 bytes (Multicast)
+        LinearWriteParams{49152, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        // Testcase: 196608 bytes (Multicast)
+        LinearWriteParams{196608, DEFAULT_ITERATIONS_LINEAR_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<LinearWriteParams>& info) {
+        return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
+               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_" +
+               (info.param.is_mcast ? "mcast" : "unicast");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorDispatcherTests,
+    DispatchPagedWriteQuasarSimulatorTestFixture,
+    ::testing::Values(
+        // Testcase: 512 pages x 16 bytes (DRAM)
+        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        // Testcase: 512 pages x 16 bytes (L1)
+        PagedWriteParams{16, 512, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        // Testcase: 128 pages x 2048 bytes (DRAM)
+        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        // Testcase: 128 pages x 2048 bytes (L1)
+        PagedWriteParams{2048, 128, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        // Testcase: 10 pages x 4128 bytes (not 4K-aligned) (DRAM)
+        PagedWriteParams{4128, 10, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (DRAM)
+        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true},
+        // Testcase: 13 pages x 16 bytes (arbitrary non-even numbers) (L1)
+        PagedWriteParams{16, 13, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, false},
+        // Testcase: 45 pages x 8192 bytes (high BW) (DRAM)
+        PagedWriteParams{8192, 45, DEFAULT_ITERATIONS_PAGED_WRITE, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedWriteParams>& info) {
+        std::stringstream ss;
+        ss << "page_size" << info.param.page_size << "_np" << info.param.num_pages << "_iter"
+           << info.param.num_iterations << "_" << (info.param.is_dram ? "DRAM" : "L1");
+        return ss.str();
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorDispatcherTests,
+    DispatchPackedWriteQuasarSimulatorTestFixture,
+    ::testing::Values(
+        // Testcase: 40960 bytes (Unicast)
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS},
+        // Testcase: 98304 bytes (= QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES = 96 KB) (Unicast)
+        PackedWriteParams{
+            QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES, DEFAULT_ITERATIONS_PACKED_WRITE, Common::DRAM_DATA_SIZE_WORDS}),
+    [](const testing::TestParamInfo<PackedWriteParams>& info) {
+        return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
+               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorDispatcherTests,
+    DispatchPackedWriteLargeQuasarSimulatorTestFixture,
+    ::testing::Values(
+        // Testcase: 40960 bytes (fits within 96 KB budget)
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
+        // Testcase: 98304 bytes (= QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES = 96 KB)
+        PackedWriteParams{
+            QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES,
+            DEFAULT_ITERATIONS_PACKED_WRITE_LARGE,
+            Common::DRAM_DATA_SIZE_WORDS}),
+    [](const testing::TestParamInfo<PackedWriteParams>& info) {
+        return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
+               "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorDispatcherTests,
+    DispatchPackedWriteLargeUnicastQuasarSimulatorTestFixture,
+    ::testing::Values(
+        // Testcase: 40960 bytes (fits within 96 KB budget)
+        PackedWriteParams{40960, DEFAULT_ITERATIONS_PACKED_WRITE_LARGE, Common::DRAM_DATA_SIZE_WORDS},
+        // Testcase: 98304 bytes (= QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES = 96 KB)
+        PackedWriteParams{
+            QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES,
+            DEFAULT_ITERATIONS_PACKED_WRITE_LARGE,
+            Common::DRAM_DATA_SIZE_WORDS}),
     [](const testing::TestParamInfo<PackedWriteParams>& info) {
         return std::to_string(info.param.transfer_size_bytes) + "B_" + std::to_string(info.param.num_iterations) +
                "iter_" + std::to_string(info.param.dram_data_size_words) + "words_";

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_dispatcher.cpp
@@ -56,6 +56,11 @@ constexpr uint32_t DEFAULT_ITERATIONS_PAGED_WRITE = 1;
 constexpr uint32_t DEFAULT_ITERATIONS_PACKED_WRITE = 1;
 constexpr uint32_t DEFAULT_ITERATIONS_PACKED_WRITE_LARGE = 1;
 
+// Packed writes accumulate into worker L1, which on the Quasar simulator is limited to the same
+// device-data budget the prefetcher tests use. Transfers above this are clamped so they fit and the
+// generated command count stays bounded.
+constexpr uint32_t QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES = 96 * 1024;
+
 // Params that control the data volume, iteration count, and multicast/unicast
 // for the linear write test
 struct LinearWriteParams {
@@ -532,6 +537,9 @@ class DispatchPackedWriteTestFixture : public BaseDispatchTestFixture,
 protected:
     void init_params(const PackedWriteParams& p) {
         transfer_size_bytes_ = p.transfer_size_bytes;
+        if (Common::is_quasar_sim()) {
+            transfer_size_bytes_ = std::min(transfer_size_bytes_, QUASAR_SIMULATION_PACKED_WRITE_MAX_BYTES);
+        }
         num_iterations_ = p.num_iterations;
         dram_data_size_words_ = p.dram_data_size_words;
     }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -93,7 +93,7 @@ void update_paged_dram_read(
     uint32_t bank_offset,
     uint32_t page_size_words) {
     for (uint32_t j = 0; j < page_size_words; j++) {
-        uint32_t datum = device_data.at(bank_core, bank_id, bank_offset + j);
+        uint32_t datum = device_data.at(bank_core, bank_id, bank_offset + j, tt::CoreType::DRAM);
         device_data.push_range(workers, datum, false);
     }
 }
@@ -114,11 +114,11 @@ void update_host_data(Common::DeviceData& device_data, const std::vector<uint32_
 
     uint32_t* cmd_as_words = reinterpret_cast<uint32_t*>(&expected_cmd);
     for (uint32_t i = 0; i < sizeof(CQDispatchCmd) / sizeof(uint32_t); i++) {
-        device_data.push_one(device_data.get_host_core(), 0, cmd_as_words[i]);
+        device_data.push_one(device_data.get_host_core(), 0, cmd_as_words[i], tt::CoreType::PCIE);
     }
 
     for (uint32_t i = 0; i < data_size_words; i++) {
-        device_data.push_one(device_data.get_host_core(), 0, data[i]);
+        device_data.push_one(device_data.get_host_core(), 0, data[i], tt::CoreType::PCIE);
     }
 }
 
@@ -133,7 +133,7 @@ void update_read(
     uint32_t bank_offset,
     uint32_t page_size_words) {
     for (uint32_t j = 0; j < page_size_words; j++) {
-        uint32_t datum = device_data.at(bank_core, bank_id, bank_offset + j);
+        uint32_t datum = device_data.at(bank_core, bank_id, bank_offset + j, tt::CoreType::DRAM);
         device_data.push_one(worker_core, datum);
     }
 }
@@ -150,8 +150,8 @@ void update_cross_device_read(
     Common::DeviceData& src_device_data,
     uint32_t size_words) {
     for (uint32_t j = 0; j < size_words; j++) {
-        uint32_t datum = src_device_data.at(src_core, src_bank_id, src_bank_offset + j);
-        dest_device_data.push_one(dest_core, dest_bank_id, datum);
+        uint32_t datum = src_device_data.at(src_core, src_bank_id, src_bank_offset + j, tt::CoreType::DRAM);
+        dest_device_data.push_one(dest_core, dest_bank_id, datum, tt::CoreType::DRAM);
     }
 }
 }  // namespace DeviceDataUpdater
@@ -801,7 +801,6 @@ public:
                 const uint32_t bank_id = page_id % num_banks_;
                 uint32_t bank_offset = page_size_words * (page_id / num_banks_);
 
-                // Get the logical core for this bank
                 const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
                 const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
 
@@ -850,7 +849,6 @@ public:
                 const uint32_t page_id = absolute_start_page + page;
                 const uint32_t bank_id = page_id % num_banks_;
 
-                // Get the logical core for this bank
                 const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
                 const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
 
@@ -860,7 +858,7 @@ public:
 
                 // Update Common::DeviceData for paged write
                 Common::DeviceDataUpdater::update_paged_write(
-                    page_payload, device_data, bank_core, bank_id, page_size_alignment_bytes);
+                    page_payload, device_data, bank_core, bank_id, page_size_alignment_bytes, tt::CoreType::DRAM);
 
                 // Append page payload to chunk payload
                 chunk_payload.insert(chunk_payload.end(), page_payload.begin(), page_payload.end());
@@ -896,7 +894,6 @@ public:
                 // Add dram_data_size_words since we're reading after the pre-populated DRAM data
                 uint32_t bank_offset = dram_data_size_words_ + page_size_words * (page_id / num_banks_);
 
-                // Get the logical core for this bank
                 const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
                 const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
 
@@ -1062,7 +1059,6 @@ public:
             const uint32_t bank_id = page_id % info_.num_banks_;
             uint32_t bank_offset = base_addr_words + (page_size_words * (page_id / info_.num_banks_));
 
-            // Get the logical core for this bank
             const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
             const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
 
@@ -1174,14 +1170,15 @@ public:
 class PrefetcherHostTestFixture : virtual public BasePrefetcherTestFixture {
 protected:
     void pad_host_data(Common::DeviceData& device_data) {
-        Common::one_core_data_t& host_data = device_data.get_data()[device_data.get_host_core()][0];
+        Common::one_core_data_t& host_data =
+            device_data.get_data()[{tt::CoreType::PCIE, device_data.get_host_core()}][0];
 
         int pad =
             dispatch_buffer_page_size_ - ((host_data.data.size() * sizeof(uint32_t)) % dispatch_buffer_page_size_);
         pad = pad % dispatch_buffer_page_size_;
 
         for (int i = 0; i < pad / sizeof(uint32_t); i++) {
-            device_data.push_one(device_data.get_host_core(), 0, HOST_DATA_DIRTY_PATTERN);
+            device_data.push_one(device_data.get_host_core(), 0, HOST_DATA_DIRTY_PATTERN, tt::CoreType::PCIE);
         }
     }
 
@@ -1695,7 +1692,8 @@ protected:
 
             EXPECT_LE(total_length + (device_data.size() * sizeof(uint32_t)), device_data_size_bytes);
 
-            const uint32_t dram_dest_addr = device_data.get_result_data_addr(dest_dram_logical, dest_bank_id);
+            const uint32_t dram_dest_addr =
+                device_data.get_result_data_addr(dest_dram_logical, dest_bank_id, tt::CoreType::DRAM);
 
             const std::vector<CQPrefetchRelayLinearPackedSubCmd> sub_cmds = build_sub_cmds(lengths, addresses);
 
@@ -1711,7 +1709,7 @@ protected:
                 const uint32_t offset_words = (addresses[i] - l1_base) / sizeof(uint32_t);
                 const uint32_t length_words = lengths[i] / sizeof(uint32_t);
                 for (uint32_t j = 0; j < length_words; j++) {
-                    device_data.push_one(dest_dram_logical, dest_bank_id, offset_words + j);
+                    device_data.push_one(dest_dram_logical, dest_bank_id, offset_words + j, tt::CoreType::DRAM);
                 }
             }
 
@@ -2050,7 +2048,8 @@ public:
                 remaining_bytes);
 
             // Capture DRAM address before updating dest_device_data
-            uint32_t dram_addr = dest_device_data.get_result_data_addr(dest_dram_logical_core, dest_dram_bank_id);
+            uint32_t dram_addr =
+                dest_device_data.get_result_data_addr(dest_dram_logical_core, dest_dram_bank_id, tt::CoreType::DRAM);
 
             DeviceCommandCalculator calc;
             calc.add_dispatch_write_linear<false, false>(length);
@@ -2203,7 +2202,8 @@ public:
 
             EXPECT_LE(total_length + (remote_device_data.size() * sizeof(uint32_t)), DEVICE_DATA_SIZE_LARGE);
 
-            const uint32_t dram_dest_addr = remote_device_data.get_result_data_addr(dest_dram_logical, dest_bank_id);
+            const uint32_t dram_dest_addr =
+                remote_device_data.get_result_data_addr(dest_dram_logical, dest_bank_id, tt::CoreType::DRAM);
 
             const std::vector<CQPrefetchRelayLinearPackedSubCmd> sub_cmds = build_sub_cmds(lengths, addresses);
 
@@ -2237,7 +2237,7 @@ public:
                 const uint32_t offset_words = (addresses[i] - l1_base) / sizeof(uint32_t);
                 const uint32_t length_words = lengths[i] / sizeof(uint32_t);
                 for (uint32_t j = 0; j < length_words; j++) {
-                    remote_device_data.push_one(dest_dram_logical, dest_bank_id, offset_words + j);
+                    remote_device_data.push_one(dest_dram_logical, dest_bank_id, offset_words + j, tt::CoreType::DRAM);
                 }
             }
 
@@ -2350,7 +2350,6 @@ protected:
             const uint32_t bank_id = page_idx % num_banks_;
             uint32_t bank_offset = base_addr_words + page_size_words * (page_idx / num_banks_);
 
-            // Get the logical core for this bank
             const auto dram_channel = device_->allocator_impl()->get_dram_channel_from_bank_id(bank_id);
             const CoreCoord bank_core = device_->logical_core_from_dram_channel(dram_channel);
 
@@ -3297,7 +3296,7 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
                 payload_generator_->generate_payload_with_page_id(page_size_words, page_id);
 
             Common::DeviceDataUpdater::update_paged_write(
-                page_payload, device_data, bank_core, bank_id, page_alignment_bytes);
+                page_payload, device_data, bank_core, bank_id, page_alignment_bytes, tt::CoreType::DRAM);
 
             chunk_payload.insert(chunk_payload.end(), page_payload.begin(), page_payload.end());
         }

--- a/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
+++ b/tests/tt_metal/tt_metal/perf_microbenchmark/dispatch/test_prefetcher.cpp
@@ -131,9 +131,10 @@ void update_read(
     const CoreCoord& bank_core,
     uint32_t bank_id,
     uint32_t bank_offset,
-    uint32_t page_size_words) {
+    uint32_t page_size_words,
+    tt::CoreType bank_core_type) {
     for (uint32_t j = 0; j < page_size_words; j++) {
-        uint32_t datum = device_data.at(bank_core, bank_id, bank_offset + j, tt::CoreType::DRAM);
+        uint32_t datum = device_data.at(bank_core, bank_id, bank_offset + j, bank_core_type);
         device_data.push_one(worker_core, datum);
     }
 }
@@ -476,6 +477,16 @@ protected:
         num_iterations_ = params.num_iterations;
         dram_data_size_words_ = params.dram_data_size_words;
         use_exec_buf_ = params.use_exec_buf;
+
+        // On the Quasar simulator the command queue is the HAL-reserved DRAM-backed CQ, which lives below dram_base_;
+        // the exec buffer and bank data sit in the unreserved window [dram_base_, physical DRAM size).
+        // Skip only if the exec_buf base alone already overruns physical DRAM (the banked exec_buf top is checked
+        // precisely in build_and_write_exec_buf_to_dram, once num_pages is known).
+        if (Common::is_quasar_sim() && compute_exec_buf_base_addr() >= Common::QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE) {
+            GTEST_SKIP() << "exec_buf base " << compute_exec_buf_base_addr()
+                         << " overruns Quasar simulator physical DRAM size "
+                         << Common::QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE;
+        }
     }
 
     void execute_generated_commands(
@@ -688,6 +699,16 @@ public:
         const uint32_t num_pages = static_cast<uint32_t>(padded_size_bytes) / page_size;
         log_info(tt::LogTest, "Total exec buf bytes: {} (padded: {})", size_bytes, padded_size_bytes);
 
+        if (Common::is_quasar_sim()) {
+            const uint32_t exec_buf_rows = (num_pages + num_banks_ - 1) / num_banks_;
+            const uint32_t exec_buf_top = exec_buf_base_addr + exec_buf_rows * page_size;
+            TT_FATAL(
+                exec_buf_top <= Common::QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE,
+                "exec_buf top {:#x} overruns Quasar simulator physical DRAM size {:#x}",
+                exec_buf_top,
+                Common::QUASAR_SIMULATION_PHYSICAL_DRAM_SIZE);
+        }
+
         uint32_t data_idx = 0;
         for (uint32_t page_idx = 0; page_idx < num_pages; ++page_idx) {
             const uint32_t bank_id = page_idx % num_banks_;
@@ -755,6 +776,9 @@ private:
 
         const std::chrono::duration<double> elapsed = end - start;
         log_info(tt::LogTest, "Ran in {:.3f} ms (for {} iterations)", elapsed.count() * 1000.0, num_iterations);
+
+        // On the Quasar simulator the completion queue is DRAM-backed; sync the host staging mirror before validating.
+        fixture.refresh_completion_data();
 
         // Validate results
         const bool pass = device_data.validate(device_);
@@ -1133,7 +1157,8 @@ public:
         // Shadow model: copy existing L1 data from src offset
         const uint32_t words = length / sizeof(uint32_t);
         const uint32_t offset_words = offset_from_current / sizeof(uint32_t);
-        DeviceDataUpdater::update_read(worker, device_data_, worker, bank_id, offset_words, words);
+        DeviceDataUpdater::update_read(
+            worker, device_data_, worker, bank_id, offset_words, words, tt::CoreType::WORKER);
         device_data_.pad(worker, bank_id, MetalContext::instance().hal().get_alignment(HalMemType::L1));
 
         // Barrier/stall to avoid RAW hazards
@@ -1182,7 +1207,7 @@ protected:
         }
     }
 
-    void dirty_host_completion_buffer(void* completion_queue_buffer, uint32_t size_bytes) {
+    virtual void dirty_host_completion_buffer(void* completion_queue_buffer, uint32_t size_bytes) {
         uint32_t* buffer = static_cast<uint32_t*>(completion_queue_buffer);
         uint32_t size_words = size_bytes / sizeof(uint32_t);
 
@@ -1387,7 +1412,7 @@ protected:
                 uint32_t words = (page_size_words > length_words - i) ? length_words - i : page_size_words;
 
                 DeviceDataUpdater::update_read(
-                    this->worker_start(), device_data, bank_core, dram_bank_id, bank_offset, words);
+                    this->worker_start(), device_data, bank_core, dram_bank_id, bank_offset, words, tt::CoreType::DRAM);
 
                 page_idx++;
             }
@@ -1812,7 +1837,7 @@ public:
 
                 uint32_t words = (page_size_words > length_words - i) ? length_words - i : page_size_words;
                 DeviceDataUpdater::update_read(
-                    this->worker_start(), device_data, bank_core, dram_bank_id, bank_offset, words);
+                    this->worker_start(), device_data, bank_core, dram_bank_id, bank_offset, words, tt::CoreType::DRAM);
 
                 page_idx++;
             }
@@ -2284,7 +2309,8 @@ protected:
         // Shadow model: copy existing L1 data from src offset
         const uint32_t data_size_words = data_size_bytes / sizeof(uint32_t);
         const uint32_t offset_words = offset_bytes / sizeof(uint32_t);
-        DeviceDataUpdater::update_read(worker_core, device_data, worker_core, bank_id, offset_words, data_size_words);
+        DeviceDataUpdater::update_read(
+            worker_core, device_data, worker_core, bank_id, offset_words, data_size_words, tt::CoreType::WORKER);
         device_data.pad(worker_core, bank_id, MetalContext::instance().hal().get_alignment(HalMemType::L1));
 
         // Build command (dispatcher linear write (dest) + relay linear read (src))
@@ -2589,7 +2615,7 @@ template <typename FDFixture>
 class SDPrefetchTestBase : public FDFixture {
 public:
     void SetUp() override {
-        if (!getenv("TT_METAL_SLOW_DISPATCH_MODE")) {
+        if (tt_metal::MetalContext::instance().rtoptions().get_fast_dispatch()) {
             GTEST_SKIP() << "Requires TT_METAL_SLOW_DISPATCH_MODE";
         }
         this->device_ = tt_metal::CreateDevice(0);
@@ -2725,9 +2751,9 @@ public:
 
         const uint32_t host_align = tt_metal::MetalContext::instance().hal().get_alignment(tt_metal::HalMemType::HOST);
 
-        // write_prefetcher_cmd: streaming-store cmd to hugepage (WH/BH) or DRAM (Quasar), then write one FetchQ entry
-        // via TLB. cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the pre-computed
-        // FetchQ value (may have MSB stall flag set for exec_buf).
+        // write_prefetcher_cmd: streaming-store cmd to hugepage (WH/BH) or DRAM (Quasar simulator), then write one
+        // FetchQ entry via TLB. cmd_size_bytes must be a multiple of 64 (host alignment) and cmd_size_entry is the
+        // pre-computed FetchQ value (may have MSB stall flag set for exec_buf).
         auto write_prefetcher_cmd = [&](const uint32_t* src, uint32_t cmd_size_bytes, uint32_t cmd_size_entry) {
             if (Common::is_quasar_sim()) {
                 TT_FATAL(
@@ -2926,8 +2952,9 @@ public:
         tt_metal::detail::LaunchProgram(this->device_, program);
         // Ensure host CPU sees any PCIe-written completion queue data before validating.
         tt_driver_atomics::mfence();
-        // On Quasar the completion queue lives in DRAM; read it back into the host staging buffer
-        // before validate() (which reads from get_completion_queue_buffer()).
+        // On the Quasar simulator the completion queue lives in DRAM (host hugepages are unavailable);
+        // read it back into the host staging buffer before validate() (which reads from
+        // get_completion_queue_buffer()).
         this->refresh_completion_data();
         EXPECT_TRUE(device_data.validate(this->device_)) << "SD prefetch test failed validation";
     }
@@ -2936,11 +2963,6 @@ public:
     // prefetch_terminate so LaunchProgram can return. The unified test bodies must not
     // re-append them, so this hook becomes a no-op in SD.
     void append_terminate_commands(std::vector<HostMemDeviceCommand>& /*cmds*/) override {}
-
-    // Called after LaunchProgram and before device_data.validate(). On Quasar the completion queue
-    // lives in DRAM bank 0 and must be read back into the host staging buffer before validation.
-    // Default no-op (WH/BH completion queue is in PCIe-mapped host memory — already visible).
-    virtual void refresh_completion_data() {}
 
 private:
     // Orchestrates exec_buf execution: builds DRAM payload, writes to DRAM, then issues the
@@ -3035,6 +3057,72 @@ private:
 
 class SDPrefetchLinearPackedReadTestFixture : public SDPrefetchTestBase<PrefetcherLinearPackedReadTestFixture> {};
 class SDPrefetchRingbufferReadTestFixture : public SDPrefetchTestBase<PrefetcherRingbufferReadTestFixture> {};
+
+// Quasar FD fixtures
+class BasePrefetcherQuasarSimulatorTestFixture : public Common::QuasarSimulatorVariant<BasePrefetcherTestFixture> {};
+class PrefetcherPackedReadQuasarSimulatorTestFixture
+    : public Common::QuasarSimulatorVariant<PrefetcherPackedReadTestFixture> {};
+class PrefetcherLinearPackedReadQuasarSimulatorTestFixture
+    : public Common::QuasarSimulatorVariant<PrefetcherLinearPackedReadTestFixture> {};
+class PrefetcherHostQuasarSimulatorTestFixture : public Common::QuasarSimulatorVariant<PrefetcherHostTestFixture> {
+public:
+    // On the Quasar simulator the completion queue is DRAM-backed. Validate against a host-side staging
+    // buffer that refresh_completion_data() fills from DRAM before validate().
+    void* get_completion_queue_buffer() override {
+        quasar_completion_buf_.resize(this->get_completion_queue_buffer_size());
+        return quasar_completion_buf_.data();
+    }
+
+    // On WH/BH the dirty pattern is written into the PCIe-mapped completion buffer, i.e. the real completion memory the
+    // dispatcher writes into. On the Quasar simulator that memory is DRAM, so dirty there too.
+    void dirty_host_completion_buffer(void* completion_queue_buffer, uint32_t size_bytes) override {
+        PrefetcherHostTestFixture::dirty_host_completion_buffer(completion_queue_buffer, size_bytes);
+        std::vector<uint32_t> dirty(size_bytes / sizeof(uint32_t), HOST_DATA_DIRTY_PATTERN);
+        tt::tt_metal::MetalContext::instance().get_cluster().write_dram_vec(
+            dirty.data(), size_bytes, this->device_->id(), completion_dram_channel(), completion_dram_addr());
+    }
+
+    // Read the dispatcher-written prefix of the DRAM completion queue into the staging buffer so
+    // device_data.validate() sees real data. Padding past the written span keeps its dirty fill.
+    void refresh_completion_data() override {
+        const uint8_t cq_id = fdcq_->id();
+        std::atomic<bool> exit_condition{false};
+        const uint32_t write_ptr_bytes = (mgr_->completion_queue_wait_front(cq_id, exit_condition) & 0x7fffffff) << 4;
+        const uint32_t read_ptr_bytes = mgr_->get_completion_queue_read_ptr(cq_id);
+        const uint32_t bytes_written = (write_ptr_bytes > read_ptr_bytes) ? (write_ptr_bytes - read_ptr_bytes) : 0;
+        if (bytes_written == 0) {
+            return;
+        }
+        TT_FATAL(
+            bytes_written <= quasar_completion_buf_.size(),
+            "Quasar completion readback {} B exceeds staging buffer {} B",
+            bytes_written,
+            quasar_completion_buf_.size());
+        tt::tt_metal::detail::ReadFromDeviceDRAMChannel(
+            this->device_,
+            completion_dram_channel(),
+            completion_dram_addr(),
+            std::span<uint8_t>(quasar_completion_buf_.data(), bytes_written));
+    }
+
+private:
+    // DRAM address of the completion region base, matching SystemMemoryManager::get_completion_queue_ptr.
+    uint32_t completion_dram_addr() const {
+        const uint8_t cq_id = fdcq_->id();
+        const SystemMemoryCQInterface& cq_iface = mgr_->get_cq_interfaces()[cq_id];
+        return mgr_->get_dram_region_base_addr() + tt::tt_metal::get_relative_cq_offset(cq_id, mgr_->get_cq_size()) +
+               cq_iface.cq_start + cq_iface.command_issue_region_size;
+    }
+    int completion_dram_channel() const {
+        return this->device_->allocator_impl()->get_dram_channel_from_bank_id(mgr_->get_dram_region_bank_id());
+    }
+
+    std::vector<uint8_t> quasar_completion_buf_;
+};
+
+class PrefetcherRingbufferReadQuasarSimulatorTestFixture
+    : public Common::QuasarSimulatorVariant<PrefetcherRingbufferReadTestFixture> {};
+class RandomQuasarSimulatorTestFixture : public Common::QuasarSimulatorVariant<RandomTestFixture> {};
 
 // In this we, we test the terminate command by adding a linear write unicast
 // with a small payload followed by commands to terminate prefetcher and dispatcher.
@@ -3389,6 +3477,70 @@ TEST_P(PrefetcherThroughputTestFixture, HostToDRAMPagedWriteThroughput) {
     }
 }
 
+// Quasar simulator FD tests — the default FD fixtures skip on Quasar simulator and these skip on WH/BH.
+TEST_P(BasePrefetcherQuasarSimulatorTestFixture, TestTerminate) {
+    log_info(
+        tt::LogTest, "BasePrefetcherQuasarSimulatorTestFixture - TestTerminate (Quasar simulator FD) - Test Start");
+    run_test_terminate_test();
+}
+
+TEST_P(BasePrefetcherQuasarSimulatorTestFixture, DRAMToL1PagedRead) {
+    log_info(
+        tt::LogTest, "BasePrefetcherQuasarSimulatorTestFixture - DRAMToL1PagedRead (Quasar simulator FD) - Test Start");
+    run_dram_to_l1_paged_read_test();
+}
+
+TEST_P(BasePrefetcherQuasarSimulatorTestFixture, PagedReadWriteTest) {
+    log_info(
+        tt::LogTest,
+        "BasePrefetcherQuasarSimulatorTestFixture - PagedReadWriteTest (Quasar simulator FD) - Test Start");
+    run_paged_read_write_test();
+}
+
+TEST_P(PrefetcherHostQuasarSimulatorTestFixture, HostTest) {
+    log_info(tt::LogTest, "PrefetcherHostQuasarSimulatorTestFixture - HostTest (Quasar simulator FD) - Test Start");
+    run_host_test();
+}
+
+TEST_P(PrefetcherHostQuasarSimulatorTestFixture, HostSmokeTest) {
+    log_info(
+        tt::LogTest, "PrefetcherHostQuasarSimulatorTestFixture - HostSmokeTest (Quasar simulator FD) - Test Start");
+    run_host_smoke_test();
+}
+
+TEST_P(PrefetcherPackedReadQuasarSimulatorTestFixture, PackedReadTest) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherPackedReadQuasarSimulatorTestFixture - PackedReadTest (Quasar simulator FD) - Test Start");
+    run_packed_read_test();
+}
+
+TEST_P(PrefetcherPackedReadQuasarSimulatorTestFixture, SmokeTest) {
+    log_info(
+        tt::LogTest, "PrefetcherPackedReadQuasarSimulatorTestFixture - SmokeTest (Quasar simulator FD) - Test Start");
+    run_smoke_test();
+}
+
+TEST_P(PrefetcherLinearPackedReadQuasarSimulatorTestFixture, LinearPackedReadTest) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherLinearPackedReadQuasarSimulatorTestFixture - LinearPackedReadTest (Quasar simulator FD) - Test "
+        "Start");
+    run_linear_packed_read_test();
+}
+
+TEST_P(PrefetcherRingbufferReadQuasarSimulatorTestFixture, RingbufferReadTest) {
+    log_info(
+        tt::LogTest,
+        "PrefetcherRingbufferReadQuasarSimulatorTestFixture - RingbufferReadTest (Quasar simulator FD) - Test Start");
+    run_ringbuffer_read_test();
+}
+
+TEST_P(RandomQuasarSimulatorTestFixture, RandomTest) {
+    log_info(tt::LogTest, "RandomQuasarSimulatorTestFixture - RandomTest (Quasar simulator FD) - Test Start");
+    run_random_test();
+}
+
 TEST_P(SDPrefetchDRAMToL1TestFixture, DRAMToL1PagedRead) {
     log_info(tt::LogTest, "SDPrefetchDRAMToL1TestFixture - DRAMToL1PagedRead (Slow Dispatch) - Test Start");
     run_dram_to_l1_paged_read_test();
@@ -3662,6 +3814,78 @@ INSTANTIATE_TEST_SUITE_P(
             DEFAULT_ITERATIONS,
             Common::DRAM_DATA_SIZE_WORDS,
             false}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherTests,
+    BasePrefetcherQuasarSimulatorTestFixture,
+    ::testing::Values(
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherTests,
+    PrefetcherPackedReadQuasarSimulatorTestFixture,
+    ::testing::Values(
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherTests,
+    PrefetcherLinearPackedReadQuasarSimulatorTestFixture,
+    ::testing::Values(
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherTests,
+    PrefetcherHostQuasarSimulatorTestFixture,
+    ::testing::Values(
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherTests,
+    PrefetcherRingbufferReadQuasarSimulatorTestFixture,
+    ::testing::Values(
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
+    [](const testing::TestParamInfo<PagedReadParams>& info) {
+        return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
+               std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +
+               "words_" + (info.param.use_exec_buf ? "use_exec_buf_enabled" : "use_exec_buf_disabled");
+    });
+
+INSTANTIATE_TEST_SUITE_P(
+    QuasarSimulatorPrefetcherTests,
+    RandomQuasarSimulatorTestFixture,
+    ::testing::Values(
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, false},
+        PagedReadParams{DRAM_PAGE_SIZE_DEFAULT, DRAM_PAGES_TO_READ_DEFAULT, 1, Common::DRAM_DATA_SIZE_WORDS, true}),
     [](const testing::TestParamInfo<PagedReadParams>& info) {
         return std::to_string(info.param.page_size) + "B_" + std::to_string(info.param.num_pages) + "pages_" +
                std::to_string(info.param.num_iterations) + "iter_" + std::to_string(info.param.dram_data_size_words) +

--- a/tt_metal/impl/dispatch/dispatch_core_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_core_manager.cpp
@@ -261,12 +261,15 @@ void dispatch_core_manager::reset_dispatch_core_manager(
         //   - chip is not MMIO-capable (RT profiler is gated to MMIO chips upstream);
         //   - dispatch core type is ETH (pool holds ethernet cores, not tensixes);
         //   - fabric tensix datamover (MUX or UDM) is enabled (it claims dispatch-pool slots
-        //     at fabric-init time and shrinking the pool further can starve fabric_mux_core).
+        //     at fabric-init time and shrinking the pool further can starve fabric_mux_core);
+        //   - chip is Quasar (FD kernels are placed on the same core, a significant architectural
+        //     change from WH/BH, so the RT profiler isn't currently supported on Quasar).
         const bool is_mmio = env.get_cluster().get_associated_mmio_device(device_id) == device_id;
         const bool fabric_tensix_datamover_enabled =
             env.get_fabric_tensix_config() != tt_fabric::FabricTensixConfig::DISABLED;
+        const bool is_quasar = env.get_cluster().arch() == tt::ARCH::QUASAR;
         if (is_mmio && get_core_type_from_config(dispatch_core_config) == CoreType::WORKER &&
-            !fabric_tensix_datamover_enabled && !logical_dispatch_cores.empty()) {
+            !fabric_tensix_datamover_enabled && !is_quasar && !logical_dispatch_cores.empty()) {
             CoreCoord rt_core = logical_dispatch_cores.back();
             logical_dispatch_cores.pop_back();
             this->reserved_realtime_profiler_core_by_device_.emplace(

--- a/tt_metal/impl/dispatch/dispatch_query_manager.cpp
+++ b/tt_metal/impl/dispatch/dispatch_query_manager.cpp
@@ -94,12 +94,13 @@ NOC DispatchQueryManager::go_signal_noc() const { return go_signal_noc_; }
 void DispatchQueryManager::reset(DispatchCoreConfig& dispatch_core_config, uint8_t num_hw_cqs) {
     num_hw_cqs_ = num_hw_cqs;
     dispatch_core_config_ = dispatch_core_config;
+    const tt::ARCH arch = MetalEnvAccessor(env_).impl().get_cluster().arch();
     dispatch_s_enabled_ =
-        (num_hw_cqs == 1 or dispatch_core_config_.get_dispatch_core_type() == DispatchCoreType::WORKER);
+        (num_hw_cqs == 1 or dispatch_core_config_.get_dispatch_core_type() == DispatchCoreType::WORKER) and
+        arch != tt::ARCH::QUASAR;
     distributed_dispatcher_ =
         (num_hw_cqs == 1 and dispatch_core_config_.get_dispatch_core_type() == DispatchCoreType::ETH);
-    const auto arch = MetalEnvAccessor(env_).impl().get_cluster().arch();
-    go_signal_noc_ = (dispatch_s_enabled_ && arch != tt::ARCH::QUASAR) ? NOC::NOC_1 : NOC::NOC_0;
+    go_signal_noc_ = dispatch_s_enabled_ ? NOC::NOC_1 : NOC::NOC_0;
     // Reset the dispatch cores reported by the manager. Will be re-populated when the associated query is made
     dispatch_cores_ = {};
     // Populate dispatch

--- a/tt_metal/impl/dispatch/hardware_command_queue.cpp
+++ b/tt_metal/impl/dispatch/hardware_command_queue.cpp
@@ -34,8 +34,8 @@ HWCommandQueue::HWCommandQueue(Device* device, uint32_t id, NOC /*noc_index*/) :
 
     CoreCoord enqueue_program_dispatch_core;
     CoreType core_type = MetalContext::instance().get_dispatch_core_manager().get_dispatch_core_type();
-    if (this->device_->num_hw_cqs() == 1 or core_type == CoreType::WORKER) {
-        // dispatch_s exists with this configuration. Workers write to dispatch_s
+    if (MetalContext::instance().get_dispatch_query_manager().dispatch_s_enabled()) {
+        // dispatch_s exists with this configuration. Workers write to dispatch_s.
         enqueue_program_dispatch_core =
             MetalContext::instance().get_dispatch_core_manager().dispatcher_s_core(device_->id(), channel, id);
     } else {

--- a/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
+++ b/tt_metal/impl/dispatch/kernels/cq_dispatch.cpp
@@ -1187,12 +1187,11 @@ void set_go_signal_noc_data() {
         reinterpret_cast<volatile CQDispatchCmd tt_l1_ptr*>(l1_uncached_addr(cmd_ptr));
     uint32_t num_words = cmd->set_go_signal_noc_data.num_words;
     ASSERT(num_words <= max_num_go_signal_noc_data_entries);
-    volatile tt_l1_ptr uint32_t* data_ptr =
-        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_uncached_addr(cmd_ptr + sizeof(CQDispatchCmd)));
+    volatile tt_l1_ptr uint32_t* data_ptr = uncached_l1_ptr<uint32_t>(cmd_ptr + sizeof(CQDispatchCmd));
     for (uint32_t i = 0; i < num_words; ++i) {
         go_signal_noc_data[i] = *(data_ptr++);
     }
-    cmd_ptr = round_up_pow2(reinterpret_cast<uintptr_t>(data_ptr), L1_ALIGNMENT);
+    cmd_ptr = round_up_pow2(l1_cached_addr(reinterpret_cast<uintptr_t>(data_ptr)), L1_ALIGNMENT);
 }
 
 static inline bool process_cmd_d(uintptr_t& cmd_ptr, uint32_t* l1_cache) {

--- a/tt_metal/impl/dispatch/topology.cpp
+++ b/tt_metal/impl/dispatch/topology.cpp
@@ -145,9 +145,8 @@ static const std::vector<DispatchKernelNode> single_chip_arch_2cq_dispatch_s = {
 };
 
 static const std::vector<DispatchKernelNode> quasar_single_chip_1cq = {
-    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, 2, x, x}, k_quasar_noc},
-    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {2, x, x, x}, k_quasar_noc},
-    {2, 0, 0, 0, DISPATCH_S, {0, x, x, x}, {1, x, x, x}, k_quasar_noc},
+    {0, 0, 0, 0, PREFETCH_HD, {x, x, x, x}, {1, x, x, x}, k_quasar_noc},
+    {1, 0, 0, 0, DISPATCH_HD, {0, x, x, x}, {x, x, x, x}, k_quasar_noc},
 };
 
 static const std::vector<DispatchKernelNode> two_chip_arch_1cq_fabric = {


### PR DESCRIPTION
### PR Category
Feature

### Summary
This branch completes the end-to-end fast dispatch bringup on Quasar with a single CQ, building on the dispatcher-side work in #45055 and the prefetcher-side work in #46549. With this PR the prefetcher and dispatcher kernels run together in fast dispatch mode on Quasar.

The key host-side changes are:
 - `dispatch_s_enabled_` is gated off for Quasar in `dispatch_query_manager.cpp`
 - the `quasar_single_chip_1cq` topology in `topology.cpp` is updated to remove the `DISPATCH_S` node, leaving only `PREFETCH_HD` and `DISPATCH_HD`
 - the RT-profiler core reservation in `dispatch_core_manager.cpp` is gated off for Quasar, since the FD kernels occupy the same core and the current layout leaves no room for it

The key device-side changes are:
 - `cq_dispatch.cpp` routes `set_go_signal_noc_data` L1 access through the `uncached_l1_ptr<T>` and `l1_cached_addr` helpers to avoid cache staleness or cache coherency issues

For testing, `test_dispatcher.cpp` and `test_prefetcher.cpp` have been updated with `QuasarSimulatorVariant<>` subclasses that gate each test suite to its intended platform (Quasar or WH/BH). The Quasar variants run in fast dispatch mode. The shared test infrastructure in `common.h` was also generalised so `DeviceData` keys its per-core map by `(CoreType, CoreCoord)` instead of `CoreCoord` alone, preventing DRAM and worker entries at the same coordinate from aliasing.

Remaining work:
 - moving the FD kernels from a regular core to a Dispatch Engine
 - using host hugepages instead of DRAM for the command queue on Quasar
 - supporting 2-CQ fast dispatch on Quasar

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:sagarwal/qsr_fd_bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:sagarwal/qsr_fd_bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=sagarwal/qsr_fd_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:sagarwal/qsr_fd_bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=sagarwal/qsr_fd_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:sagarwal/qsr_fd_bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=sagarwal/qsr_fd_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:sagarwal/qsr_fd_bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=sagarwal/qsr_fd_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:sagarwal/qsr_fd_bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=sagarwal/qsr_fd_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:sagarwal/qsr_fd_bringup)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=sagarwal/qsr_fd_bringup)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:sagarwal/qsr_fd_bringup)