### PR TITLE
Refactor LLK pack to TensorShape and add WH coverage tables

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_fast_tilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/experimental/llk_pack_fast_tilize_api.h
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include "llk_pack_common_api.h"
 #include "experimental/llk_pack_fast_tilize.h"
 
@@ -15,8 +16,8 @@ inline void llk_pack_fast_tilize_init(
     const std::uint32_t input_operand, const std::uint32_t pack_output, const std::uint32_t unit_dim) {
     const std::uint8_t output_id = get_output_id(pack_output);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
-    const uint32_t use_32bit_dest =
-        pack_src_format[output_id] == (uint)DataFormat::Float32 || pack_src_format[output_id] == (uint)DataFormat::Tf32;
+    const std::uint32_t use_32bit_dest = pack_src_format[output_id] == (std::uint32_t)DataFormat::Float32 ||
+                                         pack_src_format[output_id] == (std::uint32_t)DataFormat::Tf32;
     _llk_pack_fast_tilize_init_<DST_SYNC_MODE, DST_ACCUM_MODE>(
         use_32bit_dest, pack_dst_format[output_id], unit_dim, num_faces, pack_src_format[output_id]);
 }
@@ -24,10 +25,9 @@ inline void llk_pack_fast_tilize_init(
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_fast_tilize_uninit(const std::uint32_t pack_output) {
     const std::uint32_t output_id = get_output_id(pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
+    const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
     _llk_pack_fast_tilize_uninit_<DST_SYNC_MODE, is_fp32_dest_acc_en>(
-        pack_dst_format[output_id], face_r_dim, num_faces, pack_src_format[output_id]);
+        pack_dst_format[output_id], tensor_shape, pack_src_format[output_id]);
 }
 
 inline void llk_pack_fast_tilize_reinit_unit_dim(const std::uint32_t pack_output, const std::uint32_t new_unit_dim) {

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_common_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "internal/circular_buffer_interface.h"
 #include "ckernel.h"
 #include "ckernel_globals.h"
@@ -34,9 +35,7 @@ inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_ac
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_hw_configure(std::uint32_t pack_output) {
     const std::uint32_t output_id = get_output_id(pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
+    const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
     const bool partial_face = get_output_partial_face(output_id);
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
@@ -45,9 +44,7 @@ inline void llk_pack_hw_configure(std::uint32_t pack_output) {
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
-        face_r_dim,
-        tile_c_dim,
-        num_faces,
+        tensor_shape,
         partial_face,
         0 /*relu_config*/);
 }
@@ -147,15 +144,13 @@ inline void llk_pack_dest_init([[maybe_unused]] const std::uint32_t pack_output 
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
-    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
+    const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
 
     _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,
-        tile_c_dim,
-        num_faces,
+        tensor_shape,
         false /* partial_face */);
 }
 
@@ -174,16 +169,14 @@ template <bool is_fp32_dest_acc_en>
     "Face geometry is now derived from the output CB metadata; use the "
     "llk_pack_reconfig_data_format(const std::uint32_t) overload instead.")]] inline void
 llk_pack_reconfig_data_format_disaggregated(
-    const std::uint32_t new_output, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4) {
+    const std::uint32_t new_output, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE) {
     const std::uint32_t output_id = get_output_id(new_output);
-    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
 
     _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,
-        tile_c_dim,
-        num_faces,
+        tensor_shape,
         false /* partial_face */);
 }
 
