### PR TITLE
[tt-train] Make parallel RNG deterministic

### DIFF
--- a/tt-train/sources/examples/rng_simd/main.cpp
+++ b/tt-train/sources/examples/rng_simd/main.cpp
@@ -351,7 +351,7 @@ void benchmark_type(const std::string& type_name, size_t size) {
             .expected_median = 0.0,
             .expected_q25 = 0.0,
             .expected_q75 = 0.0,
-            .has_simd_support = true  // SIMD optimized
+            .has_simd_support = std::same_as<T, float> || std::same_as<T, bfloat16>  // SIMD for float/bfloat16 only
         };
         benchmark_distribution<T>(type_name, uniform_factory, size, params);
     }

--- a/tt-train/sources/ttml/core/random.hpp
+++ b/tt-train/sources/ttml/core/random.hpp
@@ -10,6 +10,7 @@
 #include <thread>
 #include <vector>
 
+#include "random_parallel.hpp"
 #include "random_sse.hpp"
 
 namespace ttml::core {
@@ -28,28 +29,13 @@ void parallel_generate(
     DistGenFunc dist_factory,
     uint32_t seed,
     uint32_t max_threads = std::thread::hardware_concurrency()) {
-    constexpr size_t min_size = 1 << 12;  // determined empirically that this is where we see an advantage over
-                                          // sequential generation even with 2 threads.
-    if (seq.size() < min_size) {
-        sequential_generate(seq, dist_factory, seed);
-        return;
-    }
-
-    size_t num_threads = std::min(max_threads, std::thread::hardware_concurrency());
-    std::vector<std::jthread> threads;
-    threads.reserve(num_threads);
-
-    size_t chunk_size = seq.size() / num_threads;
-    size_t remainder = seq.size() % num_threads;
-
-    size_t offset = 0;
-    for (size_t i = 0; i < num_threads; ++i) {
-        auto adjusted_chunk_size = chunk_size + (i == num_threads - 1 ? remainder : 0);
-        threads.emplace_back([&dist_factory, &seq, offset, adjusted_chunk_size, seed, i]() {
-            sequential_generate(seq.subspan(offset, adjusted_chunk_size), dist_factory, seed + i);
-        });
-        offset += adjusted_chunk_size;
-    }
+    ttml::core::rng::generate_parallel_chunks(
+        seq,
+        [dist_factory](std::span<T> s, uint32_t s_seed) {
+            sequential_generate<T, DistGenFunc>(s, dist_factory, s_seed);
+        },
+        seed,
+        max_threads);
 }
 
 }  // namespace legacy

--- a/tt-train/sources/ttml/core/random_parallel.hpp
+++ b/tt-train/sources/ttml/core/random_parallel.hpp
@@ -4,6 +4,8 @@
 
 #pragma once
 
+#include <algorithm>
+#include <cstdint>
 #include <span>
 #include <thread>
 #include <vector>
@@ -21,7 +23,7 @@ inline size_t calculate_num_chunks(size_t total_size, size_t chunk_size) noexcep
 }
 
 inline uint64_t calculate_chunk_seed(uint32_t base_seed, size_t chunk_id, size_t chunk_size) noexcept {
-    return static_cast<uint64_t>(base_seed) + (static_cast<uint64_t>(chunk_id * chunk_size) << thread_seed_shift_bits);
+    return static_cast<uint64_t>(base_seed) + static_cast<uint64_t>(chunk_id * chunk_size);
 }
 
 // chunk_fn must be callable as chunk_fn(std::span<T>, uint32_t seed).

