### PR TITLE
[Feature] Leave the NOC0 DRAM endpoint to the syseng firmware

### DIFF
--- a/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
+++ b/tests/tt_metal/tt_metal/api/test_dram_kernels.cpp
@@ -79,6 +79,29 @@ protected:
         return (static_cast<uint64_t>(t[1]) << 32) | t[0];
     }
 
+    // Logical subchannel indices of `bank` that run a DRISC kernel: every DRAM endpoint except the
+    // NOC0 worker endpoint (logical subchannel 0), which is owned by the syseng firmware and left in
+    // reset, so no DRISC kernel can be launched there. DRISC tests must only target these.
+    std::vector<uint32_t> usable_dram_endpoints(uint32_t bank) const {
+        const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(mesh_device_->build_id());
+        const uint32_t noc0_sub = logical_dram_endpoint_for_noc(soc_desc, bank, NOC::NOC_0).y;
+        const uint32_t num_endpoints = soc_desc.get_dram_compute_grid_size().y;
+        std::vector<uint32_t> usable;
+        for (uint32_t sub = 0; sub < num_endpoints; ++sub) {
+            if (sub != noc0_sub) {
+                usable.push_back(sub);
+            }
+        }
+        return usable;
+    }
+
+    // First DRISC-usable endpoint subchannel for `bank` (skips the NOC0 endpoint).
+    uint32_t first_usable_dram_endpoint(uint32_t bank) const {
+        const std::vector<uint32_t> usable = usable_dram_endpoints(bank);
+        TT_FATAL(!usable.empty(), "DRAM bank {} has no DRISC-usable endpoint (only the NOC0 endpoint?)", bank);
+        return usable.front();
+    }
+
     distributed::MeshDevice* mesh_device_{};
     IDevice* device_{};
     distributed::MeshCoordinateRange device_range_{distributed::MeshCoordinate(0, 0)};