@@ -202,8 +195,8 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const 
     std::uint32_t new_output_id = get_output_id(new_output);
 
     if ((pack_dst_format[old_output_id] != pack_dst_format[new_output_id]) &&
-        (pack_dst_format[old_output_id] != (uint)DataFormat::Invalid) &&
-        (pack_dst_format[new_output_id] != (uint)DataFormat::Invalid)) {
+        (pack_dst_format[old_output_id] != (std::uint32_t)DataFormat::Invalid) &&
+        (pack_dst_format[new_output_id] != (std::uint32_t)DataFormat::Invalid)) {
         llk_pack_reconfig_data_format<is_fp32_dest_acc_en>(new_output);
     }
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_tile_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_pack_common_api.h"
 
 /*************************************************************************
@@ -18,9 +19,7 @@ inline void llk_pack_init(
     const std::uint32_t pack_output = 16, std::uint32_t num_tiles = 1, const std::uint32_t input_operand = 0) {
     // TODO (https://github.com/tenstorrent/tt-metal/issues/18948): Revisit for narrow_tile
     const std::uint32_t output_id = get_output_id(pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
+    const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
 
     if constexpr (!skip_addrmod_config) {
         LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
@@ -31,7 +30,7 @@ inline void llk_pack_init(
     const std::uint32_t src_format = static_cast<std::uint32_t>(unpack_src_format[input_operand]);
     const bool is_input_8bit_format = IS_8BIT_FORMAT(src_format);
     _llk_pack_init_<pack_mode, zero_output, skip_addrmod_config, skip_packer_strides>(
-        pack_src_format[output_id], face_r_dim, tile_c_dim, num_faces, num_tiles, is_input_8bit_format);
+        pack_src_format[output_id], tensor_shape, num_tiles, is_input_8bit_format);
 }
 
 template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, PackMode pack_mode = PackMode::Default>
@@ -54,7 +53,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
 
 template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, PackMode pack_mode = PackMode::Default>
 inline void llk_matmul_pack(
-    std::uint32_t start_tile_index, std::uint32_t output, uint32_t ntiles, std::uint32_t output_tile_index = 0) {
+    std::uint32_t start_tile_index, std::uint32_t output, std::uint32_t ntiles, std::uint32_t output_tile_index = 0) {
     std::uint8_t output_id = get_output_id(output);
 
     static_assert(
@@ -64,7 +63,7 @@ inline void llk_matmul_pack(
         ((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
         "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
-    for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
+    for (std::uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         std::uint32_t pack_tile_addr =
             get_output_tile_address<out_of_order_output, pack_mode>(output_id, output_tile_index);
 

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_pack_untilize_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_pack_common_api.h"
 #include "llk_pack_untilize.h"
 #include "llk_param_structs.h"
@@ -27,9 +28,7 @@
 template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
 inline void llk_pack_untilize_hw_configure(const llk_pack_params_t* pack_params) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
-    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
+    const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
     const bool partial_face = get_output_partial_face(output_id);
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
@@ -38,9 +37,7 @@ inline void llk_pack_untilize_hw_configure(const llk_pack_params_t* pack_params)
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
-        face_r_dim,
-        tile_c_dim,
-        num_faces,
+        tensor_shape,
         partial_face,
         pack_params->relu_config.val);
 }
@@ -63,7 +60,6 @@ template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
 llk_pack_untilize_hw_configure(
     const llk_pack_params_t* pack_params, const std::uint32_t face_r_dim, const std::uint32_t num_faces) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
-    const std::uint32_t tile_c_dim = get_output_tile_c_dim(output_id);
     const bool partial_face = get_output_partial_face(output_id);
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
@@ -72,9 +68,8 @@ llk_pack_untilize_hw_configure(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
-        face_r_dim,
-        tile_c_dim,
-        num_faces,
+        ckernel::make_tensor_shape_from_legacy(
+            static_cast<std::uint8_t>(face_r_dim), static_cast<std::uint8_t>(num_faces)),
         partial_face,
         pack_params->relu_config.val);
 }
@@ -220,7 +215,7 @@ template <
     bool diagonal = false /* unused */,
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM /* unused */,
-    uint32_t tile_dst_ct_offset = 0,
+    std::uint32_t tile_dst_ct_offset = 0,
     bool dense = false>
 inline void llk_pack_untilize(
     std::uint32_t block_rt_dim,
@@ -274,7 +269,7 @@ template <
     bool diagonal = false /* unused */,
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM /* unused */,
-    uint32_t tile_dst_ct_offset = 0,
+    std::uint32_t tile_dst_ct_offset = 0,
     bool dense = false>
 [[deprecated(
     "Face geometry is now derived from the output CB metadata; use the "

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -20,8 +20,7 @@ inline void llk_unpack_A_init(
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
 
     const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
     const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
@@ -33,13 +32,15 @@ inline void llk_unpack_A_init(
     LLK_ASSERT_BLOCK((is_unpacker_A_configured_correctly<
                       UnpackerProgramType::ProgramByTile,
                       (BType != BroadcastType::NONE && !unpack_to_dest)>(
-        operand_unpack_src_format, operand_unpack_dst_format, face_r_dim, num_faces)));
+        operand_unpack_src_format,
+        operand_unpack_dst_format,
+        tensor_shape.face_r_dim,
+        tensor_shape.total_num_faces())));
 
     _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,
         within_face_16x16_transpose,
-        face_r_dim,
-        num_faces,
+        tensor_shape,
         operand_unpack_src_format,
         operand_unpack_dst_format);
 }

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_outputs.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_io/llk_outputs.h
@@ -5,11 +5,13 @@
 #pragma once
 #include <cstdint>
 
-// Metal specific overrides -- No support for partial tiles so hard-code to fixed 32x32 sizes
-inline uint32_t get_output_id(uint32_t output) { return (output); }
+#include "tensor_shape.h"
 
-inline const uint32_t get_output_base_id() {
-    const uint32_t OUTPUT_BASE_ID = 16;
+// Metal specific overrides -- No support for partial tiles so hard-code to fixed 32x32 sizes
+inline std::uint32_t get_output_id(std::uint32_t output) { return (output); }
+
+inline const std::uint32_t get_output_base_id() {
+    const std::uint32_t OUTPUT_BASE_ID = 16;
     return (OUTPUT_BASE_ID);
 }
 
@@ -17,26 +19,34 @@ inline const unsigned char get_output_src_format(const std::uint32_t output_id) 
 
 inline const unsigned char get_output_dst_format(const std::uint32_t output_id) { return pack_dst_format[output_id]; }
 
-inline const uint32_t get_output_num_faces(const std::uint32_t output_id) {
-    return (uint32_t)pack_tile_num_faces[output_id];
+inline const std::uint32_t get_output_num_faces(const std::uint32_t output_id) {
+    return (std::uint32_t)pack_tile_num_faces[output_id];
 }
 
-inline const uint32_t get_output_partial_face(const std::uint32_t output_id) {
-    return (uint32_t)pack_partial_face[output_id];
+inline const std::uint32_t get_output_partial_face(const std::uint32_t output_id) {
+    return (std::uint32_t)pack_partial_face[output_id];
 }
 
-inline const uint32_t get_output_face_r_dim(const std::uint32_t output_id) {
-    return (uint32_t)pack_tile_face_r_dim[output_id];
+inline const std::uint32_t get_output_face_r_dim(const std::uint32_t output_id) {
+    return (std::uint32_t)pack_tile_face_r_dim[output_id];
 }
 
-inline const uint32_t get_output_narrow_tile(const std::uint32_t output_id) {
-    return (uint32_t)pack_narrow_tile[output_id];
+inline const std::uint32_t get_output_narrow_tile(const std::uint32_t output_id) {
+    return (std::uint32_t)pack_narrow_tile[output_id];
 }
 
-inline const uint32_t get_output_tile_r_dim(const std::uint32_t output_id) {
-    return (uint32_t)pack_tile_r_dim[output_id];
+inline const std::uint32_t get_output_tile_r_dim(const std::uint32_t output_id) {
+    return (std::uint32_t)pack_tile_r_dim[output_id];
 }
 
-inline const uint32_t get_output_tile_c_dim(const std::uint32_t output_id) {
-    return (uint32_t)pack_tile_c_dim[output_id];
+inline const std::uint32_t get_output_tile_c_dim(const std::uint32_t output_id) {
+    return (std::uint32_t)pack_tile_c_dim[output_id];
+}
+
+inline ckernel::TensorShape get_output_tensor_shape(const std::uint32_t output_id) {
+    return ckernel::TensorShape{
+        pack_tile_face_r_dim[output_id],
+        ckernel::MAX_FACE_C_DIM,
+        pack_num_faces_r_dim[output_id],
+        pack_num_faces_c_dim[output_id]};
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_common_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_common_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "ckernel.h"
 #include "ckernel_globals.h"
 #include "internal/circular_buffer_interface.h"
@@ -33,10 +34,8 @@ inline void llk_pack_set_fp32_dest_acc(bool enable) { _llk_pack_set_fp32_dest_ac
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_hw_configure(std::uint32_t pack_output) {
     const std::uint32_t output_id = get_output_id(pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
+    const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
     const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
@@ -44,10 +43,8 @@ inline void llk_pack_hw_configure(std::uint32_t pack_output) {
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
-        face_r_dim,
-        num_faces,
+        tensor_shape,
         partial_face,
-        narrow_tile,
         0 /*relu_config*/);
 }
 
@@ -168,19 +165,15 @@ inline void llk_pack_dest_init(const std::uint32_t pack_output = 16) {
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_reconfig_data_format(const std::uint32_t new_output) {
     const std::uint32_t output_id = get_output_id(new_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
+    const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
     const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
     _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,
-        face_r_dim,
-        num_faces,
-        partial_face,
-        narrow_tile);
+        tensor_shape,
+        partial_face);
 }
 
 /**
@@ -198,19 +191,16 @@ template <bool is_fp32_dest_acc_en>
     "Face geometry is now derived from the output CB metadata; use the "
     "llk_pack_reconfig_data_format(const std::uint32_t) overload instead.")]] inline void
 llk_pack_reconfig_data_format_disaggregated(
-    const std::uint32_t new_output, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4) {
+    const std::uint32_t new_output, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE) {
     const std::uint32_t output_id = get_output_id(new_output);
     const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
     _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         get_local_cb_interface(output_id).fifo_page_size,
-        face_r_dim,
-        num_faces,
-        partial_face,
-        narrow_tile);
+        tensor_shape,
+        partial_face);
 }
 
 /**
@@ -228,8 +218,8 @@ inline void llk_pack_reconfig_data_format(const std::uint32_t old_output, const 
     std::uint32_t new_output_id = get_output_id(new_output);
 
     if ((pack_dst_format[old_output_id] != pack_dst_format[new_output_id]) &&
-        (pack_dst_format[old_output_id] != (uint)DataFormat::Invalid) &&
-        (pack_dst_format[new_output_id] != (uint)DataFormat::Invalid)) {
+        (pack_dst_format[old_output_id] != (std::uint32_t)DataFormat::Invalid) &&
+        (pack_dst_format[new_output_id] != (std::uint32_t)DataFormat::Invalid)) {
         llk_pack_reconfig_data_format<is_fp32_dest_acc_en>(new_output);
     }
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_fast_tilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_fast_tilize_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_pack_common_api.h"
 #include "llk_pack_fast_tilize.h"
 
@@ -16,8 +17,8 @@ inline void llk_pack_fast_tilize_init(
     const std::uint8_t output_id = get_output_id(pack_output);
     const std::uint32_t num_faces = get_output_num_faces(output_id);
 
-    const uint32_t use_32bit_dest =
-        pack_src_format[input_id] == (uint)DataFormat::Float32 || pack_src_format[input_id] == (uint)DataFormat::Tf32;
+    const std::uint32_t use_32bit_dest = pack_src_format[input_id] == (std::uint32_t)DataFormat::Float32 ||
+                                         pack_src_format[input_id] == (std::uint32_t)DataFormat::Tf32;
 
     LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
 
@@ -27,13 +28,11 @@ inline void llk_pack_fast_tilize_init(
 template <bool is_fp32_dest_acc_en>
 inline void llk_pack_fast_tilize_uninit(const std::uint32_t pack_output) {
     const std::uint32_t output_id = get_output_id(pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
+    const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
     const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
     _llk_pack_fast_tilize_uninit_<DST_SYNC_MODE, is_fp32_dest_acc_en>(
-        pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile);
+        pack_dst_format[output_id], tensor_shape, partial_face);
 }
 
 inline void llk_pack_fast_tilize_block(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_tile_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_tile_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_pack_common_api.h"
 
 /*************************************************************************
@@ -19,17 +20,15 @@ inline void llk_pack_init(const std::uint32_t pack_output = 16, std::uint32_t nu
         pack_mode == PackMode::Default || pack_mode == PackMode::Untilize,
         "Wormhole B0: pack init supports PackMode::Default and PackMode::Untilize only");
     const std::uint32_t output_id = get_output_id(pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
+    const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
     const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
     if constexpr (!skip_addrmod_config) {
         LLK_ASSERT_BLOCK(are_packers_configured_correctly(pack_src_format[output_id], pack_dst_format[output_id]));
     }
 
     _llk_pack_init_<pack_mode, zero_output, skip_addrmod_config, skip_packer_strides>(
-        pack_dst_format[output_id], face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
+        pack_dst_format[output_id], tensor_shape, partial_face, num_tiles);
 }
 
 template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, PackMode pack_mode = PackMode::Default>
@@ -53,7 +52,7 @@ inline void llk_pack(std::uint32_t tile_index, std::uint32_t output, std::uint32
 
 template <bool is_fp32_dest_acc_en, bool out_of_order_output = false, PackMode pack_mode = PackMode::Default>
 inline void llk_matmul_pack(
-    std::uint32_t start_tile_index, std::uint32_t output, uint32_t ntiles, std::uint32_t output_tile_index = 0) {
+    std::uint32_t start_tile_index, std::uint32_t output, std::uint32_t ntiles, std::uint32_t output_tile_index = 0) {
     std::uint8_t output_id = get_output_id(output);
 
     static_assert(
@@ -63,7 +62,7 @@ inline void llk_matmul_pack(
         ((start_tile_index + ntiles - 1) < get_pack_dest_max_tiles<DST_SYNC_MODE, DST_ACCUM_MODE>()),
         "Dst tile exceeds packer destination capacity for the configured W-stride.");
 
-    for (uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
+    for (std::uint32_t tile_index = start_tile_index; tile_index < start_tile_index + ntiles; tile_index++) {
         std::uint32_t pack_tile_addr =
             get_output_tile_address<out_of_order_output, pack_mode>(output_id, output_tile_index);
 

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_pack_untilize_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_pack_common_api.h"
 #include "llk_pack_untilize.h"
 #include "llk_param_structs.h"
@@ -27,10 +28,8 @@
 template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
 inline void llk_pack_untilize_hw_configure(const llk_pack_params_t* pack_params) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
-    const std::uint32_t face_r_dim = get_output_face_r_dim(output_id);
-    const std::uint32_t num_faces = get_output_num_faces(output_id);
+    const ckernel::TensorShape tensor_shape = get_output_tensor_shape(output_id);
     const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
@@ -38,10 +37,8 @@ inline void llk_pack_untilize_hw_configure(const llk_pack_params_t* pack_params)
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
-        face_r_dim,
-        num_faces,
+        tensor_shape,
         partial_face,
-        narrow_tile,
         pack_params->relu_config.val);
 }
 
@@ -64,7 +61,6 @@ llk_pack_untilize_hw_configure(
     const llk_pack_params_t* pack_params, const std::uint32_t face_r_dim, const std::uint32_t num_faces) {
     const std::uint32_t output_id = get_output_id(pack_params->pack_output);
     const bool partial_face = get_output_partial_face(output_id);
-    const bool narrow_tile = get_output_narrow_tile(output_id);
 
     const std::uint32_t tile_size = get_local_cb_interface(output_id).fifo_page_size;
 
@@ -72,10 +68,9 @@ llk_pack_untilize_hw_configure(
         pack_src_format[output_id],
         pack_dst_format[output_id],
         tile_size,
-        face_r_dim,
-        num_faces,
+        ckernel::make_tensor_shape_from_legacy(
+            static_cast<std::uint8_t>(face_r_dim), static_cast<std::uint8_t>(num_faces)),
         partial_face,
-        narrow_tile,
         pack_params->relu_config.val);
 }
 
@@ -209,7 +204,7 @@ template <
     bool diagonal = false,
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM,
-    uint32_t tile_dst_ct_offset = 0,
+    std::uint32_t tile_dst_ct_offset = 0,
     bool dense = false>
 inline void llk_pack_untilize(
     std::uint32_t block_rt_dim,
@@ -263,7 +258,7 @@ template <
     bool diagonal = false,
     bool narrow_row = false,
     std::uint32_t row_num_datums = TILE_C_DIM,
-    uint32_t tile_dst_ct_offset = 0,
+    std::uint32_t tile_dst_ct_offset = 0,
     bool dense = false>
 [[deprecated(
     "Face geometry is now derived from the output CB metadata; use the "

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -20,8 +20,7 @@ inline void llk_unpack_A_init(
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
 
     const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
     const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
@@ -29,13 +28,15 @@ inline void llk_unpack_A_init(
     LLK_ASSERT_BLOCK((is_unpacker_A_configured_correctly<
                       UnpackerProgramType::ProgramByTile,
                       (BType != BroadcastType::NONE && !unpack_to_dest)>(
-        operand_unpack_src_format, operand_unpack_dst_format, face_r_dim, num_faces)));
+        operand_unpack_src_format,
+        operand_unpack_dst_format,
+        tensor_shape.face_r_dim,
+        tensor_shape.total_num_faces())));
 
     _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,
         within_face_16x16_transpose,
-        face_r_dim,
-        num_faces,
+        tensor_shape,
         operand_unpack_src_format,
         operand_unpack_dst_format);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_outputs.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_io/llk_outputs.h
@@ -5,11 +5,13 @@
 #pragma once
 #include <cstdint>
 
-// Metal specific overrides -- No support for partial tiles so hard-code to fixed 32x32 sizes
-inline uint32_t get_output_id(uint32_t output) { return (output); }
+#include "tensor_shape.h"
 
-inline const uint32_t get_output_base_id() {
-    const uint32_t OUTPUT_BASE_ID = 16;
+// Metal specific overrides -- No support for partial tiles so hard-code to fixed 32x32 sizes
+inline std::uint32_t get_output_id(std::uint32_t output) { return (output); }
+
+inline const std::uint32_t get_output_base_id() {
+    const std::uint32_t OUTPUT_BASE_ID = 16;
     return (OUTPUT_BASE_ID);
 }
 
@@ -17,26 +19,34 @@ inline const unsigned char get_output_src_format(const std::uint32_t output_id) 
 
 inline const unsigned char get_output_dst_format(const std::uint32_t output_id) { return pack_dst_format[output_id]; }
 
-inline const uint32_t get_output_num_faces(const std::uint32_t output_id) {
-    return (uint32_t)pack_tile_num_faces[output_id];
+inline const std::uint32_t get_output_num_faces(const std::uint32_t output_id) {
+    return (std::uint32_t)pack_tile_num_faces[output_id];
 }
 
-inline const uint32_t get_output_partial_face(const std::uint32_t output_id) {
-    return (uint32_t)pack_partial_face[output_id];
+inline const std::uint32_t get_output_partial_face(const std::uint32_t output_id) {
+    return (std::uint32_t)pack_partial_face[output_id];
 }
 
-inline const uint32_t get_output_face_r_dim(const std::uint32_t output_id) {
-    return (uint32_t)pack_tile_face_r_dim[output_id];
+inline const std::uint32_t get_output_face_r_dim(const std::uint32_t output_id) {
+    return (std::uint32_t)pack_tile_face_r_dim[output_id];
 }
 
-inline const uint32_t get_output_narrow_tile(const std::uint32_t output_id) {
-    return (uint32_t)pack_narrow_tile[output_id];
+inline const std::uint32_t get_output_narrow_tile(const std::uint32_t output_id) {
+    return (std::uint32_t)pack_narrow_tile[output_id];
 }
 
-inline const uint32_t get_output_tile_r_dim(const std::uint32_t output_id) {
-    return (uint32_t)pack_tile_r_dim[output_id];
+inline const std::uint32_t get_output_tile_r_dim(const std::uint32_t output_id) {
+    return (std::uint32_t)pack_tile_r_dim[output_id];
 }
 
-inline const uint32_t get_output_tile_c_dim(const std::uint32_t output_id) {
-    return (uint32_t)pack_tile_c_dim[output_id];
+inline const std::uint32_t get_output_tile_c_dim(const std::uint32_t output_id) {
+    return (std::uint32_t)pack_tile_c_dim[output_id];
+}
+
+inline ckernel::TensorShape get_output_tensor_shape(const std::uint32_t output_id) {
+    return ckernel::TensorShape{
+        pack_tile_face_r_dim[output_id],
+        ckernel::MAX_FACE_C_DIM,
+        pack_num_faces_r_dim[output_id],
+        pack_num_faces_c_dim[output_id]};
 }

--- a/tt_metal/tt-llk/common/parse.py
+++ b/tt_metal/tt-llk/common/parse.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""TensorShape coverage parser.
+
+Reads loguru per-worker logs (test_run_gw*.log) and extracts
+'[<fn>] tensor_shape: face_r_dim=N face_c_dim=N num_faces_r_dim=N num_faces_c_dim=N'
+lines. Accumulates per-function shape sets into coverage.json.
+
+Usage:
+    parse.py harvest   <test_name>           # consume *.log files into coverage.json
+    parse.py emit      <out_header_path>     # regenerate monolithic coverage header
+    parse.py emit-pack <out_header_path>     # regenerate tensor_shape_coverage_pack.h
+    parse.py summary                         # print per-function summary
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+TT_LLK_COMMON_DIR = Path(__file__).resolve().parent
+PYTHON_TESTS_DIR = TT_LLK_COMMON_DIR.parent / "tests" / "python_tests"
+COVERAGE_JSON = Path("/tmp/ts-coverage/parsed/coverage.json")
+
+# Pack functions registered in tensor_shape_coverage.h TensorShapeFunctionCoverage.
+PACK_FUNCTIONS = (
+    "_llk_pack_hw_configure_",
+    "_llk_pack_init_",
+    "_llk_pack_mop_config_",
+    "_llk_pack_reconfig_data_format_",
+)
+
+DPRINT_RE = re.compile(
+    r"\[(?P<fn>[A-Za-z_][A-Za-z0-9_]*)\] tensor_shape: "
+    r"face_r_dim=(?P<fr>\d+) face_c_dim=(?P<fc>\d+) "
+    r"num_faces_r_dim=(?P<nfr>\d+) num_faces_c_dim=(?P<nfc>\d+)"
+)
+# DEVICE_PRINT emits TensorShapeFunctionCoverage as uint32_t (see tensor_shape.h).
+DPRINT_NUMERIC_FN_RE = re.compile(
+    r"\[(?P<fn_id>\d+)\] tensor_shape: "
+    r"face_r_dim=(?P<fr>\d+) face_c_dim=(?P<fc>\d+) "
+    r"num_faces_r_dim=(?P<nfr>\d+) num_faces_c_dim=(?P<nfc>\d+)"
+)
+
+# Must match TensorShapeFunctionCoverage declaration order in tensor_shape_coverage.h.
+FN_BY_ENUM_ID: dict[int, str] = {
+    0: "_llk_math_eltwise_binary_standard_",
+    1: "_llk_math_eltwise_binary_standard_init_",
+    2: "_llk_math_eltwise_binary_with_dest_reuse_",
+    3: "_llk_math_eltwise_binary_with_dest_reuse_init_",
+    4: "_llk_math_reduce_",
+    5: "_llk_math_reduce_init_",
+    6: "_llk_unpack_AB_init_",
+    7: "_llk_unpack_AB_mop_config_",
+    8: "_llk_unpack_AB_reduce_init_",
+    9: "_llk_unpack_reduce_init_",
+    10: "_llk_unpack_AB_reduce_mop_config_",
+    11: "_llk_unpack_A_init_",
+    12: "_llk_unpack_A_mop_config_",
+    13: "_llk_pack_hw_configure_",
+    14: "_llk_pack_init_",
+    15: "_llk_pack_mop_config_",
+    16: "_llk_pack_reconfig_data_format_",
+    17: "eltwise_binary_configure_mop_standard",
+    18: "eltwise_binary_configure_mop_with_dest_reuse",
+}
+
+# (fr, nfr, nfc) -> constexpr name. face_c_dim is always 16 by HW.
+SHAPE_NAMES = {
+    (fr, nfr, nfc): f"TENSOR_SHAPE_FR{fr}_NF{nfr}x{nfc}"
+    for fr in (1, 2, 4, 8, 16)
+    for nfr in (1, 2)
+    for nfc in (1, 2)
+}
+
+
+def _load_coverage() -> dict:
+    if COVERAGE_JSON.exists():
+        return json.loads(COVERAGE_JSON.read_text())
+    return {"tests": {}, "functions": {}}
+
+
+def _save_coverage(data: dict) -> None:
+    COVERAGE_JSON.parent.mkdir(parents=True, exist_ok=True)
+    COVERAGE_JSON.write_text(json.dumps(data, indent=2, sort_keys=True))
+
+
+def _log_paths() -> list[Path]:
+    """Per-worker logs (xdist) and single-process test_run.log."""
+    paths = sorted(PYTHON_TESTS_DIR.glob("test_run_gw*.log"))
+    single = PYTHON_TESTS_DIR / "test_run.log"
+    if single.exists():
+        paths.append(single)
+    return paths
+
+
+def _parse_dprint_line(
+    m: re.Match, by_fn: dict[str, set[tuple[int, int, int, int]]]
+) -> tuple[str, tuple[int, int, int, int]] | None:
+    if "fn_id" in m.groupdict() and m.group("fn_id") is not None:
+        fn_id = int(m.group("fn_id"))
+        fn = FN_BY_ENUM_ID.get(fn_id)
+        if fn is None:
+            return None
+    else:
+        fn = m.group("fn")
+    shape = (
+        int(m.group("fr")),
+        int(m.group("fc")),
+        int(m.group("nfr")),
+        int(m.group("nfc")),
+    )
+    by_fn.setdefault(fn, set()).add(shape)
+    return fn, shape
+
+
+def _harvest(test_name: str) -> tuple[int, int, int]:
+    """Read worker logs, extract DPRINT lines, persist into coverage.json.
+
+    Returns (lines_seen, shapes_added, function_count_after).
+    """
+    coverage = _load_coverage()
+    by_fn: dict[str, set[tuple[int, int, int, int]]] = {
+        fn: set(tuple(s) for s in shapes)
+        for fn, shapes in coverage["functions"].items()
+    }
+
+    test_lines: set[tuple[str, tuple[int, int, int, int]]] = set()
+    lines_seen = 0
+    for log_path in _log_paths():
+        try:
+            text = log_path.read_text(errors="replace")
+        except Exception:
+            continue
+        for m in DPRINT_RE.finditer(text):
+            lines_seen += 1
+            parsed = _parse_dprint_line(m, by_fn)
+            if parsed:
+                test_lines.add(parsed)
+        for m in DPRINT_NUMERIC_FN_RE.finditer(text):
+            lines_seen += 1
+            parsed = _parse_dprint_line(m, by_fn)
+            if parsed:
+                test_lines.add(parsed)
+
+    shapes_added = 0
+    for fn, shapes in by_fn.items():
+        prev = set(tuple(s) for s in coverage["functions"].get(fn, []))
+        if shapes - prev:
+            shapes_added += len(shapes - prev)
+
+    coverage["functions"] = {fn: sorted(shapes) for fn, shapes in sorted(by_fn.items())}
+    coverage["tests"][test_name] = {
+        "harvested_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "dprint_lines_seen": lines_seen,
+        "unique_fn_shape_pairs": len(test_lines),
+        "functions": sorted(set(fn for fn, _ in test_lines)),
+    }
+    _save_coverage(coverage)
+    return lines_seen, shapes_added, len(by_fn)
+
+
+def _shape_to_literal(fr: int, fc: int, nfr: int, nfc: int) -> tuple[str, bool]:
+    """Return (cpp_literal, is_known_constant)."""
+    if fc == 16 and (fr, nfr, nfc) in SHAPE_NAMES:
+        return SHAPE_NAMES[(fr, nfr, nfc)], True
+    return f"TensorShape{{{fr}, {fc}, {nfr}, {nfc}}}", False
+
+
+def _array_name(fn: str) -> str:
+    """Build a portable C++ identifier from a function name.
+
+    LLK 'internal' functions like _llk_unpack_A_init_ have leading and trailing
+    underscores. Concatenating "<fn>_covered_shapes" would produce reserved
+    identifiers (double underscore anywhere is reserved for the implementation).
+    Strip the leading/trailing underscores and prefix the array consistently.
+    """
+    cleaned = fn.strip("_")
+    return f"covered_shapes_{cleaned}"
+
+
+def _emit(out_path: Path) -> None:
+    coverage = _load_coverage()
+    fns = coverage["functions"]
+    tests_done = sorted(coverage["tests"].keys())
+
+    lines: list[str] = []
+    lines.append("// SPDX-FileCopyrightText: \u00a9 2026 Tenstorrent AI ULC")
+    lines.append("//")
+    lines.append("// SPDX-License-Identifier: Apache-2.0")
+    lines.append("//")
+    lines.append(
+        "// AUTO-GENERATED: per-function TensorShape coverage observed across LLK pytests."
+    )
+    lines.append(
+        "// Sourced from DPRINT lines emitted by LLK_DPRINT_TENSOR_SHAPE in front of"
+    )
+    lines.append(
+        "// LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(...)) call sites."
+    )
+    lines.append("//")
+    lines.append(
+        "// Regenerate by running the BH functional pytests with --logging-level=DEBUG"
+    )
+    lines.append(
+        "// and feeding the per-worker test_run_gw*.log files through /tmp/ts-coverage/parse.py."
+    )
+    lines.append("//")
+    lines.append(
+        f"// Last update : {datetime.now(timezone.utc).isoformat(timespec='seconds')}"
+    )
+    lines.append(f"// Tests run   : {len(tests_done)}")
+    lines.append(f"// Architecture: blackhole")
+    lines.append("")
+    lines.append("#pragma once")
+    lines.append("")
+    lines.append("#include <array>")
+    lines.append("")
+    lines.append('#include "tensor_shape.h"')
+    lines.append("")
+    lines.append(
+        "// The TENSOR_SHAPE_FR*_NF*x* constants this manifest references are themselves"
+    )
+    lines.append(
+        "// gated to ENABLE_LLK_ASSERT or DEBUG_PRINT_ENABLED builds (see tensor_shape.h)."
+    )
+    lines.append(
+        "// Mirror the same gate here so this header stays a no-op when included from a"
+    )
+    lines.append("// production kernel build that defines neither flag.")
+    lines.append("#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)")
+    lines.append("")
+    lines.append("namespace ckernel::coverage")
+    lines.append("{")
+    lines.append("")
+
+    for fn in sorted(fns.keys()):
+        shapes = sorted([tuple(s) for s in fns[fn]])
+        arr = _array_name(fn)
+        lines.append(f"// {fn}: {len(shapes)} unique TensorShape(s)")
+        if not shapes:
+            lines.append(f"inline constexpr std::array<TensorShape, 0> {arr} = {{}};")
+            lines.append("")
+            continue
+        rendered = []
+        any_unknown = False
+        for fr, fc, nfr, nfc in shapes:
+            literal, known = _shape_to_literal(fr, fc, nfr, nfc)
+            tag = (
+                ""
+                if known
+                else "  // out-of-bounds (validate_tensor_shape_tile_dependent_ops_ rejects)"
+            )
+            if not known:
+                any_unknown = True
+            rendered.append((literal, tag, (fr, fc, nfr, nfc)))
+        lines.append(
+            f"inline constexpr std::array<TensorShape, {len(shapes)}> {arr} = {{{{"
+        )
+        for literal, tag, dims in rendered:
+            lines.append(f"    {literal},{tag}")
+        lines.append("}};")
+        if any_unknown:
+            lines.append(
+                "// Note: this function observed shapes outside the validated set; investigate."
+            )
+        lines.append("")
+
+    if not fns:
+        lines.append("// No coverage observed yet. Run the BH functional pytests with")
+        lines.append(
+            "// --logging-level=DEBUG and re-run /tmp/ts-coverage/parse.py emit."
+        )
+        lines.append("")
+
+    lines.append("} // namespace ckernel::coverage")
+    lines.append("")
+    lines.append("#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)")
+    lines.append("")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines))
+
+
+def _emit_shape_arrays(
+    lines: list[str], fn: str, shapes: list[tuple[int, int, int, int]]
+) -> bool:
+    """Append covered_shapes_* array for fn. Returns True if any out-of-bounds shape."""
+    arr = _array_name(fn)
+    lines.append(f"// {fn}: {len(shapes)} unique TensorShape(s)")
+    if not shapes:
+        lines.append(f"inline constexpr std::array<TensorShape, 0> {arr} = {{}};")
+        lines.append("")
+        return False
+
+    any_unknown = False
+    rendered: list[tuple[str, str]] = []
+    for fr, fc, nfr, nfc in shapes:
+        literal, known = _shape_to_literal(fr, fc, nfr, nfc)
+        tag = (
+            ""
+            if known
+            else "  // out-of-bounds (validate_tensor_shape_tile_dependent_ops_ rejects)"
+        )
+        if not known:
+            any_unknown = True
+        rendered.append((literal, tag))
+
+    lines.append(
+        f"inline constexpr std::array<TensorShape, {len(shapes)}> {arr} = {{{{"
+    )
+    for literal, tag in rendered:
+        lines.append(f"    {literal},{tag}")
+    lines.append("}};")
+    if any_unknown:
+        lines.append(
+            "// Note: this function observed shapes outside the validated set; investigate."
+        )
+    lines.append("")
+    return any_unknown
+
+
+def _emit_pack(out_path: Path) -> None:
+    """Write tensor_shape_coverage_pack.h with is_pack_tensor_shape_covered()."""
+    coverage = _load_coverage()
+    all_fns = coverage["functions"]
+    pack_fns = {
+        fn: sorted([tuple(s) for s in all_fns[fn]])
+        for fn in PACK_FUNCTIONS
+        if fn in all_fns
+    }
+    tests_done = sorted(coverage["tests"].keys())
+
+    lines: list[str] = []
+    lines.append("// SPDX-FileCopyrightText: \u00a9 2026 Tenstorrent AI ULC")
+    lines.append("//")
+    lines.append("// SPDX-License-Identifier: Apache-2.0")
+    lines.append("//")
+    lines.append(
+        "// AUTO-GENERATED: pack TensorShape coverage observed across LLK pytests."
+    )
+    lines.append(
+        "// Sourced from DPRINT lines emitted by LLK_VALIDATE_TENSOR_SHAPE_PACK before"
+    )
+    lines.append("// assert_tensor_shape_unobserved_() on uncovered shapes.")
+    lines.append("//")
+    lines.append("// Regenerate: run WH pack pytests with TT_LLK_DISABLE_ASSERTS=1 and")
+    lines.append(
+        "// --logging-level=debug, then parse.py harvest <name> and parse.py emit-pack."
+    )
+    lines.append("//")
+    lines.append(
+        f"// Last update : {datetime.now(timezone.utc).isoformat(timespec='seconds')}"
+    )
+    lines.append(f"// Tests run   : {len(tests_done)}")
+    lines.append("")
+    lines.append("#pragma once")
+    lines.append("")
+    lines.append(
+        "// Match tensor_shape.h's gate so production kernel builds do not see this table."
+    )
+    lines.append("#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)")
+    lines.append("")
+    lines.append("#include <array>")
+    lines.append("")
+    lines.append('#include "tensor_shape_coverage.h"')
+    lines.append("")
+    lines.append("namespace ckernel::coverage")
+    lines.append("{")
+    lines.append("")
+
+    for fn in PACK_FUNCTIONS:
+        shapes = pack_fns.get(fn, [])
+        _emit_shape_arrays(lines, fn, shapes)
+
+    if not any(pack_fns.values()):
+        lines.append("// No pack coverage observed yet. Run WH pack pytests with")
+        lines.append(
+            "// TT_LLK_DISABLE_ASSERTS=1 --logging-level=debug and re-harvest."
+        )
+        lines.append("")
+
+    lines.append("constexpr bool is_pack_tensor_shape_covered(")
+    lines.append(
+        "    const TensorShapeFunctionCoverage fn, const TensorShape& tensor_shape)"
+    )
+    lines.append("{")
+    lines.append("    using Function = TensorShapeFunctionCoverage;")
+    lines.append("    switch (fn)")
+    lines.append("    {")
+    for fn in PACK_FUNCTIONS:
+        arr = _array_name(fn)
+        enum_case = f"Function::{fn}"
+        shapes = pack_fns.get(fn, [])
+        if shapes:
+            lines.append(f"        case {enum_case}:")
+            lines.append(
+                f"            return contains_tensor_shape({arr}, tensor_shape);"
+            )
+    lines.append("        default:")
+    lines.append("            return false;")
+    lines.append("    }")
+    lines.append("}")
+    lines.append("")
+    lines.append("} // namespace ckernel::coverage")
+    lines.append("")
+    lines.append("#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)")
+    lines.append("")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines))
+
+
+def _summary() -> None:
+    coverage = _load_coverage()
+    fns = coverage["functions"]
+    tests = coverage["tests"]
+    print(f"tests harvested: {len(tests)}")
+    for t in sorted(tests):
+        rec = tests[t]
+        print(
+            f"  {t}: {rec['dprint_lines_seen']} dprint lines, "
+            f"{rec['unique_fn_shape_pairs']} unique (fn, shape) pairs"
+        )
+    print(f"\nfunctions seen: {len(fns)}")
+    for fn in sorted(fns):
+        shapes = sorted([tuple(s) for s in fns[fn]])
+        formatted = ", ".join(f"({fr},{fc},{nfr},{nfc})" for fr, fc, nfr, nfc in shapes)
+        print(f"  {fn}: {len(shapes)} shape(s) -> {formatted}")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__)
+        return 1
+    cmd = argv[1]
+    if cmd == "harvest":
+        if len(argv) < 3:
+            print("usage: parse.py harvest <test_name>")
+            return 1
+        lines, added, fn_count = _harvest(argv[2])
+        print(
+            f"[{argv[2]}] dprint lines: {lines}, new shapes added: {added}, "
+            f"total functions tracked: {fn_count}"
+        )
+        return 0
+    if cmd == "emit":
+        if len(argv) < 3:
+            print("usage: parse.py emit <out_header_path>")
+            return 1
+        _emit(Path(argv[2]))
+        print(f"wrote {argv[2]}")
+        return 0
+    if cmd == "emit-pack":
+        if len(argv) < 3:
+            print("usage: parse.py emit-pack <out_header_path>")
+            return 1
+        _emit_pack(Path(argv[2]))
+        print(f"wrote {argv[2]}")
+        return 0
+    if cmd == "summary":
+        _summary()
+        return 0
+    print(f"unknown cmd: {cmd}")
+    print(__doc__)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tt_metal/tt-llk/common/tensor_shape.h
+++ b/tt_metal/tt-llk/common/tensor_shape.h
@@ -78,13 +78,78 @@ static_assert(sizeof(TensorShape) == 4, "TensorShape must be 4 bytes");
 constexpr TensorShape DEFAULT_TENSOR_SHAPE = {MAX_FACE_R_DIM, MAX_FACE_C_DIM, MAX_NUM_FACES_R_DIM, MAX_NUM_FACES_C_DIM};
 
 /**
- * @brief Validates tensor shape for operations that depend on face positioning within a tile.
- * Will start relaxing this constraint once we test larger tensor shapes.
+ * @brief Enumeration of all currently-supported TensorShape values.
  *
- * @param tensor_shape: Tensor shape to validate
- * @return true if tensor shape is valid, false otherwise
+ * Matches validate_tensor_shape_tile_dependent_ops_ plus the per-axis HW limits,
+ * yielding 20 unique shapes. Naming convention:
+ *   TENSOR_SHAPE_FR{face_r_dim}_NF{num_faces_r_dim}x{num_faces_c_dim}
+ *
+ * Kept out of production kernel builds unless asserts or tensor-shape DPRINT
+ * coverage need the table.
+ */
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+// face_r_dim = 1
+constexpr TensorShape TENSOR_SHAPE_FR1_NF1x1 = {1, MAX_FACE_C_DIM, 1, 1}; ///<  1 ×16
+constexpr TensorShape TENSOR_SHAPE_FR1_NF1x2 = {1, MAX_FACE_C_DIM, 1, 2}; ///<  1 ×32
+constexpr TensorShape TENSOR_SHAPE_FR1_NF2x1 = {1, MAX_FACE_C_DIM, 2, 1}; ///<  2 ×16
+constexpr TensorShape TENSOR_SHAPE_FR1_NF2x2 = {1, MAX_FACE_C_DIM, 2, 2}; ///<  2 ×32
+
+// face_r_dim = 2
+constexpr TensorShape TENSOR_SHAPE_FR2_NF1x1 = {2, MAX_FACE_C_DIM, 1, 1}; ///<  2 ×16
+constexpr TensorShape TENSOR_SHAPE_FR2_NF1x2 = {2, MAX_FACE_C_DIM, 1, 2}; ///<  2 ×32
+constexpr TensorShape TENSOR_SHAPE_FR2_NF2x1 = {2, MAX_FACE_C_DIM, 2, 1}; ///<  4 ×16
+constexpr TensorShape TENSOR_SHAPE_FR2_NF2x2 = {2, MAX_FACE_C_DIM, 2, 2}; ///<  4 ×32
+
+// face_r_dim = 4
+constexpr TensorShape TENSOR_SHAPE_FR4_NF1x1 = {4, MAX_FACE_C_DIM, 1, 1}; ///<  4 ×16
+constexpr TensorShape TENSOR_SHAPE_FR4_NF1x2 = {4, MAX_FACE_C_DIM, 1, 2}; ///<  4 ×32
+constexpr TensorShape TENSOR_SHAPE_FR4_NF2x1 = {4, MAX_FACE_C_DIM, 2, 1}; ///<  8 ×16
+constexpr TensorShape TENSOR_SHAPE_FR4_NF2x2 = {4, MAX_FACE_C_DIM, 2, 2}; ///<  8 ×32
+
+// face_r_dim = 8
+constexpr TensorShape TENSOR_SHAPE_FR8_NF1x1 = {8, MAX_FACE_C_DIM, 1, 1}; ///<  8 ×16
+constexpr TensorShape TENSOR_SHAPE_FR8_NF1x2 = {8, MAX_FACE_C_DIM, 1, 2}; ///<  8 ×32
+constexpr TensorShape TENSOR_SHAPE_FR8_NF2x1 = {8, MAX_FACE_C_DIM, 2, 1}; ///< 16 ×16
+constexpr TensorShape TENSOR_SHAPE_FR8_NF2x2 = {8, MAX_FACE_C_DIM, 2, 2}; ///< 16 ×32
+
+// face_r_dim = 16
+constexpr TensorShape TENSOR_SHAPE_FR16_NF1x1 = {16, MAX_FACE_C_DIM, 1, 1}; ///< 16 ×16
+constexpr TensorShape TENSOR_SHAPE_FR16_NF1x2 = {16, MAX_FACE_C_DIM, 1, 2}; ///< 16 ×32
+constexpr TensorShape TENSOR_SHAPE_FR16_NF2x1 = {16, MAX_FACE_C_DIM, 2, 1}; ///< 32 ×16
+constexpr TensorShape TENSOR_SHAPE_FR16_NF2x2 = {16, MAX_FACE_C_DIM, 2, 2}; ///< 32 ×32 (== DEFAULT_TENSOR_SHAPE)
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+/// Build a TensorShape from explicit face dimensions and face-grid counts.
+constexpr TensorShape make_tensor_shape(
+    const std::uint8_t face_r_dim, const std::uint8_t face_c_dim, const std::uint8_t num_faces_r_dim, const std::uint8_t num_faces_c_dim)
+{
+    return TensorShape {face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim};
+}
+
+/**
+ * @brief Construct a TensorShape from the legacy (face_r_dim, num_faces) pair.
+ *
+ * Maps the historical scalar parameters used across LLK call sites:
+ * - num_faces == 1: 1x1 face grid (face_r_dim × 16)
+ * - num_faces == 2: 1x2 face grid (face_r_dim × 32)
+ * - num_faces == 4: 2x2 face grid (face_r_dim*2 × 32; 32x32 when face_r_dim == 16)
+ *
+ * @note Caller must pass num_faces in {1, 2, 4}.
+ */
+inline TensorShape make_tensor_shape_from_legacy(const std::uint8_t face_r_dim, const std::uint8_t num_faces)
+{
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be one of the valid values: 1, 2, or 4");
+    return TensorShape {face_r_dim, MAX_FACE_C_DIM, static_cast<std::uint8_t>(num_faces == 4 ? 2 : 1), static_cast<std::uint8_t>(num_faces == 1 ? 1 : 2)};
+}
+
+/**
+ * @brief Validates shapes for ops that depend on face positioning within a tile.
+ *
+ * Keep this conservative until larger TensorShape variants have coverage.
  **/
-__attribute__((noinline)) bool validate_tensor_shape_tile_dependent_ops_(const TensorShape &tensor_shape)
+__attribute__((noinline)) inline bool validate_tensor_shape_tile_dependent_ops_(const TensorShape& tensor_shape)
 {
     const std::uint8_t num_faces  = tensor_shape.total_num_faces();
     const std::uint8_t face_r_dim = tensor_shape.face_r_dim;
@@ -93,4 +158,89 @@ __attribute__((noinline)) bool validate_tensor_shape_tile_dependent_ops_(const T
            (face_r_dim == 1 || face_r_dim == 2 || face_r_dim == 4 || face_r_dim == 8 || face_r_dim == 16) && (face_c_dim == 16);
 }
 
+/**
+ * @brief Fires the LLK_ASSERT for an unobserved TensorShape coverage hole.
+ *
+ * Keeping the assert in a noinline helper gives triage scripts a real frame
+ * containing an `ASSERT(` token instead of pointing at the macro call site.
+ */
+__attribute__((noinline, cold)) inline void assert_tensor_shape_unobserved_()
+{
+    LLK_ASSERT(false, "TensorShape not observed before, please add it to the coverage table.");
+}
+
+constexpr const char* tensor_shape_dim_name(const std::uint8_t dim)
+{
+    switch (dim)
+    {
+        case 1:
+            return "1";
+        case 2:
+            return "2";
+        case 4:
+            return "4";
+        case 8:
+            return "8";
+        case 16:
+            return "16";
+        default:
+            return "unknown";
+    }
+}
+
 } // namespace ckernel
+
+/**
+ * @brief Emit a TensorShape via DEVICE_PRINT (see tests/DPRINT.md).
+ *
+ * Place in front of validation asserts so the failing assert is preceded by the
+ * offending shape. Outside debug/assert builds this compiles to a no-op.
+ */
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+// Pull the correct DEVICE_PRINT wrapper only for DPRINT builds; assert-only builds
+// still use the dedupe path but skip the print emission.
+#ifdef DEBUG_PRINT_ENABLED
+#ifdef ENV_LLK_INFRA
+#include "dprint.h"
+#else
+#include "api/debug/dprint.h"
+#endif
+
+// Concatenate fn_name into the literal instead of using CTSTR(fn_name); CTSTR's
+// COMDAT string object conflicts with DEVICE_PRINT's own string-section metadata
+// at inline template call sites.
+#define LLK_VALIDATE_TENSOR_SHAPE_EMIT_(fn, ts)                                                   \
+    DEVICE_PRINT(                                                                                 \
+        "[{}] tensor_shape: face_r_dim={} face_c_dim={} num_faces_r_dim={} num_faces_c_dim={}\n", \
+        ::ckernel::coverage::tensor_shape_function_name(fn),                                      \
+        ::ckernel::tensor_shape_dim_name((ts).face_r_dim),                                        \
+        ::ckernel::tensor_shape_dim_name((ts).face_c_dim),                                        \
+        ::ckernel::tensor_shape_dim_name((ts).num_faces_r_dim),                                   \
+        ::ckernel::tensor_shape_dim_name((ts).num_faces_c_dim))
+#else
+#define LLK_VALIDATE_TENSOR_SHAPE_EMIT_(fn_name, ts) ((void)0)
+#endif
+
+#define LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(checker, fn, ts) \
+    do                                                          \
+    {                                                           \
+        if (!checker(fn, ts))                                   \
+        {                                                       \
+            LLK_VALIDATE_TENSOR_SHAPE_EMIT_(fn, ts);            \
+            ::ckernel::assert_tensor_shape_unobserved_();       \
+        }                                                       \
+    } while (0)
+
+#define LLK_VALIDATE_TENSOR_SHAPE_UNPACK(fn, ts) LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(::ckernel::coverage::is_unpack_tensor_shape_covered, fn, ts)
+#define LLK_VALIDATE_TENSOR_SHAPE_MATH(fn, ts)   LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(::ckernel::coverage::is_math_tensor_shape_covered, fn, ts)
+#define LLK_VALIDATE_TENSOR_SHAPE_PACK(fn, ts)   LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(::ckernel::coverage::is_pack_tensor_shape_covered, fn, ts)
+
+#else
+
+#define LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(checker, fn_name, ts) ((void)0)
+#define LLK_VALIDATE_TENSOR_SHAPE_UNPACK(fn_name, ts)                ((void)0)
+#define LLK_VALIDATE_TENSOR_SHAPE_MATH(fn_name, ts)                  ((void)0)
+#define LLK_VALIDATE_TENSOR_SHAPE_PACK(fn_name, ts)                  ((void)0)
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)

--- a/tt_metal/tt-llk/common/tensor_shape.h
+++ b/tt_metal/tt-llk/common/tensor_shape.h
@@ -207,17 +207,16 @@ constexpr const char* tensor_shape_dim_name(const std::uint8_t dim)
 #include "api/debug/dprint.h"
 #endif
 
-// Concatenate fn_name into the literal instead of using CTSTR(fn_name); CTSTR's
-// COMDAT string object conflicts with DEVICE_PRINT's own string-section metadata
-// at inline template call sites.
+// DEVICE_PRINT cannot resolve arbitrary const char* (e.g. switch-returned literals) on
+// device; emit the coverage enum and shape dims as integers for log harvesters.
 #define LLK_VALIDATE_TENSOR_SHAPE_EMIT_(fn, ts)                                                   \
     DEVICE_PRINT(                                                                                 \
         "[{}] tensor_shape: face_r_dim={} face_c_dim={} num_faces_r_dim={} num_faces_c_dim={}\n", \
-        ::ckernel::coverage::tensor_shape_function_name(fn),                                      \
-        ::ckernel::tensor_shape_dim_name((ts).face_r_dim),                                        \
-        ::ckernel::tensor_shape_dim_name((ts).face_c_dim),                                        \
-        ::ckernel::tensor_shape_dim_name((ts).num_faces_r_dim),                                   \
-        ::ckernel::tensor_shape_dim_name((ts).num_faces_c_dim))
+        static_cast<std::uint32_t>(fn),                                                           \
+        static_cast<std::uint32_t>((ts).face_r_dim),                                              \
+        static_cast<std::uint32_t>((ts).face_c_dim),                                              \
+        static_cast<std::uint32_t>((ts).num_faces_r_dim),                                         \
+        static_cast<std::uint32_t>((ts).num_faces_c_dim))
 #else
 #define LLK_VALIDATE_TENSOR_SHAPE_EMIT_(fn_name, ts) ((void)0)
 #endif

--- a/tt_metal/tt-llk/common/tensor_shape_coverage.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage.h
@@ -5,7 +5,6 @@
 // Common TensorShape coverage definitions shared by TRISC-specific coverage tables.
 //
 // Regenerate by running the functional pytests with --logging-level=DEBUG
-// and feeding the per-worker test_run_gw*.log files through /tmp/ts-coverage/parse.py.
 //
 
 #pragma once
@@ -36,6 +35,10 @@ enum class TensorShapeFunctionCoverage
     _llk_unpack_AB_reduce_mop_config_,
     _llk_unpack_A_init_,
     _llk_unpack_A_mop_config_,
+    _llk_pack_hw_configure_,
+    _llk_pack_init_,
+    _llk_pack_mop_config_,
+    _llk_pack_reconfig_data_format_,
     eltwise_binary_configure_mop_standard,
     eltwise_binary_configure_mop_with_dest_reuse,
 };
@@ -71,6 +74,14 @@ constexpr const char* tensor_shape_function_name(const TensorShapeFunctionCovera
             return "_llk_unpack_A_init_";
         case Function::_llk_unpack_A_mop_config_:
             return "_llk_unpack_A_mop_config_";
+        case Function::_llk_pack_hw_configure_:
+            return "_llk_pack_hw_configure_";
+        case Function::_llk_pack_init_:
+            return "_llk_pack_init_";
+        case Function::_llk_pack_mop_config_:
+            return "_llk_pack_mop_config_";
+        case Function::_llk_pack_reconfig_data_format_:
+            return "_llk_pack_reconfig_data_format_";
         case Function::eltwise_binary_configure_mop_standard:
             return "eltwise_binary_configure_mop_standard";
         case Function::eltwise_binary_configure_mop_with_dest_reuse:

--- a/tt_metal/tt-llk/common/tensor_shape_coverage.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage.h
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Common TensorShape coverage definitions shared by TRISC-specific coverage tables.
+//
+// Regenerate by running the functional pytests with --logging-level=DEBUG
+// and feeding the per-worker test_run_gw*.log files through /tmp/ts-coverage/parse.py.
+//
+
+#pragma once
+
+// Match tensor_shape.h's gate so production kernel builds do not see this table.
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+#include <array>
+#include <cstddef>
+
+#include "tensor_shape.h"
+
+namespace ckernel::coverage
+{
+
+enum class TensorShapeFunctionCoverage
+{
+    _llk_math_eltwise_binary_standard_,
+    _llk_math_eltwise_binary_standard_init_,
+    _llk_math_eltwise_binary_with_dest_reuse_,
+    _llk_math_eltwise_binary_with_dest_reuse_init_,
+    _llk_math_reduce_,
+    _llk_math_reduce_init_,
+    _llk_unpack_AB_init_,
+    _llk_unpack_AB_mop_config_,
+    _llk_unpack_AB_reduce_init_,
+    _llk_unpack_reduce_init_,
+    _llk_unpack_AB_reduce_mop_config_,
+    _llk_unpack_A_init_,
+    _llk_unpack_A_mop_config_,
+    eltwise_binary_configure_mop_standard,
+    eltwise_binary_configure_mop_with_dest_reuse,
+};
+
+constexpr const char* tensor_shape_function_name(const TensorShapeFunctionCoverage fn)
+{
+    using Function = TensorShapeFunctionCoverage;
+    switch (fn)
+    {
+        case Function::_llk_math_eltwise_binary_standard_:
+            return "_llk_math_eltwise_binary_standard_";
+        case Function::_llk_math_eltwise_binary_standard_init_:
+            return "_llk_math_eltwise_binary_standard_init_";
+        case Function::_llk_math_eltwise_binary_with_dest_reuse_:
+            return "_llk_math_eltwise_binary_with_dest_reuse_";
+        case Function::_llk_math_eltwise_binary_with_dest_reuse_init_:
+            return "_llk_math_eltwise_binary_with_dest_reuse_init_";
+        case Function::_llk_math_reduce_:
+            return "_llk_math_reduce_";
+        case Function::_llk_math_reduce_init_:
+            return "_llk_math_reduce_init_";
+        case Function::_llk_unpack_AB_init_:
+            return "_llk_unpack_AB_init_";
+        case Function::_llk_unpack_AB_mop_config_:
+            return "_llk_unpack_AB_mop_config_";
+        case Function::_llk_unpack_AB_reduce_init_:
+            return "_llk_unpack_AB_reduce_init_";
+        case Function::_llk_unpack_reduce_init_:
+            return "_llk_unpack_reduce_init_";
+        case Function::_llk_unpack_AB_reduce_mop_config_:
+            return "_llk_unpack_AB_reduce_mop_config_";
+        case Function::_llk_unpack_A_init_:
+            return "_llk_unpack_A_init_";
+        case Function::_llk_unpack_A_mop_config_:
+            return "_llk_unpack_A_mop_config_";
+        case Function::eltwise_binary_configure_mop_standard:
+            return "eltwise_binary_configure_mop_standard";
+        case Function::eltwise_binary_configure_mop_with_dest_reuse:
+            return "eltwise_binary_configure_mop_with_dest_reuse";
+    }
+    return "unknown";
+}
+
+constexpr bool tensor_shape_eq(const TensorShape& lhs, const TensorShape& rhs)
+{
+    return lhs.face_r_dim == rhs.face_r_dim && lhs.face_c_dim == rhs.face_c_dim && lhs.num_faces_r_dim == rhs.num_faces_r_dim &&
+           lhs.num_faces_c_dim == rhs.num_faces_c_dim;
+}
+
+template <std::size_t N>
+constexpr bool contains_tensor_shape(const std::array<TensorShape, N>& covered_shapes, const TensorShape& tensor_shape)
+{
+    for (const TensorShape& covered_shape : covered_shapes)
+    {
+        if (tensor_shape_eq(covered_shape, tensor_shape))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace ckernel::coverage
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Match tensor_shape.h's gate so production kernel builds do not see this table.
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+#include <array>
+
+#include "tensor_shape_coverage.h"
+
+namespace ckernel::coverage
+{
+
+inline constexpr std::array<TensorShape, 8> covered_shapes_llk_math_eltwise_binary_standard = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 8> covered_shapes_llk_math_eltwise_binary_standard_init = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 2> covered_shapes_llk_math_eltwise_binary_with_dest_reuse = {{
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 2> covered_shapes_llk_math_eltwise_binary_with_dest_reuse_init = {{
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 7> covered_shapes_llk_math_reduce = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 8> covered_shapes_eltwise_binary_configure_mop_standard = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 2> covered_shapes_eltwise_binary_configure_mop_with_dest_reuse = {{
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+constexpr bool is_math_tensor_shape_covered(const TensorShapeFunctionCoverage fn, const TensorShape& tensor_shape)
+{
+    using Function = TensorShapeFunctionCoverage;
+    switch (fn)
+    {
+        case Function::_llk_math_eltwise_binary_standard_:
+            return contains_tensor_shape(covered_shapes_llk_math_eltwise_binary_standard, tensor_shape);
+        case Function::_llk_math_eltwise_binary_standard_init_:
+            return contains_tensor_shape(covered_shapes_llk_math_eltwise_binary_standard_init, tensor_shape);
+        case Function::_llk_math_eltwise_binary_with_dest_reuse_:
+            return contains_tensor_shape(covered_shapes_llk_math_eltwise_binary_with_dest_reuse, tensor_shape);
+        case Function::_llk_math_eltwise_binary_with_dest_reuse_init_:
+            return contains_tensor_shape(covered_shapes_llk_math_eltwise_binary_with_dest_reuse_init, tensor_shape);
+        case Function::_llk_math_reduce_:
+        case Function::_llk_math_reduce_init_:
+            return contains_tensor_shape(covered_shapes_llk_math_reduce, tensor_shape);
+        case Function::eltwise_binary_configure_mop_standard:
+            return contains_tensor_shape(covered_shapes_eltwise_binary_configure_mop_standard, tensor_shape);
+        case Function::eltwise_binary_configure_mop_with_dest_reuse:
+            return contains_tensor_shape(covered_shapes_eltwise_binary_configure_mop_with_dest_reuse, tensor_shape);
+        default:
+            return false;
+    }
+}
+
+} // namespace ckernel::coverage
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_pack.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_pack.h
@@ -1,22 +1,83 @@
 // SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
 //
 // SPDX-License-Identifier: Apache-2.0
+//
+// AUTO-GENERATED: pack TensorShape coverage observed across LLK pytests.
+// Sourced from DPRINT lines emitted by LLK_VALIDATE_TENSOR_SHAPE_PACK before
+// assert_tensor_shape_unobserved_() on uncovered shapes.
+//
+// Regenerate: run WH pack pytests with TT_LLK_DISABLE_ASSERTS=1 and
+// --logging-level=debug, then parse.py harvest <name> and parse.py emit-pack.
+//
+// Last update : 2026-06-18T14:47:51+00:00
+// Tests run   : 4
 
 #pragma once
 
 // Match tensor_shape.h's gate so production kernel builds do not see this table.
 #if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
 
+#include <array>
+
 #include "tensor_shape_coverage.h"
 
 namespace ckernel::coverage
 {
 
-// No pack TensorShape coverage probes are currently defined.
+// _llk_pack_hw_configure_: 7 unique TensorShape(s)
+inline constexpr std::array<TensorShape, 7> covered_shapes_llk_pack_hw_configure = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
 
-constexpr bool is_pack_tensor_shape_covered(const TensorShapeFunctionCoverage, const TensorShape&)
+// _llk_pack_init_: 7 unique TensorShape(s)
+inline constexpr std::array<TensorShape, 7> covered_shapes_llk_pack_init = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+// _llk_pack_mop_config_: 7 unique TensorShape(s)
+inline constexpr std::array<TensorShape, 7> covered_shapes_llk_pack_mop_config = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+// _llk_pack_reconfig_data_format_: 1 unique TensorShape(s)
+inline constexpr std::array<TensorShape, 1> covered_shapes_llk_pack_reconfig_data_format = {{
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+constexpr bool is_pack_tensor_shape_covered(const TensorShapeFunctionCoverage fn, const TensorShape& tensor_shape)
 {
-    return false;
+    using Function = TensorShapeFunctionCoverage;
+    switch (fn)
+    {
+        case Function::_llk_pack_hw_configure_:
+            return contains_tensor_shape(covered_shapes_llk_pack_hw_configure, tensor_shape);
+        case Function::_llk_pack_init_:
+            return contains_tensor_shape(covered_shapes_llk_pack_init, tensor_shape);
+        case Function::_llk_pack_mop_config_:
+            return contains_tensor_shape(covered_shapes_llk_pack_mop_config, tensor_shape);
+        case Function::_llk_pack_reconfig_data_format_:
+            return contains_tensor_shape(covered_shapes_llk_pack_reconfig_data_format, tensor_shape);
+        default:
+            return false;
+    }
 }
 
 } // namespace ckernel::coverage

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_pack.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_pack.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Match tensor_shape.h's gate so production kernel builds do not see this table.
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+#include "tensor_shape_coverage.h"
+
+namespace ckernel::coverage
+{
+
+// No pack TensorShape coverage probes are currently defined.
+
+constexpr bool is_pack_tensor_shape_covered(const TensorShapeFunctionCoverage, const TensorShape&)
+{
+    return false;
+}
+
+} // namespace ckernel::coverage
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_unpack.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_unpack.h
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Match tensor_shape.h's gate so production kernel builds do not see this table.
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+#include <array>
+
+#include "tensor_shape_coverage.h"
+
+namespace ckernel::coverage
+{
+
+inline constexpr std::array<TensorShape, 9> covered_shapes_llk_unpack_AB_init = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x1, // TODO(#47307): ndivnic to add a test in tt-llk to cover this case
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 9> covered_shapes_llk_unpack_AB_mop_config = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x1, // TODO(#47307): ndivnic to add a test in tt-llk to cover this case
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 7> covered_shapes_llk_unpack_AB_reduce_init = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 7> covered_shapes_llk_unpack_AB_reduce_mop_config = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 9> covered_shapes_llk_unpack_A_init = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x1,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 9> covered_shapes_llk_unpack_A_mop_config = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x1,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+constexpr bool is_unpack_tensor_shape_covered(const TensorShapeFunctionCoverage fn, const TensorShape& tensor_shape)
+{
+    using Function = TensorShapeFunctionCoverage;
+    switch (fn)
+    {
+        case Function::_llk_unpack_AB_init_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_AB_init, tensor_shape);
+        case Function::_llk_unpack_AB_mop_config_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_AB_mop_config, tensor_shape);
+        case Function::_llk_unpack_AB_reduce_init_:
+        case Function::_llk_unpack_reduce_init_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_AB_reduce_init, tensor_shape);
+        case Function::_llk_unpack_AB_reduce_mop_config_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_AB_reduce_mop_config, tensor_shape);
+        case Function::_llk_unpack_A_init_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_A_init, tensor_shape);
+        case Function::_llk_unpack_A_mop_config_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_A_mop_config, tensor_shape);
+        default:
+            return false;
+    }
+}
+
+} // namespace ckernel::coverage
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)

--- a/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
+++ b/tt_metal/tt-llk/tests/helpers/include/llk_lib_pack_wrappers.h
@@ -12,6 +12,7 @@
 
 #include "llk_pack.h"
 #include "llk_pack_untilize.h"
+#include "tensor_shape.h"
 
 using ckernel::FACE_R_DIM;
 using ckernel::PackMode;
@@ -46,16 +47,12 @@ inline void _llk_pack_hw_configure_wrapper_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
-    [[maybe_unused]] const std::uint32_t tile_c_dim = TILE_C_DIM,
-    const std::uint32_t num_faces                   = 4,
-    const bool partial_face                         = false,
-    const bool narrow_tile                          = false,
-    const std::uint32_t relu_config                 = 0)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool partial_face                  = false,
+    const std::uint32_t relu_config          = 0)
 {
     static_assert(pack_mode != PackMode::Tilize, "Wormhole B0 LLK tests: pack hw configure supports PackMode::Default or PackMode::Untilize only");
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, pack_mode>(
-        pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face, narrow_tile, relu_config);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, pack_mode>(pack_src_format, pack_dst_format, tile_size, tensor_shape, partial_face, relu_config);
 }
 
 template <bool is_fp32_dest_acc_en, [[maybe_unused]] bool is_tile_dim_reconfig_en = false>
@@ -63,44 +60,35 @@ inline void _llk_pack_reconfig_data_format_wrapper_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
-    [[maybe_unused]] const std::uint32_t tile_c_dim = TILE_C_DIM,
-    const std::uint32_t num_faces                   = 4,
-    const bool partial_face                         = false,
-    const bool narrow_tile                          = false,
-    [[maybe_unused]] const std::uint32_t num_tiles  = 1)
+    const ckernel::TensorShape& tensor_shape       = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool partial_face                        = false,
+    [[maybe_unused]] const std::uint32_t num_tiles = 1)
 {
-    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face, narrow_tile);
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, tensor_shape, partial_face);
 }
 
 template <PackMode pack_mode = PackMode::Default, bool zero_output = false>
 inline void _llk_pack_init_wrapper_(
     const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
-    [[maybe_unused]] const std::uint32_t tile_c_dim = TILE_C_DIM,
-    const std::uint32_t num_faces                   = 4,
-    const bool partial_face                         = false,
-    const bool narrow_tile                          = false,
-    const std::uint32_t num_tiles                   = 1)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool partial_face                  = false,
+    const std::uint32_t num_tiles            = 1)
 {
     static_assert(pack_mode != PackMode::Tilize, "Wormhole B0 LLK tests: pack init supports PackMode::Default or PackMode::Untilize only");
-    _llk_pack_init_<pack_mode, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
+    _llk_pack_init_<pack_mode, zero_output>(pack_dst_format, tensor_shape, partial_face, num_tiles);
 }
 
 template <PackMode pack_mode = PackMode::Default, bool zero_output = false>
 inline void _llk_pack_init_with_src_wrapper_(
     [[maybe_unused]] const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim                        = FACE_R_DIM,
-    [[maybe_unused]] const std::uint32_t tile_c_dim       = TILE_C_DIM,
-    const std::uint32_t num_faces                         = 4,
+    const ckernel::TensorShape& tensor_shape              = ckernel::DEFAULT_TENSOR_SHAPE,
     const bool partial_face                               = false,
-    const bool narrow_tile                                = false,
     const std::uint32_t num_tiles                         = 1,
     [[maybe_unused]] const bool skip_bh_tilize_workaround = false)
 {
     static_assert(pack_mode != PackMode::Tilize, "Wormhole B0 LLK tests: pack init supports PackMode::Default or PackMode::Untilize only");
-    _llk_pack_init_<pack_mode, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
+    _llk_pack_init_<pack_mode, zero_output>(pack_dst_format, tensor_shape, partial_face, num_tiles);
 }
 
 template <DstSync Dst, bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
@@ -120,10 +108,10 @@ template <
 inline void _llk_pack_untilize_init_wrapper_(
     [[maybe_unused]] const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t num_faces  = 4)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
-    _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(pack_dst_format, face_r_dim, num_faces);
+    _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums>(
+        pack_dst_format, tensor_shape.face_r_dim, tensor_shape.total_num_faces());
 }
 
 template <
@@ -137,12 +125,11 @@ template <
 inline void _llk_pack_untilize_wrapper_(
     const std::uint32_t address,
     const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim                 = FACE_R_DIM,
-    [[maybe_unused]] const std::uint32_t num_faces = 4,
-    const std::uint32_t tile_dst_rt_offset         = 0)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const std::uint32_t tile_dst_rt_offset   = 0)
 {
     _llk_pack_untilize_<block_ct_dim, full_ct_dim, diagonal, narrow_row, row_num_datums, tile_dst_ct_offset>(
-        address, pack_dst_format, face_r_dim, tile_dst_rt_offset);
+        address, pack_dst_format, tensor_shape.face_r_dim, tile_dst_rt_offset);
 }
 
 inline void _llk_pack_untilize_uninit_wrapper_(
@@ -169,15 +156,11 @@ inline void _llk_pack_hw_configure_wrapper_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim          = FACE_R_DIM,
-    const std::uint32_t tile_c_dim          = TILE_C_DIM,
-    const std::uint32_t num_faces           = 4,
-    const bool partial_face                 = false,
-    [[maybe_unused]] const bool narrow_tile = false,
-    const std::uint32_t relu_config         = 0)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool partial_face                  = false,
+    const std::uint32_t relu_config          = 0)
 {
-    _llk_pack_hw_configure_<is_fp32_dest_acc_en, pack_mode>(
-        pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face, relu_config);
+    _llk_pack_hw_configure_<is_fp32_dest_acc_en, pack_mode>(pack_src_format, pack_dst_format, tile_size, tensor_shape, partial_face, relu_config);
 }
 
 template <bool is_fp32_dest_acc_en, [[maybe_unused]] bool is_tile_dim_reconfig_en = false>
@@ -185,24 +168,18 @@ inline void _llk_pack_reconfig_data_format_wrapper_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t tile_c_dim                  = TILE_C_DIM,
-    const std::uint32_t num_faces                   = 4,
-    const bool partial_face                         = false,
-    [[maybe_unused]] const bool narrow_tile         = false,
-    [[maybe_unused]] const std::uint32_t num_tiles  = 1)
+    const ckernel::TensorShape& tensor_shape       = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool partial_face                        = false,
+    [[maybe_unused]] const std::uint32_t num_tiles = 1)
 {
-    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, tile_c_dim, num_faces, partial_face);
+    _llk_pack_reconfig_data_format_<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, tensor_shape, partial_face);
 }
 
 template <PackMode pack_mode = PackMode::Default, bool zero_output = false>
 inline void _llk_pack_init_wrapper_(
     const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim           = FACE_R_DIM,
-    const std::uint32_t tile_c_dim           = TILE_C_DIM,
-    const std::uint32_t num_faces            = 4,
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
     [[maybe_unused]] const bool partial_face = false,
-    [[maybe_unused]] const bool narrow_tile  = false,
     const std::uint32_t num_tiles            = 1)
 {
     // No-src wrapper: the packer strides are owned by the preceding hw-configure/reconfig, so we skip
@@ -211,22 +188,19 @@ inline void _llk_pack_init_wrapper_(
     // (the src format is never read once strides are skipped) and bypasses the public entry point's
     // format-based num_tiles assert, which would otherwise validate against a placeholder value.
     llk_pack_internal_bh::pack_init_apply<pack_mode, zero_output, false /* skip_addrmod_config */, true /* skip_packer_strides */>(
-        pack_dst_format /* pack_src_format: ignored when strides are skipped */, face_r_dim, tile_c_dim, num_faces, num_tiles);
+        pack_dst_format /* pack_src_format: ignored when strides are skipped */, tensor_shape, num_tiles);
 }
 
 template <PackMode pack_mode = PackMode::Default, bool zero_output = false>
 inline void _llk_pack_init_with_src_wrapper_(
     const std::uint32_t pack_src_format,
     [[maybe_unused]] const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim           = FACE_R_DIM,
-    const std::uint32_t tile_c_dim           = TILE_C_DIM,
-    const std::uint32_t num_faces            = 4,
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
     [[maybe_unused]] const bool partial_face = false,
-    [[maybe_unused]] const bool narrow_tile  = false,
     const std::uint32_t num_tiles            = 1,
     const bool skip_bh_tilize_workaround     = false)
 {
-    _llk_pack_init_<pack_mode, zero_output>(pack_src_format, face_r_dim, tile_c_dim, num_faces, num_tiles, skip_bh_tilize_workaround);
+    _llk_pack_init_<pack_mode, zero_output>(pack_src_format, tensor_shape, num_tiles, skip_bh_tilize_workaround);
 }
 
 template <DstSync Dst, bool is_fp32_dest_acc_en, [[maybe_unused]] PackMode pack_mode = PackMode::Default>
