### PR TITLE
ci: adopt run-with-log wrapper across ai-summary test legs

### DIFF
--- a/.github/actions/run-with-log/README.md
+++ b/.github/actions/run-with-log/README.md
@@ -1,17 +1,21 @@
 # `run-with-log`
 
 Run a bash script like a normal `run:` step, but capture its combined output to
-a `.log` file and append a completion marker as the final line:
+a `.log` file framed by two sentinels — a start line first, a finish line last:
 
 ```
+[==tt-log-start-line==]
+…script output…
 [==tt-log-finish-line==] exit_code=<N>
 ```
 
-The marker is a generic end-of-run sentinel. Its **absence** means the shell was
-killed before finishing — most usefully a GitHub `timeout-minutes` kill, which
-leaves no trace in the log otherwise. Tooling that reads the logs (the
-`ai_summary` parser in tenstorrent/tt-github-actions) uses this to tell a
-timeout apart from a crash.
+The pair lets a reader reason **per log file**: start **and** finish → ran to
+completion; start but **no** finish → the shell was killed before finishing
+(most usefully a GitHub `timeout-minutes` kill, which leaves no other trace);
+**neither** → not produced by run-with-log, so it's ignored. The `ai_summary`
+parser (tenstorrent/tt-github-actions) uses this to tell a timeout from a crash,
+and to leave untracked logs (e.g. a backgrounded server's tail) out of the
+verdict.
 
 Replaces hand-rolled `tee` / `PIPESTATUS` blocks copied across workflows.
 

--- a/.github/actions/run-with-log/README.md
+++ b/.github/actions/run-with-log/README.md
@@ -1,0 +1,59 @@
+# `run-with-log`
+
+Run a bash script like a normal `run:` step, but capture its combined output to
+a `.log` file and append a completion marker as the final line:
+
+```
+[==tt-log-finish-line==] exit_code=<N>
+```
+
+The marker is a generic end-of-run sentinel. Its **absence** means the shell was
+killed before finishing — most usefully a GitHub `timeout-minutes` kill, which
+leaves no trace in the log otherwise. Tooling that reads the logs (the
+`ai_summary` parser in tenstorrent/tt-github-actions) uses this to tell a
+timeout apart from a crash.
+
+Replaces hand-rolled `tee` / `PIPESTATUS` blocks copied across workflows.
+
+## Usage
+
+```yaml
+- name: ${{ matrix.test-group.name }}
+  timeout-minutes: ${{ matrix.test-group.timeout }}
+  uses: ./.github/actions/run-with-log
+  with:
+    log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+    run: |
+      pytest models/demos/... -xv
+      ./some_other_command
+```
+
+## Inputs
+
+| Name | Required | Default | Description |
+|------|----------|---------|-------------|
+| `run` | yes | — | Bash script, exactly as a `run:` step body. |
+| `log-file` | yes | — | Path for the `.log`, relative to `working-directory`. Parent dirs are created. |
+| `working-directory` | no | `/work` | Defaults to the Tenstorrent container workdir; override per call as on a `run:` step. Needed because composite steps don't inherit the job's `defaults.run.working-directory`. |
+
+## What propagates
+
+- **`if:`, `timeout-minutes`** on the calling step — native; `timeout-minutes`
+  is what makes the marker meaningful (the kill skips it).
+- **Exit code / pass-fail** — the script's real exit code is forwarded, so the
+  step fails when the script fails and `failure()` / `if:` downstream work.
+- **The script itself** runs under `bash -eo pipefail` (same as a `run:` step).
+
+## Environment variables
+
+The `run:` body executes as a child process of a composite action, so:
+
+- **Workflow / job / container-level `env:`** — reaches the script. ✅
+- **`env:` on the `- uses: run-with-log` step — does NOT** reach the script
+  (a GitHub composite-action limitation). Put per-call vars inline in `run:`
+  (`FOO=bar pytest …`) or at job level. ❌
+- **`echo "X=Y" >> "$GITHUB_ENV"`** / `>> "$GITHUB_PATH"` from the script —
+  propagate to later job steps. ✅
+- **Named `$GITHUB_OUTPUT`** written in the script — not exposed (a composite
+  action only surfaces declared `outputs:`). Steps that must set outputs should
+  stay plain `run:` steps. ❌

--- a/.github/actions/run-with-log/action.yml
+++ b/.github/actions/run-with-log/action.yml
@@ -1,0 +1,47 @@
+name: Run with log
+description: >-
+  Run a bash script like a normal `run:` step, tee its combined output to a
+  .log file, and append a completion marker as the final line. The marker is a
+  generic end-of-run sentinel: its absence means the shell was killed before
+  finishing (e.g. GitHub timeout-minutes), which downstream tooling can detect.
+
+inputs:
+  run:
+    description: "Bash script to run, exactly as a `run:` step body (multi-line)."
+    required: true
+  log-file:
+    description: "Path for the .log, relative to working-directory. Parent dirs are created."
+    required: true
+  working-directory:
+    description: >-
+      Directory to run in. Defaults to /work (Tenstorrent container jobs).
+      Override per call as you would on a run: step. Required because composite
+      steps do not inherit the job's defaults.run.working-directory.
+    required: false
+    default: "/work"
+
+runs:
+  using: composite
+  steps:
+    - shell: bash
+      working-directory: ${{ inputs.working-directory }}
+      env:
+        # Via env so the script's quotes/specials reach the file verbatim.
+        RUN_WITH_LOG_SCRIPT: ${{ inputs.run }}
+        RUN_WITH_LOG_FILE: ${{ inputs.log-file }}
+      run: |
+        # errexit off for the wrapper so the marker is written even when the
+        # script fails — a failed run must stay a failure, not look like a kill.
+        set +e
+        mkdir -p "$(dirname "$RUN_WITH_LOG_FILE")"
+
+        # Run as its own bash file, matching a normal run step (errexit +
+        # pipefail), so the script keeps full fidelity and its own exit code.
+        script=$(mktemp)
+        printf '%s\n' "$RUN_WITH_LOG_SCRIPT" > "$script"
+        bash --noprofile --norc -eo pipefail "$script" 2>&1 | tee "$RUN_WITH_LOG_FILE"
+        rc=${PIPESTATUS[0]}
+        rm -f "$script"
+
+        printf '[==tt-log-finish-line==] exit_code=%s\n' "$rc" >> "$RUN_WITH_LOG_FILE"
+        exit $rc

--- a/.github/actions/run-with-log/action.yml
+++ b/.github/actions/run-with-log/action.yml
@@ -48,8 +48,6 @@ runs:
         rc=${PIPESTATUS[0]}
         rm -f "$script"
 
-        # Leading newline so the marker stays line-anchored even when the
-        # script's final output had no trailing newline (otherwise it glues onto
-        # that line and the parser's ^-anchored match misses it).
+        # Leading \n so the marker isn't glued to a newline-less final line.
         printf '\n[==tt-log-finish-line==] exit_code=%s\n' "$rc" >> "$RUN_WITH_LOG_FILE"
         exit $rc

--- a/.github/actions/run-with-log/action.yml
+++ b/.github/actions/run-with-log/action.yml
@@ -30,16 +30,21 @@ runs:
         RUN_WITH_LOG_SCRIPT: ${{ inputs.run }}
         RUN_WITH_LOG_FILE: ${{ inputs.log-file }}
       run: |
-        # errexit off for the wrapper so the marker is written even when the
+        # errexit off for the wrapper so the markers are written even when the
         # script fails — a failed run must stay a failure, not look like a kill.
         set +e
         mkdir -p "$(dirname "$RUN_WITH_LOG_FILE")"
+
+        # Start sentinel as the log's first line (truncates/creates the file).
+        # The parser treats a log that starts but never finishes as a
+        # timeout-minutes kill; logs without it are not tracked at all.
+        printf '[==tt-log-start-line==]\n' > "$RUN_WITH_LOG_FILE"
 
         # Run as its own bash file, matching a normal run step (errexit +
         # pipefail), so the script keeps full fidelity and its own exit code.
         script=$(mktemp)
         printf '%s\n' "$RUN_WITH_LOG_SCRIPT" > "$script"
-        bash --noprofile --norc -eo pipefail "$script" 2>&1 | tee "$RUN_WITH_LOG_FILE"
+        bash --noprofile --norc -eo pipefail "$script" 2>&1 | tee -a "$RUN_WITH_LOG_FILE"
         rc=${PIPESTATUS[0]}
         rm -f "$script"
 

--- a/.github/actions/run-with-log/action.yml
+++ b/.github/actions/run-with-log/action.yml
@@ -48,5 +48,8 @@ runs:
         rc=${PIPESTATUS[0]}
         rm -f "$script"
 
-        printf '[==tt-log-finish-line==] exit_code=%s\n' "$rc" >> "$RUN_WITH_LOG_FILE"
+        # Leading newline so the marker stays line-anchored even when the
+        # script's final output had no trailing newline (otherwise it glues onto
+        # that line and the parser's ^-anchored match misses it).
+        printf '\n[==tt-log-finish-line==] exit_code=%s\n' "$rc" >> "$RUN_WITH_LOG_FILE"
         exit $rc

--- a/.github/workflows/blackhole-e2e-tests-impl.yaml
+++ b/.github/workflows/blackhole-e2e-tests-impl.yaml
@@ -177,7 +177,7 @@ jobs:
         timeout-minutes: 10
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: generated/test_logs/${{ matrix.test-group.name }}.log
           run: ${{ matrix.test-group.cmd }}

--- a/.github/workflows/blackhole-e2e-tests-impl.yaml
+++ b/.github/workflows/blackhole-e2e-tests-impl.yaml
@@ -177,17 +177,10 @@ jobs:
         timeout-minutes: 10
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_logs
-          # tee combined stdout+stderr to a per-leg .log for ai-summary.
-          # Brace group: cmd may be multiple shell statements.
-          # PIPESTATUS: preserve real exit code (tee would mask it).
-          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
-          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
-          {
-            ${{ matrix.test-group.cmd }}
-          } 2>&1 | tee "$LOG_FILE"
-          exit ${PIPESTATUS[0]}
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: ${{ matrix.test-group.cmd }}
       - name: Check latency/BW results
         id: check-data
         if: ${{ !cancelled() && matrix.test-group.upload_fabric_data == true }}

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -184,17 +184,10 @@ jobs:
         timeout-minutes: 10
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_logs
-          # tee combined stdout+stderr to a per-leg .log for ai-summary.
-          # Brace group: cmd may be multiple shell statements.
-          # PIPESTATUS: preserve real exit code (tee would mask it).
-          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
-          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
-          {
-            ${{ matrix.test-group.cmd }}
-          } 2>&1 | tee "$LOG_FILE"
-          exit ${PIPESTATUS[0]}
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: ${{ matrix.test-group.cmd }}
       - name: Check latency/BW results
         id: check-data
         if: ${{ !cancelled() && matrix.test-group.name == 'fabric sanity benchmark' }}

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -184,7 +184,7 @@ jobs:
         timeout-minutes: 10
       - name: ${{ matrix.test-group.name }} tests
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: generated/test_logs/${{ matrix.test-group.name }}.log
           run: ${{ matrix.test-group.cmd }}

--- a/.github/workflows/demo-sp-release-impl.yaml
+++ b/.github/workflows/demo-sp-release-impl.yaml
@@ -131,17 +131,14 @@ jobs:
           hang-detection-timeout: ${{ contains(matrix.test-group.name, 'PERF') && '20.0' || '5.0' }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_logs
-          # tee combined stdout+stderr to a per-leg .log for ai-summary.
-          # PIPESTATUS: preserve real exit code (tee would mask it).
-          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
-          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
-          {
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
             # Store command safely using heredoc
             CMD=$(cat << 'EOF'
-          ${{ matrix.test-group.cmd }}
-          EOF
+            ${{ matrix.test-group.cmd }}
+            EOF
             )
 
             # Source T3K test scripts if needed (for run_t3000_* functions)
@@ -153,8 +150,6 @@ jobs:
 
             echo "$CMD"
             eval "$CMD"
-          } 2>&1 | tee "$LOG_FILE"
-          exit ${PIPESTATUS[0]}
       - name: Save environment data
         id: save-environment-data
         if: ${{ !cancelled() && matrix.test-group.save-perf-data }}

--- a/.github/workflows/demo-sp-release-impl.yaml
+++ b/.github/workflows/demo-sp-release-impl.yaml
@@ -131,7 +131,7 @@ jobs:
           hang-detection-timeout: ${{ contains(matrix.test-group.name, 'PERF') && '20.0' || '5.0' }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: generated/test_logs/${{ matrix.test-group.name }}.log
           run: |

--- a/.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
@@ -121,7 +121,7 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: generated/test_logs/${{ matrix.test-group.name }}.log
           run: ${{ matrix.test-group.cmd }}

--- a/.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
+++ b/.github/workflows/galaxy-deepseek-prefill-tests-impl.yaml
@@ -121,17 +121,10 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_logs
-          # tee combined stdout+stderr to a per-leg .log for ai-summary.
-          # Brace group: cmd may be multiple shell statements.
-          # PIPESTATUS: preserve real exit code (tee would mask it).
-          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
-          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
-          {
-            ${{ matrix.test-group.cmd }}
-          } 2>&1 | tee "$LOG_FILE"
-          exit ${PIPESTATUS[0]}
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: ${{ matrix.test-group.cmd }}
       - name: Publish PCC summary
         if: ${{ !cancelled() }}
         run: |

--- a/.github/workflows/models-device-perf-tests-impl.yaml
+++ b/.github/workflows/models-device-perf-tests-impl.yaml
@@ -144,7 +144,7 @@ jobs:
           wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/meta-llama http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/meta-llama/Llama-3.1-8B-Instruct/
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: generated/test_logs/${{ matrix.test-group.name }}.log
           run: |

--- a/.github/workflows/models-device-perf-tests-impl.yaml
+++ b/.github/workflows/models-device-perf-tests-impl.yaml
@@ -144,17 +144,12 @@ jobs:
           wget -r -nH -x --cut-dirs=5 -np --progress=dot:giga -R "index.html*" -P /localdev/blackhole_demos/huggingface_data/meta-llama http://yyz2-lfcache564.yyz2.tenstorrent.com/mldata/model_checkpoints/pytorch/huggingface/meta-llama/Llama-3.1-8B-Instruct/
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_reports generated/test_logs
-          # tee combined stdout+stderr to a per-leg .log for ai-summary.
-          # Brace group: cmd may be multiple shell statements.
-          # PIPESTATUS: preserve real exit code (tee would mask it).
-          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
-          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
-          {
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            mkdir -p generated/test_reports
             ${{ matrix.test-group.cmd }}
-          } 2>&1 | tee "$LOG_FILE"
-          exit ${PIPESTATUS[0]}
       - name: Merge test reports
         id: generate-device-perf-report
         if: ${{ !cancelled() }}

--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -149,23 +149,15 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_reports generated/test_logs
-          # Perf/accuracy are enforced by the "Validate perf and accuracy targets" step
-          # below; the in-test checks are warning-only, so the tests write complete
-          # benchmark JSON before validation runs.
-
-          # Mirror the matrix command's combined stdout+stderr to a per-leg
-          # log file so ai-summary can read it later. The brace group lets
-          # the cmd be multiple statements; PIPESTATUS forwards the real
-          # exit code that piping through tee would otherwise mask.
-          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
-          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
-
-          {
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            mkdir -p generated/test_reports
+            # Perf/accuracy are enforced by the "Validate perf and accuracy targets"
+            # step below; the in-test checks are warning-only, so the tests write
+            # complete benchmark JSON before validation runs.
             ${{ matrix.test-group.cmd }}
-          } 2>&1 | tee "$LOG_FILE"
-          exit "${PIPESTATUS[0]}"
       - name: Save environment data
         id: save-environment-data
         if: ${{ !cancelled() }}

--- a/.github/workflows/models-e2e-tests-impl.yaml
+++ b/.github/workflows/models-e2e-tests-impl.yaml
@@ -149,7 +149,7 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: generated/test_logs/${{ matrix.test-group.name }}.log
           run: |

--- a/.github/workflows/models-sweep-tests-impl.yaml
+++ b/.github/workflows/models-sweep-tests-impl.yaml
@@ -147,7 +147,7 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: generated/test_logs/${{ matrix.test-group.name }}.log
           run: |

--- a/.github/workflows/models-sweep-tests-impl.yaml
+++ b/.github/workflows/models-sweep-tests-impl.yaml
@@ -147,20 +147,12 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_reports generated/test_logs
-
-          # Mirror the matrix command's combined stdout+stderr to a per-leg
-          # log file so ai-summary can read it later. The brace group lets
-          # the cmd be multiple statements; PIPESTATUS forwards the real
-          # exit code that piping through tee would otherwise mask.
-          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
-          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
-
-          {
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            mkdir -p generated/test_reports
             ${{ matrix.test-group.cmd }}
-          } 2>&1 | tee "$LOG_FILE"
-          exit "${PIPESTATUS[0]}"
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/models-unit-tests-impl.yaml
+++ b/.github/workflows/models-unit-tests-impl.yaml
@@ -149,20 +149,12 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_reports generated/test_logs
-
-          # Mirror the matrix command's combined stdout+stderr to a per-leg
-          # log file so ai-summary can read it later. The brace group lets
-          # the cmd be multiple statements; PIPESTATUS forwards the real
-          # exit code that piping through tee would otherwise mask.
-          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
-          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
-
-          {
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: |
+            mkdir -p generated/test_reports
             ${{ matrix.test-group.cmd }}
-          } 2>&1 | tee "$LOG_FILE"
-          exit "${PIPESTATUS[0]}"
       - uses: tenstorrent/tt-metal/.github/actions/upload-artifact-with-job-uuid@main
         timeout-minutes: 10
         if: ${{ !cancelled() }}

--- a/.github/workflows/models-unit-tests-impl.yaml
+++ b/.github/workflows/models-unit-tests-impl.yaml
@@ -149,7 +149,7 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: generated/test_logs/${{ matrix.test-group.name }}.log
           run: |

--- a/.github/workflows/t3000-e2e-tests-impl.yaml
+++ b/.github/workflows/t3000-e2e-tests-impl.yaml
@@ -107,7 +107,7 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: generated/test_logs/${{ matrix.test-group.name }}.log
           run: ${{ matrix.test-group.cmd }}

--- a/.github/workflows/t3000-e2e-tests-impl.yaml
+++ b/.github/workflows/t3000-e2e-tests-impl.yaml
@@ -107,17 +107,10 @@ jobs:
           wheel-artifact-name: ${{ inputs.wheel-artifact-name }}
       - name: ${{ matrix.test-group.name }}
         timeout-minutes: ${{ matrix.test-group.timeout }}
-        run: |
-          mkdir -p generated/test_logs
-          # tee combined stdout+stderr to a per-leg .log for ai-summary.
-          # Brace group: cmd may be multiple shell statements.
-          # PIPESTATUS: preserve real exit code (tee would mask it).
-          SAFE_NAME=$(echo "${{ matrix.test-group.name }}" | tr ' /' '__')
-          LOG_FILE="generated/test_logs/${SAFE_NAME}_${{ job.check_run_id }}.log"
-          {
-            ${{ matrix.test-group.cmd }}
-          } 2>&1 | tee "$LOG_FILE"
-          exit ${PIPESTATUS[0]}
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: generated/test_logs/${{ matrix.test-group.name }}.log
+          run: ${{ matrix.test-group.cmd }}
       - name: 🤖 AI job summary
         if: always() && !cancelled()
         continue-on-error: true

--- a/.github/workflows/test-run-with-log.yaml
+++ b/.github/workflows/test-run-with-log.yaml
@@ -11,7 +11,7 @@ jobs:
   success-case:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-with-log
         with:
           working-directory: ${{ github.workspace }}
@@ -28,7 +28,7 @@ jobs:
   failure-case:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-with-log
         id: run
         continue-on-error: true
@@ -46,7 +46,7 @@ jobs:
   timeout-case:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: ./.github/actions/run-with-log
         id: run
         continue-on-error: true

--- a/.github/workflows/test-run-with-log.yaml
+++ b/.github/workflows/test-run-with-log.yaml
@@ -1,0 +1,66 @@
+name: "test: run-with-log"
+
+# Mechanics smoke test for the run-with-log action: a completed run appends the
+# marker; a timeout-minutes kill does not. Dispatch-only (the timeout case waits
+# ~60s). Classification of the marker is the ai_summary parser's concern, tested
+# in tenstorrent/tt-github-actions — not here.
+on:
+  workflow_dispatch:
+
+jobs:
+  success-case:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/run-with-log
+        with:
+          working-directory: ${{ github.workspace }}
+          log-file: out/ok.log
+          run: |
+            echo hello
+            echo world
+      - name: Assert marker present, exit 0
+        run: |
+          tail -3 out/ok.log
+          tail -1 out/ok.log | grep -qx '\[==tt-log-finish-line==\] exit_code=0'
+
+  failure-case:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/run-with-log
+        id: run
+        continue-on-error: true
+        with:
+          working-directory: ${{ github.workspace }}
+          log-file: out/fail.log
+          run: |
+            echo before
+            exit 7
+      - name: Assert failure forwarded, marker carries exit code
+        run: |
+          test "${{ steps.run.outcome }}" = failure
+          tail -1 out/fail.log | grep -qx '\[==tt-log-finish-line==\] exit_code=7'
+
+  timeout-case:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/run-with-log
+        id: run
+        continue-on-error: true
+        timeout-minutes: 1
+        with:
+          working-directory: ${{ github.workspace }}
+          log-file: out/timeout.log
+          run: |
+            echo started
+            sleep 120
+      - name: Assert killed, marker absent
+        run: |
+          test "${{ steps.run.outcome }}" != success
+          grep -q '^started$' out/timeout.log
+          if grep -q tt-log-finish-line out/timeout.log; then
+            echo "::error::marker present after timeout kill — bug"; exit 1
+          fi
+          echo "marker correctly absent (outcome=${{ steps.run.outcome }})"

--- a/.github/workflows/test-run-with-log.yaml
+++ b/.github/workflows/test-run-with-log.yaml
@@ -67,3 +67,18 @@ jobs:
             echo "::error::finish marker present after timeout kill — bug"; exit 1
           fi
           echo "tracked-but-truncated signature correct (outcome=${{ steps.run.outcome }})"
+
+  no-trailing-newline-case:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: ./.github/actions/run-with-log
+        with:
+          working-directory: ${{ github.workspace }}
+          log-file: out/nonl.log
+          run: printf 'no trailing newline'
+      - name: Assert finish marker stays line-anchored
+        run: |
+          tail -2 out/nonl.log
+          # script output had no trailing newline; the marker must still be its own line
+          tail -1 out/nonl.log | grep -qx '\[==tt-log-finish-line==\] exit_code=0'

--- a/.github/workflows/test-run-with-log.yaml
+++ b/.github/workflows/test-run-with-log.yaml
@@ -19,9 +19,10 @@ jobs:
           run: |
             echo hello
             echo world
-      - name: Assert marker present, exit 0
+      - name: Assert start + finish markers, exit 0
         run: |
           tail -3 out/ok.log
+          head -1 out/ok.log | grep -qx '\[==tt-log-start-line==\]'
           tail -1 out/ok.log | grep -qx '\[==tt-log-finish-line==\] exit_code=0'
 
   failure-case:
@@ -56,11 +57,13 @@ jobs:
           run: |
             echo started
             sleep 120
-      - name: Assert killed, marker absent
+      - name: Assert started but no finish marker (timeout signature)
         run: |
           test "${{ steps.run.outcome }}" != success
           grep -q '^started$' out/timeout.log
+          # start sentinel written before the script ran, finish never reached
+          head -1 out/timeout.log | grep -qx '\[==tt-log-start-line==\]'
           if grep -q tt-log-finish-line out/timeout.log; then
-            echo "::error::marker present after timeout kill — bug"; exit 1
+            echo "::error::finish marker present after timeout kill — bug"; exit 1
           fi
-          echo "marker correctly absent (outcome=${{ steps.run.outcome }})"
+          echo "tracked-but-truncated signature correct (outcome=${{ steps.run.outcome }})"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -456,8 +456,10 @@ jobs:
           mkdir -p output
 
       - name: 📀 Install vLLM
-        run: |
-          {
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: ${{ env.FILE_INSTALL_LOG }}
+          run: |
             VLLM_TARGET_DEVICE=empty uv pip install vllm/ --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
             if [ -d vllm/plugins/vllm-tt-plugin ]; then
               uv pip install --no-deps -e vllm/plugins/vllm-tt-plugin
@@ -467,8 +469,6 @@ jobs:
             case "${{ matrix.test-group.model }}" in
               google/gemma-4-*) uv pip install -r models/demos/gemma4/requirements.txt ;;
             esac
-          } 2>&1 | tee "${FILE_INSTALL_LOG}"
-          exit "${PIPESTATUS[0]}"
 
       - name: 🚀 Run server
         timeout-minutes: 1
@@ -593,27 +593,30 @@ jobs:
 
       - name: 📐 Run benchmark
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: ${{ env.FILE_BENCHMARK_LOG }}
+          run: |
+            if [ -n "${{ matrix.test-group.additional-benchmark-args }}" ]; then
+              ADDITIONAL_BENCHMARK_ARGS=(${{ matrix.test-group.additional-benchmark-args }})
+            else
+              ADDITIONAL_BENCHMARK_ARGS=()
+            fi
+
+            vllm bench serve \
+              --backend vllm \
+              --model ${{ matrix.test-group.model }} \
+              --dataset-name random \
+              --random-input-len 100 \
+              --random-output-len 100 \
+              --num-prompts 32 \
+              --ignore-eos \
+              --percentile-metrics ttft,tpot,itl,e2el \
+              --save-result \
+              --result-filename output/vllm_result.json \
+              "${ADDITIONAL_BENCHMARK_ARGS[@]}"
+      - name: Verify benchmark
         run: |
-          if [ -n "${{ matrix.test-group.additional-benchmark-args }}" ]; then
-            ADDITIONAL_BENCHMARK_ARGS=(${{ matrix.test-group.additional-benchmark-args }})
-          else
-            ADDITIONAL_BENCHMARK_ARGS=()
-          fi
-
-          vllm bench serve \
-            --backend vllm \
-            --model ${{ matrix.test-group.model }} \
-            --dataset-name random \
-            --random-input-len 100 \
-            --random-output-len 100 \
-            --num-prompts 32 \
-            --ignore-eos \
-            --percentile-metrics ttft,tpot,itl,e2el \
-            --save-result \
-            --result-filename output/vllm_result.json \
-            "${ADDITIONAL_BENCHMARK_ARGS[@]}" \
-            2>&1 | tee ${FILE_BENCHMARK_LOG}
-
           # `vllm bench serve` exits 0 even when individual requests fail (a crashed
           # engine surfaces as failed requests, not a non-zero exit). Gate on the saved result and
           # require EVERY request to complete successfully.
@@ -634,32 +637,36 @@ jobs:
       - name: 📐 Run structured output benchmark
         if: ${{ matrix.test-group.structured-output }}
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: ${{ env.FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG }}
+          run: |
+            if [ -n "${{ matrix.test-group.additional-benchmark-args }}" ]; then
+              ADDITIONAL_BENCHMARK_ARGS=(${{ matrix.test-group.additional-benchmark-args }})
+            else
+              ADDITIONAL_BENCHMARK_ARGS=()
+            fi
+
+            if [ -n "${{ matrix.test-group.additional-structured-output-args }}" ]; then
+              ADDITIONAL_STRUCTURED_OUTPUT_ARGS=(${{ matrix.test-group.additional-structured-output-args }})
+            else
+              ADDITIONAL_STRUCTURED_OUTPUT_ARGS=()
+            fi
+
+            python3 vllm/benchmarks/benchmark_serving_structured_output.py \
+              --backend vllm \
+              --model ${{ matrix.test-group.model }} \
+              --num-prompts 32 \
+              --percentile-metrics ttft,tpot,itl,e2el \
+              --dataset json-unique \
+              --output-len 1024 \
+              --save-results \
+              --result-filename output/vllm_result_structured.json \
+              "${ADDITIONAL_BENCHMARK_ARGS[@]}" \
+              "${ADDITIONAL_STRUCTURED_OUTPUT_ARGS[@]}"
+      - name: Verify structured output
+        if: ${{ success() && matrix.test-group.structured-output }}
         run: |
-          if [ -n "${{ matrix.test-group.additional-benchmark-args }}" ]; then
-            ADDITIONAL_BENCHMARK_ARGS=(${{ matrix.test-group.additional-benchmark-args }})
-          else
-            ADDITIONAL_BENCHMARK_ARGS=()
-          fi
-
-          if [ -n "${{ matrix.test-group.additional-structured-output-args }}" ]; then
-            ADDITIONAL_STRUCTURED_OUTPUT_ARGS=(${{ matrix.test-group.additional-structured-output-args }})
-          else
-            ADDITIONAL_STRUCTURED_OUTPUT_ARGS=()
-          fi
-
-          python3 vllm/benchmarks/benchmark_serving_structured_output.py \
-            --backend vllm \
-            --model ${{ matrix.test-group.model }} \
-            --num-prompts 32 \
-            --percentile-metrics ttft,tpot,itl,e2el \
-            --dataset json-unique \
-            --output-len 1024 \
-            --save-results \
-            --result-filename output/vllm_result_structured.json \
-            "${ADDITIONAL_BENCHMARK_ARGS[@]}" \
-            "${ADDITIONAL_STRUCTURED_OUTPUT_ARGS[@]}" \
-            2>&1 | tee ${FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG}
-
           # The benchmark returns zero even if responses are not correct.
           success_message="correct_rate(%) 100.0"
           if grep -q "$success_message" "${FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG}"; then
@@ -673,39 +680,43 @@ jobs:
       - name: 🖼️ Run multimodal test
         if: ${{ matrix.test-group.multimodal }}
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
-        run: |
-          curl http://localhost:8000/v1/chat/completions \
-            -H "Content-Type: application/json" \
-            -H "X-User-ID: vllm_test" \
-            -d '{
-              "model": "${{ matrix.test-group.model }}",
-              "messages": [
-                {
-                  "role": "user",
-                  "content": [
-                    {
-                      "type": "text",
-                      "text": "Describe this image in 50 words."
-                    },
-                    {
-                      "type": "image_url",
-                      "image_url": {
-                        "url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.jpeg"
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: ${{ env.FILE_MULTIMODAL_TEST_LOG }}
+          run: |
+            curl http://localhost:8000/v1/chat/completions \
+              -H "Content-Type: application/json" \
+              -H "X-User-ID: vllm_test" \
+              -d '{
+                "model": "${{ matrix.test-group.model }}",
+                "messages": [
+                  {
+                    "role": "user",
+                    "content": [
+                      {
+                        "type": "text",
+                        "text": "Describe this image in 50 words."
+                      },
+                      {
+                        "type": "image_url",
+                        "image_url": {
+                          "url": "https://huggingface.co/datasets/huggingface/documentation-images/resolve/main/cats.jpeg"
+                        }
                       }
-                    }
-                  ]
-                }
-              ],
-              "max_tokens": 512,
-              "temperature": 0.0,
-              "top_p": 0.9,
-              "top_k": 10,
-              "repetition_penalty": 1.0,
-              "stream": false,
-              "ignore_eos": false
-          }' \
-          2>&1 | tee ${FILE_MULTIMODAL_TEST_LOG}
-
+                    ]
+                  }
+                ],
+                "max_tokens": 512,
+                "temperature": 0.0,
+                "top_p": 0.9,
+                "top_k": 10,
+                "repetition_penalty": 1.0,
+                "stream": false,
+                "ignore_eos": false
+            }'
+      - name: Verify multimodal
+        if: ${{ success() && matrix.test-group.multimodal }}
+        run: |
           # If the test fails, the response will not contain the expected word
           keyword="cat"
           if ! grep -q -i "$keyword" "${FILE_MULTIMODAL_TEST_LOG}"; then
@@ -716,16 +727,16 @@ jobs:
       - name: 🧪 Run sampling tests
         if: ${{ matrix.test-group.sampling-tests }}
         timeout-minutes: ${{ matrix.test-group.sampling-test-timeout || 10 }}
-        run: |
-          {
+        uses: ./.github/actions/run-with-log
+        with:
+          log-file: ${{ env.FILE_SAMPLING_TESTS_LOG }}
+          run: |
             FILTER="${{ matrix.test-group.sampling-test-filter }}"
             if [ -n "$FILTER" ]; then
               pytest vllm/plugins/vllm-tt-plugin/tests/tt -v -k "$FILTER" --tt-server-url=http://localhost:8000 --tt-model-name=${{ matrix.test-group.model }}
             else
               pytest vllm/plugins/vllm-tt-plugin/tests/tt -v --tt-server-url=http://localhost:8000 --tt-model-name=${{ matrix.test-group.model }}
             fi
-          } 2>&1 | tee "${FILE_SAMPLING_TESTS_LOG}"
-          exit "${PIPESTATUS[0]}"
 
       - name: 🧹 Cleanup server process
         if: always()
@@ -764,9 +775,6 @@ jobs:
         run: |
           cat output/vllm_result_structured.json
 
-      # vllm-nightly tees ~6 phase logs with no single end-of-run point, so it
-      # can't emit the run-with-log completion marker. Opt out of marker-based
-      # timeout detection so a markerless log isn't misread as a timeout kill.
       - name: 🤖 AI job summary
         if: always() && !cancelled()
         continue-on-error: true
@@ -775,7 +783,6 @@ jobs:
           config: |
             {
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
-              "log_complete_marker": null,
               "workspace": "$GITHUB_WORKSPACE/docker-job",
               "input_dirs": ["output"],
               "output_dir": "ai_summaries"

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -458,7 +458,7 @@ jobs:
       - name: 📀 Install vLLM
         uses: ./docker-job/.github/actions/run-with-log
         with:
-          log-file: ${{ env.FILE_INSTALL_LOG }}
+          log-file: output/vllm_install.log
           run: |
             VLLM_TARGET_DEVICE=empty uv pip install vllm/ --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
             if [ -d vllm/plugins/vllm-tt-plugin ]; then
@@ -595,7 +595,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         uses: ./docker-job/.github/actions/run-with-log
         with:
-          log-file: ${{ env.FILE_BENCHMARK_LOG }}
+          log-file: output/vllm_benchmark.log
           run: |
             if [ -n "${{ matrix.test-group.additional-benchmark-args }}" ]; then
               ADDITIONAL_BENCHMARK_ARGS=(${{ matrix.test-group.additional-benchmark-args }})
@@ -639,7 +639,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         uses: ./docker-job/.github/actions/run-with-log
         with:
-          log-file: ${{ env.FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG }}
+          log-file: output/vllm_benchmark_structured_output.log
           run: |
             if [ -n "${{ matrix.test-group.additional-benchmark-args }}" ]; then
               ADDITIONAL_BENCHMARK_ARGS=(${{ matrix.test-group.additional-benchmark-args }})
@@ -682,7 +682,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         uses: ./docker-job/.github/actions/run-with-log
         with:
-          log-file: ${{ env.FILE_MULTIMODAL_TEST_LOG }}
+          log-file: output/vllm_multimodal_test.log
           run: |
             curl http://localhost:8000/v1/chat/completions \
               -H "Content-Type: application/json" \
@@ -729,7 +729,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.sampling-test-timeout || 10 }}
         uses: ./docker-job/.github/actions/run-with-log
         with:
-          log-file: ${{ env.FILE_SAMPLING_TESTS_LOG }}
+          log-file: output/vllm_sampling_tests.log
           run: |
             FILTER="${{ matrix.test-group.sampling-test-filter }}"
             if [ -n "$FILTER" ]; then

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -456,7 +456,7 @@ jobs:
           mkdir -p output
 
       - name: 📀 Install vLLM
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: ${{ env.FILE_INSTALL_LOG }}
           run: |
@@ -593,7 +593,7 @@ jobs:
 
       - name: 📐 Run benchmark
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: ${{ env.FILE_BENCHMARK_LOG }}
           run: |
@@ -637,7 +637,7 @@ jobs:
       - name: 📐 Run structured output benchmark
         if: ${{ matrix.test-group.structured-output }}
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: ${{ env.FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG }}
           run: |
@@ -680,7 +680,7 @@ jobs:
       - name: 🖼️ Run multimodal test
         if: ${{ matrix.test-group.multimodal }}
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: ${{ env.FILE_MULTIMODAL_TEST_LOG }}
           run: |
@@ -727,7 +727,7 @@ jobs:
       - name: 🧪 Run sampling tests
         if: ${{ matrix.test-group.sampling-tests }}
         timeout-minutes: ${{ matrix.test-group.sampling-test-timeout || 10 }}
