### PR TITLE
Refactor BH/WH math matmul to TensorShape with pairwise coverage

### DIFF
--- a/tt_metal/tt-llk/common/parse.py
+++ b/tt_metal/tt-llk/common/parse.py
@@ -1,0 +1,410 @@
+#!/usr/bin/env python3
+"""TensorShape coverage parser.
+
+Reads loguru test logs (test_run.log, test_run_gw*.log) and extracts DPRINT
+coverage lines into coverage.json.
+
+Single-shape:
+  '[<fn>] tensor_shape: face_r_dim=N face_c_dim=N num_faces_r_dim=N num_faces_c_dim=N'
+
+Pairwise (matmul):
+  '[<fn>] tensor_shape_pair: in0_face_r_dim=... in0_face_c_dim=... in0_num_faces_r_dim=... in0_num_faces_c_dim=...'
+  ' in1_face_r_dim=... in1_face_c_dim=... in1_num_faces_r_dim=... in1_num_faces_c_dim=...'
+
+Usage:
+    parse.py harvest  <test_name>            # consume *.log files into coverage.json
+    parse.py emit     <out_header_path>      # regenerate single-shape coverage header
+    parse.py emit-math <out_header_path>     # regenerate matmul pair coverage header
+    parse.py summary                         # print per-function summary
+"""
+from __future__ import annotations
+
+import json
+import re
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+LLK_COMMON_DIR = Path(__file__).resolve().parent
+LLK_ROOT = LLK_COMMON_DIR.parent
+PYTHON_TESTS_DIR = LLK_ROOT / "tests" / "python_tests"
+COVERAGE_JSON = Path("/tmp/ts-coverage/parsed/coverage.json")
+
+MATMUL_PAIR_FUNCTIONS = (
+    "matmul_configure_addrmod",
+    "matmul_configure_mop",
+    "matmul_configure_mop_throttled",
+    "_llk_math_matmul_init_",
+)
+
+DPRINT_RE = re.compile(
+    r"\[(?P<fn>[A-Za-z_][A-Za-z0-9_]*)\] tensor_shape: "
+    r"face_r_dim=(?P<fr>\d+) face_c_dim=(?P<fc>\d+) "
+    r"num_faces_r_dim=(?P<nfr>\d+) num_faces_c_dim=(?P<nfc>\d+)"
+)
+
+PAIR_DPRINT_RE = re.compile(
+    r"\[(?P<fn>[A-Za-z_][A-Za-z0-9_]*)\] tensor_shape_pair: "
+    r"in0_face_r_dim=(?P<in0_fr>\d+) in0_face_c_dim=(?P<in0_fc>\d+) "
+    r"in0_num_faces_r_dim=(?P<in0_nfr>\d+) in0_num_faces_c_dim=(?P<in0_nfc>\d+) "
+    r"in1_face_r_dim=(?P<in1_fr>\d+) in1_face_c_dim=(?P<in1_fc>\d+) "
+    r"in1_num_faces_r_dim=(?P<in1_nfr>\d+) in1_num_faces_c_dim=(?P<in1_nfc>\d+)"
+)
+
+# (fr, nfr, nfc) -> constexpr name. face_c_dim is always 16 by HW.
+SHAPE_NAMES = {
+    (fr, nfr, nfc): f"TENSOR_SHAPE_FR{fr}_NF{nfr}x{nfc}"
+    for fr in (1, 2, 4, 8, 16)
+    for nfr in (1, 2)
+    for nfc in (1, 2)
+}
+
+
+def _load_coverage() -> dict:
+    if COVERAGE_JSON.exists():
+        data = json.loads(COVERAGE_JSON.read_text())
+    else:
+        data = {"tests": {}, "functions": {}, "function_pairs": {}}
+    data.setdefault("functions", {})
+    data.setdefault("function_pairs", {})
+    data.setdefault("tests", {})
+    return data
+
+
+def _save_coverage(data: dict) -> None:
+    COVERAGE_JSON.parent.mkdir(parents=True, exist_ok=True)
+    COVERAGE_JSON.write_text(json.dumps(data, indent=2, sort_keys=True))
+
+
+def _log_paths() -> list[Path]:
+    paths: list[Path] = []
+    single = PYTHON_TESTS_DIR / "test_run.log"
+    if single.exists():
+        paths.append(single)
+    paths.extend(sorted(PYTHON_TESTS_DIR.glob("test_run_gw*.log")))
+    return paths
+
+
+def _parse_shape(match: re.Match[str], prefix: str = "") -> tuple[int, int, int, int]:
+    return (
+        int(match.group(f"{prefix}fr")),
+        int(match.group(f"{prefix}fc")),
+        int(match.group(f"{prefix}nfr")),
+        int(match.group(f"{prefix}nfc")),
+    )
+
+
+def _harvest(test_name: str) -> tuple[int, int, int, int, int]:
+    """Read worker logs, extract DPRINT lines, persist into coverage.json.
+
+    Returns (single_lines, pair_lines, shapes_added, pairs_added, function_count_after).
+    """
+    coverage = _load_coverage()
+    by_fn: dict[str, set[tuple[int, int, int, int]]] = {
+        fn: set(tuple(s) for s in shapes)
+        for fn, shapes in coverage["functions"].items()
+    }
+    by_fn_pairs: dict[
+        str, set[tuple[tuple[int, int, int, int], tuple[int, int, int, int]]]
+    ] = {
+        fn: {tuple(tuple(part) for part in pair) for pair in pairs}
+        for fn, pairs in coverage["function_pairs"].items()
+    }
+
+    test_single: set[tuple[str, tuple[int, int, int, int]]] = set()
+    test_pairs: set[
+        tuple[str, tuple[tuple[int, int, int, int], tuple[int, int, int, int]]]
+    ] = set()
+    single_lines = 0
+    pair_lines = 0
+
+    for log_path in _log_paths():
+        try:
+            text = log_path.read_text(errors="replace")
+        except OSError:
+            continue
+        for m in DPRINT_RE.finditer(text):
+            single_lines += 1
+            fn = m.group("fn")
+            shape = _parse_shape(m)
+            test_single.add((fn, shape))
+            by_fn.setdefault(fn, set()).add(shape)
+        for m in PAIR_DPRINT_RE.finditer(text):
+            pair_lines += 1
+            fn = m.group("fn")
+            in0 = _parse_shape(m, prefix="in0_")
+            in1 = _parse_shape(m, prefix="in1_")
+            pair = (in0, in1)
+            test_pairs.add((fn, pair))
+            by_fn_pairs.setdefault(fn, set()).add(pair)
+
+    shapes_added = 0
+    for fn, shapes in by_fn.items():
+        prev = set(tuple(s) for s in coverage["functions"].get(fn, []))
+        if shapes - prev:
+            shapes_added += len(shapes - prev)
+
+    pairs_added = 0
+    for fn, pairs in by_fn_pairs.items():
+        prev = {
+            tuple(tuple(part) for part in pair)
+            for pair in coverage["function_pairs"].get(fn, [])
+        }
+        if pairs - prev:
+            pairs_added += len(pairs - prev)
+
+    coverage["functions"] = {fn: sorted(shapes) for fn, shapes in sorted(by_fn.items())}
+    coverage["function_pairs"] = {
+        fn: [[list(in0), list(in1)] for in0, in1 in sorted(pairs)]
+        for fn, pairs in sorted(by_fn_pairs.items())
+    }
+    coverage["tests"][test_name] = {
+        "harvested_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "dprint_lines_seen": single_lines + pair_lines,
+        "single_dprint_lines_seen": single_lines,
+        "pair_dprint_lines_seen": pair_lines,
+        "unique_fn_shape_pairs": len(test_single) + len(test_pairs),
+        "functions": sorted(set(fn for fn, _ in test_single)),
+        "pair_functions": sorted(set(fn for fn, _ in test_pairs)),
+    }
+    _save_coverage(coverage)
+    fn_count = len(set(by_fn.keys()) | set(by_fn_pairs.keys()))
+    return single_lines, pair_lines, shapes_added, pairs_added, fn_count
+
+
+def _shape_to_literal(fr: int, fc: int, nfr: int, nfc: int) -> tuple[str, bool]:
+    """Return (cpp_literal, is_known_constant)."""
+    if fc == 16 and (fr, nfr, nfc) in SHAPE_NAMES:
+        return SHAPE_NAMES[(fr, nfr, nfc)], True
+    return f"TensorShape{{{fr}, {fc}, {nfr}, {nfc}}}", False
+
+
+def _array_name(fn: str) -> str:
+    cleaned = fn.strip("_")
+    return f"covered_shapes_{cleaned}"
+
+
+def _pair_array_name(fn: str) -> str:
+    cleaned = fn.strip("_")
+    return f"covered_shape_pairs_{cleaned}"
+
+
+def _emit_single_shape_header(out_path: Path) -> None:
+    coverage = _load_coverage()
+    fns = coverage["functions"]
+    tests_done = sorted(coverage["tests"].keys())
+
+    lines: list[str] = []
+    lines.append("// SPDX-FileCopyrightText: \u00a9 2026 Tenstorrent AI ULC")
+    lines.append("//")
+    lines.append("// SPDX-License-Identifier: Apache-2.0")
+    lines.append("//")
+    lines.append(
+        "// AUTO-GENERATED: per-function TensorShape coverage observed across LLK pytests."
+    )
+    lines.append("//")
+    lines.append(
+        "// Regenerate by running functional pytests with --logging-level=DEBUG"
+    )
+    lines.append("// and harvesting logs through common/parse.py.")
+    lines.append("//")
+    lines.append(
+        f"// Last update : {datetime.now(timezone.utc).isoformat(timespec='seconds')}"
+    )
+    lines.append(f"// Tests run   : {len(tests_done)}")
+    lines.append("")
+    lines.append("#pragma once")
+    lines.append("")
+    lines.append("#include <array>")
+    lines.append("")
+    lines.append('#include "tensor_shape.h"')
+    lines.append("")
+    lines.append("#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)")
+    lines.append("")
+    lines.append("namespace ckernel::coverage")
+    lines.append("{")
+    lines.append("")
+
+    for fn in sorted(fns.keys()):
+        shapes = sorted(tuple(s) for s in fns[fn])
+        arr = _array_name(fn)
+        lines.append(f"// {fn}: {len(shapes)} unique TensorShape(s)")
+        if not shapes:
+            lines.append(f"inline constexpr std::array<TensorShape, 0> {arr} = {{}};")
+            lines.append("")
+            continue
+        rendered = []
+        any_unknown = False
+        for fr, fc, nfr, nfc in shapes:
+            literal, known = _shape_to_literal(fr, fc, nfr, nfc)
+            tag = "" if known else "  // out-of-bounds"
+            if not known:
+                any_unknown = True
+            rendered.append((literal, tag))
+        lines.append(
+            f"inline constexpr std::array<TensorShape, {len(shapes)}> {arr} = {{{{"
+        )
+        for literal, tag in rendered:
+            lines.append(f"    {literal},{tag}")
+        lines.append("}};")
+        if any_unknown:
+            lines.append(
+                "// Note: observed shapes outside the validated set; investigate."
+            )
+        lines.append("")
+
+    lines.append("} // namespace ckernel::coverage")
+    lines.append("")
+    lines.append("#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)")
+    lines.append("")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines))
+
+
+def _emit_math_pair_header(out_path: Path) -> None:
+    coverage = _load_coverage()
+    pair_fns = coverage["function_pairs"]
+    tests_done = sorted(coverage["tests"].keys())
+
+    lines: list[str] = []
+    lines.append("// SPDX-FileCopyrightText: \u00a9 2026 Tenstorrent AI ULC")
+    lines.append("//")
+    lines.append("// SPDX-License-Identifier: Apache-2.0")
+    lines.append("//")
+    lines.append(
+        "// AUTO-GENERATED: per-function TensorShape pair coverage for matmul helpers."
+    )
+    lines.append("//")
+    lines.append("// Regenerate by running matmul pytests with --logging-level=DEBUG,")
+    lines.append(
+        "// TT_LLK_DISABLE_ASSERTS=1, then: parse.py harvest && parse.py emit-math"
+    )
+    lines.append("//")
+    lines.append(
+        f"// Last update : {datetime.now(timezone.utc).isoformat(timespec='seconds')}"
+    )
+    lines.append(f"// Tests run   : {len(tests_done)}")
+    lines.append("")
+    lines.append("#pragma once")
+    lines.append("")
+    lines.append("#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)")
+    lines.append("")
+    lines.append("#include <array>")
+    lines.append("")
+    lines.append('#include "tensor_shape_coverage.h"')
+    lines.append("")
+    lines.append("namespace ckernel::coverage")
+    lines.append("{")
+    lines.append("")
+
+    emit_fns = sorted(set(MATMUL_PAIR_FUNCTIONS) | set(pair_fns.keys()))
+    for fn in emit_fns:
+        raw_pairs = pair_fns.get(fn, [])
+        pairs = sorted(tuple(tuple(part) for part in pair) for pair in raw_pairs)
+        arr = _pair_array_name(fn)
+        lines.append(f"// {fn}: {len(pairs)} unique TensorShape pair(s)")
+        if not pairs:
+            lines.append(
+                f"inline constexpr std::array<TensorShapePair, 0> {arr} = {{}};"
+            )
+            lines.append("")
+            continue
+        any_unknown = False
+        lines.append(
+            f"inline constexpr std::array<TensorShapePair, {len(pairs)}> {arr} = {{{{"
+        )
+        for in0, in1 in pairs:
+            in0_lit, in0_known = _shape_to_literal(*in0)
+            in1_lit, in1_known = _shape_to_literal(*in1)
+            if not in0_known or not in1_known:
+                any_unknown = True
+            tag = ""
+            if not in0_known or not in1_known:
+                tag = "  // out-of-bounds"
+            lines.append(f"    {{{in0_lit}, {in1_lit}}},{tag}")
+        lines.append("}};")
+        if any_unknown:
+            lines.append(
+                "// Note: observed pair shapes outside the validated set; investigate."
+            )
+        lines.append("")
+
+    lines.append("} // namespace ckernel::coverage")
+    lines.append("")
+    lines.append("#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)")
+    lines.append("")
+
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    out_path.write_text("\n".join(lines))
+
+
+def _summary() -> None:
+    coverage = _load_coverage()
+    fns = coverage["functions"]
+    pair_fns = coverage["function_pairs"]
+    tests = coverage["tests"]
+    print(f"tests harvested: {len(tests)}")
+    for t in sorted(tests):
+        rec = tests[t]
+        print(
+            f"  {t}: {rec.get('dprint_lines_seen', 0)} dprint lines "
+            f"({rec.get('single_dprint_lines_seen', 0)} single, "
+            f"{rec.get('pair_dprint_lines_seen', 0)} pair), "
+            f"{rec.get('unique_fn_shape_pairs', 0)} unique entries"
+        )
+    print(f"\nsingle-shape functions seen: {len(fns)}")
+    for fn in sorted(fns):
+        shapes = sorted(tuple(s) for s in fns[fn])
+        formatted = ", ".join(f"({fr},{fc},{nfr},{nfc})" for fr, fc, nfr, nfc in shapes)
+        print(f"  {fn}: {len(shapes)} shape(s) -> {formatted}")
+    print(f"\npairwise functions seen: {len(pair_fns)}")
+    for fn in sorted(pair_fns):
+        pairs = sorted(tuple(tuple(part) for part in pair) for pair in pair_fns[fn])
+        formatted = ", ".join(
+            f"(({i0[0]},{i0[1]},{i0[2]},{i0[3]}),({i1[0]},{i1[1]},{i1[2]},{i1[3]}))"
+            for i0, i1 in pairs
+        )
+        print(f"  {fn}: {len(pairs)} pair(s) -> {formatted}")
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) < 2:
+        print(__doc__)
+        return 1
+    cmd = argv[1]
+    if cmd == "harvest":
+        if len(argv) < 3:
+            print("usage: parse.py harvest <test_name>")
+            return 1
+        single, pair, shapes_added, pairs_added, fn_count = _harvest(argv[2])
+        print(
+            f"[{argv[2]}] single dprint lines: {single}, pair dprint lines: {pair}, "
+            f"new shapes: {shapes_added}, new pairs: {pairs_added}, "
+            f"total functions tracked: {fn_count}"
+        )
+        return 0
+    if cmd == "emit":
+        if len(argv) < 3:
+            print("usage: parse.py emit <out_header_path>")
+            return 1
+        _emit_single_shape_header(Path(argv[2]))
+        print(f"wrote {argv[2]}")
+        return 0
+    if cmd == "emit-math":
+        if len(argv) < 3:
+            print("usage: parse.py emit-math <out_header_path>")
+            return 1
+        _emit_math_pair_header(Path(argv[2]))
+        print(f"wrote {argv[2]}")
+        return 0
+    if cmd == "summary":
+        _summary()
+        return 0
+    print(f"unknown cmd: {cmd}")
+    print(__doc__)
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))

