### PR TITLE
[Cleanup] Finalize transformer migration to Device 2.0

### DIFF
--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/dataflow_common.hpp
@@ -1571,12 +1571,12 @@ void write_block(
     CircularBuffer cb(cb_out);
     cb.wait_front(out_chunk_tiles);
 
-    uint32_t l1_read_addr = cb.get_read_ptr();
+    uint32_t tile_offset = 0;
     for (uint32_t row = 0; row < rows; ++row) {
         for (uint32_t col = 0; col < cols; ++col) {
-            noc.async_write(CoreLocalMem<uint32_t>(l1_read_addr), out_writer, tile_bytes, {}, {.page_id = tile_id});
+            noc.async_write(cb, out_writer, tile_bytes, {.offset_bytes = tile_offset}, {.page_id = tile_id});
             ++tile_id;
-            l1_read_addr += tile_bytes;
+            tile_offset += tile_bytes;
 
             if (++barrier_count == barrier_threshold) {
                 noc.async_writes_flushed();
@@ -1619,17 +1619,12 @@ void write_block_row_grouped(
         const uint32_t rows_this_group = (rg < num_full_groups) ? sbh : remainder_rows;
         const uint32_t tiles_this_group = rows_this_group * cols;
         cb.wait_front(tiles_this_group);
-        uint32_t l1_read_addr = cb.get_read_ptr();
         for (uint32_t r = 0; r < rows_this_group; ++r) {
             const uint32_t row = rg * sbh + r;
             if (row < write_rows) {
                 for (uint32_t col = 0; col < cols; ++col) {
-                    noc.async_write(
-                        CoreLocalMem<uint32_t>(l1_read_addr + col * tile_bytes),
-                        out_writer,
-                        tile_bytes,
-                        {},
-                        {.page_id = tile_id});
+                    uint32_t tile_offset = (r * cols + col) * tile_bytes;
+                    noc.async_write(cb, out_writer, tile_bytes, {.offset_bytes = tile_offset}, {.page_id = tile_id});
                     ++tile_id;
                     if (++barrier_count == barrier_threshold) {
                         noc.async_writes_flushed<NocOptions::TXN_ID>({.trid = default_trid});
@@ -1637,7 +1632,6 @@ void write_block_row_grouped(
                     }
                 }
             }
-            l1_read_addr += cols * tile_bytes;
         }
         // Flush THIS drain's writes (default trid) before pop so compute can safely reuse the L1 slot.
         noc.async_writes_flushed<NocOptions::TXN_ID>({.trid = default_trid});

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
@@ -5,6 +5,7 @@
 #include "api/dataflow/dataflow_api.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"
+#include "api/dataflow/noc_semaphore.h"
 #include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
 #include "dataflow_common.hpp"
@@ -142,7 +143,8 @@ void kernel_main() {
     const uint32_t fabric_mux_flow_control_address = get_arg_val<uint32_t>(argidx++);
     const uint32_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(argidx++);
     const uint8_t fabric_mux_channel_id = static_cast<uint8_t>(get_arg_val<uint32_t>(argidx++));
-    const uint32_t termination_sync_sem_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
+    const uint32_t termination_sync_sem_id = get_arg_val<uint32_t>(argidx++);
+    const uint32_t termination_sync_sem_addr = get_semaphore(termination_sync_sem_id);
     const uint32_t local_fabric_mux_status_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
     const uint32_t local_flow_control_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
     const uint32_t local_teardown_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
@@ -219,6 +221,8 @@ void kernel_main() {
             pkt_unicast_hdr, 1, nullptr, ag_page_size);
 
         // Pre-configure atomic inc header for signaling the injector core on the next device
+        // safe_get_noc_addr() cannot be migrated to Device 2.0 because it creates a cross-chip semaphore address,
+        // while the current Device 2.0 Semaphore class only supports same-chip operations.
         const uint64_t injector_out_ready_sem_noc_addr =
             safe_get_noc_addr(injector_noc_x, injector_noc_y, out_ready_sem_addr, 0);
         fabric_unicast_noc_unicast_atomic_inc_set_state<
@@ -484,13 +488,16 @@ void kernel_main() {
         noc.async_atomic_barrier();
         tt::tt_fabric::fabric_client_disconnect(mux_conn);
         if (is_termination_master) {
-            auto* termination_sync_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(termination_sync_sem_addr);
-            noc_semaphore_wait(termination_sync_ptr, num_mux_clients - 1);
+            Semaphore<> termination_sync_sem(termination_sync_sem_id);
+            termination_sync_sem.wait(num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
-            uint64_t dest_addr =
-                get_noc_addr(termination_master_noc_x, termination_master_noc_y, termination_sync_sem_addr);
-            noc_semaphore_inc(dest_addr, 1);
+            // noc_semaphore_inc cannot be migrated to Device 2.0 because we need
+            // to increment a semaphore at a specific address on the remote core, not the same
+            // semaphore ID.
+            const uint64_t dest_addr = get_noc_addr(
+                termination_master_noc_x, termination_master_noc_y, termination_sync_sem_addr, noc.get_noc_id());
+            noc_semaphore_inc(dest_addr, 1, noc.get_noc_id());
             noc.async_atomic_barrier();
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
@@ -144,7 +144,6 @@ void kernel_main() {
     const uint32_t fabric_mux_buffer_index_address = get_arg_val<uint32_t>(argidx++);
     const uint8_t fabric_mux_channel_id = static_cast<uint8_t>(get_arg_val<uint32_t>(argidx++));
     const uint32_t termination_sync_sem_id = get_arg_val<uint32_t>(argidx++);
-    const uint32_t termination_sync_sem_addr = get_semaphore(termination_sync_sem_id);
     const uint32_t local_fabric_mux_status_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
     const uint32_t local_flow_control_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
     const uint32_t local_teardown_addr = get_semaphore(get_arg_val<uint32_t>(argidx++));
@@ -487,17 +486,12 @@ void kernel_main() {
     if (mux_connection_valid) {
         noc.async_atomic_barrier();
         tt::tt_fabric::fabric_client_disconnect(mux_conn);
+        Semaphore<> termination_sync_sem(termination_sync_sem_id);
         if (is_termination_master) {
-            Semaphore<> termination_sync_sem(termination_sync_sem_id);
             termination_sync_sem.wait(num_mux_clients - 1);
             tt::tt_fabric::fabric_endpoint_terminate(fabric_mux_x, fabric_mux_y, fabric_mux_termination_signal_address);
         } else {
-            // noc_semaphore_inc cannot be migrated to Device 2.0 because we need
-            // to increment a semaphore at a specific address on the remote core, not the same
-            // semaphore ID.
-            const uint64_t dest_addr = get_noc_addr(
-                termination_master_noc_x, termination_master_noc_y, termination_sync_sem_addr, noc.get_noc_id());
-            noc_semaphore_inc(dest_addr, 1, noc.get_noc_id());
+            termination_sync_sem.up(noc, termination_master_noc_x, termination_master_noc_y, 1);
             noc.async_atomic_barrier();
         }
     }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/reader_interleaved.cpp
@@ -466,7 +466,7 @@ void kernel_main() {
                 // Forward K chunk to next core(s): initiate async write (NOC write channel)
                 // For mcast: send linked data + companion semaphore back-to-back.
                 // The companion must be issued immediately after the linked write —
-                // any noc_async_read_barrier() between them deadlocks (the read barrier
+                // any NOC read barrier between them deadlocks (the read barrier
                 // blocks while a linked write awaits its companion).
                 if (should_forward) {
                     Semaphore<> sender_sem(sender_semaphore_id);
@@ -572,8 +572,8 @@ void kernel_main() {
                 }
 
                 // Q subblock push: K is fully forwarded, now push Q one subblock at
-                // a time. Compute waits for K first (cb_wait_front(cb_k_in, K*N)),
-                // then waits for Q subblocks incrementally (accumulating cb_wait_front).
+                // a time. Compute waits for K first (waiting for K*N tiles in cb_k_in),
+                // then waits for Q subblocks incrementally (accumulating waits on cb_q_in).
                 // Each push unblocks the next QK subblock computation.
                 // Placed after K forward complete so no outstanding NOC writes remain
                 // (noc_async_read_barrier inside read_q_subblock deadlocks on BH

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -743,7 +743,7 @@ void kernel_main() {
                 // Skip the intra-ring prefetch when this Q is on the normalize-only path
                 // (balanced_skip_q + is_last_ring_iter): normalize produces cb_out incrementally
                 // and blocks on cb_out space; cb_out can't drain until the writer reaches
-                // write_out below. A cb_reserve_back(cb_prev_out) here would block until
+                // write_out below. Reserving space in cb_prev_out here would block until
                 // normalize finishes, creating a cycle with cb_out. Deferred prefetch below
                 // runs after write_out to break the cycle.
                 const bool defer_prefetch = balanced_skip_q && is_last_ring_iter;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/reader_decode_all.cpp
@@ -77,7 +77,7 @@ void kernel_main() {
     constexpr uint32_t cb_attention_sink = tt::CBIndex::c_4;
     // #44366: cur_pos is consumed by both the writer (c_8) and compute (c_15).
     // Using one shared CB races — whichever consumer pops first drains the
-    // count and the other hangs in cb_wait_front. Each consumer gets its own CB.
+    // count and the other hangs waiting for tiles. Each consumer gets its own CB.
     constexpr uint32_t cb_writer_cur_pos = tt::CBIndex::c_8;
     constexpr uint32_t cb_id_page_table = tt::CBIndex::c_9;
     constexpr uint32_t cb_q_rm = tt::CBIndex::c_10;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/sdpa_decode_program_factory.cpp
@@ -550,7 +550,7 @@ ProgramDescriptor SdpaDecodeDeviceOperation::create_descriptor(
     if (use_cur_pos_tensor) {
         // #44366: cur_pos is consumed by both the writer and compute kernels.
         // A single shared CB races: whichever consumer pops first drains the
-        // count and the other hangs in cb_wait_front. Use one CB per consumer
+        // count and the other hangs waiting for tiles. Use one CB per consumer
         // — c_8 for the writer, c_15 for compute — each with capacity 1. The
         // reader fills c_8 (from DRAM, or via the aliased sharded buffer)
         // then does an L1->L1 copy into c_15.


### PR DESCRIPTION
### PR Category
  Cleanup

### Summary

  Migrates transformer SDPA operations to the Device 2.0 API

  This PR implements a phased migration approach:
  - dataflow_common.hpp removed cb.get_read_ptr() by passing CB object directly to noc.async_write 
  - exp_ring_joint_writer.cpp is now using Semaphore object
  - rephrased comments in sdpa_decode kernel files

  Notes for Reviewers

  Legacy free fn safe_get_noc_addr() retained in exp_ring_joint_writer.cpp for implementing cross-chip semaphore.
  Device 2.0 Semaphore only supports same-chip operations.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/transformer_2_0_final)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/transformer_2_0_final)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/transformer_2_0_final)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/transformer_2_0_final)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/transformer_2_0_final)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/transformer_2_0_final)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/transformer_2_0_final)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/transformer_2_0_final)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/transformer_2_0_final)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/transformer_2_0_final)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/transformer_2_0_final)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/transformer_2_0_final)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/transformer_2_0_final)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/transformer_2_0_final)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/transformer_2_0_final)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/transformer_2_0_final)