-        uses: ./.github/actions/run-with-log
+        uses: ./docker-job/.github/actions/run-with-log
         with:
           log-file: ${{ env.FILE_SAMPLING_TESTS_LOG }}
           run: |

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -668,18 +668,13 @@ jobs:
               --result-filename output/vllm_result_structured.json \
               "${ADDITIONAL_BENCHMARK_ARGS[@]}" \
               "${ADDITIONAL_STRUCTURED_OUTPUT_ARGS[@]}"
-      - name: Verify structured output
-        if: ${{ success() && matrix.test-group.structured-output }}
-        run: |
-          # The benchmark returns zero even if responses are not correct.
-          success_message="correct_rate(%) 100.0"
-          if grep -q "$success_message" "${FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG}"; then
-            echo "✅ Structured output benchmark completed successfully"
-          else
-            echo "❌ Structured output benchmark failed"
-            echo "Check out the server log in a step below."
-            exit 1
-          fi
+
+            # The benchmark exits 0 even when responses are wrong; gate on the
+            # saved correct_rate(%), which must be a perfect 100.0. Reading the
+            # result file (not the log) keeps this race-free under the wrapper.
+            python3 -c "import json, sys; sys.exit(0 if float(json.load(open('output/vllm_result_structured.json'))['correct_rate(%)']) == 100.0 else 1)" \
+              || { echo '❌ Structured output failed (correct_rate(%) != 100.0)'; exit 1; }
+            echo '✅ Structured output passed'
 
       - name: 🖼️ Run multimodal test
         if: ${{ matrix.test-group.multimodal }}
