### PR TITLE
Refactor AB matmul unpack init to TensorShape and add coverage map

### DIFF
--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_unpack_AB_matmul.h"
 #include "llk_unpack_common_api.h"
 
@@ -19,40 +20,27 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const std::uint32_t kt_dim = 1) {
     // In0 -> srcB (supports partial face)
     // In1 -> srcA
-    const uint32_t operandA_id = get_operand_id(operandB);
-    const uint32_t operandB_id = get_operand_id(operandA);
+    const std::uint32_t operandA_id = get_operand_id(operandB);
+    const std::uint32_t operandB_id = get_operand_id(operandA);
 
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(operandA_id);
-    const uint32_t unpB_face_r_dim = get_operand_face_r_dim(operandB_id);
+    const ckernel::TensorShape unpA_tensor_shape = get_operand_tensor_shape(operandA_id);
+    const ckernel::TensorShape unpB_tensor_shape = get_operand_tensor_shape(operandB_id);
 
-    const bool reuse_a = ct_dim >= rt_dim;
     const bool partial_face_a = get_operand_partial_face(operandA_id);
     const bool partial_face_b = get_operand_partial_face(operandB_id);
-
-    const uint32_t unpA_num_faces = get_operand_num_faces(operandA_id);
-    const uint32_t unpB_num_faces = get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
     LLK_ASSERT_BLOCK(are_unpackers_AB_configured_correctly(
         unpack_src_format[operandA_id],
         unpack_dst_format[operandA_id],
         unpack_src_format[operandB_id],
         unpack_dst_format[operandB_id],
-        unpA_face_r_dim,
-        unpB_face_r_dim,
-        unpA_num_faces,
-        unpB_num_faces));
+        unpA_tensor_shape.face_r_dim,
+        unpB_tensor_shape.face_r_dim,
+        unpA_tensor_shape.total_num_faces(),
+        unpB_tensor_shape.total_num_faces()));
 
     _llk_unpack_AB_matmul_init_(
-        transpose,
-        ct_dim,
-        rt_dim,
-        kt_dim,
-        unpA_face_r_dim,
-        unpB_face_r_dim,
-        unpA_num_faces,
-        unpB_num_faces,
-        partial_face_a,
-        partial_face_b);
+        transpose, ct_dim, rt_dim, kt_dim, unpA_tensor_shape, unpB_tensor_shape, partial_face_a, partial_face_b);
 }
 
 inline void llk_unpack_AB_matmul(

--- a/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/blackhole/metal/llk_api/llk_unpack_A_api.h
@@ -20,8 +20,7 @@ inline void llk_unpack_A_init(
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
 
     const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
     const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
@@ -33,13 +32,15 @@ inline void llk_unpack_A_init(
     LLK_ASSERT_BLOCK((is_unpacker_A_configured_correctly<
                       UnpackerProgramType::ProgramByTile,
                       (BType != BroadcastType::NONE && !unpack_to_dest)>(
-        operand_unpack_src_format, operand_unpack_dst_format, face_r_dim, num_faces)));
+        operand_unpack_src_format,
+        operand_unpack_dst_format,
+        tensor_shape.face_r_dim,
+        tensor_shape.total_num_faces())));
 
     _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,
         within_face_16x16_transpose,
-        face_r_dim,
-        num_faces,
+        tensor_shape,
         operand_unpack_src_format,
         operand_unpack_dst_format);
 }

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_AB_matmul_api.h
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 #pragma once
+#include <cstdint>
 #include "llk_unpack_AB_matmul.h"
 #include "llk_unpack_common_api.h"
 
@@ -19,39 +20,27 @@ __attribute__((always_inline)) inline void llk_unpack_AB_matmul_init(
     const std::uint32_t kt_dim = 1) {
     // In0 -> srcB (supports partial face)
     // In1 -> srcA
-    const uint32_t operandA_id = get_operand_id(operandB);
-    const uint32_t operandB_id = get_operand_id(operandA);
+    const std::uint32_t operandA_id = get_operand_id(operandB);
+    const std::uint32_t operandB_id = get_operand_id(operandA);
 
-    const uint32_t unpA_face_r_dim = get_operand_face_r_dim(operandA_id);
-    const uint32_t unpB_face_r_dim = get_operand_face_r_dim(operandB_id);
+    const ckernel::TensorShape unpA_tensor_shape = get_operand_tensor_shape(operandA_id);
+    const ckernel::TensorShape unpB_tensor_shape = get_operand_tensor_shape(operandB_id);
 
     const bool partial_face_a = get_operand_partial_face(operandA_id);
     const bool partial_face_b = get_operand_partial_face(operandB_id);
-
-    const uint32_t unpA_num_faces = get_operand_num_faces(operandA_id);
-    const uint32_t unpB_num_faces = get_operand_num_faces(operandB_id);  // if partial face -> unpack face by face
 
     LLK_ASSERT_BLOCK(are_unpackers_AB_configured_correctly(
         unpack_src_format[operandA_id],
         unpack_dst_format[operandA_id],
         unpack_src_format[operandB_id],
         unpack_dst_format[operandB_id],
-        unpA_face_r_dim,
-        unpB_face_r_dim,
-        unpA_num_faces,
-        unpB_num_faces));
+        unpA_tensor_shape.face_r_dim,
+        unpB_tensor_shape.face_r_dim,
+        unpA_tensor_shape.total_num_faces(),
+        unpB_tensor_shape.total_num_faces()));
 
     _llk_unpack_AB_matmul_init_(
-        transpose,
-        ct_dim,
-        rt_dim,
-        kt_dim,
-        unpA_face_r_dim,
-        unpB_face_r_dim,
-        unpA_num_faces,
-        unpB_num_faces,
-        partial_face_a,
-        partial_face_b);
+        transpose, ct_dim, rt_dim, kt_dim, unpA_tensor_shape, unpB_tensor_shape, partial_face_a, partial_face_b);
 }
 
 inline void llk_unpack_AB_matmul(

--- a/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
+++ b/tt_metal/hw/ckernels/wormhole_b0/metal/llk_api/llk_unpack_A_api.h
@@ -20,8 +20,7 @@ inline void llk_unpack_A_init(
     const std::uint32_t within_face_16x16_transpose = 0,
     const std::uint32_t operand = 0) {
     const std::uint32_t operand_id = get_operand_id(operand);
-    const std::uint32_t face_r_dim = get_operand_face_r_dim(operand_id);
-    const std::uint32_t num_faces = get_operand_num_faces(operand_id);
+    const ckernel::TensorShape tensor_shape = get_operand_tensor_shape(operand_id);
 
     const std::uint32_t operand_unpack_src_format = unpack_src_format[operand_id];
     const std::uint32_t operand_unpack_dst_format = unpack_dst_format[operand_id];
@@ -29,13 +28,15 @@ inline void llk_unpack_A_init(
     LLK_ASSERT_BLOCK((is_unpacker_A_configured_correctly<
                       UnpackerProgramType::ProgramByTile,
                       (BType != BroadcastType::NONE && !unpack_to_dest)>(
-        operand_unpack_src_format, operand_unpack_dst_format, face_r_dim, num_faces)));
+        operand_unpack_src_format,
+        operand_unpack_dst_format,
+        tensor_shape.face_r_dim,
+        tensor_shape.total_num_faces())));
 
     _llk_unpack_A_init_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
         transpose_of_faces,
         within_face_16x16_transpose,
-        face_r_dim,
-        num_faces,
+        tensor_shape,
         operand_unpack_src_format,
         operand_unpack_dst_format);
 }

--- a/tt_metal/tt-llk/common/tensor_shape.h
+++ b/tt_metal/tt-llk/common/tensor_shape.h
@@ -78,13 +78,78 @@ static_assert(sizeof(TensorShape) == 4, "TensorShape must be 4 bytes");
 constexpr TensorShape DEFAULT_TENSOR_SHAPE = {MAX_FACE_R_DIM, MAX_FACE_C_DIM, MAX_NUM_FACES_R_DIM, MAX_NUM_FACES_C_DIM};
 
 /**
- * @brief Validates tensor shape for operations that depend on face positioning within a tile.
- * Will start relaxing this constraint once we test larger tensor shapes.
+ * @brief Enumeration of all currently-supported TensorShape values.
  *
- * @param tensor_shape: Tensor shape to validate
- * @return true if tensor shape is valid, false otherwise
+ * Matches validate_tensor_shape_tile_dependent_ops_ plus the per-axis HW limits,
+ * yielding 20 unique shapes. Naming convention:
+ *   TENSOR_SHAPE_FR{face_r_dim}_NF{num_faces_r_dim}x{num_faces_c_dim}
+ *
+ * Kept out of production kernel builds unless asserts or tensor-shape DPRINT
+ * coverage need the table.
+ */
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+// face_r_dim = 1
+constexpr TensorShape TENSOR_SHAPE_FR1_NF1x1 = {1, MAX_FACE_C_DIM, 1, 1}; ///<  1 ×16
+constexpr TensorShape TENSOR_SHAPE_FR1_NF1x2 = {1, MAX_FACE_C_DIM, 1, 2}; ///<  1 ×32
+constexpr TensorShape TENSOR_SHAPE_FR1_NF2x1 = {1, MAX_FACE_C_DIM, 2, 1}; ///<  2 ×16
+constexpr TensorShape TENSOR_SHAPE_FR1_NF2x2 = {1, MAX_FACE_C_DIM, 2, 2}; ///<  2 ×32
+
+// face_r_dim = 2
+constexpr TensorShape TENSOR_SHAPE_FR2_NF1x1 = {2, MAX_FACE_C_DIM, 1, 1}; ///<  2 ×16
+constexpr TensorShape TENSOR_SHAPE_FR2_NF1x2 = {2, MAX_FACE_C_DIM, 1, 2}; ///<  2 ×32
+constexpr TensorShape TENSOR_SHAPE_FR2_NF2x1 = {2, MAX_FACE_C_DIM, 2, 1}; ///<  4 ×16
+constexpr TensorShape TENSOR_SHAPE_FR2_NF2x2 = {2, MAX_FACE_C_DIM, 2, 2}; ///<  4 ×32
+
+// face_r_dim = 4
+constexpr TensorShape TENSOR_SHAPE_FR4_NF1x1 = {4, MAX_FACE_C_DIM, 1, 1}; ///<  4 ×16
+constexpr TensorShape TENSOR_SHAPE_FR4_NF1x2 = {4, MAX_FACE_C_DIM, 1, 2}; ///<  4 ×32
+constexpr TensorShape TENSOR_SHAPE_FR4_NF2x1 = {4, MAX_FACE_C_DIM, 2, 1}; ///<  8 ×16
+constexpr TensorShape TENSOR_SHAPE_FR4_NF2x2 = {4, MAX_FACE_C_DIM, 2, 2}; ///<  8 ×32
+
+// face_r_dim = 8
+constexpr TensorShape TENSOR_SHAPE_FR8_NF1x1 = {8, MAX_FACE_C_DIM, 1, 1}; ///<  8 ×16
+constexpr TensorShape TENSOR_SHAPE_FR8_NF1x2 = {8, MAX_FACE_C_DIM, 1, 2}; ///<  8 ×32
+constexpr TensorShape TENSOR_SHAPE_FR8_NF2x1 = {8, MAX_FACE_C_DIM, 2, 1}; ///< 16 ×16
+constexpr TensorShape TENSOR_SHAPE_FR8_NF2x2 = {8, MAX_FACE_C_DIM, 2, 2}; ///< 16 ×32
+
+// face_r_dim = 16
+constexpr TensorShape TENSOR_SHAPE_FR16_NF1x1 = {16, MAX_FACE_C_DIM, 1, 1}; ///< 16 ×16
+constexpr TensorShape TENSOR_SHAPE_FR16_NF1x2 = {16, MAX_FACE_C_DIM, 1, 2}; ///< 16 ×32
+constexpr TensorShape TENSOR_SHAPE_FR16_NF2x1 = {16, MAX_FACE_C_DIM, 2, 1}; ///< 32 ×16
+constexpr TensorShape TENSOR_SHAPE_FR16_NF2x2 = {16, MAX_FACE_C_DIM, 2, 2}; ///< 32 ×32 (== DEFAULT_TENSOR_SHAPE)
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+/// Build a TensorShape from explicit face dimensions and face-grid counts.
+constexpr TensorShape make_tensor_shape(
+    const std::uint8_t face_r_dim, const std::uint8_t face_c_dim, const std::uint8_t num_faces_r_dim, const std::uint8_t num_faces_c_dim)
+{
+    return TensorShape {face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim};
+}
+
+/**
+ * @brief Construct a TensorShape from the legacy (face_r_dim, num_faces) pair.
+ *
+ * Maps the historical scalar parameters used across LLK call sites:
+ * - num_faces == 1: 1x1 face grid (face_r_dim × 16)
+ * - num_faces == 2: 1x2 face grid (face_r_dim × 32)
+ * - num_faces == 4: 2x2 face grid (face_r_dim*2 × 32; 32x32 when face_r_dim == 16)
+ *
+ * @note Caller must pass num_faces in {1, 2, 4}.
+ */
+inline TensorShape make_tensor_shape_from_legacy(const std::uint8_t face_r_dim, const std::uint8_t num_faces)
+{
+    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be one of the valid values: 1, 2, or 4");
+    return TensorShape {face_r_dim, MAX_FACE_C_DIM, static_cast<std::uint8_t>(num_faces == 4 ? 2 : 1), static_cast<std::uint8_t>(num_faces == 1 ? 1 : 2)};
+}
+
+/**
+ * @brief Validates shapes for ops that depend on face positioning within a tile.
+ *
+ * Keep this conservative until larger TensorShape variants have coverage.
  **/