--- a/tt_metal/tt-llk/common/tensor_shape.h
+++ b/tt_metal/tt-llk/common/tensor_shape.h
@@ -218,8 +218,23 @@ constexpr const char* tensor_shape_dim_name(const std::uint8_t dim)
         ::ckernel::tensor_shape_dim_name((ts).face_c_dim),                                        \
         ::ckernel::tensor_shape_dim_name((ts).num_faces_r_dim),                                   \
         ::ckernel::tensor_shape_dim_name((ts).num_faces_c_dim))
+
+#define LLK_VALIDATE_TENSOR_SHAPE_PAIR_EMIT_(fn_lit, in0, in1)                                                    \
+    DEVICE_PRINT(                                                                                                 \
+        "[" fn_lit                                                                                                \
+        "] tensor_shape_pair: in0_face_r_dim={} in0_face_c_dim={} in0_num_faces_r_dim={} in0_num_faces_c_dim={} " \
+        "in1_face_r_dim={} in1_face_c_dim={} in1_num_faces_r_dim={} in1_num_faces_c_dim={}\n",                    \
+        static_cast<unsigned>((in0).face_r_dim),                                                                  \
+        static_cast<unsigned>((in0).face_c_dim),                                                                  \
+        static_cast<unsigned>((in0).num_faces_r_dim),                                                             \
+        static_cast<unsigned>((in0).num_faces_c_dim),                                                             \
+        static_cast<unsigned>((in1).face_r_dim),                                                                  \
+        static_cast<unsigned>((in1).face_c_dim),                                                                  \
+        static_cast<unsigned>((in1).num_faces_r_dim),                                                             \
+        static_cast<unsigned>((in1).num_faces_c_dim))
 #else
 #define LLK_VALIDATE_TENSOR_SHAPE_EMIT_(fn_name, ts) ((void)0)
