### PR TITLE
[Feature] TensorParameter page size relaxation in Metal 2.0

### DIFF
--- a/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
+++ b/tests/tt_metal/tt_metal/api/metal2_host_api/test_program_spec.cpp
@@ -40,6 +40,7 @@
 #include <tt-metalium/core_coord.hpp>
 #include <tt-metalium/hal.hpp>
 #include <tt-metalium/tt_metal.hpp>  // for CompileProgram (JIT trigger)
+#include <hostdevcommon/tensor_accessor/arg_config.hpp>  // tensor_accessor::ArgsConfig / ArgConfig::RuntimePageSize
 #include "impl/kernels/kernel.hpp"
 #include "impl/program/program_impl.hpp"
 #include <tt-metalium/distributed.hpp>
@@ -3267,9 +3268,11 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedKernelHashStableAcross
     // the CTAs ([args_config.raw(), aligned_page_size]) are stable across shape variations.
     // The dynamic flag thus enables JIT cache reuse for tile-layout eltwise.
     //
-    // (Row-major interleaved has a shape-dependent page_size — the last-dim element count — so
-    // its CTAs do change with shape. That's a property of the page-size convention, not of the
-    // dynamic mechanism, and is a separate orthogonal concern. This test focuses on tile.)
+    // (Row-major interleaved has a shape-dependent page_size — the last-dim element count. Under
+    // dynamic_tensor_shape the resolver demotes that page size to a per-binding CRTA word, so its
+    // CTAs become shape-stable too; that path is covered by
+    // DynamicTensorShape_InterleavedRowMajorKernelHashStableAcrossWidths below. This test focuses on
+    // tile, whose page size is dtype-fixed and never rode a shape-dependent CTA in the first place.)
     auto make_spec = [](tt::tt_metal::Shape shape) {
         ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
         auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE);
@@ -3292,6 +3295,47 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedKernelHashStableAcross
         prog_b.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash())
         << "Interleaved tile + dynamic_tensor_shape: shape variations must hash equal so the "
            "same compiled kernel binary is reused.";
+}
+
+TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedRowMajorKernelHashStableAcrossWidths) {
+    // The payoff of the page-size fold. For a ROW-MAJOR interleaved TensorParameter the page size
+    // (last_dim_width * elem_size) is shape-dependent. WITHOUT the flag it rides a compile-time arg,
+    // so two different-width tensors hash differently -- distinct cache entries, and (worse) a stale
+    // page size baked into a binary that gets reused on a cache hit: the exact bug this feature
+    // fixes. WITH dynamic_tensor_shape the page size moves to a CRTA, the CTAs become width-
+    // independent, and the two widths hash identically -- one cached binary, refreshed per-dispatch.
+    auto make_spec = [](uint32_t width, bool dynamic) {
+        ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+        auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::ROW_MAJOR);
+        auto memory_config =
+            tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+        auto tensor_layout = tt::tt_metal::TensorLayout(tt::tt_metal::DataType::BFLOAT16, page_config, memory_config);
+        TensorParameter tp{
+            .unique_id = TensorParamName{"input_tensor"},
+            .spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 1, 32, width}, std::move(tensor_layout)),
+            .advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = dynamic},
+        };
+        spec.tensor_parameters = {tp};
+        BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+        return spec;
+    };
+
+    // Baseline (flag off): different widths -> different page-size CTA -> different hash.
+    Program s_a = MakeProgramFromSpec(*mesh_device_, make_spec(/*width=*/64, /*dynamic=*/false));
+    Program s_b = MakeProgramFromSpec(*mesh_device_, make_spec(/*width=*/128, /*dynamic=*/false));
+    EXPECT_NE(
+        s_a.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash(),
+        s_b.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash())
+        << "Baseline: row-major page size rides a CTA, so different widths must hash differently.";
+
+    // With the flag: page size -> CRTA, CTAs width-independent -> identical hash (cache reuse).
+    Program d_a = MakeProgramFromSpec(*mesh_device_, make_spec(/*width=*/64, /*dynamic=*/true));
+    Program d_b = MakeProgramFromSpec(*mesh_device_, make_spec(/*width=*/128, /*dynamic=*/true));
+    EXPECT_EQ(
+        d_a.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash(),
+        d_b.impl().get_kernel_by_spec_name("dm_kernel")->compute_hash())
+        << "Row-major interleaved + dynamic_tensor_shape: page size moves to a CRTA, so different "
+           "widths hash equally (program-cache reuse; prevents the stale-page-size bug).";
 }
 
 TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedKernelHashStableAcrossShapes) {
@@ -3356,12 +3400,67 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_ShardedBindingTracksShapeCRTASlot
         << "Sharded + dynamic_tensor_shape: runtime-field CRTA words should equal BDS shape rank.";
 }
 
-TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedBindingHasNoRuntimeFieldCRTAs) {
-    // Interleaved + dynamic_tensor_shape: pure host-side validation loosening, no CTA→CRTA
-    // demotion, so num_runtime_field_crta_words should remain zero.
+TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedRowMajorBindingTracksPageSizeCRTASlot) {
+    // Row-major interleaved + dynamic_tensor_shape: the page size (= last_dim_width * elem_size) is
+    // part of the varying shape, so the resolver folds it from a compile-time arg into a single
+    // per-binding CRTA word ("A-collapse": the page-size CTA slot is dropped and the RuntimePageSize
+    // bit is set in args_config). The binding handle must advertise exactly one runtime field word,
+    // tagged as the page-size kind. MakeMinimalTensorParameter is BFLOAT16 / ROW_MAJOR / interleaved.
+    auto make_spec = [](bool dynamic) {
+        ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
+        auto tp = MakeMinimalTensorParameter("input_tensor");
+        tp.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = dynamic};
+        spec.tensor_parameters = {tp};
+        BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
+        return spec;
+    };
+
+    Program prog_dyn = MakeProgramFromSpec(*mesh_device_, make_spec(/*dynamic=*/true));
+    auto kernel = prog_dyn.impl().get_kernel_by_spec_name("dm_kernel");
+    const auto& handles = kernel->tensor_binding_handles();
+    ASSERT_EQ(handles.size(), 1u);
+    EXPECT_EQ(handles[0].num_runtime_field_crta_words, 1u)
+        << "Row-major interleaved + dynamic_tensor_shape: page size demotes to exactly one CRTA word.";
+    EXPECT_TRUE(handles[0].runtime_field_is_page_size)
+        << "The runtime field must be tagged as the page-size kind (not the sharded-shape kind).";
+
+    // The binding's args_config CTA word carries the RuntimePageSize bit.
+    const std::vector<uint32_t> dyn_ctas = kernel->compile_time_args();
+    ASSERT_LT(handles[0].cta_offset, dyn_ctas.size());
+    const auto dyn_cfg = tensor_accessor::ArgsConfig(
+        static_cast<tensor_accessor::ArgsConfig::Underlying>(dyn_ctas[handles[0].cta_offset]));
+    EXPECT_TRUE(dyn_cfg.test(tensor_accessor::ArgConfig::RuntimePageSize))
+        << "RuntimePageSize bit must be set in the binding's args_config word.";
+
+    // A-collapse: the dynamic binding omits the page-size CTA word that the static (bit-off) binding
+    // carries, so the whole-kernel CTA count is exactly one shorter. The two specs are identical
+    // apart from the flag, so the size delta is precisely the dropped page-size slot.
+    Program prog_static = MakeProgramFromSpec(*mesh_device_, make_spec(/*dynamic=*/false));
+    const std::vector<uint32_t> static_ctas =
+        prog_static.impl().get_kernel_by_spec_name("dm_kernel")->compile_time_args();
+    EXPECT_EQ(static_ctas.size(), dyn_ctas.size() + 1u)
+        << "Static binding keeps the page-size CTA; the dynamic binding drops it (A-collapse).";
+    const auto static_cfg = tensor_accessor::ArgsConfig(
+        static_cast<tensor_accessor::ArgsConfig::Underlying>(static_ctas[handles[0].cta_offset]));
+    EXPECT_FALSE(static_cfg.test(tensor_accessor::ArgConfig::RuntimePageSize))
+        << "Without the flag, the RuntimePageSize bit must NOT be set.";
+}
+
+TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedTileBindingHasNoRuntimeFieldCRTAs) {
+    // Interleaved + TILE layout: the page size is dtype/tile-fixed, independent of logical shape, so
+    // dynamic_tensor_shape does NOT demote it to a CRTA (the fold gates on ROW_MAJOR). The flag is a
+    // pure host-side validation loosening here; the binding carries no runtime field words. Guards
+    // the layout gate -- a regression that demoted tile page sizes would trip this.
     ProgramSpec spec = MakeMinimalGen1ValidProgramSpec();
-    auto tp = MakeMinimalTensorParameter("input_tensor");
-    tp.advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true};
+    auto page_config = tt::tt_metal::PageConfig(tt::tt_metal::Layout::TILE);
+    auto memory_config =
+        tt::tt_metal::MemoryConfig{tt::tt_metal::TensorMemoryLayout::INTERLEAVED, tt::tt_metal::BufferType::DRAM};
+    auto tensor_layout = tt::tt_metal::TensorLayout(tt::tt_metal::DataType::BFLOAT16, page_config, memory_config);
+    TensorParameter tp{
+        .unique_id = TensorParamName{"input_tensor"},
+        .spec = tt::tt_metal::TensorSpec(tt::tt_metal::Shape{1, 1, 32, 32}, std::move(tensor_layout)),
+        .advanced_options = TensorParameterAdvancedOptions{.dynamic_tensor_shape = true},
+    };
     spec.tensor_parameters = {tp};
     BindTensorParameterToKernel(spec.kernels[0], "input_tensor", "input_ta");
 
