### PR TITLE
blitz_decode_pipeline: global backtracking assignment for inter-mesh hops

### DIFF
--- a/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
+++ b/tests/tt_metal/tt_fabric/fabric_router/test_routing_tables.cpp
@@ -8,8 +8,11 @@
 #include <tt-metalium/experimental/fabric/mesh_graph.hpp>
 #include <filesystem>
 #include <algorithm>
+#include <optional>
 #include <unordered_set>
+#include <utility>
 #include <yaml-cpp/yaml.h>
+#include <tt-metalium/experimental/blitz_decode_pipeline.hpp>
 
 #include "fabric_fixture.hpp"
 #include "t3k_mesh_descriptor_chip_mappings.hpp"
@@ -2244,4 +2247,142 @@ TEST_F(ControlPlaneFixture, TestBlitzDecodePipelineBuilder) {
 
     validate_sp5_blitz_decode_pipeline_stages(control_plane, mesh_graph, mesh_ids, stages);
 }
+
+// ---------------------------------------------------------------------------
+// Pure CPU-only unit tests for the inter-mesh hop allocator behind the blitz
+// decode pipeline builder (detail::assign_non_colliding_hops). No control plane
+// or cluster required -- candidate pairs are synthesized to exercise contention,
+// backtracking, and infeasible corner cases. Node identity is all that matters
+// to the allocator, so synthetic FabricNodeIds stand in for real chips.
+// ---------------------------------------------------------------------------
+namespace blitz_assign_tests {
+
+using ::tt::tt_fabric::FabricNodeId;
+using ::tt::tt_fabric::MeshId;
+using ::tt::tt_metal::experimental::blitz::detail::assign_non_colliding_hops;
+using HopPair = std::pair<FabricNodeId, FabricNodeId>;
+
+FabricNodeId node(std::uint32_t mesh, std::uint32_t chip) { return FabricNodeId(MeshId{mesh}, chip); }
+
+// Assert: one pair per hop, each chosen pair came from that hop's candidate list, all nodes distinct.
+void expect_valid_assignment(const std::vector<std::vector<HopPair>>& candidates, const std::vector<HopPair>& chosen) {
+    ASSERT_EQ(chosen.size(), candidates.size());
+    std::set<FabricNodeId> seen;
+    for (std::size_t i = 0; i < chosen.size(); i++) {
+        const bool from_candidates =
+            std::find(candidates[i].begin(), candidates[i].end(), chosen[i]) != candidates[i].end();
+        EXPECT_TRUE(from_candidates) << "hop " << i << " chose a pair not in its candidate list";
+        EXPECT_TRUE(seen.insert(chosen[i].first).second) << "node reused across hops (hop " << i << " exit)";
+        EXPECT_TRUE(seen.insert(chosen[i].second).second) << "node reused across hops (hop " << i << " peer)";
+    }
+}
+
+// The OLD in-ring-order greedy first-fit, kept only to prove a given input is one the old code failed
+// on -- so each contention test documents the exact regression it guards against.
+bool greedy_first_fit_succeeds(const std::vector<std::vector<HopPair>>& candidates) {
+    std::set<FabricNodeId> used;
+    for (const auto& hop : candidates) {
+        bool found = false;
+        for (const auto& p : hop) {
+            if (used.contains(p.first) || used.contains(p.second)) {
+                continue;
+            }
+            used.insert(p.first);
+            used.insert(p.second);
+            found = true;
+            break;
+        }
+        if (!found) {
+            return false;
+        }
+    }
+    return true;
+}
+
+TEST(BlitzDecodePipelineAssignment, NoContentionLinear) {
+    const std::vector<std::vector<HopPair>> candidates = {
+        {{node(0, 0), node(1, 0)}},
+        {{node(1, 1), node(2, 0)}},
+        {{node(2, 1), node(0, 1)}},
+    };
+    auto result = assign_non_colliding_hops(candidates);
+    ASSERT_TRUE(result.has_value());
+    expect_valid_assignment(candidates, *result);
+}
+
+TEST(BlitzDecodePipelineAssignment, ResolvesContentionGreedyWouldStrand) {
+    // hop1's first candidate steals node(2,0), which hop2's only candidate needs -> in-ring-order
+    // greedy strands hop2. A valid assignment exists (hop1 takes its second candidate).
+    const std::vector<std::vector<HopPair>> candidates = {
+        {{node(0, 0), node(1, 0)}},
+        {{node(1, 1), node(2, 0)}, {node(1, 2), node(2, 1)}},
+        {{node(2, 0), node(0, 1)}},
+    };
+    EXPECT_FALSE(greedy_first_fit_succeeds(candidates)) << "input should defeat naive greedy first-fit";
+    auto result = assign_non_colliding_hops(candidates);
+    ASSERT_TRUE(result.has_value());
+    expect_valid_assignment(candidates, *result);
+}
+
+TEST(BlitzDecodePipelineAssignment, RequiresBacktracking) {
+    // hop0's first candidate (A,B) consumes both nodes that hop2's two candidates need, so the solver
+    // must undo hop0's first choice and take (C,D). (hop1 is most-constrained, visited first by MRV.)
+    const FabricNodeId A = node(0, 0), B = node(1, 0), C = node(0, 1), D = node(1, 1);
+    const FabricNodeId E = node(2, 0), F = node(2, 1), G = node(3, 0), H = node(3, 1);
+    const std::vector<std::vector<HopPair>> candidates = {
+        {{A, B}, {C, D}},
+        {{E, F}},
+        {{A, G}, {B, H}},
+    };
+    EXPECT_FALSE(greedy_first_fit_succeeds(candidates)) << "input should require backtracking";
+    auto result = assign_non_colliding_hops(candidates);
+    ASSERT_TRUE(result.has_value());
+    expect_valid_assignment(candidates, *result);
+    EXPECT_EQ((*result)[0], (HopPair{C, D})) << "hop0 should be forced onto its second candidate";
+}
+
+TEST(BlitzDecodePipelineAssignment, InfeasibleNodeReuse) {
+    // Both hops can only use node(0,0) -> no collision-free assignment.
+    const std::vector<std::vector<HopPair>> candidates = {
+        {{node(0, 0), node(1, 0)}},
+        {{node(0, 0), node(2, 0)}},
+    };
+    EXPECT_FALSE(assign_non_colliding_hops(candidates).has_value());
+}
+
+TEST(BlitzDecodePipelineAssignment, InfeasibleEmptyHop) {
+    const std::vector<std::vector<HopPair>> candidates = {
+        {{node(0, 0), node(1, 0)}},
+        {},  // no inter-mesh cable available for this hop
+    };
+    EXPECT_FALSE(assign_non_colliding_hops(candidates).has_value());
+}
+
+TEST(BlitzDecodePipelineAssignment, ResolvesEvenRingContention) {
+    // Ring of N meshes, 2 chips each, 2 candidate cables per boundary (a->a, b->b). Adjacent hops share
+    // a mesh, so a valid layout must strictly alternate a,b around the ring -- solvable for even N.
+    // Simulates the tight decode ring where naive ordering strands a mid-chain hop.
+    const std::uint32_t N = 8;
+    std::vector<std::vector<HopPair>> candidates(N);
+    for (std::uint32_t i = 0; i < N; i++) {
+        const std::uint32_t next = (i + 1) % N;
+        candidates[i] = {{node(i, 0), node(next, 0)}, {node(i, 1), node(next, 1)}};
+    }
+    auto result = assign_non_colliding_hops(candidates);
+    ASSERT_TRUE(result.has_value());
+    expect_valid_assignment(candidates, *result);
+}
+
+TEST(BlitzDecodePipelineAssignment, InfeasibleOddRingTwoCables) {
+    // Same structure with odd N: strict a/b alternation cannot close the ring -> genuinely infeasible.
+    const std::uint32_t N = 3;
+    std::vector<std::vector<HopPair>> candidates(N);
+    for (std::uint32_t i = 0; i < N; i++) {
+        const std::uint32_t next = (i + 1) % N;
+        candidates[i] = {{node(i, 0), node(next, 0)}, {node(i, 1), node(next, 1)}};
+    }
+    EXPECT_FALSE(assign_non_colliding_hops(candidates).has_value());
+}
+
+}  // namespace blitz_assign_tests
 }  // namespace tt::tt_fabric::fabric_router_tests

