### PR TITLE
Extended ttnn.prod to support float32

### DIFF
--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
@@ -11,10 +11,9 @@ from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_prod
 
 
-def get_tensors(input_shape, output_shape, device):
+def get_tensors(input_shape, output_shape, device, npu_dtype=ttnn.bfloat16):
     torch.manual_seed(2023)
-    npu_dtype = ttnn.bfloat16
-    cpu_dtype = torch.bfloat16
+    cpu_dtype = torch.float32 if npu_dtype == ttnn.float32 else torch.bfloat16
     npu_layout = ttnn.TILE_LAYOUT
 
     torch_input = torch.randint(1, 5, input_shape, dtype=cpu_dtype)
@@ -25,6 +24,7 @@ def get_tensors(input_shape, output_shape, device):
     return tt_input, tt_output, torch_input
 
 
+@pytest.mark.parametrize("npu_dtype", (ttnn.bfloat16, ttnn.float32))
 @pytest.mark.parametrize(
     "shapes",
     (
@@ -37,10 +37,10 @@ def get_tensors(input_shape, output_shape, device):
         # ([1, 3, 320, 64]), #Fails : expected result is inf but the result generated in nan
     ),
 )
-def test_prod(shapes, device):
+def test_prod(shapes, npu_dtype, device):
     output_shape = shapes.copy()
 
-    (tt_input, tt_output, torch_input) = get_tensors(shapes, shapes, device)
+    (tt_input, tt_output, torch_input) = get_tensors(shapes, shapes, device, npu_dtype)
 
     torch_output = torch.prod(torch_input)
 

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
@@ -73,8 +73,6 @@ def test_prod(shapes, npu_dtype, device):
 
 def _block_float_input(shape):
     # Block-float (bfp8_b / bfp4_b) shares one exponent per 16 elements. A full tile of random values
-    # would overflow the product, so use a mostly-ones input with a handful of 2.0s: every value is
-    # exactly representable in bfp8_b/bfp4_b and the product is a small, exact power of two.
     torch_input = torch.ones(shape, dtype=torch.float32)
     flat = torch_input.view(-1)
     num_twos = 5
@@ -92,11 +90,12 @@ def _block_float_input(shape):
     ),
 )
 def test_prod_all_block_float(shapes, npu_dtype, device):
-    # Full product (no dim) supports block-float: the result tile is unpacked to FLOAT32 on host.
     torch_input, torch_output = _block_float_input(shapes)
     tt_input = ttnn.Tensor(torch_input, npu_dtype).to(ttnn.TILE_LAYOUT).to(device)
 
-    tt_output = ttnn.prod(tt_input).cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().flatten()[0]
+    tt_result = ttnn.prod(tt_input)
+    assert tt_result.dtype == npu_dtype, f"expected {npu_dtype} result, got {tt_result.dtype}"
 
+    tt_output = ttnn.to_torch(tt_result).flatten()[0]
     logger.info(f"{npu_dtype} full-product: expected={torch_output.item()} got={tt_output.item()}")
     assert torch.isclose(tt_output, torch_output, atol=1e-2), f"expected {torch_output.item()}, got {tt_output.item()}"

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
@@ -71,8 +71,13 @@ def test_prod(shapes, npu_dtype, device):
     )
 
 
+BLOCK_FLOAT_DTYPES = (ttnn.bfloat8_b, ttnn.bfloat4_b)
+BLOCK_FLOAT_RESULT_ATOL = {ttnn.bfloat8_b: 5e-2, ttnn.bfloat4_b: 2e-1}
+
+
 def _block_float_input(shape):
-    # Block-float (bfp8_b / bfp4_b) shares one exponent per 16 elements. A full tile of random values
+    # Block-float (bfp8_b / bfp4_b) shares one exponent per 16 elements. Mostly ones with a few 2.0s:
+    # powers of two, so the whole product is exact in block-float regardless of dtype.
     torch_input = torch.ones(shape, dtype=torch.float32)
     flat = torch_input.view(-1)
     num_twos = 5
@@ -80,7 +85,28 @@ def _block_float_input(shape):
     return torch_input, torch.prod(torch_input)
 
 
-@pytest.mark.parametrize("npu_dtype", (ttnn.bfloat8_b, ttnn.bfloat4_b), ids=["bfloat8_b", "bfloat4_b"])
+def _block_float_nontrivial_input(shape):
+    # Non-trivial but block-float-exact input: values are integer multiples of 0.25 with |k| <= 7,
+    # which are represented exactly in bfp4_b/bfp8_b.
+    torch_input = torch.ones(shape, dtype=torch.float32)
+    factors = torch.tensor([1.5, 0.75, 1.25, 0.75, 1.5, 0.75, -1.0, 1.25, 0.75], dtype=torch.float32)
+    torch_input.view(-1)[: factors.numel()] = factors
+    return torch_input, torch.prod(torch_input)
+
+
+def _check_block_float_full_product(shape, npu_dtype, device, make_input, atol):
+    torch_input, torch_output = make_input(shape)
+    tt_input = ttnn.Tensor(torch_input, npu_dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+    tt_result = ttnn.prod(tt_input)
+    assert tt_result.dtype == npu_dtype, f"expected {npu_dtype} result, got {tt_result.dtype}"
+
+    tt_output = ttnn.to_torch(tt_result).flatten()[0]
+    logger.info(f"{npu_dtype} full-product: expected={torch_output.item()} got={tt_output.item()}")
+    assert torch.isclose(tt_output, torch_output, atol=atol), f"expected {torch_output.item()}, got {tt_output.item()}"
+
+
+@pytest.mark.parametrize("npu_dtype", BLOCK_FLOAT_DTYPES, ids=lambda d: d.name.lower())
 @pytest.mark.parametrize(
     "shapes",
     (
@@ -90,12 +116,20 @@ def _block_float_input(shape):
     ),
 )
 def test_prod_all_block_float(shapes, npu_dtype, device):
-    torch_input, torch_output = _block_float_input(shapes)
-    tt_input = ttnn.Tensor(torch_input, npu_dtype).to(ttnn.TILE_LAYOUT).to(device)
+    # Powers-of-two data is exact in block-float, so a single tight tolerance holds for every dtype.
+    _check_block_float_full_product(shapes, npu_dtype, device, _block_float_input, atol=1e-2)
 
-    tt_result = ttnn.prod(tt_input)
-    assert tt_result.dtype == npu_dtype, f"expected {npu_dtype} result, got {tt_result.dtype}"
 
-    tt_output = ttnn.to_torch(tt_result).flatten()[0]
-    logger.info(f"{npu_dtype} full-product: expected={torch_output.item()} got={tt_output.item()}")
-    assert torch.isclose(tt_output, torch_output, atol=1e-2), f"expected {torch_output.item()}, got {tt_output.item()}"
+@pytest.mark.parametrize("npu_dtype", BLOCK_FLOAT_DTYPES, ids=lambda d: d.name.lower())
+@pytest.mark.parametrize(
+    "shapes",
+    (
+        ([1, 4, 32, 32]),
+        ([1, 16, 32, 32]),
+    ),
+)
+def test_prod_all_block_float_nontrivial(shapes, npu_dtype, device):
+    # Off-grid partial products: the result tolerance is per-dtype (see BLOCK_FLOAT_RESULT_ATOL).
+    _check_block_float_full_product(
+        shapes, npu_dtype, device, _block_float_nontrivial_input, atol=BLOCK_FLOAT_RESULT_ATOL[npu_dtype]
+    )

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
@@ -11,7 +11,7 @@ from tests.ttnn.utils_for_testing import assert_numeric_metrics
 from tests.ttnn.nightly.unit_tests.operations.reduction.utility_functions import ttnn_prod
 
 
-def get_tensors(input_shape, output_shape, device, npu_dtype=ttnn.bfloat16):
+def get_tensors(input_shape, output_shape, device, npu_dtype):
     torch.manual_seed(2023)
     cpu_dtype = torch.float32 if npu_dtype == ttnn.float32 else torch.bfloat16
     npu_layout = ttnn.TILE_LAYOUT

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_all.py
@@ -69,3 +69,34 @@ def test_prod(shapes, npu_dtype, device):
         frobenius_threshold=1e-09,
         check_frobenius=check_frobenius,
     )