@@ -245,11 +219,11 @@ template <
 inline void _llk_pack_untilize_init_wrapper_(
     const std::uint32_t pack_src_format,
     [[maybe_unused]] const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t num_faces  = 4)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     static_assert(!diagonal, "Blackhole pack untilize does not support diagonal mode");
-    _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense>(pack_src_format, pack_dst_format, face_r_dim, num_faces);
+    _llk_pack_untilize_init_<block_ct_dim, full_ct_dim, narrow_row, row_num_datums, dense>(
+        pack_src_format, pack_dst_format, tensor_shape.face_r_dim, tensor_shape.total_num_faces());
 }
 
 template <
@@ -263,12 +237,11 @@ template <
 inline void _llk_pack_untilize_wrapper_(
     const std::uint32_t address,
     [[maybe_unused]] const std::uint32_t pack_dst_format,
-    [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t num_faces                   = 4,
-    const std::uint32_t tile_dst_rt_offset          = 0)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const std::uint32_t tile_dst_rt_offset   = 0)
 {
     static_assert(!diagonal, "Blackhole pack untilize does not support diagonal mode");
-    _llk_pack_untilize_<block_ct_dim, full_ct_dim, narrow_row, tile_dst_ct_offset, dense>(address, num_faces, tile_dst_rt_offset);
+    _llk_pack_untilize_<block_ct_dim, full_ct_dim, narrow_row, tile_dst_ct_offset, dense>(address, tensor_shape.total_num_faces(), tile_dst_rt_offset);
 }
 
 inline void _llk_pack_untilize_uninit_wrapper_(const std::uint32_t pack_src_format, [[maybe_unused]] const std::uint32_t face_r_dim = FACE_R_DIM)

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_a.py
@@ -135,18 +135,19 @@ class UnpackerA(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
+        from helpers.tile_shape import cpp_tensor_shape
+
         unpack_to_dest = compute_unit.unpack_to_dest.cpp_enum_value
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         reuse_dest = compute_unit.reuse_dest.cpp_enum_value
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        tensor_shape = cpp_tensor_shape(compute_unit.src_a.tile_shape)
         transpose_faces = compute_unit.unpack_transpose_faces.cpp_enum_value
         transpose_within_face = compute_unit.unpack_transpose_within_face.cpp_enum_value
         acc_to_dest = compute_unit.acc_to_dest.cpp_enum_value
 
         return (
             f"    _llk_unpack_A_init_<{broadcast_type}, {acc_to_dest}, {reuse_dest}, {unpack_to_dest}>(\n"
-            f"        {transpose_faces}, {transpose_within_face}, {face_r_dim}, {num_faces}, {config.sentinel.unpack_a_src_format}, {config.sentinel.unpack_a_dst_format}\n"
+            f"        {transpose_faces}, {transpose_within_face}, {tensor_shape}, {config.sentinel.unpack_a_src_format}, {config.sentinel.unpack_a_dst_format}\n"
             f"    );\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_a.py
@@ -135,18 +135,19 @@ class UnpackerA(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
+        from helpers.tile_shape import cpp_tensor_shape
+
         unpack_to_dest = compute_unit.unpack_to_dest.cpp_enum_value
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         reuse_dest = compute_unit.reuse_dest.cpp_enum_value
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        tensor_shape = cpp_tensor_shape(compute_unit.src_a.tile_shape)
         transpose_faces = compute_unit.unpack_transpose_faces.cpp_enum_value
         transpose_within_face = compute_unit.unpack_transpose_within_face.cpp_enum_value
         acc_to_dest = compute_unit.acc_to_dest.cpp_enum_value
 
         return (
             f"_llk_unpack_A_init_<{broadcast_type}, {acc_to_dest}, {reuse_dest}, {unpack_to_dest}>(\n"
-            f"    {transpose_faces}, {transpose_within_face}, {face_r_dim}, {num_faces}, {config.sentinel.unpack_a_src_format}, {config.sentinel.unpack_a_dst_format}\n"
+            f"    {transpose_faces}, {transpose_within_face}, {tensor_shape}, {config.sentinel.unpack_a_src_format}, {config.sentinel.unpack_a_dst_format}\n"
             f");\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -481,13 +481,22 @@ class TestConfig:
             in (ChipArchitecture.WORMHOLE, ChipArchitecture.BLACKHOLE)
             else ""
         )
+        # Allow disabling LLK_ASSERT via env var for shape-coverage discovery runs:
+        # with asserts off and DEVICE_PRINT_ENABLED on, LLK_VALIDATE_TENSOR_SHAPE_*
+        # emits newly-seen TensorShapes via DPRINT instead of ebreaking the kernel,
+        # so a single run can enumerate every (fn_name, shape) pair exercised.
+        llk_assert_define = (
+            ""
+            if os.environ.get("TT_LLK_DISABLE_ASSERTS") == "1"
+            else "-DENABLE_LLK_ASSERT "
+        )
         TestConfig.INITIAL_OPTIONS_COMPILE = (
             "-Wall -Werror -Wno-error=deprecated-declarations "
             "-Wunused-parameter "
             "-Wfloat-equal -Wpointer-arith -Wnull-dereference -Wredundant-decls "
             "-Wuninitialized -Wmaybe-uninitialized "
             f"{no_wh_ebreak_fixup}"
-            f"-DTENSIX_FIRMWARE -DENV_LLK_INFRA -DKERNEL_BUILD -DENABLE_LLK_ASSERT {TestConfig.ARCH_DEFINE} "
+            f"-DTENSIX_FIRMWARE -DENV_LLK_INFRA -DKERNEL_BUILD {llk_assert_define}{TestConfig.ARCH_DEFINE} "
             f"{'-DSPEED_OF_LIGHT' if TestConfig.SPEED_OF_LIGHT else ''}"
         )
         TestConfig.INCLUDES = [

--- a/tt_metal/tt-llk/tests/python_tests/helpers/tile_shape.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/tile_shape.py
@@ -86,3 +86,30 @@ def construct_tile_shape(tile_dimensions: Tuple[int, int] = (32, 32)) -> TileSha
         num_faces_r_dim=num_faces_r_dim,
         num_faces_c_dim=num_faces_c_dim,
     )
+
+
+def cpp_tensor_shape(tile_shape: TileShape) -> str:
+    """
+    Emit the C++ ``ckernel::TensorShape`` aggregate literal that matches ``tile_shape``.
+
+    Used by fuser code generators to construct the C++ TensorShape value
+    expected by LLK functions taking a ``ckernel::TensorShape`` parameter.
+    """
+    return (
+        "ckernel::make_tensor_shape("
+        f"{tile_shape.face_r_dim}, "
+        f"{tile_shape.face_c_dim}, "
+        f"{tile_shape.num_faces_r_dim}, "
+        f"{tile_shape.num_faces_c_dim})"
+    )
+
+
+def cpp_tensor_shape_from_legacy(face_r_dim: int, num_faces: int) -> str:
+    """
+    Emit a C++ ``ckernel::make_tensor_shape_from_legacy`` call string from legacy
+    scalar parameters (face_r_dim, total num_faces).
+
+    Mirrors the C++ helper of the same name for fuser code generators that only
+    have legacy scalar values available.
+    """
+    return f"ckernel::make_tensor_shape_from_legacy({face_r_dim}, {num_faces})"

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_A.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_A.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 from conftest import skip_for_blackhole
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
-from helpers.format_config import DataFormat
+from helpers.format_config import DataFormat, FormatConfig
 from helpers.golden_generators import (
     ELEMENTS_PER_TILE,
     TILE_DIMENSIONS,
@@ -42,6 +42,8 @@ from helpers.test_variant_parameters import (
     INPUT_DIMENSIONS,
     NUM_BLOCKS,
     NUM_FACES,
+    NUM_FACES_C_DIM,
+    NUM_FACES_R_DIM,
     NUM_TILES_IN_BLOCK,
     PARTIAL_FACE,
     REUSE_DEST_TYPE,
@@ -90,6 +92,16 @@ face_r_dim_values = [1, 2, 4, 8, 16]
 input_dimensions = [[r, 32] for r in face_r_dim_values] + [[256, 256]]
 # Use only cross_test_formats as it already includes same-format combinations
 test_formats = input_output_formats(supported_formats, False)
+
+
+def legacy_num_faces_to_grid(num_faces: int) -> tuple[int, int]:
+    if num_faces == 1:
+        return 1, 1
+    if num_faces == 2:
+        return 1, 2
+    if num_faces == 4:
+        return 2, 2
+    raise ValueError(f"Unsupported num_faces={num_faces}")
 
 
 # Generate unpack_A specific parameter combinations using itertools.product
@@ -389,6 +401,7 @@ def test_unpack_comprehensive(
 
     # torch.manual_seed(0.0)
     partial_face = face_r_dim < 16
+    num_faces_r_dim, num_faces_c_dim = legacy_num_faces_to_grid(num_faces)
 
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
@@ -546,6 +559,8 @@ def test_unpack_comprehensive(
             UNPACK_TRANS_FACES(transpose_of_faces),
             UNPACK_TRANS_WITHIN_FACE(within_face_16x16_transpose),
             NUM_FACES(num_faces),
+            NUM_FACES_R_DIM(num_faces_r_dim, num_faces_r_dim),
+            NUM_FACES_C_DIM(num_faces_c_dim, num_faces_c_dim),
             TILE_COUNT(tile_cnt_A),
             TEST_FACE_DIMS(face_r_dim=face_r_dim),
             NUM_TILES_IN_BLOCK(num_tiles_in_block),
@@ -569,6 +584,157 @@ def test_unpack_comprehensive(
         ),
         dest_acc=(DestAccumulation.Yes if acc_to_dest else DestAccumulation.No),
         unpack_to_dest=(formats.input_format.is_32_bit() and acc_to_dest),
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), "Assert against golden failed"
+
+
+targeted_tensor_shape_cases = [
+    pytest.param(
+        "fr8_nf1x1",
+        8,
+        1,
+        1,
+        1,
+        [8, 16],
+        None,
+        id="tensor_shape_FR8_NF1x1",
+    ),
+    pytest.param(
+        "fr16_nf2x1",
+        16,
+        2,
+        2,
+        1,
+        [32, 16],
+        [32, 16],
+        id="tensor_shape_FR16_NF2x1",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case_name, face_r_dim, num_faces, num_faces_r_dim, num_faces_c_dim, input_dimensions, tile_dimensions",
+    targeted_tensor_shape_cases,
+)
+def test_unpack_A_targeted_tensor_shape_coverage(
+    case_name,
+    face_r_dim,
+    num_faces,
+    num_faces_r_dim,
+    num_faces_c_dim,
+    input_dimensions,
+    tile_dimensions,
+):
+    del case_name
+    formats = FormatConfig(
+        unpack_A_src=DataFormat.Float16_b,
+        unpack_A_dst=DataFormat.Float16_b,
+        pack_src=DataFormat.Float16_b,
+        pack_dst=DataFormat.Float16_b,
+        math=DataFormat.Float16_b,
+    )
+
+    stimuli_kwargs = (
+        {"tile_dimensions": tile_dimensions}
+        if tile_dimensions is not None
+        else {"face_r_dim": face_r_dim, "num_faces": num_faces}
+    )
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        **stimuli_kwargs,
+    )
+
+    generate_golden = get_golden_generator(DataCopyGolden)
+    golden_tensor = generate_golden(
+        src_A,
+        formats.output_format,
+        num_faces,
+        input_dimensions,
+        face_r_dim,
+        tile_dimensions=tile_dimensions,
+    )
+
+    raw_dimensions = [
+        (
+            input_dimensions[0]
+            if input_dimensions[0] >= TILE_DIMENSIONS[0]
+            else TILE_DIMENSIONS[0]
+        ),
+        (
+            input_dimensions[1]
+            if input_dimensions[1] >= TILE_DIMENSIONS[1]
+            else TILE_DIMENSIONS[1]
+        ),
+    ]
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half,
+        DestAccumulation.No,
+        formats,
+        raw_dimensions,
+        TILE_DIMENSIONS,
+        BlocksCalculationAlgorithm.Standard,
+    )
+
+    configuration = TestConfig(
+        "sources/unpack_A_test.cpp",
+        formats,
+        templates=[
+            STOCHASTIC_ROUNDING(StochasticRounding.No),
+            BROADCAST_TYPE(BroadcastType.None_),
+            ACC_TO_DEST(False),
+            REUSE_DEST_TYPE(EltwiseBinaryReuseDestType.NONE),
+            PARTIAL_FACE(
+                partial_a=face_r_dim < 16,
+                partial_face_pack=face_r_dim < 16,
+                partial_b=face_r_dim < 16,
+                partial_face_math=face_r_dim < 16,
+            ),
+            DISABLE_SRC_ZERO_FLAG(False),
+        ],
+        runtimes=[
+            UNPACK_TRANS_FACES(Transpose.No),
+            UNPACK_TRANS_WITHIN_FACE(Transpose.No),
+            NUM_FACES(num_faces),
+            NUM_FACES_R_DIM(num_faces_r_dim, num_faces_r_dim),
+            NUM_FACES_C_DIM(num_faces_c_dim, num_faces_c_dim),
+            TILE_COUNT(tile_cnt_A),
+            TEST_FACE_DIMS(face_r_dim=face_r_dim),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+            NUM_BLOCKS(num_blocks),
+            INPUT_DIMENSIONS(
+                raw_dimensions[0] // TILE_DIMENSIONS[0],
+                raw_dimensions[1] // TILE_DIMENSIONS[1],
+            ),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+            num_faces=num_faces,
+            face_r_dim=face_r_dim,
+            tile_dimensions=tile_dimensions or [32, 32],
+            use_dense_tile_dimensions=tile_dimensions is not None,
+        ),
+        dest_acc=DestAccumulation.No,
+        unpack_to_dest=False,
     )
 
     res_from_L1 = configuration.run().result

--- a/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_pack_untilize.cpp
+++ b/tt_metal/tt-llk/tests/sources/ai_gen/eltwise_binary_sfpu_pack_untilize.cpp
@@ -84,10 +84,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 {
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>(formats.pack_src, formats.pack_dst, tile_size);
     _llk_pack_dest_init_wrapper_<DST_SYNC, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
-    _llk_pack_untilize_init_wrapper_<ct_dim>(formats.pack_src, formats.pack_dst, FACE_R_DIM, 4 /* num_faces */);
+    _llk_pack_untilize_init_wrapper_<ct_dim>(formats.pack_src, formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, 4 /* num_faces */));
 
     _llk_packer_wait_for_math_done_();
-    _llk_pack_untilize_wrapper_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, FACE_R_DIM, 4 /* num_faces */, 0 /* tile_dst_rt_offset */);
+    _llk_pack_untilize_wrapper_<ct_dim>(
+        L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, 4 /* num_faces */), 0 /* tile_dst_rt_offset */);
     _llk_pack_dest_section_done_<DST_SYNC, is_fp32_dest_acc_en>();
 }
 

--- a/tt_metal/tt-llk/tests/sources/dense_pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/dense_pack_untilize_test.cpp
@@ -27,7 +27,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     for (std::uint32_t tile_index_within_block = 0; tile_index_within_block < BLOCK_CT_DIM; ++tile_index_within_block) // Loop over tiles in the block
     {

--- a/tt_metal/tt-llk/tests/sources/dprint_tensix_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/dprint_tensix_test.cpp
@@ -31,7 +31,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
         L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src, formats.unpack_A_dst);
 }

--- a/tt_metal/tt-llk/tests/sources/dprint_tensix_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/dprint_tensix_test.cpp
@@ -90,8 +90,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
 
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_test_pack_mode_v<false, false>>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_wrapper_<llk_test_pack_mode_v<false, false>, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces));
+    _llk_pack_init_wrapper_<llk_test_pack_mode_v<false, false>, false /* zero_output */>(
+        formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces));
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
@@ -54,7 +54,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
 
         _llk_unpack_A_init_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
