### PR TITLE
sparse_sdpa: sparse MLA prefill op for Blackhole (DeepSeek V3.2 DSA)

### DIFF
--- a/docs/source/ttnn/ttnn/api.rst
+++ b/docs/source/ttnn/ttnn/api.rst
@@ -481,6 +481,7 @@ Transformer
    ttnn.transformer.ring_mla
    ttnn.transformer.scaled_dot_product_attention
    ttnn.transformer.scaled_dot_product_attention_decode
+   ttnn.transformer.sparse_sdpa
    ttnn.transformer.split_query_key_value_and_split_heads
    ttnn.transformer.windowed_scaled_dot_product_attention
    ttnn.experimental.indexer_score

--- a/tests/pipeline_reorg/ttsim-skip-list.yaml
+++ b/tests/pipeline_reorg/ttsim-skip-list.yaml
@@ -22,6 +22,7 @@ wormhole_b0:
   - tests/ttnn/unit_tests/operations/reduce/test_topk.py
   - tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py
   - tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill_v_embedding_space.py
+  # (sparse_sdpa is Blackhole-only via run_for_blackhole, so it is skipped on WH already -- see blackhole section.)
 
   # Likely OOM killer related failures -- probably need to run these tests serially
   - tests/ttnn/unit_tests/base_functionality/test_reshape.py::test_reshape_oob
@@ -55,6 +56,11 @@ blackhole:
   - tests/ttnn/unit_tests/operations/reduce/test_topk.py
   - tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill.py
   - tests/ttnn/unit_tests/operations/sdpa/test_mla_prefill_v_embedding_space.py
+  # Two ttsim gaps (op runs correctly on silicon): (1) BH fast tilize unpacks into src_a row 64 -- FIXED in
+  # ttsim releases newer than the pinned v1.8.2 (ttsim-private c753f3bc); (2) tensix_cfg_wr32 reg=119
+  # (THCON_SEC1_REG1, the fp8/LF8 SEC1 config) is still unimplemented even in latest ttsim, hit on a data-format
+  # reconfig after an fp8 program. The skip stays for (2); remove once a ttsim release with both lands in CI.
+  - tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
 
   # Likely OOM killer related failures -- probably need to run these tests serially
   - tests/ttnn/unit_tests/base_functionality/test_reshape.py::test_reshape_oob

--- a/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -1,0 +1,234 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""sparse_sdpa (sparse MLA prefill) — NIGHTLY full coverage (Blackhole only).
+
+Comprehensive sweeps over shapes, sparsity, head count, query sub-blocking, and fp8 q/kv, plus a perf-only
+case on the production shape. The fast post-commit smoke is in
+tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py (shared helpers in sparse_sdpa_test_utils.py).
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_test_utils import (
+    make_inputs,
+    golden,
+    to_dev,
+    run_op,
+    pcc,
+)
+
+K_DIM = 576  # head dim (q/kv width)
+V_DIM = 512  # V width / output width (op arg)
+
+# Open the device ONCE per module (not per test) — all tests share one device config, so this avoids the
+# ~1.7s open/close on every parametrized case. The program cache persists across tests, which is fine: the
+# recompile/indexed tests clear_program_cache() at their start, and the hash keeps distinct configs separate.
+pytestmark = pytest.mark.use_module_device
+
+
+# ---- SINGLE-CHUNK PCC (k_chunk == TOPK) vs sparse_mla golden, across shapes + sparsity ----
+@run_for_blackhole()
+@pytest.mark.parametrize("S,T,TOPK", [(64, 256, 32), (64, 512, 64), (32, 1024, 128)])
+@pytest.mark.parametrize(
+    "nv_fn,nv_id",
+    [(lambda s: 10**9, "all_valid"), (lambda s: 1 + (s % 7), "few_valid"), (lambda s: 1 + (s * 3) % 20, "boundary")],
+    ids=lambda x: x if isinstance(x, str) else "",
+)
+def test_sparse_sdpa_pcc_single_chunk(device, S, T, TOPK, nv_fn, nv_id):
+    H = 32
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, nv_fn)
+    out, scale = run_op(q, kv, indices, device, k_chunk_size=TOPK, v_dim=V_DIM)  # single chunk
+    p = pcc(out, golden(q, kv, indices, scale, V_DIM))
+    assert p >= 0.99, f"PCC {p:.5f} (S={S},T={T},TOPK={TOPK},{nv_id})"
+
+
+# ---- multi-chunk PCC vs sparse_mla golden (needs flash accumulation), across shapes + sparsity ----
+@run_for_blackhole()
+@pytest.mark.parametrize("S,T,TOPK,kc", [(64, 256, 64, 32), (64, 512, 128, 64), (32, 1024, 256, 128)])
+@pytest.mark.parametrize(
+    "nv_fn,nv_id",
+    [
+        (lambda s: 10**9, "all_valid"),
+        (lambda s: 1 + (s % 7), "few_valid"),
+        (lambda s: 1 + (s * 3) % 50, "mid_tile_boundary"),
+    ],
+    ids=lambda x: x if isinstance(x, str) else "",
+)
+def test_sparse_sdpa_pcc(device, S, T, TOPK, kc, nv_fn, nv_id):
+    H = 32
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, nv_fn)
+    out, scale = run_op(q, kv, indices, device, kc, V_DIM)
+    p = pcc(out, golden(q, kv, indices, scale, V_DIM))
+    assert p >= 0.99, f"PCC {p:.5f} (S={S},T={T},TOPK={TOPK},kc={kc},{nv_id})"
+
+
+# ---- Multi-token-per-core: S (256) > num_cores (110) => each core processes 2-3 tokens.
+#      Guards the per-token CB lifecycle (Q_IN/max/sum/out must be clean between tokens). ----
+@run_for_blackhole()
+@pytest.mark.parametrize("TOPK,kc", [(64, 64), (64, 32), (128, 32)], ids=["1chunk", "2chunk", "4chunk"])
+def test_sparse_sdpa_multitoken(device, TOPK, kc):
+    H, S, T = 32, 256, 512
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: 1 + (s * 5) % TOPK)
+    out, scale = run_op(q, kv, indices, device, kc, V_DIM)
+    p = pcc(out, golden(q, kv, indices, scale, V_DIM))
+    assert p >= 0.99, f"PCC {p:.5f} (S={S},T={T},TOPK={TOPK},kc={kc})"
+
+
+# ---- Arbitrary head count: H = Sqt*32 query tile-rows processed in DST-sized groups. The upper bound is
+#      per-core L1 (flash state + Q scale with H), so it depends on k_chunk (see the aggressive-block test).
+#      Exercises all_valid + a mid-tile boundary mask, multi-token/core (S>cores guards the cb_q_in pop). ----
+@run_for_blackhole()
+@pytest.mark.parametrize("H", [32, 64, 96, 128], ids=["h32", "h64", "h96", "h128"])
+@pytest.mark.parametrize(
+    "nv_fn,nv_id",
+    [(lambda s: 10**9, "all_valid"), (lambda s: 1 + (s * 3) % 50, "mid_tile_boundary")],
+    ids=lambda x: x if isinstance(x, str) else "",
+)
+def test_sparse_sdpa_heads(device, H, nv_fn, nv_id):
+    S, T, TOPK, kc = 256, 512, 128, 64  # 2 chunks (Skt=2); S>cores => multi-token/core (guards cb_q_in pop)
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, nv_fn)
+    out, scale = run_op(q, kv, indices, device, kc, V_DIM)
+    p = pcc(out, golden(q, kv, indices, scale, V_DIM))
+    assert p >= 0.99, f"PCC {p:.5f} (H={H},{nv_id})"
+
+
+# ---- Aggressive blocking: k_chunk=32 (smallest) minimizes the per-chunk K/score L1, freeing room for more
+#      query tile-rows. H=192 fits at k_chunk=32 but OOMs at k_chunk=256 (measured max H: 96@256, 192@32). ----
+@run_for_blackhole()
+@pytest.mark.parametrize(
+    "nv_fn,nv_id",
+    [(lambda s: 10**9, "all_valid"), (lambda s: 1 + (s * 3) % 50, "mid_tile_boundary")],
+    ids=lambda x: x if isinstance(x, str) else "",
+)
+def test_sparse_sdpa_heads_aggressive_block(device, nv_fn, nv_id):
+    H, S, T, TOPK, kc = 192, 64, 512, 128, 32  # k_chunk=32 (Skt=1) => 4 chunks; large H fits via tiny per-chunk L1
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, nv_fn)
+    out, scale = run_op(q, kv, indices, device, kc, V_DIM)
+    p = pcc(out, golden(q, kv, indices, scale, V_DIM))
+    assert p >= 0.99, f"PCC {p:.5f} (H={H},kc={kc},{nv_id})"
+
+
+# ---- fp8 K/V cache: kv stored as FP8_E4M3 (halves the dominant K-gather bytes). Compute tilizes fp8 ->
+#      bfp8_b with a 32-bit dest (auto-enabled for fp8). Golden uses the fp8-quantized kv. ----
+@run_for_blackhole()
+@pytest.mark.parametrize("S,T,TOPK,kc", [(64, 512, 128, 64), (32, 1024, 256, 128)])
+@pytest.mark.parametrize(
+    "nv_fn,nv_id",
+    [(lambda s: 10**9, "all_valid"), (lambda s: 1 + (s * 3) % 50, "mid_tile_boundary")],
+    ids=lambda x: x if isinstance(x, str) else "",
+)
+def test_sparse_sdpa_fp8_kv(device, S, T, TOPK, kc, nv_fn, nv_id):
+    H = 32
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, nv_fn)
+    out, scale = run_op(q, kv, indices, device, kc, V_DIM, kv_dtype=ttnn.fp8_e4m3)
+    kv_fp8 = kv.to(torch.float8_e4m3fn).to(torch.float32)  # what the device holds after fp8 quantization
+    p = pcc(out, golden(q, kv_fp8, indices, scale, V_DIM))
+    assert p >= 0.99, f"PCC {p:.5f} (fp8 kv, S={S},T={T},TOPK={TOPK},kc={kc},{nv_id})"
+
+
+# ---- fp8 Q: q stored as FP8_E4M3 and tilized to bfp8_b cb_q_in. Q is the QK matmul's srcB; the kernel
+#      restores srcB's bf16 format after the QK. Sweeps fp8 q alone and fp8 q + fp8 kv (both srcs bfp8). ----
+@run_for_blackhole()
+@pytest.mark.parametrize("S,T,TOPK,kc", [(64, 512, 128, 64), (32, 1024, 256, 128)])
+@pytest.mark.parametrize("kv_dtype,kv_id", [(ttnn.bfloat16, "kv_bf16"), (ttnn.fp8_e4m3, "kv_fp8")])
+def test_sparse_sdpa_fp8_q(device, S, T, TOPK, kc, kv_dtype, kv_id):
+    H = 32
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: 1 + (s * 3) % 50)
+    out, scale = run_op(q, kv, indices, device, kc, V_DIM, kv_dtype=kv_dtype, q_dtype=ttnn.fp8_e4m3)
+    q_fp8 = q.to(torch.float8_e4m3fn).to(torch.float32)  # what the device holds after fp8 quantization
+    kv_g = kv.to(torch.float8_e4m3fn).to(torch.float32) if kv_dtype == ttnn.fp8_e4m3 else kv
+    p = pcc(out, golden(q_fp8, kv_g, indices, scale, V_DIM))
+    assert p >= 0.99, f"PCC {p:.5f} (fp8 q, {kv_id}, S={S},T={T},TOPK={TOPK},kc={kc})"
+
+
+# ---- Query sub-blocking: when Sqt = H/32 exceeds dst_size, the compute kernel processes the query
+#      tile-rows in DST-sized groups (qsb = largest divisor of Sqt <= dst_size). fp32_dest_acc_en halves
+#      dst_size (8 -> 4), forcing multi-group at modest H: H=192 (Sqt=6, qsb=3, 2 groups) and H=160
+#      (Sqt=5, qsb=1, 5 groups — the qsb=1 stress path). Without fp32-acc these would be one group. ----
+@run_for_blackhole()
+@pytest.mark.parametrize("H,groups", [(192, 2), (160, 5)], ids=["h192_2grp", "h160_5grp"])
+def test_sparse_sdpa_query_subblock(device, H, groups):
+    S, T, TOPK, kc = 64, 512, 128, 32  # k_chunk=32 keeps per-chunk L1 small so the large H fits
+    cfg = ttnn.WormholeComputeKernelConfig(
+        math_fidelity=ttnn.MathFidelity.HiFi2, math_approx_mode=True, fp32_dest_acc_en=True, packer_l1_acc=False
+    )
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: 1 + (s * 3) % 50)
+    out, scale = run_op(q, kv, indices, device, kc, V_DIM, compute_kernel_config=cfg)
+    p = pcc(out, golden(q, kv, indices, scale, V_DIM))
+    assert p >= 0.99, f"PCC {p:.5f} (H={H}, {groups} query groups, fp32_dest_acc)"
+
+
+# ---- Determinism: identical inputs must yield BIT-EXACT-identical output across repeated runs. Efficient by
+#      design — cheap inputs, NO golden, and the comparison runs ON DEVICE: ttnn.ne -> ttnn.max reduces each
+#      iteration's diff to a 1-element marker (accumulated with ttnn.maximum), so only that scalar is pulled to
+#      host, not the full output every iteration. Dense multi-chunk exercises the flash accumulation +
+#      reciprocal (softmax normalize) path, the determinism-sensitive part; bf16 + fp8. ----
+@run_for_blackhole()
+@pytest.mark.parametrize(
+    "q_dtype,kv_dtype",
+    [(ttnn.bfloat16, ttnn.bfloat16), (ttnn.fp8_e4m3, ttnn.fp8_e4m3)],
+    ids=["bf16", "fp8"],
+)
+def test_sparse_sdpa_determinism(device, q_dtype, kv_dtype):
+    H, S, T, TOPK, kc, iters = 32, 128, 512, 256, 64, 10  # dense, 4 chunks/token; S>cores => some 2 tokens/core
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK)
+    q_host = q.to(torch.bfloat16) if q_dtype == ttnn.bfloat16 else q.to(torch.float32)
+    kv_host = kv.to(torch.bfloat16) if kv_dtype == ttnn.bfloat16 else kv.to(torch.float32)
+    tt_q = to_dev(q_host, device, q_dtype)  # upload ONCE; rerun the cached program on the same input bits
+    tt_kv = to_dev(kv_host, device, kv_dtype)
+    tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+
+    def comparable(o):  # ttnn.ne/max need TILE bf16 (fp8 has no eltwise); both casts are deterministic 1:1 maps
+        if o.dtype == ttnn.fp8_e4m3:
+            o = ttnn.typecast(o, ttnn.bfloat16)
+        return ttnn.to_layout(o, ttnn.TILE_LAYOUT)
+
+    ref, marker = None, None
+    for _ in range(iters):
+        cur = comparable(ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, scale=K_DIM**-0.5, k_chunk_size=kc))
+        if ref is None:
+            ref = cur
+        else:
+            m = ttnn.max(ttnn.ne(ref, cur, dtype=ttnn.bfloat16))  # 0 iff bit-exact
+            marker = m if marker is None else ttnn.maximum(marker, m)
+    mismatch = float(ttnn.to_torch(ttnn.from_device(marker)).max())  # one scalar pulled to host, once
+    assert mismatch == 0.0, "sparse_sdpa output is not deterministic across repeated runs"
+
+
+# ---- Perf-only (no golden; full-size golden gather is ~GBs). Profile with:
+#      python -m tracy -p -r -v -m pytest <thisfile>::test_sparse_sdpa_perf
+#      then read "DEVICE KERNEL DURATION [ns]" for SparseSDPAOperation. ----
+# nv (valid keys/token) patterns. Chunk-skip benefit is sparsity-dependent, so sweep it.
+_NV = {
+    "dense": lambda s, T, K: K,  # all TOPK valid (no skip) -> worst case, proves no regression
+    "half": lambda s, T, K: K // 2,
+    "causal": lambda s, T, K: min(s + 1, K),  # realistic prefill: position p has p+1 candidates
+    "sparse": lambda s, T, K: 256,
+    "mixed": lambda s, T, K: 1 + (s * 7) % K,  # earlier arbitrary distribution (for before/after compare)
+}
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize(
+    "S,T,TOPK,kc,nv",
+    [
+        (640, 56320, 2048, 256, "dense"),  # production shape (Q[32,640,576], KV[56320,576], idx[640,2048])
+        (640, 56320, 2048, 256, "half"),
+        (640, 56320, 2048, 256, "causal"),
+        (640, 56320, 2048, 256, "sparse"),
+        (640, 56320, 2048, 256, "mixed"),
+        (110, 56320, 2048, 256, "dense"),  # 1 token/core, 8 chunks, real T -> representative DRAM locality
+        (8, 56320, 2048, 256, "dense"),  # 8 cores -> low DRAM contention; isolates BW headroom vs floor
+    ],
+    ids=["prod-dense", "prod-half", "prod-causal", "prod-sparse", "prod-mixed", "zone1tok", "lowcore"],
+)
+def test_sparse_sdpa_perf(device, S, T, TOPK, kc, nv):
+    H = 32
+    nv_fn = _NV[nv]
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: nv_fn(s, T, TOPK))
+    out, _ = run_op(q, kv, indices, device, kc, V_DIM)  # no golden; correctness covered by the PCC tests
+    assert tuple(out.shape) == (1, H, S, V_DIM)