-__attribute__((noinline)) bool validate_tensor_shape_tile_dependent_ops_(const TensorShape &tensor_shape)
+__attribute__((noinline)) inline bool validate_tensor_shape_tile_dependent_ops_(const TensorShape& tensor_shape)
 {
     const std::uint8_t num_faces  = tensor_shape.total_num_faces();
     const std::uint8_t face_r_dim = tensor_shape.face_r_dim;
@@ -93,4 +158,89 @@ __attribute__((noinline)) bool validate_tensor_shape_tile_dependent_ops_(const T
            (face_r_dim == 1 || face_r_dim == 2 || face_r_dim == 4 || face_r_dim == 8 || face_r_dim == 16) && (face_c_dim == 16);
 }
 
+/**
+ * @brief Fires the LLK_ASSERT for an unobserved TensorShape coverage hole.
+ *
+ * Keeping the assert in a noinline helper gives triage scripts a real frame
+ * containing an `ASSERT(` token instead of pointing at the macro call site.
+ */
+__attribute__((noinline, cold)) inline void assert_tensor_shape_unobserved_()
+{
+    LLK_ASSERT(false, "TensorShape not observed before, please add it to the coverage table.");
+}
+
+constexpr const char* tensor_shape_dim_name(const std::uint8_t dim)
+{
+    switch (dim)
+    {
+        case 1:
+            return "1";
+        case 2:
+            return "2";
+        case 4:
+            return "4";
+        case 8:
+            return "8";
+        case 16:
+            return "16";
+        default:
+            return "unknown";
+    }
+}
+
 } // namespace ckernel
+
+/**
+ * @brief Emit a TensorShape via DEVICE_PRINT (see tests/DPRINT.md).
+ *
+ * Place in front of validation asserts so the failing assert is preceded by the
+ * offending shape. Outside debug/assert builds this compiles to a no-op.
+ */
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+// Pull the correct DEVICE_PRINT wrapper only for DPRINT builds; assert-only builds
+// still use the dedupe path but skip the print emission.
+#ifdef DEBUG_PRINT_ENABLED
+#ifdef ENV_LLK_INFRA
+#include "dprint.h"
+#else
+#include "api/debug/dprint.h"
+#endif
+
+// Concatenate fn_name into the literal instead of using CTSTR(fn_name); CTSTR's
+// COMDAT string object conflicts with DEVICE_PRINT's own string-section metadata
+// at inline template call sites.
+#define LLK_VALIDATE_TENSOR_SHAPE_EMIT_(fn, ts)                                                   \
+    DEVICE_PRINT(                                                                                 \
+        "[{}] tensor_shape: face_r_dim={} face_c_dim={} num_faces_r_dim={} num_faces_c_dim={}\n", \
+        ::ckernel::coverage::tensor_shape_function_name(fn),                                      \
+        ::ckernel::tensor_shape_dim_name((ts).face_r_dim),                                        \
+        ::ckernel::tensor_shape_dim_name((ts).face_c_dim),                                        \
+        ::ckernel::tensor_shape_dim_name((ts).num_faces_r_dim),                                   \
+        ::ckernel::tensor_shape_dim_name((ts).num_faces_c_dim))
+#else
+#define LLK_VALIDATE_TENSOR_SHAPE_EMIT_(fn_name, ts) ((void)0)
+#endif
+
+#define LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(checker, fn, ts) \
+    do                                                          \
+    {                                                           \
+        if (!checker(fn, ts))                                   \
+        {                                                       \
+            LLK_VALIDATE_TENSOR_SHAPE_EMIT_(fn, ts);            \
+            ::ckernel::assert_tensor_shape_unobserved_();       \
+        }                                                       \
+    } while (0)
+
+#define LLK_VALIDATE_TENSOR_SHAPE_UNPACK(fn, ts) LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(::ckernel::coverage::is_unpack_tensor_shape_covered, fn, ts)
+#define LLK_VALIDATE_TENSOR_SHAPE_MATH(fn, ts)   LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(::ckernel::coverage::is_math_tensor_shape_covered, fn, ts)
+#define LLK_VALIDATE_TENSOR_SHAPE_PACK(fn, ts)   LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(::ckernel::coverage::is_pack_tensor_shape_covered, fn, ts)
+
+#else
+
+#define LLK_VALIDATE_TENSOR_SHAPE_WITH_CHECKER(checker, fn_name, ts) ((void)0)
+#define LLK_VALIDATE_TENSOR_SHAPE_UNPACK(fn_name, ts)                ((void)0)
+#define LLK_VALIDATE_TENSOR_SHAPE_MATH(fn_name, ts)                  ((void)0)
+#define LLK_VALIDATE_TENSOR_SHAPE_PACK(fn_name, ts)                  ((void)0)
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)

--- a/tt_metal/tt-llk/common/tensor_shape_coverage.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage.h
@@ -1,0 +1,103 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Common TensorShape coverage definitions shared by TRISC-specific coverage tables.
+//
+// Regenerate by running the functional pytests with --logging-level=DEBUG
+// and feeding the per-worker test_run_gw*.log files through /tmp/ts-coverage/parse.py.
+//
+
+#pragma once
+
+// Match tensor_shape.h's gate so production kernel builds do not see this table.
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+#include <array>
+#include <cstddef>
+
+#include "tensor_shape.h"
+
+namespace ckernel::coverage
+{
+
+enum class TensorShapeFunctionCoverage
+{
+    _llk_math_eltwise_binary_standard_,
+    _llk_math_eltwise_binary_standard_init_,
+    _llk_math_eltwise_binary_with_dest_reuse_,
+    _llk_math_eltwise_binary_with_dest_reuse_init_,
+    _llk_math_reduce_,
+    _llk_math_reduce_init_,
+    _llk_unpack_AB_init_,
+    _llk_unpack_AB_mop_config_,
+    _llk_unpack_AB_reduce_init_,
+    _llk_unpack_reduce_init_,
+    _llk_unpack_AB_reduce_mop_config_,
+    _llk_unpack_A_init_,
+    _llk_unpack_A_mop_config_,
+    eltwise_binary_configure_mop_standard,
+    eltwise_binary_configure_mop_with_dest_reuse,
+};
+
+constexpr const char* tensor_shape_function_name(const TensorShapeFunctionCoverage fn)
+{
+    using Function = TensorShapeFunctionCoverage;
+    switch (fn)
+    {
+        case Function::_llk_math_eltwise_binary_standard_:
+            return "_llk_math_eltwise_binary_standard_";
+        case Function::_llk_math_eltwise_binary_standard_init_:
+            return "_llk_math_eltwise_binary_standard_init_";
+        case Function::_llk_math_eltwise_binary_with_dest_reuse_:
+            return "_llk_math_eltwise_binary_with_dest_reuse_";
+        case Function::_llk_math_eltwise_binary_with_dest_reuse_init_:
+            return "_llk_math_eltwise_binary_with_dest_reuse_init_";
+        case Function::_llk_math_reduce_:
+            return "_llk_math_reduce_";
+        case Function::_llk_math_reduce_init_:
+            return "_llk_math_reduce_init_";
+        case Function::_llk_unpack_AB_init_:
+            return "_llk_unpack_AB_init_";
+        case Function::_llk_unpack_AB_mop_config_:
+            return "_llk_unpack_AB_mop_config_";
+        case Function::_llk_unpack_AB_reduce_init_:
+            return "_llk_unpack_AB_reduce_init_";
+        case Function::_llk_unpack_reduce_init_:
+            return "_llk_unpack_reduce_init_";
+        case Function::_llk_unpack_AB_reduce_mop_config_:
+            return "_llk_unpack_AB_reduce_mop_config_";
+        case Function::_llk_unpack_A_init_:
+            return "_llk_unpack_A_init_";
+        case Function::_llk_unpack_A_mop_config_:
+            return "_llk_unpack_A_mop_config_";
+        case Function::eltwise_binary_configure_mop_standard:
+            return "eltwise_binary_configure_mop_standard";
+        case Function::eltwise_binary_configure_mop_with_dest_reuse:
+            return "eltwise_binary_configure_mop_with_dest_reuse";
+    }
+    return "unknown";
+}
+
+constexpr bool tensor_shape_eq(const TensorShape& lhs, const TensorShape& rhs)
+{
+    return lhs.face_r_dim == rhs.face_r_dim && lhs.face_c_dim == rhs.face_c_dim && lhs.num_faces_r_dim == rhs.num_faces_r_dim &&
+           lhs.num_faces_c_dim == rhs.num_faces_c_dim;
+}
+
+template <std::size_t N>
+constexpr bool contains_tensor_shape(const std::array<TensorShape, N>& covered_shapes, const TensorShape& tensor_shape)
+{
+    for (const TensorShape& covered_shape : covered_shapes)
+    {
+        if (tensor_shape_eq(covered_shape, tensor_shape))
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
+} // namespace ckernel::coverage
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)

--- a/tt_metal/tt-llk/common/tensor_shape_coverage.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage.h
@@ -30,6 +30,7 @@ enum class TensorShapeFunctionCoverage
     _llk_math_reduce_,
     _llk_math_reduce_init_,
     _llk_unpack_AB_init_,
+    _llk_unpack_AB_matmul_init_,
     _llk_unpack_AB_mop_config_,
     _llk_unpack_AB_reduce_init_,
     _llk_unpack_reduce_init_,
@@ -59,6 +60,8 @@ constexpr const char* tensor_shape_function_name(const TensorShapeFunctionCovera
             return "_llk_math_reduce_init_";
         case Function::_llk_unpack_AB_init_:
             return "_llk_unpack_AB_init_";
+        case Function::_llk_unpack_AB_matmul_init_:
+            return "_llk_unpack_AB_matmul_init_";
         case Function::_llk_unpack_AB_mop_config_:
             return "_llk_unpack_AB_mop_config_";
         case Function::_llk_unpack_AB_reduce_init_:

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_math.h
@@ -1,0 +1,102 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Match tensor_shape.h's gate so production kernel builds do not see this table.
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+#include <array>
+
+#include "tensor_shape_coverage.h"
+
+namespace ckernel::coverage
+{
+
+inline constexpr std::array<TensorShape, 8> covered_shapes_llk_math_eltwise_binary_standard = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 8> covered_shapes_llk_math_eltwise_binary_standard_init = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 2> covered_shapes_llk_math_eltwise_binary_with_dest_reuse = {{
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 2> covered_shapes_llk_math_eltwise_binary_with_dest_reuse_init = {{
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 7> covered_shapes_llk_math_reduce = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 8> covered_shapes_eltwise_binary_configure_mop_standard = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 2> covered_shapes_eltwise_binary_configure_mop_with_dest_reuse = {{
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+constexpr bool is_math_tensor_shape_covered(const TensorShapeFunctionCoverage fn, const TensorShape& tensor_shape)
+{
+    using Function = TensorShapeFunctionCoverage;
+    switch (fn)
+    {
+        case Function::_llk_math_eltwise_binary_standard_:
+            return contains_tensor_shape(covered_shapes_llk_math_eltwise_binary_standard, tensor_shape);
+        case Function::_llk_math_eltwise_binary_standard_init_:
+            return contains_tensor_shape(covered_shapes_llk_math_eltwise_binary_standard_init, tensor_shape);
+        case Function::_llk_math_eltwise_binary_with_dest_reuse_:
+            return contains_tensor_shape(covered_shapes_llk_math_eltwise_binary_with_dest_reuse, tensor_shape);
+        case Function::_llk_math_eltwise_binary_with_dest_reuse_init_:
+            return contains_tensor_shape(covered_shapes_llk_math_eltwise_binary_with_dest_reuse_init, tensor_shape);
+        case Function::_llk_math_reduce_:
+        case Function::_llk_math_reduce_init_:
+            return contains_tensor_shape(covered_shapes_llk_math_reduce, tensor_shape);
+        case Function::eltwise_binary_configure_mop_standard:
+            return contains_tensor_shape(covered_shapes_eltwise_binary_configure_mop_standard, tensor_shape);
+        case Function::eltwise_binary_configure_mop_with_dest_reuse:
+            return contains_tensor_shape(covered_shapes_eltwise_binary_configure_mop_with_dest_reuse, tensor_shape);
+        default:
+            return false;
+    }
+}
+
+} // namespace ckernel::coverage
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_pack.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_pack.h
@@ -1,0 +1,24 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Match tensor_shape.h's gate so production kernel builds do not see this table.
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+#include "tensor_shape_coverage.h"
+
+namespace ckernel::coverage
+{
+
+// No pack TensorShape coverage probes are currently defined.
+
+constexpr bool is_pack_tensor_shape_covered(const TensorShapeFunctionCoverage, const TensorShape&)
+{
+    return false;
+}
+
+} // namespace ckernel::coverage
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_unpack.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_unpack.h
@@ -1,0 +1,110 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+// Match tensor_shape.h's gate so production kernel builds do not see this table.
+#if defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)
+
+#include <array>
+
+#include "tensor_shape_coverage.h"
+
+namespace ckernel::coverage
+{
+
+inline constexpr std::array<TensorShape, 9> covered_shapes_llk_unpack_AB_init = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x1, // TODO(#47307): ndivnic to add a test in tt-llk to cover this case
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 9> covered_shapes_llk_unpack_AB_mop_config = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x1, // TODO(#47307): ndivnic to add a test in tt-llk to cover this case
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 7> covered_shapes_llk_unpack_AB_reduce_init = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 7> covered_shapes_llk_unpack_AB_reduce_mop_config = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 9> covered_shapes_llk_unpack_A_init = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x1,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+inline constexpr std::array<TensorShape, 9> covered_shapes_llk_unpack_A_mop_config = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x1,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x1,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x1,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
+constexpr bool is_unpack_tensor_shape_covered(const TensorShapeFunctionCoverage fn, const TensorShape& tensor_shape)
+{
+    using Function = TensorShapeFunctionCoverage;
+    switch (fn)
+    {
+        case Function::_llk_unpack_AB_init_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_AB_init, tensor_shape);
+        case Function::_llk_unpack_AB_mop_config_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_AB_mop_config, tensor_shape);
+        case Function::_llk_unpack_AB_reduce_init_:
+        case Function::_llk_unpack_reduce_init_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_AB_reduce_init, tensor_shape);
+        case Function::_llk_unpack_AB_reduce_mop_config_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_AB_reduce_mop_config, tensor_shape);
+        case Function::_llk_unpack_A_init_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_A_init, tensor_shape);
+        case Function::_llk_unpack_A_mop_config_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_A_mop_config, tensor_shape);
+        default:
+            return false;
+    }
+}
+
+} // namespace ckernel::coverage
+
+#endif // defined(ENABLE_LLK_ASSERT) || defined(DEBUG_PRINT_ENABLED)

--- a/tt_metal/tt-llk/common/tensor_shape_coverage_unpack.h
+++ b/tt_metal/tt-llk/common/tensor_shape_coverage_unpack.h
@@ -26,6 +26,15 @@ inline constexpr std::array<TensorShape, 9> covered_shapes_llk_unpack_AB_init = 
     TENSOR_SHAPE_FR16_NF2x2,
 }};
 
