### PR TITLE
[Feature] Allow `ttnn::Tensor` to release its underlying `MeshTensor`

### DIFF
--- a/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
+++ b/tests/ttnn/unit_tests/gtests/tensor/test_device_storage_ownership.cpp
@@ -203,6 +203,49 @@ TEST_F(DeviceStorageOwnershipTest, DeviceStorage_BufferGettersThrowWhenDeallocat
     EXPECT_THROW(tensor.device_storage().get_mesh_buffer(), std::exception);
 }
 
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ReleaseMeshTensorMovesOutUnderlyingMemory) {
+    auto mesh_tensor = MeshTensor::allocate_on_device(*mesh_device_, make_test_tensor_spec(), TensorTopology{});
+    DeviceStorage storage(std::move(mesh_tensor));
+
+    // Capture identity of the underlying device memory before releasing.
+    const auto address = storage.get_mesh_tensor().mesh_buffer().address();
+
+    MeshTensor released = storage.release_mesh_tensor();
+
+    // The released tensor is valid and owns the very same MeshBuffer that the storage held —
+    // proving the memory was moved out, not copied or reallocated.
+    EXPECT_FALSE(released.is_valueless_after_move());
+    EXPECT_EQ(released.address(), address);
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ReleaseMeshTensorLeavesDefaultConstructedState) {
+    auto mesh_tensor = MeshTensor::allocate_on_device(*mesh_device_, make_test_tensor_spec(), TensorTopology{});
+    DeviceStorage storage(std::move(mesh_tensor));
+    ASSERT_TRUE(storage.is_allocated());
+
+    MeshTensor released = storage.release_mesh_tensor();
+
+    // Post-condition: storage is equivalent to a default-constructed DeviceStorage.
+    EXPECT_FALSE(storage.is_allocated());
+    EXPECT_THROW(storage.get_mesh_tensor(), std::exception);
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ReleaseMeshTensorThrowsWhenDefaultConstructed) {
+    DeviceStorage storage;
+    ASSERT_FALSE(storage.is_allocated());
+
+    EXPECT_THROW(storage.release_mesh_tensor(), std::exception);
+}
+
+TEST_F(DeviceStorageOwnershipTest, DeviceStorage_ReleaseMeshTensorThrowsWhenDeallocated) {
+    auto mesh_tensor = MeshTensor::allocate_on_device(*mesh_device_, make_test_tensor_spec(), TensorTopology{});
+    DeviceStorage storage(std::move(mesh_tensor));
+    storage.deallocate();
+    ASSERT_FALSE(storage.is_allocated());
+
+    EXPECT_THROW(storage.release_mesh_tensor(), std::exception);
+}
+
 // ======================================================================================
 // Tensor Deallocation Tests
 //

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -106,10 +106,11 @@ struct DeviceStorage {
     const MeshTensor& get_mesh_tensor() const;
 
     // Get the underlying MeshTensor, throws if the DeviceStorage is deallocated.
-    // Please do not move the MeshTensor out of the DeviceStorage using this function.
+    // Please do not move the MeshTensor out of the DeviceStorage using this function,
+    // use release_mesh_tensor instead.
     MeshTensor& get_mesh_tensor();
 
-    // Moves out the MeshTensor this DeviceStorage holds.
+    // Moves out the MeshTensor this DeviceStorage holds, throws if the DeviceStorage is deallocated.
     // post-condition: this DeviceStorage will be equivalent a default constructed DeviceStorage
     MeshTensor release_mesh_tensor();
 

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -109,6 +109,10 @@ struct DeviceStorage {
     // Please do not move the MeshTensor out of the DeviceStorage using this function.
     MeshTensor& get_mesh_tensor();
 
+    // Moves out the MeshTensor this DeviceStorage holds.
+    // post-condition: this DeviceStorage will be equivalent a default constructed DeviceStorage
+    MeshTensor release_mesh_tensor();
+
     // Returns the MeshDevice associated with the underlying device memory.
     // Throws if the DeviceStorage is not constructed from a MeshTensor.
     //

--- a/ttnn/api/ttnn/tensor/storage.hpp
+++ b/ttnn/api/ttnn/tensor/storage.hpp
@@ -111,7 +111,7 @@ struct DeviceStorage {
     MeshTensor& get_mesh_tensor();
 
     // Moves out the MeshTensor this DeviceStorage holds, throws if the DeviceStorage is deallocated.
-    // post-condition: this DeviceStorage will be equivalent a default constructed DeviceStorage
+    // post-condition: this DeviceStorage will be equivalent to a default constructed DeviceStorage.
     MeshTensor release_mesh_tensor();
 
     // Returns the MeshDevice associated with the underlying device memory.

--- a/ttnn/core/tensor/storage.cpp
+++ b/ttnn/core/tensor/storage.cpp
@@ -178,6 +178,16 @@ const MeshTensor& DeviceStorage::get_mesh_tensor() const {
         mesh_tensor_holder_->state_);
 }
 
+MeshTensor DeviceStorage::release_mesh_tensor() {
+    auto result = std::visit(
+        ttsl::overloaded{
+            [](MeshTensorHolder::Allocated& allocated) -> MeshTensor { return std::move(allocated.mesh_tensor_); },
+            [](const auto&) -> MeshTensor { TT_THROW("Tensor is not allocated"); }},
+        mesh_tensor_holder_->state_);
+    mesh_tensor_holder_->state_ = MeshTensorHolder::DeallocatedDefaultConstructed{};
+    return result;
+}
+
 MeshTensor& DeviceStorage::get_mesh_tensor() {
     return std::visit(
         ttsl::overloaded{


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

Feature

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

This PR adds a safe way to decay a `TTNN::Tensor` into a `MeshTensor`.

After `MeshTensor` is released, the `ttnn::Tensor` becomes deallocated as if it's default constructed.


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

This is needed for ttnn infrastructure to support metal 2.0 porting.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=riverwu/ttnn-tensor-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:riverwu/ttnn-tensor-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=riverwu/ttnn-tensor-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:riverwu/ttnn-tensor-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=riverwu/ttnn-tensor-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:riverwu/ttnn-tensor-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=riverwu/ttnn-tensor-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:riverwu/ttnn-tensor-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=riverwu/ttnn-tensor-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:riverwu/ttnn-tensor-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=riverwu/ttnn-tensor-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:riverwu/ttnn-tensor-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=riverwu/ttnn-tensor-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:riverwu/ttnn-tensor-leak)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=riverwu/ttnn-tensor-leak)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:riverwu/ttnn-tensor-leak)