--- a/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_test_utils.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/sparse_sdpa_test_utils.py
@@ -1,0 +1,90 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared helpers for the sparse_sdpa tests (basic post-commit suite + nightly suite).
+
+Correctness uses SMALL parametric shapes (the golden gathers sel[S,k,D]; the full production
+640/2048/56320 shape is ~2.8 GiB and is only exercised by the perf-only test in the nightly suite).
+"""
+
+import torch
+
+import ttnn
+
+# Head dims (k_dim, v_dim) are supplied by each test, not baked in here. MASKED_INDEX is the op's sentinel.
+MASKED_INDEX = 0xFFFFFFFF  # sentinel: a masked slot (scores -inf, contributes 0); a contiguous tail per row
+
+
+def sparse_mla(q, kvpe, indices, scale, v_dim):
+    """Torch reference for the sparse-MLA prefill op. Absorbed MQA over the top-k selected latents named by
+    `indices` (one shared latent KV head); masking is baked into `indices` (index == MASKED_INDEX scores -inf).
+    Dims are derived from the inputs; V is the leading `v_dim` cols of the K_DIM-wide kvpe.
+        q [1,H,S,K_DIM], kvpe [T,K_DIM], indices [1,1,S,k] uint32  ->  out [1,H,S,v_dim]
+    """
+    B, H, S, Dk = q.shape
+    k = indices.shape[-1]
+    T = kvpe.shape[0]
+    idx = indices.reshape(B, S, k)
+    masked = idx == MASKED_INDEX
+    idx_safe = torch.where(masked, torch.zeros_like(idx), idx).to(torch.int64)  # clamp sentinels in-bounds
+    kv = kvpe.unsqueeze(0).expand(B, T, Dk)
+    sel = torch.gather(  # gather the k selected KV rows (shared across heads): [B,T,Dk] -> [B,S,k,Dk]
+        kv.unsqueeze(1).expand(B, S, T, Dk), 2, idx_safe.view(B, S, k, 1).expand(B, S, k, Dk)
+    )
+    scores = torch.einsum("bhsd,bsjd->bhsj", q, sel) * scale  # full-K_DIM scores [B,H,S,k]
+    scores = scores.masked_fill(masked.view(B, 1, S, k), float("-inf"))
+    probs = scores.softmax(dim=-1, dtype=torch.float32).to(q.dtype)
+    return torch.einsum("bhsj,bsjd->bhsd", probs, sel[..., :v_dim])  # weighted sum of V views [B,H,S,v_dim]
+
+
+def make_inputs(H, S, T, TOPK, k_dim, n_valid_fn, seed=0):
+    """Build (q, kv, indices) torch tensors matching the producer contract (tail-shaped sentinels)."""
+    gen = torch.Generator().manual_seed(seed)
+    q = torch.randn(1, H, S, k_dim, generator=gen, dtype=torch.float32)
+    kv = torch.randn(1, 1, T, k_dim, generator=gen, dtype=torch.float32)
+    indices = torch.full((1, 1, S, TOPK), MASKED_INDEX, dtype=torch.int64)
+    for s in range(S):
+        nv = max(1, min(TOPK, n_valid_fn(s)))
+        perm = torch.randperm(T, generator=gen)[:nv]
+        indices[0, 0, s, :nv] = perm
+    return q, kv, indices
+
+
+def golden(q, kv, indices, scale, v_dim):
+    return sparse_mla(q, kv[0, 0], indices.to(torch.int64), scale, v_dim)  # [1,H,S,v_dim]
+
+
+def to_dev(t, device, dtype):
+    return ttnn.from_torch(
+        t, dtype=dtype, layout=ttnn.ROW_MAJOR_LAYOUT, device=device, memory_config=ttnn.DRAM_MEMORY_CONFIG
+    )
+
+
+def run_op(
+    q,
+    kv,
+    indices,
+    device,
+    k_chunk_size,
+    v_dim,
+    compute_kernel_config=None,
+    kv_dtype=ttnn.bfloat16,
+    q_dtype=ttnn.bfloat16,
+):
+    q_host = q.to(torch.bfloat16) if q_dtype == ttnn.bfloat16 else q.to(torch.float32)
+    tt_q = to_dev(q_host, device, q_dtype)  # ttnn quantizes float -> fp8 when q_dtype is fp8_e4m3
+    kv_host = kv.to(torch.bfloat16) if kv_dtype == ttnn.bfloat16 else kv.to(torch.float32)
+    tt_kv = to_dev(kv_host, device, kv_dtype)  # ttnn quantizes float -> fp8 when kv_dtype is fp8_e4m3
+    tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+    scale = q.shape[-1] ** -0.5  # 1/sqrt(k_dim), from the input width
+    tt_out = ttnn.transformer.sparse_sdpa(
+        tt_q, tt_kv, tt_idx, v_dim, scale=scale, k_chunk_size=k_chunk_size, compute_kernel_config=compute_kernel_config
+    )
+    # Output dtype matches q. fp8 tensors can't be converted directly with to_torch, so typecast to bf16.
+    if tt_out.dtype == ttnn.fp8_e4m3:
+        tt_out = ttnn.typecast(tt_out, ttnn.bfloat16)
+    return ttnn.to_torch(tt_out), scale
+
+
+def pcc(out, golden_t):
+    return torch.corrcoef(torch.stack([out.flatten().float(), golden_t.flatten().float()]))[0, 1].item()

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -1,0 +1,254 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+# SPDX-License-Identifier: Apache-2.0
+
+"""sparse_sdpa (sparse MLA prefill) — BASIC post-commit smoke (Blackhole only).
+
+This file is a fast subset: op-runs/shape, output-dtype (incl. fp8), and a minimal single- and multi-chunk
+PCC with all-valid + boundary masking. The full coverage (sweeps over shapes / heads / fp8 q+kv /
+query-subblocking / sparsity, plus the perf-only test) lives in the nightly suite:
+tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py
+"""
+
+import pytest
+import torch
+
+import ttnn
+from models.common.utility_functions import run_for_blackhole
+from tests.ttnn.unit_tests.operations.sdpa.sparse_sdpa_test_utils import (
+    make_inputs,
+    golden,
+    to_dev,
+    run_op,
+    pcc,
+)
+
+K_DIM = 576  # head dim (q/kv width)
+V_DIM = 512  # V width / output width (op arg)
+
+# Open the device ONCE per module (not per test) — all tests share one device config, so this avoids the
+# ~1.7s open/close on every test. The program cache persists across tests, which is fine: the recompile and
+# indexed tests clear_program_cache() at their start, and the hash keeps distinct configs separate.
+pytestmark = pytest.mark.use_module_device
+
+
+# ---- op runs, output shape/layout correct ----
+@run_for_blackhole()
+def test_sparse_sdpa_runs(device):
+    H, S, T, TOPK, kc = 32, 64, 256, 64, 32
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK)
+    out, _ = run_op(q, kv, indices, device, kc, V_DIM)
+    assert tuple(out.shape) == (1, H, S, V_DIM), f"got {tuple(out.shape)}"
+
+
+# ---- output dtype matches q (bf16 q -> bf16 out, fp8 q -> fp8 out) ----
+@run_for_blackhole()
+@pytest.mark.parametrize("q_dtype", [ttnn.bfloat16, ttnn.fp8_e4m3], ids=["q_bf16", "q_fp8"])
+def test_sparse_sdpa_output_dtype(device, q_dtype):
+    H, S, T, TOPK, kc = 32, 64, 256, 64, 32
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK)
+    q_host = q.to(torch.bfloat16) if q_dtype == ttnn.bfloat16 else q.to(torch.float32)
+    tt_q = to_dev(q_host, device, q_dtype)
+    tt_kv = to_dev(kv.to(torch.bfloat16), device, ttnn.bfloat16)
+    tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+    out = ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, scale=K_DIM**-0.5, k_chunk_size=kc)
+    assert out.dtype == q_dtype, f"output dtype {out.dtype} != q dtype {q_dtype}"
+
+
+# ---- minimal PCC vs the sparse_mla golden: single chunk + multi chunk, all-valid + a boundary mask ----
+@run_for_blackhole()
+@pytest.mark.parametrize(
+    "nv_fn,nv_id",
+    [(lambda s: 10**9, "all_valid"), (lambda s: 1 + (s * 3) % 20, "boundary")],
+    ids=lambda x: x if isinstance(x, str) else "",
+)
+def test_sparse_sdpa_pcc_single_chunk(device, nv_fn, nv_id):
+    H, S, T, TOPK = 32, 64, 256, 32  # k_chunk == TOPK -> single chunk
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, nv_fn)
+    out, scale = run_op(q, kv, indices, device, k_chunk_size=TOPK, v_dim=V_DIM)
+    p = pcc(out, golden(q, kv, indices, scale, V_DIM))
+    assert p >= 0.99, f"PCC {p:.5f} ({nv_id})"
+
+
+@run_for_blackhole()
+@pytest.mark.parametrize(
+    "nv_fn,nv_id",
+    [(lambda s: 10**9, "all_valid"), (lambda s: 1 + (s * 3) % 50, "mid_tile_boundary")],
+    ids=lambda x: x if isinstance(x, str) else "",
+)
+def test_sparse_sdpa_pcc_multi_chunk(device, nv_fn, nv_id):
+    H, S, T, TOPK, kc = 32, 64, 256, 64, 32  # 2 chunks -> flash accumulation
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, nv_fn)
+    out, scale = run_op(q, kv, indices, device, kc, V_DIM)
+    p = pcc(out, golden(q, kv, indices, scale, V_DIM))
+    assert p >= 0.99, f"PCC {p:.5f} ({nv_id})"
+
+
+# ---- the kv (K cache) length T rides on the accessor's runtime args, so changing T must NOT recompile ----
+@run_for_blackhole()
+def test_sparse_sdpa_kv_len_no_recompile(device):
+    H, S, TOPK, kc = 32, 64, 64, 32
+    device.clear_program_cache()
+    for T in (256, 512, 1024):  # only the kv (K cache) length differs across these calls
+        q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK)
+        out, scale = run_op(q, kv, indices, device, kc, V_DIM)
+        p = pcc(out, golden(q, kv, indices, scale, V_DIM))
+        assert p >= 0.99, f"PCC {p:.5f} (T={T})"
+    n = device.num_program_cache_entries()
+    assert n == 1, f"changing kv length recompiled: {n} program-cache entries (expected 1)"
+
+
+# ---- oversized persistent kv buffer (same idea as ring_mla's reuse_max): one max-size K cache, allocated
+# ---- once and reused across calls. The cache is far larger than the keys any query attends to (T >> TOPK)
+# ---- and reads are index-driven, so the unpopulated suffix is simply never addressed. ----
+@run_for_blackhole()
+def test_sparse_sdpa_oversized_persistent_kv(device):
+    H, S, T_MAX, TOPK, kc = 32, 64, 1024, 64, 32
+    device.clear_program_cache()
+    gen = torch.Generator().manual_seed(0)
+    kv = torch.randn(1, 1, T_MAX, K_DIM, generator=gen, dtype=torch.float32)
+    tt_kv = to_dev(kv.to(torch.bfloat16), device, ttnn.bfloat16)  # ONE persistent oversized K cache
+    scale = K_DIM**-0.5
+    for valid_len in (256, 1024):  # each call's queries attend only to the [0, valid_len) populated prefix
+        q = torch.randn(1, H, S, K_DIM, generator=gen, dtype=torch.float32)
+        indices = torch.empty((1, 1, S, TOPK), dtype=torch.int64)
+        for s in range(S):
+            indices[0, 0, s, :] = torch.randperm(valid_len, generator=gen)[:TOPK]
+        tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
+        tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+        tt_out = ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, scale=scale, k_chunk_size=kc)
+        p = pcc(ttnn.to_torch(tt_out), golden(q, kv, indices, scale, V_DIM))
+        assert p >= 0.99, f"PCC {p:.5f} (valid_len={valid_len})"
+    n = device.num_program_cache_entries()  # reusing the same oversized buffer must not realloc/recompile
+    assert n == 1, f"oversized persistent kv reuse recompiled: {n} program-cache entries (expected 1)"
+
+
+def _indexed_inputs(H, S, T, TOPK, B, seed=0):
+    gen = torch.Generator().manual_seed(seed)
+    q = torch.randn(1, H, S, K_DIM, generator=gen, dtype=torch.float32)
+    kv_full = torch.randn(B, 1, T, K_DIM, generator=gen, dtype=torch.float32)  # B DISTINCT cache slots
+    indices = torch.empty((1, 1, S, TOPK), dtype=torch.int64)
+    for s in range(S):
+        indices[0, 0, s, :] = torch.randperm(T, generator=gen)[:TOPK]
+    return q, kv_full, indices
+
+
+# ---- indexed KV cache: kv is a shared [B,1,T,K_DIM] cache; cache_batch_idx selects the slot. Distinct
+# ---- random data per slot means a correct PCC for every slot proves the right slot is read, and a single
+# ---- program-cache entry across slots proves indexing is a runtime arg (no recompile). ----
+@run_for_blackhole()
+def test_sparse_sdpa_indexed_kv_cache(device):
+    H, S, T, TOPK, kc, B = 32, 64, 256, 64, 32, 3
+    device.clear_program_cache()
+    scale = K_DIM**-0.5
+    q, kv_full, indices = _indexed_inputs(H, S, T, TOPK, B)
+    tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
+    tt_kv = to_dev(kv_full.to(torch.bfloat16), device, ttnn.bfloat16)  # [B,1,T,K_DIM] shared cache
+    tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+    for cb in range(B):
+        tt_out = ttnn.transformer.sparse_sdpa(
+            tt_q, tt_kv, tt_idx, V_DIM, scale=scale, k_chunk_size=kc, cache_batch_idx=cb
+        )
+        p = pcc(ttnn.to_torch(tt_out), golden(q, kv_full[cb : cb + 1], indices, scale, V_DIM))  # golden uses slot cb
+        assert p >= 0.99, f"PCC {p:.5f} (cache_batch_idx={cb})"
+    n = device.num_program_cache_entries()  # changing the indexed slot must NOT recompile
+    assert n == 1, f"indexing into a different slot recompiled: {n} program-cache entries (expected 1)"
+
+
+# ---- indexed KV cache that is ND-sharded across DRAM banks (each batch slot is one shard). ----
+def _nd_sharded_dram_config(device, rows_per_shard):
+    num_banks = device.dram_grid_size().x
+    cores = [ttnn.CoreRange(ttnn.CoreCoord(b, 0), ttnn.CoreCoord(b, 0)) for b in range(num_banks)]
+    spec = ttnn.NdShardSpec(
+        shard_shape=[1, 1, rows_per_shard, K_DIM],
+        grid=ttnn.CoreRangeSet(cores),
+        orientation=ttnn.ShardOrientation.ROW_MAJOR,
+        shard_distribution_strategy=ttnn.ShardDistributionStrategy.ROUND_ROBIN_1D,
+    )
+    return ttnn.MemoryConfig(buffer_type=ttnn.BufferType.DRAM, nd_shard_spec=spec)
+
+
+@run_for_blackhole()
+def test_sparse_sdpa_indexed_nd_sharded_kv(device):
+    H, S, T, TOPK, kc, B = 32, 64, 256, 64, 32, 2
+    device.clear_program_cache()
+    scale = K_DIM**-0.5
+    q, kv_full, indices = _indexed_inputs(H, S, T, TOPK, B)
+    nd_cfg = _nd_sharded_dram_config(device, rows_per_shard=T)  # each [1,1,T,K_DIM] slot is one shard
+    tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
+    tt_kv = ttnn.from_torch(
+        kv_full.to(torch.bfloat16),
+        dtype=ttnn.bfloat16,
+        layout=ttnn.ROW_MAJOR_LAYOUT,
+        device=device,
+        memory_config=nd_cfg,
+    )
+    tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+    for cb in range(B):
+        tt_out = ttnn.transformer.sparse_sdpa(
+            tt_q, tt_kv, tt_idx, V_DIM, scale=scale, k_chunk_size=kc, cache_batch_idx=cb
+        )
+        p = pcc(ttnn.to_torch(tt_out), golden(q, kv_full[cb : cb + 1], indices, scale, V_DIM))
+        assert p >= 0.99, f"PCC {p:.5f} (nd-sharded, cache_batch_idx={cb})"
+
+
+# ---- A SHARDED kv's per-page bank mapping derives from its tensor shape (the accessor's shard strides), which
+# ---- are baked at create time and NOT re-emitted on a cache-hit fast path. So unlike interleaved kv, changing
+# ---- a sharded kv's T must recompile — else the 2nd call would reuse stale strides and read wrong banks. Here
+# ---- both T values share ONE shard spec (same memory_config), so the hash must distinguish them by shape;
+# ---- correct PCC for both proves it does. ----
+@run_for_blackhole()
+def test_sparse_sdpa_nd_sharded_kv_len_change(device):
+    H, S, TOPK, kc = 32, 64, 64, 32
+    device.clear_program_cache()
+    scale = K_DIM**-0.5
+    nd_cfg = _nd_sharded_dram_config(device, rows_per_shard=128)  # FIXED shard shape, independent of T
+    for T in (256, 512):  # multiples of 128; same shard spec, different T (different shard count)
+        q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK)
+        tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
+        tt_kv = ttnn.from_torch(
+            kv.to(torch.bfloat16),
+            dtype=ttnn.bfloat16,
+            layout=ttnn.ROW_MAJOR_LAYOUT,
+            device=device,
+            memory_config=nd_cfg,
+        )
+        tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+        out = ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, scale=scale, k_chunk_size=kc)
+        p = pcc(ttnn.to_torch(out), golden(q, kv, indices, scale, V_DIM))
+        assert p >= 0.99, f"PCC {p:.5f} (nd-sharded, T={T})"
+    assert device.num_program_cache_entries() == 2, "sharded kv must recompile per shape (2 distinct T -> 2 entries)"
+
+
+# ---- cache_batch_idx is excluded from the program hash, so an out-of-range slot must be rejected even on a
+# ---- program-cache HIT (validate_on_program_cache_hit re-checks the bound; without it the gather would run
+# ---- out of bounds silently). ----
+@run_for_blackhole()
+def test_sparse_sdpa_indexed_oob_rejected_on_hit(device):
+    H, S, T, TOPK, kc, B = 32, 64, 256, 64, 32, 2
+    device.clear_program_cache()
+    q, kv_full, indices = _indexed_inputs(H, S, T, TOPK, B)
+    tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
+    tt_kv = to_dev(kv_full.to(torch.bfloat16), device, ttnn.bfloat16)
+    tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+    ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, k_chunk_size=kc, cache_batch_idx=0)  # miss: builds
+    assert device.num_program_cache_entries() == 1
+    with pytest.raises(RuntimeError):  # cache HIT, slot B is out of range [0,B) -> rejected by the hit validator
+        ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, k_chunk_size=kc, cache_batch_idx=B)
+
+
+# ---- q/indices layout/memory are NOT in the program hash, so an incompatible (e.g. TILE-layout) q with the
+# ---- same shape/dtype must be rejected on a program-cache HIT too (validate_on_program_cache_hit re-checks
+# ---- all non-hashed input invariants; without it the cached row-major program would run on a tiled tensor). ----
+@run_for_blackhole()
+def test_sparse_sdpa_bad_layout_rejected_on_hit(device):
+    H, S, T, TOPK, kc = 32, 64, 256, 64, 32
+    device.clear_program_cache()
+    q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK)
+    tt_q = to_dev(q.to(torch.bfloat16), device, ttnn.bfloat16)
+    tt_kv = to_dev(kv.to(torch.bfloat16), device, ttnn.bfloat16)
+    tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
+    ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, k_chunk_size=kc)  # miss: builds the row-major program
+    assert device.num_program_cache_entries() == 1
+    tt_q_tile = ttnn.to_layout(tt_q, ttnn.TILE_LAYOUT)  # same shape+dtype (same hash) but wrong layout -> HIT
+    with pytest.raises(RuntimeError):
+        ttnn.transformer.sparse_sdpa(tt_q_tile, tt_kv, tt_idx, V_DIM, k_chunk_size=kc)

--- a/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
+++ b/tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py
@@ -223,7 +223,7 @@ def test_sparse_sdpa_nd_sharded_kv_len_change(device):
 # ---- program-cache HIT (validate_on_program_cache_hit re-checks the bound; without it the gather would run
 # ---- out of bounds silently). ----
 @run_for_blackhole()
-def test_sparse_sdpa_indexed_oob_rejected_on_hit(device):
+def test_sparse_sdpa_indexed_oob_rejected_on_hit(device, expect_error):
     H, S, T, TOPK, kc, B = 32, 64, 256, 64, 32, 2
     device.clear_program_cache()
     q, kv_full, indices = _indexed_inputs(H, S, T, TOPK, B)
@@ -232,7 +232,8 @@ def test_sparse_sdpa_indexed_oob_rejected_on_hit(device):
     tt_idx = to_dev(indices.to(torch.int32), device, ttnn.uint32)
     ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, k_chunk_size=kc, cache_batch_idx=0)  # miss: builds
     assert device.num_program_cache_entries() == 1
-    with pytest.raises(RuntimeError):  # cache HIT, slot B is out of range [0,B) -> rejected by the hit validator
+    # cache HIT, slot B is out of range [0,B) -> rejected by the hit validator
+    with expect_error(RuntimeError, "cache_batch_idx"):
         ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, k_chunk_size=kc, cache_batch_idx=B)
 
 
@@ -240,7 +241,7 @@ def test_sparse_sdpa_indexed_oob_rejected_on_hit(device):
 # ---- same shape/dtype must be rejected on a program-cache HIT too (validate_on_program_cache_hit re-checks
 # ---- all non-hashed input invariants; without it the cached row-major program would run on a tiled tensor). ----
 @run_for_blackhole()
-def test_sparse_sdpa_bad_layout_rejected_on_hit(device):
+def test_sparse_sdpa_bad_layout_rejected_on_hit(device, expect_error):
     H, S, T, TOPK, kc = 32, 64, 256, 64, 32
     device.clear_program_cache()
     q, kv, indices = make_inputs(H, S, T, TOPK, K_DIM, lambda s: TOPK)
@@ -250,5 +251,5 @@ def test_sparse_sdpa_bad_layout_rejected_on_hit(device):
     ttnn.transformer.sparse_sdpa(tt_q, tt_kv, tt_idx, V_DIM, k_chunk_size=kc)  # miss: builds the row-major program
     assert device.num_program_cache_entries() == 1
     tt_q_tile = ttnn.to_layout(tt_q, ttnn.TILE_LAYOUT)  # same shape+dtype (same hash) but wrong layout -> HIT
-    with pytest.raises(RuntimeError):
+    with expect_error(RuntimeError, "ROW_MAJOR"):
         ttnn.transformer.sparse_sdpa(tt_q_tile, tt_kv, tt_idx, V_DIM, k_chunk_size=kc)

--- a/ttnn/cpp/ttnn/operations/transformer/CMakeLists.txt
+++ b/ttnn/cpp/ttnn/operations/transformer/CMakeLists.txt
@@ -30,6 +30,7 @@ target_sources(
             attention_softmax/attention_softmax.hpp
             concatenate_heads/concatenate_heads.hpp
             sdpa/sdpa.hpp
+            sdpa/sparse_sdpa.hpp
             sdpa_decode/sdpa_decode.hpp
             sdpa_windowed/sdpa_windowed.hpp
             split_query_key_value_and_split_heads/split_query_key_value_and_split_heads.hpp

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -265,7 +265,9 @@ void kernel_main() {
                             /*trigger_reduce=*/false,
                             /*skip_pack_configure=*/true);
                     }
-                    pack_to_unpack_sync();                // out_cur PACK writes must be visible to SALAD/normalize
+                    pack_to_unpack_sync();                // flush PV's HELD out_cur packs (push_back deferred to
+                                                          // after the group loop) so SALAD's L1-accumulate (!is_first)
+                                                          // reads them; normalize reads post-push_back, so covered
                     reconfig_data_format_srca(cb_qk_im);  // PV left srcA in cb_k_in's format; restore bf16
                 }
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/compute/sparse_sdpa_compute.cpp
@@ -1,0 +1,344 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// sparse_sdpa compute: flash/online-softmax over k_chunks (compute_streaming primitives).
+// Per token: tilize Q. Per chunk: tilize K to [Skt,DHt] (both matmuls read it directly, no Kᵀ/V copies),
+// then for each query group of qsb<=dst_size tile-rows (so DST never caps H):
+//   Phase 1: Q@Kᵀ -> cb_qk_im (held wr_ptr), boundary mask add, running row-max.
+//   Phase 2: sub_exp in place (exp((s-max)*scale)) + partial row-sum (L1-acc into cur.sum), probs@V -> cur.out,
+//            then the SALAD flash combine: correction exp(prev_max-cur_max) applied to prev.out/prev.sum.
+// The partial row-sum is finalized once on the last chunk (normalize_row_streaming). num_active_chunks==1
+// degenerates to a plain single-chunk softmax (no SALAD).
+
+#include <cstdint>
+#include "api/compute/compute_kernel_api.h"
+#include "api/compute/tile_move_copy.h"
+#include "api/compute/bcast.h"  // add_tiles_bcast_rows (mask add)
+// compute_streaming.hpp needs declarations from compute_common.hpp (LightweightMaskContext, reduce helpers,
+// DEST_AUTO_LIMIT); include it first. Only compute_streaming primitives are used.
+#include "compute_common.hpp"
+#include "compute_streaming.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/tilize_helpers.hpp"
+#include "ttnn/cpp/ttnn/kernel_lib/untilize_helpers.hpp"
+#include "api/dataflow/circular_buffer.h"  // CircularBuffer: COMPILE_FOR_TRISC-aware CB lifecycle
+#include <tt-metalium/constants.hpp>       // tt::constants::TILE_HEIGHT
+
+// In-place scores[tile] += row-broadcast of mask row 0. cb_qk_im is held (hold_wr_ptr), so re-pack at the
+// absolute position. Caller has init'd the bcast-rows op + single-tile pack.
+ALWI void add_bcast_row_mask_tile(uint32_t scores_cb, uint32_t mask_cb, uint32_t score_tile) {
+    tile_regs_acquire();
+    add_tiles_bcast_rows(scores_cb, mask_cb, score_tile, 0, 0);
+    tile_regs_commit();
+    tile_regs_wait();
+    pack_tile<true>(0, scores_cb, score_tile);
+    tile_regs_release();
+}
+
+// Make in-place PACK writes to a held CB visible to the next UNPACK read (after the in-place mask/sub_exp
+// writes to cb_qk_im and the V-matmul writes to out_cur, none of which do a cb_push_back).
+ALWI void pack_to_unpack_sync() {
+    PACK((t6_semaphore_post<p_stall::STALL_PACK>(semaphore::PACK_DONE)));
+    UNPACK((t6_semaphore_wait_on_zero<p_stall::STALL_SYNC>(semaphore::PACK_DONE)));
+    UNPACK((t6_semaphore_get<>(semaphore::PACK_DONE)));
+}
+
+ALWI void swap_cb(CircularBuffer& a, CircularBuffer& b) {
+    const CircularBuffer t = a;
+    a = b;
+    b = t;
+}
+
+void kernel_main() {
+    constexpr uint32_t H = get_compile_time_arg_val(0);
+    constexpr uint32_t DHt = get_compile_time_arg_val(1);
+    constexpr uint32_t vDHt = get_compile_time_arg_val(2);
+    constexpr uint32_t Skt = get_compile_time_arg_val(3);
+    constexpr uint32_t scale_fp32 = get_compile_time_arg_val(4);
+
+    // CB ids from the factory (the SparseCB enum is the single source); order matches the factory's compute
+    // compile-arg block (5..24). They feed the templates + format helpers; the CB objects below wrap them.
+    constexpr uint32_t cb_q_rm = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_q_in = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_k_rm = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_k_in = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_neginf = get_compile_time_arg_val(9);
+    constexpr uint32_t cb_mask_part = get_compile_time_arg_val(10);
+    constexpr uint32_t cb_scale = get_compile_time_arg_val(11);
+    constexpr uint32_t cb_qk_im = get_compile_time_arg_val(12);
+    constexpr uint32_t cb_max_a = get_compile_time_arg_val(13);
+    constexpr uint32_t cb_max_b = get_compile_time_arg_val(14);
+    constexpr uint32_t cb_sum_a = get_compile_time_arg_val(15);
+    constexpr uint32_t cb_sum_b = get_compile_time_arg_val(16);
+    constexpr uint32_t cb_out_a = get_compile_time_arg_val(17);
+    constexpr uint32_t cb_out_b = get_compile_time_arg_val(18);
+    constexpr uint32_t cb_corr = get_compile_time_arg_val(19);
+    constexpr uint32_t cb_out_im = get_compile_time_arg_val(20);
+    constexpr uint32_t cb_out_rm = get_compile_time_arg_val(21);
+    constexpr uint32_t cb_ctrl = get_compile_time_arg_val(22);
+    constexpr uint32_t cb_col_identity = get_compile_time_arg_val(23);
+    constexpr uint32_t cb_recip_scratch = get_compile_time_arg_val(24);
+
+    constexpr uint32_t qsb = get_compile_time_arg_val(25);    // query tile-rows per DST group (<= dst_size)
+    constexpr uint32_t Sqt = H / tt::constants::TILE_HEIGHT;  // total query tile-rows (32 heads each)
+    constexpr uint32_t q_groups = Sqt / qsb;                  // DST-bound work runs in this many query-row passes
+    constexpr uint32_t KT_stride = Skt;                       // cb_qk_im physical row width
+    constexpr uint32_t dst_size = compute_kernel_lib::DEST_AUTO_LIMIT;
+    // sub_exp packs qsb*sbw tiles into DST: full Skt width when one group fits, else one key-tile column at a time.
+    constexpr uint32_t exp_sbw = (qsb * Skt <= dst_size) ? Skt : 1;
+
+    // CB wrappers for the fixed (non-ping-pong) buffers' lifecycle verbs.
+    CircularBuffer q_in_cb(cb_q_in), k_in_cb(cb_k_in), qk_cb(cb_qk_im), scale_cb(cb_scale), ctrl_cb(cb_ctrl);
+    CircularBuffer neginf_cb(cb_neginf), mask_part_cb(cb_mask_part), corr_cb(cb_corr);
+
+    const uint32_t tok_count = get_arg_val<uint32_t>(1);
+
+    compute_kernel_hw_startup(cb_q_rm, cb_q_in);
+    mm_init(cb_q_in, cb_k_in, cb_out_im);  // one-time full matmul init; the no_mop matmuls reinit off this
+
+    scale_cb.wait_front(1);  // persistent reduce scaler; the streaming reduce assumes it is ready
+
+    for (uint32_t tok = 0; tok < tok_count; ++tok) {
+        // tilize Q rows -> [Sqt, DHt]
+        compute_kernel_lib::tilize<DHt, cb_q_rm, cb_q_in>(/*num_blocks=*/Sqt, /*total_input_pages=*/H);
+
+        // Per-token control from the reader: num_active_chunks (>=1; all-sentinel chunks are skipped) and
+        // num_valid_keys (last chunk's mask boundary). read_tile_value mailbox-distributes the UNPACK read so
+        // all three threads see the same loop bound / mask branches.
+        ctrl_cb.wait_front(1);
+        const uint32_t num_active_chunks = ckernel::read_tile_value(cb_ctrl, /*tile=*/0, /*element_offset=*/0);
+        const uint32_t num_valid_keys = ckernel::read_tile_value(cb_ctrl, /*tile=*/0, /*element_offset=*/1);
+        ctrl_cb.pop_front(1);
+
+        // Flash running state, ping-pong. Reset every token; all buffers start empty.
+        CircularBuffer max_prev(cb_max_a), max_cur(cb_max_b);
+        CircularBuffer sum_prev(cb_sum_a), sum_cur(cb_sum_b);
+        CircularBuffer out_prev(cb_out_a), out_cur(cb_out_b);
+
+        for (uint32_t chunk = 0; chunk < num_active_chunks; ++chunk) {
+            // tilize K rows -> [Skt, DHt] (waits on reader cb_k_rm -> absorbs the K-read stall)
+            compute_kernel_lib::tilize<DHt, cb_k_rm, cb_k_in>(
+                /*num_blocks=*/Skt, /*total_input_pages=*/Skt * tt::constants::TILE_HEIGHT);
+            // fp8 K tilize leaves srcA in fp8. QK reads K (transposed -> srcA) and Q (srcB), so restore
+            // srcA=cb_k_in (bfp8 for fp8 K), srcB=cb_q_in. No-op for bf16; mm_no_mop_init_short does not reconfig.
+            reconfig_data_format(cb_k_in, cb_q_in);
+            // K tilize also leaves the packer in cb_k_in's format+strides (bfp8 for fp8). Restore bf16 once per
+            // chunk for the downstream packs (cb_qk_im/max/sum/out share its geometry); configure_pack_width in
+            // the qg loop refreshes only the MOP. No-op for bf16.
+            pack_reconfig_data_format(cb_qk_im);
+
+            const bool is_first = (chunk == 0);
+            const bool is_last = (chunk == num_active_chunks - 1);
+            const bool has_mask = is_last;  // only the last active chunk can hold sentinels
+
+            // cb_qk_im / sum_cur / out_cur span all Sqt rows; the qg loop fills them band-by-band (sub_exp & PV
+            // pack at absolute row offsets; reduce/corr reserve+push per band).
+            qk_cb.reserve_back(Sqt * KT_stride);
+            sum_cur.reserve_back(Sqt);
+            out_cur.reserve_back(Sqt * vDHt);
+            k_in_cb.wait_front(Skt * DHt);  // shared by every query group (QK + PV)
+            q_in_cb.wait_front(Sqt * DHt);
+
+            // Boundary geometry (last chunk, same for every row): keys [valid_last, k_chunk) are sentinels ->
+            // -inf. Key tiles [full_start, Skt) are fully masked (cb_neginf); a mid-tile boundary masks the
+            // straddling tile part_t via cb_mask_part.
+            const uint32_t k_chunk = Skt * tt::constants::TILE_WIDTH;
+            const uint32_t valid_last = num_valid_keys - (num_active_chunks - 1) * k_chunk;
+            const uint32_t full_start = (valid_last + tt::constants::TILE_WIDTH - 1) / tt::constants::TILE_WIDTH;
+            const uint32_t part_t = valid_last / tt::constants::TILE_WIDTH;
+            const bool has_part_mask = has_mask && (valid_last % tt::constants::TILE_WIDTH != 0);
+
+            // DST holds qsb query tile-rows; process Sqt rows in q_groups passes (one pass when qsb==Sqt).
+            for (uint32_t qg = 0; qg < q_groups; ++qg) {
+                const uint32_t row_base = qg * qsb;  // first query tile-row of this group
+
+                // Set exp to the softmax scale; salad's correction below re-inits it to unit scale.
+                exp_packthread_tile_init<true, scale_fp32, InputClamping::None>();
+
+                // ===== Phase 1: Q@Kᵀ -> cb_qk_im band, mask, running row-max =====
+                {
+                    // scores[q,sk]=ΣQ·K. in1=K, transpose=true (within-tile transpose => Kᵀ), in1_stride=1.
+                    // ct/pack_width=1: the per-chunk tilize reprograms the packer addrmods/strides, which the
+                    // wider BH blocked pack can't tolerate (configure_pack_width can't restore them). matmul ct>1 is
+                    // fine.
+                    mm_no_mop_init_short(cb_q_in, cb_k_in, /*transpose=*/true, 1, qsb, DHt);
+                    configure_row_pack_width(cb_qk_im, 1);
+                    for (uint32_t kt = 0; kt < Skt; ++kt) {
+                        blocked_matmul_and_pack<true, /*in1_stride=*/1, /*out_num_cols=*/KT_stride>(
+                            cb_q_in,
+                            cb_k_in,
+                            cb_qk_im,
+                            /*in0_index_start=*/row_base * DHt,
+                            /*in1_index_start=*/kt * DHt,
+                            /*row_subblock_idx=*/qg,
+                            /*out_col_offset=*/kt,
+                            /*subblock_w=*/1,
+                            /*subblock_h=*/qsb,
+                            /*inner_dim=*/DHt,
+                            /*matmul_stride=*/DHt,
+                            /*trigger_reduce=*/false,
+                            /*skip_pack_configure=*/true);
+                    }
+                    // Publish the band to UNPACK while holding wr_ptr (for the in-place mask/sub_exp).
+                    cb_push_back_hold_wr_ptr(cb_qk_im, qsb * KT_stride);
+                }
+
+                {
+                    // QK left srcA=cb_k_in, srcB=cb_q_in. The mask/reduce/sub_exp read cb_qk_im (srcA) + bf16
+                    // scalers (srcB); restore both to bf16. No-op for bf16 Q/K.
+                    reconfig_data_format(cb_qk_im, cb_scale);
+                    if (has_mask) {
+                        qk_cb.wait_front((qg + 1) * qsb * KT_stride);  // band visible before the in-place mask
+                        // Same mask for every query row: stamp each masked key tile across this group's rows
+                        // (cb_qk_im row row_base+r, key tile t = (row_base+r)*Skt + t).
+                        if (full_start < Skt) {
+                            neginf_cb.wait_front(1);
+                            add_bcast_rows_init_short(cb_qk_im, cb_neginf);
+                            configure_single_tile_pack(cb_qk_im);
+                            for (uint32_t r = 0; r < qsb; ++r) {
+                                for (uint32_t t = full_start; t < Skt; ++t) {
+                                    add_bcast_row_mask_tile(cb_qk_im, cb_neginf, (row_base + r) * Skt + t);
+                                }
+                            }
+                        }
+                        if (has_part_mask) {
+                            mask_part_cb.wait_front(1);  // persistent until popped after the group loop
+                            add_bcast_rows_init_short(cb_qk_im, cb_mask_part);
+                            configure_single_tile_pack(cb_qk_im);
+                            for (uint32_t r = 0; r < qsb; ++r) {
+                                add_bcast_row_mask_tile(cb_qk_im, cb_mask_part, (row_base + r) * Skt + part_t);
+                            }
+                        }
+                        pack_to_unpack_sync();  // mask PACK writes must be visible to the row-max UNPACK
+                    }
+                    // running row-max (MAX-only; eltwise-max against prev on chunk>0)
+                    max_cur.reserve_back(qsb);
+                    configure_single_tile_pack(max_cur.get_cb_id());
+                    reduce_c_row_group<cb_qk_im, cb_scale, KT_stride>(
+                        max_cur.get_cb_id(),
+                        max_prev.get_cb_id(),
+                        /*row_group_index=*/qg,
+                        /*do_eltwise_max=*/!is_first,
+                        qsb,
+                        Skt);
+                    max_cur.push_back(qsb);
+
+                    // sub_exp in place: cb_qk_im = exp((cb_qk_im - max)*scale); partial row-sum -> sum_cur (L1-acc).
+                    // Walk key-tile columns in exp_sbw steps (one step when the group fits DST); global_col_base
+                    // drives the L1-accumulate across steps.
+                    for (uint32_t kc = 0; kc < Skt; kc += exp_sbw) {
+                        sub_exp_block_bcast_cols<false, scale_fp32>(
+                            cb_qk_im,
+                            max_cur.get_cb_id(),
+                            sum_cur.get_cb_id(),
+                            /*cols_in_row=*/KT_stride,
+                            /*q_subblock=*/qg,
+                            /*global_col_base=*/kc,
+                            /*sbh=*/qsb,
+                            /*sbw=*/exp_sbw);
+                    }
+                    pack_to_unpack_sync();  // sub_exp PACK writes must be visible to the V-matmul UNPACK
+                }
+
+                // ===== Phase 2: probs@V -> out_cur band =====
+                {
+                    qk_cb.wait_front((qg + 1) * qsb * KT_stride);
+                    // out[q,vd]=Σprobs·K, V = first vDHt feature cols (rope cols skipped). in1=K, transpose=false,
+                    // in1_stride=DHt. ct/pack_width=1 (same blocked-pack reason as QK). PV reads V into srcA and
+                    // probs (cb_qk_im) into srcB (operands swap); set srcA=cb_k_in, srcB=cb_qk_im.
+                    reconfig_data_format(cb_k_in, cb_qk_im);
+                    mm_no_mop_init_short(cb_qk_im, cb_k_in, /*transpose=*/false, 1, qsb, Skt);
+                    configure_row_pack_width(out_cur.get_cb_id(), 1);
+                    for (uint32_t vd = 0; vd < vDHt; ++vd) {
+                        blocked_matmul_and_pack<false, /*in1_stride=*/DHt, /*out_num_cols=*/vDHt>(
+                            cb_qk_im,
+                            cb_k_in,
+                            out_cur.get_cb_id(),
+                            /*in0_index_start=*/row_base * Skt,
+                            /*in1_index_start=*/vd,
+                            /*row_subblock_idx=*/qg,
+                            /*out_col_offset=*/vd,
+                            /*subblock_w=*/1,
+                            /*subblock_h=*/qsb,
+                            /*inner_dim=*/Skt,
+                            /*matmul_stride=*/KT_stride,
+                            /*trigger_reduce=*/false,
+                            /*skip_pack_configure=*/true);
+                    }
+                    pack_to_unpack_sync();                // out_cur PACK writes must be visible to SALAD/normalize
+                    reconfig_data_format_srca(cb_qk_im);  // PV left srcA in cb_k_in's format; restore bf16
+                }
+
+                // ===== SALAD flash combine (skip on the first chunk) =====
+                if (!is_first) {
+                    // correction = exp((prev_max - cur_max)*scale) -> cb_corr col 0. Re-init exp at unit scale
+                    // (sub_exp_first_col_blocks applies scale itself; the group's init baked scale_fp32).
+                    exp_packthread_tile_init<EXP_APPROX_MODE>();
+                    corr_cb.reserve_back(qsb);
+                    sub_exp_first_col_blocks<false, scale_fp32>(
+                        max_prev.get_cb_id(), max_cur.get_cb_id(), cb_corr, /*q_subblock=*/qg, qsb);
+                    corr_cb.push_back(qsb);
+                    // cur.out += prev.out*corr ; cur.sum += prev.sum*corr (L1-acc). salad packs width=dst_size,
+                    // so restore Default packer geometry first (the per-chunk tilize left it in Tilize layout).
+                    PACK((
+                        llk_pack_init<ckernel::PackMode::Default, false, false, false>(out_cur.get_cb_id(), dst_size)));
+                    pack_reconfig_l1_acc(1);
+                    // out_prev & cb_corr consumed front-first per group (popped below); sum_prev cumulative (qg).
+                    salad_correct_fused<qsb, vDHt, dst_size>(
+                        out_prev.get_cb_id(),
+                        sum_prev.get_cb_id(),
+                        cb_corr,
+                        out_cur.get_cb_id(),
+                        sum_cur.get_cb_id(),
+                        /*ob_q_subblock=*/0,
+                        /*sum_q_subblock=*/qg,
+                        /*write_q_subblock=*/qg);
+                    pack_reconfig_l1_acc(0);
+                    corr_cb.pop_front(qsb);
+                    out_prev.pop_front(qsb * vDHt);  // this band's prev.out consumed into cur
+                }
+            }  // query groups
+
+            // Pop cb_mask_part once: every group bcast-added the same straddling-tile mask.
+            if (has_part_mask) {
+                mask_part_cb.pop_front(1);
+            }
+            // prev max/sum consumed into cur (out_prev popped per band above).
+            if (!is_first) {
+                max_prev.pop_front(Sqt);
+                sum_prev.pop_front(Sqt);
+            }
+
+            // Publish cur.sum / cur.out (running state for the next chunk, or the final result).
+            sum_cur.push_back(Sqt);
+            out_cur.push_back(Sqt * vDHt);
+
+            if (is_last) {
+                // Finalize: row-sum (matmul vs col-identity) -> recip -> out *= 1/sum -> cb_out_im.
+                // normalize_row_streaming is DST-safe for any sbh, so it does all Sqt rows in one call.
+                normalize_row_streaming<
+                    /*profiling_enabled=*/false,
+                    vDHt,
+                    dst_size,
+                    cb_col_identity,
+                    cb_recip_scratch,
+                    cb_out_im,
+                    scale_fp32>(sum_cur.get_cb_id(), out_cur.get_cb_id(), Sqt);
+                max_cur.pop_front(Sqt);  // running max no longer needed
+            }
+
+            // Release the held cb_qk_im rows + this chunk's K (consumed by QK and PV).
+            qk_cb.pop_front(Sqt * KT_stride);
+            k_in_cb.pop_front(Skt * DHt);
+
+            swap_cb(max_prev, max_cur);  // prev <-> cur for the next chunk
+            swap_cb(sum_prev, sum_cur);
+            swap_cb(out_prev, out_cur);
+        }
+
+        q_in_cb.pop_front(Sqt * DHt);  // Q reused across all chunks; drop it so >1 token/core stays clean
+
+        // cb_out_im was written by normalize_row_streaming; untilize -> row-major out for the writer.
+        compute_kernel_lib::untilize<vDHt, cb_out_im, cb_out_rm>(/*num_blocks=*/Sqt);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_gather.hpp
@@ -1,0 +1,52 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Shared helper for the dual-NoC K gather. The reader and writer each gather one half of every K chunk on
+// their own (factory-assigned) NoC into the same shared cb_k_rm L1; both halves use this trid ring. Include
+// after api/dataflow/dataflow_api.h and experimental_device_api.hpp (the reader/writer already do).
+#pragma once
+
+#include <stdint.h>
+
+namespace sparse_sdpa {
+
+// Per-NoC trid-ring depth for each gather half (swept: 4 is the sweet spot — with the split halving each
+// NoC's load, a shallow ring beats both the plain burst and the old deep single-NoC ring).
+constexpr uint32_t K_TRID_RING = 4;
+
+// Gather the K rows for chunk index positions [lo, hi) on `noc`, capping outstanding reads with a depth-D
+// trid ring: idx_ptr[base + p] -> k_cb at byte offset p * k_row_bytes, for p in [lo, hi). Used by the
+// reader for its half [half, valid) and by the writer for its half [0, half). `page_offset` selects the
+// batch slot of an indexed KV cache (cache_batch_idx * T); 0 for a single [1,1,T,K_DIM] cache.
+template <typename Accessor>
+FORCE_INLINE void trid_ring_gather(
+    Noc& noc,
+    const Accessor& kv,
+    experimental::CB& k_cb,
+    volatile tt_l1_ptr uint32_t* idx_ptr,
+    uint32_t base,
+    uint32_t lo,
+    uint32_t hi,
+    uint32_t k_row_bytes,
+    uint32_t page_offset) {
+    constexpr uint32_t D = K_TRID_RING;
+    const uint32_t cnt = hi - lo;
+    for (uint32_t i = 0; i < cnt; ++i) {
+        const uint32_t p = lo + i;
+        const uint32_t trid = (i % D) + 1;
+        if (i >= D) {
+            experimental::async_read_barrier_with_trid(noc, trid);  // free this trid slot before reuse
+        }
+        experimental::set_read_trid(noc, trid);
+        noc.async_read(
+            kv, k_cb, k_row_bytes, {.page_id = page_offset + idx_ptr[base + p]}, {.offset_bytes = p * k_row_bytes});
+    }
+    const uint32_t to_drain = (cnt < D) ? cnt : D;
+    for (uint32_t d = 0; d < to_drain; ++d) {
+        experimental::async_read_barrier_with_trid(noc, ((cnt - to_drain + d) % D) + 1);
+    }
+    experimental::set_read_trid(noc, 0);  // restore untagged
+}
+
+}  // namespace sparse_sdpa

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_reader.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_reader.cpp
@@ -1,0 +1,174 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// sparse_sdpa reader: per token, gather Q rows + per-chunk indexed K rows (sentinel suffix zero-filled),
+// plus the per-token partial-boundary mask tile. (The persistent scaler/col-identity/-inf tiles are built
+// by the lighter-loaded writer.) Uses the object-based NoC + circular-buffer APIs.
+//
+// Sentinels are a contiguous tail (producer contract): nv = first-sentinel index = valid-key count, so only
+// ceil(nv/k_chunk) chunks are active; all-sentinel chunks are skipped (no read/fill/compute), compute learns
+// nv + the active count via cb_ctrl. The per-chunk K gather is split across BOTH NoCs (the op is NoC-link
+// bound): the reader gathers half the rows on its NoC and hands the other half to the writer (cb_kreq/kack),
+// which gathers them on its NoC into the same shared cb_k_rm L1.
+
+#include <stdint.h>
+#include <tt-metalium/constants.hpp>  // tt::constants::TILE_HEIGHT
+#include "api/dataflow/dataflow_api.h"
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include "sparse_sdpa_gather.hpp"              // dual-NoC trid-ring gather helper (shared with the writer)
+
+constexpr uint32_t sentinel = 0xFFFFFFFFu;
+constexpr uint16_t neg_inf_bf16 = 0xFF80u;
+
+void kernel_main() {
+    constexpr uint32_t H = get_compile_time_arg_val(0);
+    constexpr uint32_t S = get_compile_time_arg_val(1);
+    constexpr uint32_t topk = get_compile_time_arg_val(2);
+    constexpr uint32_t k_chunk = get_compile_time_arg_val(3);
+    constexpr uint32_t k_dim = get_compile_time_arg_val(4);  // q/kv head dim (from the tensor)
+
+    // CB ids — passed by the factory (the SparseCB enum is the single source); order must match the
+    // factory's reader CB-arg block (compile args 5..9). cb_kreq/cb_kack come as defines (CB_KREQ/CB_KACK).
+    constexpr uint32_t cb_q_rm = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_k_rm = get_compile_time_arg_val(6);
+    constexpr uint32_t cb_mask_part = get_compile_time_arg_val(7);
+    constexpr uint32_t cb_idx = get_compile_time_arg_val(8);
+    constexpr uint32_t cb_ctrl = get_compile_time_arg_val(9);
+
+    // Element sizes (from the tensors' dtypes; passed after the CB ids so their indices stay fixed).
+    constexpr uint32_t q_elem_bytes = get_compile_time_arg_val(10);    // bf16
+    constexpr uint32_t kv_elem_bytes = get_compile_time_arg_val(11);   // bf16 or fp8_e4m3
+    constexpr uint32_t idx_elem_bytes = get_compile_time_arg_val(12);  // uint32
+
+    // kv carries a RUNTIME tensor shape (its T dim is common runtime args, not compile-time), so its accessor
+    // spans both the compile-time AND common-runtime arg streams. Thread both offsets through all three.
+    constexpr auto q_args = TensorAccessorArgs<13, 0>();
+    constexpr auto kv_args =
+        TensorAccessorArgs<q_args.next_compile_time_args_offset(), q_args.next_common_runtime_args_offset()>();
+    constexpr auto idx_args =
+        TensorAccessorArgs<kv_args.next_compile_time_args_offset(), kv_args.next_common_runtime_args_offset()>();
+
+    const uint32_t q_addr = get_arg_val<uint32_t>(0);
+    const uint32_t kv_addr = get_arg_val<uint32_t>(1);
+    const uint32_t idx_addr = get_arg_val<uint32_t>(2);
+    const uint32_t tok_start = get_arg_val<uint32_t>(3);
+    const uint32_t tok_count = get_arg_val<uint32_t>(4);
+    // Indexed KV cache: page offset (cache_batch_idx * T) selecting the cache's batch slot; 0 if not indexed.
+    const uint32_t kv_batch_page_offset = get_arg_val<uint32_t>(5);
+
+    constexpr uint32_t q_row_bytes = k_dim * q_elem_bytes;     // Q row (bf16)
+    constexpr uint32_t k_row_bytes = k_dim * kv_elem_bytes;    // K row (native dtype: fp8 or bf16)
+    constexpr uint32_t idx_row_bytes = topk * idx_elem_bytes;  // one index row
+
+    Noc noc;
+    experimental::CB q_cb(cb_q_rm), k_cb(cb_k_rm), mask_part_cb(cb_mask_part), idx_cb(cb_idx), ctrl_cb(cb_ctrl);
+    experimental::CB kreq_cb(CB_KREQ), kack_cb(CB_KACK);  // dual-NoC K-gather handoff to the writer
+    const auto q = TensorAccessor(q_args, q_addr);
+    const auto kv = TensorAccessor(kv_args, kv_addr);
+    const auto idx = TensorAccessor(idx_args, idx_addr);
+
+    // Reader-internal scratch for one token's index row (reserved once, reused).
+    idx_cb.reserve_back(1);
+    const uint32_t idx_l1 = idx_cb.get_write_ptr();
+    volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_l1);
+
+    for (uint32_t tok = tok_start; tok < tok_start + tok_count; ++tok) {
+        // Q: H head-rows -> cb_q_rm.  Q is [1,H,S,576] row-major: row (h,tok) = page h*S+tok.
+        q_cb.reserve_back(H);
+        for (uint32_t h = 0; h < H; ++h) {
+            noc.async_read(q, q_cb, q_row_bytes, {.page_id = h * S + tok}, {.offset_bytes = h * q_row_bytes});
+        }
+        noc.async_read_barrier();
+        q_cb.push_back(H);
+
+        // indices row for this token (page = tok) -> idx_cb scratch
+        noc.async_read(idx, idx_cb, idx_row_bytes, {.page_id = tok}, {.offset_bytes = 0});
+        noc.async_read_barrier();
+
+        // binary-search the first sentinel -> nv (valid-key count); only ceil(nv/k_chunk) chunks are active.
+        uint32_t nv = topk;
+        {
+            uint32_t lo = 0, hi = topk;
+            while (lo < hi) {
+                const uint32_t mid = (lo + hi) >> 1;
+                if (idx_ptr[mid] == sentinel) {
+                    hi = mid;
+                } else {
+                    lo = mid + 1;
+                }
+            }
+            nv = lo == 0 ? 1 : lo;  // contract guarantees >=1 valid; guard anyway
+        }
+        const uint32_t n_active = (nv + k_chunk - 1) / k_chunk;
+
+        // hand the active chunk count + valid-key count to compute (it can't issue DRAM reads to derive
+        // them). nv lets compute place the boundary mask (which key tiles of the last chunk to -inf).
+        ctrl_cb.reserve_back(1);
+        {
+            volatile tt_l1_ptr uint32_t* cp = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(ctrl_cb.get_write_ptr());
+            cp[0] = n_active;
+            cp[1] = nv;
+        }
+        ctrl_cb.push_back(1);
+
+        for (uint32_t chunk = 0; chunk < n_active; ++chunk) {
+            const uint32_t base = chunk * k_chunk;
+            const uint32_t valid = (nv - base) < k_chunk ? (nv - base) : k_chunk;  // (0, k_chunk]
+
+            // K chunk rows -> cb_k_rm: read the `valid` real keys, zero-fill the sentinel suffix.
+            k_cb.reserve_back(k_chunk);
+            {
+                // Dual-NoC split gather: the K-row response data is the op's bottleneck (NoC-link bound, not
+                // DRAM-controller bound), so we spread it across BOTH NoCs. The reader (this NoC) gathers
+                // rows [half,valid); it hands the writer rows [0,half) via cb_kreq, and the writer gathers
+                // them on ITS NoC into the same reserved cb_k_rm L1 (shared on-core), then acks via cb_kack -- each
+                // link then carries half the gather traffic.
+                const uint32_t half = valid >> 1;
+                kreq_cb.reserve_back(1);
+                {
+                    volatile tt_l1_ptr uint32_t* rq =
+                        reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kreq_cb.get_write_ptr());
+                    rq[0] = base;
+                    rq[1] = half;
+                    rq[2] = (chunk == n_active - 1);  // writer ends the token's gather phase on the last chunk
+                }
+                kreq_cb.push_back(1);
+                // Reader gathers its half [half, valid) on its NoC (depth-4 trid ring, shared helper).
+                sparse_sdpa::trid_ring_gather(
+                    noc, kv, k_cb, idx_ptr, base, half, valid, k_row_bytes, kv_batch_page_offset);
+                kack_cb.wait_front(1);  // writer's half landed in cb_k_rm L1
+                kack_cb.pop_front(1);
+                // Zero-fill the sentinel suffix: masked-key scores become a defined 0 (compute adds -inf).
+                if (valid < k_chunk) {
+                    noc.async_write_zeros(k_cb, (k_chunk - valid) * k_row_bytes, {.offset_bytes = valid * k_row_bytes});
+                    noc.write_zeros_l1_barrier();
+                }
+            }
+            k_cb.push_back(k_chunk);
+
+            // Boundary mask: only the LAST active chunk can have sentinels. Its key tile that straddles
+            // `valid` (tile valid/32) needs cols >= valid%32 set to -inf; the tiles after it are fully
+            // masked (compute bcast-adds the persistent cb_neginf there). Build the single partial-boundary
+            // tile here only when the boundary lands mid-tile; row 0 only (compute adds it row-broadcast).
+            if (chunk == n_active - 1 && (valid % tt::constants::TILE_WIDTH) != 0) {
+                mask_part_cb.reserve_back(1);
+                {
+                    const uint32_t first_masked_col = valid % tt::constants::TILE_WIDTH;
+                    volatile tt_l1_ptr uint16_t* mask_tile =
+                        reinterpret_cast<volatile tt_l1_ptr uint16_t*>(mask_part_cb.get_write_ptr());
+                    // Write row 0 of the tile: cols [0,FACE_WIDTH) are face0 row 0 (offset = col); cols
+                    // [FACE_WIDTH,TILE_WIDTH) are face1 row 0 (offset = FACE_HW + col - FACE_WIDTH). Cols at or
+                    // past the boundary get -inf, the rest 0.
+                    for (uint32_t col = 0; col < tt::constants::TILE_WIDTH; ++col) {
+                        const uint32_t elem_off = (col < tt::constants::FACE_WIDTH)
+                                                      ? col
+                                                      : (tt::constants::FACE_HW + col - tt::constants::FACE_WIDTH);
+                        mask_tile[elem_off] = (col >= first_masked_col) ? neg_inf_bf16 : (uint16_t)0;
+                    }
+                }
+                mask_part_cb.push_back(1);
+            }
+        }
+    }
+}

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/dataflow/sparse_sdpa_writer.cpp
@@ -1,0 +1,114 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// sparse_sdpa writer: per token, drain the untilized [H, V_DIM] row-major block from compute (Sqt*vDHt
+// tile-sized pages, row-major bytes inside) and write each head-row to the ROW-MAJOR [1,H,S,V_DIM] output.
+// Also builds the three persistent compute-input tiles once at startup (the reader is busier): the reduce
+// identity scaler, the col-identity (row-sum finalize), and the all-(-inf) mask tile.
+// Uses the object-based NoC + circular-buffer APIs.
+
+#include <stdint.h>
+#include <tt-metalium/constants.hpp>  // tt::constants::TILE_WIDTH
+#include "api/dataflow/dataflow_api.h"
+#include "ttnn/cpp/ttnn/kernel_lib/reduce_helpers_dataflow.hpp"
+#include "ttnn/cpp/ttnn/kernel/dataflow/generate_bcast_scalar.hpp"  // generate_bcast_col_scalar
+#include <ttnn/operations/pool/device/kernels/experimental_device_api.hpp>
+#include "sparse_sdpa_gather.hpp"  // dual-NoC trid-ring gather helper (shared with the reader)
+
+constexpr uint32_t one_bf16_packed = 0x3F803F80u;  // bf16(1.0) double-packed; generate_bcast_col_scalar uses >>16
+constexpr uint16_t neg_inf_bf16 = 0xFF80u;
+
+void kernel_main() {
+    constexpr uint32_t H = get_compile_time_arg_val(0);
+    constexpr uint32_t S = get_compile_time_arg_val(1);
+    constexpr uint32_t vDHt = get_compile_time_arg_val(2);
+    // CB ids — passed by the factory (the SparseCB enum is the single source); order must match the
+    // factory's writer CB-arg block (compile args 3..6).
+    constexpr uint32_t cb_out_rm = get_compile_time_arg_val(3);
+    constexpr uint32_t cb_scale = get_compile_time_arg_val(4);
+    constexpr uint32_t cb_col_identity = get_compile_time_arg_val(5);
+    constexpr uint32_t cb_neginf = get_compile_time_arg_val(6);
+    constexpr uint32_t out_elem_bytes = get_compile_time_arg_val(7);  // bf16 (from the output tensor's dtype)
+    constexpr auto out_args = TensorAccessorArgs<8, 0>();
+    // kv carries a RUNTIME tensor shape (T dim in common runtime args), so its accessor spans both arg streams.
+    constexpr auto kv_args =
+        TensorAccessorArgs<out_args.next_compile_time_args_offset(), out_args.next_common_runtime_args_offset()>();
+
+    const uint32_t out_addr = get_arg_val<uint32_t>(0);
+    const uint32_t tok_start = get_arg_val<uint32_t>(1);
+    const uint32_t tok_count = get_arg_val<uint32_t>(2);
+    const uint32_t kv_addr = get_arg_val<uint32_t>(3);  // dual-NoC K-half gather
+    // Indexed KV cache: page offset (cache_batch_idx * T) selecting the cache's batch slot; 0 if not indexed.
+    const uint32_t kv_batch_page_offset = get_arg_val<uint32_t>(4);
+
+    constexpr uint32_t row_bytes = vDHt * tt::constants::TILE_WIDTH * out_elem_bytes;  // V_DIM bytes per head-row
+    constexpr uint32_t block_tiles = (H / tt::constants::TILE_HEIGHT) * vDHt;          // Sqt*vDHt: the [H,V_DIM] block
+
+    Noc noc;
+    experimental::CB out_cb(cb_out_rm);
+    const auto out = TensorAccessor(out_args, out_addr);
+    // Dual-NoC K gather: the writer co-gathers half of each K chunk on ITS NoC into the shared cb_k_rm L1
+    // (the reader owns the reserve/push; we fill rows [0,half) at the same write ptr). This spreads the
+    // K response-data load over both NoC links. Indices live in the reader's shared cb_idx
+    // scratch; the kv accessor + row size mirror the reader.
+    constexpr uint32_t k_row_bytes = K_DIM * KV_ELEM_BYTES;
+    const auto kv = TensorAccessor(kv_args, kv_addr);
+    experimental::CB k_cb(CB_K_RM), idx_cb(CB_IDX), kreq_cb(CB_KREQ), kack_cb(CB_KACK);
+    volatile tt_l1_ptr uint32_t* idx_ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(idx_cb.get_write_ptr());
+
+    // --- persistent compute-input tiles (built once; the reader is busier with the K gather) ---
+    // Reduce identity scaler (value 1.0; the softmax scale is applied in compute's exp).
+    dataflow_kernel_lib::calculate_and_prepare_reduce_scaler<
+        cb_scale,
+        ckernel::PoolType::MAX,
+        ckernel::ReduceDim::REDUCE_ROW,
+        /*reduce_factor=*/1,
+        /*compute_uses_reduce_tile=*/true>();
+
+    // Col-identity (column 0 = 1.0): compute matmul-reduces the partial row-sum against it to finalize the
+    // within-tile reduction in normalize_row_streaming.
+    generate_bcast_col_scalar(cb_col_identity, one_bf16_packed);
+
+    // All-(-inf) tile (row 0; compute bcast-adds it to fully-masked key tiles). Only row 0 matters for the
+    // row-broadcast add: cols 0-15 -> face0 row0 (offset c), cols 16-31 -> face1 row0 (offset 256+c).
+    {
+        experimental::CB neginf_cb(cb_neginf);
+        neginf_cb.reserve_back(1);
+        volatile tt_l1_ptr uint16_t* p = reinterpret_cast<volatile tt_l1_ptr uint16_t*>(neginf_cb.get_write_ptr());
+        for (uint32_t c = 0; c < 16; ++c) {
+            p[c] = neg_inf_bf16;        // face0 row 0 (cols 0-15)
+            p[256 + c] = neg_inf_bf16;  // face1 row 0 (cols 16-31)
+        }
+        neginf_cb.push_back(1);
+    }
+
+    for (uint32_t tok = tok_start; tok < tok_start + tok_count; ++tok) {
+        // K-gather phase: process this token's active chunks (reader signals per chunk; is_last ends the
+        // token). Gather rows [0,half) on the writer's NoC into the reserved cb_k_rm L1, then ack.
+        bool last = false;
+        while (!last) {
+            kreq_cb.wait_front(1);
+            uint32_t base, half;
+            {
+                volatile tt_l1_ptr uint32_t* rq =
+                    reinterpret_cast<volatile tt_l1_ptr uint32_t*>(kreq_cb.get_read_ptr());
+                base = rq[0];
+                half = rq[1];
+                last = rq[2] != 0;
+            }
+            kreq_cb.pop_front(1);
+            // Writer gathers its half [0, half) on its NoC (depth-4 trid ring, shared helper).
+            sparse_sdpa::trid_ring_gather(noc, kv, k_cb, idx_ptr, base, 0, half, k_row_bytes, kv_batch_page_offset);
+            kack_cb.reserve_back(1);
+            kack_cb.push_back(1);
+        }
+        out_cb.wait_front(block_tiles);  // one untilized [H, V_DIM] block
+        for (uint32_t h = 0; h < H; ++h) {
+            // row h (head h) at CB read-ptr byte offset h*row_bytes; DRAM page = h*S + tok.
+            noc.async_write(out_cb, out, row_bytes, {.offset_bytes = h * row_bytes}, {.page_id = h * S + tok});
+        }
+        noc.async_write_barrier();
+        out_cb.pop_front(block_tiles);
+    }
+}

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
@@ -159,7 +159,8 @@ SparseSDPAOperation::spec_return_value_t SparseSDPAOperation::compute_output_spe
     // noc writes, so no caller-supplied memory_config is exposed (it could only ever be this).
     const tt::tt_metal::MemoryConfig out_mem{
         tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
-    return TensorSpec(shape, TensorLayout(t.q.dtype(), tt::tt_metal::PageConfig(Layout::ROW_MAJOR), out_mem));
+    return TensorSpec(
+        shape, tt::tt_metal::TensorLayout(t.q.dtype(), tt::tt_metal::PageConfig(Layout::ROW_MAJOR), out_mem));
 }
 
 SparseSDPAOperation::tensor_return_value_t SparseSDPAOperation::create_output_tensors(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
@@ -16,7 +16,8 @@ namespace {
 // All input invariants the program hash does NOT key on, so they can vary while hitting the same cached
 // program and must be re-checked on EVERY dispatch (miss AND hit). The hash keys only on q/indices shape+dtype
 // and kv dtype+memory_config — NOT on tensor layout, padding, q/indices buffer type/sharding, the kv logical
-// shape (its T rides on the accessor's runtime args), cache_batch_idx (a dynamic runtime arg), or device
+// shape (its T rides on the kv TensorAccessor's RuntimeTensorShape runtime metadata, not a kernel scalar),
+// cache_batch_idx (a dynamic runtime arg), or device
 // placement. The accessors assume ROW_MAJOR, unpadded, DRAM, interleaved q/indices, so a cache hit with a
 // tiled/padded/L1/sharded/off-device tensor would otherwise run on wrong assumptions. K_DIM comes from q,
 // whose shape IS hashed, so it is pinned. Shared by validate_on_program_cache_miss and _hit.
@@ -216,14 +217,24 @@ std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAOperation::get_dynamic_ru
     const uint32_t kv_batch_page_offset = attrs.cache_batch_idx.value() * T;
     const tt::tt_metal::CoreCoord grid = t.q.device()->compute_with_storage_grid_size();
     const uint32_t num_cores = grid.x * grid.y;
-    constexpr uint32_t kReaderKernelIdx = 0, kWriterKernelIdx = 1;
-    constexpr uint32_t kReaderBatchOffsetArg = 5, kWriterBatchOffsetArg = 4;
+    // Arg slots/kernel indices are defined once in sparse_sdpa_rt (header), shared with the program factory's
+    // emit order so a reorder can't silently desync this re-apply path from the factory.
     std::vector<tt::tt_metal::DynamicRuntimeArg> args;
     args.reserve(2 * num_cores);
     for (uint32_t i = 0; i < num_cores; ++i) {
         const tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
-        args.push_back({kReaderKernelIdx, core, kReaderBatchOffsetArg, kv_batch_page_offset, /*is_common=*/false});
-        args.push_back({kWriterKernelIdx, core, kWriterBatchOffsetArg, kv_batch_page_offset, /*is_common=*/false});
+        args.push_back(
+            {sparse_sdpa_rt::kReaderKernelIdx,
+             core,
+             sparse_sdpa_rt::kReaderBatchOffsetArg,
+             kv_batch_page_offset,
+             /*is_common=*/false});
+        args.push_back(
+            {sparse_sdpa_rt::kWriterKernelIdx,
+             core,
+             sparse_sdpa_rt::kWriterBatchOffsetArg,
+             kv_batch_page_offset,
+             /*is_common=*/false});
     }
     return args;
 }

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.cpp
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp"
+#include "ttnn/device_operation.hpp"
+#include "ttnn/operation.hpp"
+#include "ttnn/device.hpp"
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <bit>
+
+namespace ttnn::prim {
+
+namespace {
+// All input invariants the program hash does NOT key on, so they can vary while hitting the same cached
+// program and must be re-checked on EVERY dispatch (miss AND hit). The hash keys only on q/indices shape+dtype
+// and kv dtype+memory_config — NOT on tensor layout, padding, q/indices buffer type/sharding, the kv logical
+// shape (its T rides on the accessor's runtime args), cache_batch_idx (a dynamic runtime arg), or device
+// placement. The accessors assume ROW_MAJOR, unpadded, DRAM, interleaved q/indices, so a cache hit with a
+// tiled/padded/L1/sharded/off-device tensor would otherwise run on wrong assumptions. K_DIM comes from q,
+// whose shape IS hashed, so it is pinned. Shared by validate_on_program_cache_miss and _hit.
+void validate_non_hashed(const SparseSDPAParams& attrs, const SparseSDPAInputs& t) {
+    const auto& q = t.q;
+    const auto& kv = t.kv;
+    const auto& idx = t.indices;
+    TT_FATAL(
+        q.device() == kv.device() && q.device() == idx.device(), "sparse_sdpa: all inputs must be on the same device");
+    // q and indices: ROW_MAJOR, DRAM, interleaved, unpadded (row-major paged-accessor assumptions).
+    for (const Tensor* tp : {&q, &idx}) {
+        TT_FATAL(tp->layout() == Layout::ROW_MAJOR, "sparse_sdpa q/indices must be ROW_MAJOR");
+        TT_FATAL(tp->memory_config().buffer_type() == BufferType::DRAM, "sparse_sdpa q/indices must be in DRAM");
+        TT_FATAL(!tp->memory_config().is_sharded(), "sparse_sdpa q/indices must be interleaved");
+        TT_FATAL(tp->padded_shape() == tp->logical_shape(), "sparse_sdpa q/indices must not be padded");
+    }
+    // kv: ROW_MAJOR and unpadded; may be interleaved OR ND-sharded DRAM (the accessor resolves the per-page
+    // bank/shard either way — kv's DRAM/shard layout is pinned via the hashed kv.memory_config(), its
+    // ROW_MAJOR layout and padding are not).
+    TT_FATAL(kv.layout() == Layout::ROW_MAJOR, "sparse_sdpa kv must be ROW_MAJOR");
+    TT_FATAL(kv.padded_shape() == kv.logical_shape(), "sparse_sdpa kv must not be padded");
+    const uint32_t K_DIM = q.logical_shape()[3];
+    const auto kvs = kv.logical_shape();
+    // kv is [B,1,T,K_DIM]: B == 1 normally; when indexed (cache_batch_idx set) B is the cache's batch slots
+    // and cache_batch_idx selects one. q is always batch-1, so the selected slot serves the whole query.
+    TT_FATAL(
+        kvs.rank() == 4 && kvs[1] == 1 && kvs[3] == K_DIM,
+        "kv must be [B,1,T,K_DIM] with K_DIM matching q ({})",
+        K_DIM);
+    TT_FATAL(kvs[2] > 0, "kv T (cache length) must be > 0");
+    const uint32_t B = kvs[0];
+    if (attrs.cache_batch_idx.has_value()) {
+        TT_FATAL(
+            attrs.cache_batch_idx.value() < B,
+            "cache_batch_idx ({}) must be < kv batch slots ({})",
+            attrs.cache_batch_idx.value(),
+            B);
+    } else {
+        TT_FATAL(B == 1, "kv batch must be 1 unless cache_batch_idx is set (got {})", B);
+    }
+}
+}  // namespace
+
+void SparseSDPAOperation::validate_on_program_cache_hit(const SparseSDPAParams& attrs, const SparseSDPAInputs& t) {
+    validate_non_hashed(attrs, t);
+}
+
+void SparseSDPAOperation::validate_on_program_cache_miss(const SparseSDPAParams& attrs, const SparseSDPAInputs& t) {
+    const auto& q = t.q;
+    const auto& kv = t.kv;
+    const auto& idx = t.indices;
+
+    TT_FATAL(tt::tt_metal::hal::get_arch() == tt::ARCH::BLACKHOLE, "sparse_sdpa is Blackhole-only");
+
+    // dtypes. q and kv may each be bf16 or fp8_e4m3 — fp8 halves that input's K/Q-gather bytes; the reader
+    // gathers it row-major and compute tilizes fp8 -> bfp8_b cb_*_in (near-lossless, also halves the L1).
+    // fp8 inputs require fp32_dest_acc_en (the unpack-to-dest path); enforced below.
+    const bool kv_is_fp8 = (kv.dtype() == DataType::FP8_E4M3);
+    const bool q_is_fp8 = (q.dtype() == DataType::FP8_E4M3);
+    TT_FATAL(q.dtype() == DataType::BFLOAT16 || q_is_fp8, "q must be bf16 or fp8_e4m3");
+    TT_FATAL(kv.dtype() == DataType::BFLOAT16 || kv_is_fp8, "kv must be bf16 or fp8_e4m3");
+    TT_FATAL(idx.dtype() == DataType::UINT32, "indices must be uint32");
+
+    // kv DRAM residency is keyed by the hash (kv.memory_config()), so it is checked on miss only. The
+    // remaining layout/memory/padding/device invariants (q/indices layout+memory+padding, kv layout+padding,
+    // same-device) are NOT hashed and are checked in validate_non_hashed (called below, run on miss AND hit).
+    TT_FATAL(kv.memory_config().buffer_type() == BufferType::DRAM, "sparse_sdpa kv must be in DRAM");
+
+    const auto qs = q.logical_shape();
+    const auto is = idx.logical_shape();
+    TT_FATAL(qs.rank() == 4 && qs[0] == 1, "q must be [1,H,S,K_DIM]");
+    const uint32_t H = qs[1];
+    const uint32_t S = qs[2];
+    const uint32_t K_DIM = qs[3];  // head dim, taken from the tensor (not hardcoded)
+    // H heads map to H/TILE_HEIGHT query tile-rows (compute processes them in DST-sized groups, so DST
+    // doesn't cap H). The upper bound is the per-core L1 budget — the flash state (out/max/sum) and Q both
+    // scale with H — so a too-large H simply fails CB allocation at program creation rather than here.
+    constexpr uint32_t tile_h = tt::constants::TILE_HEIGHT;
+    TT_FATAL(H % tile_h == 0 && H >= tile_h, "sparse_sdpa: H must be a multiple of {} (got {})", tile_h, H);
+    // All non-hashed invariants (q/indices/kv layout+memory+padding, kv shape, cache_batch_idx, same-device).
+    // kv may be oversized: a persistent max-size cache whose logical T far exceeds the keys any query attends
+    // to. No valid-length bound is needed — reads are index-driven (indices < populated length, sentinels mark
+    // unused slots), so the unpopulated suffix is never addressed.
+    validate_non_hashed(attrs, t);
+    TT_FATAL(is.rank() == 4 && is[0] == 1 && is[1] == 1 && is[2] == S, "indices must be [1,1,S,TOPK]");
+    const uint32_t TOPK = is[3];
+    TT_FATAL(S > 0 && TOPK > 0, "S/TOPK must be > 0");
+
+    // V is the leading v_dim cols of the K_DIM-wide KV cache.
+    TT_FATAL(attrs.v_dim > 0 && attrs.v_dim <= K_DIM, "v_dim must be in (0, K_DIM={}] (got {})", K_DIM, attrs.v_dim);
+    TT_FATAL(
+        attrs.v_dim % tt::constants::TILE_WIDTH == 0,
+        "v_dim must be a multiple of {} (got {})",
+        tt::constants::TILE_WIDTH,
+        attrs.v_dim);
+    TT_FATAL(
+        K_DIM % tt::constants::TILE_WIDTH == 0,
+        "K_DIM (q/kv last dim) must be a multiple of {} (got {})",
+        tt::constants::TILE_WIDTH,
+        K_DIM);
+
+    // k_chunk_size: multiple of the tile width (it tiles the key axis), divides TOPK
+    constexpr uint32_t tile_w = tt::constants::TILE_WIDTH;
+    TT_FATAL(
+        attrs.k_chunk_size >= tile_w && attrs.k_chunk_size % tile_w == 0,
+        "k_chunk_size must be a multiple of {} (got {})",
+        tile_w,
+        attrs.k_chunk_size);
+    TT_FATAL(TOPK % attrs.k_chunk_size == 0, "k_chunk_size must divide TOPK");
+    TT_FATAL(attrs.scale > 0.0f, "scale must be > 0");
+
+    // Row-byte alignment: each Q/K/index/output row is a DRAM page the reader DMAs from / the writer DMAs
+    // to (and tensors are unpadded, so the page == one row). The row byte count must be a multiple of the
+    // DRAM access alignment; that also covers the in-L1 row offsets (DRAM alignment >= L1 alignment).
+    // Each Q/K row is one DRAM page in its native dtype (fp8 -> 1 byte, bf16 -> 2). The output dtype
+    // matches q (compute_output_specs), so its row width uses q's element size.
+    const uint32_t dram_align = tt::tt_metal::hal::get_dram_alignment();
+    TT_FATAL((K_DIM * q.element_size()) % dram_align == 0, "Q row bytes must be {}B aligned", dram_align);
+    TT_FATAL((K_DIM * kv.element_size()) % dram_align == 0, "K row bytes must be {}B aligned", dram_align);
+    TT_FATAL((TOPK * idx.element_size()) % dram_align == 0, "indices row bytes must be {}B aligned", dram_align);
+    TT_FATAL((attrs.v_dim * q.element_size()) % dram_align == 0, "output row bytes must be {}B aligned", dram_align);
+
+    // fp8 q/kv tilizes through a 32-bit dest accumulator (fp8 unpacks to fp32 in DEST, packs to bf16/bfp8),
+    // so it requires fp32_dest_acc_en. The op factory defaults it on for fp8 inputs (see sparse_sdpa.cpp).
+    // (fp32_dest_acc_en is otherwise free: the compute kernel processes the H/TILE_HEIGHT query tile-rows in
+    // DST-sized groups, so DST never caps H — only per-core L1 does.)
+    TT_FATAL(
+        !(kv_is_fp8 || q_is_fp8) || get_fp32_dest_acc_en(attrs.compute_kernel_config),
+        "fp8 q/kv requires fp32_dest_acc_en=true (32-bit dest for the fp8 tilize)");
+}
+
+SparseSDPAOperation::spec_return_value_t SparseSDPAOperation::compute_output_specs(
+    const SparseSDPAParams& attrs, const SparseSDPAInputs& t) {
+    auto shape = t.q.logical_shape();  // [1, H, S, K_DIM]
+    shape[3] = attrs.v_dim;            // [1, H, S, v_dim]
+    // Output dtype matches q (bf16 -> bf16, fp8_e4m3 -> fp8_e4m3): the final untilize packs the bf16
+    // accumulator to the output dtype (fp8 is a regular float8, not block-float, so it untilizes fine).
+    // The output is always DRAM-interleaved ROW_MAJOR — the writer drains it with per-head-row paged
+    // noc writes, so no caller-supplied memory_config is exposed (it could only ever be this).
+    const tt::tt_metal::MemoryConfig out_mem{
+        tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    return TensorSpec(shape, TensorLayout(t.q.dtype(), tt::tt_metal::PageConfig(Layout::ROW_MAJOR), out_mem));
+}
+
+SparseSDPAOperation::tensor_return_value_t SparseSDPAOperation::create_output_tensors(
+    const SparseSDPAParams& attrs, const SparseSDPAInputs& t) {
+    return create_device_tensor(compute_output_specs(attrs, t), t.q.device());
+}
+
+ttsl::hash::hash_t SparseSDPAOperation::compute_program_hash(const SparseSDPAParams& attrs, const SparseSDPAInputs& t) {
+    // dtypes + compute_kernel_config MUST be in the hash: q/kv may be bf16 or fp8_e4m3 (different CB
+    // formats, row byte widths, fp32-dest/unpack modes, and output dtype), and fp32_dest_acc_en changes
+    // the program. Same-shape-different-dtype (or -config) calls otherwise alias to one program and the
+    // second silently reuses the first's kernel (wrong results).
+    //
+    // kv's shape is hashed ONLY when kv is sharded. For an INTERLEAVED kv the per-page address is
+    // shape-independent (just page_id, page_size, num_banks), so T rides on the accessor's common runtime
+    // args and may change without recompiling. For a SHARDED kv the per-page bank mapping derives from the
+    // tensor shape (the shard-grid strides), which is baked into the accessor at create time and is NOT
+    // re-emitted on a cache-hit fast path — so a sharded kv MUST recompile when its shape changes, else a hit
+    // would reuse stale strides and read the wrong banks. (K_DIM is pinned via q's hashed shape regardless.)
+    return tt::tt_metal::operation::hash_operation<SparseSDPAOperation>(
+        std::bit_cast<uint32_t>(attrs.scale),
+        attrs.v_dim,
+        attrs.k_chunk_size,
+        attrs.compute_kernel_config,
+        t.q.logical_shape(),
+        t.q.dtype(),
+        t.kv.dtype(),
+        // kv.memory_config(): an ND-sharded kv produces different TensorAccessor compile-time args than an
+        // interleaved one, so they must be distinct programs.
+        t.kv.memory_config(),
+        // kv.logical_shape() only when sharded (see above); a fixed sentinel otherwise so interleaved T does
+        // not recompile.
+        t.kv.memory_config().is_sharded() ? t.kv.logical_shape() : tt::tt_metal::Shape{},
+        // Only whether kv is indexed (not which slot): cache_batch_idx's VALUE is a dynamic runtime arg
+        // (see get_dynamic_runtime_args), so indexing into a different slot reuses the same program.
+        attrs.has_indexed_kv_cache(),
+        t.indices.logical_shape(),
+        t.indices.dtype());
+}
+
+std::vector<tt::tt_metal::DynamicRuntimeArg> SparseSDPAOperation::get_dynamic_runtime_args(
+    const SparseSDPAParams& attrs,
+    const SparseSDPAInputs& t,
+    Tensor& /*output*/,
+    const std::optional<ttnn::MeshCoordinate>& /*mesh_dispatch_coordinate*/) {
+    // Non-indexed: the gather page offset is the baked 0 from create_descriptor (and the non-indexed program
+    // is never shared with an indexed one — has_indexed_kv_cache() is in the hash — so nothing to re-apply).
+    if (!attrs.has_indexed_kv_cache()) {
+        return {};
+    }
+    // Indexed: re-apply kv_batch_page_offset = cache_batch_idx * T to the reader (kernel 0, arg 5) and writer
+    // (kernel 1, arg 4) on every dispatch. The value is the same on every core but the slot is per-core, so
+    // emit one entry per core per kernel. The core partition mirrors the factory exactly.
+    const uint32_t T = t.kv.logical_shape()[2];
+    const uint32_t kv_batch_page_offset = attrs.cache_batch_idx.value() * T;
+    const tt::tt_metal::CoreCoord grid = t.q.device()->compute_with_storage_grid_size();
+    const uint32_t num_cores = grid.x * grid.y;
+    constexpr uint32_t kReaderKernelIdx = 0, kWriterKernelIdx = 1;
+    constexpr uint32_t kReaderBatchOffsetArg = 5, kWriterBatchOffsetArg = 4;
+    std::vector<tt::tt_metal::DynamicRuntimeArg> args;
+    args.reserve(2 * num_cores);
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        const tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
+        args.push_back({kReaderKernelIdx, core, kReaderBatchOffsetArg, kv_batch_page_offset, /*is_common=*/false});
+        args.push_back({kWriterKernelIdx, core, kWriterBatchOffsetArg, kv_batch_page_offset, /*is_common=*/false});
+    }
+    return args;
+}
+
+Tensor sparse_sdpa(
+    const Tensor& q,
+    const Tensor& kv,
+    const Tensor& indices,
+    float scale,
+    uint32_t v_dim,
+    uint32_t k_chunk_size,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config,
+    std::optional<uint32_t> cache_batch_idx) {
+    using OperationType = ttnn::prim::SparseSDPAOperation;
+    return ttnn::device_operation::launch<OperationType>(
+        OperationType::operation_attributes_t{
+            .scale = scale,
+            .v_dim = v_dim,
+            .k_chunk_size = k_chunk_size,
+            .compute_kernel_config = compute_kernel_config,
+            .cache_batch_idx = cache_batch_idx,
+        },
+        OperationType::tensor_args_t{
+            .q = q,
+            .kv = kv,
+            .indices = indices,
+        });
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
@@ -17,6 +17,17 @@
 
 namespace ttnn::prim {
 
+// Reader/writer runtime-arg layout — single source of truth shared by the program factory (which EMITS the
+// args in create_descriptor) and get_dynamic_runtime_args (which RE-APPLIES the indexed-cache page offset to
+// the cached program). kv_batch_page_offset is the LAST positional arg of each kernel's list; if that order
+// changes in the factory, update these indices here, or the dynamic re-apply silently writes the wrong slot.
+namespace sparse_sdpa_rt {
+inline constexpr uint32_t kReaderKernelIdx = 0;
+inline constexpr uint32_t kWriterKernelIdx = 1;
+inline constexpr uint32_t kReaderBatchOffsetArg = 5;  // {q, kv, idx, tok_start, tok_count, [kv_batch_page_offset]}
+inline constexpr uint32_t kWriterBatchOffsetArg = 4;  // {out, tok_start, tok_count, kv, [kv_batch_page_offset]}
+}  // namespace sparse_sdpa_rt
+
 struct SparseSDPAOperation {
     using operation_attributes_t = SparseSDPAParams;
     using tensor_args_t = SparseSDPAInputs;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
@@ -36,9 +36,7 @@ struct SparseSDPAOperation {
 
     struct SparseSDPAProgramFactory {
         static tt::tt_metal::ProgramDescriptor create_descriptor(
-            const operation_attributes_t& operation_attributes,
-            const tensor_args_t& tensor_args,
-            tensor_return_value_t& tensor_return_value);
+            const operation_attributes_t& attrs, const tensor_args_t& t, tensor_return_value_t& output);
     };
 
     using program_factory_t = std::variant<SparseSDPAProgramFactory>;

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include "ttnn/operations/core/core.hpp"
+#include <optional>
+#include <variant>
+#include <vector>
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/experimental/program_descriptor_patching.hpp>
+#include "ttnn/distributed/types.hpp"
+
+namespace ttnn::prim {
+
+struct SparseSDPAOperation {
+    using operation_attributes_t = SparseSDPAParams;
+    using tensor_args_t = SparseSDPAInputs;
+    using spec_return_value_t = TensorSpec;
+    using tensor_return_value_t = Tensor;
+
+    struct SparseSDPAProgramFactory {
+        static tt::tt_metal::ProgramDescriptor create_descriptor(
+            const operation_attributes_t& operation_attributes,
+            const tensor_args_t& tensor_args,
+            tensor_return_value_t& tensor_return_value);
+    };
+
+    using program_factory_t = std::variant<SparseSDPAProgramFactory>;
+
+    static void validate_on_program_cache_miss(const operation_attributes_t&, const tensor_args_t&);
+    // Re-validates only the inputs the program hash does not key on (so they can vary on a cache hit): the kv
+    // shape/layout (its length T rides on runtime args) and cache_batch_idx (a dynamic runtime arg). All else
+    // is pinned by the hash, so a hit already passed full validation at miss time.
+    static void validate_on_program_cache_hit(const operation_attributes_t&, const tensor_args_t&);
+    static spec_return_value_t compute_output_specs(const operation_attributes_t&, const tensor_args_t&);
+    static tensor_return_value_t create_output_tensors(const operation_attributes_t&, const tensor_args_t&);
+    static ttsl::hash::hash_t compute_program_hash(const operation_attributes_t&, const tensor_args_t&);
+
+    // cache_batch_idx is excluded from the program hash, so it must be re-applied to the cached program on
+    // every dispatch (the non-Buffer analog of buffer-address patching). Returns the per-core gather page
+    // offset (cache_batch_idx * T) for the reader/writer when indexed; empty otherwise.
+    static std::vector<tt::tt_metal::DynamicRuntimeArg> get_dynamic_runtime_args(
+        const operation_attributes_t& attrs,
+        const tensor_args_t& tensor_args,
+        tensor_return_value_t& output,
+        const std::optional<ttnn::MeshCoordinate>& mesh_dispatch_coordinate = std::nullopt);
+};
+
+Tensor sparse_sdpa(
+    const Tensor& q,
+    const Tensor& kv,
+    const Tensor& indices,
+    float scale,
+    uint32_t v_dim,
+    uint32_t k_chunk_size,
+    ttnn::DeviceComputeKernelConfig compute_kernel_config,
+    std::optional<uint32_t> cache_batch_idx = std::nullopt);
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
@@ -1,0 +1,32 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <optional>
+
+namespace ttnn::prim {
+
+// Sparse MLA prefill (DeepSeek DSA).
+struct SparseSDPAParams {
+    float scale = 1.0f;  // compile-time (folded into the program hash)
+    uint32_t v_dim;      // width of V (= leading v_dim cols of the K_DIM-wide KV cache); the output width
+    uint32_t k_chunk_size = 128;
+    DeviceComputeKernelConfig compute_kernel_config;
+    // Indexed KV cache: when set, kv is a [B,1,T,K_DIM] shared cache and this selects the batch slot to
+    // attend to (the gather page ids are offset by cache_batch_idx * T). It is a DYNAMIC runtime arg
+    // (excluded from the program hash, re-applied every dispatch), so changing it does NOT recompile.
+    std::optional<uint32_t> cache_batch_idx = std::nullopt;
+    bool has_indexed_kv_cache() const { return cache_batch_idx.has_value(); }
+};
+
+struct SparseSDPAInputs {
+    Tensor q;        // [1, H, S, K_DIM] bf16 ROW_MAJOR  (K_DIM = head dim, e.g. 576)
+    Tensor kv;       // [1, 1, T, K_DIM] bf16 ROW_MAJOR  (or [B,1,T,K_DIM] when indexed; may be ND-sharded DRAM)
+    Tensor indices;  // [1, 1, S, TOPK] uint32 ROW_MAJOR  (0xFFFFFFFF = masked)
+};
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation_types.hpp
@@ -24,8 +24,8 @@ struct SparseSDPAParams {
 };
 
 struct SparseSDPAInputs {
-    Tensor q;        // [1, H, S, K_DIM] bf16 ROW_MAJOR  (K_DIM = head dim, e.g. 576)
-    Tensor kv;       // [1, 1, T, K_DIM] bf16 ROW_MAJOR  (or [B,1,T,K_DIM] when indexed; may be ND-sharded DRAM)
+    Tensor q;   // [1, H, S, K_DIM] bf16/fp8_e4m3 ROW_MAJOR  (K_DIM = head dim, e.g. 576)
+    Tensor kv;  // [1, 1, T, K_DIM] bf16/fp8_e4m3 ROW_MAJOR  (or [B,1,T,K_DIM] when indexed; may be ND-sharded DRAM)
     Tensor indices;  // [1, 1, S, TOPK] uint32 ROW_MAJOR  (0xFFFFFFFF = masked)
 };
 

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
@@ -1,0 +1,298 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp"
+#include <tt-metalium/buffer.hpp>
+#include <tt-metalium/circular_buffer_constants.h>  // NUM_CIRCULAR_BUFFERS
+#include <tt-metalium/constants.hpp>
+#include <tt-metalium/hal.hpp>
+#include <tt-metalium/program_descriptors.hpp>
+#include <tt-metalium/tensor_accessor_args.hpp>
+#include <bit>
+#include <map>
+#include <string>
+
+namespace ttnn::prim {
+
+// Fixed CB id convention shared with the kernels.
+// Flash/online-softmax keeps ping-pong (prev/cur) buffers for the running max, sum, and output.
+enum SparseCB : uint32_t {
+    cb_q_rm = 0,   // Q rows (row-major, reader -> compute tilize)
+    cb_q_in,       // Q tiled [Sqt, DHt]
+    cb_k_rm,       // K chunk rows (row-major)
+    cb_k_in,       // K tiled [Skt, DHt] (read directly by QK via within-tile transpose and by PV)
+    cb_neginf,     // all-(-inf) tile (writer-built once): bcast-added to fully-masked key tiles
+    cb_mask_part,  // per-token partial-boundary mask tile (row 0: -inf for cols >= valid%32)
+    cb_scale,      // reduce identity scaler (1 tile)
+    cb_qk_im,      // scores [Sqt, Skt]
+    cb_max_a,      // running max ping-pong [Sqt, 1]
+    cb_max_b,
+    cb_sum_a,  // running sum ping-pong [Sqt, 1]
+    cb_sum_b,
+    cb_out_a,  // running out ping-pong [Sqt, vDHt] (single-buffered for L1 accumulation)
+    cb_out_b,
+    cb_corr,           // exp(prev_max - cur_max) correction [Sqt, 1]
+    cb_out_im,         // fixed pre-untilize copy of the final out [Sqt, vDHt]
+    cb_out_rm,         // untilized row-major out (compute -> writer)
+    cb_idx,            // reader-internal: one token's index row (uint32)
+    cb_ctrl,           // reader -> compute: [active chunk count (=ceil(valid_keys/k_chunk)), valid_keys] per token
+    cb_col_identity,   // ones-in-col0 (writer-built): finalizes the partial row-sum via matmul_reduce
+    cb_recip_scratch,  // 1-tile reciprocal scratch for normalize_row_streaming
+    cb_kreq,           // reader->writer K-gather handoff {base, half, is_last} (dual-NoC split)
+    cb_kack,           // writer->reader ack that its half of the chunk landed in cb_k_rm
+    cb_count
+};
+
+tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::create_descriptor(
+    const SparseSDPAParams& attrs, const SparseSDPAInputs& t, Tensor& output) {
+    tt::tt_metal::ProgramDescriptor desc;
+
+    const uint32_t H = t.q.logical_shape()[1];  // head count, from the tensor (any multiple of TILE_HEIGHT)
+    const uint32_t S = t.q.logical_shape()[2];
+    const uint32_t topk = t.indices.logical_shape()[3];
+    const uint32_t k_dim = t.q.logical_shape()[3];  // head dim, from the tensor (e.g. 576)
+    const uint32_t v_dim = attrs.v_dim;             // V width (op arg; e.g. 512)
+
+    const uint32_t DHt = k_dim / tt::constants::TILE_WIDTH;
+    const uint32_t vDHt = v_dim / tt::constants::TILE_WIDTH;
+    const uint32_t k_chunk = attrs.k_chunk_size;
+    const uint32_t Skt = k_chunk / tt::constants::TILE_WIDTH;  // tiles per chunk along keys
+    const uint32_t Sqt = H / tt::constants::TILE_HEIGHT;       // query tile-rows (32 heads each)
+    const uint32_t scale_packed = std::bit_cast<uint32_t>(attrs.scale);
+
+    // Element sizes come from the tensors (no hardcoded byte counts); passed to the kernels as compile args.
+    const uint32_t q_elem_bytes = t.q.element_size();          // bf16 -> 2
+    const uint32_t kv_elem_bytes = t.kv.element_size();        // bf16 -> 2, fp8_e4m3 -> 1
+    const uint32_t idx_elem_bytes = t.indices.element_size();  // uint32 -> 4
+    const uint32_t out_elem_bytes = output.element_size();     // bf16 -> 2
+    const uint32_t q_row_bytes = k_dim * q_elem_bytes;         // 1152
+    const uint32_t k_row_bytes = k_dim * kv_elem_bytes;        // 1152 (bf16) or 576 (fp8)
+    constexpr tt::DataFormat bf = tt::DataFormat::Float16_b;
+    constexpr uint32_t tile_bytes = tt::tile_size(bf);  // 2048
+    // cb_k_rm holds the row-major K in its native dtype (fp8 or bf16); compute tilizes it into cb_k_in.
+    // For fp8 K, cb_k_in is bfp8_b (fp8->bfp8 is near-lossless): it halves cb_k_in's L1 footprint vs bf16
+    // and both matmuls read it directly (the HW within-face transpose works on block-float). The compute
+    // kernel restores the bf16 unpack srcA / pack formats after each per-chunk K tilize (see comments there).
+    const tt::DataFormat k_rm_df = tt::tt_metal::datatype_to_dataformat_converter(t.kv.dtype());
+    const bool kv_is_fp8 = (k_rm_df == tt::DataFormat::Fp8_e4m3);
+    // When K arrives as fp8, tilize it into bfp8_b cb_k_in (fp8->bfp8 is near-lossless, PCC 0.99998) to
+    // halve cb_k_in's L1 footprint and cheapen both matmuls. bf16 K keeps bf16 cb_k_in (no precision loss).
+    const tt::DataFormat k_in_df = kv_is_fp8 ? tt::DataFormat::Bfp8_b : bf;
+    const uint32_t k_in_tile_bytes = tt::tile_size(k_in_df);
+    // Q is handled symmetrically: fp8 Q -> bfp8_b cb_q_in (halves cb_q_in L1, which scales with H), bf16
+    // Q -> bf16 cb_q_in. Q is read row-major in its native dtype (cb_q_rm) and tilized into cb_q_in.
+    const tt::DataFormat q_rm_df = tt::tt_metal::datatype_to_dataformat_converter(t.q.dtype());
+    const bool q_is_fp8 = (q_rm_df == tt::DataFormat::Fp8_e4m3);
+    const tt::DataFormat q_in_df = q_is_fp8 ? tt::DataFormat::Bfp8_b : bf;
+    const uint32_t q_in_tile_bytes = tt::tile_size(q_in_df);
+    // Output dtype matches q (compute_output_specs). The final untilize packs the bf16 accumulator
+    // (cb_out_im) to this format in cb_out_rm — fp8_e4m3 is a regular float8, not block-float, so it
+    // untilizes fine. cb_out_rm's tile-sized pages use the output format's tile size (fp8 -> 1024, bf16 -> 2048).
+    const tt::DataFormat out_df = tt::tt_metal::datatype_to_dataformat_converter(output.dtype());
+    const uint32_t out_tile_bytes = tt::tile_size(out_df);
+
+    auto* device = t.q.device();
+    tt::tt_metal::CoreCoord grid = device->compute_with_storage_grid_size();
+    auto core_grid = tt::tt_metal::CoreRangeSet(tt::tt_metal::CoreRange({0, 0}, {grid.x - 1, grid.y - 1}));
+    const uint32_t num_cores = grid.x * grid.y;
+    const uint32_t base = S / num_cores;
+    const uint32_t extra = S % num_cores;
+
+    // ---- CBs (fixed order = SparseCB enum) ----
+    const auto cb = [&](uint32_t page_size, uint32_t num_pages, tt::DataFormat df) {
+        const uint32_t idx = desc.cbs.size();
+        desc.cbs.push_back(tt::tt_metal::CBDescriptor{
+            .total_size = page_size * num_pages,
+            .core_ranges = core_grid,
+            .format_descriptors = {{tt::tt_metal::CBFormatDescriptor{
+                .buffer_index = static_cast<uint8_t>(idx), .data_format = df, .page_size = page_size}}},
+        });
+    };
+    cb(q_row_bytes, H, q_rm_df);              // cb_q_rm : H row-sticks (native Q dtype: fp8 or bf16)
+    cb(q_in_tile_bytes, Sqt * DHt, q_in_df);  // cb_q_in : [Sqt,DHt] (bfp8 when Q is fp8)
+    cb(k_row_bytes, k_chunk, k_rm_df);        // cb_k_rm : k_chunk row-sticks (native K dtype: fp8 or bf16)
+    cb(k_in_tile_bytes, Skt * DHt, k_in_df);  // cb_k_in : [Skt,DHt] (consumed by both QK and PV; no Kᵀ/V copies)
+    cb(tile_bytes, 1, bf);                    // cb_neginf : all-(-inf) tile (persistent)
+    cb(tile_bytes, 1, bf);                    // cb_mask_part : per-token partial-boundary mask tile
+    cb(tile_bytes, 1, bf);                    // cb_scale
+    cb(tile_bytes, Sqt * Skt, bf);            // cb_qk_im : [Sqt,Skt]
+    cb(tile_bytes, Sqt, bf);                  // cb_max_a
+    cb(tile_bytes, Sqt, bf);                  // cb_max_b
+    cb(tile_bytes, Sqt, bf);                  // cb_sum_a
+    cb(tile_bytes, Sqt, bf);                  // cb_sum_b
+    cb(tile_bytes, Sqt * vDHt, bf);           // cb_out_a : [Sqt,vDHt] (single-buffered for L1 acc)
+    cb(tile_bytes, Sqt * vDHt, bf);           // cb_out_b
+    cb(tile_bytes, Sqt, bf);                  // cb_corr : [Sqt,1]
+    cb(tile_bytes, Sqt * vDHt, bf);           // cb_out_im : [Sqt,vDHt] bf16 accumulator (pre-untilize, full precision)
+    cb(out_tile_bytes, Sqt * vDHt, out_df);   // cb_out_rm : untilized [H,V_DIM] in output dtype (fp8 or bf16)
+    cb(topk * idx_elem_bytes, 1, bf);         // cb_idx : one index row (uint32 bytes)
+    cb(16, 2, bf);                            // cb_ctrl : n_active per token (uint32; 16B aligned, double-buffered)
+    cb(tile_bytes, 1, bf);                    // cb_col_identity : ones-in-col0 (writer-built)
+    cb(tile_bytes, 1, bf);                    // cb_recip_scratch : 1-tile reciprocal scratch
+    cb(16, 2, bf);                            // cb_kreq : reader->writer K-gather handoff (dual-NoC split)
+    cb(16, 2, bf);                            // cb_kack : writer->reader gather ack
+
+    // ---- compile-time args ----
+    // CB ids are passed to each kernel as compile-time args (the SparseCB enum is the single source).
+    // Keep each block's order in sync with the kernel's reads. Layout: scalars, then CB ids, then the
+    // element-size args, then the TensorAccessorArgs (which must chain last). The element sizes sit after
+    // the CB ids so adding them leaves every CB-id index unchanged (only the accessor offset shifts).
+    std::vector<uint32_t> reader_ct = {H, S, topk, k_chunk, k_dim};
+    for (uint32_t id : {cb_q_rm, cb_k_rm, cb_mask_part, cb_idx, cb_ctrl}) {
+        reader_ct.push_back(id);
+    }
+    reader_ct.push_back(q_elem_bytes);
+    reader_ct.push_back(kv_elem_bytes);
+    reader_ct.push_back(idx_elem_bytes);
+    // kv (the K cache) uses a RUNTIME tensor shape: its T dimension (the cache length) is passed as common
+    // runtime args, NOT compile-time args, so changing T reuses the same program (no recompile). q/indices
+    // stay compile-time — their dims define the program. The accessor's runtime metadata is the same on
+    // every core, so it rides on the kernel's common (not per-core) runtime args.
+    std::vector<uint32_t> reader_crt;
+    tt::tt_metal::TensorAccessorArgs(t.q.buffer()).append_to(reader_ct, reader_crt);
+    tt::tt_metal::TensorAccessorArgs(t.kv.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(reader_ct, reader_crt);
+    tt::tt_metal::TensorAccessorArgs(t.indices.buffer()).append_to(reader_ct, reader_crt);
+
+    // The writer is the lighter dataflow kernel, so it builds the three persistent compute-input tiles.
+    std::vector<uint32_t> writer_ct = {H, S, vDHt, cb_out_rm, cb_scale, cb_col_identity, cb_neginf, out_elem_bytes};
+    std::vector<uint32_t> writer_crt;
+    tt::tt_metal::TensorAccessorArgs(output.buffer()).append_to(writer_ct, writer_crt);
+    tt::tt_metal::TensorAccessorArgs(t.kv.buffer(), tensor_accessor::ArgConfig::RuntimeTensorShape)
+        .append_to(writer_ct, writer_crt);
+
+    std::vector<uint32_t> compute_ct = {H,
+                                        DHt,
+                                        vDHt,
+                                        Skt,
+                                        scale_packed,
+                                        cb_q_rm,
+                                        cb_q_in,
+                                        cb_k_rm,
+                                        cb_k_in,
+                                        cb_neginf,
+                                        cb_mask_part,
+                                        cb_scale,
+                                        cb_qk_im,
+                                        cb_max_a,
+                                        cb_max_b,
+                                        cb_sum_a,
+                                        cb_sum_b,
+                                        cb_out_a,
+                                        cb_out_b,
+                                        cb_corr,
+                                        cb_out_im,
+                                        cb_out_rm,
+                                        cb_ctrl,
+                                        cb_col_identity,
+                                        cb_recip_scratch};
+
+    // ---- kernels ----
+    const std::string kdir = "ttnn/cpp/ttnn/operations/transformer/sdpa/device/kernels/";
+    tt::tt_metal::KernelDescriptor reader_desc;
+    reader_desc.kernel_source = kdir + "dataflow/sparse_sdpa_reader.cpp";
+    reader_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    reader_desc.core_ranges = core_grid;
+    reader_desc.compile_time_args = reader_ct;
+    reader_desc.common_runtime_args = reader_crt;  // kv runtime tensor-shape metadata (same on every core)
+    reader_desc.config = tt::tt_metal::ReaderConfigDescriptor{};
+    // Dual-NoC K gather: reader + writer each gather half the rows on their own NoC. The new CB ids are
+    // passed as defines (kept off the positional compile-arg blocks, which the kernels index tightly).
+    {
+        std::map<std::string, std::string> rdefs{
+            {"CB_KREQ", std::to_string(cb_kreq)}, {"CB_KACK", std::to_string(cb_kack)}};
+        reader_desc.defines = tt::tt_metal::KernelDescriptor::Defines(rdefs.begin(), rdefs.end());
+    }
+
+    tt::tt_metal::KernelDescriptor writer_desc;
+    writer_desc.kernel_source = kdir + "dataflow/sparse_sdpa_writer.cpp";
+    writer_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    writer_desc.core_ranges = core_grid;
+    writer_desc.compile_time_args = writer_ct;
+    writer_desc.common_runtime_args = writer_crt;  // kv runtime tensor-shape metadata (same on every core)
+    writer_desc.config = tt::tt_metal::WriterConfigDescriptor{};
+    {  // writer gathers the other half of K on its NoC (see reader defines)
+        std::map<std::string, std::string> wdefs{
+            {"CB_KREQ", std::to_string(cb_kreq)},
+            {"CB_KACK", std::to_string(cb_kack)},
+            {"CB_K_RM", std::to_string(cb_k_rm)},
+            {"CB_IDX", std::to_string(cb_idx)},
+            {"K_DIM", std::to_string(k_dim)},
+            {"KV_ELEM_BYTES", std::to_string(kv_elem_bytes)}};
+        writer_desc.defines = tt::tt_metal::KernelDescriptor::Defines(wdefs.begin(), wdefs.end());
+    }
+
+    // Order matches get_compute_kernel_config_args: (fidelity, approx_mode, fp32_dest_acc, packer_l1_acc,
+    // dst_full_sync). packer_l1_acc has no ComputeConfigDescriptor field for this op (no L1 packer accum), so
+    // it is unused here.
+    auto [math_fidelity, math_approx, fp32_acc, packer_l1_acc, dst_full_sync] =
+        get_compute_kernel_config_args(tt::tt_metal::hal::get_arch(), attrs.compute_kernel_config);
+    (void)packer_l1_acc;
+
+    // Query sub-blocking: the DST-bound primitives (matmuls, reduce, sub_exp, salad) hold `qsb` query
+    // tile-rows live in DEST, so qsb must be <= dst_size (8 without fp32 acc, 4 with, half-sync). Process
+    // Sqt rows in q_groups = Sqt/qsb passes. Pick the largest divisor of Sqt that fits so groups are
+    // equal-height (salad's sbh is a compile-time template param). qsb==Sqt (one group) for small H.
+    const uint32_t dst_size = fp32_acc ? 4u : 8u;
+    uint32_t qsb = 1;
+    for (uint32_t d = std::min(Sqt, dst_size); d >= 1; --d) {
+        if (Sqt % d == 0) {
+            qsb = d;
+            break;
+        }
+    }
+    compute_ct.push_back(qsb);
+
+    tt::tt_metal::KernelDescriptor compute_desc;
+    compute_desc.kernel_source = kdir + "compute/sparse_sdpa_compute.cpp";
+    compute_desc.source_type = tt::tt_metal::KernelDescriptor::SourceType::FILE_PATH;
+    compute_desc.core_ranges = core_grid;
+    compute_desc.compile_time_args = compute_ct;
+    // fp8 inputs must unpack into a 32-bit dest (fp8 -> fp32 in DEST, then packed to bfp8 cb_*_in).
+    std::vector<tt::tt_metal::UnpackToDestMode> unpack_to_dest_mode(
+        NUM_CIRCULAR_BUFFERS, tt::tt_metal::UnpackToDestMode::Default);
+    if (kv_is_fp8) {
+        unpack_to_dest_mode[cb_k_rm] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+    if (q_is_fp8) {
+        unpack_to_dest_mode[cb_q_rm] = tt::tt_metal::UnpackToDestMode::UnpackToDestFp32;
+    }
+    compute_desc.config = tt::tt_metal::ComputeConfigDescriptor{
+        .math_fidelity = math_fidelity,
+        .fp32_dest_acc_en = fp32_acc,
+        .dst_full_sync_en = dst_full_sync,
+        .unpack_to_dest_mode = std::move(unpack_to_dest_mode),
+        .math_approx_mode = math_approx};
+    // EXP_APPROX_MODE selects the approximate exp LLK in the compute kernel.
+    std::map<std::string, std::string> cdefs{
+        {"EXP_APPROX_MODE", std::to_string(static_cast<int>(math_approx))},
+    };
+    compute_desc.defines = tt::tt_metal::KernelDescriptor::Defines(cdefs.begin(), cdefs.end());
+
+    auto* q_buf = t.q.buffer();
+    auto* kv_buf = t.kv.buffer();
+    auto* idx_buf = t.indices.buffer();
+    auto* out_buf = output.buffer();
+    // Indexed KV cache: the gather page ids are offset by cache_batch_idx * T to select the cache's batch
+    // slot. Baked here for the cache-miss build; re-applied on every dispatch by get_dynamic_runtime_args
+    // (so changing the slot doesn't recompile). 0 when not indexed (kv is a single [1,1,T,K_DIM] cache).
+    const uint32_t kv_T = t.kv.logical_shape()[2];
+    const uint32_t kv_batch_page_offset = attrs.cache_batch_idx.value_or(0) * kv_T;
+    for (uint32_t i = 0; i < num_cores; ++i) {
+        tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
+        uint32_t tok_start = i * base + std::min(i, extra);
+        uint32_t tok_count = base + (i < extra ? 1u : 0u);
+        reader_desc.emplace_runtime_args(core, {q_buf, kv_buf, idx_buf, tok_start, tok_count, kv_batch_page_offset});
+        writer_desc.emplace_runtime_args(
+            core, {out_buf, tok_start, tok_count, kv_buf, kv_batch_page_offset});  // kv_buf: writer K-half gather
+        compute_desc.emplace_runtime_args(core, {tok_start, tok_count});
+    }
+
+    desc.kernels.push_back(std::move(reader_desc));
+    desc.kernels.push_back(std::move(writer_desc));
+    desc.kernels.push_back(std::move(compute_desc));
+    return desc;
+}
+
+}  // namespace ttnn::prim

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/device/sparse_sdpa_program_factory.cpp
@@ -283,6 +283,9 @@ tt::tt_metal::ProgramDescriptor SparseSDPAOperation::SparseSDPAProgramFactory::c
         tt::tt_metal::CoreCoord core = {i % grid.x, i / grid.x};
         uint32_t tok_start = i * base + std::min(i, extra);
         uint32_t tok_count = base + (i < extra ? 1u : 0u);
+        // kv_batch_page_offset is the LAST positional arg of each list; its index is encoded once in
+        // sparse_sdpa_rt::k{Reader,Writer}BatchOffsetArg (used by get_dynamic_runtime_args to re-apply it on a
+        // cache hit). If you reorder these lists, update those constants or the re-apply targets the wrong slot.
         reader_desc.emplace_runtime_args(core, {q_buf, kv_buf, idx_buf, tok_start, tok_count, kv_batch_page_offset});
         writer_desc.emplace_runtime_args(
             core, {out_buf, tok_start, tok_count, kv_buf, kv_batch_page_offset});  // kv_buf: writer K-half gather

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sdpa_nanobind.cpp
@@ -15,6 +15,7 @@
 #include <nanobind/stl/vector.h>
 
 #include "sdpa.hpp"
+#include "sparse_sdpa.hpp"
 #include "ttnn-nanobind/bind_function.hpp"
 #include "ttnn/operations/ccl/ccl_host_types.hpp"
 #include "ttnn/operations/ccl/ccl_common.hpp"
@@ -319,6 +320,42 @@ void bind_sdpa(nb::module_& mod) {
         nb::arg("program_config") = nb::none(),
         nb::arg("compute_kernel_config") = nb::none(),
         nb::arg("attention_sink") = nb::none());
+
+    ttnn::bind_function<"sparse_sdpa", "ttnn.transformer.">(
+        mod,
+        R"doc(
+        Sparse MLA prefill (DeepSeek DSA), Blackhole single-chip. softmax(Q@Kᵀ·scale masked)@V over the
+        top-k selected latents per query token; V = kv[..., :v_dim]. Masking is baked into `indices`
+        (0xFFFFFFFF = masked; sentinels are a contiguous tail). Inputs are ROW-MAJOR DRAM-interleaved.
+        K_DIM (the q/kv head dim) is taken from the tensors.
+
+        Args:
+            q (ttnn.Tensor):       [1, H, S, K_DIM] bf16 or fp8_e4m3 (H a multiple of 32)
+            kv (ttnn.Tensor):      [1, 1, T, K_DIM] bf16 or fp8_e4m3 (fp8 halves the K-gather bytes; tilized to bfp8_b in-op).
+                                   When cache_batch_idx is set, [B, 1, T, K_DIM] and may be ND-sharded across DRAM banks.
+            indices (ttnn.Tensor): [1, 1, S, TOPK] uint32
+            v_dim (int):           width of V (leading v_dim cols of the K_DIM-wide cache); the output width.
+
+        Keyword args:
+            scale (float, optional): defaults to K_DIM**-0.5.
+            k_chunk_size (int): defaults to 128 (must divide TOPK, multiple of 32).
+            compute_kernel_config (ttnn.DeviceComputeKernelConfig, optional).
+            cache_batch_idx (int, optional): select the batch slot of a shared [B, 1, T, K_DIM] kv cache.
+                It is a dynamic runtime arg, so changing it (or T) does not recompile the kernels.
+
+        Returns:
+            ttnn.Tensor: [1, H, S, v_dim] ROW-MAJOR, DRAM interleaved; dtype matches q (bf16->bf16, fp8->fp8).
+        )doc",
+        &ttnn::transformer::sparse_sdpa,
+        nb::arg("q").noconvert(),
+        nb::arg("kv").noconvert(),
+        nb::arg("indices").noconvert(),
+        nb::arg("v_dim"),
+        nb::kw_only(),
+        nb::arg("scale") = nb::none(),
+        nb::arg("k_chunk_size") = 128,
+        nb::arg("compute_kernel_config") = nb::none(),
+        nb::arg("cache_batch_idx") = nb::none());
 
     const auto* const chunked_doc =
         R"doc(

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.cpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.cpp
@@ -1,0 +1,37 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "ttnn/operations/transformer/sdpa/sparse_sdpa.hpp"
+#include "ttnn/operations/transformer/sdpa/device/sparse_sdpa_device_operation.hpp"
+#include <tt-metalium/hal.hpp>
+#include <cmath>
+
+namespace ttnn::transformer {
+
+ttnn::Tensor sparse_sdpa(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& kv,
+    const ttnn::Tensor& indices,
+    uint32_t v_dim,
+    std::optional<float> scale,
+    uint32_t k_chunk_size,
+    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config,
+    std::optional<uint32_t> cache_batch_idx) {
+    const uint32_t k_dim = q.logical_shape()[3];  // head dim, from the tensor
+    const float resolved_scale = scale.value_or(1.0f / std::sqrt(static_cast<float>(k_dim)));
+
+    // fp8 q/kv must be tilized through a 32-bit dest accumulator, so default fp32_dest_acc_en on for fp8.
+    const bool any_fp8 = (kv.dtype() == ttnn::DataType::FP8_E4M3) || (q.dtype() == ttnn::DataType::FP8_E4M3);
+    auto kernel_config = init_device_compute_kernel_config(
+        tt::tt_metal::hal::get_arch(),
+        compute_kernel_config,
+        /*default_fidelity=*/MathFidelity::HiFi2,
+        /*default_approx_mode=*/true,
+        /*default_fp32_acc=*/any_fp8,
+        /*default_l1_acc=*/false);
+
+    return ttnn::prim::sparse_sdpa(q, kv, indices, resolved_scale, v_dim, k_chunk_size, kernel_config, cache_batch_idx);
+}
+
+}  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.hpp
+++ b/ttnn/cpp/ttnn/operations/transformer/sdpa/sparse_sdpa.hpp
@@ -1,0 +1,39 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#pragma once
+
+#include "ttnn/tensor/tensor.hpp"
+#include "ttnn/operations/core/compute_kernel/compute_kernel_config.hpp"
+#include <optional>
+
+namespace ttnn::transformer {
+
+// Sparse MLA prefill (DeepSeek DSA), Blackhole single-chip.
+//   q       [1, H, S, K_DIM] bf16 or fp8_e4m3 ROW_MAJOR  (H = head count, any multiple of 32; K_DIM = head
+//                                                          dim, e.g. 576)
+//   kv      [1, 1, T, K_DIM] bf16 or fp8_e4m3 ROW_MAJOR  (K = full K_DIM, V = kv[..., :v_dim]; fp8 halves
+//                                                          the K-gather bytes, tilized in-op to bfp8_b)
+//   indices [1, 1, S, TOPK] uint32 ROW_MAJOR (0xFFFFFFFF = masked; sentinels are a contiguous tail)
+//   v_dim   width of V (leading v_dim cols of the K_DIM-wide cache); the output width.
+// Returns out [1, H, S, v_dim] ROW_MAJOR; the output dtype MATCHES q (bf16 q -> bf16 out, fp8 q -> fp8 out).
+// (K_DIM is taken from q/kv; scale defaults to K_DIM**-0.5.)
+//
+// cache_batch_idx: when set, kv is a shared [B, 1, T, K_DIM] cache and this selects the batch slot to attend
+// to (indices are page ids within that slot). kv may then also be ND-sharded across DRAM banks. The value is
+// a dynamic runtime arg, so changing the slot (or the cache length T) does not recompile the kernels.
+//
+// Producer preconditions (NOT validated per-element): sentinels are a contiguous tail, every row has >= 1
+// valid key, and all non-sentinel indices are < T.
+ttnn::Tensor sparse_sdpa(
+    const ttnn::Tensor& q,
+    const ttnn::Tensor& kv,
+    const ttnn::Tensor& indices,
+    uint32_t v_dim,
+    std::optional<float> scale = std::nullopt,
+    uint32_t k_chunk_size = 128,
+    std::optional<ttnn::DeviceComputeKernelConfig> compute_kernel_config = std::nullopt,
+    std::optional<uint32_t> cache_batch_idx = std::nullopt);
+
+}  // namespace ttnn::transformer

--- a/ttnn/cpp/ttnn/operations/transformer/sources.cmake
+++ b/ttnn/cpp/ttnn/operations/transformer/sources.cmake
@@ -17,6 +17,9 @@ set(TTNN_OP_TRANSFORMER_SRCS
     sdpa/device/sdpa_perf_model.cpp
     sdpa/device/sdpa_program_factory.cpp
     sdpa/sdpa.cpp
+    sdpa/device/sparse_sdpa_device_operation.cpp
+    sdpa/device/sparse_sdpa_program_factory.cpp
+    sdpa/sparse_sdpa.cpp
     sdpa_decode/device/sdpa_decode_device_operation.cpp
     sdpa_decode/device/sdpa_decode_program_factory.cpp
     sdpa_decode/sdpa_decode.cpp


### PR DESCRIPTION
> 📖 **[Interactive explainer — design walkthrough (rendered HTML) →](https://gist.githack.com/pavlejosipovic/b64e110d235066e2ee64e0f349036eec/raw/81113f8ab28eadb3ae5ba0a82944eaa080f39abe/sparse_sdpa_explainer.html)**  ·  [gist source](https://gist.github.com/pavlejosipovic/b64e110d235066e2ee64e0f349036eec)

## What

New ttnn op **`ttnn.transformer.sparse_sdpa`** — per-query-token top-k sparse MLA prefill for DeepSeek V3.2 DSA. Blackhole-only.

Inputs are ROW-MAJOR DRAM: `q [1,H,S,K_DIM]`, `kv [1,1,T,K_DIM]`, uint32 `indices [1,1,S,TOPK]`. Per token the op gathers the top-k KV rows named by `indices`, on-chip tilizes, runs flash/online-softmax (Q@Kᵀ → mask → softmax → @V with SALAD combine), and untilizes to a ROW-MAJOR `[1,H,S,v_dim]` output. Tokens are distributed across the full core grid, fully independent (no mcast).

## Key design points

- **Natural-K layout** — both matmuls read the tilized `K[Skt,DHt]` directly (QK via the within-tile haloize transpose; PV reads `V` = first `v_dim` cols). No Kᵀ/V repositioning.
- **Query sub-blocking** — H is processed in DST-sized groups, so DST never caps H (H = any multiple of 32); the upper bound is per-core L1.
- **Lightweight masking** — sentinels are a contiguous tail (truncate at `n_valid`); a persistent `-inf` tile + a per-token partial-boundary tile cover the rest.
- **dtypes** — q and kv may each be bf16 or fp8_e4m3 (fp8 tilizes to bfp8_b, near-lossless, halves L1 + gather bytes). Output dtype matches q.
- **Dual-NoC K gather** — the gather is NoC-link bound, so reader + writer each gather half of every chunk on their own NoC into shared L1 (depth-4 trid ring), ~13% over single-NoC.

## KV-cache features (persistent-cache friendly — no recompile on reuse)

- **Runtime kv length** — `T` rides on the kv `TensorAccessor`'s runtime args (excluded from the program hash), so the cache length can change without recompiling (interleaved kv).
- **Oversized persistent kv** — a max-size cache (logical `T` ≫ keys attended) works as-is; reads are index-driven.
- **Indexed ND-sharded kv** — optional `cache_batch_idx` selects a slot of a shared `[B,1,T,K_DIM]` cache (a dynamic runtime arg via `get_dynamic_runtime_args`, not in the hash); kv may be ND-sharded across DRAM banks. (A sharded kv hashes its shape, since its bank mapping is shape-derived; interleaved does not.)
- **Validation** — every input invariant not keyed by the hash (q/indices/kv layout+memory+padding, `cache_batch_idx`, same-device) is re-checked on cache **hit** as well as miss.

## Perf (prod-dense, tracy device kernel duration; K-gather/bandwidth-bound)

- bf16: **3.34 ms**, fp8 (q+kv): **1.92 ms** (~91% / ~80% of DRAM peak; fp8 ~1.6× faster — the op is bandwidth-sensitive).

## Tests

- Post-commit smoke: `tests/ttnn/unit_tests/operations/sdpa/test_sparse_sdpa.py` (14 tests).
- Nightly: `tests/ttnn/nightly/unit_tests/operations/sdpa/test_sparse_sdpa.py` (50 tests) — PCC vs the `sparse_mla` golden across shapes/sparsity/heads/query-subblock, fp8 q/kv, runtime kv length, oversized persistent, indexed ND-sharded, cache-hit validation, bit-exact determinism (on-device comparison), and a prod-shape perf case.
- ttsim: skip-listed (Blackhole) — two simulator gaps (BH fast-tilize `src_a row=64`, fixed upstream in ttsim-private; `tensix_cfg_wr32 reg=119` still unimplemented). Op runs correctly on silicon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse_mla_prefill_ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:pjosipovic/sparse_mla_prefill_ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=pjosipovic/sparse_mla_prefill_ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:pjosipovic/sparse_mla_prefill_ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=pjosipovic/sparse_mla_prefill_ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:pjosipovic/sparse_mla_prefill_ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=pjosipovic/sparse_mla_prefill_ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:pjosipovic/sparse_mla_prefill_ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=pjosipovic/sparse_mla_prefill_ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:pjosipovic/sparse_mla_prefill_ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=pjosipovic/sparse_mla_prefill_ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:pjosipovic/sparse_mla_prefill_ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=pjosipovic/sparse_mla_prefill_ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:pjosipovic/sparse_mla_prefill_ref)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=pjosipovic/sparse_mla_prefill_ref)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:pjosipovic/sparse_mla_prefill_ref)