@@ -688,7 +683,7 @@ jobs:
         with:
           log-file: ${{ env.FILE_MULTIMODAL_TEST_LOG }}
           run: |
-            curl http://localhost:8000/v1/chat/completions \
+            resp=$(curl -sS http://localhost:8000/v1/chat/completions \
               -H "Content-Type: application/json" \
               -H "X-User-ID: vllm_test" \
               -d '{
@@ -717,17 +712,13 @@ jobs:
                 "repetition_penalty": 1.0,
                 "stream": false,
                 "ignore_eos": false
-            }'
-      - name: Verify multimodal
-        if: ${{ success() && matrix.test-group.multimodal }}
-        run: |
-          # If the test fails, the response will not contain the expected word
-          keyword="cat"
-          if ! grep -q -i "$keyword" "${FILE_MULTIMODAL_TEST_LOG}"; then
-            echo "❌ The keyword \"$keyword\" not found in the response"
-            echo "Check out the server log in a step below."
-            exit 1
-          fi
+            }')
+            echo "$resp"
+            # cats.jpeg: a correct description mentions a cat, so its absence
+            # means the model or image pipeline misbehaved. Grep the captured
+            # response (not the log) to stay race-free under the wrapper.
+            grep -qi cat <<<"$resp" || { echo '❌ keyword "cat" not found in multimodal response'; exit 1; }
+            echo '✅ Multimodal response describes a cat'
       - name: 🧪 Run sampling tests
         if: ${{ matrix.test-group.sampling-tests }}
         timeout-minutes: ${{ matrix.test-group.sampling-test-timeout || 10 }}

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -392,6 +392,17 @@ jobs:
       - in-service
       # topology-6u tag is used for WH galaxies. Currently pipeline-perf machines have mlperf access and pipeline-functional machines do not.
       - ${{ ((matrix.test-group.runner-label == 'BH-Quietbox-2' || matrix.test-group.runner-label == 'topology-6u') && 'pipeline-perf') || 'pipeline-functional' }}
