### PR TITLE
[Cleanup] drop dead sharding addrgen include from nd-sharded writer

### DIFF
--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/kernels/dataflow/writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp
@@ -9,7 +9,6 @@
 #include "api/dataflow/circular_buffer.h"
 #include "api/core_local_mem.h"
 #include "api/tensor/noc_traits.h"
-#include "ttnn/operations/ccl/kernel_common/sharding_addrgen.hpp"
 #include "api/debug/dprint.h"
 
 namespace {


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Relates to https://github.com/tenstorrent/tt-metal/issues/45003.

Remove the unused `#include ".../sharding_addrgen.hpp"` from data_movement's `writer_unary_stick_layout_split_rows_multicore_nd_sharded.cpp`. The writer references none of that header's defined symbols.

### Notes for reviewers
The dead include's effect was transitively pulling legacy `InterleavedAddrGen<>` / `InterleavedAddrGenFast<>` template specializations and `noc_async_read_page(...)` calls into the kernel, which are systematically migrated into the Device 2.0 API.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/untilize-drop-dead-include)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/untilize-drop-dead-include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/untilize-drop-dead-include)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/untilize-drop-dead-include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=iwrosz/untilize-drop-dead-include)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:iwrosz/untilize-drop-dead-include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/untilize-drop-dead-include)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/untilize-drop-dead-include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/untilize-drop-dead-include)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/untilize-drop-dead-include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/untilize-drop-dead-include)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/untilize-drop-dead-include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/untilize-drop-dead-include)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/untilize-drop-dead-include)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/untilize-drop-dead-include)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/untilize-drop-dead-include)