@@ -3370,7 +3469,8 @@ TEST_F(ProgramSpecTestGen1, DynamicTensorShape_InterleavedBindingHasNoRuntimeFie
     const auto& handles = kernel->tensor_binding_handles();
     ASSERT_EQ(handles.size(), 1u);
     EXPECT_EQ(handles[0].num_runtime_field_crta_words, 0u)
-        << "Interleaved dynamic_tensor_shape is host-side-only; no runtime CRTA words.";
+        << "Interleaved TILE + dynamic_tensor_shape is host-side-only; no runtime CRTA words.";
+    EXPECT_FALSE(handles[0].runtime_field_is_page_size);
 }
 
 TEST_F(ProgramSpecTestGen1, KernelCrtaLayout_AllThreeSectionsConsistent) {

--- a/tests/tt_metal/tt_metal/api/test_tensor_accessor_default_page_size.cpp
+++ b/tests/tt_metal/tt_metal/api/test_tensor_accessor_default_page_size.cpp
@@ -27,6 +27,7 @@
 #include <tt-metalium/shape.hpp>
 #include <tt-metalium/shape2d.hpp>
 #include <tt-metalium/tensor_accessor_args.hpp>
+#include <hostdevcommon/tensor_accessor/arg_config.hpp>  // tensor_accessor::ArgConfig (RuntimePageSize / IsDram)
 #include <tt-metalium/tt_backend_api_types.hpp>
 #include <tt-metalium/tt_metal.hpp>
 
@@ -39,6 +40,14 @@ namespace {
 
 constexpr const char* KERNEL_PATH =
     "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/tensor_accessor/report_page_size.cpp";
+
+constexpr const char* RUNTIME_PAGE_SIZE_KERNEL_PATH =
+    "tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/tensor_accessor/report_runtime_page_size.cpp";
+
+// A deliberately synthetic page size for the RuntimePageSize test: distinct from any buffer's
+// natural aligned_page_size, so a passing assertion can only mean the value came from the common
+// runtime arg (not a stale CTA, and not a re-derivation from the bound buffer).
+constexpr uint32_t RUNTIME_PAGE_SIZE_SENTINEL = 0xABCD;
 
 constexpr uint32_t OUTPUT_PAGE_SIZE = 32;
 constexpr CoreCoord KERNEL_CORE(0, 0);
@@ -107,6 +116,70 @@ void verify_default_page_size(const std::shared_ptr<distributed::MeshDevice>& me
     EXPECT_EQ(result[1], expected_output) << "Output TensorAccessor.page_size should default to aligned_page_size. "
                                           << "Expected: " << expected_output << ", Got: " << result[1]
                                           << ", Buffer page_size: " << output_buffer->page_size();
+}
+
+void verify_runtime_page_size(
+    const std::shared_ptr<distributed::MeshDevice>& mesh_device,
+    const Buffer* input_buffer,
+    uint32_t sentinel_page_size) {
+    auto* device = mesh_device->get_devices()[0];
+    auto& cq = mesh_device->mesh_command_queue();
+
+    auto zero_coord = distributed::MeshCoordinate(0, 0);
+    auto device_range = distributed::MeshCoordinateRange(zero_coord, zero_coord);
+    distributed::MeshWorkload workload;
+    Program program = CreateProgram();
+    workload.add_program(device_range, std::move(program));
+    auto& prog = workload.get_programs().at(device_range);
+
+    auto output_buffer = CreateBuffer(InterleavedBufferConfig{
+        .device = device, .size = OUTPUT_PAGE_SIZE, .page_size = OUTPUT_PAGE_SIZE, .buffer_type = BufferType::DRAM});
+
+    CircularBufferConfig cb_config =
+        CircularBufferConfig(OUTPUT_PAGE_SIZE, {{0, tt::DataFormat::RawUInt32}}).set_page_size(0, OUTPUT_PAGE_SIZE);
+    CreateCircularBuffer(prog, KERNEL_CORE, cb_config);
+
+    // Forge the input accessor's compile-time args: the args_config word with the RuntimePageSize
+    // bit set, and NO aligned-page-size word (A-collapse). The legacy TensorAccessorArgs(buffer)
+    // path never sets this bit -- only the Metal 2.0 resolver does -- so we build the word by hand.
+    // The output accessor is appended normally (static); the kernel reads it at the post-A-collapse
+    // offset, which only resolves correctly if the input consumed exactly one CTA word.
+    std::vector<uint32_t> compile_time_args;
+    const uint32_t input_config_word =
+        (tensor_accessor::ArgConfig::IsDram | tensor_accessor::ArgConfig::RuntimePageSize).raw();
+    compile_time_args.push_back(input_config_word);
+    TensorAccessorArgs(*output_buffer).append_to(compile_time_args);
+
+    auto kernel = CreateKernel(
+        prog,
+        RUNTIME_PAGE_SIZE_KERNEL_PATH,
+        KERNEL_CORE,
+        DataMovementConfig{
+            .processor = DataMovementProcessor::RISCV_0,
+            .noc = NOC::RISCV_0_default,
+            .compile_args = compile_time_args});
+
+    SetRuntimeArgs(prog, kernel, KERNEL_CORE, {input_buffer->address(), output_buffer->address()});
+    // The input's dynamic page size rides common runtime arg 0 -- the channel the device accessor
+    // reads via get_aligned_page_size() when the RuntimePageSize bit is set.
+    SetCommonRuntimeArgs(prog, kernel, {sentinel_page_size});
+
+    distributed::EnqueueMeshWorkload(cq, workload, false);
+    distributed::Finish(cq);
+
+    std::vector<uint32_t> result;
+    detail::ReadFromBuffer(output_buffer, result);
+
+    EXPECT_EQ(result[0], sentinel_page_size)
+        << "RuntimePageSize input accessor must report the runtime (common-arg) page size, not a "
+           "static CTA value. Expected sentinel "
+        << sentinel_page_size << ", got " << result[0];
+
+    uint32_t expected_output = static_cast<uint32_t>(output_buffer->aligned_page_size());
+    EXPECT_EQ(result[1], expected_output)
+        << "Output accessor page size must be intact -- proves the input's A-collapse (one fewer CTA "
+           "word) did not shift the output accessor's CTA offset. Expected "
+        << expected_output << ", got " << result[1];
 }
 
 std::shared_ptr<Buffer> create_interleaved_buffer(
@@ -202,6 +275,18 @@ TEST_F(MeshDispatchFixture, TensixTensorAccessorDefaultPageSizeInterleavedL1Tili
         auto* device = mesh_device->get_devices()[0];
         auto buffer = create_interleaved_buffer(device, TILE_PAGE_SIZE, TILE_NUM_PAGES, BufferType::L1);
         verify_default_page_size(mesh_device, buffer.get());
+    }
+}
+
+// --- Runtime page size (RuntimePageSize relaxation, device-side isolation) ---
+
+TEST_F(MeshDispatchFixture, TensixTensorAccessorRuntimePageSizeInterleavedDram) {
+    for (auto& mesh_device : devices_) {
+        auto* device = mesh_device->get_devices()[0];
+        // Input is a real interleaved row-major DRAM buffer; its address is passed to the kernel but
+        // its page size is NOT -- the accessor must read the page size from the runtime sentinel.
+        auto input = create_interleaved_buffer(device, RM_PAGE_SIZE, RM_NUM_PAGES, BufferType::DRAM);
+        verify_runtime_page_size(mesh_device, input.get(), RUNTIME_PAGE_SIZE_SENTINEL);
     }
 }
 

--- a/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/tensor_accessor/report_runtime_page_size.cpp
+++ b/tests/tt_metal/tt_metal/test_kernels/dataflow/unit_tests/tensor_accessor/report_runtime_page_size.cpp
@@ -1,0 +1,55 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+// Companion to report_page_size.cpp, exercising the RuntimePageSize (dynamic page-size)
+// relaxation on its home turf -- the device TensorAccessor -- in isolation from Metal 2.0.
+//
+// The INPUT TensorAccessorArgs has the RuntimePageSize bit set in its args_config CTA word
+// and its aligned-page-size CTA slot OMITTED ("A-collapse"), so the page size is sourced
+// from a common runtime arg instead of a compile-time arg. The host forges this layout by
+// hand (the legacy TensorAccessorArgs(buffer) path never sets the bit).
+//
+// We build the input accessor with the explicit 3-arg ctor (args, addr, page_size), mirroring
+// what the Metal 2.0 binding token does internally -- the 2-arg ctor would default page_size to
+// the *static* AlignedPageSize, which is deliberately 0 when RuntimePageSize is set.
+//
+// Reports two words for host verification:
+//   ptr[0] = input accessor's aligned page size  -> must equal the common-runtime-arg value
+//            (proves get_aligned_page_size() reads the CRTA, not a stale/zero static slot)
+//   ptr[1] = output accessor's aligned page size  -> must equal its static CTA value
+//            (proves the input's A-collapse left the *next* accessor's CTA offset intact)
+
+#include "api/dataflow/dataflow_api.h"
+
+void kernel_main() {
+    uint32_t input_addr = get_arg_val<uint32_t>(0);
+    uint32_t output_addr = get_arg_val<uint32_t>(1);
+
+    // The input's dynamic page size is supplied as common runtime arg 0.
+    constexpr uint32_t input_page_size_crta_index = 0;
+
+    constexpr uint32_t input_ta_cta_offset = 0;
+    constexpr auto input_ta_args = TensorAccessorArgs<input_ta_cta_offset>();
+
+    // A-collapse: the input accessor consumes one fewer CTA word (no page-size slot), so the
+    // output accessor's CTA offset must come from next_compile_time_args_offset(), not a fixed +2.
+    constexpr uint32_t output_ta_cta_offset = input_ta_args.next_compile_time_args_offset();
+    constexpr auto output_ta_args = TensorAccessorArgs<output_ta_cta_offset>();
+
+    // 3-arg ctor: feed the page size from the args getter (which reads the CRTA), mirroring the
+    // Metal 2.0 binding token. The default-constructed args reads common arg index 0.
+    auto input_accessor = TensorAccessor(input_ta_args, input_addr, input_ta_args.get_aligned_page_size());
+    auto output_accessor = TensorAccessor(output_ta_args, output_addr);
+
+    constexpr uint32_t output_cb = 0;
+    cb_reserve_back(output_cb, 1);
+    uint32_t l1_addr = get_write_ptr(output_cb);
+    auto* ptr = reinterpret_cast<volatile tt_l1_ptr uint32_t*>(l1_addr);
+    ptr[0] = input_accessor.get_aligned_page_size();
+    ptr[1] = output_accessor.get_aligned_page_size();
+
+    uint64_t dram_noc_addr = output_accessor.get_noc_addr(0);
+    noc_async_write(l1_addr, dram_noc_addr, output_accessor.get_aligned_page_size());
+    noc_async_write_barrier();
+}

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -231,31 +231,19 @@ struct TensorParameterAdvancedOptions {
     // Permit tensor arguments with dynamic logical shape.
     // The argument's logical_shape AND padded_shape may differ from the declared shape.
     // Effects:
-    //  - Validation checks are relaxed
-    //  - For an interleaved tensor, TensorAccessor configuration is unchanged
-    //  - For a sharded tensor, the TensorAccessor configuration dynamically reflects the
-    //    argument's actual shape. (Shape becomes an implicit runtime argument.)
+    //  - Validation checks are relaxed.
+    //  - For an interleaved ROW-MAJOR tensor: the byte page size = last_dim_width * element_size is
+    //    part of the varying shape, so it becomes an implicit runtime argument (re-derived from the
+    //    bound buffer each dispatch). Otherwise a compile-time page size would go stale on a
+    //    program-cache hit and the TensorAccessor would stride by the wrong number of bytes.
+    //    CAUTION: this makes the option UNSAFE for row-major. The TensorAccessor tracks the runtime
+    //    page size, but the REST of your kernel must too -- loop bounds, circular-buffer sizing, any
+    //    address math beyond the accessor. A kernel that assumes a fixed page size will mis-address.
+    //  - For an interleaved TILED tensor: TensorAccessor configuration is unchanged (the page size
+    //    is fixed by dtype/tile dims, so it cannot vary).
+    //  - For a sharded tensor: the TensorAccessor configuration dynamically reflects the argument's
+    //    actual shape. (Shape-in-pages becomes an implicit runtime argument.)
     bool dynamic_tensor_shape = false;
-
-    // Permit tensor arguments whose byte page size varies at runtime.
-    // For an interleaved row-major tensor the page size = last_dim_width * element_size, which
-    // changes with the tensor's shape; when one compiled program is reused across shapes (a
-    // program-cache hit on the fast path) a compile-time page size goes stale and the
-    // TensorAccessor strides by the wrong number of bytes. This carries the page size as a
-    // runtime field that the host re-derives from the bound buffer every dispatch.
-    // Effects:
-    //  - The page size becomes an implicit runtime argument, auto-derived from the buffer
-    //    (the user cannot supply a wrong value).
-    //  - INTERLEAVED ROW-MAJOR only. Forbidden on tiled (page size is dtype/tile-fixed) and
-    //    sharded (page size is spec-fixed) layouts: a hard error is raised at spec resolution.
-    //
-    // CAUTION:
-    // This is an ADVANCED option. The TensorAccessor will track the runtime page size, but the
-    // REST of your kernel must too -- loop bounds, circular-buffer sizing, and any address math
-    // beyond the accessor. Setting this on a kernel that assumes a fixed page size will silently
-    // mis-address. Orthogonal to dynamic_tensor_shape: a width-varying tensor changes both its
-    // logical shape and its page size, so the typical use case sets BOTH flags.
-    bool dynamic_page_size = false;
 };
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -236,6 +236,26 @@ struct TensorParameterAdvancedOptions {
     //  - For a sharded tensor, the TensorAccessor configuration dynamically reflects the
     //    argument's actual shape. (Shape becomes an implicit runtime argument.)
     bool dynamic_tensor_shape = false;
+
+    // Permit tensor arguments whose byte page size varies at runtime.
+    // For an interleaved row-major tensor the page size = last_dim_width * element_size, which
+    // changes with the tensor's shape; when one compiled program is reused across shapes (a
+    // program-cache hit on the fast path) a compile-time page size goes stale and the
+    // TensorAccessor strides by the wrong number of bytes. This carries the page size as a
+    // runtime field that the host re-derives from the bound buffer every dispatch.
+    // Effects:
+    //  - The page size becomes an implicit runtime argument, auto-derived from the buffer
+    //    (the user cannot supply a wrong value).
+    //  - INTERLEAVED ROW-MAJOR only. Forbidden on tiled (page size is dtype/tile-fixed) and
+    //    sharded (page size is spec-fixed) layouts: a hard error is raised at spec resolution.
+    //
+    // CAUTION:
+    // This is an ADVANCED option. The TensorAccessor will track the runtime page size, but the
+    // REST of your kernel must too -- loop bounds, circular-buffer sizing, and any address math
+    // beyond the accessor. Setting this on a kernel that assumes a fixed page size will silently
+    // mis-address. Orthogonal to dynamic_tensor_shape: a width-varying tensor changes both its
+    // logical shape and its page size, so the typical use case sets BOTH flags.
+    bool dynamic_page_size = false;
 };
 
 }  // namespace tt::tt_metal::experimental

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -219,10 +219,12 @@ struct TensorParameterAdvancedOptions {
     // CAUTION:
     // These options are UNSAFE if set to true; most kernels will not function
     // correctly if the tensor argument's spec deviates from the declared spec.
-    // Use with caution and ensure that your kernel logic is compatible.
+    // Use with caution. You must ensure that your kernel logic outside of the 
+    // TensorAccessor itself is compatible with the chosen relaxation option(s)!
 
     // Permit tensor arguments whose logical_shape differs from the declared shape.
     // The argument's padded_shape must still match exactly.
+    //
     // Effects:
     //  - Validation checks are relaxed
     //  - TensorAccessor configuration is completely unchanged
@@ -230,19 +232,20 @@ struct TensorParameterAdvancedOptions {
 
     // Permit tensor arguments with dynamic logical shape.
     // The argument's logical_shape AND padded_shape may differ from the declared shape.
+    //
     // Effects:
     //  - Validation checks are relaxed.
-    //  - For an interleaved ROW-MAJOR tensor: the byte page size = last_dim_width * element_size is
-    //    part of the varying shape, so it becomes an implicit runtime argument (re-derived from the
-    //    bound buffer each dispatch). Otherwise a compile-time page size would go stale on a
-    //    program-cache hit and the TensorAccessor would stride by the wrong number of bytes.
-    //    CAUTION: this makes the option UNSAFE for row-major. The TensorAccessor tracks the runtime
-    //    page size, but the REST of your kernel must too -- loop bounds, circular-buffer sizing, any
-    //    address math beyond the accessor. A kernel that assumes a fixed page size will mis-address.
-    //  - For an interleaved TILED tensor: TensorAccessor configuration is unchanged (the page size
-    //    is fixed by dtype/tile dims, so it cannot vary).
-    //  - For a sharded tensor: the TensorAccessor configuration dynamically reflects the argument's
-    //    actual shape. (Shape-in-pages becomes an implicit runtime argument.)
+    //  - For a sharded tensor: 
+    //    The TensorAccessor configuration DYNAMICALLY reflects the tensor argument's actual shape.
+    //    Shape, expressed in pages-per-dim, becomes implicit common runtime arguments.
+    //  - For an interleaved TILED tensor: 
+    //    TensorAccessor configuration is unchanged 
+    //    (The page size is fixed by dtype/tile dims, so it cannot vary with shape).
+    //  - For an interleaved ROW-MAJOR tensor: 
+    //    The TensorAccessor configuration DYNAMICALLY reflects the tensor argument's page size.
+    //    NOTE: page_size = last_dim_width * element_size is part of the varying shape!
+    //    The aligned_page_size becomes an implicit common runtime argument.
+    //    (Your kernel can access this value via TensorAccessor::get_aligned_page_size().)
     bool dynamic_tensor_shape = false;
 };
 

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/advanced_options.hpp
@@ -219,7 +219,7 @@ struct TensorParameterAdvancedOptions {
     // CAUTION:
     // These options are UNSAFE if set to true; most kernels will not function
     // correctly if the tensor argument's spec deviates from the declared spec.
-    // Use with caution. You must ensure that your kernel logic outside of the 
+    // Use with caution. You must ensure that your kernel logic outside of the
     // TensorAccessor itself is compatible with the chosen relaxation option(s)!
 
     // Permit tensor arguments whose logical_shape differs from the declared shape.
@@ -235,13 +235,13 @@ struct TensorParameterAdvancedOptions {
     //
     // Effects:
     //  - Validation checks are relaxed.
-    //  - For a sharded tensor: 
+    //  - For a sharded tensor:
     //    The TensorAccessor configuration DYNAMICALLY reflects the tensor argument's actual shape.
     //    Shape, expressed in pages-per-dim, becomes implicit common runtime arguments.
-    //  - For an interleaved TILED tensor: 
-    //    TensorAccessor configuration is unchanged 
+    //  - For an interleaved TILED tensor:
+    //    TensorAccessor configuration is unchanged
     //    (The page size is fixed by dtype/tile dims, so it cannot vary with shape).
-    //  - For an interleaved ROW-MAJOR tensor: 
+    //  - For an interleaved ROW-MAJOR tensor:
     //    The TensorAccessor configuration DYNAMICALLY reflects the tensor argument's page size.
     //    NOTE: page_size = last_dim_width * element_size is part of the varying shape!
     //    The aligned_page_size becomes an implicit common runtime argument.

--- a/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
+++ b/tt_metal/hostdevcommon/api/hostdevcommon/tensor_accessor/arg_config.hpp
@@ -23,7 +23,9 @@ enum class ArgConfig : uint8_t {
     RuntimeTensorShape = 1 << 4,
     RuntimeShardShape = 1 << 5,
     RuntimeBankCoords = 1 << 6,
-    Runtime = RuntimeRank | RuntimeNumBanks | RuntimeTensorShape | RuntimeShardShape | RuntimeBankCoords
+    RuntimePageSize = 1 << 7,
+    Runtime =
+        RuntimeRank | RuntimeNumBanks | RuntimeTensorShape | RuntimeShardShape | RuntimeBankCoords | RuntimePageSize
 };
 
 using ArgsConfig = Flags<ArgConfig>;

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -390,7 +390,13 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
     TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
         TensorAccessor(
             TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{},
-            static_cast<uint32_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {
+            static_cast<uint32_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t))),
+            // Page size: the AlignedPageSize CTA on the common path, or -- under the
+            // dynamic_page_size relaxation -- the per-binding CRTA word the host re-derives from the
+            // bound buffer each dispatch, so it stays fresh across program-cache hits. The args
+            // getter branches CTA-vs-CRTA internally; without the explicit 3rd arg the delegate
+            // would default to the (now zero) AlignedPageSize CTA under the relaxation.
+            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{}.get_aligned_page_size()) {
         static_assert(
             ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0,
             "TensorAccessorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -392,7 +392,7 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
             TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{},
             static_cast<uint32_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t))),
             // Page size: the AlignedPageSize CTA on the common path, or -- under the
-            // dynamic_page_size relaxation -- the per-binding CRTA word the host re-derives from the
+            // page-size relaxation (dynamic_tensor_shape on row-major) -- the per-binding CRTA word the host re-derives from the
             // bound buffer each dispatch, so it stays fresh across program-cache hits. The args
             // getter branches CTA-vs-CRTA internally; without the explicit 3rd arg the delegate
             // would default to the (now zero) AlignedPageSize CTA under the relaxation.

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -384,19 +384,19 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
         aligned_page_size(page_size_in) {}
 
     // Construct TensorAccessor directly from a Metal 2.0 binding token.
-    // See the sharded specialization for the binding's CRTA section layout and the
-    // alignment rationale.
+    // (See the sharded specialization for the binding's CRTA section layout and the alignment rationale.)
     template <uint32_t CTA_OFFSET, uint32_t ADDR_CRTA_OFFSET>
     TensorAccessor(tensor_accessor::TensorAccessorBindingToken<CTA_OFFSET, ADDR_CRTA_OFFSET>) :
         TensorAccessor(
-            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{},
+            // TensorAccessorArgs: Create the args object from the token's CTA offset and CRTA offset.
+            //   (But, add 1 to the token's CRTA offset to jump over the base address slot)
+            TensorAccessorArgs<CTA_OFFSET, 1 + (ADDR_CRTA_OFFSET / sizeof(uint32_t))>{},
+            // Bank base address: Get the base address from the front of the token's CRTA section.
             static_cast<uint32_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t))),