-            UNPACK_TRANSPOSE_FACES, UNPACK_TRANSPOSE_WITHIN_FACE, FACE_R_DIM, num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+            UNPACK_TRANSPOSE_FACES,
+            UNPACK_TRANSPOSE_WITHIN_FACE,
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces),
+            formats.unpack_A_src,
+            formats.unpack_A_dst);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
@@ -281,7 +281,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Configure packer hardware
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * num_faces);
 
-        _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces);
+        _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces));
         // Initialize destination for packing
         _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_custom_test.cpp
@@ -24,7 +24,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     _llk_unpack_hw_configure_<false>(formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4, 4);
-    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false>(0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false>(
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
 
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_custom_test.cpp
@@ -71,8 +71,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     _llk_pack_hw_configure_wrapper_<false /* is_fp32_dest_acc_en */, PackMode::Default>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */);
-    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */);
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, 4 /* num_faces */));
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
+        formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, 4 /* num_faces */));
     _llk_pack_dest_init_<DstSync::SyncHalf, false>();
 
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -32,7 +32,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            0, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+            0 /* transpose_of_faces */,
+            0 /* within_face_16x16_transpose */,
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+            formats.unpack_A_src,
+            formats.unpack_A_dst);
 
         const std::uint32_t num_tiles = params.NUM_BLOCKS * params.NUM_TILES_IN_BLOCK;
 

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -91,7 +91,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-// copy srca to dest
+    // copy srca to dest
     _llk_math_eltwise_unary_datacopy_init_wrapper_<
         DataCopyType::A2D,
         is_fp32_dest_acc_en,