+#define LLK_VALIDATE_TENSOR_SHAPE_PAIR_EMIT_(fn_lit, in0, in1) ((void)0)
 #endif
 
 #define LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(checker, fn, ts) \
@@ -232,15 +247,29 @@ constexpr const char* tensor_shape_dim_name(const std::uint8_t dim)
         }                                                       \
     } while (0)
 
+#define LLK_VALIDATE_TENSOR_SHAPE_PAIR_WITH_CHECKER(checker, fn_enum, fn_lit, in0, in1) \
+    do                                                                                  \
+    {                                                                                   \
+        if (!checker(fn_enum, in0, in1))                                                \
+        {                                                                               \
+            LLK_VALIDATE_TENSOR_SHAPE_PAIR_EMIT_(fn_lit, in0, in1);                     \
+            ::ckernel::assert_tensor_shape_unobserved_();                               \
+        }                                                                               \
+    } while (0)
+
 #define LLK_VALIDATE_TENSOR_SHAPE_UNPACK(fn, ts) LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(::ckernel::coverage::is_unpack_tensor_shape_covered, fn, ts)
 #define LLK_VALIDATE_TENSOR_SHAPE_MATH(fn, ts)   LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(::ckernel::coverage::is_math_tensor_shape_covered, fn, ts)
 #define LLK_VALIDATE_TENSOR_SHAPE_PACK(fn, ts)   LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(::ckernel::coverage::is_pack_tensor_shape_covered, fn, ts)