+inline constexpr std::array<TensorShape, 6> covered_shapes_llk_unpack_AB_matmul_init = {{
+    TENSOR_SHAPE_FR1_NF1x2,
+    TENSOR_SHAPE_FR2_NF1x2,
+    TENSOR_SHAPE_FR4_NF1x2,
+    TENSOR_SHAPE_FR8_NF1x2,
+    TENSOR_SHAPE_FR16_NF1x2,
+    TENSOR_SHAPE_FR16_NF2x2,
+}};
+
 inline constexpr std::array<TensorShape, 9> covered_shapes_llk_unpack_AB_mop_config = {{
     TENSOR_SHAPE_FR1_NF1x2,
     TENSOR_SHAPE_FR2_NF1x2,
@@ -89,6 +98,8 @@ constexpr bool is_unpack_tensor_shape_covered(const TensorShapeFunctionCoverage 
     {
         case Function::_llk_unpack_AB_init_:
             return contains_tensor_shape(covered_shapes_llk_unpack_AB_init, tensor_shape);
+        case Function::_llk_unpack_AB_matmul_init_:
+            return contains_tensor_shape(covered_shapes_llk_unpack_AB_matmul_init, tensor_shape);
         case Function::_llk_unpack_AB_mop_config_:
             return contains_tensor_shape(covered_shapes_llk_unpack_AB_mop_config, tensor_shape);
         case Function::_llk_unpack_AB_reduce_init_:

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/matmul.py
@@ -88,14 +88,17 @@ class MatmulUnpacker(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
+        from helpers.tile_shape import cpp_tensor_shape
+
         rt_dim = block.block_tiles_y
         ct_dim = block.block_tiles_x
         num_cols = compute_unit.src_a.tile_shape.total_col_dim()
         kt_dim = compute_unit.src_a.dimensions[1] // num_cols
         transpose_faces = compute_unit.unpack_transpose_faces.cpp_enum_value
+        src_a_tensor_shape = cpp_tensor_shape(compute_unit.src_b.tile_shape)
+        src_b_tensor_shape = cpp_tensor_shape(compute_unit.src_a.tile_shape)
 
-        return f"_llk_unpack_AB_matmul_init_<>({transpose_faces}, {ct_dim}, {rt_dim}, {kt_dim}, {face_r_dim}, {face_r_dim});\n"
+        return f"_llk_unpack_AB_matmul_init_<>({transpose_faces}, {ct_dim}, {rt_dim}, {kt_dim}, {src_a_tensor_shape}, {src_b_tensor_shape});\n"
 
     def unpack(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/blackhole/unpacker/unpack_a.py
@@ -135,18 +135,19 @@ class UnpackerA(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
+        from helpers.tile_shape import cpp_tensor_shape
+
         unpack_to_dest = compute_unit.unpack_to_dest.cpp_enum_value
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         reuse_dest = compute_unit.reuse_dest.cpp_enum_value
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        tensor_shape = cpp_tensor_shape(compute_unit.src_a.tile_shape)
         transpose_faces = compute_unit.unpack_transpose_faces.cpp_enum_value
         transpose_within_face = compute_unit.unpack_transpose_within_face.cpp_enum_value
         acc_to_dest = compute_unit.acc_to_dest.cpp_enum_value
 
         return (
             f"    _llk_unpack_A_init_<{broadcast_type}, {acc_to_dest}, {reuse_dest}, {unpack_to_dest}>(\n"
-            f"        {transpose_faces}, {transpose_within_face}, {face_r_dim}, {num_faces}, {config.sentinel.unpack_a_src_format}, {config.sentinel.unpack_a_dst_format}\n"
+            f"        {transpose_faces}, {transpose_within_face}, {tensor_shape}, {config.sentinel.unpack_a_src_format}, {config.sentinel.unpack_a_dst_format}\n"
             f"    );\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/matmul.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/matmul.py
@@ -88,14 +88,17 @@ class MatmulUnpacker(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
+        from helpers.tile_shape import cpp_tensor_shape
+
         rt_dim = block.block_tiles_y
         ct_dim = block.block_tiles_x
         num_cols = compute_unit.src_a.tile_shape.total_col_dim()
         kt_dim = compute_unit.src_a.dimensions[1] // num_cols
         transpose_faces = compute_unit.unpack_transpose_faces.cpp_enum_value
+        src_a_tensor_shape = cpp_tensor_shape(compute_unit.src_b.tile_shape)
+        src_b_tensor_shape = cpp_tensor_shape(compute_unit.src_a.tile_shape)
 
-        return f"_llk_unpack_AB_matmul_init_<>({transpose_faces}, {ct_dim}, {rt_dim}, {kt_dim}, {face_r_dim}, {face_r_dim});\n"
+        return f"_llk_unpack_AB_matmul_init_<>({transpose_faces}, {ct_dim}, {rt_dim}, {kt_dim}, {src_a_tensor_shape}, {src_b_tensor_shape});\n"
 
     def unpack(
         self,

--- a/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_a.py
+++ b/tt_metal/tt-llk/tests/python_tests/fuser/wormhole/unpacker/unpack_a.py
@@ -135,18 +135,19 @@ class UnpackerA(Unpacker):
         compute_unit: ComputeNode,
         block: BlockData,
     ) -> str:
+        from helpers.tile_shape import cpp_tensor_shape
+
         unpack_to_dest = compute_unit.unpack_to_dest.cpp_enum_value
         broadcast_type = compute_unit.broadcast_type.cpp_enum_value
         reuse_dest = compute_unit.reuse_dest.cpp_enum_value
-        face_r_dim = compute_unit.src_a.tile_shape.face_r_dim
-        num_faces = compute_unit.src_a.tile_shape.total_num_faces()
+        tensor_shape = cpp_tensor_shape(compute_unit.src_a.tile_shape)
         transpose_faces = compute_unit.unpack_transpose_faces.cpp_enum_value
         transpose_within_face = compute_unit.unpack_transpose_within_face.cpp_enum_value
         acc_to_dest = compute_unit.acc_to_dest.cpp_enum_value
 
         return (
             f"_llk_unpack_A_init_<{broadcast_type}, {acc_to_dest}, {reuse_dest}, {unpack_to_dest}>(\n"
-            f"    {transpose_faces}, {transpose_within_face}, {face_r_dim}, {num_faces}, {config.sentinel.unpack_a_src_format}, {config.sentinel.unpack_a_dst_format}\n"
+            f"    {transpose_faces}, {transpose_within_face}, {tensor_shape}, {config.sentinel.unpack_a_src_format}, {config.sentinel.unpack_a_dst_format}\n"
             f");\n"
         )
 

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device.py
@@ -13,7 +13,7 @@ from ttexalens.coordinate import OnChipCoordinate
 from ttexalens.debug_tensix import TensixDebug
 from ttexalens.hardware.risc_debug import CallstackEntry
 from ttexalens.tt_exalens_lib import (
-    ParsedElfFile,
+    ElfFile,
     TTException,
     arc_msg,
     callstack,
@@ -360,7 +360,7 @@ def reset_mailboxes(location: str = "0,0"):
 
 def pull_coverage_stream_from_tensix(
     location: str | OnChipCoordinate,
-    elf: str | ParsedElfFile,
+    elf: str | ElfFile,
     stream_path: str,
     device_id: int = 0,
     context: Context | None = None,

--- a/tt_metal/tt-llk/tests/python_tests/helpers/device_print.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/device_print.py
@@ -342,21 +342,15 @@ class ElfStrings:
         try:
             elf = parse_elf(elf_path, require_debug_symbols=False)
             self._parsed_elf = elf
-            self.pointer_size = elf.elf.elfclass // 8
+            # LLK TRISC kernel ELFs are 32-bit; native ElfFile no longer exposes elf.elfclass.
+            self.pointer_size = 4
             self.type_table = _type_table_for(self.pointer_size)
-            self._info_record_size, self._info_unpack_fmt = _STRING_INFO_LAYOUT[
-                elf.elf.elfclass
-            ]
-            sections = (
-                elf.sections
-                if isinstance(elf.sections, dict)
-                else {s.name: s for s in elf.sections}
-            )
-            strings = sections.get(".device_print_strings")
+            self._info_record_size, self._info_unpack_fmt = _STRING_INFO_LAYOUT[32]
+            strings = elf.get_section_by_name(".device_print_strings")
             if strings is not None:
                 self._strings_addr = strings.address
                 self._strings_data = bytes(strings.data)
-            info = sections.get(".device_print_strings_info")
+            info = elf.get_section_by_name(".device_print_strings_info")
             if info is not None:
                 self._info_addr = info.address
                 self._info_data = bytes(info.data)

--- a/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/test_config.py
@@ -481,13 +481,22 @@ class TestConfig:
             in (ChipArchitecture.WORMHOLE, ChipArchitecture.BLACKHOLE)
             else ""
         )
+        # Allow disabling LLK_ASSERT via env var for shape-coverage discovery runs:
+        # with asserts off and DEVICE_PRINT_ENABLED on, LLK_VALIDATE_TENSOR_SHAPE_*
+        # emits newly-seen TensorShapes via DPRINT instead of ebreaking the kernel,
+        # so a single run can enumerate every (fn_name, shape) pair exercised.
+        llk_assert_define = (
+            ""
+            if os.environ.get("TT_LLK_DISABLE_ASSERTS") == "1"
+            else "-DENABLE_LLK_ASSERT "
+        )
         TestConfig.INITIAL_OPTIONS_COMPILE = (
             "-Wall -Werror -Wno-error=deprecated-declarations "
             "-Wunused-parameter "
             "-Wfloat-equal -Wpointer-arith -Wnull-dereference -Wredundant-decls "
             "-Wuninitialized -Wmaybe-uninitialized "
             f"{no_wh_ebreak_fixup}"
-            f"-DTENSIX_FIRMWARE -DENV_LLK_INFRA -DKERNEL_BUILD -DENABLE_LLK_ASSERT {TestConfig.ARCH_DEFINE} "
+            f"-DTENSIX_FIRMWARE -DENV_LLK_INFRA -DKERNEL_BUILD {llk_assert_define}{TestConfig.ARCH_DEFINE} "
             f"{'-DSPEED_OF_LIGHT' if TestConfig.SPEED_OF_LIGHT else ''}"
         )
         TestConfig.INCLUDES = [

--- a/tt_metal/tt-llk/tests/python_tests/helpers/tile_shape.py
+++ b/tt_metal/tt-llk/tests/python_tests/helpers/tile_shape.py
@@ -86,3 +86,30 @@ def construct_tile_shape(tile_dimensions: Tuple[int, int] = (32, 32)) -> TileSha
         num_faces_r_dim=num_faces_r_dim,
         num_faces_c_dim=num_faces_c_dim,
     )
+
+
+def cpp_tensor_shape(tile_shape: TileShape) -> str:
+    """
+    Emit the C++ ``ckernel::TensorShape`` aggregate literal that matches ``tile_shape``.
+
+    Used by fuser code generators to construct the C++ TensorShape value
+    expected by LLK functions taking a ``ckernel::TensorShape`` parameter.
+    """
+    return (
+        "ckernel::make_tensor_shape("
+        f"{tile_shape.face_r_dim}, "
+        f"{tile_shape.face_c_dim}, "
+        f"{tile_shape.num_faces_r_dim}, "
+        f"{tile_shape.num_faces_c_dim})"
+    )
+
+
+def cpp_tensor_shape_from_legacy(face_r_dim: int, num_faces: int) -> str:
+    """
+    Emit a C++ ``ckernel::make_tensor_shape_from_legacy`` call string from legacy
+    scalar parameters (face_r_dim, total num_faces).
+
+    Mirrors the C++ helper of the same name for fuser code generators that only
+    have legacy scalar values available.
+    """
+    return f"ckernel::make_tensor_shape_from_legacy({face_r_dim}, {num_faces})"

--- a/tt_metal/tt-llk/tests/python_tests/test_unpack_A.py
+++ b/tt_metal/tt-llk/tests/python_tests/test_unpack_A.py
@@ -8,7 +8,7 @@ import pytest
 import torch
 from conftest import skip_for_blackhole
 from helpers.chip_architecture import ChipArchitecture, get_chip_architecture
-from helpers.format_config import DataFormat
+from helpers.format_config import DataFormat, FormatConfig
 from helpers.golden_generators import (
     ELEMENTS_PER_TILE,
     TILE_DIMENSIONS,
@@ -42,6 +42,8 @@ from helpers.test_variant_parameters import (
     INPUT_DIMENSIONS,
     NUM_BLOCKS,
     NUM_FACES,
+    NUM_FACES_C_DIM,
+    NUM_FACES_R_DIM,
     NUM_TILES_IN_BLOCK,
     PARTIAL_FACE,
     REUSE_DEST_TYPE,
@@ -90,6 +92,16 @@ face_r_dim_values = [1, 2, 4, 8, 16]
 input_dimensions = [[r, 32] for r in face_r_dim_values] + [[256, 256]]
 # Use only cross_test_formats as it already includes same-format combinations
 test_formats = input_output_formats(supported_formats, False)
+
+
+def legacy_num_faces_to_grid(num_faces: int) -> tuple[int, int]:
+    if num_faces == 1:
+        return 1, 1
+    if num_faces == 2:
+        return 1, 2
+    if num_faces == 4:
+        return 2, 2
+    raise ValueError(f"Unsupported num_faces={num_faces}")
 
 
 # Generate unpack_A specific parameter combinations using itertools.product
@@ -389,6 +401,7 @@ def test_unpack_comprehensive(
 
     # torch.manual_seed(0.0)
     partial_face = face_r_dim < 16
+    num_faces_r_dim, num_faces_c_dim = legacy_num_faces_to_grid(num_faces)
 
     src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
         stimuli_format_A=formats.input_format,
@@ -546,6 +559,8 @@ def test_unpack_comprehensive(
             UNPACK_TRANS_FACES(transpose_of_faces),
             UNPACK_TRANS_WITHIN_FACE(within_face_16x16_transpose),
             NUM_FACES(num_faces),
+            NUM_FACES_R_DIM(num_faces_r_dim, num_faces_r_dim),
+            NUM_FACES_C_DIM(num_faces_c_dim, num_faces_c_dim),
             TILE_COUNT(tile_cnt_A),
             TEST_FACE_DIMS(face_r_dim=face_r_dim),
             NUM_TILES_IN_BLOCK(num_tiles_in_block),
@@ -569,6 +584,157 @@ def test_unpack_comprehensive(
         ),
         dest_acc=(DestAccumulation.Yes if acc_to_dest else DestAccumulation.No),
         unpack_to_dest=(formats.input_format.is_32_bit() and acc_to_dest),
+    )
+
+    res_from_L1 = configuration.run().result
+
+    assert len(res_from_L1) == len(
+        golden_tensor
+    ), "Result tensor and golden tensor are not of the same length"
+
+    res_tensor = torch.tensor(res_from_L1, dtype=format_dict[formats.output_format])
+    assert passed_test(
+        golden_tensor, res_tensor, formats.output_format
+    ), "Assert against golden failed"
+
+
+targeted_tensor_shape_cases = [
+    pytest.param(
+        "fr8_nf1x1",
+        8,
+        1,
+        1,
+        1,
+        [8, 16],
+        None,
+        id="tensor_shape_FR8_NF1x1",
+    ),
+    pytest.param(
+        "fr16_nf2x1",
+        16,
+        2,
+        2,
+        1,
+        [32, 16],
+        [32, 16],
+        id="tensor_shape_FR16_NF2x1",
+    ),
+]
+
+
+@pytest.mark.parametrize(
+    "case_name, face_r_dim, num_faces, num_faces_r_dim, num_faces_c_dim, input_dimensions, tile_dimensions",
+    targeted_tensor_shape_cases,
+)
+def test_unpack_A_targeted_tensor_shape_coverage(
+    case_name,
+    face_r_dim,
+    num_faces,
+    num_faces_r_dim,
+    num_faces_c_dim,
+    input_dimensions,
+    tile_dimensions,
+):
+    del case_name
+    formats = FormatConfig(
+        unpack_A_src=DataFormat.Float16_b,
+        unpack_A_dst=DataFormat.Float16_b,
+        pack_src=DataFormat.Float16_b,
+        pack_dst=DataFormat.Float16_b,
+        math=DataFormat.Float16_b,
+    )
+
+    stimuli_kwargs = (
+        {"tile_dimensions": tile_dimensions}
+        if tile_dimensions is not None
+        else {"face_r_dim": face_r_dim, "num_faces": num_faces}
+    )
+    src_A, tile_cnt_A, src_B, tile_cnt_B = generate_stimuli(
+        stimuli_format_A=formats.input_format,
+        input_dimensions_A=input_dimensions,
+        stimuli_format_B=formats.input_format,
+        input_dimensions_B=input_dimensions,
+        **stimuli_kwargs,
+    )
+
+    generate_golden = get_golden_generator(DataCopyGolden)
+    golden_tensor = generate_golden(
+        src_A,
+        formats.output_format,
+        num_faces,
+        input_dimensions,
+        face_r_dim,
+        tile_dimensions=tile_dimensions,
+    )
+
+    raw_dimensions = [
+        (
+            input_dimensions[0]
+            if input_dimensions[0] >= TILE_DIMENSIONS[0]
+            else TILE_DIMENSIONS[0]
+        ),
+        (
+            input_dimensions[1]
+            if input_dimensions[1] >= TILE_DIMENSIONS[1]
+            else TILE_DIMENSIONS[1]
+        ),
+    ]
+    num_blocks, num_tiles_in_block = get_num_blocks_and_num_tiles_in_block(
+        DestSync.Half,
+        DestAccumulation.No,
+        formats,
+        raw_dimensions,
+        TILE_DIMENSIONS,
+        BlocksCalculationAlgorithm.Standard,
+    )
+
+    configuration = TestConfig(
+        "sources/unpack_A_test.cpp",
+        formats,
+        templates=[
+            STOCHASTIC_ROUNDING(StochasticRounding.No),
+            BROADCAST_TYPE(BroadcastType.None_),
+            ACC_TO_DEST(False),
+            REUSE_DEST_TYPE(EltwiseBinaryReuseDestType.NONE),
+            PARTIAL_FACE(
+                partial_a=face_r_dim < 16,
+                partial_face_pack=face_r_dim < 16,
+                partial_b=face_r_dim < 16,
+                partial_face_math=face_r_dim < 16,
+            ),
+            DISABLE_SRC_ZERO_FLAG(False),
+        ],
+        runtimes=[
+            UNPACK_TRANS_FACES(Transpose.No),
+            UNPACK_TRANS_WITHIN_FACE(Transpose.No),
+            NUM_FACES(num_faces),
+            NUM_FACES_R_DIM(num_faces_r_dim, num_faces_r_dim),
+            NUM_FACES_C_DIM(num_faces_c_dim, num_faces_c_dim),
+            TILE_COUNT(tile_cnt_A),
+            TEST_FACE_DIMS(face_r_dim=face_r_dim),
+            NUM_TILES_IN_BLOCK(num_tiles_in_block),
+            NUM_BLOCKS(num_blocks),
+            INPUT_DIMENSIONS(
+                raw_dimensions[0] // TILE_DIMENSIONS[0],
+                raw_dimensions[1] // TILE_DIMENSIONS[1],
+            ),
+        ],
+        variant_stimuli=StimuliConfig(
+            src_A,
+            formats.input_format,
+            src_B,
+            formats.input_format,
+            formats.output_format,
+            tile_count_A=tile_cnt_A,
+            tile_count_B=tile_cnt_B,
+            tile_count_res=tile_cnt_A,
+            num_faces=num_faces,
+            face_r_dim=face_r_dim,
+            tile_dimensions=tile_dimensions or [32, 32],
+            use_dense_tile_dimensions=tile_dimensions is not None,
+        ),
+        dest_acc=DestAccumulation.No,
+        unpack_to_dest=False,
     )
 
     res_from_L1 = configuration.run().result

--- a/tt_metal/tt-llk/tests/sources/dense_pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/dense_pack_untilize_test.cpp
@@ -27,7 +27,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     for (std::uint32_t tile_index_within_block = 0; tile_index_within_block < BLOCK_CT_DIM; ++tile_index_within_block) // Loop over tiles in the block
     {

--- a/tt_metal/tt-llk/tests/sources/dprint_tensix_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/dprint_tensix_test.cpp
@@ -31,7 +31,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
         L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src, formats.unpack_A_dst);
 }

--- a/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_binary_sfpu_perf.cpp
@@ -54,7 +54,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
 
         _llk_unpack_A_init_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
-            UNPACK_TRANSPOSE_FACES, UNPACK_TRANSPOSE_WITHIN_FACE, FACE_R_DIM, num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+            UNPACK_TRANSPOSE_FACES,
+            UNPACK_TRANSPOSE_WITHIN_FACE,
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces),
+            formats.unpack_A_src,
+            formats.unpack_A_dst);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_custom_test.cpp
@@ -24,7 +24,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
     const FormatConfig& formats = params.formats;
 #endif
     _llk_unpack_hw_configure_<false>(formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4, 4);
-    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false>(0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false>(
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
 
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_datacopy_test.cpp
@@ -32,7 +32,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            0, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+            0 /* transpose_of_faces */,
+            0 /* within_face_16x16_transpose */,
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+            formats.unpack_A_src,
+            formats.unpack_A_dst);
 
         const std::uint32_t num_tiles = params.NUM_BLOCKS * params.NUM_TILES_IN_BLOCK;
 

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_perf.cpp
@@ -53,7 +53,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, num_faces, num_faces);
 
         _llk_unpack_A_init_<BROADCAST_TYPE, is_fp32_dest_acc_en, reuse_dest_type, unpack_to_dest>(
-            UNPACK_TRANSPOSE_FACES, UNPACK_TRANSPOSE_WITHIN_FACE, FACE_R_DIM, num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+            UNPACK_TRANSPOSE_FACES,
+            UNPACK_TRANSPOSE_WITHIN_FACE,
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, num_faces),
+            formats.unpack_A_src,
+            formats.unpack_A_dst);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/eltwise_unary_sfpu_test.cpp
@@ -32,7 +32,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES);
 
     _llk_unpack_A_init_<BroadcastType::NONE, false /* is_fp32_dest_acc_en - why true does not work? */, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, FACE_R_DIM, TILE_NUM_FACES, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, TILE_NUM_FACES),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     for (std::uint32_t i = 0; i < params.NUM_BLOCKS * params.NUM_TILES_IN_BLOCK; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/hash_cb_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/hash_cb_test.cpp
@@ -40,7 +40,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4, 4);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
     for (std::uint32_t i = 0; i < params.TILE_CNT; i++)
     {
         _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(

--- a/tt_metal/tt-llk/tests/sources/math_matmul_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_matmul_perf.cpp
@@ -71,12 +71,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
             CT_DIM,
             RT_DIM,
             KT_DIM,
-            in1_tile_r_dim < FACE_R_DIM ? in1_tile_r_dim : FACE_R_DIM,
-            in0_tile_r_dim < FACE_R_DIM ? in0_tile_r_dim : FACE_R_DIM,
-            num_faces_B,     // In1
-            num_faces_A,     // In0
-            PARTIAL_FACE_B,  // In1
-            PARTIAL_FACE_A); // In0
+            ckernel::make_tensor_shape_from_legacy(in1_tile_r_dim < FACE_R_DIM ? in1_tile_r_dim : FACE_R_DIM, num_faces_B), // In1
+            ckernel::make_tensor_shape_from_legacy(in0_tile_r_dim < FACE_R_DIM ? in0_tile_r_dim : FACE_R_DIM, num_faces_A), // In0
+            PARTIAL_FACE_B,                                                                                                 // In1
+            PARTIAL_FACE_A);                                                                                                // In0
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/math_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_matmul_test.cpp
@@ -41,12 +41,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.CT_DIM,
         params.RT_DIM,
         params.KT_DIM,
-        params.in1_tile_r_dim < FACE_R_DIM ? params.in1_tile_r_dim : FACE_R_DIM,
-        params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM,
-        params.num_faces_B,     // in1
-        params.num_faces_A,     // in0
-        params.PARTIAL_FACE_B,  // in1
-        params.PARTIAL_FACE_A); // in0
+        ckernel::make_tensor_shape_from_legacy(params.in1_tile_r_dim < FACE_R_DIM ? params.in1_tile_r_dim : FACE_R_DIM, params.num_faces_B), // in1
+        ckernel::make_tensor_shape_from_legacy(params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM, params.num_faces_A), // in0
+        params.PARTIAL_FACE_B,                                                                                                               // in1
+        params.PARTIAL_FACE_A);                                                                                                              // in0
     for (std::uint32_t j = 0; j < params.KT_DIM; j++)
     {
         _llk_unpack_AB_matmul_<>(

--- a/tt_metal/tt-llk/tests/sources/math_transpose_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/math_transpose_perf.cpp
@@ -43,7 +43,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         START_PERF_MEASURE("INIT")
 
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            UNPACK_TRANSPOSE_FACES, false, FACE_R_DIM, TILE_NUM_FACES, formats.unpack_A_src, formats.unpack_A_dst);
+            UNPACK_TRANSPOSE_FACES, false, ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, TILE_NUM_FACES), formats.unpack_A_src, formats.unpack_A_dst);
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES);
         PROFILER_SYNC();

--- a/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_and_unary_sfpu_test.cpp
@@ -53,7 +53,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_reconfig_data_format_srca_impl_<is_fp32_dest_acc_en, p_dim_stride_target::IGNORE, false>(
         formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst, TILE_SIZE_PACK);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, 4, formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::DEFAULT_TENSOR_SHAPE,
+        formats_array[run].unpack_A_src,
+        formats_array[run].unpack_A_dst);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
         L1_ADDRESS(buffer_A_tilized), formats_array[run].unpack_A_src, formats_array[run].unpack_A_dst);
 }