+
+
+def _block_float_input(shape):
+    # Block-float (bfp8_b / bfp4_b) shares one exponent per 16 elements. A full tile of random values
+    # would overflow the product, so use a mostly-ones input with a handful of 2.0s: every value is
+    # exactly representable in bfp8_b/bfp4_b and the product is a small, exact power of two.
+    torch_input = torch.ones(shape, dtype=torch.float32)
+    flat = torch_input.view(-1)
+    num_twos = 5
+    flat[: num_twos * 7 : 7] = 2.0
+    return torch_input, torch.prod(torch_input)
+
+
+@pytest.mark.parametrize("npu_dtype", (ttnn.bfloat8_b, ttnn.bfloat4_b), ids=["bfloat8_b", "bfloat4_b"])
+@pytest.mark.parametrize(
+    "shapes",
+    (
+        ([1, 1, 32, 32]),
+        ([1, 4, 32, 32]),
+        ([2, 2, 32, 32]),
+    ),
+)
+def test_prod_all_block_float(shapes, npu_dtype, device):
+    # Full product (no dim) supports block-float: the result tile is unpacked to FLOAT32 on host.
+    torch_input, torch_output = _block_float_input(shapes)
+    tt_input = ttnn.Tensor(torch_input, npu_dtype).to(ttnn.TILE_LAYOUT).to(device)
+
+    tt_output = ttnn.prod(tt_input).cpu().to(ttnn.ROW_MAJOR_LAYOUT).to_torch().flatten()[0]
+
+    logger.info(f"{npu_dtype} full-product: expected={torch_output.item()} got={tt_output.item()}")
+    assert torch.isclose(tt_output, torch_output, atol=1e-2), f"expected {torch_output.item()}, got {tt_output.item()}"

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_nc.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_nc.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -85,7 +85,15 @@ def test_prod_dims(input_shape, dims, npu_dtype, device):
     assert passing
 
 
-@pytest.mark.parametrize("npu_dtype", (ttnn.bfloat8_b, ttnn.bfloat4_b), ids=["bfloat8_b", "bfloat4_b"])
+DIM_PATH_BLOCK_FLOAT_SUPPORT = {
+    ttnn.bfloat8_b: True,
+    ttnn.bfloat4_b: False,
+}
+_dim_supported = [d for d, ok in DIM_PATH_BLOCK_FLOAT_SUPPORT.items() if ok]
+_dim_unsupported = [d for d, ok in DIM_PATH_BLOCK_FLOAT_SUPPORT.items() if not ok]
+
+
+@pytest.mark.parametrize("npu_dtype", _dim_supported, ids=lambda d: d.name.lower())
 @pytest.mark.parametrize("dim", (0, 1, 2, 3))
 def test_prod_dims_block_float(dim, npu_dtype, device):
     # Mostly-ones input with a few 2.0s: exact in block-float, product stays a small power of two.

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_nc.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_nc.py
@@ -83,3 +83,22 @@ def test_prod_dims(input_shape, dims, npu_dtype, device):
     logger.info(f"Output pcc={output_pcc}")
 
     assert passing
+
+
+@pytest.mark.parametrize("npu_dtype", (ttnn.bfloat8_b, ttnn.bfloat4_b), ids=["bfloat8_b", "bfloat4_b"])
+@pytest.mark.parametrize("dim", (0, 1, 2, 3))
+def test_prod_dims_block_float(dim, npu_dtype, device):
+    # Block-float (bfp8_b/bfp4_b) dim reductions via ttnn.prod(x, dim=...) are upcast to FLOAT32
+    # internally and return FLOAT32. Use a mostly-ones input with a few 2.0s: every value is exactly
+    # representable in block-float and the product stays a small, exact power of two.
+    torch.manual_seed(2023)
+    torch_input = torch.ones([2, 3, TILE_HEIGHT, TILE_WIDTH * 2], dtype=torch.float32)
+    torch_input.view(-1)[::13][:8] = 2.0
+
+    tt_input = ttnn.from_torch(torch_input, dtype=npu_dtype, layout=ttnn.TILE_LAYOUT, device=device)
+    tt_output = ttnn.prod(tt_input, dim=dim)
+    assert tt_output.dtype == ttnn.float32, f"expected FLOAT32 result, got {tt_output.dtype}"
+
+    out = ttnn.to_torch(tt_output)
+    ref = torch.prod(torch_input, dim=dim)
+    assert torch.allclose(out, ref, atol=1e-2), f"dim={dim} {npu_dtype}: expected {ref}, got {out}"

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_nc.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_nc.py
@@ -88,17 +88,16 @@ def test_prod_dims(input_shape, dims, npu_dtype, device):
 @pytest.mark.parametrize("npu_dtype", (ttnn.bfloat8_b, ttnn.bfloat4_b), ids=["bfloat8_b", "bfloat4_b"])
 @pytest.mark.parametrize("dim", (0, 1, 2, 3))
 def test_prod_dims_block_float(dim, npu_dtype, device):
-    # Block-float (bfp8_b/bfp4_b) dim reductions via ttnn.prod(x, dim=...) are upcast to FLOAT32
-    # internally and return FLOAT32. Use a mostly-ones input with a few 2.0s: every value is exactly
-    # representable in block-float and the product stays a small, exact power of two.
+    # Mostly-ones input with a few 2.0s: exact in block-float, product stays a small power of two.
     torch.manual_seed(2023)
     torch_input = torch.ones([2, 3, TILE_HEIGHT, TILE_WIDTH * 2], dtype=torch.float32)
     torch_input.view(-1)[::13][:8] = 2.0
 
     tt_input = ttnn.from_torch(torch_input, dtype=npu_dtype, layout=ttnn.TILE_LAYOUT, device=device)
     tt_output = ttnn.prod(tt_input, dim=dim)
-    assert tt_output.dtype == ttnn.float32, f"expected FLOAT32 result, got {tt_output.dtype}"
+    assert tt_output.dtype == npu_dtype, f"expected {npu_dtype} result, got {tt_output.dtype}"
 
     out = ttnn.to_torch(tt_output)
     ref = torch.prod(torch_input, dim=dim)
+    ref = ttnn.to_torch(ttnn.from_torch(ref, dtype=npu_dtype, layout=ttnn.TILE_LAYOUT, device=device))
     assert torch.allclose(out, ref, atol=1e-2), f"dim={dim} {npu_dtype}: expected {ref}, got {out}"

--- a/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_nc.py
+++ b/tests/ttnn/nightly/unit_tests/operations/reduction/test_prod_nc.py
@@ -14,10 +14,9 @@ TILE_HEIGHT = 32
 TILE_WIDTH = 32
 
 
-def get_tensors(input_shape, output_shape, device):
+def get_tensors(input_shape, output_shape, device, npu_dtype=ttnn.bfloat16):
     torch.manual_seed(2023)
-    npu_dtype = ttnn.bfloat16
-    cpu_dtype = torch.bfloat16
+    cpu_dtype = torch.float32 if npu_dtype == ttnn.float32 else torch.bfloat16
     npu_layout = ttnn.TILE_LAYOUT
 
     torch_input = torch.randint(-100, 100, input_shape, dtype=cpu_dtype)
@@ -62,14 +61,15 @@ def get_tensors(input_shape, output_shape, device):
     ),
     ids=["0", "1"],
 )
+@pytest.mark.parametrize("npu_dtype", (ttnn.bfloat16, ttnn.float32), ids=["bfloat16", "float32"])
 # Support for dim 2,3 in composite_ops
-def test_prod_dims(input_shape, dims, device):
+def test_prod_dims(input_shape, dims, npu_dtype, device):
     output_shape = input_shape.copy()
 
     for dim in dims:
         output_shape[dim] = 1
 