+#define LLK_VALIDATE_TENSOR_SHAPE_MATH_PAIR(fn_enum, fn_lit, in0, in1) \
+    LLK_VALIDATE_TENSOR_SHAPE_PAIR_WITH_CHECKER(::ckernel::coverage::is_math_tensor_shape_pair_covered, fn_enum, fn_lit, in0, in1)
 
 #else
 
 #define LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(checker, fn_name, ts) ((void)0)
+#define LLK_VALIDATE_TENSOR_SHAPE_PAIR_WITH_CHECKER(checker, fn_enum, fn_lit, in0, in1) ((void)0)
 #define LLK_VALIDATE_TENSOR_SHAPE_UNPACK(fn_name, ts)                ((void)0)
 #define LLK_VALIDATE_TENSOR_SHAPE_MATH(fn_name, ts)                  ((void)0)
 #define LLK_VALIDATE_TENSOR_SHAPE_PACK(fn_name, ts)                  ((void)0)
+#define LLK_VALIDATE_TENSOR_SHAPE_MATH_PAIR(fn_enum, fn_lit, in0, in1)                  ((void)0)
 
 #endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)

--- a/tt_metal/tt-llk/common/tensor_shape_coverage.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage.h
@@ -4,8 +4,7 @@
 //
 // Common TensorShape coverage definitions shared by TRISC-specific coverage tables.
 //
-// Regenerate by running the functional pytests with --logging-level=DEBUG
-// and feeding the per-worker test_run_gw*.log files through /tmp/ts-coverage/parse.py.
+// Regenerate by running the functional pytests with --logging-level=DEBUG.
 //
 
 #pragma once
@@ -38,6 +37,16 @@ enum class TensorShapeFunctionCoverage
     _llk_unpack_A_mop_config_,
     eltwise_binary_configure_mop_standard,
     eltwise_binary_configure_mop_with_dest_reuse,
+    matmul_configure_addrmod,
+    matmul_configure_mop,
+    matmul_configure_mop_throttled,
+    _llk_math_matmul_init_,
+};
+
+struct TensorShapePair
+{
+    TensorShape in0;
+    TensorShape in1;
 };
 
 constexpr const char* tensor_shape_function_name(const TensorShapeFunctionCoverage fn)
@@ -75,6 +84,14 @@ constexpr const char* tensor_shape_function_name(const TensorShapeFunctionCovera
             return "eltwise_binary_configure_mop_standard";
         case Function::eltwise_binary_configure_mop_with_dest_reuse:
             return "eltwise_binary_configure_mop_with_dest_reuse";
+        case Function::matmul_configure_addrmod:
+            return "matmul_configure_addrmod";
+        case Function::matmul_configure_mop:
+            return "matmul_configure_mop";
+        case Function::matmul_configure_mop_throttled:
+            return "matmul_configure_mop_throttled";
+        case Function::_llk_math_matmul_init_:
+            return "_llk_math_matmul_init_";
     }
     return "unknown";
 }
