### PR TITLE
[Cleanup] Finish Device 2.0 migration of data_movement/sharded kernels

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_nd_sharded_blocks.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_nd_sharded_blocks.cpp
@@ -7,7 +7,6 @@
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
-#include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 
 void kernel_main() {
     // run-time args

--- a/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/sharded/device/kernels/dataflow/reader_unary_stick_layout_sharded_blocks_interleaved_start_id.cpp
@@ -123,11 +123,15 @@ void kernel_main() {
                 }
             }
         }
-
     }
-    // Reset the sticky NOC_PACKET_TAG register for downstream untagged reads.
-    // No Device 2.0 wrapper exists for this config-only register write; this is
-    // not a NoC transaction.
-    noc_async_read_set_trid(0);
+    // Reset the sticky NOC_PACKET_TAG register for downstream untagged reads
+    UnicastEndpoint self_ep;
+    noc.set_async_read_state<NocOptions::TXN_ID>(
+        self_ep,
+        /*size_bytes=*/0,
+        {.noc_x = (uint32_t)my_x[noc.get_noc_id()],
+         .noc_y = (uint32_t)my_y[noc.get_noc_id()],
+         .addr = 0},
+        NocOptVals{.trid = 0});
     cb_in0.push_back(block_height);
 }


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Relates to issue #45003

Two fixes in`ttnn/operations/data_movement/sharded` and its borrower `interleaved_to_sharded` to fully migrate data_movement/sharded to the Device 2.0 API.

- the `noc_async_read_set_trid(0)` register reset is now expressed as `Noc::set_async_read_state<NocOptions::TXN_ID>(self_ep, /*size_bytes=*/0, {…, .addr = 0}, NocOptVals{.trid = 0})`. The state-setter internally executes `noc_async_read_set_trid(0, noc_id_)`

- `reader_unary_nd_sharded_blocks.cpp` dropped a dead `#include "sharding_addrgen.hpp"`. The kernel references none of the header's symbols; the include was the only remaining legacy API exposure pulled into its translation unit.

### Notes for reviewers


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/finish-data-movement-sharded-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/finish-data-movement-sharded-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/finish-data-movement-sharded-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/finish-data-movement-sharded-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/finish-data-movement-sharded-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/finish-data-movement-sharded-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/finish-data-movement-sharded-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/finish-data-movement-sharded-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/finish-data-movement-sharded-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/finish-data-movement-sharded-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/finish-data-movement-sharded-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/finish-data-movement-sharded-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/finish-data-movement-sharded-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/finish-data-movement-sharded-device2-migration)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/finish-data-movement-sharded-device2-migration)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/finish-data-movement-sharded-device2-migration)