--- a/tt_metal/tt-llk/tests/sources/matmul_custom_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_custom_test.cpp
@@ -42,10 +42,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.CT_DIM,
         params.RT_DIM,
         params.KT_DIM,
-        FACE_R_DIM,
-        FACE_R_DIM,
-        4 /* unpA_num_faces */,
-        4 /* unpB_num_faces */,
+        ckernel::DEFAULT_TENSOR_SHAPE,
+        ckernel::DEFAULT_TENSOR_SHAPE,
         false /* unpA_partial_face */,
         false /* unpB_partial_face */);
     for (std::uint32_t j = 0; j < params.KT_DIM; j++)

--- a/tt_metal/tt-llk/tests/sources/matmul_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_perf.cpp
@@ -58,7 +58,15 @@ void run_kernel(RUNTIME_PARAMETERS params)
             num_faces_B,
             TILE_SIZE_UNPACK_A,
             TILE_SIZE_UNPACK_B);
-        _llk_unpack_AB_matmul_init_<>(UNPACK_TRANSPOSE_FACES, CT_DIM, RT_DIM, KT_DIM, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES, false, false);
+        _llk_unpack_AB_matmul_init_<>(
+            UNPACK_TRANSPOSE_FACES,
+            CT_DIM,
+            RT_DIM,
+            KT_DIM,
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, TILE_NUM_FACES),
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, TILE_NUM_FACES),
+            false,
+            false);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/matmul_test.cpp
@@ -38,7 +38,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.num_faces_B,
         params.TILE_SIZE_UNPACK_A,
         params.TILE_SIZE_UNPACK_B);
