### PR TITLE
Route tilize(DRAM SHARDED, large row) through DRAM interleaved to avoid L1 OOM

### DIFF
--- a/tests/ttnn/unit_tests/base_functionality/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_torch_conversion.py
@@ -754,6 +754,49 @@ def test_from_torch_mesh_sharded_dram_width_no_tensorspec_crash(mesh_device, map
     assert ttnn_tensor.layout == ttnn.TILE_LAYOUT
 
 
+@pytest.mark.parametrize("mesh_device", [(1, 1)], indirect=True)
+@pytest.mark.parametrize(
+    "shard_shape",
+    [
+        (2048, 3584),
+    ],
+)
+def test_from_torch_mesh_width_sharded_dram_tile_oom_45331(mesh_device, shard_shape):
+    """
+    Regression test for https://github.com/tenstorrent/tt-metal/issues/45331.
+    """
+
+    torch.manual_seed(0)
+    # Width-shard across every DRAM bank the device exposes (12 on Wormhole,
+    # 8 on Blackhole). Hardcoding 12 cores would request a DRAM bank that does
+    # not exist on Blackhole and crash in the allocator before tilize runs.
+    num_cores = mesh_device.dram_grid_size().x
+    shard_height, shard_width = shard_shape
+    tensor_shape = (shard_height, shard_width * num_cores)
+    torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))})
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    sharded_dram_cfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        shard_spec,
+    )
+
+    tt_tile = ttnn.from_torch(
+        torch_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.TILE_LAYOUT,
+        mesh_mapper=ShardTensorToMesh(mesh_device, dim=-1),
+        memory_config=sharded_dram_cfg,
+        device=mesh_device,
+    )
+
+    assert tt_tile.layout == ttnn.TILE_LAYOUT
+    assert tt_tile.memory_config().memory_layout == ttnn.TensorMemoryLayout.WIDTH_SHARDED
+    assert tt_tile.dtype == ttnn.bfloat16
+
+
 @pytest.mark.parametrize("mesh_device", [(2, 4)], ids=["t3k"], indirect=True)
 @pytest.mark.parametrize(
     "mapper_type,ttnn_dtype,memory_config_type,enable_bfloat_opt",

--- a/tests/ttnn/unit_tests/base_functionality/test_torch_conversion.py
+++ b/tests/ttnn/unit_tests/base_functionality/test_torch_conversion.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2025-2026 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2023-2026 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_tilize.py
@@ -485,3 +485,50 @@ def test_deepseek_v3_mla_tilize_trace_mode(
     ), f"Shape mismatch: {torch_output_from_tt.shape} != {torch_output_tensor.shape}"
 
     assert_equal(torch_output_tensor, torch_output_from_tt)
+
+
+# Regression coverage for https://github.com/tenstorrent/tt-metal/issues/45331.
+# Calls ttnn.tilize directly on a width-sharded DRAM ROW_MAJOR input that
+# previously sent the op into TilizeMultiCoreDefaultProgramFactory, whose
+# full-row CB allocation (~5.5 MB) exceeded the 1.5 MB L1 per-core budget on
+# Wormhole. The ttnn::tilize wrapper now reroutes such cases via interleaved
+# DRAM so TilizeMultiCoreBlockProgramFactory (bounded CBs) is used instead.
+# The assertions are intentionally minimal: this test exists to catch a crash
+# regression, not to validate full numerical fidelity of tilize.
+@pytest.mark.parametrize(
+    "shard_shape",
+    [
+        (2048, 3584),
+    ],
+)
+def test_tilize_width_sharded_dram_input_45331(device, shard_shape):
+    torch.manual_seed(0)
+    # Width-shard across every DRAM bank the device exposes (12 on Wormhole,
+    # 8 on Blackhole). Hardcoding 12 cores would request a DRAM bank that does
+    # not exist on Blackhole and crash in the allocator before tilize runs.
+    num_cores = device.dram_grid_size().x
+    shard_height, shard_width = shard_shape
+    tensor_shape = (shard_height, shard_width * num_cores)
+    torch_tensor = torch.randn(tensor_shape, dtype=torch.bfloat16)
+
+    shard_grid = ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(num_cores - 1, 0))})
+    shard_spec = ttnn.ShardSpec(shard_grid, shard_shape, ttnn.ShardOrientation.ROW_MAJOR)
+    sharded_dram_cfg = ttnn.MemoryConfig(
+        ttnn.TensorMemoryLayout.WIDTH_SHARDED,
+        ttnn.BufferType.DRAM,
+        shard_spec,
+    )
+
+    tt_rm = ttnn.from_torch(
+        torch_tensor,
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        memory_config=sharded_dram_cfg,
+        device=device,
+    )
+
+    tt_tile = ttnn.tilize(tt_rm, memory_config=sharded_dram_cfg, use_multicore=True)
+
+    assert tt_tile.layout == ttnn.TILE_LAYOUT
+    torch_out = ttnn.to_torch(tt_tile)
+    assert torch.equal(torch_tensor, torch_out), "tilize round-trip mismatch"

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2024 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2024-2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
@@ -5,8 +5,11 @@
 #include "tilize.hpp"
 
 #include "device/tilize_device_operation.hpp"
