### PR TITLE
Use functional cast, not static_cast, optimize x^n

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -40,82 +40,80 @@ inline void calculate_polygamma(uint32_t n_packed, uint32_t scale_packed) {
     constexpr int NUM_TERMS = 11;  // Exact terms (k=0..10)
 
     // Unpack parameters using Converter (union-based type punning supported by SFPU compiler)
-    float n_float = Converter::as_float(n_packed);
-    int n = static_cast<int>(n_float);
-    int n_plus_1 = n + 1;
+    int n = int(Converter::as_float(n_packed));
     float scale = Converter::as_float(scale_packed);
 
     // Precompute Bernoulli-related coefficients for asymptotic tail
     // B_2 = 1/6 → coeff = (n+1)/12  (from B_2/(2!) * s*(s-1)... but simplified)
     // B_4 = -1/30 → coeff = -(n+1)(n+2)(n+3)/720
     // B_6 = 1/42  → coeff = (n+1)(n+2)(n+3)(n+4)(n+5)/30240
-    float n1 = static_cast<float>(n + 1);
-    float n2 = static_cast<float>(n + 2);
-    float n3 = static_cast<float>(n + 3);
-    float n4 = static_cast<float>(n + 4);
-    float n5 = static_cast<float>(n + 5);
-    float nf = static_cast<float>(n);
+    float n1 = n + 1;
+    float n2 = n + 2;
+    float n3 = n + 3;
+    float n4 = n + 4;
+    float n5 = n + 5;
+    float nf = n;
     float inv_nf = 1.0f / nf;
     float c_b2 = n1 / 12.0f;                           // B_2 term coefficient
     float c_b4 = -(n1 * n2 * n3) / 720.0f;             // B_4 term coefficient
     float c_b6 = (n1 * n2 * n3 * n4 * n5) / 30240.0f;  // B_6 term coefficient
 
+    constexpr auto RECIP = APPROXIMATION_MODE ? 0 : is_fp32_dest_acc_en ? 2 : 1;
+
+    auto power = [] __attribute__((always_inline)) (sfpi::vFloat x, int pwr, sfpi::vFloat val = 1.0f) {
+        for (;;) {
+            if (pwr & 1) {
+                val *= x;
+            }
+            pwr >>= 1;
+            if (!pwr) {
+                break;
+            }
+            x *= x;
+        }
+        return val;
+    };
+
 #pragma GCC unroll 8
     for (int d = 0; d < ITERATIONS; d++) {
         sfpi::vFloat x = sfpi::dst_reg[0];
-        sfpi::vFloat sum = sfpi::vFloat(0.0f);
+        sfpi::vFloat sum = 0.0f;
 
         // Part 1: Exact summation of first NUM_TERMS terms
         // Σ_{k=0}^{NUM_TERMS-1} 1/(x+k)^(n+1)
         for (int k = 0; k < NUM_TERMS; k++) {
-            sfpi::vFloat xi = x + static_cast<float>(k);
+            sfpi::vFloat xi = x + float(k);
 
             // Compute reciprocal first, then raise to power (avoids overflow of large intermediates)
-            sfpi::vFloat inv_xi;
-            if constexpr (APPROXIMATION_MODE) {
-                inv_xi = sfpu_reciprocal_iter<0>(xi);
-            } else if constexpr (is_fp32_dest_acc_en) {
-                inv_xi = sfpu_reciprocal_iter<2>(xi);
-            } else {
-                inv_xi = sfpu_reciprocal_iter<1>(xi);
-            }
+            sfpi::vFloat inv_xi = sfpu_reciprocal_iter<RECIP>(xi);
+            sfpi::vFloat inv_power = power(inv_xi, n, inv_xi);
 
-            sfpi::vFloat inv_power = inv_xi;
-            for (int j = 1; j < n_plus_1; j++) {
-                inv_power = inv_power * inv_xi;
-            }
-
-            sum = sum + inv_power;
+            sum += inv_power;
         }
 
         // Part 2: Euler-Maclaurin asymptotic tail correction
         // For the remaining sum Σ_{k=NUM_TERMS}^{∞} 1/(x+k)^(n+1)
         // at z = x + NUM_TERMS:
-        sfpi::vFloat z = x + static_cast<float>(NUM_TERMS);
-
-        sfpi::vFloat inv_z;
-        if constexpr (APPROXIMATION_MODE) {
-            inv_z = sfpu_reciprocal_iter<0>(z);
-        } else if constexpr (is_fp32_dest_acc_en) {
-            inv_z = sfpu_reciprocal_iter<2>(z);
-        } else {
-            inv_z = sfpu_reciprocal_iter<1>(z);
-        }
-
+        sfpi::vFloat z = x + float(NUM_TERMS);
+        sfpi::vFloat inv_z = sfpu_reciprocal_iter<RECIP>(z);
         sfpi::vFloat inv_z2 = inv_z * inv_z;
-
-        // Compute inv_z^n by repeated multiplication
-        sfpi::vFloat inv_z_n = inv_z;  // inv_z^1
-        for (int j = 1; j < n; j++) {
-            inv_z_n = inv_z_n * inv_z;  // inv_z^n
-        }
 
         // Use PolynomialEvaluator for the Bernoulli polynomial in the tail:
         // E = inv_nf + c_b2*inv_z2 + c_b4*inv_z2^2 + c_b6*inv_z2^3
         sfpi::vFloat E = PolynomialEvaluator::eval(inv_z2, inv_nf, c_b2, c_b4, c_b6);
-        sfpi::vFloat tail = inv_z_n * (E + 0.5f * inv_z);
+        sfpi::vFloat tail = E + 0.5f * inv_z;
 
-        sum = sum + tail;
+        // Scale by inv_z^n, taking advantage of inv_z^2's
+        // computation above
+        if (n & 1) {
+            tail *= inv_z;
+        }
+        if (auto n2 = n >> 1) {
+            // x^2n == (x^2)^n
+            tail = power(inv_z2, n2, tail);
+        }
+
+        sum += tail;
 
         // Apply scale: (-1)^(n+1) * n!
         sfpi::vFloat result = sum * scale;

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_sfpu/ckernel_sfpu_polygamma.h
@@ -105,12 +105,14 @@ inline void calculate_polygamma(uint32_t n_packed, uint32_t scale_packed) {
 
         // Scale by inv_z^n, taking advantage of inv_z^2's
         // computation above
-        if (n & 1) {
+        int pwr = n;
+        if (pwr & 1) {
             tail *= inv_z;
         }
-        if (auto n2 = n >> 1) {
+        pwr >>= 1;
+        if (pwr) {
             // x^2n == (x^2)^n
-            tail = power(inv_z2, n2, tail);
+            tail = power(inv_z2, pwr, tail);
         }
 
         sum += tail;

--- a/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/common/inc/sfpu/ckernel_sfpu_relu.h
@@ -84,13 +84,14 @@ inline void _relu_max_(T threshold)
     }
     else if constexpr (std::is_same_v<T, std::uint32_t>)
     {
+        float f = Converter::as_float(threshold);
         if constexpr (std::is_same_v<VectorType, sfpi::vInt>)
         {
-            v_threshold = static_cast<int>(Converter::as_float(threshold));
+            v_threshold = int(f);
         }
         else
         {
-            v_threshold = Converter::as_float(threshold);
+            v_threshold = f;
         }
     }
     else


### PR DESCRIPTION
### PR Category
Cleanup, Optimization

### Summary
https://github.com/tenstorrent/tt-metal/issues/43766 mentions that these are two cases of casting sfpi types.  That's not correct, `float` and `int` are regular scalars.  But you made me look, so fixed to elide unneeded casts and use-function style otherwise.

And because you made me look I reordered some things to reduce live values and optimized the x^n computation

### Notes for reviewers
<!-- Where should reviewers focus? Call out anything non-obvious, tradeoffs, or areas of uncertainty. -->

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=nsidwell/cast-43766)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:nsidwell/cast-43766)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=nsidwell/cast-43766)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:nsidwell/cast-43766)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=nsidwell/cast-43766)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:nsidwell/cast-43766)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=nsidwell/cast-43766)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:nsidwell/cast-43766)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=nsidwell/cast-43766)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:nsidwell/cast-43766)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=nsidwell/cast-43766)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:nsidwell/cast-43766)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=nsidwell/cast-43766)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:nsidwell/cast-43766)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=nsidwell/cast-43766)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:nsidwell/cast-43766)