@@ -91,6 +108,25 @@ constexpr bool contains_tensor_shape(const std::array<TensorShape, N>& covered_s
     for (const TensorShape& covered_shape : covered_shapes)
     {
         if (tensor_shape_eq(covered_shape, tensor_shape))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+constexpr bool tensor_shape_pair_eq(const TensorShapePair& lhs, const TensorShapePair& rhs)
+{
+    return tensor_shape_eq(lhs.in0, rhs.in0) && tensor_shape_eq(lhs.in1, rhs.in1);
+}
+
+template <std::size_t N>
+constexpr bool contains_tensor_shape_pair(const std::array<TensorShapePair, N>& covered_pairs, const TensorShape& in0, const TensorShape& in1)
+{
+    const TensorShapePair candidate {in0, in1};
+    for (const TensorShapePair& covered_pair : covered_pairs)
+    {
+        if (tensor_shape_pair_eq(covered_pair, candidate))
         {
             return true;
         }

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
@@ -10,6 +10,7 @@
 #include <array>
 
 #include "tensor_shape_coverage.h"
+#include "tensor_shape_coverage_matmul.h"
 
 namespace ckernel::coverage
 {
@@ -92,6 +93,24 @@ constexpr bool is_math_tensor_shape_covered(const TensorShapeFunctionCoverage fn
             return contains_tensor_shape(covered_shapes_eltwise_binary_configure_mop_standard, tensor_shape);
         case Function::eltwise_binary_configure_mop_with_dest_reuse:
             return contains_tensor_shape(covered_shapes_eltwise_binary_configure_mop_with_dest_reuse, tensor_shape);
+        default:
+            return false;
+    }
+}
+
+constexpr bool is_math_tensor_shape_pair_covered(const TensorShapeFunctionCoverage fn, const TensorShape& in0, const TensorShape& in1)
+{
+    using Function = TensorShapeFunctionCoverage;
+    switch (fn)
+    {
+        case Function::matmul_configure_addrmod:
+            return contains_tensor_shape_pair(covered_shape_pairs_matmul_configure_addrmod, in0, in1);
+        case Function::matmul_configure_mop:
+            return contains_tensor_shape_pair(covered_shape_pairs_matmul_configure_mop, in0, in1);
+        case Function::matmul_configure_mop_throttled:
+            return contains_tensor_shape_pair(covered_shape_pairs_matmul_configure_mop_throttled, in0, in1);
+        case Function::_llk_math_matmul_init_:
+            return contains_tensor_shape_pair(covered_shape_pairs_llk_math_matmul_init, in0, in1);
         default:
             return false;
     }

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_matmul.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_matmul.h
@@ -1,0 +1,61 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// AUTO-GENERATED: per-function TensorShape pair coverage for matmul helpers.
+//
+// Regenerate by running matmul pytests with --logging-level=DEBUG,
+// TT_LLK_DISABLE_ASSERTS=1, then: parse.py harvest && parse.py emit-math
+//
+// Last update : 2026-06-18T14:28:53+00:00
+// Tests run   : 2
+
+#pragma once
+
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+#include <array>
+
+#include "tensor_shape_coverage.h"
+
+namespace ckernel::coverage
+{
+
+// _llk_math_matmul_init_: 6 unique TensorShape pair(s)
+inline constexpr std::array<TensorShapePair, 6> covered_shape_pairs_llk_math_matmul_init = {{
+    {TENSOR_SHAPE_FR1_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR2_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR4_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR8_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR16_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR16_NF2x2, TENSOR_SHAPE_FR16_NF2x2},
+}};
+
+// matmul_configure_addrmod: 6 unique TensorShape pair(s)
+inline constexpr std::array<TensorShapePair, 6> covered_shape_pairs_matmul_configure_addrmod = {{
+    {TENSOR_SHAPE_FR1_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR2_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR4_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR8_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR16_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR16_NF2x2, TENSOR_SHAPE_FR16_NF2x2},
+}};
+
+// matmul_configure_mop: 6 unique TensorShape pair(s)
+inline constexpr std::array<TensorShapePair, 6> covered_shape_pairs_matmul_configure_mop = {{
+    {TENSOR_SHAPE_FR1_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR2_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR4_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR8_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR16_NF1x2, TENSOR_SHAPE_FR16_NF2x2},
+    {TENSOR_SHAPE_FR16_NF2x2, TENSOR_SHAPE_FR16_NF2x2},
+}};
+
+// matmul_configure_mop_throttled: 1 unique TensorShape pair(s)
+inline constexpr std::array<TensorShapePair, 1> covered_shape_pairs_matmul_configure_mop_throttled = {{
+    {TENSOR_SHAPE_FR16_NF2x2, TENSOR_SHAPE_FR16_NF2x2},
+}};
+
+} // namespace ckernel::coverage
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)

--- a/tt_metal/tt-llk/tests/sources/math_matmul_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_matmul_perf.cpp
@@ -134,8 +134,6 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const std::uint32_t in1_tile_r_dim = params.in1_tile_r_dim;
     const std::uint32_t in1_tile_c_dim = params.in1_tile_c_dim;
 
-    const bool PARTIAL_FACE_MATH = params.PARTIAL_FACE_MATH;
-
     const std::uint32_t LOOP_FACTOR = params.LOOP_FACTOR;
     const int DST_INDEX             = params.DST_INDEX;
 
@@ -149,8 +147,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         START_PERF_MEASURE("INIT")
         _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
         _llk_math_pack_sync_init_<dest_sync, is_fp32_dest_acc_en>();
-        _llk_math_matmul_init_<MATH_FIDELITY, THROTTLE_LEVEL>(
-            in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, PARTIAL_FACE_MATH, UNPACK_TRANSPOSE_FACES, CT_DIM, RT_DIM);
+        const ckernel::TensorShape in0_tensor_shape = make_matmul_tensor_shape(in0_tile_r_dim, in0_tile_c_dim);
+        const ckernel::TensorShape in1_tensor_shape = make_matmul_tensor_shape(in1_tile_r_dim, in1_tile_c_dim);
+        _llk_math_matmul_init_<MATH_FIDELITY, THROTTLE_LEVEL>(in0_tensor_shape, in1_tensor_shape, UNPACK_TRANSPOSE_FACES, CT_DIM, RT_DIM);
 
         PROFILER_SYNC();
     }

--- a/tt_metal/tt-llk/tests/sources/math_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_matmul_test.cpp
@@ -77,15 +77,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    _llk_math_matmul_init_<MATH_FIDELITY, THROTTLE_LEVEL>(
-        params.in0_tile_r_dim,
-        params.in0_tile_c_dim,
-        params.in1_tile_r_dim,
-        params.in1_tile_c_dim,
-        params.PARTIAL_FACE_MATH,
-        params.UNPACK_TRANSPOSE_FACES,
-        params.CT_DIM,
-        params.RT_DIM);
+    const ckernel::TensorShape in0_tensor_shape = make_matmul_tensor_shape(params.in0_tile_r_dim, params.in0_tile_c_dim);
+    const ckernel::TensorShape in1_tensor_shape = make_matmul_tensor_shape(params.in1_tile_r_dim, params.in1_tile_c_dim);
+    _llk_math_matmul_init_<MATH_FIDELITY, THROTTLE_LEVEL>(in0_tensor_shape, in1_tensor_shape, params.UNPACK_TRANSPOSE_FACES, params.CT_DIM, params.RT_DIM);
     _llk_math_pack_sync_init_<dest_sync, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
     _llk_math_wait_for_dest_available_<dest_sync>();

--- a/tt_metal/tt-llk/tests/sources/matmul_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_perf.cpp
@@ -137,11 +137,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
             RT_DIM);
 #else
         _llk_math_matmul_init_<MATH_FIDELITY, THROTTLE_LEVEL>(
-            /* tile A */ TILE_R_DIM,
-            /* tile A */ TILE_C_DIM,
-            /* tile B */ TILE_R_DIM,
-            /* tile B */ TILE_C_DIM,
-            /* partial face */ false,
+            ckernel::DEFAULT_TENSOR_SHAPE,
+            ckernel::DEFAULT_TENSOR_SHAPE,
             /* transpose */ false,
             CT_DIM,
             RT_DIM);

--- a/tt_metal/tt-llk/tests/sources/matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_test.cpp
@@ -69,7 +69,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
 
-    _llk_math_matmul_init_<MATH_FIDELITY>(TILE_R_DIM, TILE_C_DIM, TILE_R_DIM, TILE_C_DIM, false, 0, params.CT_DIM, params.RT_DIM);
+    _llk_math_matmul_init_<MATH_FIDELITY>(ckernel::DEFAULT_TENSOR_SHAPE, ckernel::DEFAULT_TENSOR_SHAPE, 0, params.CT_DIM, params.RT_DIM);
     _llk_math_pack_sync_init_<DstSync::SyncHalf, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
 

--- a/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
@@ -186,7 +186,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_math_pack_sync_init_<dest_sync3, false>();
 
     // Operation 3: Matmul FPU - Using experimental custom no-mop API
-    // _llk_math_matmul_init_<0, 0>(TILE_R_DIM, TILE_C_DIM, TILE_R_DIM, TILE_C_DIM, false, 0, 1, 1);
+    // _llk_math_matmul_init_<ckernel::MathFidelity::LoFi, 0>(ckernel::DEFAULT_TENSOR_SHAPE, ckernel::DEFAULT_TENSOR_SHAPE, false, 1, 1);
 
     matmul_configure_addrmod_reinit();
 

--- a/tt_metal/tt-llk/tests/sources/unpack_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_matmul_test.cpp
@@ -78,15 +78,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 #if defined(RUNTIME_FORMATS) && !defined(SPEED_OF_LIGHT)
     const FormatConfig& formats = params.formats;
 #endif
-    _llk_math_matmul_init_<MATH_FIDELITY, THROTTLE_LEVEL>(
-        params.in0_tile_r_dim,
-        params.in0_tile_c_dim,
-        params.in1_tile_r_dim,
-        params.in1_tile_c_dim,
-        params.PARTIAL_FACE_MATH,
-        params.UNPACK_TRANSPOSE_FACES,
-        params.CT_DIM,
-        params.RT_DIM);
+    const ckernel::TensorShape in0_tensor_shape = make_matmul_tensor_shape(params.in0_tile_r_dim, params.in0_tile_c_dim);
+    const ckernel::TensorShape in1_tensor_shape = make_matmul_tensor_shape(params.in1_tile_r_dim, params.in1_tile_c_dim);
+    _llk_math_matmul_init_<MATH_FIDELITY, THROTTLE_LEVEL>(in0_tensor_shape, in1_tensor_shape, params.UNPACK_TRANSPOSE_FACES, params.CT_DIM, params.RT_DIM);
     _llk_math_pack_sync_init_<dest_sync, is_fp32_dest_acc_en>();
     _llk_math_hw_configure_<is_fp32_dest_acc_en>(formats.math, formats.math);
     _llk_math_wait_for_dest_available_<dest_sync>();

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_matmul.h
@@ -12,12 +12,30 @@
 #include "cmath_common.h"
 #include "llk_assert.h"
 #include "llk_math_common.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_math.h"
 
 #ifndef HF
 #define HF 0
 #endif
 
 using namespace ckernel;
+
+inline ckernel::TensorShape make_matmul_tensor_shape(const std::uint32_t tile_r_dim, const std::uint32_t tile_c_dim)
+{
+    LLK_ASSERT(tile_r_dim > 0 && tile_r_dim <= TILE_R_DIM, "matmul tile row dimension must be in range [1, 32]");
+    LLK_ASSERT(tile_c_dim == FACE_C_DIM || tile_c_dim == TILE_C_DIM, "matmul tile column dimension must be 16 or 32");
+    return ckernel::make_tensor_shape(
+        static_cast<std::uint8_t>(tile_r_dim < FACE_R_DIM ? tile_r_dim : FACE_R_DIM),
+        FACE_C_DIM,
+        static_cast<std::uint8_t>(tile_r_dim > FACE_R_DIM ? 2 : 1),
+        static_cast<std::uint8_t>(tile_c_dim > FACE_C_DIM ? 2 : 1));
+}
+
+inline bool matmul_has_partial_face(const ckernel::TensorShape& in0_tensor_shape, const ckernel::TensorShape& in1_tensor_shape)
+{
+    return in0_tensor_shape.face_r_dim < FACE_R_DIM || in1_tensor_shape.face_r_dim < FACE_R_DIM;
+}
 
 /**
  * @brief Program the matmul address-mod slots for the given tile shapes, transpose, and fidelity.
@@ -37,13 +55,19 @@ using namespace ckernel;
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_addrmod(
     const bool transpose,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const ckernel::TensorShape& in0_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const ckernel::TensorShape& in1_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     constexpr std::uint32_t fidelity_increment = is_high_fidelity(math_fidelity) ? 1 : 0;
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in0_tensor_shape), "Invalid in0 tensor shape for matmul");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in1_tensor_shape), "Invalid in1 tensor shape for matmul");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH_PAIR(
+        ckernel::coverage::TensorShapeFunctionCoverage::matmul_configure_addrmod, "matmul_configure_addrmod", in0_tensor_shape, in1_tensor_shape);
+    const std::uint32_t in0_tile_r_dim = in0_tensor_shape.total_row_dim();
+    const std::uint32_t in0_tile_c_dim = in0_tensor_shape.total_col_dim();
+    const std::uint32_t in1_tile_r_dim = in1_tensor_shape.total_row_dim();
+    const std::uint32_t in1_tile_c_dim = in1_tensor_shape.total_col_dim();
+    const bool partial_face            = matmul_has_partial_face(in0_tensor_shape, in1_tensor_shape);
     // 16x16 inputs not supported - no dedicated math path; falls to 32x32 default which is incorrect for < 4 faces
     LLK_ASSERT(
         !((in0_tile_r_dim == FACE_R_DIM) && (in0_tile_c_dim == FACE_C_DIM) && (in1_tile_r_dim == FACE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)),
@@ -310,11 +334,8 @@ template <MathFidelity math_fidelity>
 inline void matmul_configure_mop(
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const ckernel::TensorShape& in0_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const ckernel::TensorShape& in1_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -327,6 +348,16 @@ inline void matmul_configure_mop(
 
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
+
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in0_tensor_shape), "Invalid in0 tensor shape for matmul");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in1_tensor_shape), "Invalid in1 tensor shape for matmul");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH_PAIR(
+        ckernel::coverage::TensorShapeFunctionCoverage::matmul_configure_mop, "matmul_configure_mop", in0_tensor_shape, in1_tensor_shape);
+    const std::uint32_t in0_tile_r_dim = in0_tensor_shape.total_row_dim();
+    const std::uint32_t in0_tile_c_dim = in0_tensor_shape.total_col_dim();
+    const std::uint32_t in1_tile_r_dim = in1_tensor_shape.total_row_dim();
+    const std::uint32_t in1_tile_c_dim = in1_tensor_shape.total_col_dim();
+    const bool partial_face            = matmul_has_partial_face(in0_tensor_shape, in1_tensor_shape);
 
     const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
     const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
@@ -558,11 +589,8 @@ template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_mop_throttled(
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const ckernel::TensorShape& in0_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const ckernel::TensorShape& in1_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -573,6 +601,15 @@ inline void matmul_configure_mop_throttled(
     // if col major layout faces are ordered as f0,f2,f1,f3
     constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
     static_assert((THROTTLE_LEVEL > 0) && (THROTTLE_LEVEL <= 5), "MM throttling only enabled for THROTTLE_LEVEL={1,2,3,4,5}");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in0_tensor_shape), "Invalid in0 tensor shape for matmul");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in1_tensor_shape), "Invalid in1 tensor shape for matmul");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH_PAIR(
+        ckernel::coverage::TensorShapeFunctionCoverage::matmul_configure_mop_throttled, "matmul_configure_mop_throttled", in0_tensor_shape, in1_tensor_shape);
+    const std::uint32_t in0_tile_r_dim = in0_tensor_shape.total_row_dim();
+    const std::uint32_t in0_tile_c_dim = in0_tensor_shape.total_col_dim();
+    const std::uint32_t in1_tile_r_dim = in1_tensor_shape.total_row_dim();
+    const std::uint32_t in1_tile_c_dim = in1_tensor_shape.total_col_dim();
+    const bool partial_face            = matmul_has_partial_face(in0_tensor_shape, in1_tensor_shape);
     LLK_ASSERT(
         (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == TILE_C_DIM) && !partial_face,
         "MM throttling only enabled for full 32x32 tile size");
@@ -656,28 +693,30 @@ inline void matmul_configure_mop_throttled(
  */
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
 inline void _llk_math_matmul_init_(
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false,
-    const std::uint32_t transpose      = 0,
-    const std::uint32_t ct_dim         = 1,
-    const std::uint32_t rt_dim         = 1)
+    const ckernel::TensorShape& in0_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const ckernel::TensorShape& in1_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const std::uint32_t transpose                = 0,
+    const std::uint32_t ct_dim                   = 1,
+    const std::uint32_t rt_dim                   = 1)
 {
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in0_tensor_shape), "Invalid in0 tensor shape for matmul");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in1_tensor_shape), "Invalid in1 tensor shape for matmul");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH_PAIR(
+        ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_matmul_init_, "_llk_math_matmul_init_", in0_tensor_shape, in1_tensor_shape);
+    const std::uint32_t in1_tile_r_dim = in1_tensor_shape.total_row_dim();
+    const std::uint32_t in1_tile_c_dim = in1_tensor_shape.total_col_dim();
     // in1=32x16 NOT supported with transpose (no addr_mod handling)
     LLK_ASSERT(!(transpose && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)), "Transpose with input 1 dimensions 32x16 not supported");
 