--- a/tt-train/sources/ttml/core/random_parallel.hpp
+++ b/tt-train/sources/ttml/core/random_parallel.hpp
@@ -1,0 +1,67 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include <span>
+#include <thread>
+#include <vector>
+
+namespace ttml::core::rng {
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+inline constexpr size_t thread_seed_shift_bits = 32;
+
+inline size_t calculate_num_chunks(size_t total_size, size_t chunk_size) noexcept {
+    return (total_size + chunk_size - 1) / chunk_size;
+}
+
+inline uint64_t calculate_chunk_seed(uint32_t base_seed, size_t chunk_id, size_t chunk_size) noexcept {
+    return static_cast<uint64_t>(base_seed) + (static_cast<uint64_t>(chunk_id * chunk_size) << thread_seed_shift_bits);
+}
+
+// chunk_fn must be callable as chunk_fn(std::span<T>, uint32_t seed).
+// Seed is per-chunk so output is identical regardless of thread count.
+template <typename T, typename ChunkGenFn>
+void generate_parallel_chunks(
+    std::span<T> seq, ChunkGenFn chunk_fn, uint32_t seed, uint32_t max_threads = std::thread::hardware_concurrency()) {
+    constexpr size_t min_size = 1 << 12;  // determined empirically that this is where we see an advantage over
+                                          // sequential generation even with 2 threads.
+    if (seq.size() < min_size) {
+        chunk_fn(seq, seed);
+        return;
+    }
+
+    // Fixed chunk size independent of thread count: seed is per-chunk so output
+    // is identical regardless of how many threads process those chunks.
+    static constexpr size_t CHUNK_SIZE = 512 * 512;
+    const size_t num_threads =
+        std::min(static_cast<size_t>(max_threads), static_cast<size_t>(std::thread::hardware_concurrency()));
+    const size_t num_chunks = calculate_num_chunks(seq.size(), CHUNK_SIZE);
+    const size_t actual_threads = std::min(num_threads, num_chunks);
+    const size_t chunks_per_thread = num_chunks / actual_threads;
+    const size_t leftover = num_chunks % actual_threads;
+
+    std::vector<std::jthread> threads;
+    threads.reserve(actual_threads);
+
+    size_t start_chunk = 0;
+    for (size_t t = 0; t < actual_threads; ++t) {
+        const size_t end_chunk = start_chunk + chunks_per_thread + (t < leftover ? 1 : 0);
+        threads.emplace_back([chunk_fn, seq, start_chunk, end_chunk, seed]() {
+            for (size_t chunk = start_chunk; chunk < end_chunk; ++chunk) {
+                const size_t offset = chunk * CHUNK_SIZE;
+                const size_t size = std::min(CHUNK_SIZE, seq.size() - offset);
+                uint32_t chunk_seed = calculate_chunk_seed(seed, chunk, CHUNK_SIZE);
+                chunk_fn(seq.subspan(offset, size), chunk_seed);
+            }
+        });
+        start_chunk = end_chunk;
+    }
+}
+
+}  // namespace ttml::core::rng

--- a/tt-train/sources/ttml/core/random_sse.hpp
+++ b/tt-train/sources/ttml/core/random_sse.hpp
@@ -26,6 +26,7 @@
 #include <thread>
 #include <vector>
 
+#include "random_parallel.hpp"
 #include "tt-metalium/bfloat16.hpp"
 
 namespace ttml::core::sse {
@@ -48,13 +49,6 @@ inline constexpr uint32_t float_exponent_bias = 0x3f800000;
 // ============================================================================
 // Helper Functions
 // ============================================================================
-
-// Convert float to bfloat16 by truncating to upper 16 bits
-inline bfloat16 float_to_bfloat16(float value) noexcept {
-    uint32_t float_bits = std::bit_cast<uint32_t>(value);
-    uint16_t bf16_bits = static_cast<uint16_t>(float_bits >> 16);
-    return std::bit_cast<bfloat16>(bf16_bits);
-}
 
 // Calculate cache-aligned chunk size for parallel processing
 template <typename T>
@@ -79,11 +73,6 @@ inline auto create_chunks(std::span<T> output, size_t num_threads, size_t chunk_
                return output.subspan(offset, size);
            }) |
            std::views::take_while([](auto chunk) { return !chunk.empty(); });
-}
-
-// Calculate thread-specific seed
-inline uint64_t calculate_thread_seed(uint32_t base_seed, size_t thread_id) noexcept {
-    return static_cast<uint64_t>(base_seed) + (static_cast<uint64_t>(thread_id) << thread_seed_shift_bits);
 }
 
 // ============================================================================
