### PR TITLE
[Feature] Add worker L1 validation to triage

### DIFF
--- a/tools/tests/triage/test_triage.py
+++ b/tools/tests/triage/test_triage.py
@@ -356,6 +356,9 @@ class TestTriage:
     def test_check_core_magic(self):
         self.run_triage_script("check_core_magic.py")
 
+    def test_check_l1_status(self):
+        self.run_triage_script("check_l1_status.py")
+
     def test_check_eth_status(self):
         self.run_triage_script("check_eth_status.py")
 

--- a/tools/triage/check_l1_status.py
+++ b/tools/triage/check_l1_status.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Usage:
+    check_l1_status
+
+Description:
+    Checks that each worker L1 launch value matches the expected firmware launch value from Inspector.
+
+Owner:
+    anashTT
+"""
+
+from inspector_data import run as get_inspector_data
+from metal_device_id_mapping import run as get_metal_device_id_mapping
+from run_checks import run as get_run_checks
+from triage import ScriptConfig, log_check_location, log_warning_location, run_script
+from ttexalens.context import Context
+from ttexalens.coordinate import OnChipCoordinate
+from ttexalens.tt_exalens_lib import read_word_from_device
+
+
+script_config = ScriptConfig(
+    depends=["run_checks", "inspector_data", "metal_device_id_mapping"],
+)
+
+
+def check_worker_l1_launch_value(location: OnChipCoordinate, tensix_fw_launch_values: dict[int, int]) -> None:
+    expected_fw_launch_value = tensix_fw_launch_values.get(location._device.unique_id)
+    if expected_fw_launch_value is None:
+        log_warning_location(location, "Skipping L1[0] check: missing Inspector build env data")
+        return
+
+    actual_value = read_word_from_device(location, 0)
+    log_check_location(
+        location,
+        actual_value == expected_fw_launch_value,
+        f"Worker L1[0] mismatch: read 0x{actual_value:08x}, expected 0x{expected_fw_launch_value:08x}",
+    )
+
+
+def run(args, context: Context):
+    run_checks = get_run_checks(args, context)
+    inspector_data = get_inspector_data(args, context)
+    metal_device_id_mapping = get_metal_device_id_mapping(args, context)
+    tensix_fw_launch_values = {
+        metal_device_id_mapping.get_unique_id(build_env.metalDeviceId): build_env.buildInfo.tensixFwLaunchAddrValue
+        for build_env in inspector_data.getAllBuildEnvs().buildEnvs
+    }
+
+    run_checks.run_per_block_check(
+        lambda location: check_worker_l1_launch_value(location, tensix_fw_launch_values),
+        block_filter="tensix",
+    )
+
+
+if __name__ == "__main__":
+    run_script()

--- a/tools/triage/check_l1_status.py
+++ b/tools/triage/check_l1_status.py
@@ -17,7 +17,7 @@ Owner:
 from inspector_data import run as get_inspector_data
 from metal_device_id_mapping import run as get_metal_device_id_mapping
 from run_checks import run as get_run_checks
-from triage import ScriptConfig, log_check_location, log_warning_location, run_script
+from triage import ScriptConfig, log_check_location, run_script
 from ttexalens.context import Context
 from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.tt_exalens_lib import read_word_from_device
@@ -31,8 +31,7 @@ script_config = ScriptConfig(
 def check_worker_l1_launch_value(location: OnChipCoordinate, tensix_fw_launch_values: dict[int, int]) -> None:
     expected_fw_launch_value = tensix_fw_launch_values.get(location._device.unique_id)
     if expected_fw_launch_value is None:
-        log_warning_location(location, "Skipping L1[0] check: missing Inspector build env data")
-        return
+        raise RuntimeError(f"Missing Inspector build env data for {location}")
 
     actual_value = read_word_from_device(location, 0)
     log_check_location(

--- a/tt_metal/impl/debug/inspector/data.cpp
+++ b/tt_metal/impl/debug/inspector/data.cpp
@@ -278,6 +278,12 @@ void Data::rpc_get_all_build_envs(rpc::Inspector::GetAllBuildEnvsResults::Builde
     // Populate RPC response with build environment info for all devices
     auto result_build_envs = results.initBuildEnvs(build_envs_info.size());
     const auto fw_compile_hash = this->fw_compile_hash.load(std::memory_order_acquire);
+    const auto tensix_fw_launch_addr_value = [] {
+        const auto& hal = tt::tt_metal::MetalContext::instance().hal();
+        const auto tensix_core_type_idx = hal.get_programmable_core_type_index(HalProgrammableCoreType::TENSIX);
+        return hal.get_jit_build_config(tensix_core_type_idx, 0, 0).fw_launch_addr_value;
+    }();
+
     size_t i = 0;
     for (const auto& build_env : build_envs_info) {
         auto item = result_build_envs[i++];
@@ -291,6 +297,7 @@ void Data::rpc_get_all_build_envs(rpc::Inspector::GetAllBuildEnvsResults::Builde
         // This reflects the runtime option used when initializing HAL on silicon.
         build_info.setDramProgrammableCoresEnabled(
             tt::tt_metal::MetalContext::instance().rtoptions().get_enable_blackhole_dram_programmable_cores());
+        build_info.setTensixFwLaunchAddrValue(tensix_fw_launch_addr_value);
     }
 }
 

--- a/tt_metal/impl/debug/inspector/rpc.capnp
+++ b/tt_metal/impl/debug/inspector/rpc.capnp
@@ -84,6 +84,7 @@ struct BuildEnvData {
     fwCompileHash @2 :UInt64; # Hash of the firmware compilation settings
     # Whether DRAM programmable RISC cores are enabled on this device (Blackhole only)
     dramProgrammableCoresEnabled @3 :Bool;
+    tensixFwLaunchAddrValue @4 :UInt32; # Expected value at L1[0] for TENSIX worker cores
 }
 
 struct BuildEnvPerDevice {


### PR DESCRIPTION
### PR Category
Feature

### Summary
Closes #28810

* Export expected HAL L1[0] value to triage
* Check all worker cores for expected L1[0] value within check_l1_status.py

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=anashTT/28810-triage-validate-worker-L1)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:anashTT/28810-triage-validate-worker-L1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=anashTT/28810-triage-validate-worker-L1)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:anashTT/28810-triage-validate-worker-L1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=anashTT/28810-triage-validate-worker-L1)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:anashTT/28810-triage-validate-worker-L1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=anashTT/28810-triage-validate-worker-L1)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:anashTT/28810-triage-validate-worker-L1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=anashTT/28810-triage-validate-worker-L1)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:anashTT/28810-triage-validate-worker-L1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=anashTT/28810-triage-validate-worker-L1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:anashTT/28810-triage-validate-worker-L1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=anashTT/28810-triage-validate-worker-L1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:anashTT/28810-triage-validate-worker-L1)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=anashTT/28810-triage-validate-worker-L1)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:anashTT/28810-triage-validate-worker-L1)