### PR TITLE
[Cleanup] retire data_movement legacy helpers + tt_memmove body refactor

### DIFF
--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_receive_reader_kernel.cpp
@@ -109,6 +109,8 @@ void kernel_main() {
     uint32_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
 
+    Noc noc;
+
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel>* mux_connection_handle;
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel> mux_connection;
     mux_connection = tt::tt_fabric::build_connection_to_fabric_endpoint<fabric_mux_num_buffers_per_channel>(
@@ -186,7 +188,7 @@ void kernel_main() {
     noc_async_read(packet_noc_addr, packet_l1_addr, new_packet_size_bytes);
     noc_async_read_barrier();
 
-    tt_memmove<true, false, false, 0>(dest_page_base_addr, packet_l1_addr, packet_size_bytes);
+    tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
     cb_push_back(receiver_cb_id_l, input_num_tiles);
 
     cb_reserve_back(receiver_cb_id_s, 1);
@@ -196,9 +198,12 @@ void kernel_main() {
     const uint32_t dest_page_base_addr_m = get_write_ptr(receiver_cb_id_m);
 
     tt_memmove<true, false, false, 0>(
-        dest_page_base_addr_s, packet_l1_addr + packet_size_bytes, aligned_page_size_bytes);
+        noc, dest_page_base_addr_s, packet_l1_addr + packet_size_bytes, aligned_page_size_bytes);
     tt_memmove<true, false, false, 0>(
-        dest_page_base_addr_m, packet_l1_addr + packet_size_bytes + aligned_page_size_bytes, aligned_page_size_bytes);
+        noc,
+        dest_page_base_addr_m,
+        packet_l1_addr + packet_size_bytes + aligned_page_size_bytes,
+        aligned_page_size_bytes);
     cb_push_back(receiver_cb_id_s, 1);
     cb_push_back(receiver_cb_id_m, 1);
     cb_push_back(packet_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_writer_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root2_writer_kernel.cpp
@@ -68,6 +68,8 @@ void kernel_main() {
     uint32_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
 
+    Noc noc;
+
     // device 2 writer receives data from compute kernel and sends it to device 1
 
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel>* mux_connection_handle;
@@ -114,19 +116,22 @@ void kernel_main() {
     noc_semaphore_set(local_semaphore_ptr, 0);
     cb_wait_front(cb_id_l, input_num_tiles);
     uint32_t src_page_base_addr = get_read_ptr(cb_id_l);
-    tt_memmove<true, false, false, 0>(packet_base_addr, src_page_base_addr, payload_size_bytes);
+    tt_memmove<true, false, false, 0>(noc, packet_base_addr, src_page_base_addr, payload_size_bytes);
     cb_pop_front(cb_id_l, input_num_tiles);
 
     cb_wait_front(cb_id_s, 1);
     const uint32_t src_page_base_addr_s = get_read_ptr(cb_id_s);
     tt_memmove<true, false, false, 0>(
-        packet_base_addr + payload_size_bytes, src_page_base_addr_s, aligned_page_size_bytes);
+        noc, packet_base_addr + payload_size_bytes, src_page_base_addr_s, aligned_page_size_bytes);
     cb_pop_front(cb_id_s, 1);
 
     cb_wait_front(cb_id_m, 1);
     const uint32_t src_page_base_addr_m = get_read_ptr(cb_id_m);
     tt_memmove<true, false, false, 0>(
-        packet_base_addr + payload_size_bytes + aligned_page_size_bytes, src_page_base_addr_m, aligned_page_size_bytes);
+        noc,
+        packet_base_addr + payload_size_bytes + aligned_page_size_bytes,
+        src_page_base_addr_m,
+        aligned_page_size_bytes);
     cb_pop_front(cb_id_m, 1);
     cb_push_back(packet_cb_id, 1);
 

--- a/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
+++ b/ttnn/cpp/ttnn/operations/ccl/reduce_to_root/device/kernels/root_receive_reader_kernel.cpp
@@ -112,6 +112,8 @@ void kernel_main() {
     uint32_t termination_master_noc_x = get_arg_val<uint32_t>(arg_idx++);
     uint32_t termination_master_noc_y = get_arg_val<uint32_t>(arg_idx++);
 
+    Noc noc;
+
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel>* mux_connection_handle;
     tt::tt_fabric::WorkerToFabricMuxSender<fabric_mux_num_buffers_per_channel> mux_connection;
     mux_connection = tt::tt_fabric::build_connection_to_fabric_endpoint<fabric_mux_num_buffers_per_channel>(
@@ -193,7 +195,7 @@ void kernel_main() {
     noc_async_read(packet_noc_addr, packet_l1_addr, new_packet_size_bytes);
 
     // moving l tensor
-    tt_memmove<true, false, false, 0>(dest_page_base_addr, packet_l1_addr, packet_size_bytes);
+    tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
     cb_push_back(receiver_cb_id_l, input_num_tiles);
     //  now s and m
     cb_reserve_back(receiver_cb_id_s, 1);
@@ -201,12 +203,15 @@ void kernel_main() {
 
     uint32_t dest_page_base_addr_s = get_write_ptr(receiver_cb_id_s);
     tt_memmove<true, false, false, 0>(
-        dest_page_base_addr_s, packet_l1_addr + packet_size_bytes, aligned_page_size_bytes);
+        noc, dest_page_base_addr_s, packet_l1_addr + packet_size_bytes, aligned_page_size_bytes);
     cb_push_back(receiver_cb_id_s, 1);
 
     uint32_t dest_page_base_addr_m = get_write_ptr(receiver_cb_id_m);
     tt_memmove<true, false, false, 0>(
-        dest_page_base_addr_m, packet_l1_addr + packet_size_bytes + aligned_page_size_bytes, aligned_page_size_bytes);
+        noc,
+        dest_page_base_addr_m,
+        packet_l1_addr + packet_size_bytes + aligned_page_size_bytes,
+        aligned_page_size_bytes);
     cb_push_back(receiver_cb_id_m, 1);
 
     cb_push_back(packet_cb_id, 1);
@@ -298,7 +303,7 @@ void kernel_main() {
     packet_noc_addr = get_noc_addr(core_noc_x, core_noc_y, intermediate_base_addr);
     noc_async_read(packet_noc_addr, packet_l1_addr, new_packet_size_bytes);
 
-    tt_memmove<true, false, false, 0>(dest_page_base_addr, packet_l1_addr, packet_size_bytes);
+    tt_memmove<true, false, false, 0>(noc, dest_page_base_addr, packet_l1_addr, packet_size_bytes);
     cb_push_back(receiver_cb_id_l, input_num_tiles);
 
     cb_reserve_back(receiver_cb_id_s, 1);
@@ -307,9 +312,12 @@ void kernel_main() {
     dest_page_base_addr_m = get_write_ptr(receiver_cb_id_m);
 
     tt_memmove<true, false, false, 0>(
-        dest_page_base_addr_s, packet_l1_addr + packet_size_bytes, aligned_page_size_bytes);
+        noc, dest_page_base_addr_s, packet_l1_addr + packet_size_bytes, aligned_page_size_bytes);
     tt_memmove<true, false, false, 0>(
-        dest_page_base_addr_m, packet_l1_addr + packet_size_bytes + aligned_page_size_bytes, aligned_page_size_bytes);
+        noc,
+        dest_page_base_addr_m,
+        packet_l1_addr + packet_size_bytes + aligned_page_size_bytes,
+        aligned_page_size_bytes);
     cb_push_back(receiver_cb_id_s, 1);
     cb_push_back(receiver_cb_id_m, 1);
     cb_push_back(packet_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -296,8 +296,8 @@ FORCE_INLINE void noc_async_write_sharded(
     }
 }
 
+template <typename AddrGenType>
 [[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
-template <uint32_t max_transfer_size, typename AddrGenType>
 FORCE_INLINE void noc_async_write_sharded(
     const uint32_t l1_addr,
     const AddrGenType tensor,
@@ -305,7 +305,7 @@ FORCE_INLINE void noc_async_write_sharded(
     const uint32_t offset,
     const uint32_t size) {
     Noc noc;
-    return noc_async_write_sharded<max_transfer_size, AddrGenType>(noc, l1_addr, tensor, dest_id, offset, size);
+    return noc_async_write_sharded(noc, l1_addr, tensor, dest_id, offset, size);
 }
 
 template <typename AddrGenType>

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -42,7 +42,7 @@ FORCE_INLINE void enhanced_noc_async_read(
 }
 
 template <uint32_t max_transfer_size, bool only_reads>
-[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
+[[deprecated("Use the overload with leading Noc parameter instead.")]]
 FORCE_INLINE void enhanced_noc_async_read(
     const uint64_t src_noc_addr, const uint32_t dst_l1_addr, const uint32_t bytes) {
     Noc noc;
@@ -66,7 +66,7 @@ FORCE_INLINE void enhanced_noc_async_write(
 }
 
 template <uint32_t max_transfer_size, bool only_writes>
-[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
+[[deprecated("Use the overload with leading Noc parameter instead.")]]
 FORCE_INLINE void enhanced_noc_async_write(
     const uint32_t src_l1_addr, const uint64_t dst_noc_addr, const uint32_t bytes) {
     Noc noc;
@@ -146,7 +146,7 @@ FORCE_INLINE void tt_memmove(Noc noc, const uint32_t dst_l1_addr, const uint32_t
 }
 
 template <bool guaranteed_16B_aligned, bool copy_async, bool use_read_datamover, uint32_t max_transfer_size>
-[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
+[[deprecated("Use the overload with leading Noc parameter instead.")]]
 FORCE_INLINE void tt_memmove(const uint32_t dst_l1_addr, const uint32_t src_l1_addr, const uint32_t bytes) {
     Noc noc;
     return tt_memmove<guaranteed_16B_aligned, copy_async, use_read_datamover, max_transfer_size>(
@@ -297,7 +297,7 @@ FORCE_INLINE void noc_async_write_sharded(
 }
 
 template <typename AddrGenType>
-[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
+[[deprecated("Use the overload with leading Noc parameter instead.")]]
 FORCE_INLINE void noc_async_write_sharded(
     const uint32_t l1_addr,
     const AddrGenType tensor,
@@ -342,7 +342,7 @@ FORCE_INLINE void noc_async_read_sharded(
 }
 
 template <typename AddrGenType>
-[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
+[[deprecated("Use the overload with leading Noc parameter instead.")]]
 FORCE_INLINE void noc_async_read_sharded(
     const uint32_t l1_addr,
     const AddrGenType tensor,

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -41,6 +41,14 @@ FORCE_INLINE void enhanced_noc_async_read(
         {.offset_bytes = 0});
 }
 
+[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
+template <uint32_t max_transfer_size, bool only_reads>
+FORCE_INLINE void enhanced_noc_async_read(
+    const uint64_t src_noc_addr, const uint32_t dst_l1_addr, const uint32_t bytes) {
+    Noc noc;
+    return enhanced_noc_async_read<max_transfer_size, only_reads>(noc, src_noc_addr, dst_l1_addr, bytes);
+}
+
 template <uint32_t max_transfer_size, bool only_writes>
 FORCE_INLINE void enhanced_noc_async_write(
     Noc noc, const uint32_t src_l1_addr, const uint64_t dst_noc_addr, const uint32_t bytes) {
@@ -55,6 +63,14 @@ FORCE_INLINE void enhanced_noc_async_write(
         {.noc_x = (uint32_t)NOC_UNICAST_ADDR_X(dst_noc_addr),
          .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(dst_noc_addr),
          .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(dst_noc_addr)});
+}
+
+[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
+template <uint32_t max_transfer_size, bool only_writes>
+FORCE_INLINE void enhanced_noc_async_write(
+    const uint32_t src_l1_addr, const uint64_t dst_noc_addr, const uint32_t bytes) {
+    Noc noc;
+    return enhanced_noc_async_write<max_transfer_size, only_writes>(noc, src_l1_addr, dst_noc_addr, bytes);
 }
 
 // Self-NOC src/dst args for a local L1 address on the executing core, expressed in the
@@ -127,6 +143,14 @@ FORCE_INLINE void tt_memmove(Noc noc, const uint32_t dst_l1_addr, const uint32_t
             }
         }
     }
+}
+
+[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
+template <uint32_t max_transfer_size, bool guaranteed_16B_aligned, bool copy_async, bool use_read_datamover>
+FORCE_INLINE void tt_memmove(const uint32_t dst_l1_addr, const uint32_t src_l1_addr, const uint32_t bytes) {
+    Noc noc;
+    return tt_memmove<max_transfer_size, guaranteed_16B_aligned, copy_async, use_read_datamover>(
+        noc, dst_l1_addr, src_l1_addr, bytes);
 }
 
 template <typename T = uint32_t>
@@ -272,6 +296,18 @@ FORCE_INLINE void noc_async_write_sharded(
     }
 }
 
+[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
+template <uint32_t max_transfer_size, typename AddrGenType>
+FORCE_INLINE void noc_async_write_sharded(
+    const uint32_t l1_addr,
+    const AddrGenType tensor,
+    const uint32_t dest_id,
+    const uint32_t offset,
+    const uint32_t size) {
+    Noc noc;
+    return noc_async_write_sharded<max_transfer_size, AddrGenType>(noc, l1_addr, tensor, dest_id, offset, size);
+}
+
 template <typename AddrGenType>
 FORCE_INLINE void noc_async_read_sharded(
     Noc noc, uint32_t l1_addr, AddrGenType tensor, uint32_t src_id, uint32_t offset, uint32_t size) {
@@ -303,6 +339,18 @@ FORCE_INLINE void noc_async_read_sharded(
             l1_addr += read_size;
         }
     }
+}
+
+[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
+template <uint32_t max_transfer_size, typename AddrGenType>
+FORCE_INLINE void noc_async_read_sharded(
+    const uint32_t l1_addr,
+    const AddrGenType tensor,
+    const uint32_t src_id,
+    const uint32_t offset,
+    const uint32_t size) {
+    Noc noc;
+    return noc_async_read_sharded<max_transfer_size, AddrGenType>(noc, l1_addr, tensor, src_id, offset, size);
 }
 
 }  // namespace tt::data_movement::common

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -65,8 +65,8 @@ FORCE_INLINE void enhanced_noc_async_write(
          .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(dst_noc_addr)});
 }
 
-[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
 template <uint32_t max_transfer_size, bool only_writes>
+[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
 FORCE_INLINE void enhanced_noc_async_write(
     const uint32_t src_l1_addr, const uint64_t dst_noc_addr, const uint32_t bytes) {
     Noc noc;

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -145,11 +145,11 @@ FORCE_INLINE void tt_memmove(Noc noc, const uint32_t dst_l1_addr, const uint32_t
     }
 }
 
+template <bool guaranteed_16B_aligned, bool copy_async, bool use_read_datamover, uint32_t max_transfer_size>
 [[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
-template <uint32_t max_transfer_size, bool guaranteed_16B_aligned, bool copy_async, bool use_read_datamover>
 FORCE_INLINE void tt_memmove(const uint32_t dst_l1_addr, const uint32_t src_l1_addr, const uint32_t bytes) {
     Noc noc;
-    return tt_memmove<max_transfer_size, guaranteed_16B_aligned, copy_async, use_read_datamover>(
+    return tt_memmove<guaranteed_16B_aligned, copy_async, use_read_datamover, max_transfer_size>(
         noc, dst_l1_addr, src_l1_addr, bytes);
 }
 

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -41,8 +41,8 @@ FORCE_INLINE void enhanced_noc_async_read(
         {.offset_bytes = 0});
 }
 
-[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
 template <uint32_t max_transfer_size, bool only_reads>
+[[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
 FORCE_INLINE void enhanced_noc_async_read(
     const uint64_t src_noc_addr, const uint32_t dst_l1_addr, const uint32_t bytes) {
     Noc noc;

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -27,19 +27,6 @@ namespace tt::data_movement::common {
 
 template <uint32_t max_transfer_size, bool only_reads>
 FORCE_INLINE void enhanced_noc_async_read(
-    const uint64_t src_noc_addr, const uint32_t dst_l1_addr, const uint32_t bytes) {
-    // If you do not know the max_transfer_size at compile time write 0 to it.
-    // only reads is true if we ONLY use noc_async_read and all calls to tt_memmove have use_read_datamover as True
-    if constexpr (only_reads && max_transfer_size <= NOC_MAX_BURST_SIZE) {
-        noc_async_read_one_packet(src_noc_addr, dst_l1_addr, bytes);
-    } else {
-        noc_async_read<max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size>(
-            src_noc_addr, dst_l1_addr, bytes);
-    }
-}
-
-template <uint32_t max_transfer_size, bool only_reads>
-FORCE_INLINE void enhanced_noc_async_read(
     Noc noc, const uint64_t src_noc_addr, const uint32_t dst_l1_addr, const uint32_t bytes) {
     constexpr uint32_t page_size = (only_reads && max_transfer_size <= NOC_MAX_BURST_SIZE)
                                        ? NOC_MAX_BURST_SIZE
@@ -52,19 +39,6 @@ FORCE_INLINE void enhanced_noc_async_read(
          .noc_y = (uint32_t)NOC_UNICAST_ADDR_Y(src_noc_addr),
          .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(src_noc_addr)},
         {.offset_bytes = 0});
-}
-
-template <uint32_t max_transfer_size, bool only_writes>
-FORCE_INLINE void enhanced_noc_async_write(
-    const uint32_t src_l1_addr, const uint64_t dst_noc_addr, const uint32_t bytes) {
-    // If you do not know the max_transfer_size at compile time write 0 to it.
-    // only writes is true if we ONLY use noc_async_read and all calls to tt_memmove have use_read_datamover as False
-    if constexpr (only_writes && max_transfer_size <= NOC_MAX_BURST_SIZE) {
-        noc_async_write_one_packet(src_l1_addr, dst_noc_addr, bytes);
-    } else {
-        noc_async_write<max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size>(
-            src_l1_addr, dst_noc_addr, bytes);
-    }
 }
 
 template <uint32_t max_transfer_size, bool only_writes>
@@ -83,63 +57,40 @@ FORCE_INLINE void enhanced_noc_async_write(
          .addr = (uint32_t)NOC_LOCAL_ADDR_OFFSET(dst_noc_addr)});
 }
 
-template <bool guaranteed_16B_aligned, bool copy_async, bool use_read_datamover, uint32_t max_transfer_size>
-FORCE_INLINE void tt_memmove(const uint32_t dst_l1_addr, const uint32_t src_l1_addr, const uint32_t bytes) {
-    // Function performs a memory copy between two l1 addresses in the local core
-    // Uses noc_async_read when possible to copy the data over
-    // Set guaranteed 16B aligned to true if the source and destination are externally guaranteed to be 16B aligned
-    // (dangerous) Set copy_async to true if you wish to perform the operation asynchronously, in this case you can add
-    // a noc_async_read_barrier to synchronize later
-    if constexpr (use_read_datamover) {
-        if constexpr (guaranteed_16B_aligned) {
-            enhanced_noc_async_read<max_transfer_size, false>(get_noc_addr(src_l1_addr), dst_l1_addr, bytes);
-            if constexpr (!copy_async) {
-                noc_async_read_barrier();
-            }
-        } else {
-            if ((dst_l1_addr & OFFSET_16) == (src_l1_addr & OFFSET_16)) {
-                enhanced_noc_async_read<max_transfer_size, false>(get_noc_addr(src_l1_addr), dst_l1_addr, bytes);
-                if constexpr (!copy_async) {
-                    noc_async_read_barrier();
-                }
-            } else {
-                invalidate_l1_cache();
-                memmove((void*)(dst_l1_addr), (void*)(src_l1_addr), (size_t)(bytes));
-            }
-        }
-    } else {
-        if constexpr (guaranteed_16B_aligned) {
-            enhanced_noc_async_write<max_transfer_size, false>(src_l1_addr, get_noc_addr(dst_l1_addr), bytes);
-            if constexpr (!copy_async) {
-                noc_async_write_barrier();
-            }
-        } else {
-            if ((dst_l1_addr & OFFSET_16) == (src_l1_addr & OFFSET_16)) {
-                enhanced_noc_async_write<max_transfer_size, false>(src_l1_addr, get_noc_addr(dst_l1_addr), bytes);
-                if constexpr (!copy_async) {
-                    noc_async_write_barrier();
-                }
-            } else {
-                invalidate_l1_cache();
-                memmove((void*)(dst_l1_addr), (void*)(src_l1_addr), (size_t)(bytes));
-            }
-        }
-    }
+// Self-NOC src/dst args for a local L1 address on the executing core, expressed in the
+// caller's noc coordinate space (NOC 0 and NOC 1 have different coordinate spaces, so the
+// noc id must match what the read/write will use).
+FORCE_INLINE noc_traits_t<UnicastEndpoint>::src_args_type self_l1_src_args(Noc noc, uint32_t addr) {
+    const uint8_t id = noc.get_noc_id();
+    return {.noc_x = my_x[id], .noc_y = my_y[id], .addr = addr};
+}
+FORCE_INLINE noc_traits_t<UnicastEndpoint>::dst_args_type self_l1_dst_args(Noc noc, uint32_t addr) {
+    const uint8_t id = noc.get_noc_id();
+    return {.noc_x = my_x[id], .noc_y = my_y[id], .addr = addr};
 }
 
 template <bool guaranteed_16B_aligned, bool copy_async, bool use_read_datamover, uint32_t max_transfer_size>
 FORCE_INLINE void tt_memmove(Noc noc, const uint32_t dst_l1_addr, const uint32_t src_l1_addr, const uint32_t bytes) {
+    constexpr uint32_t page_size = max_transfer_size == 0 ? NOC_MAX_BURST_SIZE + 1 : max_transfer_size;
     if constexpr (use_read_datamover) {
         if constexpr (guaranteed_16B_aligned) {
-            enhanced_noc_async_read<max_transfer_size, false>(
-                noc, get_noc_addr(src_l1_addr, noc.get_noc_id()), dst_l1_addr, bytes);
+            noc.async_read<NocOptions::DEFAULT, page_size>(
+                UnicastEndpoint{},
+                CoreLocalMem<uint32_t>(dst_l1_addr),
+                bytes,
+                self_l1_src_args(noc, src_l1_addr),
+                {.offset_bytes = 0});
             if constexpr (!copy_async) {
                 noc.async_read_barrier();
             }
         } else {
             if ((dst_l1_addr & OFFSET_16) == (src_l1_addr & OFFSET_16)) {
-                enhanced_noc_async_read<max_transfer_size, false>(
-                    noc, get_noc_addr(src_l1_addr, noc.get_noc_id()), dst_l1_addr, bytes);
+                noc.async_read<NocOptions::DEFAULT, page_size>(
+                    UnicastEndpoint{},
+                    CoreLocalMem<uint32_t>(dst_l1_addr),
+                    bytes,
+                    self_l1_src_args(noc, src_l1_addr),
+                    {.offset_bytes = 0});
                 if constexpr (!copy_async) {
                     noc.async_read_barrier();
                 }
@@ -150,15 +101,23 @@ FORCE_INLINE void tt_memmove(Noc noc, const uint32_t dst_l1_addr, const uint32_t
         }
     } else {
         if constexpr (guaranteed_16B_aligned) {
-            enhanced_noc_async_write<max_transfer_size, false>(
-                noc, src_l1_addr, get_noc_addr(dst_l1_addr, noc.get_noc_id()), bytes);
+            noc.async_write<NocOptions::DEFAULT, page_size>(
+                CoreLocalMem<uint32_t>(src_l1_addr),
+                UnicastEndpoint{},
+                bytes,
+                {.offset_bytes = 0},
+                self_l1_dst_args(noc, dst_l1_addr));
             if constexpr (!copy_async) {
                 noc.async_write_barrier();
             }
         } else {
             if ((dst_l1_addr & OFFSET_16) == (src_l1_addr & OFFSET_16)) {
-                enhanced_noc_async_write<max_transfer_size, false>(
-                    noc, src_l1_addr, get_noc_addr(dst_l1_addr, noc.get_noc_id()), bytes);
+                noc.async_write<NocOptions::DEFAULT, page_size>(
+                    CoreLocalMem<uint32_t>(src_l1_addr),
+                    UnicastEndpoint{},
+                    bytes,
+                    {.offset_bytes = 0},
+                    self_l1_dst_args(noc, dst_l1_addr));
                 if constexpr (!copy_async) {
                     noc.async_write_barrier();
                 }
@@ -281,36 +240,6 @@ struct ByteSizeAddressType<Size, typename std::enable_if<Size == 4>::type> {
 // which assumed a fully-squeezed 2D dspec and so misread the C dim for 4D NCHW inputs.
 template <typename AddrGenType>
 FORCE_INLINE void noc_async_write_sharded(
-    uint32_t l1_addr, AddrGenType tensor, uint32_t dest_id, uint32_t offset, uint32_t size) {
-    if constexpr (AddrGenType::DSpec::is_interleaved) {
-        // Interleaved TensorAccessor lacks dspec() — keep this branch inside `if constexpr`
-        // so the sharded path below is never instantiated for the interleaved specialization.
-        noc_async_write(l1_addr, tensor.get_noc_addr(dest_id, offset), size);
-    } else {
-        const auto& dspec = tensor.dspec();
-        const uint32_t r = dspec.rank();
-        const uint32_t pages_per_row = (r > 1) ? dspec.tensor_shape()[r - 1] : 1u;
-        if (pages_per_row <= 1) {
-            noc_async_write(l1_addr, tensor.get_noc_addr(dest_id, offset), size);
-            return;
-        }
-        const uint32_t page_size = tensor.get_aligned_page_size();
-        uint32_t sharded_dest_id = dest_id * pages_per_row + offset / page_size;
-        uint32_t sharded_offset = offset % page_size;
-        uint32_t num_pages = div_up(size + sharded_offset, page_size);
-        for (uint32_t i = 0; i < num_pages; i++) {
-            uint64_t dst_noc_addr = tensor.get_noc_addr(sharded_dest_id, sharded_offset);
-            uint32_t write_size = std::min(size - i * page_size, page_size - sharded_offset);
-            noc_async_write(l1_addr, dst_noc_addr, write_size);
-            sharded_dest_id++;
-            sharded_offset = 0;
-            l1_addr += write_size;
-        }
-    }
-}
-
-template <typename AddrGenType>
-FORCE_INLINE void noc_async_write_sharded(
     Noc noc, uint32_t l1_addr, AddrGenType tensor, uint32_t dest_id, uint32_t offset, uint32_t size) {
     if constexpr (AddrGenType::DSpec::is_interleaved) {
         noc.async_write(
@@ -339,34 +268,6 @@ FORCE_INLINE void noc_async_write_sharded(
             sharded_dest_id++;
             sharded_offset = 0;
             l1_addr += write_size;
-        }
-    }
-}
-
-template <typename AddrGenType>
-FORCE_INLINE void noc_async_read_sharded(
-    uint32_t l1_addr, AddrGenType tensor, uint32_t src_id, uint32_t offset, uint32_t size) {
-    if constexpr (AddrGenType::DSpec::is_interleaved) {
-        noc_async_read(tensor.get_noc_addr(src_id, offset), l1_addr, size);
-    } else {
-        const auto& dspec = tensor.dspec();
-        const uint32_t r = dspec.rank();
-        const uint32_t pages_per_row = (r > 1) ? dspec.tensor_shape()[r - 1] : 1u;
-        if (pages_per_row <= 1) {
-            noc_async_read(tensor.get_noc_addr(src_id, offset), l1_addr, size);
-            return;
-        }
-        const uint32_t page_size = tensor.get_aligned_page_size();
-        uint32_t sharded_src_id = src_id * pages_per_row + offset / page_size;
-        uint32_t sharded_offset = offset % page_size;
-        uint32_t num_pages = div_up(size + sharded_offset, page_size);
-        for (uint32_t i = 0; i < num_pages; i++) {
-            uint64_t src_noc_addr = tensor.get_noc_addr(sharded_src_id, sharded_offset);
-            uint32_t read_size = std::min(size - i * page_size, page_size - sharded_offset);
-            noc_async_read(src_noc_addr, l1_addr, read_size);
-            sharded_src_id++;
-            sharded_offset = 0;
-            l1_addr += read_size;
         }
     }
 }

--- a/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/common/kernels/common.hpp
@@ -341,8 +341,8 @@ FORCE_INLINE void noc_async_read_sharded(
     }
 }
 
+template <typename AddrGenType>
 [[deprecated("Use the overload with leading Noc parameter instead; this function will be removed ~2026-07")]]
-template <uint32_t max_transfer_size, typename AddrGenType>
 FORCE_INLINE void noc_async_read_sharded(
     const uint32_t l1_addr,
     const AddrGenType tensor,
@@ -350,7 +350,7 @@ FORCE_INLINE void noc_async_read_sharded(
     const uint32_t offset,
     const uint32_t size) {
     Noc noc;
-    return noc_async_read_sharded<max_transfer_size, AddrGenType>(noc, l1_addr, tensor, src_id, offset, size);
+    return noc_async_read_sharded(noc, l1_addr, tensor, src_id, offset, size);
 }
 
 }  // namespace tt::data_movement::common

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_higher_dim_rm_sharded.cpp
@@ -43,6 +43,8 @@ void kernel_main() {
     const uint32_t cb_slot = cb.get_write_ptr();
     cb.push_back(1);
 
+    Noc noc;
+
     for (uint32_t h = higher_dim_start; h < higher_dim_end; h++) {
         const uint32_t h_offset = h * LOWER_DIMS_TIMES_REP_DIM;
         const uint32_t h_offset_rep = h_offset * repetitions;
@@ -50,11 +52,11 @@ void kernel_main() {
             const uint32_t r_offset = r * LOWER_DIMS;
             for (uint32_t l = lower_dim_start; l < lower_dim_end; l++) {
                 const uint32_t read_offset = h_offset + r_offset + l;
-                noc_async_read_sharded(cb_slot, s, read_offset, 0, original_page_size_bytes);
+                noc_async_read_sharded(noc, cb_slot, s, read_offset, 0, original_page_size_bytes);
                 noc_async_read_barrier();
                 for (uint32_t n = 0; n < repetitions; n++) {
                     const uint32_t write_offset = h_offset_rep + n * LOWER_DIMS_TIMES_REP_DIM + r_offset + l;
-                    noc_async_write_sharded(cb_slot, d, write_offset, 0, original_page_size_bytes);
+                    noc_async_write_sharded(noc, cb_slot, d, write_offset, 0, original_page_size_bytes);
                 }
                 noc_async_write_barrier();
             }

--- a/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_sharded.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/repeat/device/kernels/repeat_last_dim_rm_sharded.cpp
@@ -37,11 +37,13 @@ void kernel_main() {
     const uint32_t cb_slot = cb.get_write_ptr();
     cb.push_back(1);
 
+    Noc noc;
+
     for (uint32_t i = page_start; i < page_end; i++) {
-        noc_async_read_sharded(cb_slot, s, i, 0, original_page_size_bytes);
+        noc_async_read_sharded(noc, cb_slot, s, i, 0, original_page_size_bytes);
         noc_async_read_barrier();
         for (uint32_t k = 0; k < num_repeats; k++) {
-            noc_async_write_sharded(cb_slot, d, i, k * original_page_size_bytes, original_page_size_bytes);
+            noc_async_write_sharded(noc, cb_slot, d, i, k * original_page_size_bytes, original_page_size_bytes);
         }
         noc_async_write_barrier();
     }

--- a/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/ccl/all_to_all_dispatch_metadata/device/kernels/dataflow/reader_all_to_all_dispatch_metadata.cpp
@@ -87,6 +87,8 @@ void kernel_main() {
     constexpr uint32_t shared_expert_data_size_bytes = num_shared_experts * sizeof(uint16_t);
     constexpr uint16_t bf16_one = 0x3f80;
 
+    Noc noc;
+
     const auto input_addr_gen = TensorAccessor(input_args, input_tensor_address, input_page_size);
     const auto indices_addr_gen = TensorAccessor(indices_args, indices_tensor_address, indices_page_size);
     const auto scores_addr_gen = TensorAccessor(scores_args, scores_tensor_address, scores_page_size);
@@ -126,7 +128,7 @@ void kernel_main() {
         if constexpr (num_shared_experts > 0) {
             const uint32_t shared_expert_id_l1_addr = l1_write_addr + indices_page_size;
             tt_memmove<false, true, true, shared_expert_data_size_bytes>(
-                shared_expert_id_l1_addr, shared_expert_ids_addr, shared_expert_data_size_bytes);
+                noc, shared_expert_id_l1_addr, shared_expert_ids_addr, shared_expert_data_size_bytes);
         }
 
         // Only primary worker reads scores (only primary sends metadata)

--- a/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/slice_write/device/kernels/dataflow/slice_write_reader_interleaved.cpp
@@ -41,6 +41,7 @@ void kernel_main() {
             noc.async_read_barrier();
             const uint32_t l1_write_addr = cb_in0.get_write_ptr() + l1_offset;
             tt::data_movement::common::tt_memmove<false, false, false, 0>(
+                noc,
                 l1_write_addr + page_offset,  // destination (shifted right)
                 l1_write_addr,                // source (original location)
                 stick_size                    // total bytes to move

--- a/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
+++ b/ttnn/cpp/ttnn/operations/experimental/transformer/nlp_create_qkv_heads_decode/device/kernels/reader_interleaved_tm_tile_layout_nlp_create_qkv_heads_decode.cpp
@@ -117,7 +117,7 @@ void kernel_main() {
                     /*guaranteed_16B_aligned=*/false,
                     /*copy_async=*/true,
                     /*use_read_datamover=*/true,
-                    /*max_transfer_size=*/SUBTILE_LINE_BYTES>(write_addr, scratch_read_offset, SUBTILE_LINE_BYTES);
+                    /*max_transfer_size=*/SUBTILE_LINE_BYTES>(noc, write_addr, scratch_read_offset, SUBTILE_LINE_BYTES);
                 scratch_read_offset += DRAM_ALIGN_BYTES;
                 write_addr += tile_size;
             }

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_receive.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/reader_receive.cpp
@@ -34,6 +34,8 @@ void kernel_main() {
     // reusing the last arg for fabric setup, therefore index overlaps.
     size_t conn_arg_idx = 9;
 
+    Noc noc;
+
     auto fabric_connection = FabricConnectionManager::build_from_args<
         FabricConnectionManager::BuildFromArgsMode::BUILD_AND_OPEN_CONNECTION_START_ONLY>(conn_arg_idx);
 
@@ -90,7 +92,7 @@ void kernel_main() {
             const uint32_t transfer_size_bytes = std::min(page_size_bytes - page_offset, packet_size_bytes);
             const uint32_t packet_l1_page_addr = packet_l1_addr + packet_page_idx * aligned_page_size_bytes;
 
-            tt_memmove<false, false, false, 0>(dest_addr, packet_l1_page_addr, transfer_size_bytes);
+            tt_memmove<false, false, false, 0>(noc, dest_addr, packet_l1_page_addr, transfer_size_bytes);
             ++packet_page_idx;
         }
         cb_push_back(receiver_cb_id, 1);

--- a/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp
+++ b/ttnn/cpp/ttnn/operations/point_to_point/device/kernels/dataflow/writer_send.cpp
@@ -33,6 +33,8 @@ void kernel_main() {
 
     const uint32_t aligned_page_size_bytes = round_up(page_size_bytes, alignment);
 
+    Noc noc;
+
     // reusing the last arg for fabric setup, therefore index overlaps.
     size_t conn_arg_idx = 9;
 
@@ -82,7 +84,7 @@ void kernel_main() {
 
             // copy page to packet buffer with offset
             const uint32_t packet_addr = packet_base_addr + packet_page_idx * aligned_page_size_bytes;
-            tt_memmove<false, false, false, 0>(packet_addr, src_addr, transfer_size_bytes);
+            tt_memmove<false, false, false, 0>(noc, packet_addr, src_addr, transfer_size_bytes);
             ++packet_page_idx;
             if (packet_page_idx >= curr_pages_per_packet) {
                 tt::tt_fabric::linear::to_noc_unicast_write(


### PR DESCRIPTION
### PR Category
Cleanup

### Summary
Relates to https://github.com/tenstorrent/tt-metal/issues/45003, second part of the migration started in PR #47050 

Retire free-fn overloads in data_movement's `common.hpp` and improve the new `tt_memmove` body to avoid `get_noc_addr()`

### Notes for reviewers

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=iwrosz/dm-common-d1-retire)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:iwrosz/dm-common-d1-retire)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=iwrosz/dm-common-d1-retire)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:iwrosz/dm-common-d1-retire)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml/badge.svg?branch=iwrosz/dm-common-d1-retire)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-sanity-tests.yaml?query=branch:iwrosz/dm-common-d1-retire)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=iwrosz/dm-common-d1-retire)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:iwrosz/dm-common-d1-retire)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=iwrosz/dm-common-d1-retire)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:iwrosz/dm-common-d1-retire)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=iwrosz/dm-common-d1-retire)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:iwrosz/dm-common-d1-retire)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=iwrosz/dm-common-d1-retire)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:iwrosz/dm-common-d1-retire)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=iwrosz/dm-common-d1-retire)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:iwrosz/dm-common-d1-retire)