-    matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(transpose, in0_tensor_shape, in1_tensor_shape);
 
     if constexpr (THROTTLE_LEVEL > 0)
     {
-        matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(
-            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(ct_dim, rt_dim, in0_tensor_shape, in1_tensor_shape);
     }
     else
     {
-        matmul_configure_mop<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        matmul_configure_mop<math_fidelity>(ct_dim, rt_dim, in0_tensor_shape, in1_tensor_shape);
     }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/experimental/llk_math_matmul_custom_no_mop.h
@@ -49,7 +49,9 @@ inline void matmul_configure_addrmod_no_mop(
     // The no-mop-specific part below only fixes up the dvalid contract for
     // reentry. Unlike BH, this WH path has to make the A/B reuse policy explicit
     // so repeated replays keep the right source valid across ct/rt shapes.
-    matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    const ckernel::TensorShape in0_tensor_shape = make_matmul_tensor_shape(in0_tile_r_dim, in0_tile_c_dim);
+    const ckernel::TensorShape in1_tensor_shape = make_matmul_tensor_shape(in1_tile_r_dim, in1_tile_c_dim);
+    matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(transpose, in0_tensor_shape, in1_tensor_shape);
 
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_matmul.h
@@ -13,12 +13,30 @@
 #include "llk_assert.h"
 #include "llk_math_common.h"
 #include "lltt.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_math.h"
 
 #ifndef HF
 #define HF 0
 #endif
 
 using namespace ckernel;
+
+inline ckernel::TensorShape make_matmul_tensor_shape(const std::uint32_t tile_r_dim, const std::uint32_t tile_c_dim)
+{
+    LLK_ASSERT(tile_r_dim > 0 && tile_r_dim <= TILE_R_DIM, "matmul tile row dimension must be in range [1, 32]");
+    LLK_ASSERT(tile_c_dim == FACE_C_DIM || tile_c_dim == TILE_C_DIM, "matmul tile column dimension must be 16 or 32");
+    return ckernel::make_tensor_shape(
+        static_cast<std::uint8_t>(tile_r_dim < FACE_R_DIM ? tile_r_dim : FACE_R_DIM),
+        FACE_C_DIM,
+        static_cast<std::uint8_t>(tile_r_dim > FACE_R_DIM ? 2 : 1),
+        static_cast<std::uint8_t>(tile_c_dim > FACE_C_DIM ? 2 : 1));
+}
+
+inline bool matmul_has_partial_face(const ckernel::TensorShape& in0_tensor_shape, const ckernel::TensorShape& in1_tensor_shape)
+{
+    return in0_tensor_shape.face_r_dim < FACE_R_DIM || in1_tensor_shape.face_r_dim < FACE_R_DIM;
+}
 
 /**
  * @brief Program the matmul address-mod slots for the given tile shapes, transpose, and fidelity.
@@ -38,13 +56,19 @@ using namespace ckernel;
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_addrmod(
     const bool transpose,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const ckernel::TensorShape& in0_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const ckernel::TensorShape& in1_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     constexpr std::uint32_t fidelity_increment = is_high_fidelity(math_fidelity) ? 1 : 0;
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in0_tensor_shape), "Invalid in0 tensor shape for matmul");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in1_tensor_shape), "Invalid in1 tensor shape for matmul");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH_PAIR(
+        ckernel::coverage::TensorShapeFunctionCoverage::matmul_configure_addrmod, "matmul_configure_addrmod", in0_tensor_shape, in1_tensor_shape);
+    const std::uint32_t in0_tile_r_dim = in0_tensor_shape.total_row_dim();
+    const std::uint32_t in0_tile_c_dim = in0_tensor_shape.total_col_dim();
+    const std::uint32_t in1_tile_r_dim = in1_tensor_shape.total_row_dim();
+    const std::uint32_t in1_tile_c_dim = in1_tensor_shape.total_col_dim();
+    const bool partial_face            = matmul_has_partial_face(in0_tensor_shape, in1_tensor_shape);
     // 16x16 inputs not supported - no dedicated math path; falls to 32x32 default which is incorrect for < 4 faces
     LLK_ASSERT(
         !((in0_tile_r_dim == FACE_R_DIM) && (in0_tile_c_dim == FACE_C_DIM) && (in1_tile_r_dim == FACE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)),
@@ -334,11 +358,8 @@ template <MathFidelity math_fidelity>
 inline void matmul_configure_mop(
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const ckernel::TensorShape& in0_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const ckernel::TensorShape& in1_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -352,6 +373,16 @@ inline void matmul_configure_mop(
 
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
+
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in0_tensor_shape), "Invalid in0 tensor shape for matmul");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in1_tensor_shape), "Invalid in1 tensor shape for matmul");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH_PAIR(
+        ckernel::coverage::TensorShapeFunctionCoverage::matmul_configure_mop, "matmul_configure_mop", in0_tensor_shape, in1_tensor_shape);
+    const std::uint32_t in0_tile_r_dim = in0_tensor_shape.total_row_dim();
+    const std::uint32_t in0_tile_c_dim = in0_tensor_shape.total_col_dim();
+    const std::uint32_t in1_tile_r_dim = in1_tensor_shape.total_row_dim();
+    const std::uint32_t in1_tile_c_dim = in1_tensor_shape.total_col_dim();
+    const bool partial_face            = matmul_has_partial_face(in0_tensor_shape, in1_tensor_shape);
 
     const bool is_in0_16x32 = (in0_tile_r_dim <= FACE_R_DIM) && (in0_tile_c_dim > FACE_C_DIM);
     const bool is_in1_32x16 = (in1_tile_r_dim > FACE_R_DIM) && (in1_tile_c_dim <= FACE_C_DIM);
@@ -656,11 +687,8 @@ template <MathFidelity math_fidelity, int THROTTLE_LEVEL>
 inline void matmul_configure_mop_throttled(
     const std::uint32_t ct_dim,
     const std::uint32_t rt_dim,
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false)
+    const ckernel::TensorShape& in0_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const ckernel::TensorShape& in1_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE)
 {
     // in0 - loaded to SrcB
     // in1 - loaded to SrcA
@@ -671,6 +699,15 @@ inline void matmul_configure_mop_throttled(
     // if col major layout faces are ordered as f0,f2,f1,f3
     constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
     static_assert((THROTTLE_LEVEL > 0) && (THROTTLE_LEVEL <= 5), "MM throttling only enabled for THROTTLE_LEVEL={1,2,3,4,5}");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in0_tensor_shape), "Invalid in0 tensor shape for matmul");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in1_tensor_shape), "Invalid in1 tensor shape for matmul");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH_PAIR(
+        ckernel::coverage::TensorShapeFunctionCoverage::matmul_configure_mop_throttled, "matmul_configure_mop_throttled", in0_tensor_shape, in1_tensor_shape);
+    const std::uint32_t in0_tile_r_dim = in0_tensor_shape.total_row_dim();
+    const std::uint32_t in0_tile_c_dim = in0_tensor_shape.total_col_dim();
+    const std::uint32_t in1_tile_r_dim = in1_tensor_shape.total_row_dim();
+    const std::uint32_t in1_tile_c_dim = in1_tensor_shape.total_col_dim();
+    const bool partial_face            = matmul_has_partial_face(in0_tensor_shape, in1_tensor_shape);
     LLK_ASSERT(
         (in0_tile_r_dim == TILE_R_DIM) && (in0_tile_c_dim == TILE_C_DIM) && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == TILE_C_DIM) && !partial_face,
         "MM throttling only enabled for full 32x32 tile size");
@@ -759,20 +796,23 @@ inline void matmul_configure_mop_throttled(
  */
 template <MathFidelity math_fidelity, int THROTTLE_LEVEL = 0>
 inline void _llk_math_matmul_init_(
-    const std::uint32_t in0_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in0_tile_c_dim = TILE_C_DIM,
-    const std::uint32_t in1_tile_r_dim = TILE_R_DIM,
-    const std::uint32_t in1_tile_c_dim = TILE_C_DIM,
-    const bool partial_face            = false,
-    const std::uint32_t transpose      = 0,
-    const std::uint32_t ct_dim         = 1,
-    const std::uint32_t rt_dim         = 1)
+    const ckernel::TensorShape& in0_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const ckernel::TensorShape& in1_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const std::uint32_t transpose                = 0,
+    const std::uint32_t ct_dim                   = 1,
+    const std::uint32_t rt_dim                   = 1)
 {
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in0_tensor_shape), "Invalid in0 tensor shape for matmul");
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(in1_tensor_shape), "Invalid in1 tensor shape for matmul");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH_PAIR(
+        ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_matmul_init_, "_llk_math_matmul_init_", in0_tensor_shape, in1_tensor_shape);
+    const std::uint32_t in1_tile_r_dim = in1_tensor_shape.total_row_dim();
+    const std::uint32_t in1_tile_c_dim = in1_tensor_shape.total_col_dim();
     // in1=32x16 NOT supported with transpose (no addr_mod handling)
     LLK_ASSERT(
         !(transpose && (in1_tile_r_dim == TILE_R_DIM) && (in1_tile_c_dim == FACE_C_DIM)), "in1=32x16 not supported with transpose (no addr_mod handling)");
 