-    (tt_input, tt_output, torch_input) = get_tensors(input_shape, output_shape, device)
+    (tt_input, tt_output, torch_input) = get_tensors(input_shape, output_shape, device, npu_dtype)
 
     torch_output = torch.prod(torch_input, dims[0], True)
 

--- a/tests/ttnn/unit_tests/operations/data_movement/test_fill_pad.py
+++ b/tests/ttnn/unit_tests/operations/data_movement/test_fill_pad.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 
 # SPDX-License-Identifier: Apache-2.0
 
@@ -59,6 +59,7 @@ ttnn_dtype_to_torch_dtype = {
     ttnn.int32: torch.int32,
     ttnn.bfloat16: torch.float32,
     ttnn.bfloat8_b: torch.bfloat16,
+    ttnn.bfloat4_b: torch.bfloat16,
     ttnn.float32: torch.float32,
 }
 
@@ -107,6 +108,15 @@ def test_fill_pad_float(
     assert_quality(padded_torch_tensor, padded_torch_output_tensor)
 
 
+BLOCK_FLOAT_FILL_PAD = {
+    ttnn.bfloat8_b: {"pcc": 0.9999, "fill_values": (1.5, float("inf"), float("-inf"))},
+    ttnn.bfloat4_b: {"pcc": 0.95, "fill_values": (1.5,)},
+}
+BLOCK_FLOAT_FILL_PAD_CASES = [
+    (dtype, fill_value) for dtype, cfg in BLOCK_FLOAT_FILL_PAD.items() for fill_value in cfg["fill_values"]
+]
+
+
 @pytest.mark.parametrize(
     "shape",
     [
@@ -123,13 +133,10 @@ def test_fill_pad_float(
         (1, 2, 3, 2, 1, 2, 97, 96),
     ],
 )
-
-# separate test for bfloat8_b where last dim is tile_width aligned (required for bf8b)
-@pytest.mark.parametrize("fill_value", [1.5, float("inf"), float("-inf")])
-@pytest.mark.parametrize("dtype", [ttnn.bfloat8_b])
+@pytest.mark.parametrize("dtype, fill_value", BLOCK_FLOAT_FILL_PAD_CASES)
 @pytest.mark.parametrize("input_mem_config", [ttnn.DRAM_MEMORY_CONFIG])
 @pytest.mark.parametrize("output_mem_config", [ttnn.DRAM_MEMORY_CONFIG])
-def test_fill_pad_bfloat8_b(
+def test_fill_pad_block_float(
     device,
     shape,
     fill_value,
@@ -148,15 +155,16 @@ def test_fill_pad_bfloat8_b(
     )
 
     output_tensor = ttnn.fill_implicit_tile_padding(input_tensor, fill_value, memory_config=output_mem_config)
-    # Guard against the rank>3 dtype leak: BFLOAT8_B inputs typecast through BFLOAT16 internally,
-    # but the helper must cast back to BFLOAT8_B on every return path (incl. the rank>3 reshape branch).
+    # Guard against the rank>3 dtype leak: block-float inputs typecast through BFLOAT16 internally,
+    # but the helper must cast back to the input dtype on every return path (incl. the rank>3 reshape branch).
     assert (
         output_tensor.dtype == dtype
     ), f"fill_implicit_tile_padding leaked dtype: expected {dtype}, got {output_tensor.dtype}"
     padded_torch_output_tensor = ttnn.from_device(output_tensor).to_torch_with_padded_shape()
 
-    # bfloat8_b is a reduced-precision format; keep PCC-based validation for stability.
-    assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor)
+    # Block-float (bfp8/bfp4) is a reduced-precision format; keep PCC-based validation for stability,
+    # with the per-dtype bound from BLOCK_FLOAT_FILL_PAD.
+    assert_with_pcc(padded_torch_tensor, padded_torch_output_tensor, BLOCK_FLOAT_FILL_PAD[dtype]["pcc"])
 
 
 @pytest.mark.parametrize(

--- a/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/fill_pad/fill_pad.cpp
@@ -1,4 +1,4 @@
-// SPDX-FileCopyrightText: © 2025 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
@@ -24,7 +24,7 @@ Tensor fill_implicit_tile_padding(
     }
     auto mutable_input_tensor = input_tensor;
     auto output_memory_config = memory_config.value_or(input_tensor.memory_config());
-    if (input_tensor.dtype() == DataType::BFLOAT8_B) {
+    if (is_block_float(input_tensor.dtype())) {
         mutable_input_tensor = ttnn::typecast(mutable_input_tensor, DataType::BFLOAT16);
     }
     Tensor output_tensor;
@@ -62,11 +62,11 @@ Tensor fill_implicit_tile_padding(
     } else {
         output_tensor = ttnn::prim::fill_pad(mutable_input_tensor, fill_value, output_memory_config);
     }
-    // BFLOAT8_B was typecast to BFLOAT16 above for fill_pad; restore the original dtype on every return path,
-    // including the rank>3 branch (previously the cast-back only fired on the rank<=3 path, leaking BFLOAT16
-    // for rank>3 BFLOAT8_B inputs).
-    if (input_tensor.dtype() == DataType::BFLOAT8_B) {
-        return ttnn::typecast(output_tensor, DataType::BFLOAT8_B);
+    // Block-float inputs were typecast to BFLOAT16 above for fill_pad; restore the original dtype on every
+    // return path, including the rank>3 branch (previously the cast-back only fired on the rank<=3 path,
+    // leaking BFLOAT16 for rank>3 block-float inputs).
+    if (is_block_float(input_tensor.dtype())) {
+        return ttnn::typecast(output_tensor, input_tensor.dtype());
     }
     return output_tensor;
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp
@@ -1,68 +1,45 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 #include "api/compute/common.h"
 #include "api/compute/tile_move_copy.h"
-#include "api/compute/eltwise_unary/eltwise_unary.h"
 #include "api/compute/eltwise_binary.h"
-#include "api/compute/eltwise_unary/sfpu_split_includes.h"
-#include "api/compute/eltwise_unary/negative.h"
 #include "api/compute/compute_kernel_api.h"
-#include "api/debug/dprint_pages.h"
 #include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     const tt::CBIndex input_cb = tt::CBIndex::c_0;
-    const tt::CBIndex partial_prod_cb = tt::CBIndex::c_2;
     const tt::CBIndex final_output_cb = tt::CBIndex::c_3;
 
     CircularBuffer input_cb_obj(input_cb);
-    CircularBuffer partial_prod_cb_obj(partial_prod_cb);
     CircularBuffer final_output_cb_obj(final_output_cb);
 
     const int one_tile = 1;
     constexpr uint32_t num_tiles = get_compile_time_arg_val(0);
-    constexpr uint32_t per_core_block_dim = get_compile_time_arg_val(1);
-    binary_op_init_common(input_cb, partial_prod_cb, final_output_cb);
 
-    reconfig_data_format(input_cb, partial_prod_cb);
+    binary_op_init_common(input_cb, input_cb, final_output_cb);
     pack_reconfig_data_format(final_output_cb);
 
-    // Ultimate goal is to have a single tile in the final output cb
     final_output_cb_obj.reserve_back(one_tile);
 
-    // Copy the first tile to DST[0]
-    input_cb_obj.wait_front(one_tile);
+    // The running product lives in DEST for the whole reduction.
     tile_regs_acquire();
 
+    // Seed DEST with the first input tile.
+    input_cb_obj.wait_front(one_tile);
     copy_tile_to_dst_init_short(input_cb);
-    copy_tile(input_cb, 0, 0);  // copy from c_in[0] to DST[0]
-
+    copy_tile(input_cb, 0, 0);
     input_cb_obj.pop_front(one_tile);
-    mul_tiles_init(input_cb, partial_prod_cb);
 
-    // When we have more than one tile, we can do the tile-wise multiplication of them all to yield one final tile
+    // Fold each remaining tile in: DEST = DEST * next_tile.
+    // DEST_TO_SRCA loads the running product from DEST into SRCA.
+    binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(input_cb);
     for (uint32_t t = 1; t < num_tiles; t++) {
-        // Save the current partial prod into CB
-        tile_regs_commit();
-        tile_regs_wait();
-
-        partial_prod_cb_obj.reserve_back(one_tile);
-        pack_tile(0, partial_prod_cb);
-        partial_prod_cb_obj.push_back(one_tile);
-        tile_regs_release();
-
-        // Load the next input tile and multiply it with the partial prod
         input_cb_obj.wait_front(one_tile);
-
-        tile_regs_acquire();
-
-        mul_tiles(input_cb, partial_prod_cb, /*tile0=*/0, /*tile1=*/0, /*dst_tile=*/0);
-
+        binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(input_cb, 0, 0);
         input_cb_obj.pop_front(one_tile);
-        partial_prod_cb_obj.pop_front(one_tile);
     }
 
     tile_regs_commit();

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp
@@ -1,11 +1,12 @@
-// SPDX-FileCopyrightText: © 2023 Tenstorrent USA, Inc.
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
 //
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
 
-#include "api/compute/eltwise_binary.h"
+#include "api/compute/common.h"
 #include "api/compute/tile_move_copy.h"
+#include "api/compute/eltwise_binary.h"
 #include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
@@ -13,50 +14,41 @@ void kernel_main() {
     const auto num_output_tiles = get_arg_val<uint32_t>(1);
 
     constexpr auto cb_in0 = tt::CBIndex::c_0;
-    constexpr auto cb_in1 = tt::CBIndex::c_1;
     constexpr auto cb_out0 = tt::CBIndex::c_3;
-    constexpr auto cb_intermed0 = tt::CBIndex::c_2;
     constexpr uint32_t onetile = 1;
     constexpr uint32_t dst0 = 0;
-    constexpr uint32_t dst1 = 1;
-    constexpr uint32_t first_tile = 0;
 
     CircularBuffer cb_in0_obj(cb_in0);
-    CircularBuffer cb_in1_obj(cb_in1);
-    CircularBuffer cb_intermed0_obj(cb_intermed0);
     CircularBuffer cb_out0_obj(cb_out0);
 
-    binary_op_init_common(cb_in0, cb_in1, cb_out0);
-    cb_in1_obj.wait_front(onetile);
+    binary_op_init_common(cb_in0, cb_in0, cb_out0);
+    pack_reconfig_data_format(cb_out0);
 
-    for (uint32_t i = 0; i < num_output_tiles; i++) {
-        bool enable_reload = false;
-        for (uint32_t j = 0; j < num_input_tiles; ++j) {
-            bool last_out = (j == num_input_tiles - 1);
-            uint32_t cb_add = (enable_reload) ? (cb_intermed0) : (cb_in1);
+    for (uint32_t i = 0; i < num_output_tiles; ++i) {
+        // Each output tile is an independent reduction of num_input_tiles.
+        // The running product lives in DEST.
+        tile_regs_acquire();
 
+        // Seed DEST with the first input tile of this reduction.
+        cb_in0_obj.wait_front(onetile);
+        copy_tile_to_dst_init_short(cb_in0);
+        copy_tile(cb_in0, 0, dst0);
+        cb_in0_obj.pop_front(onetile);
+
+        binary_dest_reuse_tiles_init<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(cb_in0);
+        for (uint32_t j = 1; j < num_input_tiles; ++j) {
             cb_in0_obj.wait_front(onetile);
-            if (enable_reload) {
-                cb_intermed0_obj.wait_front(onetile);
-            }
-
-            tile_regs_acquire();
-            mul_tiles_init(cb_in0, cb_add);
-            mul_tiles(cb_in0, cb_add, first_tile, first_tile, dst0);
-            tile_regs_commit();
-
+            binary_dest_reuse_tiles<EltwiseBinaryType::ELWMUL, EltwiseBinaryReuseDestType::DEST_TO_SRCA>(
+                cb_in0, 0, dst0);
             cb_in0_obj.pop_front(onetile);
-            if (enable_reload) {
-                cb_intermed0_obj.pop_front(onetile);
-            }
-
-            auto& cb_out_obj = last_out ? cb_out0_obj : cb_intermed0_obj;
-            cb_out_obj.reserve_back(onetile);
-            tile_regs_wait();
-            pack_tile(dst0, cb_out_obj.get_cb_id());
-            tile_regs_release();
-            cb_out_obj.push_back(onetile);
-            enable_reload = true;
         }
+
+        tile_regs_commit();
+
+        cb_out0_obj.reserve_back(onetile);
+        tile_regs_wait();
+        pack_tile(dst0, cb_out0);
+        cb_out0_obj.push_back(onetile);
+        tile_regs_release();
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/reader_prod_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/dataflow/reader_prod_nc.cpp
@@ -3,13 +3,11 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #include <cstdint>
-#include <cstring>
 
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
 #include "api/tensor/noc_traits.h"
-#include "ttnn/kernel/dataflow/cb_fill_helpers.hpp"
 
 void kernel_main() {
     const auto input_addr = get_arg_val<uint32_t>(0);
@@ -23,12 +21,6 @@ void kernel_main() {
     constexpr auto dram_input_addrg_args = TensorAccessorArgs<1>();
 
     constexpr uint32_t onetile = 1;
-    constexpr uint32_t cb_id_in1 = tt::CBIndex::c_1;
-
-    uint32_t scaler = 0;
-    const float one_f = 1.0f;
-    std::memcpy(&scaler, &one_f, sizeof(uint32_t));  // Alternative to std::bit_cast
-    fill_cb_with_value(cb_id_in1, scaler);
 
     Noc noc;
     CircularBuffer cb_in0(tt::CBIndex::c_0);

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
@@ -22,8 +22,8 @@ void ProdAllDeviceOperation::validate_on_program_cache_miss(
         "Memory layout must be INTERLEAVED, got: {}",
         input.memory_config().memory_layout());
     TT_FATAL(
-        input.dtype() == tt::tt_metal::DataType::BFLOAT16,
-        "Error - unsupported data type for prod, expected BFLOAT16 but got {}.",
+        input.dtype() == tt::tt_metal::DataType::BFLOAT16 || input.dtype() == tt::tt_metal::DataType::FLOAT32,
+        "Error - unsupported data type for prod, expected BFLOAT16 or FLOAT32 but got {}.",
         input.dtype());
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
@@ -31,10 +31,14 @@ void ProdAllDeviceOperation::validate_on_program_cache_miss(
 ProdAllDeviceOperation::spec_return_value_t ProdAllDeviceOperation::compute_output_specs(
     const operation_attributes_t& args, const tensor_args_t& tensor_args) {
     const auto& input = tensor_args.input;
+    const auto output_dtype =
+        (input.dtype() == tt::tt_metal::DataType::FLOAT32 || tt::tt_metal::is_block_float(input.dtype()))
+            ? tt::tt_metal::DataType::FLOAT32
+            : input.dtype();
     return TensorSpec(
         ttnn::Shape({1, 1, 1, input.tensor_spec().tile().get_tile_hw()}),
         tt::tt_metal::TensorLayout(
-            input.dtype(), tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), args.output_mem_config));
+            output_dtype, tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE), args.output_mem_config));
 }
 
 ProdAllDeviceOperation::tensor_return_value_t ProdAllDeviceOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_device_operation.cpp
@@ -22,8 +22,9 @@ void ProdAllDeviceOperation::validate_on_program_cache_miss(
         "Memory layout must be INTERLEAVED, got: {}",
         input.memory_config().memory_layout());
     TT_FATAL(
-        input.dtype() == tt::tt_metal::DataType::BFLOAT16 || input.dtype() == tt::tt_metal::DataType::FLOAT32,
-        "Error - unsupported data type for prod, expected BFLOAT16 or FLOAT32 but got {}.",
+        input.dtype() == tt::tt_metal::DataType::BFLOAT16 || input.dtype() == tt::tt_metal::DataType::FLOAT32 ||
+            input.dtype() == tt::tt_metal::DataType::BFLOAT8_B || input.dtype() == tt::tt_metal::DataType::BFLOAT4_B,
+        "Error - unsupported data type for prod, expected BFLOAT16, FLOAT32, BFLOAT8_B or BFLOAT4_B but got {}.",
         input.dtype());
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
@@ -87,7 +87,7 @@ ProgramDescriptor ProdAllDeviceOperation::ProdAllProgramFactory::create_descript
         1           // per_core_block_size
     };
 
-    bool fp32_dest_acc_en = false;
+    bool fp32_dest_acc_en = input.dtype() == DataType::FLOAT32;
     bool math_approx_mode = true;
     KernelDescriptor compute_desc;
     compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp";

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
@@ -21,8 +21,10 @@ ProgramDescriptor ProdAllDeviceOperation::ProdAllProgramFactory::create_descript
     CoreRange core({0, 0}, {0, 0});
     CoreRangeSet core_ranges(core);
 
-    DataFormat cb_data_format = datatype_to_dataformat_converter(input.dtype());
-    uint32_t single_tile_size = tile_size(cb_data_format);
+    DataFormat in_cb_data_format = datatype_to_dataformat_converter(input.dtype());
+    DataFormat out_cb_data_format = datatype_to_dataformat_converter(output.dtype());
+    uint32_t in_single_tile_size = tile_size(in_cb_data_format);
+    uint32_t out_single_tile_size = tile_size(out_cb_data_format);
 
     uint32_t num_tiles = input.physical_volume() / input.tensor_spec().tile().get_tile_hw();
 
@@ -30,34 +32,24 @@ ProgramDescriptor ProdAllDeviceOperation::ProdAllProgramFactory::create_descript
 
     uint32_t num_input_tiles = 2;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * single_tile_size,
+        .total_size = num_input_tiles * in_single_tile_size,
         .core_ranges = core_ranges,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(CBIndex::c_0),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
-
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = num_input_tiles * single_tile_size,
-        .core_ranges = core_ranges,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(CBIndex::c_2),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
+            .data_format = in_cb_data_format,
+            .page_size = in_single_tile_size,
         }}},
     });
 
     constexpr uint32_t output_cb_index = CBIndex::c_3;
     uint32_t num_output_tiles = 2;
     desc.cbs.push_back(CBDescriptor{
-        .total_size = num_output_tiles * single_tile_size,
+        .total_size = num_output_tiles * out_single_tile_size,
         .core_ranges = core_ranges,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(output_cb_index),
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
+            .data_format = out_cb_data_format,
+            .page_size = out_single_tile_size,
         }}},
     });
 
