### PR TITLE
guard against calls to get_tile

### DIFF
--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -1210,11 +1210,16 @@ HostTensor to_dtype(const HostTensor& input_tensor, DataType dtype) {
     const auto layout =
         (dtype == DataType::BFLOAT4_B || dtype == DataType::BFLOAT8_B) ? Layout::TILE : input_tensor.layout();
 
+    tt::tt_metal::PageConfig page_config(layout);
+    if (input_tensor.layout() == Layout::TILE) {
+        page_config = tt::tt_metal::PageConfig(layout, input_tensor.tensor_spec().tile());
+    }
+
     auto output_spec = TensorSpec(
         input_tensor.logical_shape(),
         tt::tt_metal::TensorLayout::fromPaddedShape(
             dtype,
-            tt::tt_metal::PageConfig(layout, input_tensor.tensor_spec().tile()),
+            page_config,
             input_tensor.tensor_spec().memory_config(),
             input_tensor.logical_shape(),
             input_tensor.padded_shape()));

--- a/tt_metal/impl/tensor/tensor_apis.cpp
+++ b/tt_metal/impl/tensor/tensor_apis.cpp
@@ -527,7 +527,10 @@ HostTensor to_layout_impl(const HostTensor& tensor, Layout target_layout) {
     }
 
     auto source_layout = tensor.layout();
-    auto tile = tensor.tensor_spec().tile();
+    auto tile = tt::tt_metal::Tile();
+    if (tensor.layout() == Layout::TILE) {
+        tile = tensor.tensor_spec().tile();
+    }
     auto physical_shape = tensor.tensor_spec().physical_shape();
     auto convert =
         [tile, &physical_shape, source_layout, target_layout](const HostBuffer& input_host_buffer) -> std::vector<T> {
@@ -553,7 +556,7 @@ HostTensor to_layout_impl(const HostTensor& tensor, Layout target_layout) {
             tensor.logical_shape(),
             TensorLayout::fromPaddedShape(
                 tensor.dtype(),
-                PageConfig(target_layout, tensor.tensor_spec().tile()),
+                PageConfig(target_layout, tile),
                 MemoryConfig{},
                 tensor.logical_shape(),
                 tensor.padded_shape())),
@@ -868,13 +871,19 @@ HostTensor pad_impl(
     auto transformed_buffer = tensor.buffer().transform(
         [&](const HostBuffer& buffer) { return HostBuffer(pad(buffer)); },
         DistributedHostBuffer::ProcessShardExecutionPolicy::PARALLEL);
+
+    auto tile = tt::tt_metal::Tile();
+    if (tensor.layout() == Layout::TILE) {
+        tile = tensor.tensor_spec().tile();
+    }
+
     return HostTensor(
         std::move(transformed_buffer),
         TensorSpec(
             tensor.logical_shape(),
             TensorLayout::fromPaddedShape(
                 tensor.dtype(),
-                PageConfig(tensor.layout(), tensor.tensor_spec().tile()),
+                PageConfig(tensor.layout(), tile),
                 MemoryConfig{},
                 tensor.logical_shape(),
                 output_padded_shape)),

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -23,15 +23,18 @@ namespace ttnn::operations::core::CMAKE_UNIQUE_NAMESPACE {
 namespace {
 
 bool requires_padding_change(const ttnn::Tensor& tensor, ttnn::Layout layout) {
-    auto tile = tensor.tensor_spec().tile();
     if (layout == Layout::ROW_MAJOR) {
         // There shouldn't be extra paddings for Row Major layout
         return tensor.logical_shape() != tensor.padded_shape();
     }
     // It's okay for conversion to tile layout to preserve arbitrary padding as long as it satisfies the alignment
+    tt::tt_metal::PageConfig page_config = tt::tt_metal::PageConfig(layout);
+    if (tensor.layout() == Layout::TILE) {
+        page_config = tt::tt_metal::PageConfig(layout, tensor.tensor_spec().tile());
+    }
+
     TensorSpec padded_spec(
-        tensor.padded_shape(),
-        tt::tt_metal::TensorLayout(tensor.dtype(), tt::tt_metal::PageConfig(layout, tile), tensor.memory_config()));
+        tensor.padded_shape(), tt::tt_metal::TensorLayout(tensor.dtype(), page_config, tensor.memory_config()));
     return tensor.padded_shape() != padded_spec.padded_shape();
 }
 
@@ -82,15 +85,17 @@ Tensor to_layout_impl(
     }
 
     auto tensor = tensor_arg;
-    const auto tile = tensor.tensor_spec().tile();
     auto output_shape = tensor_arg.logical_shape();
     auto output_memory_config =
         memory_config.value_or(ttnn::get_memory_config(tensor).value_or(ttnn::DRAM_MEMORY_CONFIG));
 
-    TensorSpec tile_spec(
-        tensor_arg.logical_shape(),
-        tt::tt_metal::TensorLayout(
-            tensor_arg.dtype(), tt::tt_metal::PageConfig(Layout::TILE, tile), output_memory_config));
+    tt::tt_metal::PageConfig page_config = tt::tt_metal::PageConfig(Layout::TILE);
+    if (tensor_arg.layout() == Layout::TILE) {
+        page_config = tt::tt_metal::PageConfig(Layout::TILE, tensor.tensor_spec().tile());
+    }
+    TensorSpec tile_spec = TensorSpec(
+        tensor_arg.logical_shape(), tt::tt_metal::TensorLayout(tensor_arg.dtype(), page_config, output_memory_config));
+
     auto padded_output_shape = tile_spec.padded_shape();
     auto original_rank = tensor_arg.logical_shape().rank();
     const auto& original_shape = tensor_arg.logical_shape();
@@ -121,7 +126,10 @@ Tensor to_layout_impl(
             }
             if (layout == ttnn::TILE_LAYOUT) {
                 if (tensor.is_sharded()) {
-                    const auto tensor_tile = tensor.tensor_spec().tile();
+                    tt::tt_metal::Tile tensor_tile = tt::tt_metal::Tile();
+                    if (tensor.layout() == ttnn::TILE_LAYOUT) {
+                        tensor_tile = tensor.tensor_spec().tile();
+                    }
                     uint32_t tile_height = tensor_tile.get_height();
                     uint32_t tile_width = tensor_tile.get_width();
                     const auto mem_config = get_memory_config(tensor).value();

--- a/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
+++ b/ttnn/cpp/ttnn/operations/core/to_layout/to_layout_op.cpp
@@ -91,7 +91,7 @@ Tensor to_layout_impl(
 
     tt::tt_metal::PageConfig page_config = tt::tt_metal::PageConfig(Layout::TILE);
     if (tensor_arg.layout() == Layout::TILE) {
-        page_config = tt::tt_metal::PageConfig(Layout::TILE, tensor.tensor_spec().tile());
+        page_config = tt::tt_metal::PageConfig(Layout::TILE, tensor_arg.tensor_spec().tile());
     }
     TensorSpec tile_spec = TensorSpec(
         tensor_arg.logical_shape(), tt::tt_metal::TensorLayout(tensor_arg.dtype(), page_config, output_memory_config));

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize/tilize.cpp
@@ -50,9 +50,10 @@ ttnn::Tensor tilize(
     uint32_t output_single_tile_size =
         output_dtype.has_value() ? tt::tile_size(tt::tt_metal::datatype_to_dataformat_converter(output_dtype.value()))
                                  : input_single_tile_size;
-
-    uint32_t input_tile_width = input_tensor.tensor_spec().tile().get_width();
-    uint32_t input_tile_height = input_tensor.tensor_spec().tile().get_height();
+    tt::tt_metal::Tile tile =
+        (input_tensor.layout() == Layout::TILE) ? input_tensor.tensor_spec().tile() : tt::tt_metal::Tile();
+    uint32_t input_tile_width = tile.get_width();
+    uint32_t input_tile_height = tile.get_height();
 
     uint32_t num_tiles_per_row = input_tensor.padded_shape()[-1] / input_tile_width;
     uint32_t num_tiles_per_col = input_tensor.padded_shape()[-1] / input_tile_height;

--- a/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/tilize_with_val_padding/tilize_with_val_padding.cpp
@@ -155,8 +155,10 @@ ttnn::Tensor tilize_with_zero_padding(
     using namespace tt::constants;
     auto padded_shape = input_tensor.padded_shape();
 
-    uint32_t input_tile_width = input_tensor.tensor_spec().tile().get_width();
-    uint32_t input_tile_height = input_tensor.tensor_spec().tile().get_height();
+    tt::tt_metal::Tile tile =
+        (input_tensor.layout() == Layout::TILE) ? input_tensor.tensor_spec().tile() : tt::tt_metal::Tile();
+    uint32_t input_tile_width = tile.get_width();
+    uint32_t input_tile_height = tile.get_height();
 
     padded_shape[-2] = tt::round_up(padded_shape[-2], input_tile_height);
     padded_shape[-1] = tt::round_up(padded_shape[-1], input_tile_width);

--- a/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
+++ b/ttnn/cpp/ttnn/operations/data_movement/untilize_with_unpadding/device/factories/untilize_with_unpadding_multi_core_interleaved_program_factory.cpp
@@ -166,7 +166,7 @@ tt::tt_metal::ProgramDescriptor UntilizeWithUnpaddingMultiCoreInterleavedProgram
         desc.kernels.push_back(std::move(cliff_desc));
     }
 
-    uint32_t tile_height = output.tensor_spec().tile().get_height();
+    uint32_t tile_height = input.tensor_spec().tile().get_height();
     auto core_assignments = ttnn::distribute_work(
         output_shape, input_shape, ncores, nblocks_per_core, has_cliff, nblocks_per_core_cliff, tile_height);
 


### PR DESCRIPTION
This pull request refactors how tile and page configuration information is handled when converting tensor layouts and data types, making the code more robust and consistent when dealing with different tensor layouts. The main improvements involve ensuring that tile information is only accessed when the tensor is actually in TILE layout, and centralizing the logic for constructing `PageConfig` objects.

Key changes include:

**Consistent PageConfig and Tile Handling:**

* Updated `to_dtype` in `tensor_apis.cpp` to construct `PageConfig` based on the input tensor's layout, only including tile information if the layout is TILE.
* Refactored `requires_padding_change` and `to_layout_impl` in `to_layout_op.cpp` to build `PageConfig` and access tile information only when the tensor's layout is TILE, preventing unnecessary or incorrect accesses. [[1]](diffhunk://#diff-4856411eddceca2ed9c0f2011efd671537891d0c417231d37131cffd172e4aa2L26-R37) [[2]](diffhunk://#diff-4856411eddceca2ed9c0f2011efd671537891d0c417231d37131cffd172e4aa2L85-R98)
* Improved logic in `to_layout_impl` to initialize the tile variable safely, only extracting tile information if the tensor is in TILE layout.

**Bug Fix:**

* Fixed a bug in `untilize_with_unpadding_multi_core_interleaved_program_factory.cpp` by ensuring the tile height is always taken from the input tensor, not the output tensor, for correct work distribution.### PR Category
<!-- What kind of PR is this? Clean category helps keep PR small and review high quality.
     Available options: Feature, Performance, Bug fix, Cleanup, Test Only.
     Please include this in your PR title -->

### Summary
<!-- Explain the motivation for this change. What problem does it solve?
     To link an issue: Closes #<number>  /  Fixes #<number>  /  Relates to #<number> -->

### Notes for reviewers
-it may be better to generate a page config from tensors (via member function)?
-I wonder if we can skip the entire block of code in to_layout_op.cpp:128 if the tensor is not in tile layout to begin with?

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=jameslee/remove_get_tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:jameslee/remove_get_tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=jameslee/remove_get_tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:jameslee/remove_get_tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=jameslee/remove_get_tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:jameslee/remove_get_tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=jameslee/remove_get_tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:jameslee/remove_get_tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=jameslee/remove_get_tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:jameslee/remove_get_tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=jameslee/remove_get_tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:jameslee/remove_get_tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=jameslee/remove_get_tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:jameslee/remove_get_tile)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=jameslee/remove_get_tile)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:jameslee/remove_get_tile)