### PR TITLE
[CI] Run ring SDPA perf tests only on QB2 (move off BH e2e)

### DIFF
--- a/.github/workflows/blackhole-e2e-tests.yaml
+++ b/.github/workflows/blackhole-e2e-tests.yaml
@@ -39,7 +39,6 @@ on:
           - all
           - sdpa
           - bh-sdpa-nightly-integration
-          - bh-ring-sdpa-perf
       build-type:
         required: false
         type: choice

--- a/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
+++ b/.github/workflows/blackhole-multi-card-unit-tests-impl.yaml
@@ -73,6 +73,13 @@ jobs:
             cmd: pytest tests/nightly/blackhole/sdpa/ -svv
             timeout: 20
             test-type: fast-qb2
+          - name: ring sdpa PERF tests (QB2 only)
+            cmd: |
+              SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_perf_check -svv
+              SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_mla_chunked_perf_check -svv
+              SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::test_exp_ring_joint_attention_perf_check -svv
+            timeout: 10
+            test-type: fast-qb2
           # NOTE: All slow / loudbox / qb multi-card BH tests have been migrated
           # into tests/pipeline_reorg/blackhole_e2e_tests.yaml and are now run by
           # the blackhole-e2e-tests workflow. This file only carries the

--- a/tests/pipeline_reorg/blackhole_e2e_tests.yaml
+++ b/tests/pipeline_reorg/blackhole_e2e_tests.yaml
@@ -101,23 +101,6 @@
   owner_id: U0883RN6CRE # William Ly
   team: scaleout
 
-- id: bh-ring-sdpa-perf
-  name: ring sdpa perf tests
-  tags: [sdpa]
-  cmd: |
-    SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_joint_attention_perf_check -svv
-    SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_ring_joint_sdpa.py::test_ring_mla_chunked_perf_check -svv
-    SDPA_PERF_CHECKS=1 pytest tests/nightly/blackhole/sdpa/test_exp_ring_joint_sdpa.py::test_exp_ring_joint_attention_perf_check -svv
-  skus:
-    bh_loudbox:
-      timeout: 10
-    bh_p300:
-      timeout: 10
-    bh_quietbox_2:
-      timeout: 10
-  owner_id: U07RD9YRFT9 # Slavko Krstic
-  team: ttnn
-
 # --- unit ---
 - id: bh-fabric-ttnn-udm-unit
   name: fabric and ttnn UDM unit tests


### PR DESCRIPTION
## What

Moves `bh-ring-sdpa-perf` out of the **Blackhole e2e** pipeline so it runs **only on QuietBox 2**, via the **blackhole-post-commit** multi-card `fast-qb2` leg.

## Changes

| File | Change |
| --- | --- |
| `tests/pipeline_reorg/blackhole_e2e_tests.yaml` | ➖ Remove the `bh-ring-sdpa-perf` row entirely (was on `bh_loudbox` / `bh_p300` / `bh_quietbox_2`) |
| `blackhole-e2e-tests.yaml` | ➖ Drop its now-dangling `test-selection` dropdown option |
| `blackhole-multi-card-unit-tests-impl.yaml` | ➕ Add `ring sdpa PERF tests (QB2 only)` group (`test-type: fast-qb2`) — the **PERF** name triggers the wider tracy hang-detection window |

**Net:** ring SDPA perf runs on **QB2 only**; **skipped** in BH e2e.

## CI validation runs

| Pipeline | Status | Run |
| --- | --- | --- |
| BH e2e (`test-selection: sdpa`) | [![BH e2e](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=skrstic/move-ring-sdpa-perf-to-qb2&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/27721922208) | [run ↗](https://github.com/tenstorrent/tt-metal/actions/runs/27721922208) |
| Blackhole post-commit | [![bhpc](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=skrstic/move-ring-sdpa-perf-to-qb2&event=workflow_dispatch)](https://github.com/tenstorrent/tt-metal/actions/runs/27721927695) | [run ↗](https://github.com/tenstorrent/tt-metal/actions/runs/27721927695) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