-    matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(transpose, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+    matmul_configure_addrmod<math_fidelity, THROTTLE_LEVEL>(transpose, in0_tensor_shape, in1_tensor_shape);
     const bool reuse_a        = ct_dim >= rt_dim;
     const std::uint32_t t_dim = reuse_a ? rt_dim : ct_dim;
     if (t_dim > 1)
@@ -793,12 +833,11 @@ inline void _llk_math_matmul_init_(
 
     if constexpr (THROTTLE_LEVEL > 0)
     {
-        matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(
-            ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        matmul_configure_mop_throttled<math_fidelity, THROTTLE_LEVEL>(ct_dim, rt_dim, in0_tensor_shape, in1_tensor_shape);
     }
     else
     {
-        matmul_configure_mop<math_fidelity>(ct_dim, rt_dim, in0_tile_r_dim, in0_tile_c_dim, in1_tile_r_dim, in1_tile_c_dim, partial_face);
+        matmul_configure_mop<math_fidelity>(ct_dim, rt_dim, in0_tensor_shape, in1_tensor_shape);
     }
     math::reset_counters(p_setrwc::SET_ABD_F);
 }


### PR DESCRIPTION
## Summary
- Refactor BH/WH `llk_math_matmul.h` to take `TensorShape` operands instead of legacy tile scalar params (`in0/in1_tile_r_dim`, `partial_face`).
- Add pairwise TensorShape coverage validation for `matmul_configure_addrmod`, `matmul_configure_mop`, `matmul_configure_mop_throttled`, and `_llk_math_matmul_init_`.
- Add `parse.py` to harvest DPRINT `tensor_shape_pair` lines from pytest logs and emit `tensor_shape_coverage_matmul.h`.
- Update matmul test sources and WH experimental no-MOP delegate to the new API.

## Test plan
- [x] `test_matmul` (32×32 default shapes)
- [x] `test_math_matmul` (throttled + tiny-tile cases)
- [x] `test_matmul_unpack_tilize`, `test_matmul_pack_untilize`
- [ ] Full matmul pytest matrix (186k+ cases) — coverage table seeded from sweep enumeration (6 unique pairs)

## Coverage regeneration
```bash
cd tt_metal/tt-llk/tests/python_tests
export TT_LLK_DISABLE_ASSERTS=1
pytest --logging-level=debug <matmul_test>.py
python3 ../../common/parse.py harvest <test_name>
python3 ../../common/parse.py emit-math ../../common/tensor_shape_coverage_matmul.h
```


Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/tensor_shape_math_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/tensor_shape_math_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/tensor_shape_math_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/tensor_shape_math_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/tensor_shape_math_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/tensor_shape_math_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/tensor_shape_math_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/tensor_shape_math_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/tensor_shape_math_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/tensor_shape_math_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/tensor_shape_math_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/tensor_shape_math_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/tensor_shape_math_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/tensor_shape_math_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/tensor_shape_math_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/tensor_shape_math_matmul)