+    # Per-phase log paths kept job-level so they resolve in both the ${{ env }}
+    # expression context (run-with-log log-file inputs) and the container step
+    # shells ($FILE_*). container.env is shell-only, not visible to expressions.
+    env:
+      FILE_SERVER_PID: "./server.pid"
+      FILE_INSTALL_LOG: "./output/vllm_install.log"
+      FILE_SERVER_LOG: "./output/vllm_server.log"
+      FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"
+      FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG: "./output/vllm_benchmark_structured_output.log"
+      FILE_MULTIMODAL_TEST_LOG: "./output/vllm_multimodal_test.log"
+      FILE_SAMPLING_TESTS_LOG: "./output/vllm_sampling_tests.log"
     container:
       image: ${{ inputs.docker-image }}
       env:
@@ -403,13 +414,6 @@ jobs:
         HF_HUB_OFFLINE: 1
         HF_HUB_CACHE: /mnt/MLPerf/huggingface/hub
         TT_CACHE_HOME: /mnt/MLPerf/huggingface/tt_cache
-        FILE_SERVER_PID: "./server.pid"
-        FILE_INSTALL_LOG: "./output/vllm_install.log"
-        FILE_SERVER_LOG: "./output/vllm_server.log"
-        FILE_BENCHMARK_LOG: "./output/vllm_benchmark.log"
-        FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG: "./output/vllm_benchmark_structured_output.log"
-        FILE_MULTIMODAL_TEST_LOG: "./output/vllm_multimodal_test.log"
-        FILE_SAMPLING_TESTS_LOG: "./output/vllm_sampling_tests.log"
       volumes:
         - ${{ github.workspace }}/docker-job:/work # Subdir to workaround https://github.com/actions/runner/issues/691
         - /dev/hugepages-1G:/dev/hugepages-1G