@@ -94,8 +117,8 @@ class DramKernelDRISCBWFixture : public DramKernelFixture, public testing::WithP
 // then read it back via the host and verify.
 TEST_F(DramKernelFixture, DramKernelWriteToL1) {
     constexpr uint32_t kMagicValue = 0xDEADBEEF;
-    // Pick the first logical DRAM worker core (bank=0, subchannel=0).
-    CoreCoord logical_dram_core{0, 0};
+    // Pick the first DRISC-usable endpoint of bank 0 (subchannel 0 is the syseng-owned NOC0 endpoint).
+    CoreCoord logical_dram_core{0, first_usable_dram_endpoint(0)};
     auto virtual_dram_core = mesh_device_->virtual_core_from_logical_core(logical_dram_core, CoreType::DRAM);
 
     Program program = CreateProgram();
@@ -124,13 +147,15 @@ TEST_F(DramKernelFixture, DramKernelOnMultipleCores) {
     const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(mesh_device_->build_id());
     auto dram_compute_grid = soc_desc.get_dram_compute_grid_size();
     uint32_t num_banks = std::min(static_cast<size_t>(dram_compute_grid.x), static_cast<size_t>(4));
-    uint32_t num_endpoints = dram_compute_grid.y;
+    // Skip the syseng-owned NOC0 endpoint; only DRISC-usable subchannels run a kernel.
+    const std::vector<uint32_t> usable_endpoints = usable_dram_endpoints(0);
 
-    for (uint32_t row = 0; row < num_endpoints; row++) {
+    for (uint32_t i = 0; i < usable_endpoints.size(); i++) {
+        const uint32_t row = usable_endpoints[i];
         for (uint32_t col = 0; col < num_banks; col++) {
             CoreCoord logical_dram_core{col, row};
             auto virtual_dram_core = mesh_device_->virtual_core_from_logical_core(logical_dram_core, CoreType::DRAM);
-            uint32_t expected_value = kMagicBase + (row * num_banks) + col;
+            uint32_t expected_value = kMagicBase + (i * num_banks) + col;
 
             Program program = CreateProgram();
             CreateKernel(
@@ -159,7 +184,7 @@ TEST_F(DramKernelFixture, DramKernelOnMultipleCores) {
 // Tensix reads it using the 5-arg noc_read_with_state to preserve the 64-bit DRAM_L1_NOC_OFFSET address.
 TEST_F(DramKernelFixture, DramKernelTensixReadFromDRISCL1) {
     constexpr uint32_t kMagicValue = 0xCAFEBABE;
-    CoreCoord logical_core_drisc{0, 0};
+    CoreCoord logical_core_drisc{0, first_usable_dram_endpoint(0)};
     CoreCoord logical_core_tensix{0, 0};
     CoreCoord drisc_virtual = device_->virtual_core_from_logical_core(logical_core_drisc, CoreType::DRAM);
 
@@ -197,7 +222,7 @@ TEST_F(DramKernelFixture, DramKernelTensixReadFromDRISCL1) {
 // Host writes magic value to Tensix L1, then DRISC reads it into DRISC L1
 TEST_F(DramKernelFixture, DramKernelDRISCReadFromTensixL1) {
     constexpr uint32_t kMagicValue = 0xDEADBEEF;
-    CoreCoord logical_core_drisc{0, 0};
+    CoreCoord logical_core_drisc{0, first_usable_dram_endpoint(0)};
     CoreCoord logical_core_tensix{0, 0};
     CoreCoord tensix_virtual = device_->virtual_core_from_logical_core(logical_core_tensix, CoreType::WORKER);
     CoreCoord drisc_virtual = device_->virtual_core_from_logical_core(logical_core_drisc, CoreType::DRAM);
@@ -233,14 +258,16 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCWriteToDRAM) {
     const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(mesh_device_->build_id());
     auto dram_compute_grid = soc_desc.get_dram_compute_grid_size();
     uint32_t num_banks = dram_compute_grid.x;
-    uint32_t num_endpoints = std::min(GetParam(), static_cast<uint32_t>(dram_compute_grid.y));
+    // Skip the syseng-owned NOC0 endpoint; only DRISC-usable subchannels run a kernel.
+    const std::vector<uint32_t> usable_endpoints = usable_dram_endpoints(0);
+    uint32_t num_endpoints = std::min(GetParam(), static_cast<uint32_t>(usable_endpoints.size()));
 
     const uint32_t bytes_per_iter = 64 * 1024;
     constexpr uint32_t iters = 1000;
     const uint32_t total_bytes_per_core = iters * bytes_per_iter;
     const uint32_t elements_per_endpoint = bytes_per_iter / sizeof(uint32_t);
 
-    // Endpoints within the same bank share GDDR address space - partition by endpoint row.
+    // Endpoints within the same bank share GDDR address space - partition by active-endpoint index.
     TT_FATAL(
         dram_unreserved_size_ >= num_endpoints * total_bytes_per_core,
         "Not enough DRAM: need {} bytes per bank, have {}",
@@ -262,15 +289,16 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCWriteToDRAM) {
     // Unique data per endpoint proves each endpoint has independent L1.
     std::vector<uint32_t> data =
         create_random_vector_of_bfloat16(num_banks * num_endpoints * bytes_per_iter, 1000.0f, seed);
-    auto endpoint_offset = [&](uint32_t row, uint32_t col) { return (row * num_banks + col) * elements_per_endpoint; };
+    auto endpoint_offset = [&](uint32_t i, uint32_t col) { return (i * num_banks + col) * elements_per_endpoint; };
     Program program = CreateProgram();
 
-    for (uint32_t row = 0; row < num_endpoints; row++) {
+    for (uint32_t i = 0; i < num_endpoints; i++) {
+        const uint32_t row = usable_endpoints[i];
         for (uint32_t col = 0; col < num_banks; col++) {
             CoreCoord logical_core{col, row};
             CoreCoord virtual_core = device_->virtual_core_from_logical_core(logical_core, CoreType::DRAM);
             MetalContext::instance().get_cluster().write_core(
-                data.data() + endpoint_offset(row, col),
+                data.data() + endpoint_offset(i, col),
                 bytes_per_iter,
                 tt_cxy_pair(mesh_device_->build_id(), virtual_core),
                 drisc_l1_noc_addr_);
@@ -279,8 +307,8 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCWriteToDRAM) {
                 "tests/tt_metal/tt_metal/test_kernels/misc/drisc_l1_dram_dma.cpp",
                 logical_core,
                 DramConfig{.noc = NOC::NOC_0, .defines = {{"L1_TO_GDDR_WRITE_TEST", "1"}}});
-            // Partition DRAM gddr dst addr by endpoint row
-            const uint32_t dram_dst_gddr_addr = dram_addr + row * total_bytes_per_core;
+            // Partition DRAM gddr dst addr by active-endpoint index
+            const uint32_t dram_dst_gddr_addr = dram_addr + i * total_bytes_per_core;
             SetRuntimeArgs(program, k_id, logical_core, {dram_dst_gddr_addr, drisc_l1_base_, bytes_per_iter, iters});
         }
     }
@@ -294,9 +322,10 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCWriteToDRAM) {
 
     // Verify all DRISCs writes to DRAM and calculate
     // the aggregate write bandwidth from DRISC L1 to DRAM across all endpoints
-    for (uint32_t row = 0; row < num_endpoints; row++) {
+    for (uint32_t i = 0; i < num_endpoints; i++) {
+        const uint32_t row = usable_endpoints[i];
         for (uint32_t col = 0; col < num_banks; col++) {
-            auto begin = data.begin() + endpoint_offset(row, col);
+            auto begin = data.begin() + endpoint_offset(i, col);
             std::vector<uint32_t> endpoint_data(begin, begin + elements_per_endpoint);
             uint32_t dram_channel =
                 device_->dram_channel_from_logical_core(CoreCoord{col, 0});  // channel maps by bank (col)
@@ -305,7 +334,7 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCWriteToDRAM) {
             tt::tt_metal::detail::ReadFromDeviceDRAMChannel(
                 device_,
                 dram_channel,
-                dram_addr + bytes_per_iter * (iters - 1) + total_bytes_per_core * row,
+                dram_addr + bytes_per_iter * (iters - 1) + total_bytes_per_core * i,
                 bytes_per_iter,
                 result);
             EXPECT_EQ(result, endpoint_data)
@@ -332,14 +361,16 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCReadFromDRAM) {
     const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(mesh_device_->build_id());
     auto dram_compute_grid = soc_desc.get_dram_compute_grid_size();
     uint32_t num_banks = dram_compute_grid.x;
-    uint32_t num_endpoints = std::min(GetParam(), static_cast<uint32_t>(dram_compute_grid.y));
+    // Skip the syseng-owned NOC0 endpoint; only DRISC-usable subchannels run a kernel.
+    const std::vector<uint32_t> usable_endpoints = usable_dram_endpoints(0);
+    uint32_t num_endpoints = std::min(GetParam(), static_cast<uint32_t>(usable_endpoints.size()));
 
     const uint32_t bytes_per_iter = 64 * 1024;
     constexpr uint32_t iters = 1000;
     const uint32_t total_bytes_per_core = iters * bytes_per_iter;
     const uint32_t elements_per_endpoint = bytes_per_iter / sizeof(uint32_t);
 
-    // Each endpoint within the same bank reads from its own DRAM slot (partitioned by row).
+    // Each active endpoint within the same bank reads from its own DRAM slot (partitioned by index).
     TT_FATAL(
         dram_unreserved_size_ >= num_endpoints * bytes_per_iter,
         "Not enough DRAM for {} endpoint source regions",
@@ -360,21 +391,22 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCReadFromDRAM) {
     // Unique data per endpoint proves each endpoint has independent L1.
     std::vector<uint32_t> data =
         create_random_vector_of_bfloat16(num_banks * num_endpoints * bytes_per_iter, 1000.0f, seed);
-    auto endpoint_offset = [&](uint32_t row, uint32_t col) { return (row * num_banks + col) * elements_per_endpoint; };
+    auto endpoint_offset = [&](uint32_t i, uint32_t col) { return (i * num_banks + col) * elements_per_endpoint; };
 
     // Write data from DRISCs to read to all DRAM Banks
     for (uint32_t col = 0; col < num_banks; col++) {
         uint32_t dram_channel = device_->dram_channel_from_logical_core(CoreCoord{col, 0});
-        for (uint32_t row = 0; row < num_endpoints; row++) {
-            auto begin = data.begin() + endpoint_offset(row, col);
+        for (uint32_t i = 0; i < num_endpoints; i++) {
+            auto begin = data.begin() + endpoint_offset(i, col);
             std::vector<uint32_t> endpoint_data(begin, begin + elements_per_endpoint);
             tt::tt_metal::detail::WriteToDeviceDRAMChannel(
-                device_, dram_channel, dram_addr + row * bytes_per_iter, endpoint_data);
+                device_, dram_channel, dram_addr + i * bytes_per_iter, endpoint_data);
         }
     }
 
     Program program = CreateProgram();
-    for (uint32_t row = 0; row < num_endpoints; row++) {
+    for (uint32_t i = 0; i < num_endpoints; i++) {
+        const uint32_t row = usable_endpoints[i];
         for (uint32_t col = 0; col < num_banks; col++) {
             CoreCoord logical_core{col, row};
             auto k_id = CreateKernel(
@@ -382,8 +414,8 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCReadFromDRAM) {
                 "tests/tt_metal/tt_metal/test_kernels/misc/drisc_l1_dram_dma.cpp",
                 logical_core,
                 DramConfig{.noc = NOC::NOC_0});
-            // Partition DRAM gddr src addr by endpoint row
-            const uint32_t dram_src_gddr_addr = dram_addr + row * bytes_per_iter;
+            // Partition DRAM gddr src addr by active-endpoint index
+            const uint32_t dram_src_gddr_addr = dram_addr + i * bytes_per_iter;
             SetRuntimeArgs(program, k_id, logical_core, {dram_src_gddr_addr, drisc_l1_base_, bytes_per_iter, iters});
         }
     }
@@ -396,10 +428,11 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCReadFromDRAM) {
     uint64_t max_cycles = 0;
 
     // Verify all reads into DRISC L1 over DMA from DRAM are correct
-    for (uint32_t row = 0; row < num_endpoints; row++) {
+    for (uint32_t i = 0; i < num_endpoints; i++) {
+        const uint32_t row = usable_endpoints[i];
         for (uint32_t col = 0; col < num_banks; col++) {
             CoreCoord virtual_core = device_->virtual_core_from_logical_core({col, row}, CoreType::DRAM);
-            auto begin = data.begin() + endpoint_offset(row, col);
+            auto begin = data.begin() + endpoint_offset(i, col);
             std::vector<uint32_t> endpoint_data(begin, begin + elements_per_endpoint);
             std::vector<uint32_t> result(elements_per_endpoint);
             MetalContext::instance().get_cluster().read_core(
@@ -420,11 +453,13 @@ TEST_P(DramKernelDRISCBWFixture, DramKernelDRISCReadFromDRAM) {
         max_cycles);
 }
 
+// At most 2 DRISC-usable endpoints per bank: subchannel 0 is the syseng-owned NOC0 endpoint, leaving
+// the NOC1 endpoint and the free subchannel. The per-test min() against usable_dram_endpoints() also
+// clamps this, so a larger value would just repeat the 2-endpoint case.
 INSTANTIATE_TEST_SUITE_P(
-    EndpointSweep,
-    DramKernelDRISCBWFixture,
-    testing::Values(1u, 2u, 3u),
-    [](const testing::TestParamInfo<uint32_t>& info) { return std::to_string(info.param) + "_endpoints"; });
+    EndpointSweep, DramKernelDRISCBWFixture, testing::Values(1u, 2u), [](const testing::TestParamInfo<uint32_t>& info) {
+        return std::to_string(info.param) + "_endpoints";
+    });
 
 // Read from GDDR over DMA into DRISC L1 and then multicast from DRISC L1 to a grid of 6x6 Tensix L1
 TEST_F(DramKernelFixture, DramKernelDRISCReadFromDRAMMcastToTensix) {
@@ -440,7 +475,8 @@ TEST_F(DramKernelFixture, DramKernelDRISCReadFromDRAMMcastToTensix) {
     log_info(LogTest, "Random seed: {}", seed);
     std::vector<uint32_t> data = create_random_vector_of_bfloat16(total_bytes, 1000.0f, seed);
 
-    CoreCoord logical_core{0, 0};
+    // Bank 0, first DRISC-usable endpoint (subchannel 0 is the syseng-owned NOC0 endpoint).
+    CoreCoord logical_core{0, first_usable_dram_endpoint(0)};
     uint32_t dram_channel = device_->dram_channel_from_logical_core(logical_core);
     uint32_t num_cols = 6;
     uint32_t num_rows = 6;
@@ -452,7 +488,7 @@ TEST_F(DramKernelFixture, DramKernelDRISCReadFromDRAMMcastToTensix) {
     CoreCoord sub_worker_end_coord =
         device_->virtual_core_from_logical_core(tensix_sub_logical_end_coord, CoreType::WORKER);
 
-    // Allocate a single-page DRAM buffer. Page_size == size pins it to bank 0 (logical_core {0,0})
+    // Allocate a single-page DRAM buffer. Page_size == size pins it to bank 0 (logical_core x==0)
     auto dram_buffer = CreateBuffer(InterleavedBufferConfig{
         .device = device_,
         .size = total_bytes,
@@ -507,9 +543,8 @@ TEST_F(DramKernelFixture, DramKernelDRISCReadFromDRAMMcastToTensix) {
 TEST_F(DramKernelFixture, DramKernelDRISCRTensixParallelDRAMReads) {
     const uint32_t total_bytes = 64 * 1024;
 
-    const auto& soc_desc = MetalContext::instance().get_cluster().get_soc_desc(mesh_device_->build_id());
-    auto dram_compute_grid = soc_desc.get_dram_compute_grid_size();
-    uint32_t num_endpoints = dram_compute_grid.y;  // all endpoints of a bank
+    // DRISC-usable endpoints of bank 0 (subchannel 0 is the syseng-owned NOC0 endpoint); contiguous.
+    const std::vector<uint32_t> usable_endpoints = usable_dram_endpoints(0);
 
     TT_FATAL(
         dram_unreserved_size_ >= total_bytes,
@@ -527,13 +562,13 @@ TEST_F(DramKernelFixture, DramKernelDRISCRTensixParallelDRAMReads) {
     uint32_t num_rows = 6;
     CoreCoord worker_start{0, 0};
     CoreCoord worker_end{num_cols - 1, num_rows - 1};  // 6x6 Tensix grid
-    uint32_t bank_id = 0;                              // for DRISCs: Single Bank, all endpoints
-    CoreCoord drisc_endpoint_start{bank_id, 0};
-    CoreCoord drisc_endpoint_end{bank_id, num_endpoints - 1};
+    uint32_t bank_id = 0;                              // for DRISCs: single bank, all usable endpoints
+    CoreCoord drisc_endpoint_start{bank_id, usable_endpoints.front()};
+    CoreCoord drisc_endpoint_end{bank_id, usable_endpoints.back()};
     CoreRangeSet tensix_range({CoreRange(worker_start, worker_end)});
     CoreRangeSet drisc_endpoint_range({CoreRange(drisc_endpoint_start, drisc_endpoint_end)});
 
-    // Allocate a single-page DRAM buffer. Page_size == size pins it to bank 0 (logical_core {0,0})
+    // Allocate a single-page DRAM buffer. Page_size == size pins it to bank 0 (logical_core x==0)
     auto dram_buffer = CreateBuffer(InterleavedBufferConfig{
         .device = device_,
         .size = total_bytes,
@@ -566,7 +601,7 @@ TEST_F(DramKernelFixture, DramKernelDRISCRTensixParallelDRAMReads) {
     run_workload(std::move(program));
 
     // Verify DRISC L1 reads are correct
-    for (uint32_t endpoint = 0; endpoint < num_endpoints; endpoint++) {
+    for (uint32_t endpoint : usable_endpoints) {
         CoreCoord virtual_core = device_->virtual_core_from_logical_core({bank_id, endpoint}, CoreType::DRAM);
         std::vector<uint32_t> result(data.size());
         MetalContext::instance().get_cluster().read_core(
@@ -612,12 +647,13 @@ TEST_P(DramKernelDRISCGDDRBWSweepFixture, DRISCDMAUcastToTensix) {
     log_info(LogTest, "Random seed: {}", seed);
     std::vector<uint32_t> data = create_random_vector_of_bfloat16(total_bytes, 1000.0f, seed);
 
-    CoreCoord logical_core{0, 0};
+    // Bank 0, first DRISC-usable endpoint (subchannel 0 is the syseng-owned NOC0 endpoint).
+    CoreCoord logical_core{0, first_usable_dram_endpoint(0)};
     uint32_t dram_channel = device_->dram_channel_from_logical_core(logical_core);
     CoreCoord tensix_logical{0, 0};
     CoreCoord sub_worker = device_->virtual_core_from_logical_core(tensix_logical, CoreType::WORKER);
 
-    // Allocate a single-page DRAM buffer. Page_size == size pins it to bank 0 (logical_core {0,0})
+    // Allocate a single-page DRAM buffer. Page_size == size pins it to bank 0 (logical_core x==0)
     auto dram_buffer = CreateBuffer(InterleavedBufferConfig{
         .device = device_,
         .size = total_bytes,
@@ -696,6 +732,9 @@ class DramKernelDRISCNocModeFixture : public DramKernelFixture,
 // A bank's read on tensix_noc deterministically routes to that bank's preferred DRAM endpoint for that
 // NOC (NOC0 and NOC1 use different endpoints), so the DRISC kernel is placed on that same endpoint,
 // guaranteeing both NIUs belong to one DRISC. The Tensix reader sits just below the mcast grid.
+//
+// Only tensix_noc == NOC1 is exercised: tensix_noc == NOC0 would place the DRISC kernel on the NOC0
+// endpoint, which is owned by the syseng firmware and runs no DRISC kernel (guarded below).
 TEST_P(DramKernelDRISCNocModeFixture, DramKernelDRISCNocModeStress) {
     auto [drisc_noc, tensix_noc] = GetParam();
 
@@ -719,6 +758,11 @@ TEST_P(DramKernelDRISCNocModeFixture, DramKernelDRISCNocModeStress) {
     // Place the DRISC kernel on the endpoint that tensix_noc reads route to, so one DRISC owns both NIUs
     // (stream on drisc_noc, NOC2AXI on tensix_noc).
     CoreCoord drisc_logical = logical_dram_endpoint_for_noc(soc_desc, bank, tensix_noc);
+    // The NOC0 worker endpoint is owned by the syseng firmware and runs no DRISC kernel, so the
+    // tensix-on-NOC0 configuration (which would place the DRISC kernel there) can't be exercised.
+    if (drisc_logical.y == logical_dram_endpoint_for_noc(soc_desc, bank, NOC::NOC_0).y) {
+        GTEST_SKIP() << "DRISC kernel cannot run on the syseng-owned NOC0 DRAM endpoint";
+    }
     const uint32_t dram_channel = device_->dram_channel_from_logical_core(drisc_logical);
 
     // Fill GDDR with iters random distinct chunks. DRISC and the Tensix reader both walk the same region
@@ -793,12 +837,14 @@ TEST_P(DramKernelDRISCNocModeFixture, DramKernelDRISCNocModeStress) {
     EXPECT_EQ(result, last_chunk) << "Tensix DRAM read via NOC2AXI NIU last-chunk mismatch";
 }
 
+// Only the NOC0-stream / NOC1-NOC2AXI configuration is exercised: it places the DRISC kernel on the
+// NOC1 endpoint. The mirror config (NOC1 stream / NOC0 NOC2AXI) would route the Tensix read to the
+// NOC0 endpoint and thus require the DRISC kernel there, but that endpoint is owned by the syseng
+// firmware and runs no DRISC kernel, so that case is no longer supported.
 INSTANTIATE_TEST_SUITE_P(
     NocModeSweep,
     DramKernelDRISCNocModeFixture,
-    testing::Values(
-        DRISCNocModeParams{NOC::NOC_0, NOC::NOC_1},   // NOC0 = stream, NOC1 = NOC2AXI
-        DRISCNocModeParams{NOC::NOC_1, NOC::NOC_0}),  // NOC1 = stream, NOC0 = NOC2AXI
+    testing::Values(DRISCNocModeParams{NOC::NOC_0, NOC::NOC_1}),  // NOC0 = stream, NOC1 = NOC2AXI
     [](const testing::TestParamInfo<DRISCNocModeParams>& info) {
         return info.param.drisc_noc == NOC::NOC_0 ? "Noc0StreamNoc1Noc2Axi" : "Noc1StreamNoc0Noc2Axi";
     });

--- a/tests/tt_metal/tt_metal/api/test_noc.cpp
+++ b/tests/tt_metal/tt_metal/api/test_noc.cpp
@@ -699,7 +699,8 @@ TEST_F(BlackholeSingleCardFixture, DramKernelStreamRegInc) {
     }
 
     auto mesh_device = this->devices_[0];
-    run_local_noc_stream_reg_inc(this, mesh_device, CoreCoord{0, 0}, HalProgrammableCoreType::DRAM);
+    // Subchannel 0 is the syseng-owned NOC0 DRAM endpoint (no DRISC firmware); use subchannel 1.
+    run_local_noc_stream_reg_inc(this, mesh_device, CoreCoord{0, 1}, HalProgrammableCoreType::DRAM);
 }
 
 // Tensix to DRISC stream register round trip DRISC test:
@@ -719,7 +720,8 @@ TEST_F(BlackholeSingleCardFixture, DramKernelTensixWritesDriscStreamReg) {
     auto* device = mesh_device->get_devices()[0];
     auto device_range = distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0));
 
-    CoreCoord logical_core_drisc{0, 0};
+    // Subchannel 0 is the syseng-owned NOC0 DRAM endpoint (no DRISC firmware); use subchannel 1.
+    CoreCoord logical_core_drisc{0, 1};
     CoreCoord logical_core_tensix{0, 0};
     CoreCoord drisc_virtual = device->virtual_core_from_logical_core(logical_core_drisc, CoreType::DRAM);
     uint32_t tensix_l1_addr = device->allocator()->get_base_allocator_addr(tt_metal::HalMemType::L1);
@@ -764,7 +766,8 @@ TEST_F(BlackholeSingleCardFixture, DramKernelDriscWritesTensixStreamReg) {
     auto* device = mesh_device->get_devices()[0];
     auto device_range = distributed::MeshCoordinateRange(distributed::MeshCoordinate(0, 0));
 
-    CoreCoord logical_core_drisc{0, 0};
+    // Subchannel 0 is the syseng-owned NOC0 DRAM endpoint (no DRISC firmware); use subchannel 1.
+    CoreCoord logical_core_drisc{0, 1};
     CoreCoord logical_core_tensix{0, 0};
     CoreCoord tensix_virtual = device->virtual_core_from_logical_core(logical_core_tensix, CoreType::WORKER);
     CoreCoord drisc_virtual = device->virtual_core_from_logical_core(logical_core_drisc, CoreType::DRAM);

--- a/tests/tt_metal/tt_metal/debug_tools/device_print/test_dram_print_output.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/device_print/test_dram_print_output.cpp
@@ -35,7 +35,8 @@ public:
         workload.add_program(device_range, std::move(program));
         auto& program_ = workload.get_programs().at(device_range);
 
-        constexpr CoreCoord core = {0, 0};
+        // Subchannel 0 is the syseng-owned NOC0 DRAM endpoint (no DRISC firmware); use subchannel 1.
+        constexpr CoreCoord core = {0, 1};
         KernelHandle kernel_handle = CreateKernel(program_, kernel_path, core, DramConfig{.noc = tt_metal::NOC::NOC_0});
 
         SetRuntimeArgs(program_, kernel_handle, core, runtime_args);

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_assert.cpp
@@ -171,7 +171,8 @@ static void RunTest(
                 log_info(LogTest, "Skipping: DRAM programmable cores not available on this architecture.");
                 GTEST_SKIP();
             }
-            logical_core = {0, 0};
+            // Subchannel 0 is the syseng-owned NOC0 DRAM endpoint (no DRISC firmware); use subchannel 1.
+            logical_core = {0, 1};
             virtual_core = device->virtual_core_from_logical_core(logical_core, CoreType::DRAM);
             assert_kernel = CreateKernel(program, kernel, logical_core, DramConfig{.noc = tt_metal::NOC::NOC_0});
             risc = "drisc";

--- a/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
+++ b/tests/tt_metal/tt_metal/debug_tools/watcher/test_ringbuf.cpp
@@ -122,7 +122,8 @@ void RunTest(
                 log_info(LogTest, "Skipping: DRAM programmable cores not available on this architecture.");
                 GTEST_SKIP();
             }
-            logical_core = CoreCoord{0, 0};
+            // Subchannel 0 is the syseng-owned NOC0 DRAM endpoint (no DRISC firmware); use subchannel 1.
+            logical_core = CoreCoord{0, 1};
             virtual_core = device->virtual_core_from_logical_core(logical_core, CoreType::DRAM);
             CreateKernel(
                 program,

--- a/tests/tt_metal/tt_metal/test_kernels/misc/drisc_mcast_writes_tensix.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/misc/drisc_mcast_writes_tensix.cpp
@@ -126,8 +126,7 @@ void kernel_main() {
         half_buffer_bytes,
         {.addr = dst_A},
         {.noc_x = tensix_noc_x_start, .noc_y = tensix_noc_y_start, .addr = tensix_dst_A},
-        NOC_UNICAST_WRITE_VC,
-        trid_A);
+        NocOptVals{.trid = trid_A});
 
     // Final B: drain the remaining outstanding read.
     experimental::dma_async_read_wait_n(tx_stream, 0);                        // B[last] ready
@@ -138,8 +137,7 @@ void kernel_main() {
         half_buffer_bytes,
         {.addr = dst_B},
         {.noc_x = tensix_noc_x_start, .noc_y = tensix_noc_y_start, .addr = tensix_dst_B},
-        NOC_UNICAST_WRITE_VC,
-        trid_B);
+        NocOptVals{.trid = trid_B});
 
     // Drain: wait for the final two NOC writes to be acked.
     noc.async_write_barrier<NocOptions::TXN_ID>({.trid = trid_A});

--- a/tools/triage/run_checks.py
+++ b/tools/triage/run_checks.py
@@ -211,6 +211,16 @@ def get_block_locations(
                         )
                     else:
                         block_locations[device][block_type] = _exalens_block_locations(device, block_type)
+                # Metal reports the DRAM cores it manages (TRANSLATED coords), excluding the
+                # syseng-owned NOC0 worker endpoints (which serve CMFW DRAM telemetry and run no
+                # DRISC firmware). Prefer that authoritative list over the exalens enumeration, which
+                # would include the NOC0 endpoints and dump garbage from them. TRANSLATED coords avoid
+                # the UMD-vs-metal logical-DRAM numbering mismatch.
+                dram_cores = chip_blocks_list[i].dramCores
+                if len(dram_cores) > 0:
+                    block_locations[device]["dram"] = [
+                        OnChipCoordinate(c.x, c.y, "translated", device, "dram") for c in dram_cores
+                    ]
 
     # Exalens fallback for any device Inspector didn't cover (no inspector at all, or
     # Inspector's getBlocksByType is missing this device).

--- a/tt_metal/impl/debug/inspector/data.cpp
+++ b/tt_metal/impl/debug/inspector/data.cpp
@@ -355,6 +355,7 @@ void Data::rpc_get_all_dispatch_core_infos(rpc::Inspector::GetAllDispatchCoreInf
 
 void Data::rpc_get_blocks_by_type(rpc::Inspector::GetBlocksByTypeResults::Builder results) {
     auto& control_plane = tt_metal::MetalContext::instance().get_control_plane();
+    auto& cluster = tt_metal::MetalContext::instance().get_cluster();
     auto device_ids = tt_metal::MetalContext::instance().device_manager()->get_all_active_device_ids();
 
     auto chips_builder = results.initChips(device_ids.size());
@@ -385,6 +386,18 @@ void Data::rpc_get_blocks_by_type(rpc::Inspector::GetBlocksByTypeResults::Builde
         };
         set_coords([&blocks](size_t n) { return blocks.initActiveEth(n); }, active_eth_xy);
         set_coords([&blocks](size_t n) { return blocks.initIdleEth(n); }, idle_eth_xy);
+
+        // DRAM cores Metal manages (TRANSLATED coords), reported only when DRAM programmable cores are
+        // available. get_metal_dram_cores omits the syseng-owned NOC0 worker endpoints (CMFW DRAM
+        // telemetry), where Metal runs no DRISC firmware, so tools dump only these cores.
+        std::vector<std::pair<uint32_t, uint32_t>> dram_cores_xy;
+        if (MetalContext::instance().hal().has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
+            for (const auto& dram_core :
+                 cluster.get_soc_desc(device_id).get_metal_dram_cores(CoordSystem::TRANSLATED)) {
+                dram_cores_xy.emplace_back(dram_core.x, dram_core.y);
+            }
+        }
+        set_coords([&chip_entry](size_t n) { return chip_entry.initDramCores(n); }, dram_cores_xy);
     }
 }
 

--- a/tt_metal/impl/debug/inspector/rpc.capnp
+++ b/tt_metal/impl/debug/inspector/rpc.capnp
@@ -144,6 +144,14 @@ struct LogicalCoord {
     y @1 :UInt64;
 }
 
+# Translated/virtual (UMD) (x, y) coordinate without chip - chip is the map key. A distinct type from
+# LogicalCoord so the coordinate system is explicit at the schema level; translated coords are used
+# where logical coords would be ambiguous between UMD and Metal (e.g. DRAM subchannel numbering).
+struct TranslatedCoord {
+    x @0 :UInt64;
+    y @1 :UInt64;
+}
+
 # Per-chip: block type -> list of logical coordinates
 struct BlocksByTypePerChip {
     activeEth @0 :List(LogicalCoord);
@@ -154,6 +162,12 @@ struct BlocksByTypePerChip {
 struct ChipBlocksByType {
     chipId @0 :UInt64;
     blocks @1 :BlocksByTypePerChip;
+    # The DRAM cores Metal manages, i.e. every DRAM endpoint EXCEPT each view's NOC0 worker endpoint.
+    # The excluded NOC0 endpoints carry regular NOC0 DRAM traffic and are owned by the syseng firmware
+    # (CMFW DRAM telemetry, SYS-1419); Metal runs no DRISC firmware there, so tools should dump only
+    # the cores in this list. Reported as TranslatedCoord so consumers resolve cores without the
+    # UMD-vs-metal logical-DRAM numbering mismatch.
+    dramCores @2 :List(TranslatedCoord);
 }
 
 enum ConfigurationScope {

--- a/tt_metal/impl/debug/watcher_device_reader.cpp
+++ b/tt_metal/impl/debug/watcher_device_reader.cpp
@@ -418,9 +418,10 @@ void WatcherDeviceReader::Dump(FILE* file) {
         bool has_dram_fw = hal.has_programmable_core_type(HalProgrammableCoreType::DRAM);
         if (has_dram_fw) {
             const auto& soc_d = env.get_cluster().get_soc_desc(device_id);
-            for (const auto& dram_core : soc_d.get_cores(CoreType::DRAM, CoordSystem::LOGICAL)) {
-                Core::Create(CoreCoord{dram_core.x, dram_core.y}, HalProgrammableCoreType::DRAM, *this, dump_data)
-                    .Dump();
+            // get_metal_dram_cores omits the syseng-owned NOC0 endpoints (no Metal DRISC firmware),
+            // whose launch message / debug mailbox is never initialized and would read as garbage.
+            for (const auto& logical_dram_core : soc_d.get_metal_dram_cores(CoordSystem::LOGICAL)) {
+                Core::Create(logical_dram_core, HalProgrammableCoreType::DRAM, *this, dump_data).Dump();
             }
         }
     }

--- a/tt_metal/impl/debug/watcher_server.cpp
+++ b/tt_metal/impl/debug/watcher_server.cpp
@@ -517,8 +517,8 @@ void WatcherServer::Impl::init_device(ChipId device_id) {
     // Initialize DRAM cores debug values (Blackhole only)
     bool has_dram_fw = hal.has_programmable_core_type(HalProgrammableCoreType::DRAM);
     if (has_dram_fw) {
-        for (const auto& dram_core :
-             cluster.get_soc_desc(device_id).get_cores(CoreType::DRAM, CoordSystem::TRANSLATED)) {
+        const auto& soc_desc = cluster.get_soc_desc(device_id);
+        for (const auto& dram_core : soc_desc.get_metal_dram_cores(CoordSystem::TRANSLATED)) {
             write_watcher_init_val_virtual({dram_core.x, dram_core.y}, HalProgrammableCoreType::DRAM);
         }
     }

--- a/tt_metal/impl/device/device.cpp
+++ b/tt_metal/impl/device/device.cpp
@@ -330,7 +330,8 @@ void Device::init_command_queue_device_with_topology(DispatchTopology* topo) {
         reset_launch_message_rd_ptr(logical_core, CoreType::ETH);
     }
     if (hal.has_programmable_core_type(HalProgrammableCoreType::DRAM)) {
-        for (const auto& dram_core : cluster.get_soc_desc(id_).get_cores(CoreType::DRAM, CoordSystem::TRANSLATED)) {
+        const auto& soc_desc = cluster.get_soc_desc(id_);
+        for (const auto& dram_core : soc_desc.get_metal_dram_cores(CoordSystem::TRANSLATED)) {
             reset_launch_message_rd_ptr_virtual({dram_core.x, dram_core.y}, HalProgrammableCoreType::DRAM);
         }
     }

--- a/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
+++ b/tt_metal/impl/device/firmware/risc_firmware_initializer.cpp
@@ -301,8 +301,7 @@ void RiscFirmwareInitializer::clear_l1_state(tt::ChipId device_id) {
         uint32_t dram_l1_size = hal_.get_dev_size(HalProgrammableCoreType::DRAM, HalL1MemAddrType::BASE);
         std::vector<uint32_t> dram_zero_vec(dram_l1_size / sizeof(uint32_t), 0);
         const auto& soc_d = cluster_.get_soc_desc(device_id);
-        for (const auto& dram_core : soc_d.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED)) {
-            CoreCoord virtual_core{dram_core.x, dram_core.y};
+        for (const auto& virtual_core : soc_d.get_metal_dram_cores(CoordSystem::TRANSLATED)) {
             cluster_.write_core(
                 dram_zero_vec.data(),
                 dram_l1_size,
@@ -396,8 +395,7 @@ void RiscFirmwareInitializer::assert_dram_cores(tt::ChipId device_id) {
     bool has_dram_fw = hal_.has_programmable_core_type(HalProgrammableCoreType::DRAM);
     if (has_dram_fw) {
         const auto& soc_d = cluster_.get_soc_desc(device_id);
-        for (const auto& dram_core : soc_d.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED)) {
-            CoreCoord virtual_core{dram_core.x, dram_core.y};
+        for (const auto& virtual_core : soc_d.get_metal_dram_cores(CoordSystem::TRANSLATED)) {
             cluster_.assert_risc_reset_at_core(tt_cxy_pair(device_id, virtual_core), tt::umd::RiscType::BRISC);
         }
     }
@@ -1376,10 +1374,10 @@ void RiscFirmwareInitializer::initialize_and_launch_firmware(tt::ChipId device_i
         auto dram_go_msg = dram_dev_msgs_factory.create<dev_msgs::go_msg_t>();
         dram_go_msg.view().signal() = dev_msgs::RUN_MSG_INIT;
         const metal_SocDescriptor& soc_d = cluster_.get_soc_desc(device_id);
-        for (const auto& dram_noc : soc_d.get_cores(CoreType::DRAM, CoordSystem::TRANSLATED)) {
-            CoreCoord virtual_dram_core{dram_noc.x, dram_noc.y};
-            dram_core_info.view().absolute_logical_x() = dram_noc.x;
-            dram_core_info.view().absolute_logical_y() = dram_noc.y;
+
+        for (const auto& virtual_dram_core : soc_d.get_metal_dram_cores(CoordSystem::TRANSLATED)) {
+            dram_core_info.view().absolute_logical_x() = virtual_dram_core.x;
+            dram_core_info.view().absolute_logical_y() = virtual_dram_core.y;
             uint64_t core_info_addr = hal_.get_dev_noc_addr(HalProgrammableCoreType::DRAM, HalL1MemAddrType::CORE_INFO);
             cluster_.write_core(
                 dram_core_info.data(),

--- a/tt_metal/llrt/metal_soc_descriptor.cpp
+++ b/tt_metal/llrt/metal_soc_descriptor.cpp
@@ -20,6 +20,35 @@ CoreCoord metal_SocDescriptor::get_preferred_worker_core_for_dram_view(int dram_
     return this->dram_view_worker_cores.at(dram_view).at(noc);
 };
 
+bool metal_SocDescriptor::is_noc0_dram_endpoint(const CoreCoord& translated_coord) const {
+    // dram_view_worker_cores (and thus get_preferred_worker_core_for_dram_view) holds TRANSLATED
+    // coords, so this compares like-for-like against a TRANSLATED argument. See the header note.
+    for (size_t dram_view = 0; dram_view < this->dram_view_worker_cores.size(); ++dram_view) {
+        if (get_preferred_worker_core_for_dram_view(static_cast<int>(dram_view), /*noc=*/0) == translated_coord) {
+            return true;
+        }
+    }
+    return false;
+}
+
+std::vector<CoreCoord> metal_SocDescriptor::get_metal_dram_cores(tt::CoordSystem coord_system) const {
+    // Blackhole reserves each DRAM view's NOC0 worker endpoint for the syseng firmware; no other
+    // architecture has that restriction (and future ones won't), so the exclusion is confined to this
+    // one spot rather than every DRAM loop in Metal.
+    const bool exclude_noc0_endpoints = (this->arch == tt::ARCH::BLACKHOLE);
+    std::vector<CoreCoord> dram_cores;
+    for (const tt::umd::CoreCoord& core : get_cores(tt::CoreType::DRAM, coord_system)) {
+        if (exclude_noc0_endpoints) {
+            const tt::umd::CoreCoord translated = translate_coord_to(core, tt::CoordSystem::TRANSLATED);
+            if (is_noc0_dram_endpoint({translated.x, translated.y})) {
+                continue;
+            }
+        }
+        dram_cores.push_back({core.x, core.y});
+    }
+    return dram_cores;
+}
+
 CoreCoord metal_SocDescriptor::get_preferred_eth_core_for_dram_view(int dram_view, uint8_t noc) const {
     TT_ASSERT(
         dram_view < this->dram_view_eth_cores.size(),

--- a/tt_metal/llrt/metal_soc_descriptor.hpp
+++ b/tt_metal/llrt/metal_soc_descriptor.hpp
@@ -42,6 +42,15 @@ public:
 
     CoreCoord get_preferred_worker_core_for_dram_view(int dram_view, uint8_t noc) const;
     CoreCoord get_preferred_eth_core_for_dram_view(int dram_view, uint8_t noc) const;
+
+    // The DRAM cores Metal may place kernels/firmware on, in the requested coordinate system. This is
+    // the single source of truth for "usable DRAM cores": every DRAM loop in Metal (firmware init,
+    // launch-message reset, watcher, inspector) should iterate this rather than get_cores(DRAM) so the
+    // usable set is defined in one place. On Blackhole it excludes each DRAM view's NOC0 worker
+    // endpoint, which is owned by the syseng firmware (CMFW DRAM telemetry, SYS-1419) and runs no
+    // DRISC firmware. Hardware without that restriction returns all DRAM cores -- callers never need
+    // to special-case it.
+    std::vector<CoreCoord> get_metal_dram_cores(tt::CoordSystem coord_system) const;
     CoreCoord get_logical_core_for_dram_view(int dram_view) const;
     size_t get_address_offset(int dram_view) const;
     size_t get_channel_for_dram_view(int dram_view) const;
@@ -66,6 +75,11 @@ public:
     std::map<CoreCoord, int32_t> physical_routing_to_profiler_flat_id;
 
 private:
+    // True if `translated_coord` is any DRAM view's NOC0 worker endpoint (the subchannel a NOC0 DRAM
+    // access routes to) -- the syseng-owned endpoint excluded by get_metal_dram_cores on Blackhole.
+    // Argument must be a TRANSLATED (UMD) coord; a metal-logical {view, subchannel} coord never matches.
+    bool is_noc0_dram_endpoint(const CoreCoord& translated_coord) const;
+
     void load_dram_metadata_from_device_descriptor();
     void generate_logical_eth_coords_mapping();
     void generate_physical_routing_to_profiler_flat_id();


### PR DESCRIPTION
### PR Category
Feature

### Summary
On Blackhole, each DRAM bank/view has multiple NOC endpoint subchannels. The
subchannel a NOC0 access routes to (the NOC0 worker endpoint) carries regular
NOC0 DRAM traffic and is owned by the syseng firmware, which keeps doing its
own work there. Metal must leave that core entirely alone.

This change makes Metal stop touching the NOC0 DRAM endpoint:

- **Firmware init** (`risc_firmware_initializer.cpp`): no DRISC firmware load,
  no RISC deassert, excluded from the init-complete wait, not asserted into
  reset, and its L1 is not zeroed.
- **Launch-message reset** (`device.cpp`): skip it in the
  `reset_launch_message_rd_ptr` DRAM loop.
- **Watcher** (`watcher_server.cpp`, `watcher_device_reader.cpp`): don't write
  init values to it and don't dump it. Its launch message / debug mailbox is
  never initialized, so the watcher would otherwise read garbage and report
  false data corruption.

Identification is centralized in
`metal_SocDescriptor::is_noc0_dram_endpoint()` and reused across all the loops
above.

Tests are updated to keep DRISC kernels off the now-reserved endpoint
(logical subchannel 0): `test_dram_kernels.cpp` gains a fixture helper that
enumerates DRISC-usable endpoints; the per-bank endpoint sweep tops out at 2
(NOC1 endpoint + free subchannel); the NocMode sweep drops the case that would
require a DRISC kernel on the NOC0 endpoint. `test_noc.cpp`, the watcher/print
debug-tools tests use subchannel 1. A pre-existing `async_write` API drift in
the unicast drain path of `drisc_mcast_writes_tensix.cpp` (only compiled by the
unicast `DRISCDMAUcastToTensix` test) is fixed to the current `NocOptVals`
signature.

Relates to #45751

### Notes for reviewers
- **Coordinate-system care.** `is_noc0_dram_endpoint` matches against
  TRANSLATED (UMD) coords, since `get_cores(DRAM, TRANSLATED)` and
  `get_preferred_worker_core_for_dram_view` both use that space. The watcher
  dump iterates UMD-logical coords and converts to virtual first; a
  metal-logical `{view, subchannel}` coord would never match. The predicate
  intentionally computes the endpoint via `get_preferred_worker_core_for_dram_view`
  rather than assuming "subchannel 0", to avoid baking in the descriptor's
  construction order.
- **Coverage delta** (forced by reserving the endpoint): at most 2 DRISC-usable
  endpoints per bank now; the NocMode NOC1-stream/NOC0-NOC2AXI scenario is no
  longer testable (it would need a DRISC kernel on the NOC0 endpoint). The
  NOC0-stream/NOC1-NOC2AXI scenario still exercises both NIUs of one DRISC.
- **Verified on a Blackhole p150b** (slow dispatch + DRAM programmable cores):
  `*DramKernel*` 20/20, DRAM debug-tools (watcher ringbuf/assert + dram print)
  7/7, GCB-DRISC-sender + subchannel-helper 6/6. No hangs, no false watcher
  corruption.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jbauman/dram-skip-noc0-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jbauman/dram-skip-noc0-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jbauman/dram-skip-noc0-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jbauman/dram-skip-noc0-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jbauman/dram-skip-noc0-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jbauman/dram-skip-noc0-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jbauman/dram-skip-noc0-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jbauman/dram-skip-noc0-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jbauman/dram-skip-noc0-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jbauman/dram-skip-noc0-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jbauman/dram-skip-noc0-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jbauman/dram-skip-noc0-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jbauman/dram-skip-noc0-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jbauman/dram-skip-noc0-endpoint)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jbauman/dram-skip-noc0-endpoint)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jbauman/dram-skip-noc0-endpoint)