@@ -87,10 +79,13 @@ ProgramDescriptor ProdAllDeviceOperation::ProdAllProgramFactory::create_descript
         1           // per_core_block_size
     };
 
-    bool fp32_dest_acc_en = input.dtype() == DataType::FLOAT32;
-    // On Wormhole, HiFi4 must not be combined with fp32_dest_acc_en due to a hardware bug
-    // (see tenstorrent/tt-metal#38306); use HiFi3 in that case.
-    const auto math_fidelity = fp32_dest_acc_en ? tt::tt_metal::MathFidelity::HiFi3 : tt::tt_metal::MathFidelity::HiFi4;
+    bool fp32_dest_acc_en = true;
+    // On Wormhole B0, HiFi4 must not be combined with fp32_dest_acc_en due to a hardware bug
+    // (see tenstorrent/tt-metal#38306); drop to HiFi3 only on that arch. Other architectures keep HiFi4.
+    const bool needs_wh_fp32_workaround =
+        fp32_dest_acc_en && tensor_args.input.device()->arch() == tt::ARCH::WORMHOLE_B0;
+    const auto math_fidelity =
+        needs_wh_fp32_workaround ? tt::tt_metal::MathFidelity::HiFi3 : tt::tt_metal::MathFidelity::HiFi4;
     bool math_approx_mode = true;
     KernelDescriptor compute_desc;
     compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp";

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_all_program_factory.cpp
@@ -88,6 +88,9 @@ ProgramDescriptor ProdAllDeviceOperation::ProdAllProgramFactory::create_descript
     };
 
     bool fp32_dest_acc_en = input.dtype() == DataType::FLOAT32;