+#include "ttnn/operations/core/core.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
 #include "ttnn/operations/data_movement/reshape_view/reshape.hpp"
+
+#include <tt-logger/tt-logger.hpp>
 
 using namespace tt::tt_metal;
 
@@ -64,6 +67,28 @@ ttnn::Tensor tilize(
         input_tensor, input_single_tile_size, output_single_tile_size, num_tiles_per_row);
 
     auto base_tilize = [=](const ttnn::Tensor& input_tensor) {
+        // Workaround for https://github.com/tenstorrent/tt-metal/issues/45331:
+        // ttnn::prim::tilize routes wide width-sharded input to
+        // TilizeMultiCoreDefaultProgramFactory, whose CBs are sized to a full
+        // row of tiles (ntiles_per_block = ceil(logical_width / TILE_WIDTH))
+        // and exceed L1. Reroute via interleaved DRAM so the prim selects
+        // TilizeMultiCoreBlockProgramFactory, whose CBs are bounded by
+        // max_l1 / (input_tile_size + output_tile_size) by construction.
+        if (input_tensor.memory_config().is_sharded() && !enough_space_height) {
+            log_debug(tt::LogOp, "ttnn::tilize: rerouting wide sharded input via DRAM interleaved (#45331)");
+            const auto target_memory_config = memory_config.value_or(input_tensor.memory_config());
+            auto interleaved_input = ttnn::to_memory_config(input_tensor, ttnn::DRAM_MEMORY_CONFIG);
+            auto interleaved_tile = ttnn::prim::tilize(
+                interleaved_input,
+                ttnn::DRAM_MEMORY_CONFIG,
+                output_dtype,
+                use_multicore,
+                enough_space_width,
+                /*enough_space_height=*/false,
+                use_low_perf,
+                sub_core_grids);
+            return ttnn::to_memory_config(interleaved_tile, target_memory_config);
+        }
         return ttnn::prim::tilize(
             input_tensor,
             memory_config,


### PR DESCRIPTION
### PR Category

Fix for #45331

### Summary

Puts a patch into the ttnn.tilize() method so it doesn't crash with L1 OOM on a width-sharded DRAM input with large rows.

The patch: If the tensor is sharded & the row is too large, turn the tensor to DRAM-interleaved, then call tilize, then turn the tensor back to sharded.

The DRAM interleaved case calls TilizeMultiCoreBlockProgramFactory, which supports tilizing on tensors with large rows but can't be used with sharded tensors.

### Notes for reviewers

Proper fix should have implement a device op that supports large rows & can read from a sharded tensor in the reader kernel.

### CI Runs

* [L2-nightly](https://github.com/tenstorrent/tt-metal/actions/runs/27854919794) -- [compared to main](https://github.com/tenstorrent/tt-metal/actions/runs/27721031417)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ichovpan/tilize-patch)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ichovpan/tilize-patch)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ichovpan/tilize-patch)