### PR TITLE
[Bug fix] Fix Llama-3.1-8B eval accuracy under vLLM async scheduling

### DIFF
--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1614,6 +1614,28 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                 sm_bs = sampling_module.seed_manager.max_batch_size
                 rank_remap = slot_remap[i * sm_bs : (i + 1) * sm_bs]
                 sampling_module.seed_manager.apply_slot_remap(rank_remap)
+            # Register each request's explicit seed into the seed manager and
+            # tie its RNG counter to the absolute decode position before
+            # advancing. Without registration the per-request seed never reaches
+            # the device (the seed manager stays unseeded), so sampling falls
+            # back to per-slot boot RNG and two requests sharing a seed diverge
+            # (this regressed when #45166 dropped these calls from the decode
+            # flow). Position alignment then keeps the stream reproducible even
+            # when vLLM evicts a running request and re-admits it in a different
+            # slot under async scheduling. Mirrors the llama3_70b_galaxy decode path.
+            if active_seed_slots:
+                seed_bs = sampling_module.tt_sampling.max_batch_size
+                if len(model_chunks) == 1:
+                    seed_values = format_sampling_params(model_chunks[0], seed_bs).seed
+                else:
+                    seed_values = []
+                    for chunk in model_chunks:
+                        s = format_sampling_params(chunk, seed_bs).seed
+                        seed_values += s if isinstance(s, list) else [s] * seed_bs
+                sampling_module.seed_manager.reset_seed_from_slots_if_needed(seed_values, active_seed_slots)
+                sampling_module.seed_manager.align_seed_counters_to_positions(
+                    seed_values, active_seed_slots, start_values
+                )
             sampling_module.seed_manager.get_new_values(active_seed_slots)
 
         sampled_outputs = []

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -547,6 +547,15 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
             # Only paged attention is supported for prefill
             enable_trace = False
 
+        # Track slots refreshed by this prefill so the next decode reset keeps
+        # device-fed tokens for all other slots (their host token is one step
+        # stale under vLLM async scheduling).
+        if not hasattr(self, "_slots_prefilled_since_decode"):
+            self._slots_prefilled_since_decode = set()
+        self._slots_prefilled_since_decode.update(
+            range(tokens.shape[0]) if empty_slots is None else [int(s) for s in empty_slots]
+        )
+
         on_device_sampling_requested = sampling_params is not None
 
         # we need this here because of tt-metal tests
@@ -1224,6 +1233,77 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         tokens = torch.chunk(tokens, self.data_parallel, 0)
         start_pos = torch.chunk(start_pos, self.data_parallel, 0)
         page_table = torch.chunk(page_table, self.data_parallel, 0) if page_table is not None else None
+
+        # vLLM under async scheduling supplies a one-step-stale last token at
+        # reset steps (its host state lags device sampling). The device token
+        # buffer holds the authoritative token sampled at the previous decode
+        # step, so on a reset keep it: permute per slot_remap (condense moves),
+        # only taking host tokens for slots freshly prefilled since the last
+        # decode submit (their last token came from prefill, not decode).
+        if (
+            on_device_sampling
+            and (reset_batch or mode_switched)
+            and enable_trace
+            and self.trace_inputs_decode[on_device_sampling]
+        ):
+            new_tokens = []
+            new_start_pos = []
+            # Correctness fix (on by default; set TT_FIX_RESET_POS=0 to disable for
+            # A/B). When we take the device's async-ahead token for a continuing
+            # slot, the token sits at position dev_pos; staging the lagging host
+            # position (=dev_pos-1) re-processes that token at the wrong position
+            # (overwriting KV / regenerating a position -> duplicate/flipped tokens
+            # under concurrency). Pair the device token with the device position.
+            _fix_reset_pos = os.environ.get("TT_FIX_RESET_POS", "1") != "0"
+            for i, tok_chunk in enumerate(tokens):
+                trace_in = self.trace_inputs_decode[on_device_sampling][i]
+                dev_toks = (
+                    ttnn.to_torch(ttnn.get_device_tensors(trace_in[0])[0])
+                    .reshape(-1)[: tok_chunk.shape[0]]
+                    .to(tok_chunk.dtype)
+                )
+                dev_pos = (
+                    ttnn.to_torch(ttnn.get_device_tensors(trace_in[1])[0])
+                    .reshape(-1)[: tok_chunk.shape[0]]
+                    .to(torch.int64)
+                )
+                if slot_remap is not None:
+                    chunk = dev_toks.shape[0]
+                    remap = slot_remap[i * chunk : (i + 1) * chunk]
+                    remap_t = (remap if isinstance(remap, torch.Tensor) else torch.tensor(remap)).long()
+                    # slot_remap holds GLOBAL slot indices: the vLLM plugin offsets
+                    # each DP rank's local [0,B) remap by rank*B for the row-sharded
+                    # SeedManager. dev_toks/dev_pos are this rank's *local* size-B
+                    # tensors, so rebase the global indices back to [0,B) before
+                    # gathering -- otherwise rank i>=1 indexes past the end (e.g.
+                    # value 32 into a size-32 tensor).
+                    remap_t = remap_t - i * chunk
+                    dev_toks = dev_toks[remap_t]
+                    dev_pos = dev_pos[remap_t]
+                # The device token is authoritative only for slots whose device
+                # position chain is continuous with the host view; slots that
+                # were re-added, resumed, or freshly prefilled take host tokens.
+                # The host position itself may lag the device by one step under
+                # async scheduling, so accept both.
+                host_pos = start_pos[i].reshape(-1).to(torch.int64)
+                use_dev = (dev_pos == host_pos) | (dev_pos == host_pos + 1)
+                prefilled = getattr(self, "_slots_prefilled_since_decode", None)
+                if prefilled:
+                    bs = tok_chunk.shape[0]
+                    for slot in prefilled:
+                        if i * bs <= slot < (i + 1) * bs:
+                            use_dev[slot - i * bs] = False
+                merged = torch.where(use_dev, dev_toks.view(-1), tok_chunk.view(-1)).view(tok_chunk.shape)
+                new_tokens.append(merged.to(tok_chunk.dtype))
+                if _fix_reset_pos:
+                    merged_pos = torch.where(use_dev, dev_pos, host_pos)
+                    new_start_pos.append(merged_pos.view(start_pos[i].shape).to(start_pos[i].dtype))
+                else:
+                    new_start_pos.append(start_pos[i])
+            tokens = new_tokens
+            start_pos = new_start_pos
+        self._slots_prefilled_since_decode = set()
+
         decode_kwargs = {
             "current_pos": start_pos,
             "tokens": tokens,

--- a/models/tt_transformers/tt/generator.py
+++ b/models/tt_transformers/tt/generator.py
@@ -1248,13 +1248,11 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
         ):
             new_tokens = []
             new_start_pos = []
