### PR TITLE
[Bugfix] Fixing PCC drop in Deepseek v3 prefill MoE

### DIFF
--- a/models/demos/deepseek_v3_d_p/tests/model_variants.py
+++ b/models/demos/deepseek_v3_d_p/tests/model_variants.py
@@ -88,7 +88,7 @@ DSV3 = TestVariant(
     mla_ref_cache_env="DEEPSEEK_V3_MLA_REF_CACHE",
     ttnn_cache_env="TT_DS_PREFILL_TTNN_CACHE",
     mla_pcc_threshold=0.996,
-    moe_pcc_threshold=0.94,
+    moe_pcc_threshold=0.982,
     prefill_trace_default="/mnt/models/deepseek-prefill-cache/golden/longbook_qa_eng_prefill_56320_nopad",
 )
 

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -255,9 +255,9 @@ def test_forward_pass(
         logits_pcc_threshold = 0.997
         scores_pcc_threshold = 0.99
     else:
-        recall_threshold = 0.7
+        recall_threshold = 0.93
         logits_pcc_threshold = 0.997
-        scores_pcc_threshold = 0.7
+        scores_pcc_threshold = 0.92
 
     seq_len_per_device = reference_logits.shape[0] // mesh_device.shape[0]
     sp_composer = get_sp_mesh_composer(mesh_device)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -29,6 +29,11 @@ from models.demos.deepseek_v3_d_p.tt.moe.validation_helpers import (
 )
 from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import log_validation_results
 from models.demos.deepseek_v3_d_p.utils.test_utils import adjust_shapes_for_testing, get_input_mem_config
+from models.demos.deepseek_v3_d_p.utils.transformer_helpers import GOLDEN_LONGBOOK_TRACE, load_trace_gate_input
+
+# First MoE layer in DeepSeek-V3 (metadata moe_layer_offset == 3); the golden
+# trace stores its gate input as post_attn_norm_layer_3.
+_MOE_LAYER_IDX = 3
 
 _DEFAULT_HF_REPO = "deepseek-ai/DeepSeek-V3"
 _LOCAL_FALLBACKS = (
@@ -66,29 +71,22 @@ def _try_load_real_gate_weights(n_routed_experts: int, dim: int) -> dict | None:
 
 
 def _try_load_real_gate_input(max_seq_len: int, dim: int) -> torch.Tensor | None:
-    """Try to load a saved gate input tensor; return None on failure."""
-    gate_input_cache = os.environ.get("DEEPSEEK_V3_GATE_INPUT_CACHE")
-    moe_dir = Path(gate_input_cache) if gate_input_cache else Path(__file__).parent.parent.parent / "tt" / "moe"
+    """Try to load the gate input from the golden GPU prefill trace; return None on failure.
 
-    for name in ("gate_input_layer3_seq100000.pt", "gate_input_layer3.pt"):
-        path = moe_dir / name
-        if path.exists():
-            saved = torch.load(path, weights_only=True)
-            real_input = saved["gate_input"].squeeze(0).to(torch.bfloat16)
-            if real_input.shape[0] >= max_seq_len:
-                result = real_input[:max_seq_len, :dim]
-            else:
-                repeats = (max_seq_len + real_input.shape[0] - 1) // real_input.shape[0]
-                result = real_input.repeat(repeats, 1)[:max_seq_len, :dim]
-            logger.info(f"Loaded real gate input from {path} (raw {real_input.shape}, sliced to {result.shape})")
-            return result
-
-    return None
+    Mirrors test_ttnn_moe / test_prefill_transformer: the gate input is the
+    post-attention RMSNorm output (``post_attn_norm_layer_{i}``) of the first MoE
+    layer in the bit_sculpt golden trace. ``DEEPSEEK_V3_GATE_INPUT_CACHE`` may
+    override the trace directory. Returns ``None`` when the trace is unavailable
+    so the caller can fall back to synthetic input.
+    """
+    trace_dir_env = os.environ.get("DEEPSEEK_V3_GATE_INPUT_CACHE")
+    trace_dir = Path(trace_dir_env) if trace_dir_env else GOLDEN_LONGBOOK_TRACE
+    return load_trace_gate_input(trace_dir, layer_idx=_MOE_LAYER_IDX, max_seq_len=max_seq_len, dim=dim)
 
 
 @pytest.mark.parametrize(
     "gate_fallback_mode",
-    [GateComputeMode.HOST_ALL, GateComputeMode.DEVICE, GateComputeMode.DEVICE_FP32],
+    [GateComputeMode.HOST_ALL, GateComputeMode.DEVICE_FP32],
 )
 @pytest.mark.parametrize(
     "mesh_device, device_params, num_links, topology",
@@ -255,9 +253,9 @@ def test_forward_pass(
         logits_pcc_threshold = 0.997
         scores_pcc_threshold = 0.99
     else:
-        recall_threshold = 0.93
+        recall_threshold = 0.95
         logits_pcc_threshold = 0.997
-        scores_pcc_threshold = 0.92
+        scores_pcc_threshold = 0.985
 
     seq_len_per_device = reference_logits.shape[0] // mesh_device.shape[0]
     sp_composer = get_sp_mesh_composer(mesh_device)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -255,7 +255,7 @@ def test_forward_pass(
     else:
         recall_threshold = 0.95
         logits_pcc_threshold = 0.997
-        scores_pcc_threshold = 0.985
+        scores_pcc_threshold = 0.97
 
     seq_len_per_device = reference_logits.shape[0] // mesh_device.shape[0]
     sp_composer = get_sp_mesh_composer(mesh_device)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_moe_gate_prefill2d.py
@@ -255,7 +255,7 @@ def test_forward_pass(
     else:
         recall_threshold = 0.95
         logits_pcc_threshold = 0.997
-        scores_pcc_threshold = 0.97
+        scores_pcc_threshold = 0.93
 
     seq_len_per_device = reference_logits.shape[0] // mesh_device.shape[0]
     sp_composer = get_sp_mesh_composer(mesh_device)

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -55,7 +55,12 @@ from models.demos.deepseek_v3_d_p.tt.moe.visualization_helpers import (
     visualize_expert_dispatch_table,
 )
 from models.demos.deepseek_v3_d_p.utils.fast_cache_checker import init_checker
+from models.demos.deepseek_v3_d_p.utils.transformer_helpers import GOLDEN_LONGBOOK_TRACE, load_trace_gate_input
 from tests.ttnn.utils_for_testing import comp_pcc
+
+# First MoE layer in DeepSeek-V3 (metadata moe_layer_offset == 3); the golden
+# trace stores its post-attention RMSNorm output, i.e. the MoE block input.
+_MOE_LAYER_IDX = 3
 
 
 # dispatch_buffer_capacity_factor below is ceil(N/2) of the most conservative
@@ -228,8 +233,21 @@ def run_model(
     # ========================================
     profiler.start("input_creation")
 
+    # Prefer a realistic MoE-block input (post-attention RMSNorm of the first MoE
+    # layer) from the golden trace; fall back to synthetic noise when unavailable.
+    # Restricted to PCC runs on the DeepSeek hidden dim so perf baselines and the
+    # Kimi variant keep their established synthetic input.
     # currently cannot use ttnn.empty on x; because indices become ND beyond max dispatch token limit.
-    x = torch.randn(dispatch_group_size, seq_len_per_chip, emb_dim, dtype=torch.bfloat16)
+    x = None
+    if run_pcc_check and emb_dim == DeepSeekV3Config.EMB_SIZE:
+        total_tokens = dispatch_group_size * seq_len_per_chip
+        trace_input = load_trace_gate_input(
+            GOLDEN_LONGBOOK_TRACE, layer_idx=_MOE_LAYER_IDX, max_seq_len=total_tokens, dim=emb_dim
+        )
+        if trace_input is not None:
+            x = trace_input.reshape(dispatch_group_size, seq_len_per_chip, emb_dim).to(torch.bfloat16)
+    if x is None:
+        x = torch.randn(dispatch_group_size, seq_len_per_chip, emb_dim, dtype=torch.bfloat16)
     profiler.end("input_creation")
 
     # TtMoe.forward deallocates its input (tt_moe.py:522), so tt_x must be re-uploaded each iter.

--- a/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
+++ b/models/demos/deepseek_v3_d_p/tests/pcc/test_ttnn_moe.py
@@ -367,7 +367,7 @@ def run_model(
     if gate_fallback_mode == GateComputeMode.HOST_ALL:
         target_recall = 0.99
     else:
-        target_recall = 0.90
+        target_recall = 0.977
 
     recall_result = validate_composed(
         tt_indices.view(1, n_sp_devices, seq_len_per_chip, -1),
@@ -397,8 +397,8 @@ def run_model(
     # fmt: off
     dense_checks = [
         ("shared_output", tt_intermediates.shared_output, torch_intermediates.shared_output, get_tp_mesh_composer(mesh_device), 0.997),
-        ("routed_output", tt_intermediates.routed_output, torch_intermediates.routed_output, get_tp_mesh_composer(mesh_device), 0.90),
-        ("final_output", tt_output, torch_output, get_tp_mesh_composer(mesh_device), 0.94),
+        ("routed_output", tt_intermediates.routed_output, torch_intermediates.routed_output, get_tp_mesh_composer(mesh_device), 0.96),
+        ("final_output", tt_output, torch_output, get_tp_mesh_composer(mesh_device), 0.982),
     ]
     # fmt: on
 

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -54,8 +54,8 @@ class TtMoEGateConfig:
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=56,
-                    out_subblock_h=2,
-                    out_subblock_w=2,
+                    out_subblock_h=1,
+                    out_subblock_w=4,
                     out_block_h=2,
                     out_block_w=4,
                     per_core_M=2,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_moe_gate_prefill.py
@@ -47,13 +47,15 @@ class TtMoEGateConfig:
     mm_configs: dict = field(
         default_factory=lambda: {
             # Keyed by (sp_dim, per_device_emb_dim, n_routed_experts); forward() looks up the tuple.
+            # The seq-len element below is a placeholder — __post_init__ rewrites it to the actual
+            # per-chip sequence length (self.sp_dim) so the lookup tracks the real workload.
             # per_core_N = n_routed_experts / 32 (tile width). Missing key → TTNN auto-picks.
             (4096, DeepSeekV3Config.EMB_SIZE // 4, DeepSeekV3Config.NUM_ROUTED_EXPERTS): (
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=56,
                     out_subblock_h=2,
-                    out_subblock_w=4,
+                    out_subblock_w=2,
                     out_block_h=2,
                     out_block_w=4,
                     per_core_M=2,
@@ -66,7 +68,7 @@ class TtMoEGateConfig:
                 ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
                     compute_with_storage_grid_size=ttnn.CoreCoord(11, 10),
                     in0_block_w=56,
-                    out_subblock_h=2,
+                    out_subblock_h=1,
                     out_subblock_w=4,
                     out_block_h=2,
                     out_block_w=4,
@@ -79,7 +81,7 @@ class TtMoEGateConfig:
             "COMPUTE_CONFIG": ttnn.types.BlackholeComputeKernelConfig(
                 math_fidelity=ttnn.MathFidelity.HiFi4,
                 math_approx_mode=False,
-                fp32_dest_acc_en=False,
+                fp32_dest_acc_en=True,
                 packer_l1_acc=False,
             ),
         }
@@ -103,6 +105,16 @@ class TtMoEGateConfig:
             else ttnn.CoreRangeSet({ttnn.CoreRange(ttnn.CoreCoord(0, 0), ttnn.CoreCoord(7, 7))})
         )
     )
+
+    def __post_init__(self):
+        # The mm_configs tuple keys are authored with a placeholder seq-len. Re-key them to the
+        # actual per-chip sequence length (sp_dim) so _device_matmul's lookup
+        # (sp_dim, per_device_emb_dim, n_routed_experts) hits the tuned program config instead of
+        # silently falling back to TTNN's default tiling.
+        self.mm_configs = {
+            ((self.sp_dim, *key[1:]) if isinstance(key, tuple) else key): value
+            for key, value in self.mm_configs.items()
+        }
 
     @property
     def num_cores(self):

--- a/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
+++ b/models/demos/deepseek_v3_d_p/utils/transformer_helpers.py
@@ -1020,3 +1020,64 @@ def load_debug_trace(trace_dir: Path, num_layers: int | None = None) -> DebugTra
         logits=logits,
         metadata=metadata,
     )
+
+
+# Golden bit_sculpt prefill trace (DeepSeek-R1-0528, 256 experts, hidden_dim 7168).
+# Layer 3 is the first MoE layer (metadata moe_layer_offset == 3).
+GOLDEN_LONGBOOK_TRACE = Path("/mnt/models/deepseek-prefill-cache/golden/longbook_qa_eng_prefill_56320_nopad")
+
+
+def load_trace_gate_input(
+    trace_dir: Path,
+    layer_idx: int,
+    max_seq_len: int,
+    dim: int,
+    dtype: torch.dtype = torch.bfloat16,
+) -> torch.Tensor | None:
+    """Load the MoE/gate block input from a bit_sculpt golden trace.
+
+    The trace stores ``post_attn_norm_layer_{i}`` per layer — the post-attention
+    RMSNorm output, which is exactly the tensor fed into the gate + experts at
+    layer ``i`` (unlike ``decoder_output_layer_{i}``, the unnormalized residual
+    stream). Returns ``[max_seq_len, dim]`` (tiled if the trace is shorter than
+    ``max_seq_len``), or ``None`` if the trace/key is unavailable or ``dim``
+    exceeds the trace hidden dim.
+
+    A sliced read is used so only the requested ``[max_seq_len, dim]`` block is
+    materialized rather than the full (seq, hidden_dim) tensor.
+    """
+    from safetensors import safe_open
+
+    layer_path = Path(trace_dir) / "hidden_states" / f"layer_{layer_idx}.safetensors"
+    if not layer_path.exists():
+        logger.warning(f"Trace file not found: {layer_path}. Falling back to synthetic input.")
+        return None
+
+    key = f"post_attn_norm_layer_{layer_idx}"
+    try:
+        with safe_open(layer_path, framework="pt") as f:
+            if key not in f.keys():
+                logger.warning(f"{key} not in {layer_path}. Falling back to synthetic input.")
+                return None
+            sl = f.get_slice(key)
+            seq_total, hidden_dim = sl.get_shape()
+            if dim > hidden_dim:
+                logger.warning(
+                    f"Requested dim {dim} > trace hidden_dim {hidden_dim} ({key}). Falling back to synthetic input."
+                )
+                return None
+            n = min(max_seq_len, seq_total)
+            hidden = sl[:n, :dim].to(dtype)
+    except Exception as e:  # safetensors / IO errors — fall back to synthetic
+        logger.warning(f"Could not load {key} from {layer_path}: {e}. Falling back to synthetic input.")
+        return None
+
+    if hidden.shape[0] < max_seq_len:
+        repeats = (max_seq_len + hidden.shape[0] - 1) // hidden.shape[0]
+        hidden = hidden.repeat(repeats, 1)[:max_seq_len]
+
+    logger.info(
+        f"Loaded gate input from {Path(trace_dir).name} {key} "
+        f"(trace {seq_total}x{hidden_dim}, sliced to {tuple(hidden.shape)})"
+    )
+    return hidden


### PR DESCRIPTION

### Summary
Several things affected the MoE PCC:

1. test_ttnn_moe was using a randomly generated input instead of a realistic one (ex. from trace)
2. Gate matmul had fp32_dest_acc_en turned off, meaning that even though the moe_grouped_topk sorts values in fp32, the inputs logits have already been downcast.

### CIs
- [![(Blackhole) e2e tests](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ddjekic/moe_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ddjekic/moe_pcc_fix) (Relevant tests passed)
- [![(Galaxy) DeepSeek Prefill tests](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ddjekic/moe_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ddjekic/moe_pcc_fix) Passed

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ddjekic/moe_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ddjekic/moe_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ddjekic/moe_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ddjekic/moe_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ddjekic/moe_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ddjekic/moe_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ddjekic/moe_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ddjekic/moe_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ddjekic/moe_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ddjekic/moe_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ddjekic/moe_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ddjekic/moe_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ddjekic/moe_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ddjekic/moe_pcc_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ddjekic/moe_pcc_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ddjekic/moe_pcc_fix)