-    _llk_unpack_AB_matmul_init_<>(0, params.CT_DIM, params.RT_DIM, params.KT_DIM, FACE_R_DIM, FACE_R_DIM, 4, 4, false, false);
+    _llk_unpack_AB_matmul_init_<>(0, params.CT_DIM, params.RT_DIM, params.KT_DIM, ckernel::DEFAULT_TENSOR_SHAPE, ckernel::DEFAULT_TENSOR_SHAPE, false, false);
     for (std::uint32_t j = 0; j < params.KT_DIM; j++)
     {
         _llk_unpack_AB_matmul_<>(

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_perf.cpp
@@ -48,7 +48,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             /* num_faces */ 4,
             /* num_faces */ 4);
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+            0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
         PROFILER_SYNC();
 
         for (std::uint32_t tile = 0; tile < TILE_CNT; tile++)

--- a/tt_metal/tt-llk/tests/sources/pack_dest_bank_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_dest_bank_test.cpp
@@ -32,7 +32,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            0, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+            0 /* transpose_of_faces */,
+            0 /* within_face_16x16_transpose */,
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+            formats.unpack_A_src,
+            formats.unpack_A_dst);
 
         const int num_total_tiles = params.NUM_TILES_IN_BLOCK * params.NUM_BLOCKS;
 

--- a/tt_metal/tt-llk/tests/sources/pack_rows_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_rows_test.cpp
@@ -26,7 +26,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /*num_faces*/, 4 /*num_faces*/);
     _llk_unpack_A_init_<BroadcastType::NONE, false /*acc_to_dest*/, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0 /*transpose_of_faces*/, 0 /*within_face_16x16_transpose*/, FACE_R_DIM, 4 /*num_faces*/, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /*transpose_of_faces*/, 0 /*within_face_16x16_transpose*/, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
 
     const int num_total_tiles = params.NUM_TILES_IN_BLOCK * params.NUM_BLOCKS;
 

--- a/tt_metal/tt-llk/tests/sources/pack_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_test.cpp
@@ -28,7 +28,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     const int num_total_tiles = params.NUM_TILES_IN_BLOCK * params.NUM_BLOCKS;
 

--- a/tt_metal/tt-llk/tests/sources/pack_tiny_tile_block_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_tiny_tile_block_test.cpp
@@ -44,7 +44,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.num_faces);
 
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false>(
-        0, 0, params.TEST_FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     const int total_tiles = params.NUM_TILES_IN_BLOCK * params.NUM_BLOCKS;
     for (int i = 0; i < total_tiles; ++i)

--- a/tt_metal/tt-llk/tests/sources/pack_tiny_tile_reconfig_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_tiny_tile_reconfig_test.cpp
@@ -45,7 +45,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.num_faces);
 
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false>(
-        0, 0, params.TEST_FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     const int total_tiles = params.NUM_TILES_IN_BLOCK * params.NUM_BLOCKS;
     for (int i = 0; i < total_tiles; ++i)

--- a/tt_metal/tt-llk/tests/sources/pack_untilize_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_untilize_perf.cpp
@@ -49,7 +49,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     {
         START_PERF_MEASURE("INIT")
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+            0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src,
             formats.unpack_B_src,

--- a/tt_metal/tt-llk/tests/sources/pack_untilize_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/pack_untilize_test.cpp
@@ -47,7 +47,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     const std::uint32_t num_blocks_per_col = FULL_CT_DIM / BLOCK_CT_DIM;
 

--- a/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sdpa_reinits_test.cpp
@@ -40,7 +40,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<false>(unpack_a_src_format0, unpack_b_src_format0, unpack_a_dst_format0, unpack_b_dst_format0, 16, 16, 4, 4, 128, 128);
     for (std::uint32_t batch = 0; batch < 1; ++batch)
     {
-        _llk_unpack_AB_matmul_init_<>(false, 1, 1, 1, 16, 16);
+        _llk_unpack_AB_matmul_init_<>(false, 1, 1, 1);
         {
             const std::uint32_t mt = batch;
             for (std::uint32_t kt = 0; kt < 1; ++kt)
@@ -98,7 +98,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     t6_semaphore_get<>(semaphore::PACK_DONE);
     for (std::uint32_t batch = 0; batch < 1; ++batch)
     {
-        _llk_unpack_AB_matmul_init_<>(false, 1, 1, 1, 16, 16);
+        _llk_unpack_AB_matmul_init_<>(false, 1, 1, 1);
         {
             const std::uint32_t mt = batch;
             for (std::uint32_t kt = 0; kt < 1; ++kt)

--- a/tt_metal/tt-llk/tests/sources/sfpu_binary_bcast_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binary_bcast_test.cpp
@@ -31,7 +31,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES);
 
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, TILE_NUM_FACES, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, TILE_NUM_FACES),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
         L1_ADDRESS(params.buffer_A[0]), formats.unpack_A_src, formats.unpack_A_dst);

--- a/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_binary_test.cpp
@@ -27,7 +27,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
     _llk_unpack_A_init_<BROADCAST_TYPE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
     for (std::uint32_t i = 0; i < params.TILE_CNT; i++)
     {
         _llk_unpack_A_<BROADCAST_TYPE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_row_max_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_row_max_perf.cpp
@@ -48,7 +48,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             4 /* num_faces */,
             4 /* num_faces */);
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+            0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_perf.cpp
@@ -50,7 +50,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
             4 /* num_faces */,
             4 /* num_faces */);
         _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-            0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+            0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
         PROFILER_SYNC();
     }
     {

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_sdpa_test.cpp
@@ -31,7 +31,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
 
     // Unpack tiles from L1 to source register A
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)

--- a/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/sfpu_reduce_test.cpp
@@ -30,7 +30,7 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        0, 0, FACE_R_DIM, 4, formats.unpack_A_src, formats.unpack_A_dst);
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, formats.unpack_A_src, formats.unpack_A_dst);
 
     const std::uint32_t num_total_tiles = params.NUM_TILES_IN_BLOCK * params.NUM_BLOCKS;
 

--- a/tt_metal/tt-llk/tests/sources/topk_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/topk_test.cpp
@@ -179,10 +179,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
                     // only do face level transpose in the first iteration to turn in into column-wise format.
                     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-                        /* transpose_of_faces */ (current_iteration == 0) ? 1 : 0,
-                        /* within_face_16x16_transpose */ (current_iteration == 0) ? 1 : 0,
-                        /* face_r_dim     */ FACE_R_DIM,
-                        /* num_faces      */ 4,
+                        ((current_iteration == 0) ? 1 : 0) /* transpose_of_faces */,
+                        ((current_iteration == 0) ? 1 : 0) /* within_face_16x16_transpose */,
+                        ckernel::DEFAULT_TENSOR_SHAPE,
                         unpack_src_format,
                         unpack_dst_format);
 

--- a/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_dest_test.cpp
@@ -27,7 +27,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
-        params.UNPACK_TRANSPOSE_FACES, 0, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        params.UNPACK_TRANSPOSE_FACES,
+        0 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/transpose_wh_int8_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/transpose_wh_int8_test.cpp
@@ -36,7 +36,11 @@ void run_kernel(RUNTIME_PARAMETERS params)
         formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, params.num_faces, params.num_faces);
     // Mirror transpose_wh_init i8 branch: acc_to_dest=true, transpose_of_faces=1, within_face_16x16_transpose=1.
     _llk_unpack_A_init_<BroadcastType::NONE, true, EltwiseBinaryReuseDestType::NONE, false /* unpack_to_dest */>(
-        1 /* transpose_of_faces */, 1 /* within_face_16x16_transpose */, FACE_R_DIM, params.num_faces, formats.unpack_A_src, formats.unpack_A_dst);
+        1 /* transpose_of_faces */,
+        1 /* within_face_16x16_transpose */,
+        ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, params.num_faces),
+        formats.unpack_A_src,
+        formats.unpack_A_dst);
 
     for (std::uint32_t i = 0; i < params.TILE_CNT; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/ttnn_where_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/ttnn_where_test.cpp
@@ -45,7 +45,8 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
     _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
         UNPACK_FMT, UNPACK_FMT, UNPACK_FMT, UNPACK_FMT, FACE_R_DIM, FACE_R_DIM, 4 /* num_faces */, 4 /* num_faces */);
-    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(0, 0, FACE_R_DIM, 4, UNPACK_FMT, UNPACK_FMT);
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, UNPACK_FMT, UNPACK_FMT);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_A[0]), UNPACK_FMT, UNPACK_FMT);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_B[0]), UNPACK_FMT, UNPACK_FMT);
     _llk_unpack_A_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, unpack_to_dest>(L1_ADDRESS(params.buffer_C[0]), UNPACK_FMT, UNPACK_FMT);

--- a/tt_metal/tt-llk/tests/sources/unpack_A_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_A_test.cpp
@@ -41,13 +41,9 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.num_faces,
         params.num_faces);
     _llk_unpack_configure_stoch_rnd_<STOCHASTIC_RND>();