@@ -458,7 +462,7 @@ jobs:
       - name: 📀 Install vLLM
         uses: ./docker-job/.github/actions/run-with-log
         with:
-          log-file: output/vllm_install.log
+          log-file: ${{ env.FILE_INSTALL_LOG }}
           run: |
             VLLM_TARGET_DEVICE=empty uv pip install vllm/ --extra-index-url https://download.pytorch.org/whl/cpu --index-strategy unsafe-best-match
             if [ -d vllm/plugins/vllm-tt-plugin ]; then
@@ -595,7 +599,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         uses: ./docker-job/.github/actions/run-with-log
         with:
-          log-file: output/vllm_benchmark.log
+          log-file: ${{ env.FILE_BENCHMARK_LOG }}
           run: |
             if [ -n "${{ matrix.test-group.additional-benchmark-args }}" ]; then
               ADDITIONAL_BENCHMARK_ARGS=(${{ matrix.test-group.additional-benchmark-args }})
@@ -639,7 +643,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         uses: ./docker-job/.github/actions/run-with-log
         with:
-          log-file: output/vllm_benchmark_structured_output.log
+          log-file: ${{ env.FILE_BENCHMARK_STRUCTURED_OUTPUT_LOG }}
           run: |
             if [ -n "${{ matrix.test-group.additional-benchmark-args }}" ]; then
               ADDITIONAL_BENCHMARK_ARGS=(${{ matrix.test-group.additional-benchmark-args }})