--- a/tt_metal/api/tt-metalium/experimental/blitz_decode_pipeline.hpp
+++ b/tt_metal/api/tt-metalium/experimental/blitz_decode_pipeline.hpp
@@ -5,9 +5,12 @@
 #pragma once
 
 #include <cstddef>
+#include <optional>
+#include <utility>
 #include <vector>
 
 #include <tt-metalium/mesh_coord.hpp>
+#include <tt-metalium/experimental/fabric/fabric_types.hpp>
 
 namespace tt::tt_metal::experimental::blitz {
 
@@ -18,5 +21,22 @@ struct BlitzDecodePipelineStage {
 };
 
 std::vector<BlitzDecodePipelineStage> generate_blitz_decode_pipeline(bool initialize_loopback = true);
+
+namespace detail {
+
+// Choose one (exit, peer) FabricNodeId pair per hop such that no node is reused across hops.
+// `candidates[i]` are the candidate pairs for ring-position hop i; returns the chosen pairs in hop
+// order, or std::nullopt if no collision-free assignment exists (any hop empty, or overconstrained).
+//
+// Exposed for unit testing (pure, CPU-only, no control plane). build_pipeline_from_topology() uses
+// this to lay out the inter-mesh ring: per-hop greedy first-fit can strand a mid-chain hop on tight
+// rings (few cable pairs per boundary), so this does a backtracking global assignment (system of
+// distinct representatives, most-constrained-hop-first) that succeeds whenever a valid layout exists.
+std::optional<std::vector<std::pair<::tt::tt_fabric::FabricNodeId, ::tt::tt_fabric::FabricNodeId>>>
+assign_non_colliding_hops(
+    const std::vector<std::vector<std::pair<::tt::tt_fabric::FabricNodeId, ::tt::tt_fabric::FabricNodeId>>>&
+        candidates);
+
+}  // namespace detail
 
 }  // namespace tt::tt_metal::experimental::blitz