@@ -204,12 +193,18 @@ inline __m128 _mm_log_ps(__m128 x) noexcept {
     mantissa = _mm_or_si128(mantissa, _mm_set1_epi32(0x3F000000));
     x = _mm_castsi128_ps(mantissa);
 
-    // Polynomial approximation for ln(x)
-    __m128 x_minus_one = _mm_sub_ps(x, one);
-    __m128 x2 = _mm_mul_ps(x_minus_one, x_minus_one);
-    __m128 ln_x = _mm_add_ps(x_minus_one, _mm_mul_ps(x2, _mm_set1_ps(-0.5f)));
+    // 4th-order Taylor polynomial: ln(1+t) ≈ t - t²/2 + t³/3 - t⁴/4, t = x-1 ∈ [-0.5, 0)
+    // 2nd-order leaves ~1.5% systematic variance bias in Box-Muller; 4th-order reduces it to ~0.1%.
+    __m128 t = _mm_sub_ps(x, one);
+    __m128 t2 = _mm_mul_ps(t, t);
+    __m128 t3 = _mm_mul_ps(t2, t);
+    __m128 t4 = _mm_mul_ps(t3, t);
+    __m128 ln_x = _mm_add_ps(
+        _mm_add_ps(t, _mm_mul_ps(t2, _mm_set1_ps(-0.5f))),
+        _mm_add_ps(_mm_mul_ps(t3, _mm_set1_ps(1.0f / 3.0f)), _mm_mul_ps(t4, _mm_set1_ps(-0.25f))));
 
-    return _mm_add_ps(_mm_mul_ps(e_f, ln2), _mm_mul_ps(ln_x, ln2));
+    // ln(x) = (e_f + 1)*ln2 + ln(x_new), where x_new ∈ [0.5, 1.0) (exponent set to 126 = -1 unbiased)
+    return _mm_add_ps(_mm_add_ps(_mm_mul_ps(e_f, ln2), ln2), ln_x);
 }
 
 // Portable SIMD square root
@@ -274,7 +269,7 @@ inline void fill_remainder_simd(
                 __m128 rand = rng.generate_float_x4();
                 float val = _mm_cvtss_f32(rand);
                 float scaled = min + val * range;
-                output[i] = float_to_bfloat16(scaled);
+                output[i] = bfloat16(scaled);
             }
         } else if constexpr (std::same_as<Dist, std::normal_distribution<float>>) {
             const float mean = params.mean();
@@ -293,7 +288,7 @@ inline void fill_remainder_simd(
                 float theta = two_pi * u2_val;
                 float z = r * std::cos(theta);
                 float result = z * stddev + mean;
-                output[i] = float_to_bfloat16(result);
+                output[i] = bfloat16(result);
             }
         }
     }
@@ -329,30 +324,6 @@ void generate_uniform_simd(std::span<float> output, uint32_t seed, auto dist_fac
 
     // Process remainder with SIMD
     fill_remainder_simd(output, num_batches * simd_float_batch_size, seed, dist_factory);
-}
-
-// Parallel SIMD generation for uniform_real_distribution<float>
-template <typename DistFactory>
-void generate_uniform_simd_parallel(
-    std::span<float> output, DistFactory dist_factory, uint32_t seed, size_t num_threads) {
-    if (output.size() < parallel_min_size) [[unlikely]] {
-        generate_uniform_simd(output, seed, dist_factory);
-        return;
-    }
-
-    size_t chunk_size = calculate_aligned_chunk_size<float>(output.size(), num_threads, simd_float_batch_size);
-    auto chunks = create_chunks(output, num_threads, chunk_size);
-
-    std::vector<std::jthread> threads;
-    threads.reserve(num_threads);
-
-    size_t thread_id = 0;
-    for (auto chunk : chunks) {
-        uint64_t thread_seed = calculate_thread_seed(seed, thread_id++);
-        threads.emplace_back([chunk, thread_seed, dist_factory]() {
-            generate_uniform_simd(chunk, static_cast<uint32_t>(thread_seed), dist_factory);
-        });
-    }
 }
 
 // ============================================================================
@@ -424,30 +395,6 @@ void generate_normal_simd(std::span<float> output, uint32_t seed, auto dist_fact
     fill_remainder_simd(output, i, seed, dist_factory);
 }
 
-// Parallel SIMD generation for normal_distribution<float>
-template <typename DistFactory>
-void generate_normal_simd_parallel(
-    std::span<float> output, DistFactory dist_factory, uint32_t seed, size_t num_threads) {
-    if (output.size() < parallel_min_size) [[unlikely]] {
-        generate_normal_simd(output, seed, dist_factory);
-        return;
-    }
-
-    size_t chunk_size = calculate_aligned_chunk_size<float>(output.size(), num_threads, simd_float_batch_size);
-    auto chunks = create_chunks(output, num_threads, chunk_size);
-
-    std::vector<std::jthread> threads;
-    threads.reserve(num_threads);
-
-    size_t thread_id = 0;
-    for (auto chunk : chunks) {
-        uint64_t thread_seed = calculate_thread_seed(seed, thread_id++);
-        threads.emplace_back([chunk, thread_seed, dist_factory]() {
-            generate_normal_simd(chunk, static_cast<uint32_t>(thread_seed), dist_factory);
-        });
-    }
-}
-
 // ============================================================================
 // Portable SIMD Generation (bfloat16 - Uniform with Pure SIMD)
 // ============================================================================