@@ -682,7 +686,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.benchmark-timeout }}
         uses: ./docker-job/.github/actions/run-with-log
         with:
-          log-file: output/vllm_multimodal_test.log
+          log-file: ${{ env.FILE_MULTIMODAL_TEST_LOG }}
           run: |
             curl http://localhost:8000/v1/chat/completions \
               -H "Content-Type: application/json" \
@@ -729,7 +733,7 @@ jobs:
         timeout-minutes: ${{ matrix.test-group.sampling-test-timeout || 10 }}
         uses: ./docker-job/.github/actions/run-with-log
         with:
-          log-file: output/vllm_sampling_tests.log
+          log-file: ${{ env.FILE_SAMPLING_TESTS_LOG }}
           run: |
             FILTER="${{ matrix.test-group.sampling-test-filter }}"
             if [ -n "$FILTER" ]; then

--- a/.github/workflows/vllm-nightly-tests-impl.yaml
+++ b/.github/workflows/vllm-nightly-tests-impl.yaml
@@ -764,6 +764,9 @@ jobs:
         run: |
           cat output/vllm_result_structured.json
 
+      # vllm-nightly tees ~6 phase logs with no single end-of-run point, so it
+      # can't emit the run-with-log completion marker. Opt out of marker-based
+      # timeout detection so a markerless log isn't misread as a timeout kill.
       - name: 🤖 AI job summary
         if: always() && !cancelled()
         continue-on-error: true