-            // Page size: the AlignedPageSize CTA on the common path, or -- under the
-            // page-size relaxation (dynamic_tensor_shape on row-major) -- the per-binding CRTA word the host re-derives from the
-            // bound buffer each dispatch, so it stays fresh across program-cache hits. The args
-            // getter branches CTA-vs-CRTA internally; without the explicit 3rd arg the delegate
-            // would default to the (now zero) AlignedPageSize CTA under the relaxation.
-            TensorAccessorArgs<CTA_OFFSET, ADDR_CRTA_OFFSET / sizeof(uint32_t) + 1>{}.get_aligned_page_size()) {
+            // Aligned page size: Create the args object again to grab the aligned_page_size from
+            //   the TensorAccessorArgs getter. The aligned page size may be housed either as a CTA
+            //   (static case) or as a CRTA (dynamic case) field. The getter handles resolution for us.
+            TensorAccessorArgs<CTA_OFFSET, 1 + (ADDR_CRTA_OFFSET / sizeof(uint32_t))>{}.get_aligned_page_size()) {
         static_assert(
             ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0,
             "TensorAccessorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor.h
@@ -378,7 +378,7 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
     TensorAccessor(
         const TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>& args,
         const uint32_t bank_base_address_in,
-        const uint32_t page_size_in = TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>::AlignedPageSize) :
+        const uint32_t page_size_in = TensorAccessorArgs<CTA_OFFSET, CRTA_OFFSET>{}.get_aligned_page_size()) :
         InterleavedAddrGen<IsDram>(
             {.bank_base_address = static_cast<uint32_t>(bank_base_address_in), .page_size = page_size_in}),
         aligned_page_size(page_size_in) {}
@@ -392,11 +392,7 @@ struct TensorAccessor<tensor_accessor::DistributionSpec<
             //   (But, add 1 to the token's CRTA offset to jump over the base address slot)
             TensorAccessorArgs<CTA_OFFSET, 1 + (ADDR_CRTA_OFFSET / sizeof(uint32_t))>{},
             // Bank base address: Get the base address from the front of the token's CRTA section.
-            static_cast<uint32_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t))),
-            // Aligned page size: Create the args object again to grab the aligned_page_size from
-            //   the TensorAccessorArgs getter. The aligned page size may be housed either as a CTA
-            //   (static case) or as a CRTA (dynamic case) field. The getter handles resolution for us.
-            TensorAccessorArgs<CTA_OFFSET, 1 + (ADDR_CRTA_OFFSET / sizeof(uint32_t))>{}.get_aligned_page_size()) {
+            static_cast<uint32_t>(get_common_arg_val<uint32_t>(ADDR_CRTA_OFFSET / sizeof(uint32_t)))) {
         static_assert(
             ADDR_CRTA_OFFSET % sizeof(uint32_t) == 0,
             "TensorAccessorBindingToken: ADDR_CRTA_OFFSET must be 4-byte aligned");

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
@@ -29,6 +29,7 @@ struct TensorAccessorArgs {
     static constexpr bool tensor_shape_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeTensorShape);
     static constexpr bool shard_shape_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeShardShape);
     static constexpr bool bank_coords_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimeBankCoords);