@@ -130,8 +130,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_test_pack_mode_v<false, tilize_en>>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_wrapper_<llk_test_pack_mode_v<false, tilize_en>, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces));
+    _llk_pack_init_wrapper_<llk_test_pack_mode_v<false, tilize_en>, false /* zero_output */>(
+        formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces));
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 
     for (int block_num = 0; block_num < params.NUM_BLOCKS; ++block_num)

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
@@ -53,7 +53,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
 
         _llk_unpack_A_init_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
-            UNPACK_TRANSPOSE_FACES, UNPACK_TRANSPOSE_WITHIN_FACE, FACE_R_DIM, num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+            UNPACK_TRANSPOSE_FACES,
+            UNPACK_TRANSPOSE_WITHIN_FACE,
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces),
+            formats.unpack_A_src,
+            formats.unpack_A_dst);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
@@ -289,7 +289,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         // Configure packer hardware
         _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * num_faces);
 
-        _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces);
+        _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces));
         // Initialize destination for packing
         _llk_pack_dest_init_<DST_SYNC_MODE, is_fp32_dest_acc_en>();
 

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -32,7 +32,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES);
 
     _llk_unpack_A_init_<BroadcastType::NONE, false /* is_fp32_dest_acc_en - why true does not work? */, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, FACE_R_DIM, TILE_NUM_FACES, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, TILE_NUM_FACES),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     for (std::uint32_t i = 0; i < params.NUM_BLOCKS * params.NUM_TILES_IN_BLOCK; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -64,7 +64,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-// copy srca to dest
+    // copy srca to dest
     _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false /* is_int_fpu_en */, PackMode::Default>(
         TILE_NUM_FACES, formats.math);
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
@@ -123,7 +123,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
-    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, TILE_NUM_FACES));
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
     LLK_ASSERT(
         (params.NUM_TILES_IN_BLOCK <= get_dest_max_tiles<DST_SYNC, is_fp32_dest_acc_en, DstTileShape::Tile32x32>()),

--- a/tt_metal/tt-llk/tests/sources/fast_tilize_bh_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/fast_tilize_bh_test.cpp
@@ -114,7 +114,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             ZONE_SCOPED("INIT")
             _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-                formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* unpA_num_faces */, 4 /* unpB_num_faces */);
+                formats.unpack_A_src,
+                formats.unpack_B_src,
+                formats.unpack_A_dst,
+                formats.unpack_B_dst,
+                FACE_R_DIM,
+                FACE_R_DIM,
+                4 /* unpA_num_faces */,
+                4 /* unpB_num_faces */);
             _llk_unpack_tilize_init_(formats.unpack_A_src, formats.unpack_A_dst, BLOCK_CT_DIM, FACE_R_DIM, false /* narrow_tile */);
         }
         {
@@ -124,7 +131,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
                 for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
                 {
                     _llk_unpack_tilize_dispatch_(
-                        _llk_unpack_tilize_, L1_ADDRESS(buffer_A[0]), 0, formats.unpack_A_src, formats.unpack_A_dst, FACE_R_DIM, 4 /* num_faces */, false /* narrow_tile */);
+                        _llk_unpack_tilize_,
+                        L1_ADDRESS(buffer_A[0]),
+                        0,
+                        formats.unpack_A_src,
+                        formats.unpack_A_dst,
+                        FACE_R_DIM,
+                        4 /* num_faces */,
+                        false /* narrow_tile */);
                 }
             }
         }
@@ -144,13 +158,27 @@ void run_kernel(RUNTIME_PARAMETERS params)
         {
             const std::uint32_t compat_dst = ckernel::to_underlying(DataFormat::Float16_b);
             _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-                formats.unpack_A_src, formats.unpack_B_src, compat_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* unpA_num_faces */, 4 /* unpB_num_faces */);
+                formats.unpack_A_src,
+                formats.unpack_B_src,
+                compat_dst,
+                formats.unpack_B_dst,
+                FACE_R_DIM,
+                FACE_R_DIM,
+                4 /* unpA_num_faces */,
+                4 /* unpB_num_faces */);
             _llk_unpack_fast_tilize_init_(compat_dst, BLOCK_CT_DIM, unit_dims[0]);
         }
         else
         {
             _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
-                formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* unpA_num_faces */, 4 /* unpB_num_faces */);
+                formats.unpack_A_src,
+                formats.unpack_B_src,
+                formats.unpack_A_dst,
+                formats.unpack_B_dst,
+                FACE_R_DIM,
+                FACE_R_DIM,
+                4 /* unpA_num_faces */,
+                4 /* unpB_num_faces */);
             _llk_unpack_fast_tilize_init_(formats.unpack_A_dst, BLOCK_CT_DIM, unit_dims[0]);
         }
         // Base address is programmed per-call inside _llk_unpack_fast_tilize_block_
@@ -224,14 +252,16 @@ void run_kernel(RUNTIME_PARAMETERS params)
             ZONE_SCOPED("INIT")
             _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, PackMode::Tilize>(4 /* num_faces */, formats.math);
+            _llk_math_eltwise_unary_datacopy_init_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, false, PackMode::Tilize>(
+                4 /* num_faces */, formats.math);
         }
         {
             ZONE_SCOPED("TILE_LOOP")
             for (std::uint32_t loop = 0; loop < LOOP_FACTOR; loop++)
             {
                 _llk_math_wait_for_dest_available_<DstSync::SyncHalf>();
-                _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en>(0 /* dst_index */, formats.math, formats.math, 4 /* num_faces */);
+                _llk_math_eltwise_unary_datacopy_<DataCopyType::A2D, DstSync::SyncHalf, is_fp32_dest_acc_en>(
+                    0 /* dst_index */, formats.math, formats.math, 4 /* num_faces */);
                 _llk_math_dest_section_done_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             }
         }
@@ -335,7 +365,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(
                 formats.pack_src, formats.pack_dst, SCALE_DATUM_SIZE(formats.pack_dst, TILE_C_DIM * TILE_R_DIM));
             _llk_pack_init_<ckernel::PackMode::Tilize, false /* zero_output */, false /* skip_addrmod_config */, false /* skip_packer_strides */>(
-                formats.pack_src, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
+                formats.pack_src, ckernel::DEFAULT_TENSOR_SHAPE, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
         }
         {
             ZONE_SCOPED("TILE_LOOP")
@@ -358,7 +388,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
             _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(
                 formats.pack_src, formats.pack_dst, SCALE_DATUM_SIZE(formats.pack_dst, TILE_C_DIM * TILE_R_DIM));
-            _llk_pack_fast_tilize_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>(0 /* use_32bit_dest */, formats.pack_dst, unit_dims[0], 4 /* num_faces */, formats.pack_src);
+            _llk_pack_fast_tilize_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>(
+                0 /* use_32bit_dest */, formats.pack_dst, unit_dims[0], 4 /* num_faces */, formats.pack_src);
         }
         {
             ZONE_SCOPED("TILE_LOOP")
@@ -405,7 +436,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         }
         {
             ZONE_SCOPED("UNINIT")
-            _llk_pack_fast_tilize_uninit_<DstSync::SyncHalf, is_fp32_dest_acc_en>(formats.pack_dst, FACE_R_DIM, 4 /* num_faces */, formats.pack_src);
+            _llk_pack_fast_tilize_uninit_<DstSync::SyncHalf, is_fp32_dest_acc_en>(formats.pack_dst, ckernel::DEFAULT_TENSOR_SHAPE, formats.pack_src);
         }
 
     } // end else (fast tilize path)

--- a/tt_metal/tt-llk/tests/sources/fast_tilize_metal_api_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/fast_tilize_metal_api_test.cpp
@@ -200,7 +200,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     }
 
     // fast_tilize_uninit
-    _llk_pack_fast_tilize_uninit_<DstSync::SyncHalf, is_fp32_dest_acc_en>(formats.pack_dst, FACE_R_DIM, 4);
+    _llk_pack_fast_tilize_uninit_<DstSync::SyncHalf, is_fp32_dest_acc_en>(formats.pack_dst, ckernel::DEFAULT_TENSOR_SHAPE);
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/fast_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/fast_tilize_test.cpp
@@ -326,7 +326,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         PROFILER_SYNC();
     }
 
-    _llk_pack_fast_tilize_uninit_<DstSync::SyncHalf, is_fp32_dest_acc_en>(formats.pack_dst, FACE_R_DIM, num_faces);
+    _llk_pack_fast_tilize_uninit_<DstSync::SyncHalf, is_fp32_dest_acc_en>(formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces));
 }
 
 #endif

--- a/tt_metal/tt-llk/tests/sources/hash_cb_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/hash_cb_test.cpp
@@ -40,7 +40,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4, 4);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
     for (std::uint32_t i = 0; i < params.TILE_CNT; i++)
     {
         _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(

--- a/tt_metal/tt-llk/tests/sources/hash_cb_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/hash_cb_test.cpp
@@ -103,10 +103,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // DEST datums without a numeric (FP32) conversion.
     constexpr std::uint32_t int32_fmt = static_cast<std::uint32_t>(DataFormat::Int32);
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, PackMode::Default>(
-        int32_fmt, int32_fmt, 32 * 32 * 4 /* INT32 tile size in bytes */, FACE_R_DIM, 4 /* num_faces */);
+        int32_fmt, int32_fmt, 32 * 32 * 4 /* INT32 tile size in bytes */, ckernel::DEFAULT_TENSOR_SHAPE);
     // The hw-configure above established the packer strides, so the wrapper skips re-programming them;
     // it still programs the X (datum) counter, which configure_pack does not touch.
-    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(int32_fmt, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */);
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(int32_fmt, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, 4 /* num_faces */));
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/math_transpose_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_transpose_perf.cpp
@@ -43,7 +43,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         START_PERF_MEASURE("INIT")
 
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            UNPACK_TRANSPOSE_FACES, false, FACE_R_DIM, TILE_NUM_FACES, formats.unpack_A_src, formats.unpack_A_dst);
+            UNPACK_TRANSPOSE_FACES, false, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, TILE_NUM_FACES), formats.unpack_A_src, formats.unpack_A_dst);
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
@@ -53,7 +53,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
         formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, TILE_SIZE_PACK);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, 4, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::DEFAULT_TENSOR_SHAPE,
+        formats_array[run].unpack_A_src,
+        formats_array[run].unpack_A_dst);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
         L1_ADDRESS(buffer_A_tilized), formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst);
 }

--- a/tt_metal/tt-llk/tests/sources/matmul_pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_pack_untilize_test.cpp
@@ -73,9 +73,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>(formats.pack_src, formats.pack_dst, tile_size);
     _llk_pack_dest_init_wrapper_<sync, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
-    _llk_pack_untilize_init_wrapper_<ct_dim>(formats.pack_src, formats.pack_dst, FACE_R_DIM, 4 /* num_faces */);
+    _llk_pack_untilize_init_wrapper_<ct_dim>(formats.pack_src, formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, 4 /* num_faces */));
     _llk_packer_wait_for_math_done_();
-    _llk_pack_untilize_wrapper_<ct_dim>(L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, FACE_R_DIM, 4 /* num_faces */, 0 /* tile_dst_rt_offset */);
+    _llk_pack_untilize_wrapper_<ct_dim>(
+        L1_ADDRESS(params.buffer_Res[0]), formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, 4 /* num_faces */), 0 /* tile_dst_rt_offset */);
     _llk_pack_dest_section_done_<sync, is_fp32_dest_acc_en>();
 }
 

--- a/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_unpack_tilize_test.cpp
@@ -190,7 +190,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #ifdef ARCH_BLACKHOLE
     // Strides + X counter were re-established by the reconfig above, so skip strides here.
     _llk_pack_init_<ckernel::PackMode::Default, false /* zero_output */, false /* skip_addrmod_config */, true /* skip_packer_strides */>(
-        formats_array[run].pack_src, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
+        formats_array[run].pack_src, ckernel::DEFAULT_TENSOR_SHAPE, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
 #endif
 
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
@@ -48,7 +48,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             /* num_faces */ 4,
             /* num_faces */ 4);
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+            0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
         PROFILER_SYNC();
 
         for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
@@ -205,9 +205,13 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("INIT")
         _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
-            formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */);
+            formats.pack_src, formats.pack_dst, TILE_WIDTH * TILE_HEIGHT, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, 4 /* num_faces */));
         _llk_pack_init_with_src_wrapper_<PackMode::Default, false /* zero_output */>(
-            formats.pack_src, formats.pack_dst, FACE_R_DIM, TILE_C_DIM, num_faces, false /* partial_face */, false /* narrow_tile */, TILE_CNT /* num_tiles */);
+            formats.pack_src,
+            formats.pack_dst,
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces),
+            false /* partial_face */,
+            TILE_CNT /* num_tiles */);
         reconfigure_packer_l1_acc(L1_ACC);
         _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
         _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_test.cpp
@@ -32,7 +32,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            0, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+            0 /* transpose_of_faces */,
+            0 /* within_face_16x16_transpose */,
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+            formats.unpack_A_src,
+            formats.unpack_A_dst);
 
         const int num_total_tiles = params.NUM_TILES_IN_BLOCK * params.NUM_BLOCKS;
 

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_test.cpp
@@ -91,7 +91,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-// copy srca to dest
+    // copy srca to dest
     _llk_math_eltwise_unary_datacopy_init_wrapper_<
         DataCopyType::A2D,
         is_fp32_dest_acc_en,
@@ -133,15 +133,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int num_blocks         = params.NUM_BLOCKS;
 
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_test_pack_mode_v<false, tilize_en>>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces));
     _llk_pack_init_with_src_wrapper_<llk_test_pack_mode_v<false, tilize_en>, false /* zero_output */>(
         formats.pack_src,
         formats.pack_dst,
-        FACE_R_DIM,
-        TILE_C_DIM,
-        params.num_faces,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
         false /* partial_face */,
-        false /* narrow_tile */,
         num_tiles_in_block /* num_tiles */);
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     reconfigure_packer_l1_acc(params.L1_ACC);

--- a/tt_metal/tt-llk/tests/sources/pack_rows_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_rows_test.cpp
@@ -26,7 +26,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /*num_faces*/, 4 /*num_faces*/);
     _llk_unpack_A_init_<BroadcastType::NONE, false /*acc_to_dest*/, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0 /*transpose_of_faces*/, 0 /*within_face_16x16_transpose*/, FACE_R_DIM, 4 /*num_faces*/, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /*transpose_of_faces*/, 0 /*within_face_16x16_transpose*/, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
 
     const int num_total_tiles = params.NUM_TILES_IN_BLOCK * params.NUM_BLOCKS;
 

--- a/tt_metal/tt-llk/tests/sources/pack_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_test.cpp
@@ -28,7 +28,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     const int num_total_tiles = params.NUM_TILES_IN_BLOCK * params.NUM_BLOCKS;
 

--- a/tt_metal/tt-llk/tests/sources/pack_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_test.cpp
@@ -63,7 +63,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-// copy srca to dest
+    // copy srca to dest
     _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, is_int_fpu_en, PackMode::Default>(
         params.num_faces, formats.math);
     _llk_math_pack_sync_init_<dest_sync, is_fp32_dest_acc_en>();
@@ -103,13 +103,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.pack_src,
         formats.pack_dst,
         16 * 16 * 4 /* tile_size */,
-        FACE_R_DIM,
-        TILE_C_DIM,
-        params.num_faces,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
         false /* partial_face */,
-        false /* narrow_tile */,
         params.RELU_CONFIG /* relu_config */);
-    _llk_pack_init_wrapper_<llk_test_pack_mode_v<false, tilize_en>, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+    _llk_pack_init_wrapper_<llk_test_pack_mode_v<false, tilize_en>, false /* zero_output */>(
+        formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces));
     _llk_pack_dest_init_<dest_sync, is_fp32_dest_acc_en>();
     const std::uint32_t num_tiles_in_block = params.NUM_TILES_IN_BLOCK;
     const std::uint32_t num_blocks         = params.NUM_BLOCKS;

--- a/tt_metal/tt-llk/tests/sources/pack_tiny_tile_block_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_tiny_tile_block_test.cpp
@@ -44,7 +44,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.num_faces);
 
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false>(
-        0, 0, params.TEST_FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     const int total_tiles = params.NUM_TILES_IN_BLOCK * params.NUM_BLOCKS;
     for (int i = 0; i < total_tiles; ++i)

--- a/tt_metal/tt-llk/tests/sources/pack_tiny_tile_block_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_tiny_tile_block_test.cpp
@@ -127,17 +127,14 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const int num_blocks         = params.NUM_BLOCKS;
 
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces);
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4, ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces));
 
     // Standard init sets addr_mods and strides for the tile shape.
     _llk_pack_init_with_src_wrapper_<PackMode::Default, false /* zero_output */>(
         formats.pack_src,
         formats.pack_dst,
-        params.TEST_FACE_R_DIM,
-        params.in0_tile_c_dim,
-        params.num_faces,
+        ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces),
         false /* partial_face */,
-        false /* narrow_tile */,
         1 /* num_tiles */);
 
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en>();