+    const ckernel::TensorShape tensor_shape = ckernel::make_tensor_shape_from_legacy(params.TEST_FACE_R_DIM, params.num_faces);
     _llk_unpack_A_init_<BROADCAST_TYPE, ACC_TO_DEST, REUSE_DEST_TYPE, unpack_to_dest>(
-        params.UNPACK_TRANSPOSE_FACES,
-        params.UNPACK_TRANSPOSE_WITHIN_FACE,
-        params.TEST_FACE_R_DIM,
-        params.num_faces,
-        formats.unpack_A_src,
-        formats.unpack_A_dst);
+        params.UNPACK_TRANSPOSE_FACES, params.UNPACK_TRANSPOSE_WITHIN_FACE, tensor_shape, formats.unpack_A_src, formats.unpack_A_dst);
 
     for (std::uint32_t i = 0; i < num_tiles_in_block * num_blocks; ++i)
     {

--- a/tt_metal/tt-llk/tests/sources/unpack_matmul_test.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_matmul_test.cpp
@@ -42,12 +42,10 @@ void run_kernel(RUNTIME_PARAMETERS params)
         params.CT_DIM,
         params.RT_DIM,
         params.KT_DIM,
-        params.in1_tile_r_dim < FACE_R_DIM ? params.in1_tile_r_dim : FACE_R_DIM,
-        params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM,
-        params.num_faces_B,     // in1
-        params.num_faces_A,     // in0
-        params.PARTIAL_FACE_B,  // in1
-        params.PARTIAL_FACE_A); // in0
+        ckernel::make_tensor_shape_from_legacy(params.in1_tile_r_dim < FACE_R_DIM ? params.in1_tile_r_dim : FACE_R_DIM, params.num_faces_B), // in1
+        ckernel::make_tensor_shape_from_legacy(params.in0_tile_r_dim < FACE_R_DIM ? params.in0_tile_r_dim : FACE_R_DIM, params.num_faces_A), // in0
+        params.PARTIAL_FACE_B,                                                                                                               // in1
+        params.PARTIAL_FACE_A);                                                                                                              // in0
     for (std::uint32_t j = 0; j < params.KT_DIM; j++)
     {
         _llk_unpack_AB_matmul_<>(

--- a/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
+++ b/tt_metal/tt-llk/tests/sources/unpack_transpose_perf.cpp
@@ -45,7 +45,12 @@ void run_kernel(RUNTIME_PARAMETERS params)
 
         _llk_unpack_hw_configure_<is_fp32_dest_acc_en>(
             formats.unpack_A_src, formats.unpack_B_src, formats.unpack_A_dst, formats.unpack_B_dst, FACE_R_DIM, FACE_R_DIM, TILE_NUM_FACES, TILE_NUM_FACES);
-        _llk_unpack_A_init_<>(UNPACK_TRANSPOSE_FACES, UNPACK_TRANSPOSE_WITHIN_FACE, FACE_R_DIM, TILE_NUM_FACES, formats.unpack_A_src, formats.unpack_A_dst);
+        _llk_unpack_A_init_<>(
+            UNPACK_TRANSPOSE_FACES,
+            UNPACK_TRANSPOSE_WITHIN_FACE,
+            ckernel::make_tensor_shape_from_legacy(FACE_R_DIM, TILE_NUM_FACES),
+            formats.unpack_A_src,
+            formats.unpack_A_dst);
         PROFILER_SYNC();
     }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/experimental/llk_unpack_fast_untilize.h
@@ -55,7 +55,8 @@ inline void _llk_unpack_fast_untilize_mop_config_(const std::uint32_t unit_dim)
 template <bool is_fp32_dest_acc_en>
 inline void _llk_unpack_fast_untilize_init_(const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format, const std::uint32_t init_unit_dim)
 {
-    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false>(0, 0, FACE_R_DIM, 4, unpack_src_format, unpack_dst_format);
+    _llk_unpack_A_init_<BroadcastType::NONE, false, EltwiseBinaryReuseDestType::NONE, false>(
+        0 /* transpose_of_faces */, 0 /* within_face_16x16_transpose */, ckernel::DEFAULT_TENSOR_SHAPE, unpack_src_format, unpack_dst_format);
     _llk_unpack_fast_untilize_mop_config_<is_fp32_dest_acc_en>(init_unit_dim);
 }
 

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_eltwise_binary.h
@@ -6,13 +6,14 @@
 
 #include <cstdint>
 
-#include "../../common/tensor_shape.h"
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
 #include "cmath_common.h"
 #include "llk_assert.h"
 #include "llk_math_common.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_math.h"
 
 using namespace ckernel;
 
@@ -116,6 +117,7 @@ inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_des
     static_assert(
         math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
         "Math fidelity larger than LoFi only works with Eltwise multiply");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::eltwise_binary_configure_mop_standard, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const std::uint32_t num_faces       = tensor_shape.total_num_faces();
     const std::uint32_t num_faces_c_dim = tensor_shape.num_faces_c_dim;
@@ -202,6 +204,7 @@ inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_des
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType src_b_bcast_type, MathFidelity math_fidelity = MathFidelity::LoFi>
 inline void _llk_math_eltwise_binary_standard_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_standard_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     eltwise_binary_configure_addrmod<eltwise_binary_type, src_b_bcast_type, math_fidelity>();
@@ -239,6 +242,7 @@ inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tenso
         (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
             (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_standard_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
     constexpr bool high_fidelity        = is_high_fidelity(math_fidelity);
@@ -367,6 +371,7 @@ inline void eltwise_binary_configure_mop_with_dest_reuse(const std::uint32_t acc
     static_assert(
         math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
         "Math fidelity larger than LoFi only works with Eltwise multiply");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::eltwise_binary_configure_mop_with_dest_reuse, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     constexpr bool high_fidelity    = is_high_fidelity(math_fidelity);
     constexpr std::uint8_t addr_mod = ADDR_MOD_0;
@@ -455,6 +460,7 @@ template <
 inline void _llk_math_eltwise_binary_with_dest_reuse_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
 {
     static_assert(binary_reuse_dest != EltwiseBinaryReuseDestType::NONE, "Use _llk_math_eltwise_binary_standard_init_ for no dest reuse");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_with_dest_reuse_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     eltwise_binary_configure_addrmod<eltwise_binary_type, src_b_bcast_type, math_fidelity>();
@@ -531,6 +537,7 @@ inline void _llk_math_eltwise_binary_with_dest_reuse_(const ckernel::TensorShape
         (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
             (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_with_dest_reuse_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     // Dest counter always jumps by 32x32 tile spacing regardless of actual tile size

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_math_reduce.h
@@ -14,6 +14,7 @@
 #include "llk_assert.h"
 #include "llk_math_common.h"
 #include "tensor_shape.h"
+#include "tensor_shape_coverage_math.h"
 
 using namespace ckernel;
 
@@ -181,6 +182,7 @@ template <
     bool enforce_fp32_accumulation = false>
 inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_reduce_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     // Supported narrow tiles per BH Tiny Tile Summary: [16]x16 (num_faces=1) and [32]x16 (num_faces=2) only

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_A.h
@@ -14,6 +14,8 @@
 #include "cunpack_common.h"
 #include "llk_assert.h"
 #include "llk_unpack_common.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -30,7 +32,7 @@ using namespace ckernel::unpacker;
  * @tparam binary_reuse_dest: Reuse dest as a source operand, values = <NONE/DEST_TO_SRCA/DEST_TO_SRCB>
  * @tparam unpack_to_dest: Unpack directly into the dest register (32-bit datums).
  * @param transpose_of_faces: Whether faces are reordered (transposed) during the unpack.
- * @param num_faces: Number of faces in the tile, valid values = <1, 2, 4>.
+ * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim).
  * @param unpack_src_format: Source data format of the operand in L1.
  * @param unpack_dst_format: Destination data format the operand is converted to.
  */
@@ -40,14 +42,16 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest                          = false>
 inline void _llk_unpack_A_mop_config_(
-    const bool transpose_of_faces, const std::uint32_t num_faces, const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format = 0)
+    const bool transpose_of_faces, const ckernel::TensorShape tensor_shape, const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format = 0)
 {
     static_assert(
         !((BType != BroadcastType::NONE) && acc_to_dest && (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)), "Not supported configuration!");
     static_assert(
         !(((acc_to_dest) || (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE)) && (unpack_to_dest)),
         "Not supported configuration when unpacking to dest!");
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_A_mop_config_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const std::uint8_t num_faces = tensor_shape.total_num_faces();
 
     static constexpr std::uint32_t unpack_srca =
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
@@ -215,11 +219,11 @@ inline void _llk_unpack_A_mop_config_(
  * @tparam unpack_to_dest: Unpack directly into the dest register (32-bit datums).
  * @param transpose_of_faces: Nonzero to reorder (transpose) faces during the unpack.
  * @param within_face_16x16_transpose: Nonzero to enable the 16x16 within-face transpose (haloize mode).
- * @param face_r_dim: Number of rows per face.
- * @param num_faces: Number of faces in the tile, valid values = <1, 2, 4>.
+ * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim).
  * @param unpack_src_format: Source data format of the operand in L1.
  * @param unpack_dst_format: Destination data format the operand is converted to.
- * @note Call @ref _llk_unpack_A_uninit_ to restore the modified datum-count state.
+ * @note Call @ref _llk_unpack_A_uninit_ as the matching teardown; it is currently a no-op
+ *       because unpacker X counters are reprogrammed by init.
  * @ref _llk_unpack_A_ is the matching execute call.
  * @ref _llk_math_eltwise_unary_datacopy_init_ is the matching init on the math thread (datacopy/transpose consumer).
  */
@@ -231,12 +235,14 @@ template <
 inline void _llk_unpack_A_init_(
     const std::uint32_t transpose_of_faces          = 0,
     const std::uint32_t within_face_16x16_transpose = 0,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
-    const std::uint32_t num_faces                   = 4,
+    const ckernel::TensorShape tensor_shape         = ckernel::DEFAULT_TENSOR_SHAPE,
     const std::uint32_t unpack_src_format           = 0,
     const std::uint32_t unpack_dst_format           = 0)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_A_init_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const std::uint8_t face_r_dim = tensor_shape.face_r_dim;
+    const std::uint8_t num_faces  = tensor_shape.total_num_faces();
     LLK_ASSERT(BType != BroadcastType::COL || num_faces == 4, "Unary Broadcast Column requires num_faces == 4 (32x32 only)");
     LLK_ASSERT(transpose_of_faces == 0 || face_r_dim == 16, "Partial faces are not supported for transpose datacopy, face_r_dim must be 16 rows");
     LLK_ASSERT(transpose_of_faces == 0 || num_faces == 4 || num_faces == 1, "Transpose requires num_faces == 4 or 1 (32x32 and 16x16 only)");
@@ -271,10 +277,8 @@ inline void _llk_unpack_A_init_(
         //   acc_to_dest DEST_TO_SRCA   -> SrcB only      (SrcA comes from DEST, e.g. hardswish x*hardsigmoid(x))
         //   acc_to_dest DEST_TO_SRCB   -> SrcA only      (SrcB comes from DEST)
         //   broadcast                  -> SrcB
-        constexpr bool reads_srca =
-            (BType == BroadcastType::NONE) && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA);
-        constexpr bool reads_srcb =
-            (BType != BroadcastType::NONE) || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB);
+        constexpr bool reads_srca       = (BType == BroadcastType::NONE) && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA);
+        constexpr bool reads_srcb       = (BType != BroadcastType::NONE) || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB);
         constexpr std::uint32_t UNP_SEL = (reads_srca && reads_srcb) ? p_setadc::UNP_AB : (reads_srca ? p_setadc::UNP_A : p_setadc::UNP_B);
         config_unpacker_x_end<UNP_SEL>(face_r_dim);
     }
@@ -284,17 +288,17 @@ inline void _llk_unpack_A_init_(
     {
         _llk_unpack_dbg_feature_disable_();
     }
-    _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(transpose_of_faces > 0, num_faces, unpack_src_format, unpack_dst_format);
+    _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
+        transpose_of_faces > 0, tensor_shape, unpack_src_format, unpack_dst_format);
 }
 
 /**
- * @brief Restore unpacker datum-count state after single-operand (A) unpacking.
+ * @brief No-op teardown after single-operand (A) unpacking.
  *
- * Resets the X-dimension address counter for the unpacker used by this broadcast mode back to
- * a full face worth of datums.
+ * The unpacker X counter is transient and reprogrammed by each operation's init, so there is
+ * nothing to restore here.
  *
  * @tparam BType: Broadcast type, values = <NONE/COL/ROW/SCALAR>
- * @param face_r_dim: Number of rows per face, used to compute the restored datum count.
  * @note Call @ref _llk_unpack_A_init_ with matching template args before this function.
  */
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB.h
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 
-#include "../../common/tensor_shape.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_globals.h"
@@ -16,6 +15,8 @@
 #include "llk_assert.h"
 #include "llk_defs.h"
 #include "llk_unpack_common.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -36,6 +37,7 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
     const std::uint32_t num_faces_c_dim = tensor_shape.num_faces_c_dim;
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_mop_config_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     if (transpose_of_faces)
@@ -160,6 +162,7 @@ template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const ckernel::Transpose transpose)
 {
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const bool within_face_16x16_transpose = transpose == ckernel::Transpose::IntraFace || transpose == ckernel::Transpose::Both;
     const bool transpose_of_faces          = transpose == ckernel::Transpose::InterFace || transpose == ckernel::Transpose::Both;

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_matmul.h
@@ -14,6 +14,8 @@
 #include "cunpack_common.h"
 #include "llk_assert.h"
 #include "llk_unpack_common.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -212,10 +214,8 @@ inline void _llk_unpack_AB_matmul_mop_config_(
  * @param ct_dim: Number of column tiles in the output block.
  * @param rt_dim: Number of row tiles in the output block.
  * @param kt_dim: Number of tiles along the contraction (K) dimension.
- * @param unpA_face_r_dim: Rows per face for operand A.
- * @param unpB_face_r_dim: Rows per face for operand B.
- * @param unpA_num_faces: Number of faces for operand A, valid values = <1, 2, 4>.
- * @param unpB_num_faces: Number of faces for operand B, valid values = <1, 2, 4>.
+ * @param src_a_tensor_shape: Tensor shape for input1 (In1 -> SrcA).
+ * @param src_b_tensor_shape: Tensor shape for input0 (In0 -> SrcB).
  * @param unpA_partial_face: Whether operand A is unpacked face-by-face (partial faces).
  * @param unpB_partial_face: Whether operand B is unpacked face-by-face (partial faces).
  * @note Call @ref _llk_unpack_AB_matmul_uninit_ to restore the modified datum-count state.
@@ -224,17 +224,21 @@ inline void _llk_unpack_AB_matmul_mop_config_(
  */
 template <std::uint32_t kernel_broadcast_a = 0, std::uint32_t kernel_broadcast_b = 0>
 __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
-    const std::uint32_t transpose       = 0,
-    const std::uint32_t ct_dim          = 1,
-    const std::uint32_t rt_dim          = 1,
-    const std::uint32_t kt_dim          = 1,
-    const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpB_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpA_num_faces  = 4,
-    const std::uint32_t unpB_num_faces  = 4,
-    const bool unpA_partial_face        = false,
-    const bool unpB_partial_face        = false)
+    const std::uint32_t transpose                 = 0,
+    const std::uint32_t ct_dim                    = 1,
+    const std::uint32_t rt_dim                    = 1,
+    const std::uint32_t kt_dim                    = 1,
+    const ckernel::TensorShape src_a_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const ckernel::TensorShape src_b_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool unpA_partial_face                  = false,
+    const bool unpB_partial_face                  = false)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_matmul_init_, src_a_tensor_shape);
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_matmul_init_, src_b_tensor_shape);
+    const std::uint8_t unpA_num_faces  = src_a_tensor_shape.total_num_faces();
+    const std::uint8_t unpB_num_faces  = src_b_tensor_shape.total_num_faces();
+    const std::uint8_t unpA_face_r_dim = src_a_tensor_shape.face_r_dim;
+    const std::uint8_t unpB_face_r_dim = src_b_tensor_shape.face_r_dim;
     LLK_ASSERT(unpA_num_faces == 1 || unpA_num_faces == 2 || unpA_num_faces == 4, "unpA_num_faces must be 1, 2, or 4");
     LLK_ASSERT(unpB_num_faces == 1 || unpB_num_faces == 2 || unpB_num_faces == 4, "unpB_num_faces must be 1, 2, or 4");
     // 16x16 matmul not supported - no dedicated math path; falls to 32x32 default which is incorrect for < 4 faces

