### PR TITLE
[Bugfix] Fixing OOM problem in Kimi 2.6 shared expert

### DIFF
--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -54,11 +54,21 @@ def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int
         fuse_batch=False,
         mcast_in0=False,
     )
+
+    down_subblock_w = 8
+    down_quarter = down_n_tiles // 4
+    down_out_block_w = (
+        down_quarter
+        if down_quarter > 0 and down_n_tiles % down_quarter == 0 and down_quarter % down_subblock_w == 0
+        else down_n_tiles
+    )
     down = ttnn.MatmulMultiCoreReuseMultiCast1DProgramConfig(
         compute_with_storage_grid_size=grid,
         in0_block_w=1,
         out_subblock_h=1,
-        out_subblock_w=8,
+        out_subblock_w=down_subblock_w,
+        out_block_h=1,
+        out_block_w=down_out_block_w,
         per_core_M=per_core_M,
         per_core_N=down_n_tiles,
         fuse_batch=False,

--- a/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
+++ b/models/demos/deepseek_v3_d_p/tt/moe/tt_shared_expert.py
@@ -54,7 +54,9 @@ def get_bh_program_configs(per_core_M: int, gate_n_tiles: int, down_n_tiles: int
         fuse_batch=False,
         mcast_in0=False,
     )
-
+    # Use quarter-width output blocks to keep the CBs small,
+    # but only if that quarter is a legal out_block_w (a multiple of the subblock and an even divisor of per_core_N);
+    # otherwise use the full width.
     down_subblock_w = 8
     down_quarter = down_n_tiles // 4
     down_out_block_w = (


### PR DESCRIPTION


### Summary
The Blackhole shared-expert down-projection matmul didn't set `out_block_w`/`out_block_h`, so its in1/output/interm L1 circular buffers defaulted to the full output width (`per_core_N`=224) and overran the L1

https://github.com/tenstorrent/tt-metal/actions/runs/27741546307/job/82071089089

## solution:
Setting `out_block_h=1` and `out_block_w=56`

### Checklist
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml/badge.svg?branch=ddjekic/kimi_moe_oom_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-e2e-tests.yaml?query=branch:ddjekic/kimi_moe_oom_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml/badge.svg?branch=ddjekic/kimi_moe_oom_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/galaxy-deepseek-prefill-tests.yaml?query=branch:ddjekic/kimi_moe_oom_fix)
- 
### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ddjekic/kimi_moe_oom_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ddjekic/kimi_moe_oom_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ddjekic/kimi_moe_oom_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ddjekic/kimi_moe_oom_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ddjekic/kimi_moe_oom_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ddjekic/kimi_moe_oom_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ddjekic/kimi_moe_oom_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ddjekic/kimi_moe_oom_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ddjekic/kimi_moe_oom_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ddjekic/kimi_moe_oom_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ddjekic/kimi_moe_oom_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ddjekic/kimi_moe_oom_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ddjekic/kimi_moe_oom_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ddjekic/kimi_moe_oom_fix)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ddjekic/kimi_moe_oom_fix)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ddjekic/kimi_moe_oom_fix)