### PR TITLE
#46565: Extend universal input/output support for ttnn::gather

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_gather.py
+++ b/tests/ttnn/nightly/unit_tests/operations/data_movement/test_universal_input_tm_gather.py
@@ -1,0 +1,963 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+
+# SPDX-License-Identifier: Apache-2.0
+
+"""Universal input/output tests for ttnn.gather — one case per routing path."""
+
+import pytest
+import torch
+
+import ttnn
+
+from tests.ttnn.utils_for_testing import assert_equal, assert_with_pcc
+
+_TTNN_TO_TORCH_DTYPE = {
+    ttnn.bfloat16: torch.bfloat16,
+    ttnn.float32: torch.float32,
+}
+
+_TILE_H = 32
+_TILE_W = 32
+
+L1_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.L1)
+DRAM_INTERLEAVED = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.INTERLEAVED, ttnn.BufferType.DRAM)
+
+
+def _round_up(x, m):
+    return ((x + m - 1) // m) * m
+
+
+def _layout_hw_for_shard(shape, layout):
+    """Return (total_height, width). TILE pads last-two dims to a tile each; RM uses logical dims."""
+    if layout == ttnn.TILE_LAYOUT:
+        total_h = 1
+        for d in shape[:-2]:
+            total_h *= d
+        total_h *= _round_up(shape[-2], _TILE_H)
+        return total_h, _round_up(shape[-1], _TILE_W)
+    total_h = 1
+    for d in shape[:-1]:
+        total_h *= d
+    return total_h, shape[-1]
+
+
+def _tile_align(shard_shape, layout):
+    h, w = shard_shape
+    if layout == ttnn.TILE_LAYOUT:
+        return (_round_up(h, _TILE_H), _round_up(w, _TILE_W))
+    return (h, w)
+
+
+def _interleaved_l1(_d):
+    return L1_INTERLEAVED
+
+
+def _interleaved_dram(_d):
+    return DRAM_INTERLEAVED
+
+
+def _height_sharded(
+    shape,
+    device,
+    num_cores=4,
+    layout=ttnn.TILE_LAYOUT,
+    buffer_type=ttnn.BufferType.L1,
+    orientation=ttnn.ShardOrientation.ROW_MAJOR,
+):
+    grid = device.compute_with_storage_grid_size()
+    num_cores = min(num_cores, grid.x * grid.y)
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, grid, True)
+    total_h, w = _layout_hw_for_shard(shape, layout)
+    shard_shape = _tile_align(((total_h + num_cores - 1) // num_cores, w), layout)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+        buffer_type,
+        ttnn.ShardSpec(shard_grid, shard_shape, orientation),
+    )
+
+
+def _width_sharded(shape, device, num_cores=4, layout=ttnn.TILE_LAYOUT, orientation=ttnn.ShardOrientation.ROW_MAJOR):
+    grid = device.compute_with_storage_grid_size()
+    num_cores = min(num_cores, grid.x * grid.y)
+    shard_grid = ttnn.num_cores_to_corerangeset(num_cores, grid, True)
+    total_h, w = _layout_hw_for_shard(shape, layout)
+    shard_shape = _tile_align((total_h, (w + num_cores - 1) // num_cores), layout)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(shard_grid, shard_shape, orientation),
+    )
+
+
+def _block_sharded(shape, device, layout=ttnn.TILE_LAYOUT, orientation=ttnn.ShardOrientation.ROW_MAJOR):
+    grid = device.compute_with_storage_grid_size()
+    gx = min(2, grid.x)
+    gy = min(2, grid.y)
+    total_h, w = _layout_hw_for_shard(shape, layout)
+    shard_shape = _tile_align(((total_h + gy - 1) // gy, (w + gx - 1) // gx), layout)
+    return ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ttnn.BufferType.L1,
+        ttnn.ShardSpec(
+            ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(gx - 1, gy - 1))}),
+            shard_shape,
+            orientation,
+        ),
+    )
+
+
+# Explicit shard helpers — caller-controlled grid + shard shape (irregular, uneven, sub-tile).
+
+
+def _explicit_height_shard_config(device, ncores, sh, sw):
+    compute_grid = device.compute_with_storage_grid_size()
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has {compute_grid.x * compute_grid.y} cores, test needs {ncores}")
+    spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1, spec)
+
+
+def _explicit_width_shard_config(device, ncores, sh, sw):
+    compute_grid = device.compute_with_storage_grid_size()
+    if ncores > compute_grid.x * compute_grid.y:
+        pytest.skip(f"Device has {compute_grid.x * compute_grid.y} cores, test needs {ncores}")
+    spec = ttnn.ShardSpec(
+        ttnn.num_cores_to_corerangeset(ncores, compute_grid, True),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.WIDTH_SHARDED, ttnn.BufferType.L1, spec)
+
+
+def _explicit_block_shard_config(device, grid_y, grid_x, sh, sw):
+    compute_grid = device.compute_with_storage_grid_size()
+    if grid_y > compute_grid.y or grid_x > compute_grid.x:
+        pytest.skip(f"Device grid ({compute_grid.y}x{compute_grid.x}) too small for requested {grid_y}x{grid_x}")
+    spec = ttnn.ShardSpec(
+        ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(grid_x - 1, grid_y - 1))}),
+        (sh, sw),
+        ttnn.ShardOrientation.ROW_MAJOR,
+    )
+    return ttnn.MemoryConfig(ttnn.TensorMemoryLayout.BLOCK_SHARDED, ttnn.BufferType.L1, spec)
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Shared runner — mirrors slice / permute conventions.
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+def _run_gather(
+    input_shape,
+    index_shape,
+    dim,
+    layout,
+    input_mem_config,
+    index_mem_config,
+    output_mem_config,
+    dtype,
+    device,
+    expect_bit_exact=True,
+    expected_shard_orientation=None,
+):
+    """Run gather; validate memory_layout + shard_spec match the request, then compare values."""
+    torch.manual_seed(12345)
+    torch_dtype = _TTNN_TO_TORCH_DTYPE[dtype]
+    x = torch.randn(input_shape, dtype=torch_dtype)
+    idx = torch.randint(0, input_shape[dim], index_shape, dtype=torch.int64)
+
+    ttnn_in = ttnn.from_torch(x, layout=layout, dtype=dtype, device=device, memory_config=input_mem_config)
+    ttnn_idx = ttnn.from_torch(idx, layout=layout, dtype=ttnn.uint32, device=device, memory_config=index_mem_config)
+
+    result = ttnn.gather(ttnn_in, dim, index=ttnn_idx, memory_config=output_mem_config)
+
+    if output_mem_config is not None:
+        actual = result.memory_config()
+        assert (
+            actual.memory_layout == output_mem_config.memory_layout
+        ), f"Expected memory_layout {output_mem_config.memory_layout}, got {actual.memory_layout}"
+        if output_mem_config.memory_layout in (
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            ttnn.TensorMemoryLayout.BLOCK_SHARDED,
+        ):
+            assert actual.shard_spec is not None, "Sharded output requested but result has no shard_spec"
+            if expected_shard_orientation is not None:
+                actual_orientation = actual.shard_spec.orientation
+                assert (
+                    actual_orientation == expected_shard_orientation
+                ), f"Expected shard orientation {expected_shard_orientation}, got {actual_orientation}"
+
+    ref = torch.gather(x, dim, idx)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+
+    # Gather is pure data-movement for bf16/f32 native paths; composite arm still routes through
+    # tilize which shuffles (not quantizes) non-block dtypes, so bit-exact holds for all paths here.
+    if expect_bit_exact:
+        try:
+            assert_equal(ref, got)
+        except AssertionError as e:
+            raise AssertionError(f"dtype={dtype}: {e}") from e
+    else:
+        assert_with_pcc(ref.float(), got.float(), 0.9999)
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group A: TILE — interleaved & sharded in/out, bf16 + f32 (bf8b unsupported)
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "f32"])
+@pytest.mark.parametrize(
+    "input_shape, index_shape, dim, input_factory, index_factory, output_factory",
+    [
+        pytest.param(
+            (1, 1, 128, 128),
+            (1, 1, 128, 64),
+            -1,
+            _interleaved_l1,
+            _interleaved_l1,
+            _interleaved_l1,
+            id="L1_interleaved_baseline",
+        ),
+        pytest.param(
+            (1, 1, 128, 128),
+            (1, 1, 128, 64),
+            -1,
+            _interleaved_dram,
+            _interleaved_dram,
+            _interleaved_dram,
+            id="DRAM_interleaved",
+        ),
+        # TILE sharded in/index → interleaved out (HEIGHT-sharded baseline).
+        pytest.param(
+            (1, 1, 128, 64),
+            (1, 1, 128, 64),
+            -1,
+            lambda d: _height_sharded((1, 1, 128, 64), d),
+            lambda d: _height_sharded((1, 1, 128, 64), d),
+            _interleaved_l1,
+            id="TILE_height_to_interleaved",
+        ),
+        # TILE interleaved → HEIGHT-sharded out (explicit spec).
+        pytest.param(
+            (1, 1, 128, 128),
+            (1, 1, 128, 64),
+            -1,
+            _interleaved_l1,
+            _interleaved_l1,
+            lambda d: _height_sharded((1, 1, 128, 64), d),
+            id="TILE_interleaved_to_height",
+        ),
+        # TILE interleaved → BLOCK-sharded out (explicit spec).
+        pytest.param(
+            (1, 1, 128, 128),
+            (1, 1, 128, 64),
+            -1,
+            _interleaved_l1,
+            _interleaved_l1,
+            lambda d: _block_sharded((1, 1, 128, 64), d),
+            id="TILE_interleaved_to_block",
+        ),
+        # TILE HEIGHT-sharded → HEIGHT-sharded (same layout, explicit specs).
+        pytest.param(
+            (1, 1, 128, 64),
+            (1, 1, 128, 64),
+            -1,
+            lambda d: _height_sharded((1, 1, 128, 64), d),
+            lambda d: _height_sharded((1, 1, 128, 64), d),
+            lambda d: _height_sharded((1, 1, 128, 64), d),
+            id="TILE_height_to_height",
+        ),
+        # TILE WIDTH-sharded → WIDTH-sharded.
+        pytest.param(
+            (1, 1, 64, 128),
+            (1, 1, 64, 64),
+            -1,
+            lambda d: _width_sharded((1, 1, 64, 128), d),
+            lambda d: _width_sharded((1, 1, 64, 64), d),
+            lambda d: _width_sharded((1, 1, 64, 64), d),
+            id="TILE_width_to_width",
+        ),
+        # TILE BLOCK-sharded → BLOCK-sharded.
+        pytest.param(
+            (1, 1, 128, 128),
+            (1, 1, 128, 64),
+            -1,
+            lambda d: _block_sharded((1, 1, 128, 128), d),
+            lambda d: _block_sharded((1, 1, 128, 64), d),
+            lambda d: _block_sharded((1, 1, 128, 64), d),
+            id="TILE_block_to_block",
+        ),
+        # Implicit-output — no memory_config arg, sharded input passes through.
+        pytest.param(
+            (1, 1, 128, 128),
+            (1, 1, 128, 64),
+            -1,
+            lambda d: _block_sharded((1, 1, 128, 128), d),
+            lambda d: _block_sharded((1, 1, 128, 64), d),
+            None,
+            id="TILE_block_default_output",
+        ),
+    ],
+)
+def test_gather_tile(input_shape, index_shape, dim, input_factory, index_factory, output_factory, dtype, device):
+    _run_gather(
+        input_shape,
+        index_shape,
+        dim,
+        ttnn.TILE_LAYOUT,
+        input_factory(device),
+        index_factory(device),
+        output_factory(device) if output_factory is not None else None,
+        dtype,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group B: TILE — sharded output without explicit shard_spec (derivation path)
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize(
+    "memory_layout",
+    [
+        pytest.param(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, id="height"),
+        pytest.param(ttnn.TensorMemoryLayout.WIDTH_SHARDED, id="width"),
+        pytest.param(ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="block"),
+    ],
+)
+def test_gather_tile_interleaved_to_sharded_no_spec(memory_layout, dtype, device):
+    """TILE interleaved in/index → sharded output **without** explicit shard_spec.
+    Exercises compute_output_specs derivation via generate_transpose_shard_spec."""
+    out_mc = ttnn.MemoryConfig(memory_layout, ttnn.BufferType.L1)
+    _run_gather(
+        (1, 1, 128, 128),
+        (1, 1, 128, 64),
+        -1,
+        ttnn.TILE_LAYOUT,
+        L1_INTERLEAVED,
+        L1_INTERLEAVED,
+        out_mc,
+        dtype,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group C: RM — interleaved single-core + multi-core + sharded in/out, bf16 + f32.
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "f32"])
+@pytest.mark.parametrize(
+    "input_shape, index_shape, dim, input_factory, index_factory, output_factory",
+    [
+        # Pure interleaved RM — single-core (Wt below threshold).
+        pytest.param(
+            (1, 1, 32, 64),
+            (1, 1, 32, 32),
+            -1,
+            _interleaved_l1,
+            _interleaved_l1,
+            _interleaved_l1,
+            id="RM_interleaved_baseline",
+        ),
+        # DRAM variant.
+        pytest.param(
+            (1, 1, 64, 128),
+            (1, 1, 64, 64),
+            -1,
+            _interleaved_dram,
+            _interleaved_dram,
+            _interleaved_dram,
+            id="RM_interleaved_DRAM",
+        ),
+        # Multi-core RM (W > 60 * TILE_W = 1920).
+        pytest.param(
+            (1, 1, 4, 2048),
+            (1, 1, 4, 1024),
+            -1,
+            _interleaved_dram,
+            _interleaved_dram,
+            _interleaved_dram,
+            id="RM_interleaved_multi_core",
+        ),
+        # RM HEIGHT-sharded in/index/out (matching).
+        pytest.param(
+            (1, 1, 64, 64),
+            (1, 1, 64, 32),
+            -1,
+            lambda d: _height_sharded((1, 1, 64, 64), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _height_sharded((1, 1, 64, 32), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _height_sharded((1, 1, 64, 32), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="RM_height_to_height",
+        ),
+        # RM HEIGHT-sharded in → INTERLEAVED out.
+        pytest.param(
+            (1, 1, 64, 64),
+            (1, 1, 64, 32),
+            -1,
+            lambda d: _height_sharded((1, 1, 64, 64), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _height_sharded((1, 1, 64, 32), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            _interleaved_l1,
+            id="RM_height_to_interleaved",
+        ),
+        # RM WIDTH-sharded regular (W tile-aligned) — per-shard page-size override engages.
+        pytest.param(
+            (1, 1, 32, 128),
+            (1, 1, 32, 64),
+            -1,
+            lambda d: _width_sharded((1, 1, 32, 128), d, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _width_sharded((1, 1, 32, 64), d, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _width_sharded((1, 1, 32, 64), d, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="RM_width_regular_to_width",
+        ),
+        # RM BLOCK-sharded regular — same per-shard page-size mechanism.
+        pytest.param(
+            (1, 1, 64, 128),
+            (1, 1, 64, 64),
+            -1,
+            lambda d: _block_sharded((1, 1, 64, 128), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _block_sharded((1, 1, 64, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _block_sharded((1, 1, 64, 64), d, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="RM_block_regular_to_block",
+        ),
+    ],
+)
+def test_gather_rm(input_shape, index_shape, dim, input_factory, index_factory, output_factory, dtype, device):
+    _run_gather(
+        input_shape,
+        index_shape,
+        dim,
+        ttnn.ROW_MAJOR_LAYOUT,
+        input_factory(device),
+        index_factory(device),
+        output_factory(device) if output_factory is not None else None,
+        dtype,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group D: RM — sharded output without explicit shard_spec (derivation path)
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize(
+    "memory_layout",
+    [
+        pytest.param(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, id="height"),
+        pytest.param(ttnn.TensorMemoryLayout.BLOCK_SHARDED, id="block"),
+    ],
+)
+def test_gather_rm_interleaved_to_sharded_no_spec(memory_layout, dtype, device):
+    """RM interleaved in/index → sharded output without shard_spec → compute_output_specs derives."""
+    out_mc = ttnn.MemoryConfig(memory_layout, ttnn.BufferType.L1)
+    _run_gather(
+        (1, 1, 32, 128),
+        (1, 1, 32, 64),
+        -1,
+        ttnn.ROW_MAJOR_LAYOUT,
+        L1_INTERLEAVED,
+        L1_INTERLEAVED,
+        out_mc,
+        dtype,
+        device,
+    )
+
+
+def test_gather_rm_sharded_in_sharded_no_spec_out(device):
+    """RM HEIGHT-sharded in → HEIGHT no-spec out: derivation must work when input is already sharded."""
+    in_shape = (1, 1, 64, 64)
+    idx_shape = (1, 1, 64, 32)
+    in_mc = _height_sharded(in_shape, device, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT)
+    idx_mc = _height_sharded(idx_shape, device, num_cores=4, layout=ttnn.ROW_MAJOR_LAYOUT)
+    out_no_spec = ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1)
+    _run_gather(
+        in_shape,
+        idx_shape,
+        -1,
+        ttnn.ROW_MAJOR_LAYOUT,
+        in_mc,
+        idx_mc,
+        out_no_spec,
+        ttnn.bfloat16,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group E: Irregular logical shapes — mirrors transpose's irregular matrix.
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+# NoC-aligned shapes only. W=97 deferred pending the cross-op helper fix in #47299.
+_IRREGULAR_SHAPES = [
+    pytest.param((1, 1, 65, 96), (1, 1, 65, 48), id="shape_65x96"),
+    pytest.param((1, 1, 33, 64), (1, 1, 33, 32), id="shape_33x64"),
+]
+
+
+@pytest.mark.parametrize("input_shape, index_shape", _IRREGULAR_SHAPES)
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT], ids=["TILE", "RM"])
+def test_gather_irregular_shapes_interleaved(input_shape, index_shape, layout, device):
+    _run_gather(
+        input_shape,
+        index_shape,
+        -1,
+        layout,
+        L1_INTERLEAVED,
+        L1_INTERLEAVED,
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+    )
+
+
+@pytest.mark.parametrize("input_shape, index_shape", _IRREGULAR_SHAPES)
+@pytest.mark.parametrize(
+    "shard_factory",
+    [
+        pytest.param(_height_sharded, id="height"),
+        pytest.param(_width_sharded, id="width"),
+        pytest.param(_block_sharded, id="block"),
+    ],
+)
+@pytest.mark.parametrize("layout", [ttnn.TILE_LAYOUT, ttnn.ROW_MAJOR_LAYOUT], ids=["TILE", "RM"])
+def test_gather_irregular_shapes_sharded(input_shape, index_shape, shard_factory, layout, device):
+    """2 shapes × 3 shard layouts × 2 element layouts; RM B/W-sharded routes via composite arm."""
+    # block_sharded helper has no num_cores arg.
+    if shard_factory is _block_sharded:
+        in_mc = shard_factory(input_shape, device, layout=layout)
+        idx_mc = shard_factory(index_shape, device, layout=layout)
+    else:
+        in_mc = shard_factory(input_shape, device, num_cores=4, layout=layout)
+        idx_mc = shard_factory(index_shape, device, num_cores=4, layout=layout)
+    _run_gather(
+        input_shape,
+        index_shape,
+        -1,
+        layout,
+        in_mc,
+        idx_mc,
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group F: Sharded inputs with explicit grids/shapes — irregular, uneven splits
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "input_shape, index_shape, dim, in_mc_factory, idx_mc_factory",
+    [
+        # TILE HEIGHT-sharded with explicit 3-core grid (uneven split of H).
+        pytest.param(
+            (1, 1, 96, 64),
+            (1, 1, 96, 32),
+            -1,
+            lambda d: _explicit_height_shard_config(d, 3, 32, 64),
+            lambda d: _explicit_height_shard_config(d, 3, 32, 32),
+            id="TILE_height_3_uneven",
+        ),
+        # TILE WIDTH-sharded with explicit 4-core grid — width evenly split per core.
+        pytest.param(
+            (1, 1, 32, 128),
+            (1, 1, 32, 128),
+            -1,
+            lambda d: _explicit_width_shard_config(d, 4, 32, 32),
+            lambda d: _explicit_width_shard_config(d, 4, 32, 32),
+            id="TILE_width_4_even",
+        ),
+    ],
+)
+def test_gather_tile_explicit_sharded_inputs(input_shape, index_shape, dim, in_mc_factory, idx_mc_factory, device):
+    _run_gather(
+        input_shape,
+        index_shape,
+        dim,
+        ttnn.TILE_LAYOUT,
+        in_mc_factory(device),
+        idx_mc_factory(device),
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group G: Multi-batch / multi-channel sharded inputs (N>1 or C>1)
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "input_shape, index_shape, dim, layout, in_mc_factory, idx_mc_factory",
+    [
+        # TILE C=2 BLOCK-sharded. Both input W=128 and index W=64 split 2x2 stay tile-aligned.
+        pytest.param(
+            (1, 2, 64, 128),
+            (1, 2, 64, 64),
+            -1,
+            ttnn.TILE_LAYOUT,
+            lambda d: _explicit_block_shard_config(d, 2, 2, 64, 64),
+            lambda d: _explicit_block_shard_config(d, 2, 2, 64, 32),
+            id="TILE_C2_block",
+        ),
+        # RM N=2 C=2 HEIGHT-sharded.
+        pytest.param(
+            (2, 2, 32, 64),
+            (2, 2, 32, 32),
+            -1,
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda d: _explicit_height_shard_config(d, 4, 32, 64),
+            lambda d: _explicit_height_shard_config(d, 4, 32, 32),
+            id="RM_N2C2_height",
+        ),
+    ],
+)
+def test_gather_multi_batch_channel(input_shape, index_shape, dim, layout, in_mc_factory, idx_mc_factory, device):
+    _run_gather(
+        input_shape,
+        index_shape,
+        dim,
+        layout,
+        in_mc_factory(device),
+        idx_mc_factory(device),
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group H: Higher-rank inputs (rank > 4) — host pipeline collapses to 4D
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16], ids=["bf16"])
+@pytest.mark.parametrize(
+    "input_shape, index_shape, dim, layout, input_factory, index_factory",
+    [
+        # Rank-5 with HEIGHT-sharded inputs (parity with slice's rank5 coverage).
+        pytest.param(
+            (1, 2, 4, 32, 64),
+            (1, 2, 4, 32, 32),
+            -1,
+            ttnn.TILE_LAYOUT,
+            lambda d: _height_sharded((1, 2, 4, 32, 64), d),
+            lambda d: _height_sharded((1, 2, 4, 32, 32), d),
+            id="TILE_rank5_height_sharded",
+        ),
+        pytest.param(
+            (1, 1, 2, 8, 2, 64),
+            (1, 1, 2, 8, 2, 32),
+            -1,
+            ttnn.TILE_LAYOUT,
+            _interleaved_l1,
+            _interleaved_l1,
+            id="TILE_rank6_interleaved",
+        ),
+    ],
+)
+def test_gather_higher_rank(input_shape, index_shape, dim, layout, input_factory, index_factory, dtype, device):
+    _run_gather(
+        input_shape,
+        index_shape,
+        dim,
+        layout,
+        input_factory(device),
+        index_factory(device),
+        L1_INTERLEAVED,
+        dtype,
+        device,
+    )
+
+
+def test_gather_higher_rank_to_sharded_no_spec(device):
+    """Rank-5 TILE in/idx → HEIGHT-sharded out without spec — exercises spec derivation."""
+    _run_gather(
+        (1, 2, 4, 32, 64),
+        (1, 2, 4, 32, 32),
+        -1,
+        ttnn.TILE_LAYOUT,
+        L1_INTERLEAVED,
+        L1_INTERLEAVED,
+        ttnn.MemoryConfig(ttnn.TensorMemoryLayout.HEIGHT_SHARDED, ttnn.BufferType.L1),
+        ttnn.bfloat16,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group I: DRAM-sharded input — TensorAccessor is buffer-type agnostic at tile granularity.
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+def test_gather_dram_sharded_input(device):
+    """TILE HEIGHT-sharded in DRAM."""
+    shape = (1, 1, 128, 64)
+    idx_shape = (1, 1, 128, 32)
+    dram_sharded = _height_sharded(shape, device, buffer_type=ttnn.BufferType.DRAM)
+    idx_dram_sharded = _height_sharded(idx_shape, device, buffer_type=ttnn.BufferType.DRAM)
+    _run_gather(
+        shape,
+        idx_shape,
+        -1,
+        ttnn.TILE_LAYOUT,
+        dram_sharded,
+        idx_dram_sharded,
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group J: Default-memory-config regression guards
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+def test_gather_block_sharded_default_mc_no_longer_fatal(device):
+    """Regression guard for the lifted sharded-output TT_FATAL: implicit out must inherit BLOCK_SHARDED."""
+    in_shape = (1, 1, 64, 64)
+    idx_shape = (1, 1, 64, 32)
+    in_mc = _block_sharded(in_shape, device)
+    idx_mc = _block_sharded(idx_shape, device)
+
+    torch.manual_seed(0)
+    x = torch.randn(in_shape, dtype=torch.bfloat16)
+    idx = torch.randint(0, in_shape[-1], idx_shape, dtype=torch.int64)
+    ttnn_in = ttnn.from_torch(x, layout=ttnn.TILE_LAYOUT, dtype=ttnn.bfloat16, device=device, memory_config=in_mc)
+    ttnn_idx = ttnn.from_torch(idx, layout=ttnn.TILE_LAYOUT, dtype=ttnn.uint32, device=device, memory_config=idx_mc)
+
+    result = ttnn.gather(ttnn_in, -1, index=ttnn_idx)
+    assert result.memory_config().memory_layout == ttnn.TensorMemoryLayout.BLOCK_SHARDED
+
+    ref = torch.gather(x, -1, idx)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_equal(ref, got)
+
+
+def test_gather_rm_irregular_width_composite_arm_fires(device):
+    """Regression guard for needs_rm_irregular_composite — RM WIDTH-sharded W=49 must route via composite."""
+    in_shape = (1, 1, 32, 49)
+    idx_shape = (1, 1, 32, 49)
+    in_mc = _width_sharded(in_shape, device, num_cores=1, layout=ttnn.ROW_MAJOR_LAYOUT)
+    idx_mc = _width_sharded(idx_shape, device, num_cores=1, layout=ttnn.ROW_MAJOR_LAYOUT)
+    _run_gather(
+        in_shape,
+        idx_shape,
+        -1,
+        ttnn.ROW_MAJOR_LAYOUT,
+        in_mc,
+        idx_mc,
+        L1_INTERLEAVED,
+        ttnn.bfloat16,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group K: Multi-core RM sharded — RmSingleRowMultiCore on sharded buffers.
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "input_shape, index_shape, in_factory, idx_factory, out_factory",
+    [
+        # Wide W triggers the multi-core kernel; HEIGHT-sharded in/out.
+        pytest.param(
+            (1, 1, 8, 2048),
+            (1, 1, 8, 1024),
+            lambda d: _height_sharded((1, 1, 8, 2048), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _height_sharded((1, 1, 8, 1024), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _height_sharded((1, 1, 8, 1024), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="RM_multicore_height_sharded",
+        ),
+        # Wide W + WIDTH-sharded (regular) → multi-core + per-shard page-size override.
+        pytest.param(
+            (1, 1, 8, 2048),
+            (1, 1, 8, 1024),
+            lambda d: _width_sharded((1, 1, 8, 2048), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _width_sharded((1, 1, 8, 1024), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            _interleaved_l1,
+            id="RM_multicore_width_to_interleaved",
+        ),
+        # Wide W + WIDTH-sharded OUT → exercises noc_async_write_sharded with offset=w_start*elem_size
+        # into a WIDTH-sharded buffer where w_per_core != shard_W in general.
+        pytest.param(
+            (1, 1, 8, 2048),
+            (1, 1, 8, 1024),
+            lambda d: _width_sharded((1, 1, 8, 2048), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _width_sharded((1, 1, 8, 1024), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            lambda d: _width_sharded((1, 1, 8, 1024), d, num_cores=8, layout=ttnn.ROW_MAJOR_LAYOUT),
+            id="RM_multicore_width_sharded_in_out",
+        ),
+    ],
+)
+def test_gather_rm_multicore_sharded(input_shape, index_shape, in_factory, idx_factory, out_factory, device):
+    _run_gather(
+        input_shape,
+        index_shape,
+        -1,
+        ttnn.ROW_MAJOR_LAYOUT,
+        in_factory(device),
+        idx_factory(device),
+        out_factory(device),
+        ttnn.bfloat16,
+        device,
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group L: dim variations — non-last dims via the pre/post-gather transform pipeline.
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("dtype", [ttnn.bfloat16, ttnn.float32], ids=["bf16", "f32"])
+@pytest.mark.parametrize(
+    "input_shape, index_shape, dim, layout",
+    [
+        # dim=2 (H): pre-gather pipeline transposes H↔W before the device op.
+        pytest.param((1, 1, 128, 64), (1, 1, 32, 64), 2, ttnn.TILE_LAYOUT, id="TILE_dim2_H"),
+        pytest.param((1, 1, 128, 64), (1, 1, 32, 64), 2, ttnn.ROW_MAJOR_LAYOUT, id="RM_dim2_H"),
+        # dim=1 (C): pre-gather pipeline transposes C to the W position.
+        pytest.param((1, 8, 32, 64), (1, 4, 32, 64), 1, ttnn.TILE_LAYOUT, id="TILE_dim1_C"),
+        # dim=0 (N): pre-gather pipeline transposes N to the W position.
+        pytest.param((4, 1, 32, 64), (2, 1, 32, 64), 0, ttnn.TILE_LAYOUT, id="TILE_dim0_N"),
+    ],
+)
+def test_gather_dim_variations(input_shape, index_shape, dim, layout, dtype, device):
+    # dim != -1 routes through perform_transpose, which downcasts f32 → bf16 internally
+    # (transpose kernel doesn't have a native f32 path); PCC for f32, bit-exact for bf16.
+    _run_gather(
+        input_shape,
+        index_shape,
+        dim,
+        layout,
+        L1_INTERLEAVED,
+        L1_INTERLEAVED,
+        L1_INTERLEAVED,
+        dtype,
+        device,
+        expect_bit_exact=(dtype == ttnn.bfloat16),
+    )
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group M: Preallocated `out=` — exercises the optional-output-tensor pipeline on
+# TILE and RM (regression guard for #46565 review finding #8).
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "layout",
+    [
+        pytest.param(ttnn.TILE_LAYOUT, id="TILE"),
+        pytest.param(ttnn.ROW_MAJOR_LAYOUT, id="RM"),
+    ],
+)
+def test_gather_preallocated_output(layout, device):
+    """Pre-allocated `out=` tensor must be filled in place and returned."""
+    in_shape = (1, 1, 64, 128)
+    idx_shape = (1, 1, 64, 64)
+    torch.manual_seed(0)
+    x = torch.randn(in_shape, dtype=torch.bfloat16)
+    idx = torch.randint(0, in_shape[-1], idx_shape, dtype=torch.int64)
+    ttnn_in = ttnn.from_torch(x, layout=layout, dtype=ttnn.bfloat16, device=device, memory_config=L1_INTERLEAVED)
+    ttnn_idx = ttnn.from_torch(idx, layout=layout, dtype=ttnn.uint32, device=device, memory_config=L1_INTERLEAVED)
+    out_alloc = ttnn.from_torch(
+        torch.zeros(idx_shape, dtype=torch.bfloat16),
+        layout=layout,
+        dtype=ttnn.bfloat16,
+        device=device,
+        memory_config=L1_INTERLEAVED,
+    )
+
+    result = ttnn.gather(ttnn_in, -1, index=ttnn_idx, out=out_alloc)
+
+    ref = torch.gather(x, -1, idx)
+    got = ttnn.to_torch(result.cpu().to(ttnn.ROW_MAJOR_LAYOUT))
+    assert_equal(ref, got)
+
+
+# ────────────────────────────────────────────────────────────────────────────────
+# Group N: COL_MAJOR shard-orientation preservation (mirrors #48025 for gather).
+# ────────────────────────────────────────────────────────────────────────────────
+
+
+_COL = ttnn.ShardOrientation.COL_MAJOR
+
+
+@pytest.mark.parametrize(
+    "input_shape, index_shape, element_layout, input_factory, index_factory, out_mem_layout",
+    [
+        # Same-layout HEIGHT→HEIGHT: adjust_shard_spec_to_shape fast path (already preserved orientation
+        # pre-#48025; kept as regression guard).
+        pytest.param(
+            (1, 1, 128, 128),
+            (1, 1, 128, 64),
+            ttnn.TILE_LAYOUT,
+            lambda s, d: _height_sharded(s, d, orientation=_COL),
+            lambda s, d: _height_sharded(s, d, orientation=_COL),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            id="TILE_same_layout_H_to_H",
+        ),
+        # Cross-layout TILE HEIGHT→WIDTH: adjust skipped, generate_transpose_shard_spec via hint.
+        pytest.param(
+            (1, 1, 128, 128),
+            (1, 1, 128, 128),
+            ttnn.TILE_LAYOUT,
+            lambda s, d: _height_sharded(s, d, orientation=_COL),
+            lambda s, d: _height_sharded(s, d, orientation=_COL),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            id="TILE_cross_layout_H_to_W",
+        ),
+        # Cross-layout RM HEIGHT→WIDTH: same fix, RM factories.
+        pytest.param(
+            (1, 1, 128, 128),
+            (1, 1, 128, 128),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda s, d: _height_sharded(s, d, layout=ttnn.ROW_MAJOR_LAYOUT, orientation=_COL),
+            lambda s, d: _height_sharded(s, d, layout=ttnn.ROW_MAJOR_LAYOUT, orientation=_COL),
+            ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+            id="RM_cross_layout_H_to_W",
+        ),
+        # Composite arm (W=49 irregular): pre-hop orientation snapshot in gather.cpp.
+        pytest.param(
+            (1, 1, 32, 49),
+            (1, 1, 32, 49),
+            ttnn.ROW_MAJOR_LAYOUT,
+            lambda s, d: _width_sharded(s, d, num_cores=1, layout=ttnn.ROW_MAJOR_LAYOUT, orientation=_COL),
+            lambda s, d: _width_sharded(s, d, num_cores=1, layout=ttnn.ROW_MAJOR_LAYOUT, orientation=_COL),
+            ttnn.TensorMemoryLayout.HEIGHT_SHARDED,
+            id="RM_composite_W49_W_to_H",
+        ),
+    ],
+)
+def test_gather_col_major_orientation_preserved(
+    input_shape, index_shape, element_layout, input_factory, index_factory, out_mem_layout, device
+):
+    """COL_MAJOR orientation is preserved through native and composite synthesis paths (#48025 pattern)."""
+    _run_gather(
+        input_shape,
+        index_shape,
+        -1,
+        element_layout,
+        input_factory(input_shape, device),
+        index_factory(index_shape, device),
+        ttnn.MemoryConfig(out_mem_layout, ttnn.BufferType.L1),
+        ttnn.bfloat16,
+        device,
+        expected_shard_orientation=_COL,
+    )

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.cpp
@@ -4,8 +4,11 @@
 
 #include "gather_device_operation.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
+#include "ttnn/operations/data_movement/transpose/device/transpose_utils.hpp"
 #include "ttnn/device_operation.hpp"
 #include "ttnn/tensor/tensor_ops.hpp"
+
+#include <tt-metalium/constants.hpp>
 
 using namespace tt::tt_metal;
 
@@ -15,9 +18,20 @@ constexpr uint32_t GATHER_WT_THRESHOLD = 60;
 
 GatherDeviceOperation::program_factory_t GatherDeviceOperation::select_program_factory(
     const operation_attributes_t& /*operation_attributes*/, const tensor_args_t& tensor_args) {
-    // Calculate Wt to decide which program factory to use
     const auto input_tensor_shape = tensor_args.input_tensor.padded_shape();
     const auto input_index_tensor_shape = tensor_args.input_index_tensor.padded_shape();
+
+    if (tensor_args.input_tensor.layout() == Layout::ROW_MAJOR) {
+        // Multi-core splits over W_index only (each core owns a slice of every output row);
+        // W_input is mirrored in full to every core, so it gives no parallelism gain.
+        const uint32_t W_index = input_index_tensor_shape[-1];
+        constexpr uint32_t rm_w_threshold = GATHER_WT_THRESHOLD * tt::constants::TILE_WIDTH;
+        if (W_index > rm_w_threshold) {
+            return RmSingleRowMultiCore{};
+        }
+        return RmSingleRowSingleCore{};
+    }
+
     const auto tile_width = tensor_args.input_tensor.tensor_spec().tile().get_width();
     const uint32_t Wt_input = input_tensor_shape[3] / tile_width;
     const uint32_t Wt_index = input_index_tensor_shape[3] / tile_width;
@@ -71,19 +85,29 @@ void GatherDeviceOperation::validate_on_program_cache_miss(
             input_index_tensor_shape[i],
             input_tensor_shape[i]);
     }
+    // Both input and index must share the same layout; mixed TILE/RM is unsupported because
+    // the value/index/output streams are co-iterated stick-for-stick (or tile-for-tile).
     TT_FATAL(
-        attributes.output_mem_config.is_sharded() == false,
-        "Sharded implementation not supported yet. Shard status: {}",
-        attributes.output_mem_config.is_sharded());
-
-    TT_FATAL(
-        tensor_args.input_tensor.layout() == Layout::TILE,
-        "The input tensor must be in tiled format. Current layout: {}",
-        tensor_args.input_tensor.layout());
-    TT_FATAL(
-        tensor_args.input_index_tensor.layout() == Layout::TILE,
-        "The input index tensor must be in tiled format. Current layout: {}",
+        tensor_args.input_tensor.layout() == tensor_args.input_index_tensor.layout(),
+        "Input tensor and index tensor must have the same layout. Got input layout: {} and index layout: {}",
+        tensor_args.input_tensor.layout(),
         tensor_args.input_index_tensor.layout());
+    TT_FATAL(
+        tensor_args.input_tensor.layout() == Layout::TILE || tensor_args.input_tensor.layout() == Layout::ROW_MAJOR,
+        "Gather only supports TILE or ROW_MAJOR layout. Current layout: {}",
+        tensor_args.input_tensor.layout());
+
+    // TILE-only: any user-provided output shard_spec must be tile-aligned. RM operates at
+    // stick granularity, so sub-tile shards are valid there.
+    if (tensor_args.input_tensor.layout() == Layout::TILE && attributes.output_mem_config.is_sharded() &&
+        attributes.output_mem_config.shard_spec().has_value()) {
+        const auto& spec = attributes.output_mem_config.shard_spec().value();
+        TT_FATAL(
+            spec.shape[0] % tt::constants::TILE_HEIGHT == 0 && spec.shape[1] % tt::constants::TILE_WIDTH == 0,
+            "TILE sharded gather requires tile-aligned output shard shape; got ({}, {})",
+            spec.shape[0],
+            spec.shape[1]);
+    }
 
     TT_FATAL(
         (tensor_args.input_tensor.buffer() != nullptr) && (tensor_args.input_index_tensor.buffer() != nullptr),
@@ -105,12 +129,46 @@ GatherDeviceOperation::spec_return_value_t GatherDeviceOperation::compute_output
     if (tensor_args.output_tensor.has_value()) {
         return tensor_args.output_tensor.value().tensor_spec();
     }
-    // Create output tensor specs
-    const auto input_index_tensor_shape = tensor_args.input_index_tensor.logical_shape();
-    const auto tensor_specs = TensorSpec(
-        input_index_tensor_shape,
-        TensorLayout(tensor_args.input_tensor.dtype(), PageConfig(Layout::TILE), attributes.output_mem_config));
-    return tensor_specs;
+
+    const auto output_shape = tensor_args.input_index_tensor.logical_shape();
+    auto output_mem_config = attributes.output_mem_config;
+
+    // Synthesize shard_spec when the user requested sharded output without one. Mirrors slice.
+    if (output_mem_config.is_sharded() && !output_mem_config.shard_spec().has_value()) {
+        const auto& index = tensor_args.input_index_tensor;
+        std::optional<ShardSpec> derived;
+        if (index.is_sharded() && index.memory_config().shard_spec().has_value() &&
+            index.memory_config().memory_layout() == output_mem_config.memory_layout() &&
+            index.logical_shape().rank() == output_shape.rank()) {
+            auto adjusted = ttnn::operations::data_movement::transpose::adjust_shard_spec_to_shape(
+                *index.memory_config().shard_spec(), index.logical_shape(), output_shape);
+            if (adjusted.has_value()) {
+                // TILE factories require tile-aligned shards; otherwise re-derive below.
+                const bool tile_layout = tensor_args.input_tensor.layout() == Layout::TILE;
+                const bool tile_aligned = adjusted->shape[0] % tt::constants::TILE_HEIGHT == 0 &&
+                                          adjusted->shape[1] % tt::constants::TILE_WIDTH == 0;
+                if (!tile_layout || tile_aligned) {
+                    derived = std::move(adjusted);
+                }
+            }
+        }
+        if (!derived.has_value()) {
+            // Preserve index orientation on cross-layout / sub-tile-fallthrough (mirrors #48025).
+            std::optional<ShardOrientation> orientation_hint;
+            if (index.shard_spec().has_value()) {
+                orientation_hint = index.shard_spec()->orientation;
+            }
+            derived = ttnn::operations::data_movement::transpose::generate_transpose_shard_spec(
+                tensor_args.input_tensor, output_shape, output_mem_config.memory_layout(), orientation_hint);
+        }
+        output_mem_config = MemoryConfig(output_mem_config.memory_layout(), output_mem_config.buffer_type(), derived);
+    }
+
+    // Output layout matches the input layout: TILE-in → TILE-out, RM-in → RM-out.
+    return TensorSpec(
+        output_shape,
+        TensorLayout(
+            tensor_args.input_tensor.dtype(), PageConfig(tensor_args.input_tensor.layout()), output_mem_config));
 }
 
 GatherDeviceOperation::tensor_return_value_t GatherDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_device_operation.hpp
@@ -31,7 +31,19 @@ struct GatherDeviceOperation {
             const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
     };
 
-    using program_factory_t = std::variant<SingleRowSingleCore, SingleRowMultiCore>;
+    // ROW_MAJOR variants: row/column split at stick granularity; noc_async_*_sharded with per-shard page size.
+    struct RmSingleRowSingleCore {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+    };
+
+    struct RmSingleRowMultiCore {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t&, const tensor_args_t&, tensor_return_value_t&);
+    };
+
+    using program_factory_t =
+        std::variant<SingleRowSingleCore, SingleRowMultiCore, RmSingleRowSingleCore, RmSingleRowMultiCore>;
 
     static program_factory_t select_program_factory(const operation_attributes_t&, const tensor_args_t&);
 

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/gather_program_factory.cpp
@@ -21,6 +21,29 @@ constexpr const char* kReaderMulti =
     "ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_single_row_multi_core.cpp";
 constexpr const char* kWriterMulti =
     "ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_single_row_multi_core.cpp";
+constexpr const char* kReaderRmSingle =
+    "ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/"
+    "gather_reader_rm_single_row_single_core.cpp";
+constexpr const char* kWriterRmSingle =
+    "ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/"
+    "gather_writer_rm_single_row_single_core.cpp";
+constexpr const char* kReaderRmMulti =
+    "ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/"
+    "gather_reader_rm_single_row_multi_core.cpp";
+constexpr const char* kWriterRmMulti =
+    "ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/"
+    "gather_writer_rm_single_row_multi_core.cpp";
+
+// Per-shard page size for noc_async_*_sharded: shard_W * elem_size on B/W, full row otherwise.
+uint32_t per_shard_page_size_bytes(const Tensor& t, uint32_t row_bytes) {
+    const auto& mc = t.memory_config();
+    if (mc.is_sharded() && (mc.memory_layout() == TensorMemoryLayout::BLOCK_SHARDED ||
+                            mc.memory_layout() == TensorMemoryLayout::WIDTH_SHARDED)) {
+        const auto& spec = mc.shard_spec().value();
+        return spec.shape[1] * t.element_size();
+    }
+    return row_bytes;
+}
 
 }  // namespace
 
@@ -166,9 +189,7 @@ ProgramDescriptor GatherDeviceOperation::SingleRowSingleCore::create_descriptor(
                     writer_desc.emplace_runtime_args(
                         core, {input_tensor_buffer, output_tensor_buffer, work_per_core, id});
                 } else {
-                    // Idle core (work_per_core == 0): the kernel short-circuits, so no
-                    // BufferBinding is registered — that would force a GetRuntimeArgs
-                    // lookup on every cache hit for a core that never reads/writes.
+                    // Idle core: no BufferBinding so GetRuntimeArgs isn't hit on every cache-hit dispatch.
                     reader_desc.emplace_runtime_args(core, {0u, 0u, tile_width, tile_height, id});
                     writer_desc.emplace_runtime_args(core, {0u, 0u, 0u, id});
                 }
@@ -329,6 +350,319 @@ ProgramDescriptor GatherDeviceOperation::SingleRowMultiCore::create_descriptor(
                     reader_desc.emplace_runtime_args(core, {0u, 0u, tile_width, tile_height, id});
                     writer_desc.emplace_runtime_args(core, {0u, 0u, 0u, id});
                 }
+                id++;
+            }
+        }
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    return desc;
+}
+
+// =========================================================================================
+// ROW_MAJOR factories — row-distributed (single-core) and column-distributed (multi-core).
+// =========================================================================================
+ProgramDescriptor GatherDeviceOperation::RmSingleRowSingleCore::create_descriptor(
+    const GatherParams& attributes, const GatherInputs& tensor_args, Tensor& output_tensor) {
+    const tt::DataFormat input_tensor_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_tensor.dtype());
+    const tt::DataFormat input_index_tensor_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_index_tensor.dtype());
+    const tt::DataFormat output_tensor_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
+
+    auto* input_tensor_buffer = tensor_args.input_tensor.buffer();
+    auto* input_index_tensor_buffer = tensor_args.input_index_tensor.buffer();
+    auto* output_tensor_buffer = output_tensor.buffer();
+
+    const uint32_t input_elem_size = tensor_args.input_tensor.element_size();
+    const uint32_t input_index_elem_size = tensor_args.input_index_tensor.element_size();
+    const uint32_t output_elem_size = output_tensor.element_size();
+
+    const auto input_shape = tensor_args.input_tensor.padded_shape();
+    const auto input_index_shape = tensor_args.input_index_tensor.padded_shape();
+
+    const uint32_t W_input = input_shape[-1];
+    const uint32_t W_index = input_index_shape[-1];
+    // H = product of all leading dims. For 4D (pre-transform output) this is N*C*H*1.
+    const uint32_t H = tensor_args.input_index_tensor.physical_volume() / W_index;
+
+    const uint32_t input_stick_size_bytes = W_input * input_elem_size;
+    const uint32_t input_index_stick_size_bytes = W_index * input_index_elem_size;
+    const uint32_t output_stick_size_bytes = W_index * output_elem_size;
+
+    auto* device = tensor_args.input_tensor.device();
+    const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const uint32_t max_number_of_cores = compute_with_storage_grid_size.y * compute_with_storage_grid_size.x;
+
+    CoreRangeSet core_grid =
+        tt::tt_metal::num_cores_to_corerangeset(max_number_of_cores, compute_with_storage_grid_size, true);
+    if (attributes.sub_core_grids.has_value()) {
+        core_grid = attributes.sub_core_grids.value();
+    }
+
+    const auto [total_number_of_cores, core_range, core_group_1, core_group_2, rows_per_core_g1, rows_per_core_g2] =
+        tt::tt_metal::split_work_to_cores(core_grid, H, true);
+    const auto work_groups = {
+        std::make_pair(core_group_1, rows_per_core_g1), std::make_pair(core_group_2, rows_per_core_g2)};
+
+    ProgramDescriptor desc;
+
+    constexpr uint32_t input_tensor_cb_index = tt::CBIndex::c_0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = input_stick_size_bytes,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_tensor_cb_index),
+            .data_format = input_tensor_cb_data_format,
+            .page_size = input_stick_size_bytes,
+        }}},
+    });
+
+    constexpr uint32_t input_index_tensor_cb_index = tt::CBIndex::c_1;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = input_index_stick_size_bytes,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_index_tensor_cb_index),
+            .data_format = input_index_tensor_cb_data_format,
+            .page_size = input_index_stick_size_bytes,
+        }}},
+    });
+
+    constexpr uint32_t output_tensor_cb_index = tt::CBIndex::c_2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = output_stick_size_bytes,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_tensor_cb_index),
+            .data_format = output_tensor_cb_data_format,
+            .page_size = output_stick_size_bytes,
+        }}},
+    });
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        input_tensor_cb_index,
+        input_index_tensor_cb_index,
+        output_tensor_cb_index,
+        H,
+        W_input,
+        W_index,
+        total_number_of_cores,
+        input_elem_size,
+        input_index_elem_size,
+        output_elem_size};
+    TensorAccessorArgs(*input_index_tensor_buffer).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = kReaderRmSingle;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_range;
+    reader_desc.compile_time_args = reader_compile_time_args;
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    std::vector<uint32_t> writer_compile_time_args = {
+        input_tensor_cb_index,
+        output_tensor_cb_index,
+        H,
+        W_input,
+        W_index,
+        total_number_of_cores,
+        input_elem_size,
+        output_elem_size};
+    TensorAccessorArgs(*input_tensor_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(*output_tensor_buffer).append_to(writer_compile_time_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = kWriterRmSingle;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_range;
+    writer_desc.compile_time_args = writer_compile_time_args;
+    writer_desc.config = WriterConfigDescriptor{};
+
+    // Per-shard page sizes drive the multi-shard split in noc_async_*_sharded for B/W RM.
+    const uint32_t input_per_shard_page_size =
+        per_shard_page_size_bytes(tensor_args.input_tensor, input_stick_size_bytes);
+    const uint32_t input_index_per_shard_page_size =
+        per_shard_page_size_bytes(tensor_args.input_index_tensor, input_index_stick_size_bytes);
+    const uint32_t output_per_shard_page_size = per_shard_page_size_bytes(output_tensor, output_stick_size_bytes);
+
+    uint32_t id = 0;
+    for (const auto& [group, work_per_core] : work_groups) {
+        for (const auto& range : group.ranges()) {
+            for (const auto& core : range) {
+                if (work_per_core > 0) {
+                    reader_desc.emplace_runtime_args(
+                        core, {input_index_tensor_buffer, work_per_core, id, input_index_per_shard_page_size});
+                    writer_desc.emplace_runtime_args(
+                        core,
+                        {input_tensor_buffer,
+                         output_tensor_buffer,
+                         work_per_core,
+                         id,
+                         input_per_shard_page_size,
+                         output_per_shard_page_size});
+                } else {
+                    // Idle core: no BufferBinding so cache-hit patching skips this entry.
+                    reader_desc.emplace_runtime_args(core, {0u, 0u, id, input_index_per_shard_page_size});
+                    writer_desc.emplace_runtime_args(
+                        core, {0u, 0u, 0u, id, input_per_shard_page_size, output_per_shard_page_size});
+                }
+                id++;
+            }
+        }
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    return desc;
+}
+
+// Column-distributed: each core owns [w_start, w_start+w_per_core) of every H row (wide W).
+ProgramDescriptor GatherDeviceOperation::RmSingleRowMultiCore::create_descriptor(
+    const GatherParams& attributes, const GatherInputs& tensor_args, Tensor& output_tensor) {
+    const tt::DataFormat input_tensor_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_tensor.dtype());
+    const tt::DataFormat input_index_tensor_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(tensor_args.input_index_tensor.dtype());
+    const tt::DataFormat output_tensor_cb_data_format =
+        tt::tt_metal::datatype_to_dataformat_converter(output_tensor.dtype());
+
+    auto* const input_tensor_buffer = tensor_args.input_tensor.buffer();
+    auto* const input_index_tensor_buffer = tensor_args.input_index_tensor.buffer();
+    auto* const output_tensor_buffer = output_tensor.buffer();
+
+    const uint32_t input_elem_size = tensor_args.input_tensor.element_size();
+    const uint32_t input_index_elem_size = tensor_args.input_index_tensor.element_size();
+    const uint32_t output_elem_size = output_tensor.element_size();
+
+    const auto input_shape = tensor_args.input_tensor.padded_shape();
+    const auto input_index_shape = tensor_args.input_index_tensor.padded_shape();
+
+    const uint32_t W_input = input_shape[-1];
+    const uint32_t W_index = input_index_shape[-1];
+    const uint32_t H = tensor_args.input_index_tensor.physical_volume() / W_index;
+
+    const uint32_t input_stick_size_bytes = W_input * input_elem_size;
+
+    auto* device = tensor_args.input_tensor.device();
+    const auto compute_with_storage_grid_size = device->compute_with_storage_grid_size();
+    const uint32_t max_number_of_cores = compute_with_storage_grid_size.y * compute_with_storage_grid_size.x;
+
+    CoreRangeSet core_grid =
+        tt::tt_metal::num_cores_to_corerangeset(max_number_of_cores, compute_with_storage_grid_size, true);
+    if (attributes.sub_core_grids.has_value()) {
+        core_grid = attributes.sub_core_grids.value();
+    }
+
+    // Split W_index across cores; group_1 holds the larger slice when it doesn't divide evenly.
+    const auto [total_number_of_cores, core_range, core_group_1, core_group_2, w_per_core_g1, w_per_core_g2] =
+        tt::tt_metal::split_work_to_cores(core_grid, W_index, true);
+    const auto work_groups = {std::make_pair(core_group_1, w_per_core_g1), std::make_pair(core_group_2, w_per_core_g2)};
+
+    // CB sticks sized for the LARGEST per-core slice (group 1); group 2 uses a shorter slice.
+    const uint32_t max_w_per_core = std::max(w_per_core_g1, w_per_core_g2);
+    const uint32_t max_input_index_slice_bytes = max_w_per_core * input_index_elem_size;
+    const uint32_t max_output_slice_bytes = max_w_per_core * output_elem_size;
+
+    ProgramDescriptor desc;
+    constexpr uint32_t buffer_scale_factor = 2;
+
+    constexpr uint32_t input_tensor_cb_index = tt::CBIndex::c_0;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = buffer_scale_factor * input_stick_size_bytes,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_tensor_cb_index),
+            .data_format = input_tensor_cb_data_format,
+            .page_size = input_stick_size_bytes,
+        }}},
+    });
+
+    constexpr uint32_t input_index_tensor_cb_index = tt::CBIndex::c_1;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = max_input_index_slice_bytes,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(input_index_tensor_cb_index),
+            .data_format = input_index_tensor_cb_data_format,
+            .page_size = max_input_index_slice_bytes,
+        }}},
+    });
+
+    constexpr uint32_t output_tensor_cb_index = tt::CBIndex::c_2;
+    desc.cbs.push_back(CBDescriptor{
+        .total_size = max_output_slice_bytes,
+        .core_ranges = core_range,
+        .format_descriptors = {{CBFormatDescriptor{
+            .buffer_index = static_cast<uint8_t>(output_tensor_cb_index),
+            .data_format = output_tensor_cb_data_format,
+            .page_size = max_output_slice_bytes,
+        }}},
+    });
+
+    std::vector<uint32_t> reader_compile_time_args = {
+        input_tensor_cb_index,
+        input_index_tensor_cb_index,
+        output_tensor_cb_index,
+        H,
+        W_input,
+        W_index,
+        input_elem_size,
+        input_index_elem_size,
+        output_elem_size};
+    TensorAccessorArgs(*input_index_tensor_buffer).append_to(reader_compile_time_args);
+
+    KernelDescriptor reader_desc;
+    reader_desc.kernel_source = kReaderRmMulti;
+    reader_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_range;
+    reader_desc.compile_time_args = reader_compile_time_args;
+    reader_desc.config = ReaderConfigDescriptor{};
+
+    std::vector<uint32_t> writer_compile_time_args = {
+        input_tensor_cb_index, output_tensor_cb_index, H, W_input, W_index, input_elem_size, output_elem_size};
+    TensorAccessorArgs(*input_tensor_buffer).append_to(writer_compile_time_args);
+    TensorAccessorArgs(*output_tensor_buffer).append_to(writer_compile_time_args);
+
+    KernelDescriptor writer_desc;
+    writer_desc.kernel_source = kWriterRmMulti;
+    writer_desc.source_type = KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_range;
+    writer_desc.compile_time_args = writer_compile_time_args;
+    writer_desc.config = WriterConfigDescriptor{};
+
+    const uint32_t input_per_shard_page_size =
+        per_shard_page_size_bytes(tensor_args.input_tensor, input_stick_size_bytes);
+    const uint32_t input_index_per_shard_page_size =
+        per_shard_page_size_bytes(tensor_args.input_index_tensor, W_index * input_index_elem_size);
+    const uint32_t output_per_shard_page_size = per_shard_page_size_bytes(output_tensor, W_index * output_elem_size);
+
+    uint32_t id = 0;
+    uint32_t w_cursor = 0;  // Cumulative w_start across cores (iterating in group order matches split_work_to_cores).
+    for (const auto& [group, w_per_core] : work_groups) {
+        for (const auto& range : group.ranges()) {
+            for (const auto& core : range) {
+                const uint32_t w_start = w_cursor;
+                if (w_per_core > 0) {
+                    reader_desc.emplace_runtime_args(
+                        core, {input_index_tensor_buffer, w_per_core, w_start, id, input_index_per_shard_page_size});
+                    writer_desc.emplace_runtime_args(
+                        core,
+                        {input_tensor_buffer,
+                         output_tensor_buffer,
+                         w_per_core,
+                         w_start,
+                         id,
+                         input_per_shard_page_size,
+                         output_per_shard_page_size});
+                } else {
+                    reader_desc.emplace_runtime_args(core, {0u, 0u, w_start, id, input_index_per_shard_page_size});
+                    writer_desc.emplace_runtime_args(
+                        core, {0u, 0u, 0u, w_start, id, input_per_shard_page_size, output_per_shard_page_size});
+                }
+                w_cursor += w_per_core;
                 id++;
             }
         }

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_common.hpp
@@ -66,3 +66,17 @@ FORCE_INLINE void write_value_to_tile(
         }
     }
 }