+    static constexpr bool page_size_is_crta = args_config.test(tensor_accessor::ArgConfig::RuntimePageSize);
 
     // Impossible to have runtime rank without runtime tensor and shard shapes since then impossible to calculate CTA
     // offsets in compile time
@@ -38,13 +39,31 @@ struct TensorAccessorArgs {
     static_assert(
         !is_sharded || !num_banks_is_crta || (num_banks_is_crta && bank_coords_is_crta),
         "If num_banks is runtime, bank_coords must also be runtime");
+    // A runtime (CRTA) page size is an interleaved-row-major-only relaxation: a sharded page size
+    // is fixed by the spec (the shard shape is held constant across binds), so it never goes
+    // runtime. Enforced here as device-side defense-in-depth; the host spec resolver is the
+    // primary gate (it also forbids tiled, where the page size is dtype-fixed).
+    static_assert(
+        !is_sharded || !page_size_is_crta, "RuntimePageSize (dynamic_page_size) is not supported on sharded tensors");
 
-    // aligned_page_size is always at CTA_OFFSET + 1
+    // aligned_page_size sits at CTA_OFFSET + 1, UNLESS the page size is a runtime field
+    // (RuntimePageSize): then the CTA slot is omitted (A-collapse) and the page size is read from
+    // a CRTA word at runtime by get_aligned_page_size(). The conditional lambda keeps the
+    // out-of-range CTA read from being instantiated when the slot doesn't exist.
     static constexpr uint32_t AlignedPageSizeCTAOffset = CTA_OFFSET + 1;
-    static constexpr uint32_t AlignedPageSize = get_compile_time_arg_val(AlignedPageSizeCTAOffset);
+    static constexpr uint32_t AlignedPageSize = [] {
+        if constexpr (page_size_is_crta) {
+            return uint32_t{0};
+        } else {
+            return get_compile_time_arg_val(AlignedPageSizeCTAOffset);
+        }
+    }();
 
-    // Calculate offsets for compile-time arguments
-    static constexpr uint32_t RankCTAOffset = CTA_OFFSET + 2;
+    // Calculate offsets for compile-time arguments. When the page size is a runtime field its CTA
+    // slot is omitted, so the words after the config word shift down by one. (Sharded +
+    // RuntimePageSize is forbidden, so page_size_is_crta is always false for a sharded accessor and
+    // this stays CTA_OFFSET + 2; the term keeps the slot map self-consistent regardless.)
+    static constexpr uint32_t RankCTAOffset = CTA_OFFSET + 2 - (page_size_is_crta ? 1 : 0);
     static constexpr uint32_t NumBanksCTAOffset = RankCTAOffset + (rank_is_crta ? 0 : 1);
 
     static constexpr uint32_t RankCT = [] {
@@ -72,8 +91,11 @@ struct TensorAccessorArgs {
     static constexpr uint32_t ShardShapeCTAOffset = TensorShapeCTAOffset + (tensor_shape_is_crta ? 0 : RankCT);
     static constexpr uint32_t BankCoordsCTAOffset = ShardShapeCTAOffset + (shard_shape_is_crta ? 0 : RankCT);
 
+    // Non-sharded payload is the config word + the aligned_page_size word, or just the config word
+    // when the page size is a runtime field. Sharded derives from the offset chain above.
     static constexpr uint32_t NumArgsCT =
-        is_sharded ? (BankCoordsCTAOffset + (bank_coords_is_crta ? 0 : PhysicalNumBanksCT) - CTA_OFFSET) : 2;
+        is_sharded ? (BankCoordsCTAOffset + (bank_coords_is_crta ? 0 : PhysicalNumBanksCT) - CTA_OFFSET)
+                   : (page_size_is_crta ? 1 : 2);
 
 private:
     uint32_t crta_offset_rt_;
@@ -91,7 +113,17 @@ public:
         }
     }
 
-    static constexpr uint32_t get_aligned_page_size() { return AlignedPageSize; }
+    // The page size: the AlignedPageSize CTA on the common path, or -- under the RuntimePageSize
+    // relaxation -- a CRTA word read at runtime. For an interleaved accessor the page-size word is
+    // the first (and only) runtime accessor field, immediately after the base-address word, i.e. at
+    // crta_offset(). Mirrors get_rank()/get_num_banks()'s CTA-vs-CRTA branch.
+    constexpr uint32_t get_aligned_page_size() const {
+        if constexpr (!page_size_is_crta) {
+            return AlignedPageSize;
+        } else {
+            return get_common_arg_val<uint32_t>(crta_offset());
+        }
+    }
 
     constexpr uint32_t rank_crta_offset() const { return crta_offset(); }
     constexpr uint32_t num_banks_crta_offset() const { return crta_offset() + rank_is_crta; }
@@ -145,7 +177,9 @@ public:
      */
     constexpr uint32_t num_common_runtime_args() const {
         if constexpr (!is_sharded) {
-            return 0;
+            // Interleaved carries one common runtime arg only under the RuntimePageSize relaxation
+            // (the page-size word); otherwise none.
+            return page_size_is_crta ? 1 : 0;
         }
         return bank_coords_crta_offset() + (bank_coords_is_crta ? get_physical_num_banks() : 0) - crta_offset();
     }

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
@@ -44,7 +44,8 @@ struct TensorAccessorArgs {
     // runtime. Enforced here as device-side defense-in-depth; the host spec resolver is the
     // primary gate (it also forbids tiled, where the page size is dtype-fixed).
     static_assert(
-        !is_sharded || !page_size_is_crta, "RuntimePageSize (dynamic_page_size) is not supported on sharded tensors");
+        !is_sharded || !page_size_is_crta,
+        "RuntimePageSize (the runtime page-size relaxation) is not supported on sharded tensors");
 
     // aligned_page_size sits at CTA_OFFSET + 1, UNLESS the page size is a runtime field
     // (RuntimePageSize): then the CTA slot is omitted (A-collapse) and the page size is read from

--- a/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
+++ b/tt_metal/hw/inc/api/tensor/tensor_accessor_args.h
@@ -39,31 +39,31 @@ struct TensorAccessorArgs {
     static_assert(
         !is_sharded || !num_banks_is_crta || (num_banks_is_crta && bank_coords_is_crta),
         "If num_banks is runtime, bank_coords must also be runtime");
-    // A runtime (CRTA) page size is an interleaved-row-major-only relaxation: a sharded page size
-    // is fixed by the spec (the shard shape is held constant across binds), so it never goes
-    // runtime. Enforced here as device-side defense-in-depth; the host spec resolver is the
-    // primary gate (it also forbids tiled, where the page size is dtype-fixed).
+    // A runtime (CRTA) page size is required for an interleaved-row-major tensor with dynamic shape.
+    // (Because in that configuration, page size = last_dim_width * element_size)
+    // For a sharded tensor, or interleaved-tiled tensor, page size is static.
     static_assert(
         !is_sharded || !page_size_is_crta,
         "RuntimePageSize (the runtime page-size relaxation) is not supported on sharded tensors");
 
-    // aligned_page_size sits at CTA_OFFSET + 1, UNLESS the page size is a runtime field
-    // (RuntimePageSize): then the CTA slot is omitted (A-collapse) and the page size is read from
-    // a CRTA word at runtime by get_aligned_page_size(). The conditional lambda keeps the
-    // out-of-range CTA read from being instantiated when the slot doesn't exist.
+    // aligned_page_size comes from one of two places depending on the configuration:
+    //  - static case:  AlignedPageSize = CTA_OFFSET + 1
+    //  - dynamic case: AlignedPageSize is IGNORED (handled by the getter; see below)
+    // (The conditional lambda keeps the CTA read from being instantiated when the slot doesn't exist.)
     static constexpr uint32_t AlignedPageSizeCTAOffset = CTA_OFFSET + 1;
     static constexpr uint32_t AlignedPageSize = [] {
         if constexpr (page_size_is_crta) {
-            return uint32_t{0};
+            return 0;  // ignored, getter uses the CRTA value instead
         } else {
             return get_compile_time_arg_val(AlignedPageSizeCTAOffset);
         }
     }();
 
-    // Calculate offsets for compile-time arguments. When the page size is a runtime field its CTA
-    // slot is omitted, so the words after the config word shift down by one. (Sharded +
-    // RuntimePageSize is forbidden, so page_size_is_crta is always false for a sharded accessor and
-    // this stays CTA_OFFSET + 2; the term keeps the slot map self-consistent regardless.)
+    // Calculate offsets for compile-time arguments.
+    // When the page size is a runtime field, its CTA slot is omitted, so the words after the config
+    // word shift down by one.
+    // (RuntimePageSize + sharded tensor is a forbidden combo, so page_size_is_crta is always false
+    // for a sharded accessor. Then this stays CTA_OFFSET + 2.)
     static constexpr uint32_t RankCTAOffset = CTA_OFFSET + 2 - (page_size_is_crta ? 1 : 0);
     static constexpr uint32_t NumBanksCTAOffset = RankCTAOffset + (rank_is_crta ? 0 : 1);
 
@@ -114,14 +114,15 @@ public:
         }
     }
 