--- a/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
+++ b/tt_metal/distributed/experimental/blitz_decode_pipeline.cpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
+#include <functional>
 #include <map>
 #include <optional>
 #include <set>
@@ -60,36 +61,43 @@ std::vector<BlitzDecodePipelineStage> build_pipeline_from_topology(bool initiali
     // When selecting a pair for each hop, skip any pair that would reuse an already-claimed node.
     std::set<tt::tt_fabric::FabricNodeId> used_nodes;
 
-    // Select one inter-mesh pair per hop, avoiding collisions.
+    // Select one inter-mesh pair per hop such that NO FabricNodeId is reused across hops.
     // With loopback:    N hops: mesh_0→mesh_1→...→mesh_{N-1}→mesh_0
     // Without loopback: N-1 hops: mesh_0→mesh_1→...→mesh_{N-1} (no return)
+    //
+    // This is a system-of-distinct-representatives problem: per-hop greedy first-fit can strand a later
+    // hop by claiming a chip that hop's only remaining candidate needs (common on rings where each
+    // inter-mesh boundary exposes very few cable pairs, e.g. a large LINE-dimension ring). Solve it with
+    // backtracking over all hops, trying the most-constrained hop first (minimum remaining values) so a
+    // valid assignment is found whenever one exists.
     const std::size_t num_hops = initialize_loopback ? num_meshes : num_meshes - 1;
-    std::vector<std::pair<tt::tt_fabric::FabricNodeId, tt::tt_fabric::FabricNodeId>> hops;
-    hops.reserve(num_hops);
+    using HopPair = std::pair<tt::tt_fabric::FabricNodeId, tt::tt_fabric::FabricNodeId>;
+
+    // Gather candidate exit/peer pairs for every hop, indexed by ring position.
+    std::vector<std::vector<HopPair>> candidates(num_hops);
     for (std::size_t i = 0; i < num_hops; i++) {
         const auto next = initialize_loopback ? (i + 1) % num_meshes : i + 1;
-        auto pairs =
+        candidates[i] =
             control_plane.get_intermesh_exit_peer_fabric_node_id_pairs_between_meshes(mesh_ids[i], mesh_ids[next]);
-        TT_FATAL(!pairs.empty(), "No inter-mesh connection from mesh {} to mesh {}", *mesh_ids[i], *mesh_ids[next]);
-
-        bool found = false;
-        for (const auto& pair : pairs) {
-            if (used_nodes.contains(pair.first) || used_nodes.contains(pair.second)) {
-                continue;
-            }
-            hops.push_back(pair);
-            used_nodes.insert(pair.first);
-            used_nodes.insert(pair.second);
-            found = true;
-            break;
-        }
         TT_FATAL(
-            found,
-            "No non-colliding inter-mesh pair from mesh {} to mesh {} "
-            "(all {} candidate pairs overlap with already-claimed nodes)",
-            *mesh_ids[i],
-            *mesh_ids[next],
-            pairs.size());
+            !candidates[i].empty(), "No inter-mesh connection from mesh {} to mesh {}", *mesh_ids[i], *mesh_ids[next]);
+    }
+
+    // Resolve a collision-free pair for every hop. Greedy first-fit can strand a mid-chain hop on
+    // rings with few cable pairs per boundary, so detail::assign_non_colliding_hops() does a
+    // backtracking global assignment that succeeds whenever a valid layout exists.
+    auto assignment = detail::assign_non_colliding_hops(candidates);
+    TT_FATAL(
+        assignment.has_value(),
+        "Could not assign non-colliding inter-mesh pairs for all {} hops of the blitz decode pipeline ring "
+        "(each hop needs a distinct exit/peer chip pair; the inter-mesh cabling is overconstrained for this MGD).",
+        num_hops);
+    std::vector<HopPair>& hops = *assignment;
+
+    // Mark all chosen nodes used; the downstream mesh_0 entry/loopback search relies on `used_nodes`.
+    for (const auto& [exit_node, peer_node] : hops) {
+        used_nodes.insert(exit_node);
+        used_nodes.insert(peer_node);
     }
 
     // Pipeline data flow (with loopback):