+    // On Wormhole, HiFi4 must not be combined with fp32_dest_acc_en due to a hardware bug
+    // (see tenstorrent/tt-metal#38306); use HiFi3 in that case.
+    const auto math_fidelity = fp32_dest_acc_en ? tt::tt_metal::MathFidelity::HiFi3 : tt::tt_metal::MathFidelity::HiFi4;
     bool math_approx_mode = true;
     KernelDescriptor compute_desc;
     compute_desc.kernel_source = "ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_all.cpp";
@@ -95,7 +98,7 @@ ProgramDescriptor ProdAllDeviceOperation::ProdAllProgramFactory::create_descript
     compute_desc.core_ranges = core_ranges;
     compute_desc.compile_time_args = std::move(compute_kernel_args);
     compute_desc.config = ComputeConfigDescriptor{
-        .math_fidelity = tt::tt_metal::MathFidelity::HiFi4,
+        .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,
         .dst_full_sync_en = false,
         .math_approx_mode = math_approx_mode,

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.cpp
@@ -31,10 +31,10 @@ void ProdNcDeviceOperation::validate_on_program_cache_miss(
             output_shape[i]);
     }
 
-    // prod supports bfloat16 and float32, per ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.hpp
     TT_FATAL(
-        input.dtype() == tt::tt_metal::DataType::BFLOAT16 || input.dtype() == tt::tt_metal::DataType::FLOAT32,
-        "Error - unsupported data type for prod, expected BFLOAT16 or FLOAT32 but got {}.",
+        input.dtype() == tt::tt_metal::DataType::BFLOAT16 || input.dtype() == tt::tt_metal::DataType::FLOAT32 ||
+            input.dtype() == tt::tt_metal::DataType::BFLOAT8_B,
+        "Error - unsupported data type for prod, expected BFLOAT16, FLOAT32 or BFLOAT8_B but got {}.",
         input.dtype());
 
     const auto& out_memory_config = output.memory_config();

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_device_operation.cpp
@@ -31,10 +31,10 @@ void ProdNcDeviceOperation::validate_on_program_cache_miss(
             output_shape[i]);
     }
 
-    // prod supports only bfloat16, per ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.hpp
+    // prod supports bfloat16 and float32, per ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.hpp
     TT_FATAL(
-        input.dtype() == tt::tt_metal::DataType::BFLOAT16,
-        "Error - unsupported data type for prod, expected BFLOAT16 but got {}.",
+        input.dtype() == tt::tt_metal::DataType::BFLOAT16 || input.dtype() == tt::tt_metal::DataType::FLOAT32,
+        "Error - unsupported data type for prod, expected BFLOAT16 or FLOAT32 but got {}.",
         input.dtype());
 
     const auto& out_memory_config = output.memory_config();

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -135,7 +135,9 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
     ////////////////////////////////////////////////////////////////////////////
     const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1};
 
-    const bool fp32_dest_acc_en = true;
+    // Enabling fp32 DEST accumulation for bf16 output forces the Wormhole HiFi3
+    // workaround below, which adversly affects the accuracy of the reduction.
+    const bool fp32_dest_acc_en = output.dtype() != tt::tt_metal::DataType::BFLOAT16;
     // On Wormhole B0, HiFi4 must not be combined with fp32_dest_acc_en due to a hardware bug
     // (see tenstorrent/tt-metal#38306); drop to HiFi3 only on that arch. Other architectures keep HiFi4.
     const bool needs_wh_fp32_workaround = fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0;

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -70,10 +70,8 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
     const auto num_cores_y = grid.y;
     TT_FATAL(num_cores_y != 0, "Compute grid y-dimension must be non-zero");
 