-            # Correctness fix (on by default; set TT_FIX_RESET_POS=0 to disable for
-            # A/B). When we take the device's async-ahead token for a continuing
-            # slot, the token sits at position dev_pos; staging the lagging host
-            # position (=dev_pos-1) re-processes that token at the wrong position
+            # When we take the device's async-ahead token for a continuing slot,
+            # the token sits at position dev_pos; staging the lagging host position
+            # (=dev_pos-1) would re-process that token at the wrong position
             # (overwriting KV / regenerating a position -> duplicate/flipped tokens
             # under concurrency). Pair the device token with the device position.
-            _fix_reset_pos = os.environ.get("TT_FIX_RESET_POS", "1") != "0"
             for i, tok_chunk in enumerate(tokens):
                 trace_in = self.trace_inputs_decode[on_device_sampling][i]
                 dev_toks = (
@@ -1295,11 +1293,8 @@ class Generator(ModelCapabilitiesMixin, WarmupForwardMixin):
                             use_dev[slot - i * bs] = False
                 merged = torch.where(use_dev, dev_toks.view(-1), tok_chunk.view(-1)).view(tok_chunk.shape)
                 new_tokens.append(merged.to(tok_chunk.dtype))
-                if _fix_reset_pos:
-                    merged_pos = torch.where(use_dev, dev_pos, host_pos)
-                    new_start_pos.append(merged_pos.view(start_pos[i].shape).to(start_pos[i].dtype))
-                else:
-                    new_start_pos.append(start_pos[i])
+                merged_pos = torch.where(use_dev, dev_pos, host_pos)
+                new_start_pos.append(merged_pos.view(start_pos[i].shape).to(start_pos[i].dtype))
             tokens = new_tokens
             start_pos = new_start_pos
         self._slots_prefilled_since_decode = set()

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -605,9 +605,9 @@ class ModelArgs:
         # test_non_uniform_seeding). Forcing per-user batch-1 prefill removes the
         # variance. Workaround until the prefill kernels are batch-invariant.
         # Disabled for Qwen3-32B (P150x4) and Llama-3.1-8B (P300/P150x4/P150x8).
-        self.disable_batched_prefill = (
-            self.base_model_name == "Qwen3-32B" and self.device_name == "P150x4"
-        ) or (self.base_model_name == "Llama-3.1-8B" and self.device_name in ("P300", "P150x4", "P150x8"))
+        self.disable_batched_prefill = (self.base_model_name == "Qwen3-32B" and self.device_name == "P150x4") or (
+            self.base_model_name == "Llama-3.1-8B" and self.device_name in ("P300", "P150x4", "P150x8")
+        )
 
         if (
             self.base_model_name

--- a/models/tt_transformers/tt/model_config.py
+++ b/models/tt_transformers/tt/model_config.py
@@ -597,15 +597,17 @@ class ModelArgs:
         # Set the max number of tokens for each prefill chunk based on the model and device
         self.max_prefill_chunk_size = self.get_max_prefill_chunk_size()
         # TODO: Enable batched_prefill once this is fixed: https://github.com/tenstorrent/tt-metal/issues/47238
-        # Qwen3-32B prefill logits are batch-variant on multi-chip Blackhole: the
+        # Prefill logits are batch-variant on multi-chip Blackhole: the
         # float-reduction order in the prefill matmul/attention depends on the
         # batched-token count, so identical same-seed requests that land in
         # different-sized prefill batches get slightly different logits. Seeded
         # sampling under concurrency then diverges (tt-inference-server#4004,
         # test_non_uniform_seeding). Forcing per-user batch-1 prefill removes the
-        # variance. Workaround until the prefill kernels are batch-invariant;
-        # mirrors the existing Llama-3.1-8B P300/P150x8 handling.
-        self.disable_batched_prefill = self.base_model_name == "Qwen3-32B" and self.device_name == "P150x4"
+        # variance. Workaround until the prefill kernels are batch-invariant.
+        # Disabled for Qwen3-32B (P150x4) and Llama-3.1-8B (P300/P150x4/P150x8).
+        self.disable_batched_prefill = (
+            self.base_model_name == "Qwen3-32B" and self.device_name == "P150x4"
+        ) or (self.base_model_name == "Llama-3.1-8B" and self.device_name in ("P300", "P150x4", "P150x8"))
 
         if (
             self.base_model_name


### PR DESCRIPTION
### Summary
Under --async-scheduling, Llama-3.1-8B produced incorrect decode output at reset / batch-condense steps, regressing the eval/accuracy tests. The main fix restores correct generation by keeping the authoritative device token across decode resets. Two supporting fixes restore seeded-sampling determinism on multi-chip Blackhole (which also unblocks the seed=0 chat-completions test).

### Main fix - keep the device "async-ahead" token across decode reset (generator.py)
Under async scheduling, the host-supplied last token lags device sampling at reset / prefill→decode mode-switch steps. Staging that stale host token (and its lagging position) re-processes a token at the wrong position - overwriting KV / regenerating positions - which produces duplicate or flipped tokens under concurrency and degrades eval accuracy.

This keeps the authoritative device token (and its position) for continuing slots, taking host tokens only for slots freshly prefilled since the last decode submit (_slots_prefilled_since_decode). slot_remap carries global slot indices (the plugin offsets each DP rank's local [0,B) map by rank*B), so it's rebased to per-rank local before gathering dev_toks/dev_pos, otherwise rank ≥1 indexes out of bounds. Position pairing is gated by TT_FIX_RESET_POS (default on).

### Supporting fixes (seeded-sampling determinism)
#### Restore seed registration + RNG-counter↔position alignment (generator.py)
Main #45166 ("Clean up sampling separation in generators") dropped reset_seed_from_slots_if_needed + align_seed_counters_to_positions from sample_decode_on_device. Without them the per-request seed never reaches the device (the seed manager stays unseeded) and the RNG counter isn't tied to the absolute decode position, so seeded sampling is non-deterministic under async scheduling. Restores both calls before get_new_values, matching the known-good path. (This is what was failing the seed=0 test; the SeedManager methods themselves were untouched - they just stopped being called.)

#### Disable batched prefill on multi-chip Blackhole (model_config.py, #4004)
Prefill logits are batch-variant on multi-chip Blackhole (float-reduction order depends on batched-token count), so same-seed requests in different-sized prefill batches diverge. Disabled for Llama-3.1-8B on P300/P150x4/P150x8 (alongside main's existing Qwen3-32B/P150x4 case).

### Potential impact on other models
The two generator.py changes live in the shared tt_transformers.Generator, so Qwen3-32B, Mistral, Phi, gemma3, gemma4 and gpt_oss inherit them too (positive for seeded sampling, no-op when unseeded). Not affected: llama3_70b_galaxy (already has the alignment - it's the reference) and deepseek_v3 (own generator, lacks the alignment independently — flagged for its owners).

### Potentially important information for reviewers
The seed-registration change restores behavior #45166 intentionally removed across all shared-generator models, so might need to inform PR's author (Tomasz Cheda) so it isn't dropped again.

### CI runs
INFO: Gemma 4 fix is on current main, this branch doesn't contain it, so because of this there are Gemma 4 fails on tests, but this fix doesn't even target this model

CI evals + seeding tests: https://github.com/tenstorrent/tt-shield/actions/runs/27765421449/job/82176698553
vLLM nightly: https://github.com/tenstorrent/tt-metal/actions/runs/27815973961
Tier 1 + 2 E2E tests: https://github.com/tenstorrent/tt-metal/actions/runs/27818140967

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ctr-ifabijanic/async-decode-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ctr-ifabijanic/async-decode-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ctr-ifabijanic/async-decode-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ctr-ifabijanic/async-decode-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ctr-ifabijanic/async-decode-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ctr-ifabijanic/async-decode-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ctr-ifabijanic/async-decode-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ctr-ifabijanic/async-decode-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ctr-ifabijanic/async-decode-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ctr-ifabijanic/async-decode-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ctr-ifabijanic/async-decode-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ctr-ifabijanic/async-decode-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ctr-ifabijanic/async-decode-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ctr-ifabijanic/async-decode-reset)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ctr-ifabijanic/async-decode-reset)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ctr-ifabijanic/async-decode-reset)