### PR TITLE
fix(matmul): compute 2d-mcast output shard grid instead of trusting user grid

### DIFF
--- a/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/matmul/device/matmul_device_operation.cpp
@@ -1992,15 +1992,25 @@ MatmulDeviceOperation::spec_return_value_t MatmulDeviceOperation::compute_output
 
                     uint32_t num_blocks_y = ((M - 1) / per_core_M) + 1;
                     uint32_t num_blocks_x = ((N - 1) / per_core_N) + 1;
-                    ShardOrientation shard_orientation =
-                        program_config.transpose_mcast ? ShardOrientation::COL_MAJOR : ShardOrientation::ROW_MAJOR;
+                    // The output CB is globally allocated against the output tensor on the factory's
+                    // work grid {start_core, start_core + num_blocks - 1}, so the output shard grid
+                    // computed here must match it exactly. Mirror the factory's start_core derivation
+                    // (allowed_worker_cores is the single source of truth for core placement) rather
+                    // than trusting a user-supplied output shard grid, which need not agree.
+                    const CoreCoord start_core =
+                        program_config.allowed_worker_cores.has_value()
+                            ? program_config.allowed_worker_cores.value().bounding_box().start_coord
+                            : CoreCoord{0, 0};
                     CoreRangeSet all_cores;
-                    if (attributes.output_mem_config.shard_spec().has_value()) {
-                        all_cores = attributes.output_mem_config.shard_spec()->grid;
-                    } else if (program_config.transpose_mcast) {
-                        all_cores = CoreRangeSet({CoreRange({0, 0}, {num_blocks_y - 1, num_blocks_x - 1})});
+                    ShardOrientation shard_orientation;
+                    if (program_config.transpose_mcast) {
+                        all_cores = CoreRangeSet({CoreRange(
+                            start_core, {start_core.x + num_blocks_y - 1, start_core.y + num_blocks_x - 1})});
+                        shard_orientation = ShardOrientation::COL_MAJOR;
                     } else {
-                        all_cores = CoreRangeSet({CoreRange({0, 0}, {num_blocks_x - 1, num_blocks_y - 1})});
+                        all_cores = CoreRangeSet({CoreRange(
+                            start_core, {start_core.x + num_blocks_x - 1, start_core.y + num_blocks_y - 1})});
+                        shard_orientation = ShardOrientation::ROW_MAJOR;
                     }
                     tt::tt_metal::ShardSpec shard_spec = tt::tt_metal::ShardSpec{
                         all_cores,


### PR DESCRIPTION
## Summary

Fixes the Stable Diffusion demo all-zeros regression (`test_demo_sd`: PCC **0.06** vs 0.935 threshold), introduced by #45037 (commit 3934951be50).

The `MatmulMultiCoreReuseMultiCastProgramConfig` branch of `compute_output_specs` began taking the user-supplied `output_mem_config` shard grid **verbatim** when present. But the 2d-mcast factory lays output work on a grid `{start_core, start_core + num_blocks - 1}` and globally allocates the output CB against the output tensor *on that grid* — so the output tensor's declared shard grid **must equal** the factory's work grid. When the supplied grid disagreed (as in the SD UNet), cores read/wrote the wrong L1 addresses → all-zeros output.

## Fix

Compute the grid the factory actually uses — the canonical `num_blocks` shape offset by the same `start_core` derivation (`allowed_worker_cores` bounding-box start, else `{0,0}`) — rather than trusting the user grid.

- **Non-fused** (e.g. SD): `allowed_worker_cores` unset → `start_core = {0,0}`, restoring pre-#45037 behavior.
- **Fusion**: matches the factory's offset placement (`allowed_worker_cores` is the single source of truth for core placement).

## Root cause / bisect

- Confirmed regression caused by 3934951be50, isolated to `matmul_device_operation.cpp`.
- A/B bisected to a single hunk: the 2d-mcast `compute_output_specs` branch. Reverting only that hunk restored correctness.

## Test plan

- ✅ SD demo repro: PCC restored (was 0.06, now passes ≥0.935)
- ✅ `parallel_sequential` fusion suite: 89/89 pass (exercises the non-(0,0) `start_core` offset path)
- ✅ `test_matmul_compute_output_specs_with_allowed_worker_cores` + `test_matmul_2d_nd_sharded_in1` pass
- ✅ matmul unit files pass with no functional regressions: `test_custom_grids` (28), `test_addmm` (333), `test_linear` (169), `test_experimental`, `test_matmul_batch_mismatch`, `test_ring_matmul`, `test_sparse_matmul` (11)

> Note: a few tiny-tile / DRAM-sharded matmul unit tests device-hang on the dev board used here (`test_optional_output_argument_with_tiny_tiles`, `test_matmul_in1_dram_sharded_tiny_tile`, `test_matmul_l1_dram_sharded[moe_gate]`). Confirmed **pre-existing** — they reproduce on clean `main` with this fix reverted, and live on code paths this change does not touch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rmillerTT/fix_stable_diffusion_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rmillerTT/fix_stable_diffusion_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rmillerTT/fix_stable_diffusion_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rmillerTT/fix_stable_diffusion_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rmillerTT/fix_stable_diffusion_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rmillerTT/fix_stable_diffusion_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rmillerTT/fix_stable_diffusion_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rmillerTT/fix_stable_diffusion_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rmillerTT/fix_stable_diffusion_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rmillerTT/fix_stable_diffusion_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rmillerTT/fix_stable_diffusion_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rmillerTT/fix_stable_diffusion_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rmillerTT/fix_stable_diffusion_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rmillerTT/fix_stable_diffusion_test)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rmillerTT/fix_stable_diffusion_test)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rmillerTT/fix_stable_diffusion_test)