### PR TITLE
[skip ci] Disable Galaxy DiT Qwen-Image perf test (bricks runners with TLB-window leak)

### DIFF
--- a/tests/pipeline_reorg/galaxy_perf_tests.yaml
+++ b/tests/pipeline_reorg/galaxy_perf_tests.yaml
@@ -77,19 +77,26 @@
   save-perf-data: true
   model-type: mochi
 
-- name: Galaxy DiT Qwen-Image model perf tests
-  cmd: |
-    export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
-    pytest models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k "4x8" --timeout=1000
-  model: qwenimage
-  skus:
-    wh_galaxy_perf:
-      timeout: 20
-  owner_id: U08TED0JM9D # Samuel Adesoye
-  team: models
-  arch: wormhole_b0
-  save-perf-data: true
-  model-type: QwenImage
+# TEMPORARILY DISABLED - see https://github.com/tenstorrent/tt-metal/issues/47355
+# The 4x8 Qwen-Image pipeline perf test hangs the device mid-pipeline in an
+# uninterruptible driver call (pytest --timeout does not fire). The hung process is
+# SIGKILLed by the CI action timeout, leaking TLB windows that `tt-smi reset` reports
+# as successfully reset but does not actually reclaim. This bricks the runner so that
+# all subsequent jobs fail with "Failed to allocate TLB window (tt_tlb_alloc -12)".
+# Re-enable once the hang is fixed / the runner reset reliably reclaims TLB windows.
+# - name: Galaxy DiT Qwen-Image model perf tests
+#   cmd: |
+#     export TT_DIT_CACHE_DIR="/tmp/TT_DIT_CACHE"
+#     pytest models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k "4x8" --timeout=1000
+#   model: qwenimage
+#   skus:
+#     wh_galaxy_perf:
+#       timeout: 20
+#   owner_id: U08TED0JM9D # Samuel Adesoye
+#   team: models
+#   arch: wormhole_b0
+#   save-perf-data: true
+#   model-type: QwenImage
 
 - name: Galaxy DeepSeek V3 decode perf tests
   cmd: export MESH_DEVICE=TG && uv pip install -r models/demos/deepseek_v3/reference/deepseek/requirements.txt && pytest models/demos/deepseek_v3/demo/test_decode_demo_perf.py --timeout=1200


### PR DESCRIPTION
## What

Comments out the **`Galaxy DiT Qwen-Image model perf tests`** entry (`-k "4x8"`) in `tests/pipeline_reorg/galaxy_perf_tests.yaml`, with an inline note pointing to #47355.

## Why

This test (`models/tt_dit/tests/models/qwenimage/test_performance_qwenimage.py -k "4x8"`) hangs the device mid-pipeline in an **uninterruptible driver call** — `pytest --timeout=1000` never fires, and only the CI action 60-min timeout kills it (via SIGKILL). The killed process **leaks TLB windows**; the per-job `tt-smi reset` then reports *"reset was successful"* but does **not** reclaim them, so every subsequent job on that runner fails with:

```
RuntimeError: Failed to allocate TLB window ... tt_tlb_alloc failed with error code -12
```

Over the last 30 days this test **hung 27 times** across nearly all WH Galaxy staging runners and directly bricked multiple runners for hours/days (e.g. `OM1-01A03-STGWH02`, `g05glx04`, `OM1-01A02-STGWH01`). Full analysis and root cause in #47355.

## Scope

- Disables only the 4x8 Galaxy variant in the perf pipeline. The T3000 `2x4` variant in `run_t3000_perf_tests.sh` is left untouched.
- Temporary — revert once the hang is fixed and/or the runner reset reliably reclaims TLB windows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=mtairum/disable-galaxy-qwenimage-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:mtairum/disable-galaxy-qwenimage-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=mtairum/disable-galaxy-qwenimage-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:mtairum/disable-galaxy-qwenimage-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=mtairum/disable-galaxy-qwenimage-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:mtairum/disable-galaxy-qwenimage-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=mtairum/disable-galaxy-qwenimage-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:mtairum/disable-galaxy-qwenimage-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=mtairum/disable-galaxy-qwenimage-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:mtairum/disable-galaxy-qwenimage-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=mtairum/disable-galaxy-qwenimage-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:mtairum/disable-galaxy-qwenimage-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=mtairum/disable-galaxy-qwenimage-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:mtairum/disable-galaxy-qwenimage-perf-tlb-hang)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=mtairum/disable-galaxy-qwenimage-perf-tlb-hang)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:mtairum/disable-galaxy-qwenimage-perf-tlb-hang)