--- a/tt_metal/tt-llk/tests/sources/pack_tiny_tile_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_tiny_tile_reconfig_test.cpp
@@ -45,7 +45,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.num_faces);
 
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false>(
-        0, 0, params.TEST_FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     const int total_tiles = params.NUM_TILES_IN_BLOCK * params.NUM_BLOCKS;
     for (int i = 0; i < total_tiles; ++i)

--- a/tt_metal/tt-llk/tests/sources/pack_tiny_tile_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_tiny_tile_reconfig_test.cpp
@@ -130,10 +130,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
 #ifdef ARCH_BLACKHOLE
     // --- Phase 1: Init for standard 32x32 tiles ---
-    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, 16 * 16 * 4, FACE_R_DIM, TILE_C_DIM, 4);
+    _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, 4));
 
     _llk_pack_init_with_src_wrapper_<PackMode::Default, false /* zero_output */>(
-        formats.pack_src, formats.pack_dst, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */, false /* partial_face */, false /* narrow_tile */, 1 /* num_tiles */);
+        formats.pack_src, formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, 4 /* num_faces */), false /* partial_face */, 1 /* num_tiles */);
 
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     reconfigure_packer_l1_acc(params.L1_ACC);
@@ -142,17 +143,21 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // This overwrites the 32x32 config established in Phase 1, testing
     // that the transition from one tile shape to another is correct.
     _llk_pack_hw_configure_<is_fp32_dest_acc_en, ckernel::PackMode::Default>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces);
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4, ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces));
 
     _llk_pack_init_<ckernel::PackMode::Default, false /* zero_output */, false /* skip_addrmod_config */, false /* skip_packer_strides */>(
-        formats.pack_src, params.TEST_FACE_R_DIM, params.in0_tile_c_dim, params.num_faces, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
+        formats.pack_src,
+        ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces),
+        1 /* num_tiles */,
+        false /* skip_bh_tilize_workaround */);
 
     // Replace MOP with the block-contiguous version (REPLAY + W-per-tile).
     _llk_pack_block_contiguous_mop_config_<>(params.TEST_FACE_R_DIM, params.num_faces);
 #else
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4, params.TEST_FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, params.TEST_FACE_R_DIM, TILE_C_DIM, params.num_faces);
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4, ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces));
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
+        formats.pack_dst, ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces));
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, PackMode::Default>();
 #endif
 

--- a/tt_metal/tt-llk/tests/sources/pack_untilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_untilize_perf.cpp
@@ -49,7 +49,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("INIT")
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+            0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src,
             formats.unpack_B_src,

--- a/tt_metal/tt-llk/tests/sources/pack_untilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_untilize_perf.cpp
@@ -193,7 +193,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>(
             formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */);
         _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
-        _llk_pack_untilize_init_wrapper_<BLOCK_CT_DIM, FULL_CT_DIM>(formats.pack_src, formats.pack_dst, FACE_R_DIM, 4 /* num_faces */);
+        _llk_pack_untilize_init_wrapper_<BLOCK_CT_DIM, FULL_CT_DIM>(
+            formats.pack_src, formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, 4 /* num_faces */));
         PROFILER_SYNC();
     }
 

--- a/tt_metal/tt-llk/tests/sources/pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_untilize_test.cpp
@@ -47,7 +47,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     const std::uint32_t num_blocks_per_col = FULL_CT_DIM / BLOCK_CT_DIM;
 

--- a/tt_metal/tt-llk/tests/sources/pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_untilize_test.cpp
@@ -84,7 +84,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #endif
     const bool is_int_fpu_en = false;
 
-// copy srca to dest
+    // copy srca to dest
     _llk_math_eltwise_unary_datacopy_init_wrapper_<DataCopyType::A2D, is_fp32_dest_acc_en, BroadcastType::NONE, is_int_fpu_en, PackMode::Default>(
         params.num_faces, formats.math);
     _llk_math_pack_sync_init_<dest_sync, is_fp32_dest_acc_en>();
@@ -138,7 +138,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>(
         formats.pack_src, formats.pack_dst, NUM_DATUMS_IN_TILE /* tile_size */);
     _llk_pack_dest_init_wrapper_<dest_sync, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();
-    _llk_pack_untilize_init_wrapper_<BLOCK_CT_DIM, FULL_CT_DIM>(formats.pack_src, formats.pack_dst, FACE_R_DIM, params.num_faces);
+    _llk_pack_untilize_init_wrapper_<BLOCK_CT_DIM, FULL_CT_DIM>(
+        formats.pack_src, formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces));
     const std::uint32_t num_blocks_per_col = FULL_CT_DIM / BLOCK_CT_DIM;
 
     for (std::uint32_t rt = 0; rt < FULL_RT_DIM; rt++) // Loop over all tiles vertically
@@ -149,7 +150,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
             _llk_packer_wait_for_math_done_();
             _llk_pack_untilize_wrapper_<BLOCK_CT_DIM, FULL_CT_DIM, false /* diagonal */, false /* narrow_row */, TILE_C_DIM, TILE_DST_CT_OFFSET>(
-                pack_addr_16B, formats.pack_dst, FACE_R_DIM, params.num_faces, 0 /* tile_dst_rt_offset */);
+                pack_addr_16B, formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces), 0 /* tile_dst_rt_offset */);
             _llk_pack_dest_section_done_<dest_sync, is_fp32_dest_acc_en>();
         }
     }

--- a/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
@@ -218,14 +218,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t pack_dst_format0 = ckernel::to_underlying(DataFormat::Float16_b);
     _llk_pack_hw_configure_wrapper_<false /* is_fp32_dest_acc_en */, PackMode::Default>(pack_src_format0, pack_dst_format0, 128 /* tile_size */);
     _llk_pack_init_with_src_wrapper_<PackMode::Default, false /* zero_output */>(
-        pack_src_format0,
-        pack_dst_format0,
-        16 /* face_r_dim */,
-        TILE_C_DIM,
-        4 /* num_faces */,
-        false /* partial_face */,
-        false /* narrow_tile */,
-        1 /* num_tiles */);
+        pack_src_format0, pack_dst_format0, ckernel::DEFAULT_TENSOR_SHAPE, false /* partial_face */, 1 /* num_tiles */);
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, false /* is_fp32_dest_acc_en */, PackMode::Default>();
     for (std::uint32_t batch = 0; batch < 1; ++batch)
     {
@@ -246,14 +239,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_reconfig_data_format_wrapper_<false /* is_fp32_dest_acc_en */, false /* is_tile_dim_reconfig_en */>(
         pack_src_format1, pack_dst_format1, 128 /* tile_size */);
     _llk_pack_init_with_src_wrapper_<PackMode::Default, false /* zero_output */>(
-        pack_src_format1,
-        pack_dst_format1,
-        16 /* face_r_dim */,
-        TILE_C_DIM,
-        4 /* num_faces */,
-        false /* partial_face */,
-        false /* narrow_tile */,
-        1 /* num_tiles */);
+        pack_src_format1, pack_dst_format1, ckernel::DEFAULT_TENSOR_SHAPE, false /* partial_face */, 1 /* num_tiles */);
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, false /* is_fp32_dest_acc_en */, PackMode::Default>();
     _llk_pack_reduce_mask_config_<ckernel::ReduceDim::REDUCE_ROW>();
     for (std::uint32_t batch = 0; batch < 1; ++batch)
@@ -276,14 +262,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_reconfig_data_format_wrapper_<false /* is_fp32_dest_acc_en */, false /* is_tile_dim_reconfig_en */>(
         pack_src_format2, pack_dst_format2, 128 /* tile_size */);
     _llk_pack_init_with_src_wrapper_<PackMode::Default, false /* zero_output */>(
-        pack_src_format2,
-        pack_dst_format2,
-        16 /* face_r_dim */,
-        TILE_C_DIM,
-        4 /* num_faces */,
-        false /* partial_face */,
-        false /* narrow_tile */,
-        1 /* num_tiles */);
+        pack_src_format2, pack_dst_format2, ckernel::DEFAULT_TENSOR_SHAPE, false /* partial_face */, 1 /* num_tiles */);
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, false /* is_fp32_dest_acc_en */, PackMode::Default>();
     for (std::uint32_t batch = 0; batch < 1; ++batch)
     {
@@ -304,14 +283,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_pack_reconfig_data_format_wrapper_<false /* is_fp32_dest_acc_en */, false /* is_tile_dim_reconfig_en */>(
         pack_src_format3, pack_dst_format3, 128 /* tile_size */);
     _llk_pack_init_with_src_wrapper_<PackMode::Default, false /* zero_output */>(
-        pack_src_format3,
-        pack_dst_format3,
-        16 /* face_r_dim */,
-        TILE_C_DIM,
-        4 /* num_faces */,
-        false /* partial_face */,
-        false /* narrow_tile */,
-        1 /* num_tiles */);
+        pack_src_format3, pack_dst_format3, ckernel::DEFAULT_TENSOR_SHAPE, false /* partial_face */, 1 /* num_tiles */);
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, false /* is_fp32_dest_acc_en */, PackMode::Default>();
     for (std::uint32_t batch = 0; batch < 1; ++batch)
     {

--- a/tt_metal/tt-llk/tests/sources/sfpu_binary_bcast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binary_bcast_test.cpp
@@ -31,7 +31,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES);
 
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, TILE_NUM_FACES, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, TILE_NUM_FACES),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
         L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src, formats.unpack_A_dst);

--- a/tt_metal/tt-llk/tests/sources/sfpu_binary_bcast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binary_bcast_test.cpp
@@ -105,7 +105,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(formats.pack_src, formats.pack_dst, FACE_R_DIM * FACE_C_DIM * TILE_NUM_FACES);
-    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, TILE_NUM_FACES);
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, TILE_NUM_FACES));
     _llk_pack_dest_init_<DST_SYNC, is_fp32_dest_acc_en>();
 
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
@@ -27,7 +27,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
     _llk_unpack_A_init_<BROADCAST_TYPE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
     for (std::uint32_t i = 0; i < params.TILE_CNT; i++)
     {
         _llk_unpack_A_<BROADCAST_TYPE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_row_max_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_row_max_perf.cpp
@@ -48,7 +48,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             4 /* num_faces */,
             4 /* num_faces */);
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+            0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_perf.cpp
@@ -50,7 +50,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             4 /* num_faces */,
             4 /* num_faces */);
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+            0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_test.cpp
@@ -31,7 +31,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
 
     // Unpack tiles from L1 to source register A
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
@@ -30,7 +30,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
 
     const std::uint32_t num_total_tiles = params.NUM_TILES_IN_BLOCK * params.NUM_BLOCKS;
 

--- a/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
+++ b/tt_metal/tt-llk/tests/sources/tilize_calculate_untilize_L1.cpp
@@ -197,7 +197,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // The hw-configure above re-established the packer strides, so skip strides here. The X (datum)
     // counter is not touched by configure_pack; this init programs it (init owns SETADCXX).
     _llk_pack_init_<ckernel::PackMode::Default, false /* zero_output */, false /* skip_addrmod_config */, true /* skip_packer_strides */>(
-        formats_array[run].pack_src, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
+        formats_array[run].pack_src, ckernel::DEFAULT_TENSOR_SHAPE, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
 #endif
 
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/topk_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_test.cpp
@@ -179,10 +179,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
                     // only do face level transpose in the first iteration to turn in into column-wise format.
                     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-                        /* transpose_of_faces */ (current_iteration == 0) ? 1 : 0,
-                        /* within_face_16x16_transpose */ (current_iteration == 0) ? 1 : 0,
-                        /* face_r_dim     */ FACE_R_DIM,
-                        /* num_faces      */ 4,
+                        ((current_iteration == 0) ? 1 : 0) /* transpose_of_faces */,
+                        ((current_iteration == 0) ? 1 : 0) /* within_face_16x16_transpose */,
+                        ckernel::DEFAULT_TENSOR_SHAPE,
                         unpack_src_format,
                         unpack_dst_format);
 

--- a/tt_metal/tt-llk/tests/sources/topk_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_test.cpp
@@ -448,11 +448,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
                             pack_src_format,
                             pack_dst_format,
                             16 * 16 * 4 /* tile_size */,
-                            FACE_R_DIM,
-                            TILE_C_DIM,
-                            4 /* num_faces */,
+                            ckernel::DEFAULT_TENSOR_SHAPE,
                             false /* partial_face */,
-                            false /* narrow_tile */,
                             1 /* num_tiles */);
                     }
 

--- a/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
@@ -27,7 +27,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        params.UNPACK_TRANSPOSE_FACES, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        params.UNPACK_TRANSPOSE_FACES,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
@@ -98,8 +98,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces));
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces));
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/transpose_wh_int8_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_wh_int8_test.cpp
@@ -114,8 +114,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, FACE_R_DIM, TILE_C_DIM, params.num_faces);
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces));
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces));
     _llk_pack_dest_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
 
     _llk_packer_wait_for_math_done_();

--- a/tt_metal/tt-llk/tests/sources/transpose_wh_int8_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_wh_int8_test.cpp
@@ -36,7 +36,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     // Mirror transpose_wh_init i8 branch: acc_to_dest=true, transpose_of_faces=1, within_face_16x16_transpose=1.
     _llk_unpack_A_init_<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE, false /* unpack_to_dest */>(
-        1 /* transpose_of_faces */, 1 /* within_face_16x16_transpose */, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        1 /* transpose_of_faces */,
+        1 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/ttnn_where_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/ttnn_where_test.cpp
@@ -45,7 +45,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         UNPACK_FMT, UNPACK_FMT, UNPACK_FMT, UNPACK_FMT, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
-    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(0, 0, FACE_R_DIM, 4, UNPACK_FMT, UNPACK_FMT);
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, UNPACK_FMT, UNPACK_FMT);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_A[0]), UNPACK_FMT, UNPACK_FMT);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_B[0]), UNPACK_FMT, UNPACK_FMT);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_C[0]), UNPACK_FMT, UNPACK_FMT);

--- a/tt_metal/tt-llk/tests/sources/unpack_A_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_A_test.cpp
@@ -121,8 +121,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
     // Test configuration constants
     constexpr DstSync sync_mode = DstSync::SyncHalf;
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, PackMode::Default>(
-        formats.pack_src, formats.pack_dst, params.TEST_FACE_R_DIM * params.TEST_FACE_C_DIM * 4, params.TEST_FACE_R_DIM, TILE_C_DIM, params.num_faces);
-    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(formats.pack_dst, params.TEST_FACE_R_DIM, TILE_C_DIM, params.num_faces);
+        formats.pack_src,
+        formats.pack_dst,
+        params.TEST_FACE_R_DIM * params.TEST_FACE_C_DIM * 4,
+        ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces));
+    _llk_pack_init_wrapper_<PackMode::Default, false /* zero_output */>(
+        formats.pack_dst, ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces));
 
     _llk_pack_dest_init_wrapper_<sync_mode, is_fp32_dest_acc_en, PackMode::Default>();
 

--- a/tt_metal/tt-llk/tests/sources/unpack_A_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_A_test.cpp
@@ -41,13 +41,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.num_faces,
         params.num_faces);
     _llk_unpack_configure_stoch_rnd_<STOCHASTIC_RND>();
+    const ckernel::TensorShape tensor_shape = ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces);
     _llk_unpack_A_init_<BROADCAST_TYPE, ACC_TO_DEST, REUSE_DEST_TYPE, unpack_to_dest>(
-        params.UNPACK_TRANSPOSE_FACES,
-        params.UNPACK_TRANSPOSE_WITHIN_FACE,
-        params.TEST_FACE_R_DIM,
-        params.num_faces,
-        formats.unpack_A_src,
-        formats.unpack_A_dst);
+        params.UNPACK_TRANSPOSE_FACES, params.UNPACK_TRANSPOSE_WITHIN_FACE, tensor_shape, formats.unpack_A_src, formats.unpack_A_dst);
 
     for (std::uint32_t i = 0; i < num_tiles_in_block * num_blocks; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_tilize_test.cpp
@@ -71,7 +71,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const bool is_int_fpu_en      = false;
 
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
-// copy srca to dest
+    // copy srca to dest
     const bool is_8bit_format = _llk_math_skip_bh_tilize_workaround_wrapper_(formats.unpack_A_src);
     const bool TILIZE         = true;
     _llk_math_eltwise_unary_datacopy_init_wrapper_<
@@ -113,21 +113,18 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    const std::uint32_t num_faces = params.num_faces;
+    const std::uint32_t num_faces  = params.num_faces;
     static constexpr bool UNTILIZE = false;
 
     static constexpr bool TILIZE = true;
-    const bool is_8bit_format = _llk_pack_skip_bh_tilize_workaround_wrapper_(formats.unpack_A_src);
+    const bool is_8bit_format    = _llk_pack_skip_bh_tilize_workaround_wrapper_(formats.unpack_A_src);
     _llk_pack_hw_configure_wrapper_<is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>(
-        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, FACE_R_DIM, TILE_C_DIM, num_faces);
+        formats.pack_src, formats.pack_dst, 16 * 16 * 4 /* tile_size */, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces));
     _llk_pack_init_with_src_wrapper_<llk_unpack_tilize_sweep_pack_cfg_mode_v<UNTILIZE, TILIZE>, false /* zero_output */>(
         formats.pack_src,
         formats.pack_dst,
-        FACE_R_DIM,
-        TILE_C_DIM,
-        num_faces,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces),
         false /* partial_face */,
-        false /* narrow_tile */,
         1 /* num_tiles */,
         is_8bit_format /* skip_bh_tilize_workaround */);
     _llk_pack_dest_init_wrapper_<DstSync::SyncHalf, is_fp32_dest_acc_en, llk_test_pack_mode_v<UNTILIZE, false>>();

--- a/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
@@ -45,7 +45,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES);
-        _llk_unpack_A_init_<>(UNPACK_TRANSPOSE_FACES, UNPACK_TRANSPOSE_WITHIN_FACE, FACE_R_DIM, TILE_NUM_FACES, formats.unpack_A_src, formats.unpack_A_dst);
+        _llk_unpack_A_init_<>(
+            UNPACK_TRANSPOSE_FACES,
+            UNPACK_TRANSPOSE_WITHIN_FACE,
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, TILE_NUM_FACES),
+            formats.unpack_A_src,
+            formats.unpack_A_dst);
         PROFILER_SYNC();
     }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_pack_fast_tilize.h
@@ -268,16 +268,15 @@ inline void _llk_pack_fast_tilize_block_(
 template <DstSync Dst, bool is_fp32_dest_acc_en>
 inline void _llk_pack_fast_tilize_uninit_(
     const std::uint32_t pack_dst_format,
-    [[maybe_unused]] const std::uint32_t face_r_dim,
-    [[maybe_unused]] const std::uint32_t num_faces,
-    const std::uint32_t pack_src_format = (std::uint32_t)DataFormat::Float16_b)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const std::uint32_t pack_src_format      = (std::uint32_t)DataFormat::Float16_b)
 {
     if constexpr (is_fp32_dest_acc_en)
     {
         // Mirror of init: restore caller's pack_src_format via reconfig, which also
         // sets Read_32b correctly (=1 for fp32/dest_acc per cpack_common logic).
         const std::uint32_t tile_size = SCALE_DATUM_SIZE(pack_dst_format, TILE_C_DIM * TILE_R_DIM);
-        reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, TILE_C_DIM, num_faces, /*partial_face=*/false);
+        reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, tensor_shape, /*partial_face=*/false);
     }
     // DEST remap is NOT cleared here — set/owned by the math thread (see init comment).
     // BH-specific: restore strides modified by fast-tilize init (WH doesn't modify them).