-    // The page size: the AlignedPageSize CTA on the common path, or -- under the RuntimePageSize
-    // relaxation -- a CRTA word read at runtime. For an interleaved accessor the page-size word is
-    // the first (and only) runtime accessor field, immediately after the base-address word, i.e. at
-    // crta_offset(). Mirrors get_rank()/get_num_banks()'s CTA-vs-CRTA branch.
+    // Getter for aligned page size
+    // The aligned page size can come from one of two places, depending on the configuration:
+    // - static case:  AlignedPageSize (previously retrieved CTA value)
+    // - dynamic case: Read the TensorAccessorArgs' first CRTA word (at runtime)
     constexpr uint32_t get_aligned_page_size() const {
         if constexpr (!page_size_is_crta) {
             return AlignedPageSize;
         } else {
+            // In the dynamic case, the aligned page size lives in the first args CRTA slot
             return get_common_arg_val<uint32_t>(crta_offset());
         }
     }

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -107,10 +107,10 @@ struct TensorBindingHandle {
     // Count of runtime accessor field words that immediately follow the address slot
     // in this binding's CRTA section. Non-zero when the TensorParameter opts into a
     // CRTA-resident dynamic field: sharded + dynamic_tensor_shape (the runtime tensor's
-    // shape-in-pages, `rank` words) or interleaved + dynamic_page_size (one page-size word).
+    // shape-in-pages, `rank` words) or interleaved row-major + dynamic_tensor_shape (one page-size word).
     // The first runtime field word lives at byte offset addr_crta_offset + sizeof(uint32_t).
     uint32_t num_runtime_field_crta_words = 0;
-    // Which runtime field the words above hold: the interleaved dynamic_page_size page-size word
+    // Which runtime field the words above hold: the interleaved row-major page-size word
     // (true) or the sharded dynamic_tensor_shape shape words (false). The two are mutually
     // exclusive per binding (page size is interleaved-only, shape is sharded-only); the
     // enqueue-time emitter branches on this because an interleaved tensor has no

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -105,11 +105,17 @@ struct TensorBindingHandle {
     uint32_t cta_offset;                // first word index of this binding's payload in the kernel's compile-time args
     uint32_t addr_crta_offset;  // byte offset of this binding's base-address slot within the kernel's CRTA buffer
     // Count of runtime accessor field words that immediately follow the address slot
-    // in this binding's CRTA section. Non-zero only when the TensorParameter has
-    // dynamic_tensor_shape=true and is sharded: the runtime tensor's shape-in-pages
-    // is written here at enqueue time. The first runtime field word lives at byte
-    // offset addr_crta_offset + sizeof(uint32_t).
+    // in this binding's CRTA section. Non-zero when the TensorParameter opts into a
+    // CRTA-resident dynamic field: sharded + dynamic_tensor_shape (the runtime tensor's
+    // shape-in-pages, `rank` words) or interleaved + dynamic_page_size (one page-size word).
+    // The first runtime field word lives at byte offset addr_crta_offset + sizeof(uint32_t).
     uint32_t num_runtime_field_crta_words = 0;
+    // Which runtime field the words above hold: the interleaved dynamic_page_size page-size word
+    // (true) or the sharded dynamic_tensor_shape shape words (false). The two are mutually
+    // exclusive per binding (page size is interleaved-only, shape is sharded-only); the
+    // enqueue-time emitter branches on this because an interleaved tensor has no
+    // BufferDistributionSpec to source a shape from.
+    bool runtime_field_is_page_size = false;
 };
 
 class Kernel : public JitBuildSettings {

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -103,18 +103,19 @@ struct TensorBindingHandle {
     std::string accessor_name;          // user-facing identifier (kernel symbol in `ta::`)
     std::string tensor_parameter_name;  // refers back to the program-level TensorParameter
     uint32_t cta_offset;                // first word index of this binding's payload in the kernel's compile-time args
-    uint32_t addr_crta_offset;  // byte offset of this binding's base-address slot within the kernel's CRTA buffer
+    uint32_t addr_crta_offset;          // byte offset of this binding's base-address slot within the kernel's CRTA buffer
     // Count of runtime accessor field words that immediately follow the address slot
-    // in this binding's CRTA section. Non-zero when the TensorParameter opts into a
-    // CRTA-resident dynamic field: sharded + dynamic_tensor_shape (the runtime tensor's
-    // shape-in-pages, `rank` words) or interleaved row-major + dynamic_tensor_shape (one page-size word).
+    // in this binding's CRTA section. 
+    // Non-zero when the TensorParameter opts into a CRTA-resident dynamic field.
     // The first runtime field word lives at byte offset addr_crta_offset + sizeof(uint32_t).
     uint32_t num_runtime_field_crta_words = 0;
-    // Which runtime field the words above hold: the interleaved row-major page-size word
-    // (true) or the sharded dynamic_tensor_shape shape words (false). The two are mutually
-    // exclusive per binding (page size is interleaved-only, shape is sharded-only); the
-    // enqueue-time emitter branches on this because an interleaved tensor has no
-    // BufferDistributionSpec to source a shape from.
+    // What info the runtime field CRTA words actually contain depends on the relaxation chosen.
+    // Currently, there are only two mutually exclusive possibilities (though more may be added):
+    //  1. The interleaved row-major page-size (one CRTA only)
+    //  2. The sharded dynamic_tensor_shape shape (one CRTA per tensor dim) 
+    // For now, since there are only two mutually exclusive possibilities, it's sufficient to 
+    // distinguish them with a boolean. 
+    // (We'll need to extend this to something more flexible if additional possibilities are added.)
     bool runtime_field_is_page_size = false;
 };
 

--- a/tt_metal/impl/kernels/kernel.hpp
+++ b/tt_metal/impl/kernels/kernel.hpp
@@ -105,16 +105,16 @@ struct TensorBindingHandle {
     uint32_t cta_offset;                // first word index of this binding's payload in the kernel's compile-time args
     uint32_t addr_crta_offset;          // byte offset of this binding's base-address slot within the kernel's CRTA buffer
     // Count of runtime accessor field words that immediately follow the address slot
-    // in this binding's CRTA section. 
+    // in this binding's CRTA section.
     // Non-zero when the TensorParameter opts into a CRTA-resident dynamic field.
     // The first runtime field word lives at byte offset addr_crta_offset + sizeof(uint32_t).
     uint32_t num_runtime_field_crta_words = 0;
     // What info the runtime field CRTA words actually contain depends on the relaxation chosen.
     // Currently, there are only two mutually exclusive possibilities (though more may be added):
     //  1. The interleaved row-major page-size (one CRTA only)
-    //  2. The sharded dynamic_tensor_shape shape (one CRTA per tensor dim) 
-    // For now, since there are only two mutually exclusive possibilities, it's sufficient to 
-    // distinguish them with a boolean. 
+    //  2. The sharded dynamic_tensor_shape shape (one CRTA per tensor dim)
+    // For now, since there are only two mutually exclusive possibilities, it's sufficient to
+    // distinguish them with a boolean.
     // (We'll need to extend this to something more flexible if additional possibilities are added.)
     bool runtime_field_is_page_size = false;
 };

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -331,7 +331,7 @@ void ValidateProgramRunArgs(const Program& program, const ProgramRunArgs& params
 //   - tensor_shape_in_pages, for sharded TensorParameters with dynamic_tensor_shape=true
 //     (`rank` shape words); or
 //   - the aligned page size, for interleaved row-major TensorParameters with
-//     dynamic_page_size=true (one word).
+//     dynamic_tensor_shape=true (one word).
 //
 // Allocation-free by design: this runs once per binding on every enqueue, so callers
 // emit straight into their destination (push_back onto the assembled CRTA vector on the
@@ -363,7 +363,7 @@ void EmitBindingCrtaValues(const TensorBindingHandle& handle, const MeshTensor& 
         handle.tensor_parameter_name);
 
     if (handle.runtime_field_is_page_size) {
-        // dynamic_page_size (interleaved row-major): emit the buffer's aligned page size, re-derived
+        // Page-size runtime field (interleaved row-major): emit the buffer's aligned page size, re-derived
         // each dispatch so it tracks a width-varying tensor across program-cache hits. Exactly one
         // word by construction (ResolveTensorParameterStaticCTAs reserves a single slot). No
         // BufferDistributionSpec is involved -- interleaved tensors have none, which is exactly why

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -326,9 +326,12 @@ void ValidateProgramRunArgs(const Program& program, const ProgramRunArgs& params
 //
 // The base address always lives in CRTAs (per-enqueue, since the bound MeshTensor's
 // address can change between binds). Additional runtime field words appear immediately
-// after, when the TensorParameter opts into a dynamic accessor field. Currently the
-// only such field is tensor_shape_in_pages, for sharded TensorParameters with
-// dynamic_tensor_shape=true; in that case there are `rank` shape words.
+// after, when the TensorParameter opts into a dynamic accessor field. Two kinds exist,
+// mutually exclusive per binding (discriminated by handle.runtime_field_is_page_size):
+//   - tensor_shape_in_pages, for sharded TensorParameters with dynamic_tensor_shape=true
+//     (`rank` shape words); or
+//   - the aligned page size, for interleaved row-major TensorParameters with
+//     dynamic_page_size=true (one word).
 //
 // Allocation-free by design: this runs once per binding on every enqueue, so callers
 // emit straight into their destination (push_back onto the assembled CRTA vector on the
@@ -347,35 +350,53 @@ void EmitBindingCrtaValues(const TensorBindingHandle& handle, const MeshTensor& 
         address);
     emit(static_cast<uint32_t>(address));
 
-    if (handle.num_runtime_field_crta_words > 0) {
-        // Currently the only runtime accessor field that lives in CRTAs is tensor_shape_in_pages
-        // (sharded TensorParameter with dynamic_tensor_shape=true). Read it from the bound
-        // MeshTensor's buffer.
-        const tt::tt_metal::Buffer* buffer = tensor.mesh_buffer().get_reference_buffer();
+    if (handle.num_runtime_field_crta_words == 0) {
+        return;
+    }
+
+    // Both runtime-field kinds source their values from the bound MeshTensor's reference buffer.
+    const tt::tt_metal::Buffer* buffer = tensor.mesh_buffer().get_reference_buffer();
+    TT_FATAL(
+        buffer != nullptr,
+        "Tensor binding '{}' has runtime accessor field CRTA words but no backing Buffer to "
+        "source them from.",
+        handle.tensor_parameter_name);
+
+    if (handle.runtime_field_is_page_size) {
+        // dynamic_page_size (interleaved row-major): emit the buffer's aligned page size, re-derived
+        // each dispatch so it tracks a width-varying tensor across program-cache hits. Exactly one
+        // word by construction (ResolveTensorParameterStaticCTAs reserves a single slot). No
+        // BufferDistributionSpec is involved -- interleaved tensors have none, which is exactly why
+        // the field-kind discriminator exists (the shape path below would FATAL on a missing BDS).
+        const auto aligned_page_size = buffer->aligned_page_size();
         TT_FATAL(
-            buffer != nullptr,
-            "Tensor binding '{}' has runtime accessor field CRTA words but no backing Buffer to "
-            "source them from.",
-            handle.tensor_parameter_name);
-        const auto& bds_opt = buffer->buffer_distribution_spec();
-        TT_FATAL(
-            bds_opt.has_value(),
-            "Tensor binding '{}' has runtime accessor field CRTA words but its bound MeshTensor's "
-            "buffer has no BufferDistributionSpec. dynamic_tensor_shape currently requires a sharded "
-            "TensorParameter.",
-            handle.tensor_parameter_name);
-        const auto& tensor_shape = bds_opt->tensor_shape_in_pages();
-        TT_FATAL(
-            tensor_shape.rank() == handle.num_runtime_field_crta_words,
-            "Tensor binding '{}' supplied a MeshTensor whose shape rank ({}) differs from the rank "
-            "({}) reserved at ProgramSpec resolution time. Rank must remain constant across binds; "
-            "only the per-dim shape values may vary.",
+            aligned_page_size <= std::numeric_limits<uint32_t>::max(),
+            "Tensor binding '{}' aligned page size {} exceeds uint32_t max",
             handle.tensor_parameter_name,
-            tensor_shape.rank(),
-            handle.num_runtime_field_crta_words);
-        for (size_t i = 0; i < tensor_shape.rank(); ++i) {
-            emit(static_cast<uint32_t>(tensor_shape[i]));
-        }
+            aligned_page_size);
+        emit(static_cast<uint32_t>(aligned_page_size));
+        return;
+    }
+
+    // dynamic_tensor_shape (sharded): the runtime tensor's shape-in-pages, one word per dim.
+    const auto& bds_opt = buffer->buffer_distribution_spec();
+    TT_FATAL(
+        bds_opt.has_value(),
+        "Tensor binding '{}' has runtime accessor field CRTA words but its bound MeshTensor's "
+        "buffer has no BufferDistributionSpec. dynamic_tensor_shape currently requires a sharded "
+        "TensorParameter.",
+        handle.tensor_parameter_name);
+    const auto& tensor_shape = bds_opt->tensor_shape_in_pages();
+    TT_FATAL(
+        tensor_shape.rank() == handle.num_runtime_field_crta_words,
+        "Tensor binding '{}' supplied a MeshTensor whose shape rank ({}) differs from the rank "
+        "({}) reserved at ProgramSpec resolution time. Rank must remain constant across binds; "
+        "only the per-dim shape values may vary.",
+        handle.tensor_parameter_name,
+        tensor_shape.rank(),
+        handle.num_runtime_field_crta_words);
+    for (size_t i = 0; i < tensor_shape.rank(); ++i) {
+        emit(static_cast<uint32_t>(tensor_shape[i]));
     }
 }
 

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -368,13 +368,7 @@ void EmitBindingCrtaValues(const TensorBindingHandle& handle, const MeshTensor& 
         // word by construction (ResolveTensorParameterStaticCTAs reserves a single slot). No
         // BufferDistributionSpec is involved -- interleaved tensors have none, which is exactly why
         // the field-kind discriminator exists (the shape path below would FATAL on a missing BDS).
-        const auto aligned_page_size = buffer->aligned_page_size();
-        TT_FATAL(
-            aligned_page_size <= std::numeric_limits<uint32_t>::max(),
-            "Internal error: Tensor argument for TensorParameter '{}' aligned page size {} exceeds uint32_t max",
-            handle.tensor_parameter_name,
-            aligned_page_size);
-        emit(static_cast<uint32_t>(aligned_page_size));
+        emit(static_cast<uint32_t>(buffer->aligned_page_size()));
         return;
     }
 

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -345,7 +345,7 @@ void EmitBindingCrtaValues(const TensorBindingHandle& handle, const MeshTensor& 
     const auto address = tensor.address();
     TT_FATAL(
         address <= std::numeric_limits<uint32_t>::max(),
-        "Tensor argument for TensorParameter '{}' base address exceeds uint32_t max",
+        "Tensor argument for TensorParameter '{}' base address {} exceeds uint32_t max",
         handle.tensor_parameter_name,
         address);
     emit(static_cast<uint32_t>(address));

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -345,7 +345,7 @@ void EmitBindingCrtaValues(const TensorBindingHandle& handle, const MeshTensor& 
     const auto address = tensor.address();
     TT_FATAL(
         address <= std::numeric_limits<uint32_t>::max(),
-        "TensorParameter '{}' base address {} exceeds uint32_t max",
+        "Tensor argument for TensorParameter '{}' base address exceeds uint32_t max",
         handle.tensor_parameter_name,
         address);
     emit(static_cast<uint32_t>(address));
@@ -358,7 +358,7 @@ void EmitBindingCrtaValues(const TensorBindingHandle& handle, const MeshTensor& 
     const tt::tt_metal::Buffer* buffer = tensor.mesh_buffer().get_reference_buffer();
     TT_FATAL(
         buffer != nullptr,
-        "Tensor binding '{}' has runtime accessor field CRTA words but no backing Buffer to "
+        "Tensor argument for TensorParameter '{}' has runtime accessor field CRTA words but no backing Buffer to "
         "source them from.",
         handle.tensor_parameter_name);
 
@@ -371,7 +371,7 @@ void EmitBindingCrtaValues(const TensorBindingHandle& handle, const MeshTensor& 
         const auto aligned_page_size = buffer->aligned_page_size();
         TT_FATAL(
             aligned_page_size <= std::numeric_limits<uint32_t>::max(),
-            "Tensor binding '{}' aligned page size {} exceeds uint32_t max",
+            "Internal error: Tensor argument for TensorParameter '{}' aligned page size {} exceeds uint32_t max",
             handle.tensor_parameter_name,
             aligned_page_size);
         emit(static_cast<uint32_t>(aligned_page_size));
@@ -382,14 +382,12 @@ void EmitBindingCrtaValues(const TensorBindingHandle& handle, const MeshTensor& 
     const auto& bds_opt = buffer->buffer_distribution_spec();
     TT_FATAL(
         bds_opt.has_value(),
-        "Tensor binding '{}' has runtime accessor field CRTA words but its bound MeshTensor's "
-        "buffer has no BufferDistributionSpec. dynamic_tensor_shape currently requires a sharded "
-        "TensorParameter.",
+        "Tensor argument for TensorParameter '{}' has no BufferDistributionSpec.",
         handle.tensor_parameter_name);
     const auto& tensor_shape = bds_opt->tensor_shape_in_pages();
     TT_FATAL(
         tensor_shape.rank() == handle.num_runtime_field_crta_words,
-        "Tensor binding '{}' supplied a MeshTensor whose shape rank ({}) differs from the rank "
+        "Tensor argument for TensorParameter '{}' supplied a MeshTensor whose shape rank ({}) differs from the rank "
         "({}) reserved at ProgramSpec resolution time. Rank must remain constant across binds; "
         "only the per-dim shape values may vary.",
         handle.tensor_parameter_name,

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2038,14 +2038,14 @@ KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
 // slot) that this binding occupies, used by the device-side accessor to read
 // runtime-resolved fields. Non-zero when the TensorParameter opts into a dynamic
 // field that lives in CRTAs: either sharded + dynamic_tensor_shape (which puts
-// `rank` shape words in CRTAs), or interleaved + dynamic_page_size (one page-size
-// word). The two are mutually exclusive per binding -- see runtime_field_is_page_size.
+// `rank` shape words in CRTAs), or interleaved row-major + dynamic_tensor_shape (one
+// page-size word). The two are mutually exclusive per binding -- see runtime_field_is_page_size.
 struct ResolvedTensorParameter {
     std::vector<uint32_t> cta_payload;
     uint32_t extra_crta_words = 0;
     // Discriminates which runtime accessor field the extra_crta_words hold: the sharded
-    // dynamic_tensor_shape shape words (false), or the single interleaved dynamic_page_size
-    // word (true). The emitter needs this because an interleaved tensor has no
+    // dynamic_tensor_shape shape words (false), or the single interleaved row-major
+    // page-size word (true). The emitter needs this because an interleaved tensor has no
     // BufferDistributionSpec to source a shape from -- it must take the page-size path instead.
     bool runtime_field_is_page_size = false;
 };
@@ -2079,21 +2079,17 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
     // the device-side accessor doesn't read it), so the flag is a pure host-side
     // validation loosening and has no effect on the CTA/CRTA layout.
     const bool dyn_shape = tensor_parameter.advanced_options.dynamic_tensor_shape && is_sharded;
-    // dynamic_page_size carries the page size as a runtime CRTA word so it tracks a width-varying
-    // interleaved row-major tensor across program-cache hits. Interleaved-row-major only: a tiled
-    // page size is dtype/tile-fixed and a sharded page size is spec-fixed, so neither can vary --
-    // setting the flag there is a hard error rather than a silent no-op.
-    const bool dyn_page = tensor_parameter.advanced_options.dynamic_page_size;
-    if (dyn_page) {
-        TT_FATAL(
-            !is_sharded && spec.layout() == Layout::ROW_MAJOR,
-            "TensorParameter '{}' sets dynamic_page_size, which is only supported on interleaved "
-            "row-major tensors (got {}, {}). A tiled page size is fixed by dtype/tile dims and a "
-            "sharded page size is fixed by the spec, so neither can vary at runtime.",
-            tensor_parameter.unique_id,
-            is_sharded ? "sharded" : "interleaved",
-            spec.layout() == Layout::ROW_MAJOR ? "row-major" : "tiled");
-    }
+    // dynamic_tensor_shape lets the bound tensor's logical shape vary. For an interleaved ROW-MAJOR
+    // tensor the page size (= last_dim_width * elem_size) is part of that varying shape, so it must
+    // ride a runtime CRTA word too -- otherwise it goes stale on a program-cache hit and the
+    // accessor strides by the wrong number of bytes. We fold that in here rather than expose a
+    // separate flag: a useful page-size change is ALWAYS a shape change on row-major (you can't vary
+    // the width without varying the logical shape), so there is no "page size varies but shape
+    // doesn't" case to give a flag to. Tiled page size is dtype-fixed and sharded page size is
+    // spec-fixed, so neither triggers this; sharded dynamic_tensor_shape carries shape-in-pages
+    // words instead (dyn_shape above). dyn_shape and dyn_page are mutually exclusive by layout.
+    const bool dyn_page =
+        tensor_parameter.advanced_options.dynamic_tensor_shape && !is_sharded && spec.layout() == Layout::ROW_MAJOR;
 
     tensor_accessor::ArgsConfig args_config;
     if (is_sharded) {
@@ -2128,9 +2124,9 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
     if (!dyn_page) {
         cta_payload.push_back(static_cast<uint32_t>(aligned_page_size));
     }
-    // else: under dynamic_page_size the page size lives in a CRTA word (filled per-dispatch from
-    // the bound buffer), not a CTA -- omit the slot (A-collapse), matching the device-side
-    // TensorAccessorArgs layout where the RuntimePageSize bit drops the same word.
+    // else: when dyn_page the page size lives in a CRTA word (filled per-dispatch from the bound
+    // buffer), not a CTA -- omit the slot (A-collapse), matching the device-side TensorAccessorArgs
+    // layout where the RuntimePageSize bit drops the same word.
 
     if (!is_sharded) {
         if (dyn_page) {

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2036,12 +2036,18 @@ KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
 //
 // extra_crta_words: additional CRTA words (beyond the always-present base address
 // slot) that this binding occupies, used by the device-side accessor to read
-// runtime-resolved fields. Non-zero only when the TensorParameter opts into a
-// dynamic field that lives in CRTAs (currently: sharded + dynamic_tensor_shape,
-// which puts `rank` shape words in CRTAs).
+// runtime-resolved fields. Non-zero when the TensorParameter opts into a dynamic
+// field that lives in CRTAs: either sharded + dynamic_tensor_shape (which puts
+// `rank` shape words in CRTAs), or interleaved + dynamic_page_size (one page-size
+// word). The two are mutually exclusive per binding -- see runtime_field_is_page_size.
 struct ResolvedTensorParameter {
     std::vector<uint32_t> cta_payload;
     uint32_t extra_crta_words = 0;
+    // Discriminates which runtime accessor field the extra_crta_words hold: the sharded
+    // dynamic_tensor_shape shape words (false), or the single interleaved dynamic_page_size
+    // word (true). The emitter needs this because an interleaved tensor has no
+    // BufferDistributionSpec to source a shape from -- it must take the page-size path instead.
+    bool runtime_field_is_page_size = false;
 };
 
 // Resolve a TensorParameter's static layout into a CTA payload + an extra CRTA word
@@ -2073,6 +2079,21 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
     // the device-side accessor doesn't read it), so the flag is a pure host-side
     // validation loosening and has no effect on the CTA/CRTA layout.
     const bool dyn_shape = tensor_parameter.advanced_options.dynamic_tensor_shape && is_sharded;
+    // dynamic_page_size carries the page size as a runtime CRTA word so it tracks a width-varying
+    // interleaved row-major tensor across program-cache hits. Interleaved-row-major only: a tiled
+    // page size is dtype/tile-fixed and a sharded page size is spec-fixed, so neither can vary --
+    // setting the flag there is a hard error rather than a silent no-op.
+    const bool dyn_page = tensor_parameter.advanced_options.dynamic_page_size;
+    if (dyn_page) {
+        TT_FATAL(
+            !is_sharded && spec.layout() == Layout::ROW_MAJOR,
+            "TensorParameter '{}' sets dynamic_page_size, which is only supported on interleaved "
+            "row-major tensors (got {}, {}). A tiled page size is fixed by dtype/tile dims and a "
+            "sharded page size is fixed by the spec, so neither can vary at runtime.",
+            tensor_parameter.unique_id,
+            is_sharded ? "sharded" : "interleaved",
+            spec.layout() == Layout::ROW_MAJOR ? "row-major" : "tiled");
+    }
 
     tensor_accessor::ArgsConfig args_config;
     if (is_sharded) {
@@ -2083,6 +2104,9 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
     }
     if (dyn_shape) {
         args_config.set(tensor_accessor::ArgConfig::RuntimeTensorShape);
+    }
+    if (dyn_page) {
+        args_config.set(tensor_accessor::ArgConfig::RuntimePageSize);
     }
 
     // aligned_page_size: align the unaligned page size up to the buffer-type alignment.
@@ -2101,11 +2125,22 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
 
     // Common header (always emitted, sharded or not):
     cta_payload.push_back(args_config.raw());
-    cta_payload.push_back(static_cast<uint32_t>(aligned_page_size));
+    if (!dyn_page) {
+        cta_payload.push_back(static_cast<uint32_t>(aligned_page_size));
+    }
+    // else: under dynamic_page_size the page size lives in a CRTA word (filled per-dispatch from
+    // the bound buffer), not a CTA -- omit the slot (A-collapse), matching the device-side
+    // TensorAccessorArgs layout where the RuntimePageSize bit drops the same word.
 
     if (!is_sharded) {
-        // Interleaved tensors don't carry shape / bank-coord data: the device-side accessor
-        // computes addresses from page id + num_banks alone.
+        if (dyn_page) {
+            // One runtime field: the page size, re-derived from the bound buffer each dispatch
+            // and emitted immediately after the base-address word (see EmitBindingCrtaValues).
+            result.extra_crta_words = 1;
+            result.runtime_field_is_page_size = true;
+        }
+        // Interleaved tensors otherwise don't carry shape / bank-coord data: the device-side
+        // accessor computes addresses from page id + num_banks alone.
         return result;
     }
 
@@ -2208,6 +2243,7 @@ TensorBindingsForKernel ResolveTensorBindingsForKernel(
         handle.cta_offset = cta_word_offset;
         handle.addr_crta_offset = static_cast<uint32_t>(crta_word_index * sizeof(uint32_t));
         handle.num_runtime_field_crta_words = resolved.extra_crta_words;
+        handle.runtime_field_is_page_size = resolved.runtime_field_is_page_size;
 
         out.cta_words.insert(out.cta_words.end(), binding_ctas.begin(), binding_ctas.end());
         cta_word_offset += static_cast<uint32_t>(binding_ctas.size());

--- a/tt_metal/impl/metal2_host_api/program_spec.cpp
+++ b/tt_metal/impl/metal2_host_api/program_spec.cpp
@@ -2042,11 +2042,17 @@ KernelRiscMaskMap BuildGen1KernelRiscMasks(const ProgramSpec& spec) {
 // page-size word). The two are mutually exclusive per binding -- see runtime_field_is_page_size.
 struct ResolvedTensorParameter {
     std::vector<uint32_t> cta_payload;
+
+    // How many CRTA words (beyond the base address) does this binding consume?
+    // This is only used if TensorParameter relaxations have been requested.
     uint32_t extra_crta_words = 0;
-    // Discriminates which runtime accessor field the extra_crta_words hold: the sharded
-    // dynamic_tensor_shape shape words (false), or the single interleaved row-major
-    // page-size word (true). The emitter needs this because an interleaved tensor has no
-    // BufferDistributionSpec to source a shape from -- it must take the page-size path instead.
+
+    // What info the runtime field CRTA words actually contain depends on the relaxation.
+    // Currently, there are only two mutually exclusive possibilities (though more may be added):
+    //  1. The interleaved row-major page-size (one CRTA only)
+    //  2. The sharded dynamic_tensor_shape shape (one CRTA per tensor dim)
+    // For now, since there are only two mutually exclusive possibilities, it's sufficient to
+    // distinguish them with a boolean.
     bool runtime_field_is_page_size = false;
 };
 
@@ -2121,24 +2127,28 @@ ResolvedTensorParameter ResolveTensorParameterStaticCTAs(
 
     // Common header (always emitted, sharded or not):
     cta_payload.push_back(args_config.raw());
+    // If the page size is static, it rides as a CTA.
+    // (If it's dynamic, it will live in a CRTA word instead.)
     if (!dyn_page) {
         cta_payload.push_back(static_cast<uint32_t>(aligned_page_size));
-    }
-    // else: when dyn_page the page size lives in a CRTA word (filled per-dispatch from the bound
-    // buffer), not a CTA -- omit the slot (A-collapse), matching the device-side TensorAccessorArgs
-    // layout where the RuntimePageSize bit drops the same word.
+    } else {
+        TT_FATAL(!is_sharded, "Internal error: dynamic page size should not occur on a sharded tensor parameter");
 
+        // One runtime field: the page size, re-derived from the bound buffer each dispatch
+        // and emitted immediately after the base-address word (see EmitBindingCrtaValues).
+        result.extra_crta_words = 1;
+        result.runtime_field_is_page_size = true;
+    }
+
+    // The rest of the logic in this function pertains to sharded tensors only.
+    // Early return for a non-sharded tensor.
     if (!is_sharded) {
-        if (dyn_page) {
-            // One runtime field: the page size, re-derived from the bound buffer each dispatch
-            // and emitted immediately after the base-address word (see EmitBindingCrtaValues).
-            result.extra_crta_words = 1;
-            result.runtime_field_is_page_size = true;
-        }
-        // Interleaved tensors otherwise don't carry shape / bank-coord data: the device-side
-        // accessor computes addresses from page id + num_banks alone.
         return result;
     }
+
+    //////////////////////////////////
+    // Sharded tensor handling
+    //////////////////////////////////
 
     // Sharded: emit rank, num_banks, tensor_shape_in_pages (CTA only when static),
     // shard_shape_in_pages, bank_coords.


### PR DESCRIPTION
## PR Category
Feature

## Summary
This PR adds support for tensor **dynamic page size** in Metal 2.0's ProgramSpec TensorParameters. 

This is an advanced feature. It's required by ops whose kernels are designed to support a dynamic tensor shape. For the specific case of interleaved row-major tensors, these kernels accept a dynamic aligned_page_size (i.e. the value is supplied as an enqueue argument, not a compile-time argument) to enable greater fast-path generality.

### Background: `TensorAccessor`

`TensorAccessor`'s legacy constructor accepts three arguments:

1.  The `TensorAccessorArgs` carries all pertinent structural information about the tensor
2. The base address gives the tensor's memory location.
3. **(OPTIONAL)** The page_size allows the user to override the aligned page size supplied via the `TensorAccessorArgs`.

```cpp
auto my_ta = TensorAccessor(tensor_accessor_args, base_addr, aligned_page_size_override); 
// aligned_page_size_override is optional, seldom used, and highly bug-prone
```

In Metal 2.0, the `TensorAccessor` constructor arguments are handled implicitly by the runtime infrastructure.
```cpp
auto my_ta = TensorAccessor(tensor::my_tensor_name); 
// my_tensor_name is a host-declared kernel tensor parameter binding
// It's an opaque token type that carries all the info that TensorAccessor needs
```

The current implementation doesn't support page size override. You just get the aligned_page_size that the runtime infrastructure pulls off the `TensorSpec` you provide for your `TensorParameter`.

### Background: `TensorParameter` relaxations

In Metal 2.0, a `ProgramSpec` declares a `TensorParameter`: a placeholder for a tensor argument that must be provided when the program is enqueued.

A `TensorParameter` carries a `TensorSpec` (which defines a tensor's data format, shape, layout, etc). By default, the tensor argument provided at enqueue must have a _matching_ `TensorSpec`. 

However, some kernels are specially designed to permit their tensor arguments' `TensorSpec`s to vary from enqueue to enqueue in narrowly defined ways. For example, many eltwise ops are tolerant of changes to the tensor shape. Metal 2.0 supports this via `TensorParameter` relaxations (see advanced_options.hpp).

### Changes in this PR

This PR adds support for a dynamic page size, via the **pre-existing** "dynamic tensor shape" `TensorParameter` relaxation. For the specific case of an **interleaved ROW-MAJOR tensor**, the page_size (calculated as last_dim_width * element_size) is actually _part_ of the varying shape!

This required adding a new dynamic (i.e. optionally CRTA-carried) field to `TensorAccessorArgs` infra. Previously, the `AlignedPageSize` was always passed as a static `TensorAccessorArgs` parameter. This PR extends it to be optionally dynamic.

With this change, there should be no need for manual kernel-level page size overrides of `TensorAccessor`. This is a _highly_ bug-prone pattern; the new design instead tethers the configuration to the host-side declarations. The rest of the kernel code can access the dynamic `aligned_page_size` value via `TensorAccessor::get_aligned_page_size()`.

This is a natural extension of https://github.com/tenstorrent/tt-metal/issues/38958 to the dynamic case, using the machinery from https://github.com/tenstorrent/tt-metal/pull/43687/.

### Testing

 - **TensorAccessor regression check**. Ran all existing `TensorAccessor` tests I could find to check for regressions. I'm confident I haven't disturbed any existing functionality.
 - **TensorAccessor new `RuntimePageSize`**. Added a new test (using the new report_runtime_page_size.cpp kernel). A hand-crafted RuntimePageSize accessor reads its page size from a common runtime arg (verified with a synthetic sentinel distinct from any buffer's natural page size). This also checks that a neighboring static accessor's CTA offset still works, despite the positional shift.
 - **Metal 2.0 host resolution support**. New mock device tests in test_program_spec.cpp. For an interleaved row-major TensorParameter with `dynamic_tensor_shape`, the resolver sets the `RuntimePageSize` bit, omits the page-size CTA, and passes the pertinent info down info the runtime. 


## Notes for reviewers
 - I'd appreciate some careful review from someone familiar with `TensorAccessor`. I'm unfamiliar with that code.  That said, I've tripled checked this and all the comments in the modified implementation are human-written for clarity.

 - NOTE: Enabling `dynamic_tensor_shape` causes some of the `TensorAccessorArgs` handled by the runtime infra to flip from implicit CTAs to implicit CRTAs. There are some narrow use cases where this actually isn't strictly needed by the kernel code; we could consider optimizing those in the future with finer grained knobs. However.... I very highly doubt that this would ever be worth it. The `dynamic_tensor_shape` relaxation is rarely used. CRTAs are pretty cheap, and we already need them for tensor base pointers. The dynamic page size only adds one CRTA. The flit-quantization of CRTA dispatch means that in the _vast_ majority of situations, the extra CRTAs will ride along at no extra cost.

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=akertesz/page-size-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:akertesz/page-size-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=akertesz/page-size-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:akertesz/page-size-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=akertesz/page-size-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:akertesz/page-size-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=akertesz/page-size-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:akertesz/page-size-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=akertesz/page-size-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:akertesz/page-size-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=akertesz/page-size-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:akertesz/page-size-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=akertesz/page-size-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:akertesz/page-size-relaxation)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=akertesz/page-size-relaxation)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:akertesz/page-size-relaxation)