--- a/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_blackhole/llk_lib/llk_unpack_AB_reduce.h
@@ -15,6 +15,7 @@
 #include "llk_assert.h"
 #include "llk_unpack_common.h"
 #include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -33,6 +34,7 @@ template <PoolType pool_type, ReduceDim reduce_dim>
 inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_reduce_mop_config_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     // Data valid for clear instructions is set to 0 since the MATH kernel should not process this data.
@@ -106,6 +108,7 @@ template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulati
 inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape &tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_reduce_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     if constexpr (enforce_fp32_accumulation)

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_math_reduce.h
@@ -8,6 +8,7 @@
 
 #include "llk_math_common.h"
 #include "tensor_shape.h"
+#include "tensor_shape_coverage_math.h"
 using namespace ckernel;
 using namespace ckernel::trisc;
 using namespace ckernel::math;
@@ -352,6 +353,7 @@ inline void _llk_math_reduce_addrmod_()
 template <PoolType POOL_TYPE, ReduceDim REDUCE_DIMENSION, ckernel::MathFidelity MATH_FIDELITY_TYPE>
 inline void _llk_math_reduce_init_(const TensorShape& tensor_shape)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_reduce_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     _llk_math_reduce_addrmod_<REDUCE_DIMENSION, MATH_FIDELITY_TYPE>();
 

--- a/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_quasar/llk_lib/llk_unpack_reduce.h
@@ -9,6 +9,7 @@
 #include "ckernel_trisc_common.h"
 #include "llk_unpack_common.h"
 #include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 using namespace ckernel;
 
 /**
@@ -66,6 +67,7 @@ template <ReduceDim REDUCE_DIMENSION>
 inline void _llk_unpack_reduce_init_(
     const std::uint32_t buf_desc_id_0, const std::uint32_t buf_desc_id_1, const TensorShape& tensor_shape, const std::uint32_t num_tiles = NUM_TILES)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_reduce_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     cfg_rmw(THCON_UNPACKER0_REG0_TRANSPOSE_RMW, (REDUCE_DIMENSION == ReduceDim::REDUCE_ROW));
     _llk_unpack_reduce_mop_config_<REDUCE_DIMENSION>(buf_desc_id_0, buf_desc_id_1, tensor_shape, num_tiles);

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_eltwise_binary.h
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 
-#include "../../common/tensor_shape.h"
 #include "ckernel_include.h"
 #include "ckernel_ops.h"
 #include "ckernel_template.h"
@@ -14,6 +13,8 @@
 #include "llk_assert.h"
 #include "llk_math_common.h"
 #include "lltt.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_math.h"
 
 using namespace ckernel;
 
@@ -30,9 +31,12 @@ using namespace ckernel;
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType bcast_type, MathFidelity math_fidelity>
 inline void eltwise_binary_configure_addrmod()
 {
-    static_assert(math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL, "Math fidelity larger than LoFi only works with Eltwise multiply");
     static_assert(
-        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) || (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
+        math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
+        "Math fidelity larger than LoFi only works with Eltwise multiply");
+    static_assert(
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+            (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
 
     constexpr std::uint32_t fidelity_increment = is_high_fidelity(math_fidelity) ? 1 : 0;
@@ -77,7 +81,8 @@ template <EltwiseBinaryType eltwise_binary_type>
 inline auto eltwise_binary_func(std::uint8_t clr_src, std::uint8_t acc_to_dest, std::uint8_t broadcast_type, std::uint8_t addr_mod)
 {
     static_assert(
-        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) || (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+            (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
 
     if constexpr (eltwise_binary_type == EltwiseBinaryType::ELWADD)
@@ -109,11 +114,12 @@ inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_des
     static_assert(
         math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
         "Math fidelity larger than LoFi only works with Eltwise multiply");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::eltwise_binary_configure_mop_standard, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
-    const std::uint32_t num_faces           = tensor_shape.total_num_faces();
-    const std::uint32_t num_faces_c_dim     = tensor_shape.num_faces_c_dim;
-    constexpr bool high_fidelity            = is_high_fidelity(math_fidelity);
-    constexpr std::uint8_t addr_mod         = ADDR_MOD_0;
+    const std::uint32_t num_faces       = tensor_shape.total_num_faces();
+    const std::uint32_t num_faces_c_dim = tensor_shape.num_faces_c_dim;
+    constexpr bool high_fidelity        = is_high_fidelity(math_fidelity);
+    constexpr std::uint8_t addr_mod     = ADDR_MOD_0;
 
     // Inner loop: number of MAX_FPU_ROWS (8-row) operations per face
     // Even if face_r_dim < 16, we still process at least 1 inner loop iteration
@@ -193,6 +199,7 @@ inline void eltwise_binary_configure_mop_standard(const std::uint32_t acc_to_des
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType src_b_bcast_type, MathFidelity math_fidelity = MathFidelity::LoFi>
 inline void _llk_math_eltwise_binary_standard_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_standard_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     eltwise_binary_configure_addrmod<eltwise_binary_type, src_b_bcast_type, math_fidelity>();
@@ -223,11 +230,15 @@ template <
     MathFidelity math_fidelity = MathFidelity::LoFi>
 inline void _llk_math_eltwise_binary_standard_(const ckernel::TensorShape &tensor_shape, std::uint32_t dst_index)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_standard_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
-    static_assert(math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL, "Math fidelity larger than LoFi only works with Eltwise multiply");
     static_assert(
-        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) || (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
+        math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
+        "Math fidelity larger than LoFi only works with Eltwise multiply");
+    static_assert(
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+            (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
     constexpr bool high_fidelity = is_high_fidelity(math_fidelity);
 
@@ -352,7 +363,10 @@ inline void eltwise_binary_reuse_dest_as_src()
 template <EltwiseBinaryType eltwise_binary_type, BroadcastType bcast_type, MathFidelity math_fidelity = MathFidelity::LoFi>
 inline void eltwise_binary_configure_mop_with_dest_reuse(const std::uint32_t acc_to_dest, const ckernel::TensorShape &tensor_shape)
 {
-    static_assert(math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL, "Math fidelity larger than LoFi only works with Eltwise multiply");
+    static_assert(
+        math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
+        "Math fidelity larger than LoFi only works with Eltwise multiply");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::eltwise_binary_configure_mop_with_dest_reuse, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     constexpr bool high_fidelity    = is_high_fidelity(math_fidelity);
     constexpr std::uint8_t addr_mod = ADDR_MOD_0;
@@ -441,6 +455,7 @@ template <
 inline void _llk_math_eltwise_binary_with_dest_reuse_init_(const ckernel::TensorShape &tensor_shape, const std::uint32_t acc_to_dest)
 {
     static_assert(binary_reuse_dest != EltwiseBinaryReuseDestType::NONE, "Use _llk_math_eltwise_binary_standard_init_ for no dest reuse");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_with_dest_reuse_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     eltwise_binary_configure_addrmod<eltwise_binary_type, src_b_bcast_type, math_fidelity>();
@@ -514,10 +529,14 @@ template <
 inline void _llk_math_eltwise_binary_with_dest_reuse_(const ckernel::TensorShape &tensor_shape, std::uint32_t dst_index, const bool clear_fp32_dst_acc)
 {
     static_assert(binary_reuse_dest != EltwiseBinaryReuseDestType::NONE, "Use _llk_math_eltwise_binary_standard_ for no dest reuse");
-    static_assert(math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL, "Math fidelity larger than LoFi only works with Eltwise multiply");
     static_assert(
-        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) || (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
+        math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
+        "Math fidelity larger than LoFi only works with Eltwise multiply");
+    static_assert(
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+            (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_eltwise_binary_with_dest_reuse_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const std::uint32_t num_faces       = tensor_shape.total_num_faces();
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
@@ -741,9 +760,12 @@ inline void eltwise_binary_configure_addrmod()
 template <EltwiseBinaryType eltwise_binary_type, MathFidelity math_fidelity = MathFidelity::LoFi>
 inline void _llk_math_eltwise_binary_init_(std::uint32_t srca_reuse_count = 4)
 {
-    static_assert(math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL, "Math fidelity larger than LoFi only works with Eltwise multiply");
     static_assert(
-        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) || (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
+        math_fidelity == MathFidelity::LoFi || eltwise_binary_type == EltwiseBinaryType::ELWMUL,
+        "Math fidelity larger than LoFi only works with Eltwise multiply");
+    static_assert(
+        (eltwise_binary_type == EltwiseBinaryType::ELWADD) || (eltwise_binary_type == EltwiseBinaryType::ELWSUB) ||
+            (eltwise_binary_type == EltwiseBinaryType::ELWMUL),
         "eltwise_binary_type must be ELWADD, ELWSUB, or ELWMUL");
 
     eltwise_binary_configure_addrmod();

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_math_reduce.h
@@ -14,6 +14,7 @@
 #include "llk_assert.h"
 #include "llk_math_common.h"
 #include "tensor_shape.h"
+#include "tensor_shape_coverage_math.h"
 
 using namespace ckernel;
 
@@ -193,6 +194,7 @@ template <
     bool enforce_fp32_accumulation = false>
 inline void _llk_math_reduce_(const std::uint32_t dst_index, const ckernel::TensorShape& tensor_shape)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_MATH(ckernel::coverage::TensorShapeFunctionCoverage::_llk_math_reduce_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     // Supported narrow tiles per BH Tiny Tile Summary: [16]x16 (num_faces=1) and [32]x16 (num_faces=2) only

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_A.h
@@ -16,6 +16,8 @@
 #include "llk_unpack_common.h"
 #include "lltt.h"
 #include "sfpi.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -32,7 +34,7 @@ using namespace ckernel::unpacker;
  * @tparam binary_reuse_dest: Reuse dest as a source operand, values = <NONE/DEST_TO_SRCA/DEST_TO_SRCB>
  * @tparam unpack_to_dest: Unpack directly into the dest register (32-bit datums).
  * @param transpose_of_faces: Whether faces are reordered (transposed) during the unpack.
- * @param num_faces: Number of faces in the tile, valid values = <1, 2, 4>.
+ * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim).
  * @param unpack_src_format: Source data format of the operand in L1.
  * @param unpack_dst_format: Destination data format the operand is converted to.
  */