@@ -286,5 +285,5 @@ inline void _llk_pack_fast_tilize_uninit_(
     // Restore X counter, addr_mods, and MOP via _llk_pack_init_ (aligned with WH approach); init owns
     // the X counter and sets it itself. Strides are restored just above, so skip them in init.
     _llk_pack_init_<PackMode::Default, false /* zero_output */, false /* skip_addrmod_config */, true /* skip_packer_strides */>(
-        pack_src_format, FACE_R_DIM, TILE_C_DIM, 4 /* num_faces */, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
+        pack_src_format, tensor_shape, 1 /* num_tiles */, false /* skip_bh_tilize_workaround */);
 }

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
@@ -55,7 +55,8 @@ inline void _llk_unpack_fast_untilize_mop_config_(const std::uint32_t unit_dim)
 template <bool is_fp32_dest_acc_en>
 inline void _llk_unpack_fast_untilize_init_(const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format, const std::uint32_t init_unit_dim)
 {
-    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false>(0, 0, FACE_R_DIM, 4, unpack_src_format, unpack_dst_format);
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false>(
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, unpack_src_format, unpack_dst_format);
     _llk_unpack_fast_untilize_mop_config_<is_fp32_dest_acc_en>(init_unit_dim);
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
@@ -6,13 +6,14 @@
 
 #include <cstdint>
 
-#include "../../common/tensor_shape.h"
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
 #include "cmath_common.h"
 #include "llk_assert.h"
 #include "llk_math_common.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_math.h"
 
 using namespace ckernel;
 
@@ -116,6 +117,7 @@ inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_des
     static_assert(
         math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
         "Math fidelity larger than LoFi only works with Eltwise multiply");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::eltwise_binary_configure_mop_standard, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const std::uint32_t num_faces       = tensor_shape.total_num_faces();
     const std::uint32_t num_faces_c_dim = tensor_shape.num_faces_c_dim;
@@ -202,6 +204,7 @@ inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_des
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType src_b_bcast_type, MathFidelity math_fidelity = MathFidelity::LoFi>
 inline void _llk_math_eltwise_binary_standard_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_standard_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     eltwise_binary_configure_addrmod<eltwise_binary_type, src_b_bcast_type, math_fidelity>();
@@ -239,6 +242,7 @@ inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tenso
         (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
             (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_standard_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
     constexpr bool high_fidelity        = is_high_fidelity(math_fidelity);
@@ -367,6 +371,7 @@ inline void eltwise_binary_configure_mop_with_dest_reuse(const std::uint32_t acc
     static_assert(
         math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
         "Math fidelity larger than LoFi only works with Eltwise multiply");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::eltwise_binary_configure_mop_with_dest_reuse, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     constexpr bool high_fidelity    = is_high_fidelity(math_fidelity);
     constexpr std::uint8_t addr_mod = ADDR_MOD_0;
@@ -455,6 +460,7 @@ template <
 inline void _llk_math_eltwise_binary_with_dest_reuse_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
 {
     static_assert(binary_reuse_dest != EltwiseBinaryReuseDestType::NONE, "Use _llk_math_eltwise_binary_standard_init_ for no dest reuse");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_with_dest_reuse_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     eltwise_binary_configure_addrmod<eltwise_binary_type, src_b_bcast_type, math_fidelity>();
@@ -531,6 +537,7 @@ inline void _llk_math_eltwise_binary_with_dest_reuse_(const ckernel::TensorShape
         (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
             (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_with_dest_reuse_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     // Dest counter always jumps by 32x32 tile spacing regardless of actual tile size

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -14,6 +14,7 @@
 #include "llk_assert.h"
 #include "llk_math_common.h"
 #include "tensor_shape.h"
+#include "tensor_shape_coverage_math.h"
 
 using namespace ckernel;
 
@@ -181,6 +182,7 @@ template <
     bool enforce_fp32_accumulation = false>
 inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_reduce_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     // Supported narrow tiles per BH Tiny Tile Summary: [16]x16 (num_faces=1) and [32]x16 (num_faces=2) only

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_pack.h
@@ -13,6 +13,8 @@
 #include "llk_assert.h"
 #include "llk_defs.h"
 #include "llk_pack_common.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_pack.h"
 
 using namespace ckernel;
 using namespace ckernel::packer;
@@ -85,20 +87,18 @@ inline void _llk_pack_configure_addrmod_()
  *
  * @tparam pack_mode: Packing layout, values = <Default/Tilize/Untilize>
  * @tparam zero_output: When true, packer emits zeros instead of dest data.
- * @param face_r_dim: Number of rows per face.
- * @param tile_c_dim: Tile column dimension (datums).
- * @param num_faces: Faces per tile, valid values = <1, 2, 4>
+ * @param tensor_shape: Tile face geometry and face-grid layout.
  * @param num_tiles: Number of tiles processed per MOP run.
  * @note @ref _llk_pack_configure_addrmod_ must have programmed the ADDR_MOD slots for the same pack_mode.
  */
 template <PackMode pack_mode = PackMode::Default, bool zero_output = false>
-inline void _llk_pack_mop_config_(
-    const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t tile_c_dim = TILE_C_DIM,
-    const std::uint32_t num_faces  = 4,
-    const std::uint32_t num_tiles  = 1)
+inline void _llk_pack_mop_config_(const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE, const std::uint32_t num_tiles = 1)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_VALIDATE_TENSOR_SHAPE_PACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_pack_mop_config_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const std::uint8_t face_r_dim = tensor_shape.face_r_dim;
+    const std::uint8_t tile_c_dim = tensor_shape.total_col_dim();
+    const std::uint8_t num_faces  = tensor_shape.total_num_faces();
 
     constexpr std::uint32_t MEGAROW          = 1;
     constexpr std::uint32_t ZERO_OUTPUT_FLAG = zero_output ? p_pacr::P_ZERO_OUTPUT_ENABLED : p_pacr::P_ZERO_OUTPUT_DISABLED;
@@ -346,29 +346,22 @@ namespace llk_pack_internal_bh
  * @tparam skip_addrmod_config: When true, leave the ADDR_MOD slots untouched.
  * @tparam skip_packer_strides: When true, do not re-program the packer strides.
  * @param pack_src_format: Source (dest register) data format; only used when programming strides.
- * @param face_r_dim: Number of rows per face.
- * @param tile_c_dim: Tile column dimension (datums).
- * @param num_faces: Faces per tile, valid values = <1, 2, 4>
+ * @param tensor_shape: Tile face geometry and face-grid layout.
  * @param num_tiles: Number of tiles processed per MOP run.
  * @note Init owns the packer X (datum) counter (SETADCXX): every init programs its own value, mirroring
  *       the Wormhole contract. On Blackhole the value is always a single row (FACE_C_DIM - 1).
  */
 template <PackMode pack_mode, bool zero_output, bool skip_addrmod_config, bool skip_packer_strides>
-inline void pack_init_apply(
-    const std::uint32_t pack_src_format,
-    const std::uint32_t face_r_dim,
-    const std::uint32_t tile_c_dim,
-    const std::uint32_t num_faces,
-    const std::uint32_t num_tiles)
+inline void pack_init_apply(const std::uint32_t pack_src_format, const ckernel::TensorShape& tensor_shape, const std::uint32_t num_tiles)
 {
     if constexpr (!skip_addrmod_config)
     {
         _llk_pack_configure_addrmod_<pack_mode>();
     }
-    _llk_pack_mop_config_<pack_mode, zero_output>(face_r_dim, tile_c_dim, num_faces, num_tiles);
+    _llk_pack_mop_config_<pack_mode, zero_output>(tensor_shape, num_tiles);
     if constexpr (!skip_packer_strides)
     {
-        set_packer_strides<pack_mode>(pack_src_format, tile_c_dim);
+        set_packer_strides<pack_mode>(pack_src_format, tensor_shape.total_col_dim());
     }
 
     // Program the packer X (datum) counter. Per the "inits own SETADCXX" contract, every init sets its
@@ -386,9 +379,7 @@ inline void pack_init_apply(
  * @param pack_src_format: Source (dest register) data format.
  * @param pack_dst_format: Destination (L1) data format.
  * @param tile_size: Size of one output tile in bytes.
- * @param face_r_dim: Number of rows per face.
- * @param tile_c_dim: Tile column dimension (datums).
- * @param num_faces: Faces per tile, valid values = <1, 2, 4>
+ * @param tensor_shape: Tile face geometry and face-grid layout.
  * @param partial_face: True if packing a partial (sub-face-row) face.
  */
 template <bool is_fp32_dest_acc_en>
@@ -396,12 +387,13 @@ inline void _llk_pack_reconfig_data_format_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t tile_c_dim = TILE_C_DIM,
-    const std::uint32_t num_faces  = 4,
-    const bool partial_face        = false)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool partial_face                  = false)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, tile_c_dim, num_faces, partial_face);
+    LLK_VALIDATE_TENSOR_SHAPE_PACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_pack_reconfig_data_format_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    reconfig_packer_data_format<is_fp32_dest_acc_en>(
+        pack_src_format, pack_dst_format, tile_size, tensor_shape.total_col_dim(), tensor_shape.total_num_faces(), partial_face);
 }
 
 /**
@@ -427,9 +419,7 @@ inline void _llk_pack_set_fp32_dest_acc_(bool enable)
  * @param pack_src_format: Source (dest register) data format.
  * @param pack_dst_format: Destination (L1) data format.
  * @param tile_size: Size of one output tile in bytes.
- * @param face_r_dim: Number of rows per face.
- * @param tile_c_dim: Tile column dimension (datums).
- * @param num_faces: Faces per tile, valid values = <1, 2, 4>
+ * @param tensor_shape: Tile face geometry and face-grid layout.
  * @param partial_face: True if packing a partial (sub-face-row) face.
  * @param relu_config: Packed relu mode and threshold configuration (0 disables relu).
  * @note For 8-bit unpack-source datums, do not use PackMode::Tilize: the Blackhole row-unswizzling workaround is skipped (and is unnecessary, as 8-bit formats
@@ -440,14 +430,21 @@ inline void _llk_pack_hw_configure_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim  = FACE_R_DIM,
-    const std::uint32_t tile_c_dim  = TILE_C_DIM,
-    const std::uint32_t num_faces   = 4,
-    const bool partial_face         = false,
-    const std::uint32_t relu_config = 0)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool partial_face                  = false,
+    const std::uint32_t relu_config          = 0)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    configure_pack<is_fp32_dest_acc_en, pack_mode>(pack_src_format, pack_dst_format, tile_size, face_r_dim, tile_c_dim, num_faces, partial_face, relu_config);
+    LLK_VALIDATE_TENSOR_SHAPE_PACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_pack_hw_configure_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    configure_pack<is_fp32_dest_acc_en, pack_mode>(
+        pack_src_format,
+        pack_dst_format,
+        tile_size,
+        tensor_shape.face_r_dim,
+        tensor_shape.total_col_dim(),
+        tensor_shape.total_num_faces(),
+        partial_face,
+        relu_config);
 }
 
 /**
@@ -464,23 +461,17 @@ inline void _llk_pack_hw_configure_(
  * @tparam skip_packer_strides: When true, do not re-program the packer strides (e.g. when a prior
  *         hw-configure / reconfig already established them, or the caller programs them itself).
  * @param pack_src_format: Source (dest register) data format. Only consulted when programming strides.
- * @param face_r_dim: Number of rows per face.
- * @param tile_c_dim: Tile column dimension (datums).
- * @param num_faces: Faces per tile, valid values = <1, 2, 4>
+ * @param tensor_shape: Tile face geometry and face-grid layout.
  * @param num_tiles: Number of tiles processed per MOP run.
  * @param skip_bh_tilize_workaround: When true (8-bit src datums), skip the Blackhole tilize row-unswizzle workaround.
  * @note Pair with @ref _llk_pack_uninit_ after the matching @ref _llk_pack_ execute calls.
  */
 template <PackMode pack_mode = PackMode::Default, bool zero_output = false, bool skip_addrmod_config = false, bool skip_packer_strides = false>
 inline void _llk_pack_init_(
-    const std::uint32_t pack_src_format,
-    const std::uint32_t face_r_dim,
-    const std::uint32_t tile_c_dim,
-    const std::uint32_t num_faces,
-    const std::uint32_t num_tiles,
-    const bool skip_bh_tilize_workaround)
+    const std::uint32_t pack_src_format, const ckernel::TensorShape& tensor_shape, const std::uint32_t num_tiles, const bool skip_bh_tilize_workaround)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_VALIDATE_TENSOR_SHAPE_PACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_pack_init_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const DataFormat src_format = static_cast<DataFormat>(pack_src_format);
     if (src_format == DataFormat::Float32)
     {
@@ -496,12 +487,11 @@ inline void _llk_pack_init_(
     if (skip_bh_tilize_workaround && pack_mode == PackMode::Tilize)
     {
         llk_pack_internal_bh::pack_init_apply<PackMode::Default, zero_output, skip_addrmod_config, skip_packer_strides>(
-            pack_src_format, face_r_dim, tile_c_dim, num_faces, num_tiles);
+            pack_src_format, tensor_shape, num_tiles);
     }
     else
     {
-        llk_pack_internal_bh::pack_init_apply<pack_mode, zero_output, skip_addrmod_config, skip_packer_strides>(
-            pack_src_format, face_r_dim, tile_c_dim, num_faces, num_tiles);
+        llk_pack_internal_bh::pack_init_apply<pack_mode, zero_output, skip_addrmod_config, skip_packer_strides>(pack_src_format, tensor_shape, num_tiles);
     }
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -14,6 +14,8 @@
 #include "cunpack_common.h"
 #include "llk_assert.h"
 #include "llk_unpack_common.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -30,7 +32,7 @@ using namespace ckernel::unpacker;
  * @tparam binary_reuse_dest: Reuse dest as a source operand, values = <NONE/DEST_TO_SRCA/DEST_TO_SRCB>
  * @tparam unpack_to_dest: Unpack directly into the dest register (32-bit datums).
  * @param transpose_of_faces: Whether faces are reordered (transposed) during the unpack.
- * @param num_faces: Number of faces in the tile, valid values = <1, 2, 4>.
+ * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim).
  * @param unpack_src_format: Source data format of the operand in L1.
  * @param unpack_dst_format: Destination data format the operand is converted to.
  */
@@ -40,14 +42,16 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest                          = false>
 inline void _llk_unpack_A_mop_config_(
-    const bool transpose_of_faces, const std::uint32_t num_faces, const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format = 0)
+    const bool transpose_of_faces, const ckernel::TensorShape tensor_shape, const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format = 0)
 {
     static_assert(
         !((BType != BroadcastType::NONE) && acc_to_dest && (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)), "Not supported configuration!");
     static_assert(
         !(((acc_to_dest) || (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE)) && (unpack_to_dest)),
         "Not supported configuration when unpacking to dest!");
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_A_mop_config_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const std::uint8_t num_faces = tensor_shape.total_num_faces();
 
     static constexpr std::uint32_t unpack_srca =
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
@@ -215,11 +219,11 @@ inline void _llk_unpack_A_mop_config_(
  * @tparam unpack_to_dest: Unpack directly into the dest register (32-bit datums).
  * @param transpose_of_faces: Nonzero to reorder (transpose) faces during the unpack.
  * @param within_face_16x16_transpose: Nonzero to enable the 16x16 within-face transpose (haloize mode).
- * @param face_r_dim: Number of rows per face.
- * @param num_faces: Number of faces in the tile, valid values = <1, 2, 4>.
+ * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim).
  * @param unpack_src_format: Source data format of the operand in L1.
  * @param unpack_dst_format: Destination data format the operand is converted to.
- * @note Call @ref _llk_unpack_A_uninit_ to restore the modified datum-count state.
+ * @note Call @ref _llk_unpack_A_uninit_ as the matching teardown; it is currently a no-op
+ *       because unpacker X counters are reprogrammed by init.
  * @ref _llk_unpack_A_ is the matching execute call.
  * @ref _llk_math_eltwise_unary_datacopy_init_ is the matching init on the math thread (datacopy/transpose consumer).
  */
@@ -231,12 +235,14 @@ template <
 inline void _llk_unpack_A_init_(
     const std::uint32_t transpose_of_faces          = 0,
     const std::uint32_t within_face_16x16_transpose = 0,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
-    const std::uint32_t num_faces                   = 4,
+    const ckernel::TensorShape tensor_shape         = ckernel::DEFAULT_TENSOR_SHAPE,
     const std::uint32_t unpack_src_format           = 0,
     const std::uint32_t unpack_dst_format           = 0)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_A_init_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const std::uint8_t face_r_dim = tensor_shape.face_r_dim;
+    const std::uint8_t num_faces  = tensor_shape.total_num_faces();
     LLK_ASSERT(BType != BroadcastType::COL || num_faces == 4, "Unary Broadcast Column requires num_faces == 4 (32x32 only)");
     LLK_ASSERT(transpose_of_faces == 0 || face_r_dim == 16, "Partial faces are not supported for transpose datacopy, face_r_dim must be 16 rows");
     LLK_ASSERT(transpose_of_faces == 0 || num_faces == 4 || num_faces == 1, "Transpose requires num_faces == 4 or 1 (32x32 and 16x16 only)");
@@ -271,10 +277,8 @@ inline void _llk_unpack_A_init_(
         //   acc_to_dest DEST_TO_SRCA   -> SrcB only      (SrcA comes from DEST, e.g. hardswish x*hardsigmoid(x))
         //   acc_to_dest DEST_TO_SRCB   -> SrcA only      (SrcB comes from DEST)
         //   broadcast                  -> SrcB
-        constexpr bool reads_srca =
-            (BType == BroadcastType::NONE) && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA);
-        constexpr bool reads_srcb =
-            (BType != BroadcastType::NONE) || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB);
+        constexpr bool reads_srca       = (BType == BroadcastType::NONE) && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA);
+        constexpr bool reads_srcb       = (BType != BroadcastType::NONE) || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB);
         constexpr std::uint32_t UNP_SEL = (reads_srca && reads_srcb) ? p_setadc::UNP_AB : (reads_srca ? p_setadc::UNP_A : p_setadc::UNP_B);
         config_unpacker_x_end<UNP_SEL>(face_r_dim);
     }
@@ -284,17 +288,17 @@ inline void _llk_unpack_A_init_(
     {
         _llk_unpack_dbg_feature_disable_();
     }
-    _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(transpose_of_faces > 0, num_faces, unpack_src_format, unpack_dst_format);
+    _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
+        transpose_of_faces > 0, tensor_shape, unpack_src_format, unpack_dst_format);
 }
 
 /**
- * @brief Restore unpacker datum-count state after single-operand (A) unpacking.
+ * @brief No-op teardown after single-operand (A) unpacking.
  *
- * Resets the X-dimension address counter for the unpacker used by this broadcast mode back to
- * a full face worth of datums.
+ * The unpacker X counter is transient and reprogrammed by each operation's init, so there is
+ * nothing to restore here.
  *
  * @tparam BType: Broadcast type, values = <NONE/COL/ROW/SCALAR>
- * @param face_r_dim: Number of rows per face, used to compute the restored datum count.
  * @note Call @ref _llk_unpack_A_init_ with matching template args before this function.
  */
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 
-#include "../../common/tensor_shape.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_globals.h"
@@ -16,6 +15,8 @@
 #include "llk_assert.h"
 #include "llk_defs.h"
 #include "llk_unpack_common.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -36,6 +37,7 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
     const std::uint32_t num_faces_c_dim = tensor_shape.num_faces_c_dim;
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_mop_config_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     if (transpose_of_faces)
@@ -160,6 +162,7 @@ template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const ckernel::Transpose transpose)
 {
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const bool within_face_16x16_transpose = transpose == ckernel::Transpose::IntraFace || transpose == ckernel::Transpose::Both;
     const bool transpose_of_faces          = transpose == ckernel::Transpose::InterFace || transpose == ckernel::Transpose::Both;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
@@ -15,6 +15,7 @@
 #include "llk_assert.h"
 #include "llk_unpack_common.h"
 #include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -33,6 +34,7 @@ template <PoolType pool_type, ReduceDim reduce_dim>
 inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_reduce_mop_config_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     // Data valid for clear instructions is set to 0 since the MATH kernel should not process this data.
@@ -106,6 +108,7 @@ template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulati
 inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape &tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_reduce_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     if constexpr (enforce_fp32_accumulation)

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -8,6 +8,7 @@
 
 #include "llk_math_common.h"
 #include "tensor_shape.h"
+#include "tensor_shape_coverage_math.h"
 using namespace ckernel;
 using namespace ckernel::trisc;
 using namespace ckernel::math;
@@ -352,6 +353,7 @@ inline void _llk_math_reduce_addrmod_()
 template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, ckernel::MathFidelity MATH_FIDELITY_TYPE>
 inline void _llk_math_reduce_init_(const TensorShape& tensor_shape)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_reduce_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     _llk_math_reduce_addrmod_<REDUCE_DIMENSION, MATH_FIDELITY_TYPE>();
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
@@ -9,6 +9,7 @@
 #include "ckernel_trisc_common.h"
 #include "llk_unpack_common.h"
 #include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 using namespace ckernel;
 
 /**
@@ -66,6 +67,7 @@ template <ReduceDim REDUCE_DIMENSION>
 inline void _llk_unpack_reduce_init_(
     const std::uint32_t buf_desc_id_0, const std::uint32_t buf_desc_id_1, const TensorShape& tensor_shape, const std::uint32_t num_tiles = NUM_TILES)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_reduce_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, (REDUCE_DIMENSION == ReduceDim::REDUCE_ROW));
     _llk_unpack_reduce_mop_config_<REDUCE_DIMENSION>(buf_desc_id_0, buf_desc_id_1, tensor_shape, num_tiles);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 
-#include "../../common/tensor_shape.h"
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
@@ -14,6 +13,8 @@
 #include "llk_assert.h"
 #include "llk_math_common.h"
 #include "lltt.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_math.h"
 
 using namespace ckernel;
 
@@ -30,9 +31,12 @@ using namespace ckernel;
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType bcast_type, MathFidelity math_fidelity>
 inline void eltwise_binary_configure_addrmod()
 {
-    static_assert(math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL, "Math fidelity larger than LoFi only works with Eltwise multiply");
     static_assert(
-        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) || (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
+        math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
+        "Math fidelity larger than LoFi only works with Eltwise multiply");
+    static_assert(
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+            (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
 
     constexpr std::uint32_t fidelity_increment = is_high_fidelity(math_fidelity) ? 1 : 0;
@@ -77,7 +81,8 @@ template <EltwiseBinaryType eltwise_binary_type>
 inline auto eltwise_binary_func(std::uint8_t clr_src, std::uint8_t acc_to_dest, std::uint8_t broadcast_type, std::uint8_t addr_mod)
 {
     static_assert(
-        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) || (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+            (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
 
     if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWADD)
@@ -109,11 +114,12 @@ inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_des
     static_assert(
         math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
         "Math fidelity larger than LoFi only works with Eltwise multiply");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::eltwise_binary_configure_mop_standard, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
-    const std::uint32_t num_faces           = tensor_shape.total_num_faces();
-    const std::uint32_t num_faces_c_dim     = tensor_shape.num_faces_c_dim;
-    constexpr bool high_fidelity            = is_high_fidelity(math_fidelity);
-    constexpr std::uint8_t addr_mod         = ADDR_MOD_0;
+    const std::uint32_t num_faces       = tensor_shape.total_num_faces();
+    const std::uint32_t num_faces_c_dim = tensor_shape.num_faces_c_dim;
+    constexpr bool high_fidelity        = is_high_fidelity(math_fidelity);
+    constexpr std::uint8_t addr_mod     = ADDR_MOD_0;
 
     // Inner loop: number of MAX_FPU_ROWS (8-row) operations per face
     // Even if face_r_dim < 16, we still process at least 1 inner loop iteration
@@ -193,6 +199,7 @@ inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_des
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType src_b_bcast_type, MathFidelity math_fidelity = MathFidelity::LoFi>
 inline void _llk_math_eltwise_binary_standard_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_standard_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     eltwise_binary_configure_addrmod<eltwise_binary_type, src_b_bcast_type, math_fidelity>();
@@ -223,11 +230,15 @@ template <
     MathFidelity math_fidelity = MathFidelity::LoFi>
 inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tensor_shape, std::uint32_t dst_index)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_standard_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
-    static_assert(math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL, "Math fidelity larger than LoFi only works with Eltwise multiply");
     static_assert(
-        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) || (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
+        math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
+        "Math fidelity larger than LoFi only works with Eltwise multiply");
+    static_assert(
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+            (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
     constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
 
@@ -352,7 +363,10 @@ inline void eltwise_binary_reuse_dest_as_src()
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType bcast_type, MathFidelity math_fidelity = MathFidelity::LoFi>
 inline void eltwise_binary_configure_mop_with_dest_reuse(const std::uint32_t acc_to_dest, const ckernel::TensorShape &tensor_shape)
 {
-    static_assert(math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL, "Math fidelity larger than LoFi only works with Eltwise multiply");
+    static_assert(
+        math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
+        "Math fidelity larger than LoFi only works with Eltwise multiply");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::eltwise_binary_configure_mop_with_dest_reuse, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     constexpr bool high_fidelity    = is_high_fidelity(math_fidelity);
     constexpr std::uint8_t addr_mod = ADDR_MOD_0;
@@ -441,6 +455,7 @@ template <
 inline void _llk_math_eltwise_binary_with_dest_reuse_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
 {
     static_assert(binary_reuse_dest != EltwiseBinaryReuseDestType::NONE, "Use _llk_math_eltwise_binary_standard_init_ for no dest reuse");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_with_dest_reuse_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     eltwise_binary_configure_addrmod<eltwise_binary_type, src_b_bcast_type, math_fidelity>();
@@ -514,10 +529,14 @@ template <
 inline void _llk_math_eltwise_binary_with_dest_reuse_(const ckernel::TensorShape &tensor_shape, std::uint32_t dst_index, const bool clear_fp32_dst_acc)
 {
     static_assert(binary_reuse_dest != EltwiseBinaryReuseDestType::NONE, "Use _llk_math_eltwise_binary_standard_ for no dest reuse");
-    static_assert(math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL, "Math fidelity larger than LoFi only works with Eltwise multiply");
     static_assert(
-        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) || (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
+        math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
+        "Math fidelity larger than LoFi only works with Eltwise multiply");
+    static_assert(
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+            (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_with_dest_reuse_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const std::uint32_t num_faces       = tensor_shape.total_num_faces();
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
@@ -741,9 +760,12 @@ inline void eltwise_binary_configure_addrmod()
 template <EltwiseBinaryType eltwise_binary_type, MathFidelity math_fidelity = MathFidelity::LoFi>
 inline void _llk_math_eltwise_binary_init_(std::uint32_t srca_reuse_count = 4)
 {
-    static_assert(math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL, "Math fidelity larger than LoFi only works with Eltwise multiply");
     static_assert(
-        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) || (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
+        math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
+        "Math fidelity larger than LoFi only works with Eltwise multiply");
+    static_assert(
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+            (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
 
     eltwise_binary_configure_addrmod();

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -14,6 +14,7 @@
 #include "llk_assert.h"
 #include "llk_math_common.h"
 #include "tensor_shape.h"
+#include "tensor_shape_coverage_math.h"
 
 using namespace ckernel;
 
@@ -193,6 +194,7 @@ template <
     bool enforce_fp32_accumulation = false>
 inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_reduce_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     // Supported narrow tiles per BH Tiny Tile Summary: [16]x16 (num_faces=1) and [32]x16 (num_faces=2) only

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack.h
@@ -14,6 +14,8 @@
 #include "llk_defs.h"
 #include "llk_memory_checks.h"
 #include "llk_pack_common.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_pack.h"
 
 using namespace ckernel;
 using namespace ckernel::packer;
@@ -120,14 +122,13 @@ inline std::uint32_t _llk_pack_output_size_bytes_(const std::uint32_t pack_dst_f
  * a count of 16-byte words, the stride used to advance the L1 destination between tiles.
  *
  * @param pack_dst_format: Destination (L1) data format.
- * @param face_r_dim: Number of rows per face.
- * @param num_faces: Faces per tile, valid values = <1, 2, 4>
+ * @param tensor_shape: Tile face geometry and face-grid layout.
  * @return Per-tile L1 offset in 16-byte words.
  */
 inline std::uint32_t _llk_pack_output_addr_offset_words_(
-    const std::uint32_t pack_dst_format, const std::uint32_t face_r_dim = FACE_R_DIM, const std::uint32_t num_faces = 4)
+    const std::uint32_t pack_dst_format, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
-    const std::uint32_t tile_elements = face_r_dim * FACE_C_DIM * num_faces;
+    const std::uint32_t tile_elements = tensor_shape.total_tensor_size();
     std::uint32_t tile_size           = _llk_pack_output_size_bytes_(pack_dst_format, tile_elements);
 
     return tile_size >> 4;
@@ -185,23 +186,23 @@ inline void _llk_pack_configure_addrmod_()
  * @tparam pack_mode: Packing layout, values = <Default/Untilize>
  * @tparam zero_output: When true, packer emits zeros instead of dest data.
  * @param pack_dst_format: Destination (L1) data format.
- * @param face_r_dim: Number of rows per face.
- * @param num_faces: Faces per tile, valid values = <1, 2, 4>
+ * @param tensor_shape: Tile face geometry and face-grid layout.
  * @param partial_face: True if packing a partial (sub-face-row) face.
- * @param narrow_tile: True if the tile occupies fewer than the full set of packer interfaces.
  * @param num_tiles: Number of tiles processed per MOP run.
  * @note @ref _llk_pack_configure_addrmod_ must have programmed the ADDR_MOD slots for the same pack_mode.
  */
 template <PackMode pack_mode = PackMode::Default, bool zero_output = false>
 inline void _llk_pack_mop_config_(
     const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t num_faces  = 4,
-    const bool partial_face        = false,
-    const bool narrow_tile         = false,
-    const std::uint32_t num_tiles  = 1)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool partial_face                  = false,
+    const std::uint32_t num_tiles            = 1)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_VALIDATE_TENSOR_SHAPE_PACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_pack_mop_config_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const std::uint8_t face_r_dim = tensor_shape.face_r_dim;
+    const std::uint8_t num_faces  = tensor_shape.total_num_faces();
+    const bool narrow_tile        = tensor_shape.num_faces_c_dim < tensor_shape.num_faces_r_dim;
     LLK_ASSERT(num_tiles >= 1, "num_tiles must be >= 1");
 
     if constexpr (pack_mode != PackMode::Untilize)
