### PR TITLE
Fix concat error

### DIFF
--- a/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.inl
+++ b/ttnn/cpp/ttnn/kernel_lib/untilize_helpers.inl
@@ -36,10 +36,20 @@ constexpr bool has_supported_fast_untilize_format() {
     return supported_input && supported_output;
 }
 
+// Maximum row width (in tiles) the BH fast-untilize path can produce correctly.
+// The strided packer (llk_pack_fast_untilize_block_strided, templated on full_ct_dim)
+// corrupts output once full_ct_dim exceeds this; empirically full_ct_dim <= 132 is
+// correct and >= 133 produces garbage (verified on Blackhole, bf16). Wider rows fall
+// back to the block-based pack_untilize path, which sub-blocks to the DEST limit and
+// is correct for any width. The underlying LLK limit should be lifted separately so
+// the fast path can cover wide rows too.
+constexpr uint32_t FAST_UNTILIZE_MAX_BLOCK_WIDTH_TILES = 132;
+
 template <uint32_t block_width_tiles, uint32_t input_dfb, uint32_t output_dfb>
 constexpr bool can_use_fast_untilize() {
 #ifdef ARCH_BLACKHOLE
-    return block_width_tiles >= 2 && dfb_has_32x32_tiles<input_dfb>() && dfb_has_32x32_tiles<output_dfb>() &&
+    return block_width_tiles >= 2 && block_width_tiles <= FAST_UNTILIZE_MAX_BLOCK_WIDTH_TILES &&
+           dfb_has_32x32_tiles<input_dfb>() && dfb_has_32x32_tiles<output_dfb>() &&
            has_supported_fast_untilize_format<input_dfb, output_dfb>();
 #else
     return false;


### PR DESCRIPTION
### PR Category
Bug fix

### Summary
This is to fix the issue #47293 , an error in concat operation with specific dtype and shape.

### Bug
`untilize_with_unpadding` (multi-core interleaved program factory) feeds the full row width to the compute kernel without bounding it. The untilize compute helper then selects the BH `fast_untilize` path for bf16 regardless of row width. The underlying experimental LLK (`llk_pack_fast_untilize_block_strided`, templated on `full_ct_dim`) corrupts its output once the row width exceeds 132 tiles (verified on Blackhole: ≤132 correct, ≥133 garbage). This surfaced through `ttnn.concat` (which routes tile-padded concats through `untilize_with_unpadding`), but affects any caller that untilizes rows wider than 132 tiles.

### Fix
Add a width bound to `can_use_fast_untilize`: when `block_width_tiles > 132` (`FAST_UNTILIZE_MAX_BLOCK_WIDTH_TILES`), fall back to the block-based `pack_untilize` path, which sub-blocks the row to the DEST limit and is correct for any width. This is a correctness guard in the upper layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=ronnie/47293_concat-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:ronnie/47293_concat-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=ronnie/47293_concat-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:ronnie/47293_concat-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=ronnie/47293_concat-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:ronnie/47293_concat-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=ronnie/47293_concat-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:ronnie/47293_concat-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=ronnie/47293_concat-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:ronnie/47293_concat-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=ronnie/47293_concat-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:ronnie/47293_concat-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=ronnie/47293_concat-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:ronnie/47293_concat-error)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=ronnie/47293_concat-error)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:ronnie/47293_concat-error)