### PR TITLE
[Cleanup] Migrate reduction kernels and  bcast scalar helpers to Device 2.0

### DIFF
--- a/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
+++ b/models/demos/deepseek_v3_b1/unified_kernels/sampling.hpp
@@ -1660,7 +1660,8 @@ struct TopKSampling {
                         {
                             DeviceZoneScopedN("SP-FC-STAGE");
 
-                            generate_bcast_col_scalar(CTArgs::p_bcast_cb, bf16_pack_to_uint32(float_to_bf16_rne(p)));
+                            generate_bcast_col_scalar(
+                                CircularBuffer(CTArgs::p_bcast_cb), bf16_pack_to_uint32(float_to_bf16_rne(p)));
 
                             cb_reserve_back(CTArgs::softmax_in_cb, 1);
                             auto tile_u32 =
@@ -1694,7 +1695,7 @@ struct TopKSampling {
                             auto rand_u16 =
                                 reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_read_ptr(CTArgs::rand_cb));
                             rand = rand_u16[0];
-                            generate_bcast_col_scalar(CTArgs::rand_bcast_cb, bf16_pack_to_uint32(rand));
+                            generate_bcast_col_scalar(CircularBuffer(CTArgs::rand_bcast_cb), bf16_pack_to_uint32(rand));
                         }
 
                         {

--- a/ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include "api/dataflow/circular_buffer.h"
 #include "api/dataflow/dataflow_api.h"
 
 // W-bcast scalar
@@ -44,6 +45,6 @@ FORCE_INLINE void generate_bcast_unary_scalar(CircularBuffer cb, uint32_t scalar
     const uint32_t scalar_val = scalar >> 16;
     cb.reserve_back(1);
     volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
-    ptr[0] = scalar >> 16;
+    ptr[0] = scalar_val;
     cb.push_back(1);
 }

--- a/ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp
+++ b/ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp
@@ -9,41 +9,41 @@
 // W-bcast scalar
 // Tile is assumed to have 16-bit elements
 // Scalar is assumed to be a 16-bit value double packed into a u32
-FORCE_INLINE void generate_bcast_col_scalar(const uint32_t cb_id, const uint32_t scalar) {
+FORCE_INLINE void generate_bcast_col_scalar(CircularBuffer cb, uint32_t scalar) {
     const uint16_t scalar_val = scalar >> 16;
-    cb_reserve_back(cb_id, 1);
-    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(get_write_ptr(cb_id));
+    cb.reserve_back(1);
+    volatile tt_l1_ptr uint16_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(cb.get_write_ptr());
     for (int k = 0; k < 4; k += 2) {
         uint32_t idx = k << 8;
         for (int j = 0; j < 256; j += 16) {
             ptr[idx + j] = scalar_val;
         }
     }
-    cb_push_back(cb_id, 1);
+    cb.push_back(1);
 }
 
 // H-bcast scalar
 // Tile is assumed to have 16-bit elements
 // Scalar is assumed to be a 16-bit value double packed into a u32
-FORCE_INLINE void generate_bcast_row_scalar(const uint32_t cb_id, const uint32_t scalar) {
-    cb_reserve_back(cb_id, 1);
-    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+FORCE_INLINE void generate_bcast_row_scalar(CircularBuffer cb, uint32_t scalar) {
+    cb.reserve_back(1);
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
     for (int k = 0; k < 2; ++k) {
         uint32_t idx = k << 7;
         for (int j = 0; j < 8; ++j) {
             ptr[idx + j] = scalar;
         }
     }
-    cb_push_back(cb_id, 1);
+    cb.push_back(1);
 }
 
 // HW-bcast scalar
 // Tile is assumed to have 16-bit elements
 // Scalar is assumed to be a 16-bit value double packed into a u32
-FORCE_INLINE void generate_bcast_unary_scalar(const uint32_t cb_id, const uint32_t scalar) {
+FORCE_INLINE void generate_bcast_unary_scalar(CircularBuffer cb, uint32_t scalar) {
     const uint32_t scalar_val = scalar >> 16;
-    cb_reserve_back(cb_id, 1);
-    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(get_write_ptr(cb_id));
+    cb.reserve_back(1);
+    volatile tt_l1_ptr uint32_t* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(cb.get_write_ptr());
     ptr[0] = scalar >> 16;
-    cb_push_back(cb_id, 1);
+    cb.push_back(1);
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_scalar_interleaved_partitioned.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/bcast/device/kernels/dataflow/reader_bcast_scalar_interleaved_partitioned.cpp
@@ -37,7 +37,7 @@ void kernel_main() {
     cb_in0.push_back(num_tiles);
 #endif
 
-    generate_bcast_unary_scalar(cb_id_in1, packed_scalar);
+    generate_bcast_unary_scalar(CircularBuffer(cb_id_in1), packed_scalar);
 
     for (uint32_t i = 0; i < num_tiles; i++) {
         uint32_t curr_id = base_start_id_HtWt + curr_id_from_base;

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/rms_allgather/device/kernels/dataflow/rms_writer.cpp
@@ -94,7 +94,7 @@ void kernel_main() {
 
     const uint32_t out_single_tile_size_bytes = get_tile_size(cb_out);
     const uint32_t eps = get_arg_val<uint32_t>(base_post_rt + 1);
-    generate_bcast_col_scalar(eps_cb_id, eps);
+    generate_bcast_col_scalar(CircularBuffer(eps_cb_id), eps);
     const uint32_t iteration_number = get_arg_val<uint32_t>(arg_idx++);
     const size_t out_ready_sem_bank_addr = get_arg_val<uint32_t>(arg_idx++);
     uint32_t out_ready_sem_wait_value = get_arg_val<uint32_t>(arg_idx++);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/kernels/dataflow/reader_layernorm_postallgather_dit.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_post_all_gather/device/kernels/dataflow/reader_layernorm_postallgather_dit.cpp
@@ -55,7 +55,7 @@ void kernel_main() {
     const uint32_t tile_row_start = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t tile_row_end = get_arg_val<uint32_t>(arg_idx++);
     const uint32_t eps = get_arg_val<uint32_t>(arg_idx++);
-    generate_bcast_col_scalar(cb_eps, eps);
+    generate_bcast_col_scalar(CircularBuffer(cb_eps), eps);
 
     const auto src_a = TensorAccessor(src_args, src_addr);
     const auto src_stats = TensorAccessor(stats_args, stats_addr);

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/kernels/dataflow/reader_layernorm_preallgather_dit.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/dit_layernorm_pre_all_gather/device/kernels/dataflow/reader_layernorm_preallgather_dit.cpp
@@ -10,7 +10,6 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
-#include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "api/debug/assert.h"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_post_allgather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_post_allgather_reader.cpp
@@ -75,7 +75,7 @@ void kernel_main() {
         ckernel::PoolType::AVG,
         ckernel::ReduceDim::REDUCE_ROW,
         reduce_factor>();
-    generate_bcast_col_scalar(epsilon_cb, epsilon_value);
+    generate_bcast_col_scalar(CircularBuffer(epsilon_cb), epsilon_value);
 
     if constexpr (fuse_rope) {
         // Read the single-tile transformation matrix for ROPE.

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_pre_allgather_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/fused_distributed_rmsnorm/device/kernels/dataflow/rms_pre_allgather_reader.cpp
@@ -9,7 +9,6 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
-#include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "api/debug/assert.h"
 
 void kernel_main() {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_gn_rm_gb.cpp
@@ -105,7 +105,7 @@ void kernel_main() {
     }
 
     // Send eps, mask, gamma, and beta to the compute kernel
-    generate_bcast_col_scalar(cb_eps_id, eps_val);
+    generate_bcast_col_scalar(CircularBuffer(cb_eps_id), eps_val);
 
     cb_input_mask.reserve_back(block_w * num_groups_per_core);
     uint32_t l1_write_addr_input_mask = cb_input_mask.get_write_ptr();

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/welford_writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -64,7 +64,7 @@ void kernel_main() {
 
     constexpr uint32_t eps_cb_id = tt::CBIndex::c_3;
     const uint32_t eps = get_arg_val<uint32_t>(0);
-    generate_bcast_col_scalar(eps_cb_id, eps);
+    generate_bcast_col_scalar(CircularBuffer(eps_cb_id), eps);
 
     uint32_t input_mask_tile_id = input_mask_tile_start_id;
     for (uint32_t i = 0; i < num_groups_per_core; ++i) {

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_gn_rm_gb.cpp
@@ -152,7 +152,7 @@ void kernel_main() {
 
                 constexpr uint32_t eps_cb_id = tt::CBIndex::c_3;
                 const uint32_t eps = get_arg_val<uint32_t>(0);
-                generate_bcast_col_scalar(eps_cb_id, eps);
+                generate_bcast_col_scalar(CircularBuffer(eps_cb_id), eps);
 
                 if constexpr (fuse_gamma) {
                     const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma_id);

--- a/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/groupnorm/device/kernels/dataflow/writer_unary_sharded_gn_rm_gb_v2.cpp
@@ -144,7 +144,7 @@ void kernel_main() {
 
                 constexpr uint32_t eps_cb_id = tt::CBIndex::c_3;
                 const uint32_t eps = get_arg_val<uint32_t>(0);
-                generate_bcast_col_scalar(eps_cb_id, eps);
+                generate_bcast_col_scalar(CircularBuffer(eps_cb_id), eps);
 
                 if constexpr (fuse_gamma) {
                     const uint32_t gamma_tile_bytes = get_tile_size(cb_gamma_id);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln.cpp
@@ -148,7 +148,7 @@ void kernel_main() {
     }
 
     const uint32_t eps = get_arg_val<uint32_t>(5);
-    generate_bcast_col_scalar(cb_eps, eps);
+    generate_bcast_col_scalar(CircularBuffer(cb_eps), eps);
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         const uint32_t curr_tile_row = start_tile_row + ncht;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor.cpp
@@ -139,7 +139,7 @@ void kernel_main() {
     }
     constexpr uint32_t eps_cb_id = get_named_compile_time_arg_val("cb_eps");
     const uint32_t eps = get_arg_val<uint32_t>(5);
-    generate_bcast_col_scalar(eps_cb_id, eps);
+    generate_bcast_col_scalar(CircularBuffer(eps_cb_id), eps);
 
     for (uint32_t ncht = 0; ncht < NCHt; ncht++) {
         const uint32_t curr_tile_row = start_tile_row + ncht;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor_welford.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_large_tensor_welford.cpp
@@ -70,7 +70,7 @@ void kernel_main() {
 
     constexpr uint32_t eps_cb_id = get_named_compile_time_arg_val("cb_eps");
     const uint32_t eps = get_arg_val<uint32_t>(5);
-    generate_bcast_col_scalar(eps_cb_id, eps);
+    generate_bcast_col_scalar(CircularBuffer(eps_cb_id), eps);
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     uint32_t offs = 0;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb.cpp
@@ -89,7 +89,7 @@ void kernel_main() {
     }
     constexpr uint32_t eps_cb_id = get_named_compile_time_arg_val("cb_eps");
     const uint32_t eps = get_arg_val<uint32_t>(5);
-    generate_bcast_col_scalar(eps_cb_id, eps);
+    generate_bcast_col_scalar(CircularBuffer(eps_cb_id), eps);
 
     // read a ublock of tiles from src to CB, and then push the ublock to unpacker
     uint32_t offs = 0;

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln.cpp
@@ -61,7 +61,7 @@ void kernel_main() {
 
         constexpr uint32_t eps_cb_id = get_named_compile_time_arg_val("cb_eps");
         const uint32_t eps = get_arg_val<uint32_t>(2);
-        generate_bcast_col_scalar(eps_cb_id, eps);
+        generate_bcast_col_scalar(CircularBuffer(eps_cb_id), eps);
 
         if constexpr (is_all_to_all_worker) {
             constexpr uint32_t cb_in_4 = get_named_compile_time_arg_val("cb_in_4");

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_rm_gb.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm/device/kernels/dataflow/writer_unary_sharded_ln_rm_gb.cpp
@@ -64,7 +64,7 @@ void kernel_main() {
 
         constexpr uint32_t eps_cb_id = get_named_compile_time_arg_val("cb_eps");
         const uint32_t eps = get_arg_val<uint32_t>(2);
-        generate_bcast_col_scalar(eps_cb_id, eps);
+        generate_bcast_col_scalar(CircularBuffer(eps_cb_id), eps);
 
         if constexpr (is_all_to_all_worker) {
             constexpr uint32_t cb_in_4 = get_named_compile_time_arg_val("cb_in_4");

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_layernorm_preallgather_2d.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_layernorm_preallgather_2d.cpp
@@ -10,7 +10,6 @@
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/cpp/ttnn/kernel_lib/l1_helpers.hpp"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
-#include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "api/debug/assert.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_post_allgather.cpp
@@ -102,7 +102,7 @@ void kernel_main() {
         reduce_factor,
         /*compute_uses_reduce_tile=*/true>();
     const uint32_t eps = get_arg_val<uint32_t>(5);
-    generate_bcast_col_scalar(cb_eps, eps);
+    generate_bcast_col_scalar(CircularBuffer(cb_eps), eps);
 
     Noc noc;
     CircularBuffer cb_inp_buf(cb_inp);

--- a/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_pre_allgather.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/layernorm_distributed/device/kernels/dataflow/reader_unary_interleaved_ln_rm_gb_pre_allgather.cpp
@@ -9,7 +9,6 @@
 #include <stdint.h>
 #include "api/dataflow/dataflow_api.h"
 #include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
-#include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"
 #include "api/debug/assert.h"
 #include "api/dataflow/noc.h"
 #include "api/dataflow/circular_buffer.h"

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm.cpp
@@ -51,7 +51,7 @@ void kernel_main() {
     bool read_mask = true;
     constexpr auto cb_fused_scale = tt::CBIndex::c_3;
     const uint32_t pre_scale = get_arg_val<uint32_t>(2);
-    generate_bcast_unary_scalar(cb_fused_scale, pre_scale);
+    generate_bcast_unary_scalar(CircularBuffer(cb_fused_scale), pre_scale);
 #endif
 
     const auto src_a = TensorAccessor(src0_args, src_addr);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm_large_tensor.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_interleaved_sm_large_tensor.cpp
@@ -52,7 +52,7 @@ void kernel_main() {
     uint32_t mask_id = start_mask_id;
     bool read_mask = true;
     constexpr auto cb_fused_scale = tt::CBIndex::c_3;
-    generate_bcast_unary_scalar(cb_fused_scale, pre_scale);
+    generate_bcast_unary_scalar(CircularBuffer(cb_fused_scale), pre_scale);
 #endif
 
     const auto src_a = TensorAccessor(src0_args, src_addr);

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm.cpp
@@ -41,7 +41,7 @@ void kernel_main() {
 
     constexpr auto cb_fused_scale = tt::CBIndex::c_2;
     const uint32_t pre_scale = get_arg_val<uint32_t>(0);
-    generate_bcast_unary_scalar(cb_fused_scale, pre_scale);
+    generate_bcast_unary_scalar(CircularBuffer(cb_fused_scale), pre_scale);
 
 #if defined(CAUSAL_MASK) && !defined(SHARDED_CAUSAL_MASK)
 

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm_causal_mask_hw_dims.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm_causal_mask_hw_dims.cpp
@@ -42,7 +42,7 @@ void kernel_main() {
 
     constexpr auto cb_fused_scale = tt::CBIndex::c_2;
     const uint32_t pre_scale = get_arg_val<uint32_t>(0);
-    generate_bcast_unary_scalar(cb_fused_scale, pre_scale);
+    generate_bcast_unary_scalar(CircularBuffer(cb_fused_scale), pre_scale);
 
     constexpr uint32_t block_ht = get_compile_time_arg_val(mask_args.next_compile_time_args_offset() + 2);
     for (uint32_t h = 0; h < block_ht; h++) {

--- a/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm_rm_mask.cpp
+++ b/ttnn/cpp/ttnn/operations/normalization/softmax/device/kernels/attention/dataflow/reader_unary_sharded_sm_rm_mask.cpp
@@ -27,7 +27,7 @@ void kernel_main() {
 
     constexpr auto cb_fused_scale = tt::CBIndex::c_2;
     const uint32_t pre_scale = get_arg_val<uint32_t>(0);
-    generate_bcast_unary_scalar(cb_fused_scale, pre_scale);
+    generate_bcast_unary_scalar(CircularBuffer(cb_fused_scale), pre_scale);
 
     constexpr uint32_t FLOAT32_DTYPE = get_compile_time_arg_val(mask_args.next_compile_time_args_offset() + 1);
     constexpr uint32_t mask_read_tile_face_bytes = FLOAT32_DTYPE ? 64 : 32;

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_nc_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/argmax_nc_compute.cpp
@@ -10,6 +10,7 @@
 #include "api/compute/eltwise_unary/fill.h"
 #include "api/compute/eltwise_unary/where.h"
 #include "api/compute/eltwise_binary_sfpu.h"
+#include "api/dataflow/circular_buffer.h"
 
 /**
  * Register-based argmax along a non-HW (N or C) dim for TILE-layout inputs.
@@ -50,6 +51,9 @@ void kernel_main() {
     constexpr auto cb_out = tt::CBIndex::c_16;
     constexpr uint32_t onetile = 1;
 
+    CircularBuffer cb_val_obj(cb_val);
+    CircularBuffer cb_out_obj(cb_out);
+
     // Slot layout inside DST (32-bit mode):
     //   slot 0: max_val       (fp value)
     //   slot 1: argmax        (uint32 index)
@@ -75,9 +79,9 @@ void kernel_main() {
 
         // --- Initialize running accumulators from tile k=0 ---
         // max_val <- val[0]
-        cb_wait_front(cb_val, onetile);
+        cb_val_obj.wait_front(onetile);
         copy_tile(cb_val, 0, dst_max);
-        cb_pop_front(cb_val, onetile);
+        cb_val_obj.pop_front(onetile);
 
         // argmax <- 0 (uint32, materialized in-place via SFPU)
         fill_tile_int<DataFormat::UInt32>(dst_argmax, 0u);
@@ -85,9 +89,9 @@ void kernel_main() {
         // --- Reduce over remaining tiles k=1 .. num_reduce_tiles-1 ---
         for (uint32_t k = 1; k < num_reduce_tiles; ++k) {
             // new_val -> scratch_a
-            cb_wait_front(cb_val, onetile);
+            cb_val_obj.wait_front(onetile);
             copy_tile(cb_val, 0, dst_scratch_a);
-            cb_pop_front(cb_val, onetile);
+            cb_val_obj.pop_front(onetile);
 
             // mask (raw 0 / 1) = (new_val > max_val) -> scratch_b
             gt_binary_tile(dst_scratch_a, dst_max, dst_scratch_b);
@@ -105,10 +109,10 @@ void kernel_main() {
 
         tile_regs_commit();
 
-        cb_reserve_back(cb_out, onetile);
+        cb_out_obj.reserve_back(onetile);
         tile_regs_wait();
         pack_tile(dst_argmax, cb_out);
         tile_regs_release();
-        cb_push_back(cb_out, onetile);
+        cb_out_obj.push_back(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_nc.cpp
@@ -4,6 +4,8 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 
 /**
  * Reader kernel for register-based argmax over a non-HW dim (NC-style).
@@ -43,16 +45,19 @@ void kernel_main() {
     constexpr auto input_tensor_args = TensorAccessorArgs<0>();
     const auto s0 = TensorAccessor(input_tensor_args, input_addr);
 
+    Noc noc;
+    CircularBuffer cb(cb_in0);
+    const uint32_t tile_bytes = get_tile_size(cb_in0);
+
     for (uint32_t out_i = 0; out_i < num_output_tiles; ++out_i) {
         const uint32_t output_tile_id = start_id + out_i;
         uint32_t read_tile_id = compute_read_tile_id(output_tile_id, reduce_tile_size, inner_tile_size, dim_is_zero_b);
 
         for (uint32_t k = 0; k < num_reduce_tiles; ++k) {
-            cb_reserve_back(cb_in0, onetile);
-            const uint32_t write_ptr = get_write_ptr(cb_in0);
-            noc_async_read_tile(read_tile_id, s0, write_ptr);
-            noc_async_read_barrier();
-            cb_push_back(cb_in0, onetile);
+            cb.reserve_back(onetile);
+            noc.async_read(s0, cb, tile_bytes, {.page_id = read_tile_id}, {.offset_bytes = 0});
+            noc.async_read_barrier();
+            cb.push_back(onetile);
 
             read_tile_id += inner_tile_size;
         }

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout_h.cpp
@@ -6,6 +6,7 @@
 #include "argmax_common.hpp"
 #include "api/dataflow/dataflow_api.h"
 #include "api/tensor/tensor_accessor.h"
+#include "api/dataflow/circular_buffer.h"
 
 #include <stdint.h>
 
@@ -47,9 +48,11 @@ void kernel_main() {
     auto s_dst = TensorAccessor(s_dst_args, dst_base_addr);
     using dst_accessor_type = decltype(s_dst);
 
-    const uint32_t src_cb_addr = get_write_ptr(src_cb_idx);
+    CircularBuffer src_cb(src_cb_idx);
+    const uint32_t src_cb_addr = src_cb.get_write_ptr();
     constexpr DataFormat src_data_format = get_dataformat(src_cb_idx);
-    const uint32_t dst_cb_addr = get_write_ptr(dst_cb_idx);
+    CircularBuffer dst_cb(dst_cb_idx);
+    const uint32_t dst_cb_addr = dst_cb.get_write_ptr();
 
     auto default_val = get_default_value<src_data_format>();
     using src_element_type = decltype(default_val);
@@ -98,9 +101,8 @@ void kernel_main() {
             for (uint32_t h_tile = 0; h_tile < input_height; h_tile++) {
                 const int src_tile_id = outer_index * inner_size + h_tile * input_width + w_tile;
 
-                const uint64_t src_noc_addr = get_noc_addr(src_tile_id, s_src);
-                noc_async_read(src_noc_addr, src_cb_addr, src_page_size);
-                noc_async_read_barrier();
+                noc.async_read(s_src, src_cb, src_page_size, {.page_id = src_tile_id}, {.offset_bytes = 0});
+                noc.async_read_barrier();
 
                 process_loaded_tile_all_h_columns<src_element_type, src_data_format>(
                     input_ctx, w_tile, h_tile, max_vals, arg_maxs);

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout_h.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/reader_argmax_tile_layout_h.cpp
@@ -99,7 +99,7 @@ void kernel_main() {
             }
 
             for (uint32_t h_tile = 0; h_tile < input_height; h_tile++) {
-                const int src_tile_id = outer_index * inner_size + h_tile * input_width + w_tile;
+                const uint32_t src_tile_id = outer_index * inner_size + h_tile * input_width + w_tile;
 
                 noc.async_read(s_src, src_cb, src_page_size, {.page_id = src_tile_id}, {.offset_bytes = 0});
                 noc.async_read_barrier();

--- a/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/writer_argmax_nc.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/argmax/device/kernels/writer_argmax_nc.cpp
@@ -8,6 +8,8 @@
 
 #include <cstdint>
 #include "api/dataflow/dataflow_api.h"
+#include "api/dataflow/noc.h"
+#include "api/dataflow/circular_buffer.h"
 
 void kernel_main() {
     // Runtime args
@@ -21,12 +23,20 @@ void kernel_main() {
     constexpr auto output_tensor_args = TensorAccessorArgs<0>();
     const auto s0 = TensorAccessor(output_tensor_args, output_addr);
 
+    Noc noc;
+    CircularBuffer cb(cb_out0);
+    const uint32_t tile_bytes = get_tile_size(cb_out0);
+
     for (uint32_t out_i = 0; out_i < num_output_tiles; ++out_i) {
         const uint32_t write_tile_id = start_id + out_i;
-        cb_wait_front(cb_out0, onetile);
-        const uint32_t read_ptr = get_read_ptr(cb_out0);
-        noc_async_write_tile(write_tile_id, s0, read_ptr);
-        noc_async_write_barrier();
-        cb_pop_front(cb_out0, onetile);
+        cb.wait_front(onetile);
+        noc.async_write(
+            use<CircularBuffer::AddrSelector::READ_PTR>(cb),
+            s0,
+            tile_bytes,
+            {.offset_bytes = 0},
+            {.page_id = write_tile_id});
+        noc.async_write_barrier();
+        cb.pop_front(onetile);
     }
 }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_h_neg.cpp
@@ -41,9 +41,13 @@ void kernel_main() {
         constexpr uint32_t row_chunk = compute_kernel_lib::DEST_AUTO_LIMIT - 1;
         constexpr uint32_t work_dst = row_chunk;
 
+        CircularBuffer cb_input_obj(cb_input);
+        CircularBuffer cb_scaler_obj(cb_scaler);
+        CircularBuffer cb_output_obj(cb_output);
+
         init_sfpu(cb_input, cb_output);
         copy_tile_to_dst_init_short(cb_input);
-        cb_wait_front(cb_scaler, onetile);
+        cb_scaler_obj.wait_front(onetile);
         PACK((llk_pack_reduce_mask_config<REDUCE_DIM, PackMode::Default>(cb_output)));
 
         for (uint32_t nc = 0; nc < NC; ++nc) {
@@ -58,7 +62,7 @@ void kernel_main() {
 
                 for (uint32_t ht = 0; ht < Ht; ++ht) {
                     for (uint32_t k = 0; k < current_chunk; ++k) {
-                        cb_wait_front(cb_input, onetile);
+                        cb_input_obj.wait_front(onetile);
                         if (ht == 0) {
                             copy_tile(cb_input, 0, k);
                             if constexpr (reduce_format == DataFormat::Int32) {
@@ -75,7 +79,7 @@ void kernel_main() {
                             }
                             compute_kernel_lib::detail::sfpu_reduce_max_fold_tile<reduce_format>(k, work_dst, k);
                         }
-                        cb_pop_front(cb_input, onetile);
+                        cb_input_obj.pop_front(onetile);
                     }
                 }
 
@@ -97,9 +101,9 @@ void kernel_main() {
                 tile_regs_commit();
                 tile_regs_wait();
                 for (uint32_t k = 0; k < current_chunk; ++k) {
-                    cb_reserve_back(cb_output, onetile);
+                    cb_output_obj.reserve_back(onetile);
                     pack_tile(k, cb_output);
-                    cb_push_back(cb_output, onetile);
+                    cb_output_obj.push_back(onetile);
                 }
                 tile_regs_release();
             }

--- a/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/generic/device/kernels/compute/reduce_w_neg.cpp
@@ -43,9 +43,13 @@ void kernel_main() {
         constexpr uint32_t acc_dst = 0;
         constexpr uint32_t work_dst = 1;
 
+        CircularBuffer cb_input_obj(cb_input);
+        CircularBuffer cb_scaler_obj(cb_scaler);
+        CircularBuffer cb_output_obj(cb_output);
+
         init_sfpu(cb_input, cb_output);
         copy_tile_to_dst_init_short(cb_input);
-        cb_wait_front(cb_scaler, onetile);
+        cb_scaler_obj.wait_front(onetile);
         PACK((llk_pack_reduce_mask_config<REDUCE_DIM, PackMode::Default>(cb_output)));
 
         for (uint32_t nc = 0; nc < NC; ++nc) {
@@ -57,7 +61,7 @@ void kernel_main() {
                 }
 
                 for (uint32_t wt = 0; wt < Wt; ++wt) {
-                    cb_wait_front(cb_input, onetile);
+                    cb_input_obj.wait_front(onetile);
                     if (wt == 0) {
                         copy_tile(cb_input, 0, acc_dst);
                         if constexpr (reduce_format == DataFormat::Int32) {
@@ -75,7 +79,7 @@ void kernel_main() {
                         compute_kernel_lib::detail::sfpu_reduce_max_fold_tile<reduce_format>(
                             acc_dst, work_dst, acc_dst);
                     }
-                    cb_pop_front(cb_input, onetile);
+                    cb_input_obj.pop_front(onetile);
                 }
 
                 sfpu_reduce_init<REDUCE_OP, reduce_format>();
@@ -90,11 +94,11 @@ void kernel_main() {
 #endif
 
                 tile_regs_commit();
-                cb_reserve_back(cb_output, onetile);
+                cb_output_obj.reserve_back(onetile);
                 tile_regs_wait();
                 pack_tile(acc_dst, cb_output);
                 tile_regs_release();
-                cb_push_back(cb_output, onetile);
+                cb_output_obj.push_back(onetile);
             }
         }
 

--- a/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/reduction/sampling/device/kernels/dataflow/writer_interleaved.cpp
@@ -124,7 +124,7 @@ void kernel_main() {
     // Index into the chunk to get this core's value
     uint16_t temp = temp_ptr[core_id];
     uint32_t temp_packed = (static_cast<uint32_t>(temp) << 16) + static_cast<uint32_t>(temp);
-    generate_bcast_unary_scalar(cb_id_temp, temp_packed);
+    generate_bcast_unary_scalar(CircularBuffer(cb_id_temp), temp_packed);
     // generate the top-k mask
     constexpr uint32_t one = 1;
     generate_mask<cb_id_mask, one>(one, ids_per_batch / 32, k - 1);

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/exp_ring_joint_writer.cpp
@@ -257,8 +257,8 @@ void kernel_main() {
     constexpr uint32_t cb_col_identity = tt::CBIndex::c_8;
     constexpr uint32_t cb_identity_scale_in = tt::CBIndex::c_5;
 
-    generate_bcast_unary_scalar(cb_scale_in, scale_val);
-    generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
+    generate_bcast_unary_scalar(CircularBuffer(cb_scale_in), scale_val);
+    generate_bcast_col_scalar(CircularBuffer(cb_col_identity), identity_scalar_packed);
     dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
         cb_identity_scale_in,
         ckernel::PoolType::MAX,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/joint_writer.cpp
@@ -66,7 +66,7 @@ void kernel_main() {
         ckernel::ReduceDim::REDUCE_ROW,
         dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
         /*compute_uses_reduce_tile=*/true>();
-    generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
+    generate_bcast_col_scalar(CircularBuffer(cb_col_identity), identity_scalar_packed);
 
     for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
         for (uint32_t nq = local_nh_start; nq < local_nh_end; ++nq) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/ring_joint_writer.cpp
@@ -495,8 +495,8 @@ void kernel_main() {
     const auto out_generator = PaddedAddrGenerator(out_writer, output_tile_logical);
     const auto joint_out_generator = PaddedAddrGenerator(joint_out_writer, joint_tile_logical);
 
-    generate_bcast_unary_scalar(cb_scale_in, scale_val);
-    generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
+    generate_bcast_unary_scalar(CircularBuffer(cb_scale_in), scale_val);
+    generate_bcast_col_scalar(CircularBuffer(cb_col_identity), identity_scalar_packed);
     dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
         cb_identity_scale_in,
         ckernel::PoolType::MAX,

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/writer_interleaved.cpp
@@ -81,7 +81,7 @@ void kernel_main() {
         ckernel::ReduceDim::REDUCE_ROW,
         dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
         /*compute_uses_reduce_tile=*/true>();
-    generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
+    generate_bcast_col_scalar(CircularBuffer(cb_col_identity), identity_scalar_packed);
 
     // Lightweight mask: generate template tiles once, leave permanently fronted.
     // Sliding layout: [neginf, trailing_primary, leading_prev, leading_current, trailing_next, k_partial?].

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_decode/device/kernels/dataflow/writer_decode_all.cpp
@@ -213,7 +213,7 @@ void kernel_main() {
         dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
         /*compute_uses_reduce_tile=*/true>();
     dataflow_kernel_lib::prepare_zero_tile<cb_zero_in>();
-    generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
+    generate_bcast_col_scalar(CircularBuffer(cb_col_identity), identity_scalar_packed);
 
     // Generate sliding window mask only if we have local data and need it
     if (has_local_data && k_chunk_start == window_start_chunk && window_start_unaligned > 0) {

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/dataflow/writer_windowed.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa_windowed/device/kernels/dataflow/writer_windowed.cpp
@@ -60,7 +60,7 @@ void kernel_main() {
         ckernel::ReduceDim::REDUCE_ROW,
         dataflow_kernel_lib::SUM_AND_MAX_REDUCE_FACTOR,
         /*compute_uses_reduce_tile=*/true>();
-    generate_bcast_col_scalar(cb_col_identity, identity_scalar_packed);
+    generate_bcast_col_scalar(CircularBuffer(cb_col_identity), identity_scalar_packed);
 
     for (uint32_t nb = local_batch_start; nb < local_batch_end; ++nb) {
         const uint32_t q_batch_offset = nb * NQH * Sqt * DHt;


### PR DESCRIPTION
### PR Category

Cleanup

### Summary

Relates to the broader Device 2.0 kernel-side migration https://github.com/tenstorrent/tt-metal/issues/45003.

Migrate `reduction/argmax`, `reduction/sampling` and `reduction/generic`. Covers also the shared helper `ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp` consumed across normalization, softmax, sdpa, bcast, experimental, and reduction.

The header's three helpers now take a `CircularBuffer` by value instead of a `uint32_t cb_id`. The call sites across of the helper functions are updated.

Some pre-allgather readers had a dead `#include "ttnn/kernel/dataflow/generate_bcast_scalar.hpp"` - dropped.

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/device-2.0-reduction-and-bcast-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/device-2.0-reduction-and-bcast-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/device-2.0-reduction-and-bcast-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/device-2.0-reduction-and-bcast-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/device-2.0-reduction-and-bcast-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/device-2.0-reduction-and-bcast-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/device-2.0-reduction-and-bcast-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/device-2.0-reduction-and-bcast-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/device-2.0-reduction-and-bcast-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/device-2.0-reduction-and-bcast-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/device-2.0-reduction-and-bcast-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/device-2.0-reduction-and-bcast-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/device-2.0-reduction-and-bcast-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/device-2.0-reduction-and-bcast-scalar)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/device-2.0-reduction-and-bcast-scalar)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/device-2.0-reduction-and-bcast-scalar)