@@ -213,7 +214,7 @@ inline void _llk_pack_mop_config_(
             LLK_ASSERT(!narrow_tile, "multi-tile pack does not support narrow tiles");
             TT_SETDMAREG(
                 p_setdmareg::PAYLOAD_IMMEDIATE,
-                _llk_pack_output_addr_offset_words_(pack_dst_format, face_r_dim, num_faces),
+                _llk_pack_output_addr_offset_words_(pack_dst_format, tensor_shape),
                 p_setdmareg::MODE_IMMEDIATE,
                 LO_16(p_gpr_pack::OUTPUT_ADDR_OFFSET));
         }
@@ -295,23 +296,21 @@ inline void _llk_pack_mop_config_(
  * @param pack_src_format: Source (dest register) data format.
  * @param pack_dst_format: Destination (L1) data format.
  * @param tile_size: Size of one output tile in bytes.
- * @param face_r_dim: Number of rows per face.
- * @param num_faces: Faces per tile, valid values = <1, 2, 4>
+ * @param tensor_shape: Tile face geometry and face-grid layout.
  * @param partial_face: True if packing a partial (sub-face-row) face.
- * @param narrow_tile: True if the tile occupies fewer than the full set of packer interfaces.
  */
 template <bool is_fp32_dest_acc_en>
 inline void _llk_pack_reconfig_data_format_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim          = FACE_R_DIM,
-    const std::uint32_t num_faces           = 4,
-    const bool partial_face                 = false,
-    [[maybe_unused]] const bool narrow_tile = false)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool partial_face                  = false)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    reconfig_packer_data_format<is_fp32_dest_acc_en>(pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face);
+    LLK_VALIDATE_TENSOR_SHAPE_PACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_pack_reconfig_data_format_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    reconfig_packer_data_format<is_fp32_dest_acc_en>(
+        pack_src_format, pack_dst_format, tile_size, tensor_shape.face_r_dim, tensor_shape.total_num_faces(), partial_face);
 }
 
 /**
@@ -337,10 +336,8 @@ inline void _llk_pack_set_fp32_dest_acc_(bool enable)
  * @param pack_src_format: Source (dest register) data format.
  * @param pack_dst_format: Destination (L1) data format.
  * @param tile_size: Size of one output tile in bytes.
- * @param face_r_dim: Number of rows per face.
- * @param num_faces: Faces per tile, valid values = <1, 2, 4>
+ * @param tensor_shape: Tile face geometry and face-grid layout.
  * @param partial_face: True if packing a partial (sub-face-row) face.
- * @param narrow_tile: True if the tile occupies fewer than the full set of packer interfaces.
  * @param relu_config: Packed relu mode and threshold configuration (0 disables relu).
  */
 template <bool is_fp32_dest_acc_en, PackMode pack_mode = PackMode::Default>
@@ -348,14 +345,15 @@ inline void _llk_pack_hw_configure_(
     const std::uint32_t pack_src_format,
     const std::uint32_t pack_dst_format,
     const std::uint32_t tile_size,
-    const std::uint32_t face_r_dim  = FACE_R_DIM,
-    const std::uint32_t num_faces   = 4,
-    const bool partial_face         = false,
-    const bool narrow_tile          = false,
-    const std::uint32_t relu_config = 0)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool partial_face                  = false,
+    const std::uint32_t relu_config          = 0)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
-    configure_pack<is_fp32_dest_acc_en, pack_mode>(pack_src_format, pack_dst_format, tile_size, face_r_dim, num_faces, partial_face, narrow_tile, relu_config);
+    LLK_VALIDATE_TENSOR_SHAPE_PACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_pack_hw_configure_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const bool narrow_tile = tensor_shape.num_faces_c_dim < tensor_shape.num_faces_r_dim;
+    configure_pack<is_fp32_dest_acc_en, pack_mode>(
+        pack_src_format, pack_dst_format, tile_size, tensor_shape.face_r_dim, tensor_shape.total_num_faces(), partial_face, narrow_tile, relu_config);
 }
 
 /**
@@ -372,10 +370,8 @@ inline void _llk_pack_hw_configure_(
  *         so this flag has no effect; retained because existing callers (e.g. SDPA `compute_streaming.hpp`)
  *         and shared tests still pass it.
  * @param pack_dst_format: Destination (L1) data format.
- * @param face_r_dim: Number of rows per face.
- * @param num_faces: Faces per tile, valid values = <1, 2, 4>
+ * @param tensor_shape: Tile face geometry and face-grid layout.
  * @param partial_face: True if packing a partial (sub-face-row) face.
- * @param narrow_tile: True if the tile occupies fewer than the full set of packer interfaces.
  * @param num_tiles: Number of tiles processed per MOP run.
  * @note Init programs ADDR_MOD + MOP + the packer X (datum) counter. The X counter is pack_mode-dependent
  *       (Untilize packs a single face row, Default a full face), so it is per-op state owned here; the
@@ -387,20 +383,21 @@ inline void _llk_pack_hw_configure_(
 template <PackMode pack_mode = PackMode::Default, bool zero_output = false, bool skip_addrmod_config = false, [[maybe_unused]] bool skip_packer_strides = false>
 inline void _llk_pack_init_(
     const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t num_faces  = 4,
-    const bool partial_face        = false,
-    const bool narrow_tile         = false,
-    const std::uint32_t num_tiles  = 1)
+    const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool partial_face                  = false,
+    const std::uint32_t num_tiles            = 1)
 {
     static_assert(
         pack_mode == PackMode::Default || pack_mode == PackMode::Untilize, "Wormhole B0 pack init supports only PackMode::Default and PackMode::Untilize");
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_VALIDATE_TENSOR_SHAPE_PACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_pack_init_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const std::uint8_t face_r_dim = tensor_shape.face_r_dim;
+    const bool narrow_tile        = tensor_shape.num_faces_c_dim < tensor_shape.num_faces_r_dim;
     if constexpr (!skip_addrmod_config)
     {
         _llk_pack_configure_addrmod_<pack_mode>();
     }
-    _llk_pack_mop_config_<pack_mode, zero_output>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile, num_tiles);
+    _llk_pack_mop_config_<pack_mode, zero_output>(pack_dst_format, tensor_shape, partial_face, num_tiles);
     if constexpr (!skip_packer_strides)
     {
         set_packer_l1_offset(pack_dst_format, face_r_dim);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_fast_tilize.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_pack_fast_tilize.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 
 #include "llk_pack.h"
+#include "tensor_shape.h"
 
 using namespace ckernel;
 using namespace ckernel::packer;
@@ -217,22 +218,16 @@ inline void _llk_pack_fast_tilize_init_(
  * @tparam Dst: Destination sync mode, values = <SyncHalf/SyncFull>
  * @tparam is_fp32_dest_acc_en: True if the destination register accumulates in FP32.
  * @param pack_dst_format: Destination (L1) data format used to re-run the default packer init.
- * @param face_r_dim: Number of rows per face.
- * @param num_faces: Faces per tile, valid values = <1, 2, 4>
+ * @param tensor_shape: Tile face geometry and face-grid layout.
  * @param partial_face: True if packing a partial (sub-face-row) face.
- * @param narrow_tile: True if the tile occupies fewer than the full set of packer interfaces.
  * @note Call @ref _llk_pack_fast_tilize_init_ before this function.
  */
 template <DstSync Dst, bool is_fp32_dest_acc_en>
 inline void _llk_pack_fast_tilize_uninit_(
-    const std::uint32_t pack_dst_format,
-    const std::uint32_t face_r_dim = FACE_R_DIM,
-    const std::uint32_t num_faces  = 4,
-    const bool partial_face        = false,
-    const bool narrow_tile         = false)
+    const std::uint32_t pack_dst_format, const ckernel::TensorShape& tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE, const bool partial_face = false)
 {
     TTI_STALLWAIT(p_stall::STALL_CFG, p_stall::PACK);
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     // restore PCK_DEST_RD_CTRL_Read_32b_data to the original value
     cfg_reg_rmw_tensix<PCK_DEST_RD_CTRL_Read_32b_data_RMW>(is_fp32_dest_acc_en);
 
@@ -245,7 +240,7 @@ inline void _llk_pack_fast_tilize_uninit_(
     // for some reason short inits avoid the packer init (probably since it is usually the same)
     // but that means calling it here with reasonable defaults is needed
     // it just initializes the address mods and mop
-    _llk_pack_init_<PackMode::Default, false /* zero_output */>(pack_dst_format, face_r_dim, num_faces, partial_face, narrow_tile);
+    _llk_pack_init_<PackMode::Default, false /* zero_output */>(pack_dst_format, tensor_shape, partial_face, 1 /* num_tiles */);
 }
 
 /**

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -16,6 +16,8 @@
 #include "llk_unpack_common.h"
 #include "lltt.h"
 #include "sfpi.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -32,7 +34,7 @@ using namespace ckernel::unpacker;
  * @tparam binary_reuse_dest: Reuse dest as a source operand, values = <NONE/DEST_TO_SRCA/DEST_TO_SRCB>
  * @tparam unpack_to_dest: Unpack directly into the dest register (32-bit datums).
  * @param transpose_of_faces: Whether faces are reordered (transposed) during the unpack.
- * @param num_faces: Number of faces in the tile, valid values = <1, 2, 4>.
+ * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim).
  * @param unpack_src_format: Source data format of the operand in L1.
  * @param unpack_dst_format: Destination data format the operand is converted to.
  */
@@ -42,14 +44,16 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest                          = false>
 inline void _llk_unpack_A_mop_config_(
-    const bool transpose_of_faces, const std::uint32_t num_faces, const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format = 0)
+    const bool transpose_of_faces, const ckernel::TensorShape tensor_shape, const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format = 0)
 {
     static_assert(
         !((BType != BroadcastType::NONE) && acc_to_dest && (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)), "Not supported configuration!");
     static_assert(
         !(((acc_to_dest) || (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE)) && (unpack_to_dest)),
         "Not supported configuration when unpacking to dest!");
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_A_mop_config_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const std::uint8_t num_faces = tensor_shape.total_num_faces();
 
     static constexpr std::uint32_t unpack_srca =
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
@@ -216,11 +220,11 @@ inline void _llk_unpack_A_mop_config_(
  * @tparam unpack_to_dest: Unpack directly into the dest register (32-bit datums).
  * @param transpose_of_faces: Nonzero to reorder (transpose) faces during the unpack.
  * @param within_face_16x16_transpose: Nonzero to enable the 16x16 within-face transpose (haloize mode).
- * @param face_r_dim: Number of rows per face.
- * @param num_faces: Number of faces in the tile, valid values = <1, 2, 4>.
+ * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim).
  * @param unpack_src_format: Source data format of the operand in L1.
  * @param unpack_dst_format: Destination data format the operand is converted to.
- * @note Call @ref _llk_unpack_A_uninit_ after this function to restore the modified datum-count state.
+ * @note Call @ref _llk_unpack_A_uninit_ as the matching teardown; it is currently a no-op
+ *       because unpacker X counters are reprogrammed by init.
  * @ref _llk_unpack_A_ is the matching execute call.
  * @ref _llk_math_eltwise_unary_datacopy_init_ is the matching init on the math thread (datacopy/transpose consumer).
  */
@@ -232,12 +236,14 @@ template <
 inline void _llk_unpack_A_init_(
     const std::uint32_t transpose_of_faces          = 0,
     const std::uint32_t within_face_16x16_transpose = 0,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
-    const std::uint32_t num_faces                   = 4,
+    const ckernel::TensorShape tensor_shape         = ckernel::DEFAULT_TENSOR_SHAPE,
     const std::uint32_t unpack_src_format           = 0,
     const std::uint32_t unpack_dst_format           = 0)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_A_init_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const std::uint8_t face_r_dim = tensor_shape.face_r_dim;
+    const std::uint8_t num_faces  = tensor_shape.total_num_faces();
     LLK_ASSERT(BType != BroadcastType::COL || num_faces == 4, "Unary Broadcast Column requires num_faces == 4 (32x32 only)");
     LLK_ASSERT(transpose_of_faces == 0 || face_r_dim == 16, "Partial faces are not supported for transpose datacopy, face_r_dim must be 16 rows");
     LLK_ASSERT(transpose_of_faces == 0 || num_faces == 4 || num_faces == 1, "Transpose requires num_faces == 4 or 1 (32x32 and 16x16 only)");
@@ -272,15 +278,14 @@ inline void _llk_unpack_A_init_(
         //   acc_to_dest DEST_TO_SRCA   -> SrcB only      (SrcA comes from DEST, e.g. hardswish x*hardsigmoid(x))
         //   acc_to_dest DEST_TO_SRCB   -> SrcA only      (SrcB comes from DEST)
         //   broadcast                  -> SrcB
-        constexpr bool reads_srca =
-            (BType == BroadcastType::NONE) && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA);
-        constexpr bool reads_srcb =
-            (BType != BroadcastType::NONE) || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB);
+        constexpr bool reads_srca       = (BType == BroadcastType::NONE) && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA);
+        constexpr bool reads_srcb       = (BType != BroadcastType::NONE) || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB);
         constexpr std::uint32_t UNP_SEL = (reads_srca && reads_srcb) ? p_setadc::UNP_AB : (reads_srca ? p_setadc::UNP_A : p_setadc::UNP_B);
         config_unpacker_x_end<UNP_SEL>(face_r_dim);
     }
 
-    _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(transpose_of_faces > 0, num_faces, unpack_src_format, unpack_dst_format);
+    _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
+        transpose_of_faces > 0, tensor_shape, unpack_src_format, unpack_dst_format);
 }
 
 /**
@@ -365,13 +370,12 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
 }
 
 /**
- * @brief Restore unpacker datum-count state after single-operand (A) unpacking.
+ * @brief No-op teardown after single-operand (A) unpacking.
  *
- * Resets the X-dimension address counter for the unpacker used by this broadcast mode back to
- * a full face worth of datums.
+ * The unpacker X counter is transient and reprogrammed by each operation's init, so there is
+ * nothing to restore here.
  *
  * @tparam BType: Broadcast type, values = <NONE/COL/ROW/SCALAR>
- * @param face_r_dim: Number of rows per face, used to compute the restored datum count.
  * @note Call @ref _llk_unpack_A_init_ with matching template args before this function.
  */
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 
-#include "../../common/tensor_shape.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_globals.h"
@@ -17,6 +16,8 @@
 #include "llk_defs.h"
 #include "llk_unpack_common.h"
 #include "lltt.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -37,6 +38,7 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
     const std::uint32_t num_faces_c_dim = tensor_shape.num_faces_c_dim;
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_mop_config_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     if (transpose_of_faces)
@@ -149,6 +151,7 @@ template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const ckernel::Transpose transpose)
 {
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const bool within_face_16x16_transpose = transpose == ckernel::Transpose::IntraFace || transpose == ckernel::Transpose::Both;
     const bool transpose_of_faces          = transpose == ckernel::Transpose::InterFace || transpose == ckernel::Transpose::Both;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
@@ -25,6 +25,7 @@
 #include "llk_unpack_common.h"
 #include "lltt.h"
 #include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -43,6 +44,7 @@ template <PoolType pool_type, ReduceDim reduce_dim>
 inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_reduce_mop_config_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     // Data valid for clear instructions is set to 0 since the MATH kernel should not process this data.
@@ -110,6 +112,7 @@ template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulati
 inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape &tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_reduce_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     // Enable transpose (haloize mode) if reducing along rows


### PR DESCRIPTION
## Summary
- Refactor WH/BH `llk_pack.h` and API layers to take a single `TensorShape` instead of separate `face_r_dim` / `num_faces` / `narrow_tile` parameters, and update LLK test wrappers/callers accordingly.
- Add `common/parse.py` with `harvest`, `emit-pack`, and `summary` to collect DPRINT `tensor_shape` lines from pytest logs and generate `tensor_shape_coverage_pack.h`.
- Populate wormhole pack TensorShape coverage (hw_configure, init, mop_config, reconfig_data_format) via DPRINT discovery runs; fix DPRINT emission to use numeric enum/dimension values so logs are harvestable.
- Includes prior unpack-A TensorShape coverage work on this branch.

## Test plan
- [x] WH pack discovery batches (A/B/C) with `TT_LLK_DISABLE_ASSERTS=1` and `--logging-level=debug`, harvested via `parse.py`
- [x] Assert build spot-check: `test_zzz_pack.py`, `test_pack_tiny_tile_block.py`, `test_sdpa_reinits.py` (1708 passed, no coverage DPRINT lines)
- [ ] Merge Gate CI


Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/tensor_shape_llk_pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/tensor_shape_llk_pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/tensor_shape_llk_pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/tensor_shape_llk_pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/tensor_shape_llk_pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/tensor_shape_llk_pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/tensor_shape_llk_pack)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_pack)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/tensor_shape_llk_pack)