-    const uint32_t in0_t = 2;        // input
-    const uint32_t in1_t = 1;        // zero
-    const uint32_t intermed0_t = 1;  // accumulated sum
-    const uint32_t out0_t = 2;       // output
+    const uint32_t in0_t = 2;   // input
+    const uint32_t out0_t = 2;  // output
     const auto
         [num_cores_to_be_used,
          all_cores,
@@ -92,24 +90,6 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
         .core_ranges = all_cores,
         .format_descriptors = {{CBFormatDescriptor{
             .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_0),  // input
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = in1_t * single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_1),  // zero
-            .data_format = cb_data_format,
-            .page_size = single_tile_size,
-        }}},
-    });
-    desc.cbs.push_back(CBDescriptor{
-        .total_size = intermed0_t * single_tile_size,
-        .core_ranges = all_cores,
-        .format_descriptors = {{CBFormatDescriptor{
-            .buffer_index = static_cast<uint8_t>(tt::CBIndex::c_2),  // accumulated sum
             .data_format = cb_data_format,
             .page_size = single_tile_size,
         }}},
@@ -155,12 +135,12 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
     ////////////////////////////////////////////////////////////////////////////
     const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1};
 
-    // Accumulate the running product in full fp32 precision when the tensor is fp32; otherwise the
-    // dst register would round each partial product to bf16 and defeat the purpose of fp32 input.
-    const bool fp32_dest_acc_en = input.dtype() == DataType::FLOAT32;
-    // On Wormhole, HiFi4 must not be combined with fp32_dest_acc_en due to a hardware bug
-    // (see tenstorrent/tt-metal#38306); use HiFi3 in that case.
-    const auto math_fidelity = fp32_dest_acc_en ? tt::tt_metal::MathFidelity::HiFi3 : tt::tt_metal::MathFidelity::HiFi4;
+    const bool fp32_dest_acc_en = true;
+    // On Wormhole B0, HiFi4 must not be combined with fp32_dest_acc_en due to a hardware bug
+    // (see tenstorrent/tt-metal#38306); drop to HiFi3 only on that arch. Other architectures keep HiFi4.
+    const bool needs_wh_fp32_workaround = fp32_dest_acc_en && device->arch() == tt::ARCH::WORMHOLE_B0;
+    const auto math_fidelity =
+        needs_wh_fp32_workaround ? tt::tt_metal::MathFidelity::HiFi3 : tt::tt_metal::MathFidelity::HiFi4;
 
     KernelDescriptor compute_desc_1;
     compute_desc_1.kernel_source = "ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp";

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -157,7 +157,10 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
 
     // Accumulate the running product in full fp32 precision when the tensor is fp32; otherwise the
     // dst register would round each partial product to bf16 and defeat the purpose of fp32 input.
-    const bool fp32_dest_acc_en = output.dtype() == DataType::FLOAT32;
+    const bool fp32_dest_acc_en = input.dtype() == DataType::FLOAT32;
+    // On Wormhole, HiFi4 must not be combined with fp32_dest_acc_en due to a hardware bug
+    // (see tenstorrent/tt-metal#38306); use HiFi3 in that case.
+    const auto math_fidelity = fp32_dest_acc_en ? tt::tt_metal::MathFidelity::HiFi3 : tt::tt_metal::MathFidelity::HiFi4;
 
     KernelDescriptor compute_desc_1;
     compute_desc_1.kernel_source = "ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp";
@@ -165,6 +168,7 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
     compute_desc_1.core_ranges = core_group_1;
     compute_desc_1.compile_time_args = compute_args_group_1;
     compute_desc_1.config = ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
         .fp32_dest_acc_en = fp32_dest_acc_en,
         .dst_full_sync_en = false,
     };
@@ -178,6 +182,7 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
         cd2.core_ranges = core_group_2;
         cd2.compile_time_args = compute_args_group_2;
         cd2.config = ComputeConfigDescriptor{
+            .math_fidelity = math_fidelity,
             .fp32_dest_acc_en = fp32_dest_acc_en,
             .dst_full_sync_en = false,
         };

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_nc_program_factory.cpp
@@ -155,12 +155,17 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
     ////////////////////////////////////////////////////////////////////////////
     const std::vector<uint32_t> compute_args_group_1{num_cols_per_core_group_1};
 
+    // Accumulate the running product in full fp32 precision when the tensor is fp32; otherwise the
+    // dst register would round each partial product to bf16 and defeat the purpose of fp32 input.
+    const bool fp32_dest_acc_en = output.dtype() == DataType::FLOAT32;
+
     KernelDescriptor compute_desc_1;
     compute_desc_1.kernel_source = "ttnn/cpp/ttnn/operations/reduction/prod/device/kernels/compute/prod_nc.cpp";
     compute_desc_1.source_type = KernelDescriptor::SourceType::FILE_PATH;
     compute_desc_1.core_ranges = core_group_1;
     compute_desc_1.compile_time_args = compute_args_group_1;
     compute_desc_1.config = ComputeConfigDescriptor{
+        .fp32_dest_acc_en = fp32_dest_acc_en,
         .dst_full_sync_en = false,
     };
 