+
+// RM helpers: read/write at a linear element offset within a stick; tile-helper dispatch reused (no face math).
+FORCE_INLINE uint32_t
+get_value_from_stick(const uint32_t l1_read_addr, const uint32_t element_offset, const uint32_t data_format_size) {
+    return get_value_from_tile(l1_read_addr, element_offset, data_format_size);
+}
+
+FORCE_INLINE void write_value_to_stick(
+    const uint32_t l1_write_addr,
+    const uint32_t element_offset,
+    const uint32_t data_format_size,
+    const uint32_t value) {
+    write_value_to_tile(l1_write_addr, element_offset, data_format_size, value);
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_rm_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_rm_single_row_multi_core.cpp
@@ -1,0 +1,86 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gather_common.hpp"
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+
+#include <cstdint>
+
+// RM gather reader — column-distributed multi-core. Each core owns [w_start, w_start+w_per_core) of every row.
+// Reads its index slice via noc_async_read_sharded (per-shard page size); writes gather result to output_cb.
+void kernel_main() {
+    // Runtime args
+    const uint32_t input_index_tensor_buffer_addr = get_arg_val<uint32_t>(0);
+    const uint32_t w_per_core = get_arg_val<uint32_t>(1);
+    const uint32_t w_start = get_arg_val<uint32_t>(2);
+    const uint32_t core_id = get_arg_val<uint32_t>(3);
+    const uint32_t input_index_per_shard_page_size_bytes = get_arg_val<uint32_t>(4);
+
+    // Compile time args
+    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t input_index_tensor_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(2);
+    constexpr uint32_t H = get_compile_time_arg_val(3);
+    constexpr uint32_t W_input = get_compile_time_arg_val(4);
+    constexpr uint32_t W_index = get_compile_time_arg_val(5);
+    constexpr uint32_t input_tensor_data_format_size = get_compile_time_arg_val(6);
+    constexpr uint32_t input_index_tensor_data_format_size = get_compile_time_arg_val(7);
+    constexpr uint32_t output_tensor_data_format_size = get_compile_time_arg_val(8);
+    constexpr auto input_index_tensor_args = TensorAccessorArgs<9>();
+
+    // Idle cores (work_per_core == 0 from split_work_to_cores) skip without touching CBs.
+    if (w_per_core == 0) {
+        return;
+    }
+
+    constexpr uint32_t one_stick = 1;
+    const uint32_t input_index_byte_offset = w_start * input_index_tensor_data_format_size;
+    const uint32_t input_index_slice_bytes = w_per_core * input_index_tensor_data_format_size;
+
+    const auto input_index_accessor =
+        TensorAccessor(input_index_tensor_args, input_index_tensor_buffer_addr, input_index_per_shard_page_size_bytes);
+
+    Noc noc;
+    CircularBuffer input_cb(input_tensor_cb_index);
+    CircularBuffer input_index_cb(input_index_tensor_cb_index);
+    CircularBuffer output_cb(output_tensor_cb_index);
+
+    for (uint32_t h = 0; h < H; h++) {
+        input_index_cb.reserve_back(one_stick);
+        tt::data_movement::common::noc_async_read_sharded(
+            input_index_cb.get_write_ptr(),
+            input_index_accessor,
+            /*src_id=*/h,
+            /*offset=*/input_index_byte_offset,
+            /*size=*/input_index_slice_bytes);
+        noc.async_read_barrier();
+        input_index_cb.push_back(one_stick);
+
+        input_cb.wait_front(one_stick);
+        output_cb.reserve_back(one_stick);
+
+        const uint32_t input_l1_read_addr = input_cb.get_read_ptr();
+        const uint32_t input_index_l1_read_addr = input_index_cb.get_read_ptr();
+        const uint32_t output_l1_write_addr = output_cb.get_write_ptr();
+
+        // Linear gather over this core's slice: output[w] = input[index[w]] for
+        // w in [0, w_per_core). The full input row is in input_cb so any index is valid.
+        for (uint32_t w_local = 0; w_local < w_per_core; w_local++) {
+            const uint32_t global_index =
+                get_value_from_stick(input_index_l1_read_addr, w_local, input_index_tensor_data_format_size);
+            const uint32_t value =
+                get_value_from_stick(input_l1_read_addr, global_index, input_tensor_data_format_size);
+            write_value_to_stick(output_l1_write_addr, w_local, output_tensor_data_format_size, value);
+        }
+
+        output_cb.push_back(one_stick);
+        input_index_cb.pop_front(one_stick);
+        input_cb.pop_front(one_stick);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_rm_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_reader_rm_single_row_single_core.cpp
@@ -1,0 +1,83 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "gather_common.hpp"
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+
+#include <cstdint>
+
+// RM gather reader — row-distributed single-core. Reads index stick, gathers from input_cb, writes to output_cb.
+// I/O via noc_async_*_sharded with per-shard page size; same kernel covers interleaved + H/B/W-sharded.
+void kernel_main() {
+    // Runtime args
+    const uint32_t input_index_tensor_buffer_addr = get_arg_val<uint32_t>(0);
+    const uint32_t core_loop_count = get_arg_val<uint32_t>(1);
+    const uint32_t core_id = get_arg_val<uint32_t>(2);
+    const uint32_t input_index_per_shard_page_size_bytes = get_arg_val<uint32_t>(3);
+
+    // Compile time args
+    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t input_index_tensor_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(2);
+    constexpr uint32_t H = get_compile_time_arg_val(3);
+    constexpr uint32_t W_input = get_compile_time_arg_val(4);
+    constexpr uint32_t W_index = get_compile_time_arg_val(5);
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(6);
+    constexpr uint32_t input_tensor_data_format_size = get_compile_time_arg_val(7);
+    constexpr uint32_t input_index_tensor_data_format_size = get_compile_time_arg_val(8);
+    constexpr uint32_t output_tensor_data_format_size = get_compile_time_arg_val(9);
+    constexpr auto input_index_tensor_args = TensorAccessorArgs<10>();
+
+    constexpr uint32_t one_stick = 1;
+    constexpr uint32_t input_index_stick_size_bytes = W_index * input_index_tensor_data_format_size;
+
+    // Per-shard page size drives the multi-shard split: shard_W * elem_size for B/W, full row otherwise.
+    const auto input_index_accessor =
+        TensorAccessor(input_index_tensor_args, input_index_tensor_buffer_addr, input_index_per_shard_page_size_bytes);
+
+    Noc noc;
+    CircularBuffer input_cb(input_tensor_cb_index);
+    CircularBuffer input_index_cb(input_index_tensor_cb_index);
+    CircularBuffer output_cb(output_tensor_cb_index);
+
+    for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
+        const uint32_t h = core_loop * total_number_of_cores + core_id;
+
+        input_index_cb.reserve_back(one_stick);
+        tt::data_movement::common::noc_async_read_sharded(
+            input_index_cb.get_write_ptr(),
+            input_index_accessor,
+            /*src_id=*/h,
+            /*offset=*/0,
+            /*size=*/input_index_stick_size_bytes);
+        noc.async_read_barrier();
+        input_index_cb.push_back(one_stick);
+
+        input_cb.wait_front(one_stick);
+        output_cb.reserve_back(one_stick);
+
+        const uint32_t input_l1_read_addr = input_cb.get_read_ptr();
+        const uint32_t input_index_l1_read_addr = input_index_cb.get_read_ptr();
+        const uint32_t output_l1_write_addr = output_cb.get_write_ptr();
+
+        // Linear gather: output[w] = input[index[w]]. No tile-face math — RM data is
+        // contiguous and `get_value_from_stick` indexes by element offset directly.
+        for (uint32_t w = 0; w < W_index; w++) {
+            const uint32_t global_index =
+                get_value_from_stick(input_index_l1_read_addr, w, input_index_tensor_data_format_size);
+            const uint32_t value =
+                get_value_from_stick(input_l1_read_addr, global_index, input_tensor_data_format_size);
+            write_value_to_stick(output_l1_write_addr, w, output_tensor_data_format_size, value);
+        }
+
+        output_cb.push_back(one_stick);
+        input_index_cb.pop_front(one_stick);
+        input_cb.pop_front(one_stick);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_rm_single_row_multi_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_rm_single_row_multi_core.cpp
@@ -1,0 +1,75 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+
+#include <cstdint>
+
+// RM gather writer — column-distributed multi-core. Parks FULL input row in input_cb (reader needs any w).
+// Drains the reader's output slice to memory at [w_start, w_start+w_per_core) via noc_async_*_sharded.
+void kernel_main() {
+    // Runtime args
+    const uint32_t input_tensor_buffer_addr = get_arg_val<uint32_t>(0);
+    const uint32_t output_tensor_buffer_addr = get_arg_val<uint32_t>(1);
+    const uint32_t w_per_core = get_arg_val<uint32_t>(2);
+    const uint32_t w_start = get_arg_val<uint32_t>(3);
+    const uint32_t core_id = get_arg_val<uint32_t>(4);
+    const uint32_t input_per_shard_page_size_bytes = get_arg_val<uint32_t>(5);
+    const uint32_t output_per_shard_page_size_bytes = get_arg_val<uint32_t>(6);
+
+    // Compile time args
+    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t H = get_compile_time_arg_val(2);
+    constexpr uint32_t W_input = get_compile_time_arg_val(3);
+    constexpr uint32_t W_index = get_compile_time_arg_val(4);
+    constexpr uint32_t input_tensor_data_format_size = get_compile_time_arg_val(5);
+    constexpr uint32_t output_tensor_data_format_size = get_compile_time_arg_val(6);
+    constexpr auto input_tensor_args = TensorAccessorArgs<7>();
+    constexpr auto output_tensor_args = TensorAccessorArgs<input_tensor_args.next_compile_time_args_offset()>();
+
+    if (w_per_core == 0) {
+        return;
+    }
+
+    constexpr uint32_t one_stick = 1;
+    constexpr uint32_t input_stick_size_bytes = W_input * input_tensor_data_format_size;
+    const uint32_t output_byte_offset = w_start * output_tensor_data_format_size;
+    const uint32_t output_slice_bytes = w_per_core * output_tensor_data_format_size;
+
+    const auto input_accessor =
+        TensorAccessor(input_tensor_args, input_tensor_buffer_addr, input_per_shard_page_size_bytes);
+    const auto output_accessor =
+        TensorAccessor(output_tensor_args, output_tensor_buffer_addr, output_per_shard_page_size_bytes);
+
+    Noc noc;
+    CircularBuffer input_cb(input_tensor_cb_index);
+    CircularBuffer output_cb(output_tensor_cb_index);
+
+    for (uint32_t h = 0; h < H; h++) {
+        input_cb.reserve_back(one_stick);
+        tt::data_movement::common::noc_async_read_sharded(
+            input_cb.get_write_ptr(),
+            input_accessor,
+            /*src_id=*/h,
+            /*offset=*/0,
+            /*size=*/input_stick_size_bytes);
+        noc.async_read_barrier();
+        input_cb.push_back(one_stick);
+
+        output_cb.wait_front(one_stick);
+        tt::data_movement::common::noc_async_write_sharded(
+            output_cb.get_read_ptr(),
+            output_accessor,
+            /*dest_id=*/h,
+            /*offset=*/output_byte_offset,
+            /*size=*/output_slice_bytes);
+        noc.async_write_barrier();
+        output_cb.pop_front(one_stick);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_rm_single_row_single_core.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/device/kernels/dataflow/gather_writer_rm_single_row_single_core.cpp
@@ -1,0 +1,72 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
+#include "api/tensor/noc_traits.h"
+#include "ttnn/operations/data_movement/common/kernels/common.hpp"
+
+#include <cstdint>
+
+// RM gather writer — row-distributed single-core. Parks input rows in input_cb; drains output_cb to memory.
+// I/O via noc_async_*_sharded with per-shard page sizes for B/W RM buffers.
+void kernel_main() {
+    // Runtime args
+    const uint32_t input_tensor_buffer_addr = get_arg_val<uint32_t>(0);
+    const uint32_t output_tensor_buffer_addr = get_arg_val<uint32_t>(1);
+    const uint32_t core_loop_count = get_arg_val<uint32_t>(2);
+    const uint32_t core_id = get_arg_val<uint32_t>(3);
+    const uint32_t input_per_shard_page_size_bytes = get_arg_val<uint32_t>(4);
+    const uint32_t output_per_shard_page_size_bytes = get_arg_val<uint32_t>(5);
+
+    // Compile time args
+    constexpr uint32_t input_tensor_cb_index = get_compile_time_arg_val(0);
+    constexpr uint32_t output_tensor_cb_index = get_compile_time_arg_val(1);
+    constexpr uint32_t H = get_compile_time_arg_val(2);
+    constexpr uint32_t W_input = get_compile_time_arg_val(3);
+    constexpr uint32_t W_index = get_compile_time_arg_val(4);
+    constexpr uint32_t total_number_of_cores = get_compile_time_arg_val(5);
+    constexpr uint32_t input_tensor_data_format_size = get_compile_time_arg_val(6);
+    constexpr uint32_t output_tensor_data_format_size = get_compile_time_arg_val(7);
+    constexpr auto input_tensor_args = TensorAccessorArgs<8>();
+    constexpr auto output_tensor_args = TensorAccessorArgs<input_tensor_args.next_compile_time_args_offset()>();
+
+    constexpr uint32_t one_stick = 1;
+    constexpr uint32_t input_stick_size_bytes = W_input * input_tensor_data_format_size;
+    constexpr uint32_t output_stick_size_bytes = W_index * output_tensor_data_format_size;
+
+    const auto input_accessor =
+        TensorAccessor(input_tensor_args, input_tensor_buffer_addr, input_per_shard_page_size_bytes);
+    const auto output_accessor =
+        TensorAccessor(output_tensor_args, output_tensor_buffer_addr, output_per_shard_page_size_bytes);
+
+    Noc noc;
+    CircularBuffer input_cb(input_tensor_cb_index);
+    CircularBuffer output_cb(output_tensor_cb_index);
+
+    for (uint32_t core_loop = 0; core_loop < core_loop_count; core_loop++) {
+        const uint32_t h = core_loop * total_number_of_cores + core_id;
+
+        input_cb.reserve_back(one_stick);
+        tt::data_movement::common::noc_async_read_sharded(
+            input_cb.get_write_ptr(),
+            input_accessor,
+            /*src_id=*/h,
+            /*offset=*/0,
+            /*size=*/input_stick_size_bytes);
+        noc.async_read_barrier();
+        input_cb.push_back(one_stick);
+
+        output_cb.wait_front(one_stick);
+        tt::data_movement::common::noc_async_write_sharded(
+            output_cb.get_read_ptr(),
+            output_accessor,
+            /*dest_id=*/h,
+            /*offset=*/0,
+            /*size=*/output_stick_size_bytes);
+        noc.async_write_barrier();
+        output_cb.pop_front(one_stick);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/data_movement/gather/gather.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/gather/gather.cpp
@@ -13,6 +13,32 @@
 #include "ttnn/tensor/shape/shape.hpp"
 #include "ttnn/operations/data_movement/slice/slice.hpp"
 #include "ttnn/operations/data_movement/transpose/transpose.hpp"
+#include "ttnn/operations/data_movement/transpose/device/transpose_utils.hpp"
+
+#include <tt-metalium/constants.hpp>
+
+namespace ttnn::detail {
+
+// Fires if either input or index is RM B/W-sharded with non-tile-aligned W; the composite arm then
+// round-trips BOTH tensors through TILE to dodge the noc_async_*_sharded misread. Retires with #47299.
+inline bool needs_rm_irregular_composite(const ttnn::Tensor& input_tensor, const ttnn::Tensor& index_tensor) {
+    if (input_tensor.layout() != tt::tt_metal::Layout::ROW_MAJOR) {
+        return false;
+    }
+    auto is_bw_sharded = [](const ttnn::Tensor& t) {
+        const auto& mc = t.memory_config();
+        return mc.is_sharded() && (mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::BLOCK_SHARDED ||
+                                   mc.memory_layout() == tt::tt_metal::TensorMemoryLayout::WIDTH_SHARDED);
+    };
+    auto last_dim_not_tile = [](const ttnn::Tensor& t) {
+        const auto& s = t.logical_shape();
+        return s.rank() >= 1 && s[-1] % tt::constants::TILE_WIDTH != 0;
+    };
+    return (is_bw_sharded(input_tensor) && last_dim_not_tile(input_tensor)) ||
+           (is_bw_sharded(index_tensor) && last_dim_not_tile(index_tensor));
+}
+
+}  // namespace ttnn::detail
 
 namespace ttnn::operations::data_movement {
 namespace {
@@ -57,9 +83,12 @@ Tensor pre_gather_transform_tensor(
     // If input is not rank 4 transform it to 4D
     const Tensor transformed_tensor = reduction_common::transform_to_4d_tensor(transposed_tensor, is_rank_le_4d);
 
+    // fill_implicit_tile_padding is TILE-only; RM has no tile-face padding so skip it.
+    const bool is_tile = transformed_tensor.layout() == tt::tt_metal::Layout::TILE;
+
     if (padding_index_tensor) {
         // Index tensor padding
-        return ttnn::fill_implicit_tile_padding(transformed_tensor, 0.0f);
+        return is_tile ? ttnn::fill_implicit_tile_padding(transformed_tensor, 0.0f) : transformed_tensor;
     }
 
     // Input tensor processing
@@ -77,7 +106,7 @@ Tensor pre_gather_transform_tensor(
     const Tensor sliced_tensor =
         ttnn::slice(transformed_tensor, start_index, end_index, step, input_tensor.memory_config());
 
-    return ttnn::fill_implicit_tile_padding(sliced_tensor, std::numeric_limits<float>::min());
+    return is_tile ? ttnn::fill_implicit_tile_padding(sliced_tensor, std::numeric_limits<float>::min()) : sliced_tensor;
 }
 
 /**
@@ -127,8 +156,7 @@ Tensor post_gather_transform_tensor(
         // First transpose while still in 4D, then reshape to original higher-dimensional form
         if (!is_dim_last_idx) {
             const auto index_dim = (dim < 0) ? (orig_rank + dim) : dim;
-            const auto dim_adj =
-                (orig_rank <= 4) ? index_dim : (index_dim + (output_tensor.padded_shape().rank() - orig_rank));
+            const auto dim_adj = index_dim + (output_tensor.padded_shape().rank() - orig_rank);
             output_tensor = ttnn::transpose(output_tensor, dim_adj, -1, index_tensor.memory_config());
         }
         ttsl::SmallVector<uint32_t> result_shape(input_shape.cbegin(), input_shape.cend());
@@ -173,6 +201,37 @@ Tensor gather(
     }
     if (original_index_tensor_lshape == ttnn::Shape{}) {
         return input_index_tensor;
+    }
+
+    // Narrow composite hop for RM B/W-sharded inputs with non-tile-aligned W. Retire when #47299 lands.
+    if (ttnn::detail::needs_rm_irregular_composite(input_tensor, input_index_tensor)) {
+        // Snapshot orientation before the staging hop drops shard_spec (mirrors #48025); prefer index.
+        std::optional<tt::tt_metal::ShardOrientation> orientation_hint;
+        const auto& idx_mc = input_index_tensor.memory_config();
+        if (idx_mc.is_sharded() && idx_mc.shard_spec().has_value()) {
+            orientation_hint = idx_mc.shard_spec()->orientation;
+        } else if (input_tensor.memory_config().is_sharded() && input_tensor.memory_config().shard_spec().has_value()) {
+            orientation_hint = input_tensor.memory_config().shard_spec()->orientation;
+        }
+        const auto l1_interleaved =
+            tt::tt_metal::MemoryConfig(tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::L1);
+        const auto tile_input =
+            ttnn::to_layout(ttnn::to_memory_config(input_tensor, l1_interleaved), tt::tt_metal::Layout::TILE);
+        const auto tile_index =
+            ttnn::to_layout(ttnn::to_memory_config(input_index_tensor, l1_interleaved), tt::tt_metal::Layout::TILE);
+        auto requested_mc = memory_config.has_value() ? memory_config.value() : input_tensor.memory_config();
+        const auto tile_out =
+            ttnn::gather(tile_input, dim, tile_index, sparse_grad, l1_interleaved, std::nullopt, sub_core_grids);
+        auto rm_out = ttnn::to_layout(tile_out, tt::tt_metal::Layout::ROW_MAJOR);
+        // Sharded-no-spec requested_mc: synthesize a shard_spec via the same helper compute_output_specs
+        // uses, since to_memory_config does not derive a spec for the actual allocation call.
+        if (requested_mc.is_sharded() && !requested_mc.shard_spec().has_value()) {
+            const auto derived = ttnn::operations::data_movement::transpose::generate_transpose_shard_spec(
+                rm_out, rm_out.padded_shape(), requested_mc.memory_layout(), orientation_hint);
+            requested_mc =
+                tt::tt_metal::MemoryConfig(requested_mc.memory_layout(), requested_mc.buffer_type(), derived);
+        }
+        return ttnn::to_memory_config(rm_out, requested_mc);
     }
 
     // Normalize negative dimension to positive index with bounds check


### PR DESCRIPTION
### Ticket
Link to Github Issue #46565

### Problem
`ttnn::gather` had no universal input/output story — any sharded output rejected with `TT_FATAL ("Output cannot be sharded")`, any `Layout::ROW_MAJOR` input rejected with `TT_FATAL ("input tensor must be in tiled format")`, and a sharded output requested without an explicit `shard_spec` would either fall through to a wrong layout or `TT_FATAL` downstream. Only TILE interleaved in / TILE interleaved out had a native path; every other (layout × sharding) combination was unsupported. The four existing kernels (`gather_{reader,writer}_single_row_{single,multi}_core.cpp`) were TILE-only by construction (face-tiled coordinate math), so there was no path forward for ROW_MAJOR without new kernels. Additionally, once sharded output-spec derivation was in place, a `COL_MAJOR` sharded input feeding a sharded-no-spec output silently flipped the output orientation to `ROW_MAJOR` — same family of bug as #48027 (transpose / permute / slice / repeat).

### What this PR does
- **Add composite-fallback predicate in `gather.cpp::detail`** — `needs_rm_irregular_composite` routes any RM B/W-sharded input *or* index whose last-dim is not `TILE_WIDTH`-aligned through an L1-interleaved TILE hop; every other (layout × sharding) combination flows natively. The composite arm round-trips **both** tensors through TILE to dodge the `noc_async_*_sharded` `pages_per_row` limitation on either side, and synthesizes a `shard_spec` via `generate_transpose_shard_spec` on the closing `to_memory_config` when the requested output is sharded-without-spec (the host op's spec derivation is bypassed on this path). Scoped to W-only since gather's output shape equals the index shape and never overshoots the buffer on H alone.
- **Add four new native RM kernels** — `gather_{reader,writer}_rm_single_row_{single,multi}_core.cpp` operate at stick (= row of W elements) granularity using `noc_async_*_sharded` so the same kernel handles interleaved, HEIGHT-sharded, and (regular) BLOCK/WIDTH-sharded buffers. The single-core variant is row-distributed (each core processes its assigned rows end-to-end), and the multi-core variant is column-distributed (each core owns a contiguous slice `[w_start, w_start + w_per_core)` of every H row). The reader performs the linear gather (`output[w] = input[index[w]]`) via new `get_value_from_stick` / `write_value_to_stick` helpers that reuse the existing datatype dispatch.
- **Pass per-shard `page_size_override` to the RM kernels** — `gather_program_factory.cpp::per_shard_page_size_bytes` computes `shard_W * elem_size` for BLOCK/WIDTH-sharded buffers (full row width otherwise) and feeds it as the `TensorAccessor` page-size override on the input, index, and output. Without this the kernel-side override would defeat the multi-shard split inside `noc_async_*_sharded` and corrupt regular-shape B/W I/O.
- **Synthesize output `shard_spec` in `compute_output_specs`** — when the user requests a sharded output without a spec, the device op derives one via `adjust_shard_spec_to_shape` (when the index tensor is sharded with a matching layout and rank) and falls back to `generate_transpose_shard_spec` otherwise. TILE rejects sub-tile adjusted shards and falls through to the fresh-spec branch.
- **Preserve `COL_MAJOR` shard orientation across synthesized output specs (#48025 pattern)** — both call sites of `generate_transpose_shard_spec` (native `compute_output_specs` fallback + composite arm's closing `to_memory_config`) now thread an explicit `orientation_hint` derived from the index tensor's `shard_spec` (falling back to the input tensor's on the composite path, since the staging hop discards `shard_spec` before the helper is called). Without this, a `COL_MAJOR` sharded input feeding a sharded-no-spec output silently flipped the output orientation to `ROW_MAJOR`. Same-layout sharded-to-sharded paths were unaffected because `adjust_shard_spec_to_shape` already preserves orientation.
- **Lift `TT_FATAL`s in `validate_on_program_cache_miss`** — drop the "Output cannot be sharded" rejection and the TILE-only layout rejection; add an input/index layout-consistency check (mixed TILE/RM unsupported because value/index/output streams are co-iterated stick-for-stick) and a tile-alignment check on user-supplied TILE sharded output `shard_spec`s.
- **Route `Layout::ROW_MAJOR` in `select_program_factory`** — TILE branches unchanged (`Wt > GATHER_WT_THRESHOLD` → `SingleRowMultiCore`, else `SingleRowSingleCore`); RM pivots on `W_index > GATHER_WT_THRESHOLD * TILE_WIDTH` (= 60 × 32 = 1920 elements) only, since the multi-core variant is column-distributed and `W_input` is mirrored in full to every core (no parallelism gain from `W_input`).
- **Skip `fill_implicit_tile_padding` on RM** — `pre_gather_transform_tensor` now checks `Layout::TILE` before calling `ttnn::fill_implicit_tile_padding`; RM has no tile-face padding so the helper would `TT_FATAL` ("FillPad should only be used for tile layout").
- **Cleanup in `post_gather_transform_tensor`** — dropped an unreachable ternary branch inside the `orig_rank > 4` arm (the inner `(orig_rank <= 4) ? ... : ...` was provably always taking the second branch).
- **Add comprehensive test suite (`test_gather_universal_io.py`, nightly)** — 81 cases organised into 13 lettered groups (A–N, slice/permute convention) covering: TILE interleaved + sharded I/O (bf16 + f32); TILE sharded-out without `shard_spec` (HEIGHT/WIDTH/BLOCK); TILE explicit shard configs (uneven splits and W-sharded inputs); RM interleaved single-core + multi-core + sharded I/O (bf16 + f32); RM sharded-out without spec (HEIGHT/BLOCK); RM sharded-in → sharded-no-spec-out (compute_output_specs derivation regression); irregular logical shapes (last-two not tile multiples) across {interleaved, HEIGHT, WIDTH, BLOCK} × {TILE, RM} (RM B/W routes composite); multi-batch / multi-channel sharded inputs; rank-5 sharded inputs; DRAM-sharded TILE inputs; default-mc regression guards (BLOCK_SHARDED inherits implicit out; RM W=49 fires composite); multi-core RM sharded variants (HEIGHT in/out, WIDTH in → interleaved, WIDTH in/out exercising `noc_async_write_sharded` with `w_per_core != shard_W`); pre-allocated `out=` on TILE and RM; `dim ∈ {0, 1, 2}` non-last-dim coverage (bf16 + f32); and `COL_MAJOR` shard-orientation preservation across native and composite synthesis paths. The main matrix runs **bf16** with **f32** mixed into Groups A, C, and L; bf8b is not covered natively because `fill_implicit_tile_padding` rejects BFP.

### Tests
All on Wormhole B0 (`tests/ttnn/nightly/unit_tests/operations/data_movement/test_gather_universal_io.py`):
- `test_gather_tile` — 18 cases (interleaved baselines, TILE HEIGHT/BLOCK sharded in/out, cross-layout, implicit inheritance × **bf16 + f32**) — **PASSED**
- `test_gather_tile_interleaved_to_sharded_no_spec` — 3 cases (HEIGHT/WIDTH/BLOCK × bf16) — **PASSED**
- `test_gather_rm` — 14 cases (RM interleaved single + multi-core, HEIGHT-sh, BLOCK-sh tile-aligned, cross-layout × **bf16 + f32**) — **PASSED**
- `test_gather_rm_interleaved_to_sharded_no_spec` — 2 cases (HEIGHT/BLOCK × bf16) — **PASSED**
- `test_gather_rm_sharded_in_sharded_no_spec_out` — 1 case (RM HEIGHT-sharded-in → HEIGHT no-spec-out, `compute_output_specs` derivation regression) — **PASSED**
- `test_gather_irregular_shapes_interleaved` — 4 cases (2 NoC-aligned irregular shapes × TILE/RM) — **PASSED**
- `test_gather_irregular_shapes_sharded` — 12 cases (2 shapes × HEIGHT/WIDTH/BLOCK × TILE/RM; RM B/W routes composite) — **PASSED**
- `test_gather_tile_explicit_sharded_inputs` — 2 cases (TILE HEIGHT-sharded 3-core uneven split, TILE WIDTH-sharded 4-core even split) — **PASSED**
- `test_gather_multi_batch_channel` — 2 cases (TILE N>1 height, TILE C>1 block) — **PASSED**
- `test_gather_higher_rank` — 2 cases (rank-5 TILE interleaved, rank-5 TILE HEIGHT-sharded) — **PASSED**
- `test_gather_higher_rank_to_sharded_no_spec` — 1 case (rank-5 TILE → HEIGHT-sharded out without spec) — **PASSED**
- `test_gather_dram_sharded_input` — 1 case (DRAM HEIGHT-sharded TILE input) — **PASSED**
- `test_gather_block_sharded_default_mc_no_longer_fatal` — 1 case (implicit-inheritance regression guard) — **PASSED**
- `test_gather_rm_irregular_width_composite_arm_fires` — 1 case (RM WIDTH-sharded W=49 → `needs_rm_irregular_composite`) — **PASSED**
- `test_gather_rm_multicore_sharded` — 3 cases (wide-W RM HEIGHT-sh in/out, wide-W RM WIDTH-sh → interleaved, wide-W RM WIDTH-sh in/out exercising `noc_async_write_sharded` with `w_per_core != shard_W`) — **PASSED**
- `test_gather_dim_variations` — 8 cases (`dim ∈ {0, 1, 2}` × bf16 + f32 on TILE/RM) — **PASSED**
- `test_gather_preallocated_output` — 2 cases (pre-allocated `out=` on TILE and RM, validates host-side optional-output pipeline) — **PASSED**
- `test_gather_col_major_orientation_preserved` — 4 cases (TILE same-layout fast path, TILE + RM cross-layout via hint, RM composite arm W=49 pre-hop snapshot; each asserts output `shard_spec.orientation == COL_MAJOR`) — **PASSED**

Total: **81 passed in ~19s**.

Pre-existing `tests/ttnn/unit_tests/operations/data_movement/test_gather.py` regression-clean (no changes to TILE-only paths).

One geometry deferred: `RM HEIGHT-sharded` with `W·E` not 16-byte aligned (e.g. `W = 97`, bf16). This is a `noc_async_*_sharded` helper-side limitation in `common.hpp` that affects `gather` / `slice` / `transpose` / `permute` identically — tracked under #47299. The parametrization for `(1, 1, 32, 97)` was removed from `_IRREGULAR_SHAPES` pending that upgrade and will be re-added when the helper fix lands.

### Notes for Reviewers
- The full gap analysis and routing tables (before/after) live on issue #46565 — recommended reading alongside the diff.
- Gather's pipeline adds **four new RM kernel files** because the pre-existing kernels were TILE-only with face-tiled coordinate math, and has **no `needs_sharded_output_reshard` equivalent** because the output shape always equals the **index** shape, so `compute_output_specs` can always seed a valid spec from the index tensor or via `generate_transpose_shard_spec`.
- Shared with the data-movement op family: `adjust_shard_spec_to_shape`, `generate_transpose_shard_spec` + its `orientation_hint` parameter (from `transpose/device/transpose_utils.hpp`), `tt::data_movement::common::noc_async_*_sharded` (from `common/kernels/common.hpp`), and the per-shard `page_size_override` pattern.
- The `needs_rm_irregular_composite` predicate retires when the cross-op helper fix in #47299 lands (same `pages_per_row` line; W-misalignment goes from composite to native).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mouliraj/gather_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mouliraj/gather_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mouliraj/gather_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mouliraj/gather_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=mouliraj/gather_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:mouliraj/gather_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mouliraj/gather_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mouliraj/gather_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mouliraj/gather_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mouliraj/gather_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mouliraj/gather_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mouliraj/gather_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mouliraj/gather_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mouliraj/gather_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mouliraj/gather_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mouliraj/gather_fix)