@@ -490,28 +437,6 @@ void generate_uniform_simd_bfloat16(std::span<bfloat16> output, uint32_t seed, a
     fill_remainder_simd(output, num_batches * simd_bf16_batch_size, seed, dist_factory);
 }
 
-void generate_uniform_simd_parallel_bfloat16(
-    std::span<bfloat16> output, uint32_t seed, auto dist_factory, size_t num_threads) {
-    if (output.size() < parallel_min_size) [[unlikely]] {
-        generate_uniform_simd_bfloat16(output, seed, dist_factory);
-        return;
-    }
-
-    size_t chunk_size = calculate_aligned_chunk_size<bfloat16>(output.size(), num_threads, simd_bf16_batch_size);
-    auto chunks = create_chunks(output, num_threads, chunk_size);
-
-    std::vector<std::jthread> threads;
-    threads.reserve(num_threads);
-
-    size_t thread_id = 0;
-    for (auto chunk : chunks) {
-        uint64_t thread_seed = calculate_thread_seed(seed, thread_id++);
-        threads.emplace_back([chunk, thread_seed, dist_factory]() {
-            generate_uniform_simd_bfloat16(chunk, static_cast<uint32_t>(thread_seed), dist_factory);
-        });
-    }
-}
-
 // ============================================================================
 // Drop-in Replacement API
 // ============================================================================
@@ -538,7 +463,7 @@ inline void sequential_generate(std::span<T> seq, DistGenFunc dist_factory, uint
             std::vector<float> temp(seq.size());
             generate_normal_simd(std::span<float>{temp}, seed, dist_factory);
             for (size_t i = 0; i < seq.size(); ++i) {
-                seq[i] = float_to_bfloat16(temp[i]);
+                seq[i] = bfloat16(temp[i]);
             }
         }
     }
@@ -555,22 +480,39 @@ inline void parallel_generate(
     if constexpr (std::same_as<T, float>) {
         using Dist = decltype(dist_factory());
         if constexpr (std::same_as<Dist, std::uniform_real_distribution<float>>) {
-            generate_uniform_simd_parallel(seq, dist_factory, seed, max_threads);
+            ttml::core::rng::generate_parallel_chunks(
+                seq,
+                [dist_factory](std::span<float> s, uint32_t s_seed) { generate_uniform_simd(s, s_seed, dist_factory); },
+                seed,
+                max_threads);
         } else if constexpr (std::same_as<Dist, std::normal_distribution<float>>) {
-            generate_normal_simd_parallel(seq, dist_factory, seed, max_threads);
+            ttml::core::rng::generate_parallel_chunks(
+                seq,
+                [dist_factory](std::span<float> s, uint32_t s_seed) { generate_normal_simd(s, s_seed, dist_factory); },
+                seed,
+                max_threads);
         }
-    }
-    // SIMD fast path for bfloat16 distributions
-    else if constexpr (std::same_as<T, bfloat16>) {
+        // SIMD fast path for bfloat16 distributions
+    } else if constexpr (std::same_as<T, bfloat16>) {
         using Dist = decltype(dist_factory());
         if constexpr (std::same_as<Dist, std::uniform_real_distribution<float>>) {
-            generate_uniform_simd_parallel_bfloat16(seq, seed, dist_factory, max_threads);
+            ttml::core::rng::generate_parallel_chunks(
+                seq,
+                [dist_factory](std::span<bfloat16> s, uint32_t s_seed) {
+                    generate_uniform_simd_bfloat16(s, s_seed, dist_factory);
+                },
+                seed,
+                max_threads);
         } else if constexpr (std::same_as<Dist, std::normal_distribution<float>>) {
             // For normal distribution with bfloat16, generate as float then convert
             std::vector<float> temp(seq.size());
-            generate_normal_simd_parallel(std::span<float>{temp}, dist_factory, seed, max_threads);
+            ttml::core::rng::generate_parallel_chunks(
+                std::span<float>{temp},
+                [dist_factory](std::span<float> s, uint32_t s_seed) { generate_normal_simd(s, s_seed, dist_factory); },
+                seed,
+                max_threads);
             for (size_t i = 0; i < seq.size(); ++i) {
-                seq[i] = float_to_bfloat16(temp[i]);
+                seq[i] = bfloat16(temp[i]);
             }
         }
     }

--- a/tt-train/sources/ttml/core/random_sse.hpp
+++ b/tt-train/sources/ttml/core/random_sse.hpp
@@ -395,6 +395,15 @@ void generate_normal_simd(std::span<float> output, uint32_t seed, auto dist_fact
     fill_remainder_simd(output, i, seed, dist_factory);
 }
 
+void generate_normal_simd_bfloat16(std::span<bfloat16> output, uint32_t seed, auto dist_factory) {
+    std::vector<float> temp(output.size());
+    generate_normal_simd(std::span<float>{temp}, seed, dist_factory);
+
+    for (size_t i = 0; i < output.size(); ++i) {
+        output[i] = bfloat16(temp[i]);
+    }
+}
+
 // ============================================================================
 // Portable SIMD Generation (bfloat16 - Uniform with Pure SIMD)
 // ============================================================================
@@ -505,15 +514,13 @@ inline void parallel_generate(
                 max_threads);
         } else if constexpr (std::same_as<Dist, std::normal_distribution<float>>) {
             // For normal distribution with bfloat16, generate as float then convert
-            std::vector<float> temp(seq.size());
             ttml::core::rng::generate_parallel_chunks(
-                std::span<float>{temp},
-                [dist_factory](std::span<float> s, uint32_t s_seed) { generate_normal_simd(s, s_seed, dist_factory); },
+                seq,
+                [dist_factory](std::span<bfloat16> s, uint32_t s_seed) {
+                    generate_normal_simd_bfloat16(s, s_seed, dist_factory);
+                },
                 seed,
                 max_threads);
-            for (size_t i = 0; i < seq.size(); ++i) {
-                seq[i] = bfloat16(temp[i]);
-            }
         }
     }
 }

