### PR TITLE
[API Cleanup] Rename remote DFB to cross-node DFB

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -956,7 +956,7 @@ TEST_F(ProgramSpecTestQuasar, CrossNodeDFBNotYetSupportedAtRuntime) {
     consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
 
     spec.kernels = {producer, consumer};
-    spec.remote_dataflow_buffers = {CrossNodeDataflowBufferSpec{
+    spec.cross_node_dataflow_buffers = {CrossNodeDataflowBufferSpec{
         .dfb_spec = MakeMinimalDFB("dfb"),
         .producer_consumer_map = {{producer_node, consumer_node}},
     }};

--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -91,7 +91,8 @@ static_assert(hashable_v<ProgramSpec>, "ProgramSpec must be hashable via ttsl re
 static_assert(hashable_v<WorkUnitSpec>, "WorkUnitSpec must be hashable via ttsl reflection");
 static_assert(hashable_v<KernelSpec>, "KernelSpec must be hashable via ttsl reflection");
 static_assert(hashable_v<DataflowBufferSpec>, "DataflowBufferSpec must be hashable via ttsl reflection");
-static_assert(hashable_v<RemoteDataflowBufferSpec>, "RemoteDataflowBufferSpec must be hashable via ttsl reflection");
+static_assert(
+    hashable_v<CrossNodeDataflowBufferSpec>, "CrossNodeDataflowBufferSpec must be hashable via ttsl reflection");
 static_assert(hashable_v<SemaphoreSpec>, "SemaphoreSpec must be hashable via ttsl reflection");
 static_assert(hashable_v<TensorParameter>, "TensorParameter must be hashable via ttsl reflection");
 
@@ -940,8 +941,8 @@ TEST_F(ProgramSpecTestQuasar, RoleHintIgnoredOnGen2Succeeds) {
     EXPECT_NO_THROW({ MakeProgramFromSpec(*mesh_device_, spec); });
 }
 
-// Remote DFBs are part of the API surface but not yet supported by the runtime.
-TEST_F(ProgramSpecTestQuasar, RemoteDFBNotYetSupportedAtRuntime) {
+// Cross-node DFBs are part of the API surface but not yet supported by the runtime.
+TEST_F(ProgramSpecTestQuasar, CrossNodeDFBNotYetSupportedAtRuntime) {
     NodeCoord producer_node{0, 0};
     NodeCoord consumer_node{1, 0};
 
@@ -955,7 +956,7 @@ TEST_F(ProgramSpecTestQuasar, RemoteDFBNotYetSupportedAtRuntime) {
     consumer.dfb_bindings.push_back(ConsumerOf(DFBSpecName{"dfb"}, "in"));
 
     spec.kernels = {producer, consumer};
-    spec.remote_dataflow_buffers = {RemoteDataflowBufferSpec{
+    spec.remote_dataflow_buffers = {CrossNodeDataflowBufferSpec{
         .dfb_spec = MakeMinimalDFB("dfb"),
         .producer_consumer_map = {{producer_node, consumer_node}},
     }};
@@ -2487,8 +2488,8 @@ static_assert(
     std::is_aggregate_v<KernelSpec::RuntimeArgSchema>,
     "RuntimeArgSchema must remain an aggregate to support designated initializers");
 static_assert(
-    std::is_aggregate_v<RemoteDataflowBufferSpec>,
-    "RemoteDataflowBufferSpec must remain an aggregate to support designated initializers");
+    std::is_aggregate_v<CrossNodeDataflowBufferSpec>,
+    "CrossNodeDataflowBufferSpec must remain an aggregate to support designated initializers");
 
 // These tests document the intended construction pattern using designated initializers.
 // They serve as living documentation and will fail to compile if aggregate status is broken.
@@ -2721,7 +2722,7 @@ TEST(AggregateSpecTypes, NestedStructsDesignatedInitializers) {
     };
     EXPECT_EQ(gen1.processor, tt::tt_metal::DataMovementProcessor::RISCV_1);
 
-    RemoteDataflowBufferSpec remote_dfb{
+    CrossNodeDataflowBufferSpec remote_dfb{
         .dfb_spec =
             DataflowBufferSpec{
                 .unique_id = DFBSpecName{"remote_dfb"},

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -186,7 +186,7 @@ struct SemaphoreAdvancedOptions {
 
     // NOTE: Setting a non-zero initial value is not supported on Gen2 architectures.
     // NOTE: Runtime wants to deprecate this feature for ALL architectures.
-    //       When remote DFB becomes available, non-zero initial values will be removed.
+    //       When cross-node DFB becomes available, non-zero initial values will be removed.
     [[deprecated("Non-zero semaphore initialization is deprecated and will be removed.")]]
     uint32_t initial_value = 0;
 };

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -138,7 +138,7 @@ struct DataflowBufferSpec {
 
 // NOTE: Cross-Node DataflowBuffer is not yet supported!
 //       A sketch is included in the experimental Metal 2.0 APIs for visibility.
-//       See also Global DataFlowBuffer (which has a user-managed lifetime).
+//       See also Global DataflowBuffer (which has a user-managed lifetime).
 //
 // CrossNodeDataflowBufferSpec is the descriptor for a "cross-node" DFB:
 // A DFB whose producer and consumer kernels run on different nodes, with data

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -133,39 +133,40 @@ struct DataflowBufferSpec {
 };
 
 //------------------------------------------------
-// RemoteDataflowBufferSpec
+// CrossNodeDataflowBufferSpec
 //------------------------------------------------
 
-// NOTE: Remote DataflowBuffer is not yet supported!
+// NOTE: Cross-Node DataflowBuffer is not yet supported!
 //       A sketch is included in the experimental Metal 2.0 APIs for visibility.
+//       See also Global DataFlowBuffer (which has a user-managed lifetime).
 //
-// RemoteDataflowBufferSpec is the descriptor for a "remote" DFB:
+// CrossNodeDataflowBufferSpec is the descriptor for a "cross-node" DFB:
 // A DFB whose producer and consumer kernels run on different nodes, with data
 // flowing over the NoC. Its semantics should be as close as possible to that of
 // a local DFB.
 //
-// A RemoteDataflowBufferSpec has all of the properties of a DataflowBufferSpec,
-// but must specify additional remote-DFB specific properties, such as the
+// A CrossNodeDataflowBufferSpec has all of the properties of a DataflowBufferSpec,
+// but must specify additional cross-node DFB specific properties, such as the
 // producer-consumer node mapping.
 //
-// TBD: Much about remote DFBs is still TBD! Everything below this line is expected
+// TBD: Much about cross-node DFBs is still TBD! Everything below this line is expected
 //   to change with the implementation.
 //
-// Invariant: Every remote DFB instance has exactly one producer kernel instance and
+// Invariant: Every cross-node DFB instance has exactly one producer kernel instance and
 //   one consumer kernel instance. The instances must not be on the same node.
 //
-// Instancing: At runtime, one remote DFB instance is allocated per entry in the
+// Instancing: At runtime, one cross-node DFB instance is allocated per entry in the
 //   producer_consumer_map. The runtime infrastructure allocates SRAM ("L1") at both
 //   endpoints.
 //
 // Placement: Specified directly via producer_consumer_map (rather than derived as
-//   for local DFBs).
+//   for local DFBs.
 //
-struct RemoteDataflowBufferSpec {
-    // A remote DFB has all of the same properties as a local DFB
+struct CrossNodeDataflowBufferSpec {
+    // A cross-node DFB has all of the same properties as a local DFB
     DataflowBufferSpec dfb_spec;
 
-    // Plus, some remote-DFB-specific properties.
+    // Plus, some cross-node DFB-specific properties.
     // (These are TBD...)
 
     // Producer-consumer node mapping: each entry pairs a producer node with the

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp
@@ -160,7 +160,7 @@ struct DataflowBufferSpec {
 //   endpoints.
 //
 // Placement: Specified directly via producer_consumer_map (rather than derived as
-//   for local DFBs.
+//   for local DFBs).
 //
 struct CrossNodeDataflowBufferSpec {
     // A cross-node DFB has all of the same properties as a local DFB

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -78,7 +78,7 @@ struct ProgramSpec {
     // Kernels, DFBs (local + remote), and semaphores that make up the Program
     Group<KernelSpec> kernels;
     Group<DataflowBufferSpec> dataflow_buffers;
-    Group<RemoteDataflowBufferSpec> remote_dataflow_buffers;
+    Group<CrossNodeDataflowBufferSpec> remote_dataflow_buffers;
     Group<SemaphoreSpec> semaphores;
 
     // Tensor parameter declarations

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_spec.hpp
@@ -75,10 +75,13 @@ struct ProgramSpec {
     // Human-readable name (debug/messaging only; no uniqueness invariant).
     std::string name;
 
-    // Kernels, DFBs (local + remote), and semaphores that make up the Program
+    // Kernels that make up the Program
     Group<KernelSpec> kernels;
+
+    // Program-scope resources (allocated for the Program's execution lifetime)
+    // DFBs (local + cross-node), and semaphores
     Group<DataflowBufferSpec> dataflow_buffers;
-    Group<CrossNodeDataflowBufferSpec> remote_dataflow_buffers;
+    Group<CrossNodeDataflowBufferSpec> cross_node_dataflow_buffers;
     Group<SemaphoreSpec> semaphores;
 
     // Tensor parameter declarations

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -54,10 +54,10 @@ struct CollectedSpecData {
     // Name -> spec lookups.
     // dfb_by_name covers BOTH local and cross-node DFBs.
     // For cross-node DFBs, the pointee is the inner dfb_spec.
-    // To check if a DFB is remote, check the remote_dfb_by_name map.
+    // To check if a DFB is cross-node, check the cross_node_dfb_by_name map.
     std::unordered_map<KernelSpecName, const KernelSpec*> kernel_by_name;
     std::unordered_map<DFBSpecName, const DataflowBufferSpec*> dfb_by_name;
-    std::unordered_map<DFBSpecName, const CrossNodeDataflowBufferSpec*> remote_dfb_by_name;
+    std::unordered_map<DFBSpecName, const CrossNodeDataflowBufferSpec*> cross_node_dfb_by_name;
     std::unordered_map<SemaphoreSpecName, const SemaphoreSpec*> semaphore_by_name;
     std::unordered_map<TensorParamName, const TensorParameter*> tensor_parameter_by_name;
 
@@ -299,11 +299,11 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
     // Collect CrossNodeDataflowBufferSpecs (cross-node DFBs).
     // Cross-node DFBs share the DFB name space with local DFBs, since kernel bindings
     // refer to either kind by the same DFBSpecName.
-    for (const auto& remote_dfb : spec.remote_dataflow_buffers) {
-        const DFBSpecName& name = remote_dfb.dfb_spec.unique_id;
-        auto [it1, inserted1] = collected.dfb_by_name.try_emplace(name, &remote_dfb.dfb_spec);
+    for (const auto& cross_node_dfb : spec.cross_node_dataflow_buffers) {
+        const DFBSpecName& name = cross_node_dfb.dfb_spec.unique_id;
+        auto [it1, inserted1] = collected.dfb_by_name.try_emplace(name, &cross_node_dfb.dfb_spec);
         TT_FATAL(inserted1, "Duplicate DataflowBufferSpec name '{}' (across local and cross-node DFBs)", name);
-        auto [it2, inserted2] = collected.remote_dfb_by_name.try_emplace(name, &remote_dfb);
+        auto [it2, inserted2] = collected.cross_node_dfb_by_name.try_emplace(name, &cross_node_dfb);
         TT_FATAL(inserted2, "Duplicate CrossNodeDataflowBufferSpec name '{}'", name);
     }
 
@@ -411,15 +411,15 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
         TT_FATAL(!endpoint_info.consumers.empty(), "DFB '{}' has no consumer", dfb_name);
     }
 
-    // Referential integrity: every declared DFB (local or remote) must be bound by some kernel
+    // Referential integrity: every declared DFB (local or cross-node) must be bound by some kernel
     for (const auto& dfb : spec.dataflow_buffers) {
         TT_FATAL(
             collected.dfb_endpoints.contains(dfb.unique_id),
             "DFB '{}' is defined but not bound by any kernel",
             dfb.unique_id);
     }
-    for (const auto& remote_dfb : spec.remote_dataflow_buffers) {
-        const DFBSpecName& name = remote_dfb.dfb_spec.unique_id;
+    for (const auto& cross_node_dfb : spec.cross_node_dataflow_buffers) {
+        const DFBSpecName& name = cross_node_dfb.dfb_spec.unique_id;
         TT_FATAL(
             collected.dfb_endpoints.contains(name),
             "CrossNodeDataflowBufferSpec '{}' is defined but not bound by any kernel",
@@ -1286,11 +1286,11 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
     //       p_node != c_node.
 
     TT_FATAL(
-        spec.remote_dataflow_buffers.empty(),
+        spec.cross_node_dataflow_buffers.empty(),
         "CrossNodeDataflowBufferSpec is part of the Metal 2.0 API surface but is not yet supported "
         "by the runtime. (ProgramSpec '{}' has {} cross-node DFB(s).)",
         spec.name,
-        spec.remote_dataflow_buffers.size());
+        spec.cross_node_dataflow_buffers.size());
 
     // Validate borrowed-memory DFBs.
     //

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -52,12 +52,12 @@ static constexpr uint32_t QUASAR_TENSIX_ENGINES_PER_NODE = 4;
 // Data structure built up from ProgramSpec to enable fast lookups
 struct CollectedSpecData {
     // Name -> spec lookups.
-    // dfb_by_name covers BOTH local and remote DFBs.
-    // For remote DFBs, the pointee is the inner dfb_spec.
+    // dfb_by_name covers BOTH local and cross-node DFBs.
+    // For cross-node DFBs, the pointee is the inner dfb_spec.
     // To check if a DFB is remote, check the remote_dfb_by_name map.
     std::unordered_map<KernelSpecName, const KernelSpec*> kernel_by_name;
     std::unordered_map<DFBSpecName, const DataflowBufferSpec*> dfb_by_name;
-    std::unordered_map<DFBSpecName, const RemoteDataflowBufferSpec*> remote_dfb_by_name;
+    std::unordered_map<DFBSpecName, const CrossNodeDataflowBufferSpec*> remote_dfb_by_name;
     std::unordered_map<SemaphoreSpecName, const SemaphoreSpec*> semaphore_by_name;
     std::unordered_map<TensorParamName, const TensorParameter*> tensor_parameter_by_name;
 
@@ -66,7 +66,7 @@ struct CollectedSpecData {
     std::unordered_map<TensorParamName, std::vector<const KernelSpec*>> tensor_parameter_users;
 
     // DFB endpoint info (derived from kernel bindings).
-    // Populated for both local and remote DFBs.
+    // Populated for both local and cross-node DFBs.
     //
     // Multiple PRODUCER KernelSpecs (and multiple CONSUMER KernelSpecs) may bind the same DFB,
     // provided they have non-overlapping node coverage and matching binding-site parameters
@@ -296,15 +296,15 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
         TT_FATAL(inserted, "Duplicate DataflowBufferSpec name '{}'", dfb.unique_id);
     }
 
-    // Collect RemoteDataflowBufferSpecs (remote DFBs).
-    // Remote DFBs share the DFB name space with local DFBs, since kernel bindings
+    // Collect CrossNodeDataflowBufferSpecs (cross-node DFBs).
+    // Cross-node DFBs share the DFB name space with local DFBs, since kernel bindings
     // refer to either kind by the same DFBSpecName.
     for (const auto& remote_dfb : spec.remote_dataflow_buffers) {
         const DFBSpecName& name = remote_dfb.dfb_spec.unique_id;
         auto [it1, inserted1] = collected.dfb_by_name.try_emplace(name, &remote_dfb.dfb_spec);
-        TT_FATAL(inserted1, "Duplicate DataflowBufferSpec name '{}' (across local and remote DFBs)", name);
+        TT_FATAL(inserted1, "Duplicate DataflowBufferSpec name '{}' (across local and cross-node DFBs)", name);
         auto [it2, inserted2] = collected.remote_dfb_by_name.try_emplace(name, &remote_dfb);
-        TT_FATAL(inserted2, "Duplicate RemoteDataflowBufferSpec name '{}'", name);
+        TT_FATAL(inserted2, "Duplicate CrossNodeDataflowBufferSpec name '{}'", name);
     }
 
     // Build DFB endpoint info from kernel bindings
@@ -398,7 +398,7 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
             } else if (dfb_binding.endpoint_type == DFBEndpointType::CONSUMER) {
                 endpoint_info.consumers.push_back({&kernel, &dfb_binding});
             } else {
-                TT_FATAL(false, "RELAY endpoints are only used for remote DFB, which is not supported yet");
+                TT_FATAL(false, "RELAY endpoints are only used for cross-node DFB, which is not supported yet");
             }
         }
     }
@@ -422,7 +422,7 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
         const DFBSpecName& name = remote_dfb.dfb_spec.unique_id;
         TT_FATAL(
             collected.dfb_endpoints.contains(name),
-            "RemoteDataflowBufferSpec '{}' is defined but not bound by any kernel",
+            "CrossNodeDataflowBufferSpec '{}' is defined but not bound by any kernel",
             name);
     }
 
@@ -506,7 +506,7 @@ CollectedSpecData CollectSpecData(const ProgramSpec& spec) {
     // kernel binds the parameter directly. Count that as a use so the completeness check below doesn't
     // reject a borrowed-only parameter. Existence of the referent is validated separately in the
     // borrowed-DFB checks. Only local DFBs are walked here: borrowed memory is a local-L1 feature,
-    // so spec.dataflow_buffers is the relevant set (remote DFBs are runtime-unsupported).
+    // so spec.dataflow_buffers is the relevant set (cross-node DFBs are runtime-unsupported).
     for (const auto& dfb : spec.dataflow_buffers) {
         if (dfb.borrowed_from.has_value()) {
             collected.tensor_parameter_users[*dfb.borrowed_from];  // register as used (no kernel user)
@@ -1279,16 +1279,16 @@ void ValidateProgramSpec(const ProgramSpec& spec, const CollectedSpecData& colle
         }
     }
 
-    // Remote DFBs are not yet supported.
+    // Cross-node DFBs are not yet supported.
     //
-    // TODO: When remote DFB is supported, add a validation checks. Enforce that
+    // TODO: When cross-node DFB is supported, add a validation checks. Enforce that
     //       each (producer_node, consumer_node) entry in producer_consumer_map has
     //       p_node != c_node.
 
     TT_FATAL(
         spec.remote_dataflow_buffers.empty(),
-        "RemoteDataflowBufferSpec is part of the Metal 2.0 API surface but is not yet supported "
-        "by the runtime. (ProgramSpec '{}' has {} remote DFB(s).)",
+        "CrossNodeDataflowBufferSpec is part of the Metal 2.0 API surface but is not yet supported "
+        "by the runtime. (ProgramSpec '{}' has {} cross-node DFB(s).)",
         spec.name,
         spec.remote_dataflow_buffers.size());
 


### PR DESCRIPTION
### PR Category
API cleanup

### Summary
The Metal 2.0 APIs contain the stub (unimplemented) for a new DFB construct: an ephemeral memory object (i.e. Program-execution lifetime) like DFB, but enabling cross-node communication. In the legacy APIs, this could only be achieved with semaphores and NoC writes. The new APIs will (eventually) have a native way to handle within-device, cross-node communication.

Previously, the stub object was named `RemoteDataflowBufferSpec` and the comments referred to "remote DFB". This was a poor name choice, because the existing codebase uses "remote CB" as a colloquial way to refer to GlobalCircularBuffer, and the "remote" name even leaks into the public device-side APIs.

This was causing a ton of confusion on legacy -> Metal 2.0 ports.

This PR renames `RemoteDataflowBuffer` to `CrossNodeDataflowBuffer`. This is more descriptive and doesn't alias any existing concepts.

### Notes for reviewers
Since this API is stubbed in, not implemented, there is zero blast radius from the change. The only users are legality checks that error out if anyone attempts to use it.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/rename-remote-DFB)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/rename-remote-DFB)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/rename-remote-DFB)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/rename-remote-DFB)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/rename-remote-DFB)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/rename-remote-DFB)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/rename-remote-DFB)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/rename-remote-DFB)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/rename-remote-DFB)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/rename-remote-DFB)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/rename-remote-DFB)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/rename-remote-DFB)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/rename-remote-DFB)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/rename-remote-DFB)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/rename-remote-DFB)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/rename-remote-DFB)