@@ -672,6 +680,61 @@ void validate_pipeline(const std::vector<BlitzDecodePipelineStage>& stages, bool
 }
 
 }  // namespace
+
+namespace detail {
+
+std::optional<std::vector<std::pair<tt::tt_fabric::FabricNodeId, tt::tt_fabric::FabricNodeId>>>
+assign_non_colliding_hops(
+    const std::vector<std::vector<std::pair<tt::tt_fabric::FabricNodeId, tt::tt_fabric::FabricNodeId>>>& candidates) {
+    using HopPair = std::pair<tt::tt_fabric::FabricNodeId, tt::tt_fabric::FabricNodeId>;
+    const std::size_t num_hops = candidates.size();
+
+    // Visit the most-constrained hops first (fewest candidates) so the search prunes quickly.
+    std::vector<std::size_t> visit_order(num_hops);
+    for (std::size_t i = 0; i < num_hops; i++) {
+        visit_order[i] = i;
+    }
+    std::stable_sort(visit_order.begin(), visit_order.end(), [&](std::size_t a, std::size_t b) {
+        return candidates[a].size() < candidates[b].size();
+    });
+
+    // selected_hop[i] = chosen (exit, peer) pair for ring position i.
+    std::vector<std::optional<HopPair>> selected_hop(num_hops);
+    std::set<tt::tt_fabric::FabricNodeId> used_nodes;
+    std::function<bool(std::size_t)> assign = [&](std::size_t k) -> bool {
+        if (k == num_hops) {
+            return true;
+        }
+        const std::size_t hop = visit_order[k];
+        for (const auto& pair : candidates[hop]) {
+            if (used_nodes.contains(pair.first) || used_nodes.contains(pair.second)) {
+                continue;
+            }
+            selected_hop[hop] = pair;
+            used_nodes.insert(pair.first);
+            used_nodes.insert(pair.second);
+            if (assign(k + 1)) {
+                return true;
+            }
+            used_nodes.erase(pair.first);
+            used_nodes.erase(pair.second);
+            selected_hop[hop].reset();
+        }
+        return false;
+    };
+    if (!assign(0)) {
+        return std::nullopt;
+    }
+
+    std::vector<HopPair> hops;
+    hops.reserve(num_hops);
+    for (auto& hop : selected_hop) {
+        hops.push_back(*hop);
+    }
+    return hops;
+}
+
+}  // namespace detail
 
 std::vector<BlitzDecodePipelineStage> generate_blitz_decode_pipeline(bool initialize_loopback) {
     auto stages = build_pipeline_from_topology(initialize_loopback);


### PR DESCRIPTION
## What
Fix + tests for the blitz decode pipeline's inter-mesh hop allocator, on `blaze-metal-main`.

`build_pipeline_from_topology()` chose one inter-mesh exit/peer pair per hop with **greedy first-fit in ring order**. On rings where each boundary exposes very few candidate cable pairs (e.g. the **64-mesh 110C decode ring**), greedy can claim a chip a *later* hop's only pair needs, stranding a mid-chain hop:

```
TT_FATAL: No non-colliding inter-mesh pair from mesh 15 to mesh 16
          (all 2 candidate pairs overlap with already-claimed nodes)
```

## Fix
- Extracted the assignment into **`detail::assign_non_colliding_hops`** (pure, no control plane).
- Replaced greedy with a **backtracking global assignment** (system of distinct representatives, most-constrained-hop-first / MRV). Finds a valid layout whenever one exists; fails with a clear *"overconstrained"* message only if genuinely infeasible.

## Tests (CPU-only, no cluster — `BlitzDecodePipelineAssignment.*`)
| Test | Covers |
|------|--------|
| `NoContentionLinear` | baseline, unique pairs |
| `ResolvesContentionGreedyWouldStrand` | input where old greedy strands a hop; asserts greedy fails + solver succeeds |
| `RequiresBacktracking` | forces the solver to undo a first choice; asserts the forced alternative |
| `InfeasibleNodeReuse` / `InfeasibleEmptyHop` | must report no assignment |
| `ResolvesEvenRingContention` (N=8) | tight ring needing alternating cables — solvable |
| `InfeasibleOddRingTwoCables` (N=3) | same structure, genuinely unsatisfiable |

## Validation
- Builds cleanly on `blaze-metal-main` (full debug build, exit 0).
- All 7 unit tests pass (`fabric_unit_tests --gtest_filter="BlitzDecodePipelineAssignment.*"`, runs instantly, no MPI/cluster).
- Reproduced + (with the fix) resolved on the failing 64-stage 110C topology via `TestBlitzDecodePipelineBuilder`.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=rsong/blitz-decode-ring-closing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:rsong/blitz-decode-ring-closing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=rsong/blitz-decode-ring-closing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:rsong/blitz-decode-ring-closing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=rsong/blitz-decode-ring-closing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:rsong/blitz-decode-ring-closing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=rsong/blitz-decode-ring-closing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:rsong/blitz-decode-ring-closing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=rsong/blitz-decode-ring-closing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:rsong/blitz-decode-ring-closing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=rsong/blitz-decode-ring-closing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:rsong/blitz-decode-ring-closing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=rsong/blitz-decode-ring-closing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:rsong/blitz-decode-ring-closing-fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=rsong/blitz-decode-ring-closing-fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:rsong/blitz-decode-ring-closing-fix)