--- a/tt-train/tests/core/random_tests.cpp
+++ b/tt-train/tests/core/random_tests.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <chrono>
 #include <random>
+#include <thread>
 
 #include "autograd/auto_context.hpp"
 #include "core/random.hpp"
@@ -75,6 +76,68 @@ TEST_F(RandomGenerationTests, UniformInitsGoodMeanAndRange) {
 
     EXPECT_NEAR(parallel_mean, 0.0, 0.01);
     EXPECT_NEAR(sequential_mean, 0.0, 0.01);
+}
+
+TEST_F(RandomGenerationTests, ParallelUniformThreadAgnostic) {
+    // Ensure that parlallel RNG gives same results regardless of number of threads.
+    // Here, we compare outputs with 7 threads and all threads against sequential RNG.
+    constexpr size_t size = 1024 * 256 * 384;  // ~100M elements
+
+    std::vector<float> sequential_vec(size);
+    std::vector<float> parallel_vec(size);
+    std::vector<float> parallel_all_threads_vec(size);
+
+    const uint32_t num_threads = std::min<uint32_t>(7u, std::thread::hardware_concurrency());
+    const uint32_t all_threads = std::thread::hardware_concurrency();
+
+    ttml::core::legacy::parallel_generate(
+        std::span{sequential_vec.data(), sequential_vec.size()},
+        []() { return std::uniform_real_distribution<float>(-1.0f, 1.0f); },
+        42,
+        1);
+    ttml::core::legacy::parallel_generate(
+        std::span{parallel_vec.data(), parallel_vec.size()},
+        []() { return std::uniform_real_distribution<float>(-1.0f, 1.0f); },
+        42,
+        num_threads);
+    ttml::core::legacy::parallel_generate(
+        std::span{parallel_all_threads_vec.data(), parallel_all_threads_vec.size()},
+        []() { return std::uniform_real_distribution<float>(-1.0f, 1.0f); },
+        42,
+        all_threads);
+
+    EXPECT_EQ(sequential_vec, parallel_vec);
+    EXPECT_EQ(sequential_vec, parallel_all_threads_vec);
+}
+
+TEST_F(RandomGenerationTests, ParallelNormalThreadAgnostic) {
+    // Same thread-agnostic property as above, for the normal distribution.
+    constexpr size_t size = 1024 * 256 * 384;  // ~100M elements
+
+    std::vector<float> sequential_vec(size);
+    std::vector<float> parallel_vec(size);
+    std::vector<float> parallel_all_threads_vec(size);
+
+    const uint32_t num_threads = std::min<uint32_t>(7u, std::thread::hardware_concurrency());
+    const uint32_t all_threads = std::thread::hardware_concurrency();
+    ttml::core::legacy::parallel_generate(
+        std::span{sequential_vec.data(), sequential_vec.size()},
+        []() { return std::normal_distribution<float>(0.0f, 1.0f); },
+        42,
+        1);
+    ttml::core::legacy::parallel_generate(
+        std::span{parallel_vec.data(), parallel_vec.size()},
+        []() { return std::normal_distribution<float>(0.0f, 1.0f); },
+        42,
+        num_threads);
+    ttml::core::legacy::parallel_generate(
+        std::span{parallel_all_threads_vec.data(), parallel_all_threads_vec.size()},
+        []() { return std::normal_distribution<float>(0.0f, 1.0f); },
+        42,
+        all_threads);
+
+    EXPECT_EQ(sequential_vec, parallel_vec);
+    EXPECT_EQ(sequential_vec, parallel_all_threads_vec);
 }
 
 TEST_F(RandomGenerationTests, ParallelUniformInitDeterminismSSE) {


### PR DESCRIPTION
### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->


### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

Closes #46837

Right now, output of multithreaded random generator depends on number of threads: seed is set from thread id. For a given data point, output can be different on a machine with 2 cores vs. a machine with 16. 

Instead of seeding once per thread, the PR slices data into chunks, where each chunk has a fixed seed. 
Chunks will then be spread between threads. 

For instance:
- Chunk 0: seed 335
- Chunk 1: seed 336
- Chunk 2: seed 337
- Chunk 3: seed 338

If we have two threads, then Thread 0 may get Chunks 0 and 1, and thread 1 may get 2 and 3. But regardless, each thread would re-seed upon a new chunk. 
If we have three thread, then Thread 0 gets Chunk 0 and 1, while Thread 1 and 2 would get chunks 2 and 3 respectively. 

To reduce overhead of RNG state reinitialization, chunk size is set to be "large enough". In this case chunks 262k elements long (512x512).
This is an arbitrary number. It has been picked because it is large enough (e.g. typical size of classical test images), but still allow a good level of parallelization on large tensor (e.g. a `7168x2048` would have 56 chunks, and RNG would parallelize up to 56 threads).   

This PR also does the following:
- A bug in `simd_rng` tests where tests would try non-existing float64 SIMD RNG. 
- A bug with the normal SIMD normal distribution.  
- In RNG code, it replaces truncation in float -> bfloat16 conversion with round-to-nearest-tie-on-even. 


### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

#### Performance

For most distribution, performance remains comparable as before. For normal + bfloat16, data path is slightly faster (float32 -> bfloat16 conversion has been moved to parallel section)

**main vs new**

<img width="1775" height="1179" alt="fig1_sse_threads_vs_throughput" src="https://github.com/user-attachments/assets/e2c5dcae-a595-48d7-8011-fc8357875f18" />

**perf on main**

<img width="1775" height="1179" alt="fig2_main_path_comparison" src="https://github.com/user-attachments/assets/55db0cf7-04ba-4e74-a337-7b65cfacbe7e" />

**perf on new branch**

<img width="1775" height="1179" alt="fig2_nmaurice_fix-rng_path_comparison" src="https://github.com/user-attachments/assets/11092ce3-07a1-4f83-87f9-e4e58cae6c27" />


**Note:** Scalar uniform implementation is faster than SSE version. This is likely because uniform code is simple enough to get autovectorized to AVX512 on evaluated machines, where SSE versions is limited to 128-bits wide SIMD.


### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nmaurice/tt-train-fix-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nmaurice/tt-train-fix-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nmaurice/tt-train-fix-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nmaurice/tt-train-fix-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nmaurice/tt-train-fix-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nmaurice/tt-train-fix-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nmaurice/tt-train-fix-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nmaurice/tt-train-fix-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nmaurice/tt-train-fix-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nmaurice/tt-train-fix-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nmaurice/tt-train-fix-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nmaurice/tt-train-fix-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nmaurice/tt-train-fix-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nmaurice/tt-train-fix-parallel-rng)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nmaurice/tt-train-fix-parallel-rng)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nmaurice/tt-train-fix-parallel-rng)