@@ -42,14 +44,16 @@ template <
     EltwiseBinaryReuseDestType binary_reuse_dest = EltwiseBinaryReuseDestType::NONE,
     bool unpack_to_dest                          = false>
 inline void _llk_unpack_A_mop_config_(
-    const bool transpose_of_faces, const std::uint32_t num_faces, const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format = 0)
+    const bool transpose_of_faces, const ckernel::TensorShape tensor_shape, const std::uint32_t unpack_src_format, const std::uint32_t unpack_dst_format = 0)
 {
     static_assert(
         !((BType != BroadcastType::NONE) && acc_to_dest && (binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCB)), "Not supported configuration!");
     static_assert(
         !(((acc_to_dest) || (binary_reuse_dest != EltwiseBinaryReuseDestType::NONE)) && (unpack_to_dest)),
         "Not supported configuration when unpacking to dest!");
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_A_mop_config_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const std::uint8_t num_faces = tensor_shape.total_num_faces();
 
     static constexpr std::uint32_t unpack_srca =
         TT_OP_UNPACR(SrcA, 0b1 /*Z inc*/, 0, 0, 0, 1 /* Set OvrdThreadId*/, 1 /*Set Dvalid*/, p_unpacr::RAREFYB_DISABLE, 0, 0, 0, 0, 1);
@@ -216,11 +220,11 @@ inline void _llk_unpack_A_mop_config_(
  * @tparam unpack_to_dest: Unpack directly into the dest register (32-bit datums).
  * @param transpose_of_faces: Nonzero to reorder (transpose) faces during the unpack.
  * @param within_face_16x16_transpose: Nonzero to enable the 16x16 within-face transpose (haloize mode).
- * @param face_r_dim: Number of rows per face.
- * @param num_faces: Number of faces in the tile, valid values = <1, 2, 4>.
+ * @param tensor_shape: Tensor shape describing tile dimensions (face_r_dim, face_c_dim, num_faces_r_dim, num_faces_c_dim).
  * @param unpack_src_format: Source data format of the operand in L1.
  * @param unpack_dst_format: Destination data format the operand is converted to.
- * @note Call @ref _llk_unpack_A_uninit_ after this function to restore the modified datum-count state.
+ * @note Call @ref _llk_unpack_A_uninit_ as the matching teardown; it is currently a no-op
+ *       because unpacker X counters are reprogrammed by init.
  * @ref _llk_unpack_A_ is the matching execute call.
  * @ref _llk_math_eltwise_unary_datacopy_init_ is the matching init on the math thread (datacopy/transpose consumer).
  */
@@ -232,12 +236,14 @@ template <
 inline void _llk_unpack_A_init_(
     const std::uint32_t transpose_of_faces          = 0,
     const std::uint32_t within_face_16x16_transpose = 0,
-    const std::uint32_t face_r_dim                  = FACE_R_DIM,
-    const std::uint32_t num_faces                   = 4,
+    const ckernel::TensorShape tensor_shape         = ckernel::DEFAULT_TENSOR_SHAPE,
     const std::uint32_t unpack_src_format           = 0,
     const std::uint32_t unpack_dst_format           = 0)
 {
-    LLK_ASSERT(num_faces == 1 || num_faces == 2 || num_faces == 4, "num_faces must be 1, 2, or 4");
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_A_init_, tensor_shape);
+    LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
+    const std::uint8_t face_r_dim = tensor_shape.face_r_dim;
+    const std::uint8_t num_faces  = tensor_shape.total_num_faces();
     LLK_ASSERT(BType != BroadcastType::COL || num_faces == 4, "Unary Broadcast Column requires num_faces == 4 (32x32 only)");
     LLK_ASSERT(transpose_of_faces == 0 || face_r_dim == 16, "Partial faces are not supported for transpose datacopy, face_r_dim must be 16 rows");
     LLK_ASSERT(transpose_of_faces == 0 || num_faces == 4 || num_faces == 1, "Transpose requires num_faces == 4 or 1 (32x32 and 16x16 only)");
@@ -272,15 +278,14 @@ inline void _llk_unpack_A_init_(
         //   acc_to_dest DEST_TO_SRCA   -> SrcB only      (SrcA comes from DEST, e.g. hardswish x*hardsigmoid(x))
         //   acc_to_dest DEST_TO_SRCB   -> SrcA only      (SrcB comes from DEST)
         //   broadcast                  -> SrcB
-        constexpr bool reads_srca =
-            (BType == BroadcastType::NONE) && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA);
-        constexpr bool reads_srcb =
-            (BType != BroadcastType::NONE) || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB);
+        constexpr bool reads_srca       = (BType == BroadcastType::NONE) && !(acc_to_dest && binary_reuse_dest == EltwiseBinaryReuseDestType::DEST_TO_SRCA);
+        constexpr bool reads_srcb       = (BType != BroadcastType::NONE) || (acc_to_dest && binary_reuse_dest != EltwiseBinaryReuseDestType::DEST_TO_SRCB);
         constexpr std::uint32_t UNP_SEL = (reads_srca && reads_srcb) ? p_setadc::UNP_AB : (reads_srca ? p_setadc::UNP_A : p_setadc::UNP_B);
         config_unpacker_x_end<UNP_SEL>(face_r_dim);
     }
 
-    _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(transpose_of_faces > 0, num_faces, unpack_src_format, unpack_dst_format);
+    _llk_unpack_A_mop_config_<BType, acc_to_dest, binary_reuse_dest, unpack_to_dest>(
+        transpose_of_faces > 0, tensor_shape, unpack_src_format, unpack_dst_format);
 }
 
 /**
@@ -365,13 +370,12 @@ inline void _llk_unpack_A_(const std::uint32_t address, const std::uint32_t unpa
 }
 
 /**
- * @brief Restore unpacker datum-count state after single-operand (A) unpacking.
+ * @brief No-op teardown after single-operand (A) unpacking.
  *
- * Resets the X-dimension address counter for the unpacker used by this broadcast mode back to
- * a full face worth of datums.
+ * The unpacker X counter is transient and reprogrammed by each operation's init, so there is
+ * nothing to restore here.
  *
  * @tparam BType: Broadcast type, values = <NONE/COL/ROW/SCALAR>
- * @param face_r_dim: Number of rows per face, used to compute the restored datum count.
  * @note Call @ref _llk_unpack_A_init_ with matching template args before this function.
  */
 template <BroadcastType BType = BroadcastType::NONE>

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB.h
@@ -6,7 +6,6 @@
 
 #include <cstdint>
 
-#include "../../common/tensor_shape.h"
 #include "ckernel.h"
 #include "ckernel_defs.h"
 #include "ckernel_globals.h"
@@ -17,6 +16,8 @@
 #include "llk_defs.h"
 #include "llk_unpack_common.h"
 #include "lltt.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -37,6 +38,7 @@ inline void _llk_unpack_AB_mop_config_(const bool transpose_of_faces, const cker
     const std::uint32_t num_faces_r_dim = tensor_shape.num_faces_r_dim;
     const std::uint32_t num_faces_c_dim = tensor_shape.num_faces_c_dim;
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_mop_config_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     if (transpose_of_faces)
@@ -149,6 +151,7 @@ template <BroadcastType BType = BroadcastType::NONE>
 inline void _llk_unpack_AB_init_(const ckernel::TensorShape tensor_shape, const ckernel::Transpose transpose)
 {
     // TODO: Remove this assert after testing >4 num_faces because there is no reason to limit this for non-broadcast versions
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
     const bool within_face_16x16_transpose = transpose == ckernel::Transpose::IntraFace || transpose == ckernel::Transpose::Both;
     const bool transpose_of_faces          = transpose == ckernel::Transpose::InterFace || transpose == ckernel::Transpose::Both;

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_matmul.h
@@ -16,6 +16,8 @@
 #include "llk_unpack_common.h"
 #include "lltt.h"
 #include "sfpi.h"
+#include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -180,10 +182,8 @@ inline void _llk_unpack_AB_matmul_mop_config_(
  * @param ct_dim: Number of column tiles in the output block.
  * @param rt_dim: Number of row tiles in the output block.
  * @param kt_dim: Number of tiles along the contraction (K) dimension.
- * @param unpA_face_r_dim: Rows per face for operand A.
- * @param unpB_face_r_dim: Rows per face for operand B.
- * @param unpA_num_faces: Number of faces for operand A, valid values = <1, 2, 4>.
- * @param unpB_num_faces: Number of faces for operand B, valid values = <1, 2, 4>.
+ * @param src_a_tensor_shape: Tensor shape for input1 (In1 -> SrcA).
+ * @param src_b_tensor_shape: Tensor shape for input0 (In0 -> SrcB).
  * @param unpA_partial_face: Whether operand A is unpacked face-by-face (partial faces).
  * @param unpB_partial_face: Whether operand B is unpacked face-by-face (partial faces).
  * @note Call @ref _llk_unpack_AB_matmul_uninit_ after this function to restore the modified datum-count state.
@@ -192,17 +192,21 @@ inline void _llk_unpack_AB_matmul_mop_config_(
  */
 template <std::uint32_t kernel_broadcast_a = 0, std::uint32_t kernel_broadcast_b = 0>
 __attribute__((always_inline)) inline void _llk_unpack_AB_matmul_init_(
-    const std::uint32_t transpose       = 0,
-    const std::uint32_t ct_dim          = 1,
-    const std::uint32_t rt_dim          = 1,
-    const std::uint32_t kt_dim          = 1,
-    const std::uint32_t unpA_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpB_face_r_dim = FACE_R_DIM,
-    const std::uint32_t unpA_num_faces  = 4,
-    const std::uint32_t unpB_num_faces  = 4,
-    const bool unpA_partial_face        = false,
-    const bool unpB_partial_face        = false)
+    const std::uint32_t transpose                 = 0,
+    const std::uint32_t ct_dim                    = 1,
+    const std::uint32_t rt_dim                    = 1,
+    const std::uint32_t kt_dim                    = 1,
+    const ckernel::TensorShape src_a_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const ckernel::TensorShape src_b_tensor_shape = ckernel::DEFAULT_TENSOR_SHAPE,
+    const bool unpA_partial_face                  = false,
+    const bool unpB_partial_face                  = false)
 {
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_matmul_init_, src_a_tensor_shape);
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_matmul_init_, src_b_tensor_shape);
+    const std::uint8_t unpA_num_faces  = src_a_tensor_shape.total_num_faces();
+    const std::uint8_t unpB_num_faces  = src_b_tensor_shape.total_num_faces();
+    const std::uint8_t unpA_face_r_dim = src_a_tensor_shape.face_r_dim;
+    const std::uint8_t unpB_face_r_dim = src_b_tensor_shape.face_r_dim;
     LLK_ASSERT(unpA_num_faces == 1 || unpA_num_faces == 2 || unpA_num_faces == 4, "unpA_num_faces must be 1, 2, or 4");
     LLK_ASSERT(unpB_num_faces == 1 || unpB_num_faces == 2 || unpB_num_faces == 4, "unpB_num_faces must be 1, 2, or 4");
     // 16x16 inputs not supported - no dedicated math path; falls to 32x32 default which is incorrect for < 4 faces

--- a/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
+++ b/tt_metal/tt-llk/tt_llk_wormhole_b0/llk_lib/llk_unpack_AB_reduce.h
@@ -25,6 +25,7 @@
 #include "llk_unpack_common.h"
 #include "lltt.h"
 #include "tensor_shape.h"
+#include "tensor_shape_coverage_unpack.h"
 
 using namespace ckernel;
 using namespace ckernel::unpacker;
@@ -43,6 +44,7 @@ template <PoolType pool_type, ReduceDim reduce_dim>
 inline void _llk_unpack_AB_reduce_mop_config_(const ckernel::TensorShape &tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_reduce_mop_config_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     // Data valid for clear instructions is set to 0 since the MATH kernel should not process this data.
@@ -110,6 +112,7 @@ template <PoolType pool_type, ReduceDim reduce_dim, bool enforce_fp32_accumulati
 inline void _llk_unpack_AB_reduce_init_(const ckernel::TensorShape &tensor_shape)
 {
     // Validate tensor shape for tile-dependent operations
+    LLK_VALIDATE_TENSOR_SHAPE_UNPACK(ckernel::coverage::TensorShapeFunctionCoverage::_llk_unpack_AB_reduce_init_, tensor_shape);
     LLK_ASSERT(validate_tensor_shape_tile_dependent_ops_(tensor_shape), "Invalid tensor shape for tile-dependent op");
 
     // Enable transpose (haloize mode) if reducing along rows


### PR DESCRIPTION
## Summary
- Replace legacy `face_r_dim` / `num_faces` scalars with `TensorShape` parameters in BH/WH `_llk_unpack_AB_matmul_init_` and API wrappers.
- Add `_llk_unpack_AB_matmul_init_` to the TensorShape coverage infrastructure with validation via `LLK_VALIDATE_TENSOR_SHAPE_UNPACK`.
- Populate `covered_shapes_llk_unpack_AB_matmul_init` with shapes exercised by matmul sweeps (full 32×32 and tiny-tile src_b variants).
- Update LLK test sources, fuser matmul generators, and tt-exalens compatibility fixes in the test harness (`ElfFile`, device print section parsing).

## Test plan
- [ ] Merge Gate workflow (manual dispatch on branch)
- [ ] `pytest test_matmul.py test_unpack_matmul.py test_math_matmul.py` on BH with asserts enabled
- [ ] Confirm no `_llk_unpack_AB_matmul_init_` DPRINT lines when coverage table is populated


Made with [Cursor](https://cursor.com)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_unpack_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ndivnic/tensor_shape_llk_unpack_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_unpack_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ndivnic/tensor_shape_llk_unpack_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_unpack_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ndivnic/tensor_shape_llk_unpack_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_unpack_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ndivnic/tensor_shape_llk_unpack_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_unpack_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ndivnic/tensor_shape_llk_unpack_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_unpack_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ndivnic/tensor_shape_llk_unpack_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_unpack_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ndivnic/tensor_shape_llk_unpack_matmul)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ndivnic/tensor_shape_llk_unpack_matmul)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ndivnic/tensor_shape_llk_unpack_matmul)