@@ -173,6 +178,7 @@ tt::tt_metal::ProgramDescriptor ProdNcDeviceOperation::ProdNcProgramFactory::cre
         cd2.core_ranges = core_group_2;
         cd2.compile_time_args = compute_args_group_2;
         cd2.config = ComputeConfigDescriptor{
+            .fp32_dest_acc_en = fp32_dest_acc_en,
             .dst_full_sync_en = false,
         };
         compute_desc_2 = std::move(cd2);

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -10,6 +10,10 @@ namespace tt::operations::primary {
 
 tt::tt_metal::Tensor prod_all(const tt::tt_metal::Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config) {
     tt::tt_metal::Tensor result = ttnn::prim::prod_all(input, output_mem_config);
+    if (result.dtype() == tt::tt_metal::DataType::FLOAT32) {
+        return ttnn::prod_result_computation_WH_B0<float>(
+            result, result.dtype(), result.layout(), result.device(), output_mem_config);
+    }
     return ttnn::prod_result_computation_WH_B0<bfloat16>(
         result, result.dtype(), result.layout(), result.device(), output_mem_config);
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -5,7 +5,6 @@
 #include "prod_all_device_operation.hpp"
 
 #include <ttnn/operations/functions.hpp>
-#include "ttnn/tensor/tensor_ops.hpp"
 
 namespace tt::operations::primary {
 
@@ -18,21 +17,9 @@ tt::tt_metal::Tensor prod_all(const tt::tt_metal::Tensor& input, const tt::tt_me
         case tt::tt_metal::DataType::BFLOAT16:
             return ttnn::prod_result_computation_WH_B0<bfloat16>(
                 result, result.dtype(), result.layout(), result.device(), output_mem_config);
-        case tt::tt_metal::DataType::BFLOAT8_B:
-        case tt::tt_metal::DataType::BFLOAT4_B: {
-            // Block-float tiles share one exponent per 16 elements, so a single value cannot be read
-            // as a C++ scalar via host_buffer::get_as. Unpack to FLOAT32 on host first (the same path
-            // ttnn.to_torch() uses) and reuse the float computation.
-            auto* device = result.device();
-            const tt::tt_metal::Tensor result_fp32 =
-                tt::tt_metal::to_dtype(result.cpu(), tt::tt_metal::DataType::FLOAT32);
-            return ttnn::prod_result_computation_WH_B0<float>(
-                result_fp32, tt::tt_metal::DataType::FLOAT32, result_fp32.layout(), device, output_mem_config);
-        }
         default:
             TT_THROW(
-                "Error - unsupported data type for prod, expected BFLOAT16, FLOAT32, BFLOAT8_B or BFLOAT4_B but got "
-                "{}.",
+                "Error - unexpected prod_all result data type, expected BFLOAT16 or FLOAT32 but got {}.",
                 result.dtype());
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -5,6 +5,7 @@
 #include "prod_all_device_operation.hpp"
 
 #include <ttnn/operations/functions.hpp>
+#include "ttnn/tensor/tensor_ops.hpp"
 
 namespace tt::operations::primary {
 
@@ -17,9 +18,22 @@ tt::tt_metal::Tensor prod_all(const tt::tt_metal::Tensor& input, const tt::tt_me
         case tt::tt_metal::DataType::BFLOAT16:
             return ttnn::prod_result_computation_WH_B0<bfloat16>(
                 result, result.dtype(), result.layout(), result.device(), output_mem_config);
+        case tt::tt_metal::DataType::BFLOAT8_B:
+        case tt::tt_metal::DataType::BFLOAT4_B: {
+            // Block-float tiles share one exponent per 16 elements, so a single value cannot be read
+            // as a C++ scalar via host_buffer::get_as. Unpack to FLOAT32 on host first (the same path
+            // ttnn.to_torch() uses) and reuse the float computation.
+            auto* device = result.device();
+            const tt::tt_metal::Tensor result_fp32 =
+                tt::tt_metal::to_dtype(result.cpu(), tt::tt_metal::DataType::FLOAT32);
+            return ttnn::prod_result_computation_WH_B0<float>(
+                result_fp32, tt::tt_metal::DataType::FLOAT32, result_fp32.layout(), device, output_mem_config);
+        }
         default:
             TT_THROW(
-                "Error - unsupported data type for prod, expected BFLOAT16 or FLOAT32 but got {}.", result.dtype());
+                "Error - unsupported data type for prod, expected BFLOAT16, FLOAT32, BFLOAT8_B or BFLOAT4_B but got "
+                "{}.",
+                result.dtype());
     }
 }
 

--- a/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/device/prod_op_all.cpp
@@ -10,12 +10,17 @@ namespace tt::operations::primary {
 
 tt::tt_metal::Tensor prod_all(const tt::tt_metal::Tensor& input, const tt::tt_metal::MemoryConfig& output_mem_config) {
     tt::tt_metal::Tensor result = ttnn::prim::prod_all(input, output_mem_config);
-    if (result.dtype() == tt::tt_metal::DataType::FLOAT32) {
-        return ttnn::prod_result_computation_WH_B0<float>(
-            result, result.dtype(), result.layout(), result.device(), output_mem_config);
+    switch (result.dtype()) {
+        case tt::tt_metal::DataType::FLOAT32:
+            return ttnn::prod_result_computation_WH_B0<float>(
+                result, result.dtype(), result.layout(), result.device(), output_mem_config);
+        case tt::tt_metal::DataType::BFLOAT16:
+            return ttnn::prod_result_computation_WH_B0<bfloat16>(
+                result, result.dtype(), result.layout(), result.device(), output_mem_config);
+        default:
+            TT_THROW(
+                "Error - unsupported data type for prod, expected BFLOAT16 or FLOAT32 but got {}.", result.dtype());
     }
-    return ttnn::prod_result_computation_WH_B0<bfloat16>(
-        result, result.dtype(), result.layout(), result.device(), output_mem_config);
 }
 
 }  // namespace tt::operations::primary

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -110,12 +110,13 @@ Tensor prod_impl(
         return result;
     }
 
-    // Block-float can't seed the reduction's identity tile and loses precision under permute, so
-    // compute the dim reduction in FLOAT32 (the public prod re-quantizes the result to the input dtype).
-    const Tensor dim_input = (input_a_padded.dtype() == tt::tt_metal::DataType::BFLOAT8_B ||
-                              input_a_padded.dtype() == tt::tt_metal::DataType::BFLOAT4_B)
-                                 ? ttnn::typecast(input_a_padded, tt::tt_metal::DataType::FLOAT32)
-                                 : input_a_padded;
+    // bfloat4_b is not supported on the dim path: the reduction dim may be repositioned with
+    // ttnn::permute, which re-quantizes bfloat4_b. Permute has a bf16 fallback for bfloat8_b but
+    // not bfloat4_b, see issue #48813. The full-product path above still supports bfloat4_b.
+    TT_FATAL(
+        input_a_padded.dtype() != tt::tt_metal::DataType::BFLOAT4_B,
+        "ttnn.prod with a dim argument does not support bfloat4_b");
+    const Tensor& dim_input = input_a_padded;
 
     // For higher dimension Tensors, we need to squeeze to 4D to perform the reduction
     if (old_rank > 4) {

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -110,10 +110,8 @@ Tensor prod_impl(
         return result;
     }
 
-    // Block-float (bfp8_b/bfp4_b) tiles can't seed the per-dim reduction's identity (1.0) tile, and
-    // permuting them reshuffles elements across shared-exponent groups (lossy, esp. for bfp4_b). So
-    // upcast to FLOAT32 up front — before any permute — and return FLOAT32, consistent with the
-    // full-product (prod_all) path.
+    // Block-float can't seed the reduction's identity tile and loses precision under permute, so
+    // compute the dim reduction in FLOAT32 (the public prod re-quantizes the result to the input dtype).
     const Tensor dim_input = (input_a_padded.dtype() == tt::tt_metal::DataType::BFLOAT8_B ||
                               input_a_padded.dtype() == tt::tt_metal::DataType::BFLOAT4_B)
                                  ? ttnn::typecast(input_a_padded, tt::tt_metal::DataType::FLOAT32)
@@ -230,7 +228,13 @@ namespace ttnn {
 
 Tensor prod(
     const Tensor& input, std::optional<int64_t> dim, bool keepdim, const std::optional<MemoryConfig>& memory_config) {
-    return operations::reduction::prod_impl(input, dim, keepdim, memory_config);
+    Tensor result = operations::reduction::prod_impl(input, dim, keepdim, memory_config);
+    // Block-float is computed in FLOAT32; return the result in the input dtype to match it
+    if ((input.dtype() == tt::tt_metal::DataType::BFLOAT8_B || input.dtype() == tt::tt_metal::DataType::BFLOAT4_B) &&
+        result.dtype() != input.dtype()) {
+        result = ttnn::typecast(result, input.dtype());
+    }
+    return result;
 }
 
 Tensor prod(

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod.cpp
@@ -6,6 +6,7 @@
 #include "device/prod_op_all.hpp"
 
 #include "ttnn/operations/core/core.hpp"
+#include "ttnn/operations/copy/typecast/typecast.hpp"
 #include "ttnn/operations/creation/creation.hpp"
 #include "ttnn/operations/data_movement/clone/clone.hpp"
 #include "ttnn/operations/data_movement/common/common.hpp"
@@ -109,6 +110,15 @@ Tensor prod_impl(
         return result;
     }
 
+    // Block-float (bfp8_b/bfp4_b) tiles can't seed the per-dim reduction's identity (1.0) tile, and
+    // permuting them reshuffles elements across shared-exponent groups (lossy, esp. for bfp4_b). So
+    // upcast to FLOAT32 up front — before any permute — and return FLOAT32, consistent with the
+    // full-product (prod_all) path.
+    const Tensor dim_input = (input_a_padded.dtype() == tt::tt_metal::DataType::BFLOAT8_B ||
+                              input_a_padded.dtype() == tt::tt_metal::DataType::BFLOAT4_B)
+                                 ? ttnn::typecast(input_a_padded, tt::tt_metal::DataType::FLOAT32)
+                                 : input_a_padded;
+
     // For higher dimension Tensors, we need to squeeze to 4D to perform the reduction
     if (old_rank > 4) {
         // Bring dim into range [0, old_rank - 1]
@@ -129,7 +139,7 @@ Tensor prod_impl(
 
         // Tensor with target reduction dim at third last position
         ttnn::Tensor permuted =
-            permute_required ? ttnn::permute(input_a_padded, post_permute_dims, output_mem_config) : input_a_padded;
+            permute_required ? ttnn::permute(dim_input, post_permute_dims, output_mem_config) : dim_input;
 
         // Now squeeze to 4D and do the 4D prod.
         // Dim0 grows to include the rest of the dimensions, and our "third last" dim moves into dim1, which is our 4D
@@ -156,7 +166,7 @@ Tensor prod_impl(
     }
     // 4D or lower dimension Tensors
     // For lower dimension Tensors, we need to unsqueeze to 4D
-    auto input_tensor_4d = ttnn::unsqueeze_to_4D(input_a_padded);
+    auto input_tensor_4d = ttnn::unsqueeze_to_4D(dim_input);
 
     // Update the dim because we unsqueezed input to 4d
     // If dim is negative, counting from the back is not impacted by the unsqueeze

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.cpp
@@ -57,7 +57,7 @@ void bind_reduction_prod_operation(nb::module_& mod) {
                       - layout
                     * - BFLOAT16, FLOAT32
                       - TILE, ROW_MAJOR
-                    * - BFLOAT8_B, BFLOAT4_B (full product only)
+                    * - BFLOAT8_B, BFLOAT4_B
                       - TILE
 
                 The :attr:`output_tensor` will be in the following data type and layout:
@@ -76,7 +76,7 @@ void bind_reduction_prod_operation(nb::module_& mod) {
             Limitations:
                 - All input tensors must be on-device.
                 - When :attr:`dim` is not specified (i.e. full product), keepdim=True is not supported  (as this operation results in a scalar).
-                - BFLOAT8_B and BFLOAT4_B are supported only for the full product (when :attr:`dim` is not specified), must be TILE layout, and the result is returned as FLOAT32. Reductions along a :attr:`dim` require BFLOAT16 or FLOAT32.
+                - BFLOAT8_B and BFLOAT4_B inputs must be TILE layout and are upcast to FLOAT32 internally, so the result is returned as FLOAT32. This applies to the full product and to dim-based reductions via ``ttnn.prod(input, dim=...)``; the explicit :attr:`output_tensor` (``dims=...``) overload requires BFLOAT16 or FLOAT32.
                 - Sharding is not supported for this operation
         )doc",
         "prod",

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.cpp
@@ -78,7 +78,8 @@ void bind_reduction_prod_operation(nb::module_& mod) {
             Limitations:
                 - All input tensors must be on-device.
                 - When :attr:`dim` is not specified (i.e. full product), keepdim=True is not supported  (as this operation results in a scalar).
-                - BFLOAT8_B and BFLOAT4_B inputs must be TILE layout. They are computed in FLOAT32 internally and the result is returned in the input dtype (re-quantized to block-float on output, like ``ttnn.sum``). This applies to the full product and to dim-based reductions via ``ttnn.prod(input, dim=...)``; the explicit :attr:`output_tensor` (``dims=...``) overload requires BFLOAT16 or FLOAT32.
+                - BFLOAT8_B and BFLOAT4_B inputs must be TILE layout.
+                - Dim-based reductions do not support BFLOAT4_B.
                 - Sharding is not supported for this operation
         )doc",
         "prod",

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.cpp
@@ -69,6 +69,8 @@ void bind_reduction_prod_operation(nb::module_& mod) {
                       - layout
                     * - BFLOAT16, FLOAT32
                       - TILE
+                    * - BFLOAT8_B, BFLOAT4_B
+                      - TILE
 
             Memory Support:
                 - Interleaved: DRAM and L1
@@ -76,7 +78,7 @@ void bind_reduction_prod_operation(nb::module_& mod) {
             Limitations:
                 - All input tensors must be on-device.
                 - When :attr:`dim` is not specified (i.e. full product), keepdim=True is not supported  (as this operation results in a scalar).
-                - BFLOAT8_B and BFLOAT4_B inputs must be TILE layout and are upcast to FLOAT32 internally, so the result is returned as FLOAT32. This applies to the full product and to dim-based reductions via ``ttnn.prod(input, dim=...)``; the explicit :attr:`output_tensor` (``dims=...``) overload requires BFLOAT16 or FLOAT32.
+                - BFLOAT8_B and BFLOAT4_B inputs must be TILE layout. They are computed in FLOAT32 internally and the result is returned in the input dtype (re-quantized to block-float on output, like ``ttnn.sum``). This applies to the full product and to dim-based reductions via ``ttnn.prod(input, dim=...)``; the explicit :attr:`output_tensor` (``dims=...``) overload requires BFLOAT16 or FLOAT32.
                 - Sharding is not supported for this operation
         )doc",
         "prod",

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.cpp
@@ -57,6 +57,8 @@ void bind_reduction_prod_operation(nb::module_& mod) {
                       - layout
                     * - BFLOAT16, FLOAT32
                       - TILE, ROW_MAJOR
+                    * - BFLOAT8_B, BFLOAT4_B (full product only)
+                      - TILE
 
                 The :attr:`output_tensor` will be in the following data type and layout:
 
@@ -74,6 +76,7 @@ void bind_reduction_prod_operation(nb::module_& mod) {
             Limitations:
                 - All input tensors must be on-device.
                 - When :attr:`dim` is not specified (i.e. full product), keepdim=True is not supported  (as this operation results in a scalar).
+                - BFLOAT8_B and BFLOAT4_B are supported only for the full product (when :attr:`dim` is not specified), must be TILE layout, and the result is returned as FLOAT32. Reductions along a :attr:`dim` require BFLOAT16 or FLOAT32.
                 - Sharding is not supported for this operation
         )doc",
         "prod",

--- a/ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/prod/prod_nanobind.cpp
@@ -55,7 +55,7 @@ void bind_reduction_prod_operation(nb::module_& mod) {
 
                     * - dtype
                       - layout
-                    * - BFLOAT16
+                    * - BFLOAT16, FLOAT32
                       - TILE, ROW_MAJOR
 
                 The :attr:`output_tensor` will be in the following data type and layout:
@@ -65,7 +65,7 @@ void bind_reduction_prod_operation(nb::module_& mod) {
 
                     * - dtype
                       - layout
-                    * - BFLOAT16
+                    * - BFLOAT16, FLOAT32
                       - TILE
 
             Memory Support:
@@ -73,7 +73,7 @@ void bind_reduction_prod_operation(nb::module_& mod) {
 
             Limitations:
                 - All input tensors must be on-device.
-                - When :attr:`dim` is not specified (i.e. full product), the :attr:`input_tensor` must be bfloat16, and keepdim=True is not supported  (as this operation results in a scalar).
+                - When :attr:`dim` is not specified (i.e. full product), keepdim=True is not supported  (as this operation results in a scalar).
                 - Sharding is not supported for this operation
         )doc",
         "prod",


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->
[Feature] Extend ttnn.prod to support float32)

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

ttnn.prod (full reduction over the whole tensor) only accepted bfloat16; float32 dtype hit a TT_FATAL in the device op:

```
Error - unsupported data type for prod, expected BFLOAT16 but got DataType::FLOAT32.
```

This PR adds float32 support to the prod_all path

`prod_all_device_operation.cpp` — relaxed the dtype TT_FATAL to accept FLOAT32 in addition to BFLOAT16 (and updated the message).
`prod_op_all.cpp` — the host-side final tile reduction prod_result_computation_WH_B0<T> was hardcoded to <bfloat16>; it now dispatches to <float> when the result is fp32, so the device tile is read back at full precision.
`prod_all_program_factory.cpp` — set fp32_dest_acc_en = (input.dtype() == FLOAT32) so the dest register isn't truncated to bf16 between the per-tile multiplications.
The CB data format and output tensor spec already derive from input.dtype(), so no further plumbing was needed.

Test coverage: test_prod_all.py::test_prod is now parametrized over {bfloat16, float32}.

Closes #24297



### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->
This PR only covers ttnn.prod(x) (no dim) — the full-tensor reduction, which is exactly what the issue reports. Calling ttnn.prod(x, dim=...) takes a different code path (prod_nc) that still only accepts bfloat16. I left it out to keep this change small, but I can add fp32 there too if you'd like it in the same PR.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ign/prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ign/prod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ign/prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ign/prod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=ign/prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:ign/prod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ign/prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ign/prod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ign/prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ign/prod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ign/prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ign/prod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ign/prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ign/prod)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ign/prod)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ign/prod)