@@ -772,6 +775,7 @@ jobs:
           config: |
             {
               "model": "${{ vars.AI_SUMMARY_MODEL }}",
+              "log_complete_marker": null,
               "workspace": "$GITHUB_WORKSPACE/docker-job",
               "input_dirs": ["output"],
               "output_dir": "ai_summaries"


### PR DESCRIPTION
Adds a local composite action `.github/actions/run-with-log` and adopts it in every test leg that runs `ai_summary/job`. The action runs the leg's command exactly like a `run:` step, tees combined output to a per-leg `.log`, forwards the real exit code, and appends a completion marker as the log's final line:

```
[==tt-log-finish-line==] exit_code=<N>
```

The marker's **absence** means the shell was hard-killed before finishing — most usefully a GitHub `timeout-minutes` kill, which otherwise leaves no trace in the tee'd log. The ai-summary parser (in `tenstorrent/tt-github-actions`) uses it to tell a timeout apart from a crash, instead of mis-reporting a killed job as a clean SUCCESS.

This replaces the hand-rolled `tee`/`PIPESTATUS`/`SAFE_NAME` blocks copied across ~9 workflows with one reviewed action.

### Examples
- [(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/runs/27712404412) - One failure, one timeout.
- [vLLM nightly tests](https://github.com/tenstorrent/tt-metal/actions/runs/27712554161)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ppetrovic/run-with-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ppetrovic/run-with-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ppetrovic/run-with-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ppetrovic/run-with-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ppetrovic/run-with-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ppetrovic/run-with-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ppetrovic/run-with-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ppetrovic/run-with-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ppetrovic/run-with-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ppetrovic/run-with-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ppetrovic/run-with-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ppetrovic/run-with-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ppetrovic/run-with-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ppetrovic/run-with-log)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ppetrovic/run-with-log)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ppetrovic/run-with-log)