### PR TITLE
[Cleanup] Rename device side tensor bindings to `tensor` namespace

### DIFF
--- a/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
+++ b/tests/tt_metal/tt_metal/api/dataflow_buffer/test_dataflow_buffer.cpp
@@ -248,7 +248,7 @@ void run_single_dfb_program(
             .dfb_bindings = {experimental::ProducerOf(DFB_NAME, "out")},
             .tensor_bindings = {{
                 .tensor_parameter_name = IN_TENSOR,
-                .accessor_name = "src_tensor",  // kernel: ta::src_tensor
+                .accessor_name = "src_tensor",  // kernel: tensor::src_tensor
             }},
             .compile_time_args =
                 {
@@ -288,7 +288,7 @@ void run_single_dfb_program(
             }},
             .tensor_bindings = {{
                 .tensor_parameter_name = OUT_TENSOR,
-                .accessor_name = "dst_tensor",  // kernel: ta::dst_tensor
+                .accessor_name = "dst_tensor",  // kernel: tensor::dst_tensor
             }},
             .compile_time_args =
                 {
@@ -961,7 +961,7 @@ void run_sequential_dfbs_program(
         num_producers + num_consumers <= 6,
         "num_producers + num_consumers must fit in 6 available Quasar DM threads (DM0 reserved for dispatch)");
     // dfb_seq_producer / dfb_seq_consumer kernels unroll up to TEST_NUM_DFBS bindings
-    // referencing dfb::dfb_<i> / ta::src_<i> / ta::dst_<i> for i in [0, TEST_NUM_DFBS).
+    // referencing dfb::dfb_<i> / tensor::src_<i> / tensor::dst_<i> for i in [0, TEST_NUM_DFBS).
     TT_FATAL(num_dfbs <= 6, "num_dfbs must be <= 6 (kernel binding-name limit dfb::dfb_0..5)");
 
     const CoreCoord core(0, 0);
@@ -1002,7 +1002,7 @@ void run_sequential_dfbs_program(
     const experimental::KernelSpecName PRODUCER{"producer"};
     const experimental::KernelSpecName CONSUMER{"consumer"};
 
-    // Producer kernel: N DFB bindings (dfb::dfb_0..N-1) + N tensor bindings (ta::src_0..N-1).
+    // Producer kernel: N DFB bindings (dfb::dfb_0..N-1) + N tensor bindings (tensor::src_0..N-1).
     // TEST_NUM_DFBS compiler define gates the per-DFB unrolled blocks; it must equal the
     // number of dfb_bindings / tensor_bindings registered here. Name is prefixed to avoid
     // colliding with dfb::NUM_DFBS in dataflow_buffer_config.h.

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -3127,7 +3127,7 @@ TEST_F(ProgramSpecTestGen1, InvalidTensorAccessorNameFails) {
 
 TEST_F(ProgramSpecTestGen1, AccessorNamesAcrossCategoriesAreSeparateNamespaces) {
     // DFB / Semaphore / TensorAccessor accessor names live in separate namespaces (each gets
-    // its own emitted namespace in kernel_bindings_generated.h: dfb::, sem::, ta::). Reusing
+    // its own emitted namespace in kernel_bindings_generated.h: dfb::, sem::, tensor::). Reusing
     // the same identifier across categories within one kernel must be allowed.
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
 
@@ -3163,7 +3163,7 @@ TEST_F(ProgramSpecTestGen1, MinimalValidProgramSpecWithTensorParameterSucceeds) 
 // SECTION 10: TensorParameter JIT Smoke Tests (Gen1 / WH)
 // ============================================================================
 // Codegen-path smoke test for the Metal 2.0 TensorAccessor binding feature. Ends in
-// CompileProgram, so the auto-generated kernel_bindings_generated.h (with its `ta::` namespace)
+// CompileProgram, so the auto-generated kernel_bindings_generated.h (with its `tensor::` namespace)
 // must be syntactically valid and compose correctly with the rest of the kernel build. Doesn't
 // validate runtime behavior — catches regressions in codegen string-formatting, token type alias
 // generation, and include-path resolution.
@@ -3176,7 +3176,7 @@ TEST_F(ProgramSpecTestGen1, MinimalValidProgramSpecWithTensorParameterSucceeds) 
 
 TEST_F(ProgramSpecTestGen1, TensorAccessorBindingJITSmokeDMKernel) {
     // DM kernel constructs a TensorAccessor from a binding token + invokes a NoC-using method.
-    // Exercises: ta:: namespace token, type alias <name>_t, the token ctor and its deduction
+    // Exercises: tensor:: namespace token, type alias <name>_t, the token ctor and its deduction
     // guide, get_common_arg_val for the implicit base address.
     NodeCoord node{0, 0};
 
@@ -3186,7 +3186,7 @@ TEST_F(ProgramSpecTestGen1, TensorAccessorBindingJITSmokeDMKernel) {
     auto dm_kernel = MakeMinimalGen1DMKernel("dm_kernel");
     dm_kernel.source = KernelSpec::SourceCode{R"(
 void kernel_main() {
-    TensorAccessor accessor(ta::input_tensor);
+    TensorAccessor accessor(tensor::input_tensor);
     auto noc_addr = accessor.get_noc_addr(0);
     (void)noc_addr;
 }

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec_hw.cpp
@@ -526,14 +526,14 @@ TEST_F(ProgramSpecHWTest, SemaphoreAccessorNameLoopback) {
 //      (page size, args_config, bank coords, alignment).
 //   2. Each binding's slot in the kernel's TensorBinding address section is filled with
 //      MeshTensor::address() at enqueue.
-//   3. kernel_bindings_generated.h emits a `ta::` namespace with a working type alias + token.
-//   4. TensorAccessor(ta::name) constructs an accessor whose get_noc_addr returns
+//   3. kernel_bindings_generated.h emits a `tensor::` namespace with a working type alias + token.
+//   4. TensorAccessor(tensor::name) constructs an accessor whose get_noc_addr returns
 //      addresses that NoC reads/writes actually use correctly.
 //
 // Pipeline:
 //   Host writes known data → input MeshTensor (DRAM)
-//   Producer DM kernel (BRISC):  input MeshTensor → DFB,  via TensorAccessor(ta::input_tensor)
-//   Consumer DM kernel (NCRISC): DFB → output MeshTensor, via TensorAccessor(ta::output_tensor)
+//   Producer DM kernel (BRISC):  input MeshTensor → DFB,  via TensorAccessor(tensor::input_tensor)
+//   Consumer DM kernel (NCRISC): DFB → output MeshTensor, via TensorAccessor(tensor::output_tensor)
 //   Host reads output MeshTensor and verifies match
 //
 // DM-only on purpose. The TensorAccessor library is currently DM-only (TRISC builds don't

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_consumer.cpp
@@ -27,8 +27,8 @@ void kernel_main() {
     const uint32_t entry_size_a = dfb_a.get_entry_size();
     const uint32_t entry_size_b = dfb_b.get_entry_size();
 
-    const auto dst_a = TensorAccessor(ta::dst_a);
-    const auto dst_b = TensorAccessor(ta::dst_b);
+    const auto dst_a = TensorAccessor(tensor::dst_a);
+    const auto dst_b = TensorAccessor(tensor::dst_b);
 
     for (uint32_t tile = 0; tile < num_entries_per_consumer_a; tile++) {
         const uint32_t page_id = chunk_offset_a + tile * num_consumers + consumer_idx;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/alias_dfb_producer.cpp
@@ -27,8 +27,8 @@ void kernel_main() {
     const uint32_t entry_size_a = dfb_a.get_entry_size();
     const uint32_t entry_size_b = dfb_b.get_entry_size();
 
-    const auto src_a = TensorAccessor(ta::src_a);
-    const auto src_b = TensorAccessor(ta::src_b);
+    const auto src_a = TensorAccessor(tensor::src_a);
+    const auto src_b = TensorAccessor(tensor::src_b);
 
     for (uint32_t tile = 0; tile < num_entries_per_producer_a; tile++) {
         const uint32_t page_id = chunk_offset_a + tile * num_producers + producer_idx;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_consumer.cpp
@@ -25,7 +25,7 @@ void kernel_main() {
     // DPRINT("consumer_idx: {} num_entries_per_consumer: {}\n", consumer_idx, num_entries_per_consumer);
 
     uint32_t entry_size = dfb.get_entry_size();
-    const auto tensor_accessor = TensorAccessor(ta::dst_tensor);
+    const auto tensor_accessor = TensorAccessor(tensor::dst_tensor);
 
     for (uint32_t tile_id = 0; tile_id < num_entries_per_consumer; tile_id++) {
         uint32_t page_id = 0;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer.cpp
@@ -15,7 +15,7 @@
 //   args::chunk_offset
 // Bindings:
 //   dfb::in                - consumer endpoint of this instance's DFB
-//   ta::dst_tensor         - shared DRAM out_tensor accessor
+//   tensor::dst_tensor     - shared DRAM out_tensor accessor
 
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/noc.h"
@@ -30,7 +30,7 @@ void kernel_main() {
     DataflowBuffer dfb(dfb::in);
     Noc noc;
     const uint32_t entry_size = dfb.get_entry_size();
-    const auto tensor_accessor = TensorAccessor(ta::dst_tensor);
+    const auto tensor_accessor = TensorAccessor(tensor::dst_tensor);
 
     for (uint32_t tile_id = 0; tile_id < num_entries_per_consumer; tile_id++) {
         const uint32_t page_id = chunk_offset + tile_id;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_consumer_sep.cpp
@@ -5,7 +5,7 @@
 // Single-DFB consumer kernel with a separate DRAM output buffer per DFB (Gap 7).
 //
 // Like dfb_multi_consumer.cpp but each instance writes to its own independent DRAM
-// output buffer (per-instance ta::dst_tensor binding pointing at a per-DFB
+// output buffer (per-instance tensor::dst_tensor binding pointing at a per-DFB
 // OUT_TENSOR_i parameter). Used for TensixDMTest4xDFB_1Sx1S where the host
 // verifies each out_buffer separately.
 //
@@ -14,7 +14,7 @@
 //   args::implicit_sync
 // Bindings:
 //   dfb::in                - consumer endpoint of this instance's DFB
-//   ta::dst_tensor         - this instance's per-DFB DRAM out_tensor accessor
+//   tensor::dst_tensor     - this instance's per-DFB DRAM out_tensor accessor
 
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/noc.h"
@@ -28,7 +28,7 @@ void kernel_main() {
     DataflowBuffer dfb(dfb::in);
     Noc noc;
     const uint32_t entry_size = dfb.get_entry_size();
-    const auto tensor_accessor = TensorAccessor(ta::dst_tensor);
+    const auto tensor_accessor = TensorAccessor(tensor::dst_tensor);
 
     // 1Sx1S sole consumer: pages are sequential starting from 0.
     for (uint32_t tile_id = 0; tile_id < num_entries_per_consumer; tile_id++) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_multi_producer.cpp
@@ -15,7 +15,7 @@
 //   args::chunk_offset
 // Bindings:
 //   dfb::out               - producer endpoint of this instance's DFB
-//   ta::src_tensor         - shared DRAM in_tensor accessor
+//   tensor::src_tensor     - shared DRAM in_tensor accessor
 
 #include "api/dataflow/dataflow_buffer.h"
 #include "api/dataflow/noc.h"
@@ -30,7 +30,7 @@ void kernel_main() {
     DataflowBuffer dfb(dfb::out);
     Noc noc;
     const uint32_t entry_size = dfb.get_entry_size();
-    const auto tensor_accessor = TensorAccessor(ta::src_tensor);
+    const auto tensor_accessor = TensorAccessor(tensor::src_tensor);
 
     for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
         const uint32_t page_id = chunk_offset + tile_id;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_producer.cpp
@@ -22,7 +22,7 @@ void kernel_main() {
     Noc noc;
 
     uint32_t entry_size = dfb.get_entry_size();
-    const auto tensor_accessor = TensorAccessor(ta::src_tensor);
+    const auto tensor_accessor = TensorAccessor(tensor::src_tensor);
 
     for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {
         // Strided access: producer i owns pages i, i+P, i+2P, ...

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_consumer.cpp
@@ -9,7 +9,7 @@
 // patterns are supported on a per-DFB basis (controlled by the is_blocked
 // CTA for each DFB).
 //
-// Per-DFB endpoints are bound by name (dfb::dfb_<i>, ta::dst_<i>) and the kernel
+// Per-DFB endpoints are bound by name (dfb::dfb_<i>, tensor::dst_<i>) and the kernel
 // unrolls one block per declared DFB.  Per-DFB STRIDED/BLOCKED choice and per-DFB
 // entries_per_consumer become CTAs (entries_per_consumer_<i>, is_blocked_<i>)
 // since the values are known at host build time.
@@ -48,7 +48,7 @@
         constexpr uint32_t is_blocked = get_arg(args::is_blocked_##I);                              \
         DataflowBuffer dfb(dfb::dfb_##I);                                                           \
         const uint32_t entry_size = dfb.get_entry_size();                                           \
-        const auto tensor_accessor = TensorAccessor(ta::dst_##I);                                   \
+        const auto tensor_accessor = TensorAccessor(tensor::dst_##I);                               \
         for (uint32_t tile_id = 0; tile_id < entries_per_consumer; tile_id++) {                     \
             const uint32_t page_id = is_blocked ? tile_id : tile_id * num_consumers + consumer_idx; \
             if constexpr (implicit_sync) {                                                          \

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/dfb_seq_producer.cpp
@@ -6,9 +6,9 @@
 //
 // All N producer threads cooperate on DFB_0 (each handling its own strided slice),
 // then cooperate on DFB_1, and so on.  Every DFB has its own independent DRAM
-// source buffer: each DFB binds via dfb::dfb_<i> + ta::src_<i> (compile-time names);
+// source buffer: each DFB binds via dfb::dfb_<i> + tensor::src_<i> (compile-time names);
 // the kernel unrolls one block per declared DFB. TEST_NUM_DFBS compiler define
-// gates how many ta::src_<i> bindings the kernel references (must match the host's
+// gates how many tensor::src_<i> bindings the kernel references (must match the host's
 // KernelSpec bindings count). The name is prefixed to avoid collision with
 // dfb::NUM_DFBS from dataflow_buffer_config.h.
 //
@@ -46,7 +46,7 @@
     do {                                                                                    \
         DataflowBuffer dfb(dfb::dfb_##I);                                                   \
         const uint32_t entry_size = dfb.get_entry_size();                                   \
-        const auto tensor_accessor = TensorAccessor(ta::src_##I);                           \
+        const auto tensor_accessor = TensorAccessor(tensor::src_##I);                       \
         for (uint32_t tile_id = 0; tile_id < num_entries_per_producer; tile_id++) {         \
             const uint32_t page_id = tile_id * num_producers + producer_idx;                \
             if constexpr (implicit_sync) {                                                  \

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bmm_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_bmm_8bank.cpp
@@ -33,8 +33,8 @@ void kernel_main() {
     const uint32_t entry_size1 = dfb1.get_entry_size();
 #endif
 
-    const auto s0 = TensorAccessor(ta::src0);
-    const auto s1 = TensorAccessor(ta::src1);
+    const auto s0 = TensorAccessor(tensor::src0);
+    const auto s1 = TensorAccessor(tensor::src1);
 
     uint32_t itileA_batch = batch_start * MtKt;
     uint32_t itileB_batch = batch_start * KtNt;

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_8bank_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_8bank_2_0.cpp
@@ -48,7 +48,7 @@ void kernel_main() {
     DataflowBuffer dfb0(dfb::out_data);
     const uint32_t tile_bytes = dfb0.get_entry_size();
 
-    const auto src_a = TensorAccessor(ta::src_tensor);
+    const auto src_a = TensorAccessor(tensor::src_tensor);
 
 #if GENERATE_BCAST_SCALER
     // TODO(AP): cleanup, probably with named args/param pack/reflection.

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_8bank.cpp
@@ -26,7 +26,7 @@ void kernel_main() {
     uint32_t i_tile_N = 0;  // first tile in current batch
     uint32_t i_tile = 0;
 
-    const auto s = TensorAccessor(ta::src_tensor);
+    const auto s = TensorAccessor(tensor::src_tensor);
 
     // this reader will read a NHW tensor in NWH order
     for (uint32_t n = 0; n < N; n++) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/reader_unary_transpose_wh_interleaved.cpp
@@ -57,7 +57,7 @@ void kernel_main() {
     uint32_t i_tile_N = 0;  // first tile in current batch
     uint32_t i_tile = 0;
 
-    const auto s = TensorAccessor(ta::src_tensor);
+    const auto s = TensorAccessor(tensor::src_tensor);
 
     // this reader will read a NHW tensor in NWH order
     for (uint32_t n = 0; n < N; n++) {

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_consumer.cpp
@@ -4,7 +4,7 @@
 
 // Test kernel: TensorAccessor loopback consumer using a Metal 2.0 TensorBinding.
 // Pops entries from a DFB bound via dfb::input_dfb and writes them as pages to an output tensor
-// via TensorAccessor(ta::output_tensor). The base address comes from the binding's slot in the
+// via TensorAccessor(tensor::output_tensor). The base address comes from the binding's slot in the
 // kernel's TensorBinding address section, filled by SetProgramRunArgs from TensorArgument.
 //
 // Runtime args:
@@ -15,7 +15,7 @@
 void kernel_main() {
     uint32_t num_pages = get_arg_val<uint32_t>(0);
 
-    TensorAccessor accessor(ta::output_tensor);
+    TensorAccessor accessor(tensor::output_tensor);
     DataflowBuffer buf(dfb::input_dfb);
     uint32_t entry_size = buf.get_entry_size();
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_producer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/tensor_accessor_loopback_producer.cpp
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 // Test kernel: TensorAccessor loopback producer using a Metal 2.0 TensorBinding.
-// Reads pages from an input tensor via TensorAccessor(ta::input_tensor) and pushes them
+// Reads pages from an input tensor via TensorAccessor(tensor::input_tensor) and pushes them
 // entry by entry into a DFB bound via dfb::input_dfb. The base address comes from the binding's
 // slot in the kernel's TensorBinding address section, filled by SetProgramRunArgs from
 // TensorArgument.
@@ -16,7 +16,7 @@
 void kernel_main() {
     uint32_t num_pages = get_arg_val<uint32_t>(0);
 
-    TensorAccessor accessor(ta::input_tensor);
+    TensorAccessor accessor(tensor::input_tensor);
     DataflowBuffer buf(dfb::input_dfb);
     uint32_t entry_size = buf.get_entry_size();
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_bmm_8bank.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_bmm_8bank.cpp
@@ -24,7 +24,7 @@ void kernel_main() {
     const uint32_t entry_size = dfb.get_entry_size();
 #endif
 
-    const auto s = TensorAccessor(ta::dst);
+    const auto s = TensorAccessor(tensor::dst);
 
     Noc noc;
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank_2_0.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/writer_unary_8bank_2_0.cpp
@@ -14,7 +14,7 @@ void kernel_main() {
     constexpr uint32_t onetile = 1;
     DataflowBuffer dfb_out(dfb::in);
     uint32_t tile_bytes = dfb_out.get_entry_size();
-    const auto s = TensorAccessor(ta::dst_tensor);
+    const auto s = TensorAccessor(tensor::dst_tensor);
 
     Noc noc;
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/zero_memory_api_consumer.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/zero_memory_api_consumer.cpp
@@ -27,7 +27,7 @@ void kernel_main() {
     dfb.wait_front(1);
 
 #ifdef ZERO_DRAM
-    const auto out = TensorAccessor(ta::out);
+    const auto out = TensorAccessor(tensor::out);
     Noc noc;
     for (uint32_t p = page_start; p < page_end; ++p) {
         noc.async_write_zeros(out, page_size, {.page_id = p}, dfb);

--- a/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local_via_bank_base.cpp
+++ b/tests/ttnn/unit_tests/gtests/accessor/kernels/copy_local_via_bank_base.cpp
@@ -18,7 +18,7 @@ void kernel_main() {
     auto args_dst =
         TensorAccessorArgs<args_src.next_compile_time_args_offset(), args_src.next_common_runtime_args_offset()>();
 
-    // In Metal 2.0, this would just be TensorAccessor(ta::my_accessor_name)
+    // In Metal 2.0, this would just be TensorAccessor(tensor::my_accessor_name)
     // The bank base address would not be available in scope.
     auto tensor_accessor_src = TensorAccessor(args_src, input_base_address);
     auto tensor_accessor_dst = TensorAccessor(args_dst, output_base_address);

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/kernel_spec.hpp
@@ -145,7 +145,7 @@ struct KernelSpec {
 
     // Tensor bindings
     // Declares that this kernel accesses a tensor parameter (declared at the ProgramSpec level)
-    // The kernel constructs the accessor via TensorAccessor(ta::<accessor_name>)
+    // The kernel constructs the accessor via TensorAccessor(tensor::<accessor_name>)
     struct TensorBinding {
         TensorParamName tensor_parameter_name;      // identify the TensorBinding within the ProgramSpec
         std::string accessor_name;                  // tensor accessor name (used in the kernel source code)

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -614,7 +614,7 @@ namespace tensor_accessor {
 // auto-generated kernel_bindings_generated.h) to construct the TensorAccessor directly.
 //
 // The user's kernel code looks like:
-//  auto ta = TensorAccessor(ta::my_host_declared_accessor_name);
+//  auto ta = TensorAccessor(tensor::my_host_declared_accessor_name);
 //
 // No more fussing around with TensorAccessorArgs!
 // All of the boilerplate, nasty args offset logic, and raw base pointer are now fully hidden

--- a/tt_metal/impl/emulation/emulated_program_runner.cpp
+++ b/tt_metal/impl/emulation/emulated_program_runner.cpp
@@ -614,7 +614,7 @@ static Metal2BindingsSnapshot build_metal2_snapshot(const tt::tt_metal::Kernel& 
     return s;
 }
 
-// Emits args::/dfb::/sem::/ta:: namespaces into the JIT wrapper, replacing
+// Emits args::/dfb::/sem::/tensor:: namespaces into the JIT wrapper, replacing
 // kernel_args_generated.h + kernel_bindings_generated.h that upstream's JIT
 // build produces. Must stay text-equivalent to genfiles.cpp's
 // write_kernel_{args,bindings}_generated_header.
@@ -673,13 +673,13 @@ static void emit_metal2_namespaces(
         f << "}  // namespace sem\n";
     }
     if (!s.ta_accessors.empty()) {
-        f << "namespace ta {\n";
+        f << "namespace tensor {\n";
         for (const auto& ta : s.ta_accessors) {
             f << "using " << ta.name << "_t = ::tensor_accessor::TensorAccessorBindingToken<"
               << ta.cta_offset << "u, " << ta.addr_crta_offset << "u>;\n";
             f << "constexpr " << ta.name << "_t " << ta.name << "{};\n";
         }
-        f << "}  // namespace ta\n";
+        f << "}  // namespace tensor\n";
     }
 
     // Vararg helpers — always emitted for Metal 2.0 kernels (mirrors

--- a/tt_metal/impl/kernels/kernel.cpp
+++ b/tt_metal/impl/kernels/kernel.cpp
@@ -533,7 +533,7 @@ uint64_t Kernel::compute_hash() const {
     }
     // Tensor binding handles:
     //  - stored as a std::vector (user-specified order), so no sort step needed
-    //  - genfiles.cpp emits the `ta::` namespace in the same order
+    //  - genfiles.cpp emits the `tensor::` namespace in the same order
     //  - hash the size first to avoid the [a, b] vs [ab] collision noted below.
     //  - tensor_parameter_name is intentionally omitted, as it doesn't appear in
     //    the generated headers

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -100,7 +100,7 @@ using SemaphoreLocalAccessorHandleMap = std::unordered_map<std::string, uint16_t
 // TensorParameter name so SetProgramRunArgs can fill the binding's base-address slot
 // (and any runtime accessor fields) from the corresponding TensorArgument at enqueue time.
 struct TensorBindingHandle {
-    std::string accessor_name;          // user-facing identifier (kernel symbol in `ta::`)
+    std::string accessor_name;          // user-facing identifier (kernel symbol in `tensor::`)
     std::string tensor_parameter_name;  // refers back to the program-level TensorParameter
     uint32_t cta_offset;                // first word index of this binding's payload in the kernel's compile-time args
     uint32_t addr_crta_offset;  // byte offset of this binding's base-address slot within the kernel's CRTA buffer

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -532,7 +532,7 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
     // RTA layout has two sections: named RTAs and RTA varargs.
     // CRTA layout has three sections: named CRTAs, TensorBinding addresses, and CRTA varargs.
     //
-    // TensorBinding address section is used by headergen to emit the `ta::` namespace tokens.
+    // TensorBinding address section is used by headergen to emit the `tensor::` namespace tokens.
     // The device-side get_vararg / get_common_vararg helpers invisibly add the combined named-arg + binding
     // offset, so kernel code indexes varargs from 0.
     for (const auto& kernel_params : params.kernel_run_args) {

--- a/tt_metal/jit_build/genfiles.cpp
+++ b/tt_metal/jit_build/genfiles.cpp
@@ -124,7 +124,7 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
     // Emit the header content:
     //  - DFB accessors are emitted into the dfb namespace
     //  - Semaphore accessors are emitted into the sem namespace
-    //  - TensorBindings are emitted into the ta namespace
+    //  - TensorBindings are emitted into the tensor namespace
     //
     // NOTE: DFB and Semaphore accessors are emitted as constexpr variables, i.e. as implicit CTAs.
     //       This is a design decision; we could alternatively emit them as implicit CRTAs.
@@ -178,13 +178,13 @@ void write_kernel_bindings_generated_header(const string& out_dir, const JitBuil
             //
             // Per-binding type alias (`<name>_t`) lets the framework extend the underlying token
             // template with extra metadata in the future without touching kernel source.
-            content << "namespace ta {\n";
+            content << "namespace tensor {\n";
             for (const auto& entry : ta_entries) {
                 content << "using " << entry.name << "_t = ::tensor_accessor::TensorAccessorBindingToken<"
                         << entry.cta_offset << "u, " << entry.addr_crta_offset << "u>;\n";
                 content << "constexpr " << entry.name << "_t " << entry.name << "{};\n";
             }
-            content << "}  // namespace ta\n";
+            content << "}  // namespace tensor\n";
         }
     }
     write_file(path, content.str());

--- a/tt_metal/jit_build/jit_build_settings.hpp
+++ b/tt_metal/jit_build/jit_build_settings.hpp
@@ -67,7 +67,7 @@ public:
         std::function<void(const std::string& accessor_name, uint16_t semaphore_id)>) const {}
 
     // TensorBinding callback emits the codegen-relevant fields only:
-    //  - accessor_name: kernel-side identifier, used as the symbol name in the `ta::` namespace
+    //  - accessor_name: kernel-side identifier, used as the symbol name in the `tensor::` namespace
     //  - cta_offset: starting word index of this binding's CTA payload in the kernel's
     //    positional compile-time-args buffer
     //  - addr_crta_offset: byte offset of the implicit base-address CRTA within the kernel's


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

 Cleanup

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Metal 2.0 injects tensor information into the device side as instructed by their `TensorBinding` configuration.
These information are currently injected into `ta` namespace which is non descriptive.
This PR changes the namespace it's injected to to `tensor` per request of @akerteszTT .

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/rename-ta-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/rename-ta-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/rename-ta-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/rename-ta-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/rename-ta-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/rename-ta-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/rename-ta-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/rename-ta-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/rename-ta-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/rename-ta-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/rename-ta-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/rename-ta-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/rename-ta-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/rename-ta-tensor)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/rename-ta-tensor)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/rename-ta-tensor)