### PR TITLE
[Metal 2.0] Heap-free run-arg keys (RtaName) + small-vector run-arg Tables

### DIFF
--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/program_run_args.hpp
@@ -15,6 +15,7 @@
 #include <tt-metalium/experimental/metal2_host_api/advanced_options.hpp>
 #include <tt-metalium/experimental/metal2_host_api/kernel_spec.hpp>
 #include <tt-metalium/experimental/metal2_host_api/dataflow_buffer_spec.hpp>
+#include <tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp>
 #include <tt-metalium/experimental/metal2_host_api/tensor_parameter.hpp>
 #include <tt-metalium/experimental/metal2_host_api/node_coord.hpp>
 #include <tt-metalium/experimental/metal2_host_api/utility/group.hpp>
@@ -57,7 +58,11 @@ struct ProgramRunArgs {
         //
         // NOTE: If a kernel runtime argument always has the same value for all nodes,
         // passing a common runtime argument would provide better dispatch efficiency.
-        using RuntimeArgValues = Table<std::string, uint32_t>;
+        //
+        // Key type is the heap-free inline RtaName, not std::string: this per-node Table is rebuilt
+        // every dispatch, so a std::string key would heap-allocate for any name past the SSO threshold.
+        // RtaName stores the name inline. Ops still write {{"name", value}} -- the API is unchanged.
+        using RuntimeArgValues = Table<RtaName, uint32_t>;
         struct NodeRuntimeArgs {
             NodeCoord node;
             RuntimeArgValues args;

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp
@@ -1,0 +1,64 @@
+// SPDX-FileCopyrightText: © 2026 Tenstorrent USA, Inc.
+//
+// SPDX-License-Identifier: Apache-2.0
+#pragma once
+
+#include <cstdint>
+#include <cstring>
+#include <functional>
+#include <string>
+#include <string_view>
+
+#include <fmt/format.h>
+#include <tt_stl/assert.hpp>
+
+namespace tt::tt_metal::experimental {
+
+// Heap-free, inline, fixed-capacity name key for per-node runtime-arg Tables.
+//
+// Replaces std::string as the key of RuntimeArgValues (Table<RtaName, uint32_t>). The
+// per-node run-args loop builds ~(#kernels x #cores) of these every dispatch; with std::string
+// keys, names longer than the 15-char SSO threshold (e.g. "output_tile_start_id"=20) heap-allocate
+// per entry. RtaName stores the name inline (no heap, ever) and is a trivially-copyable POD so the
+// backing small-vector relocates by memcpy and comparison is a length-gated memcmp.
+//
+// Implicitly constructible from string literals / std::string, so op factories keep writing
+// {{"name", value}} unchanged -- the public API design is untouched.
+struct RtaName {
+    static constexpr std::size_t CAP = 32;  // longest runtime-arg name in use is 28 chars; 32 leaves margin
+    char data_[CAP] = {};
+    std::uint8_t len_ = 0;
+
+    RtaName() = default;
+    RtaName(std::string_view s) {  // NOLINT(google-explicit-constructor): implicit by design
+        // Fail loud rather than silently truncate: two names that differ only past CAP would alias to
+        // the same key and fetch each other's args. A name this long means CAP needs raising, not trimming.
+        TT_FATAL(s.size() <= CAP, "RtaName '{}' exceeds inline capacity {} ({} chars)", s, CAP, s.size());
+        len_ = static_cast<std::uint8_t>(s.size());
+        std::memcpy(data_, s.data(), len_);
+    }
+    RtaName(const char* s) : RtaName(std::string_view(s)) {}         // NOLINT(google-explicit-constructor)
+    RtaName(const std::string& s) : RtaName(std::string_view(s)) {}  // NOLINT(google-explicit-constructor)
+
+    std::string_view view() const { return std::string_view(data_, len_); }
+
+    bool operator==(const RtaName& o) const { return len_ == o.len_ && std::memcmp(data_, o.data_, len_) == 0; }
+};
+
+}  // namespace tt::tt_metal::experimental
+
+template <>
+struct fmt::formatter<tt::tt_metal::experimental::RtaName> : fmt::formatter<std::string_view> {
+    auto format(const tt::tt_metal::experimental::RtaName& n, fmt::format_context& ctx) const {
+        return fmt::formatter<std::string_view>::format(n.view(), ctx);
+    }
+};
+
+template <>
+struct std::hash<tt::tt_metal::experimental::RtaName> {
+    std::size_t operator()(const tt::tt_metal::experimental::RtaName& n) const noexcept {
+        // Delegate to the platform's optimized byte hash (chunked) rather than a naive
+        // per-byte FNV loop — the apply path does ~hundreds of slot-map lookups per dispatch.
+        return std::hash<std::string_view>{}(n.view());
+    }
+};

--- a/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
+++ b/tt_metal/api/tt-metalium/experimental/metal2_host_api/utility/table.hpp
@@ -19,6 +19,7 @@
 
 #include <tt_stl/assert.hpp>
 #include <tt_stl/optional_reference.hpp>
+#include <tt_stl/small_vector.hpp>
 
 // Forward declarations of the ttsl::hash entry points used by the std::hash<Table> specialization
 // below, so this header need not pull in the (heavy) <tt_stl/reflection.hpp>. The definitions live
@@ -67,7 +68,11 @@ private:
     // Entries are stored as a mutable std::pair<K, V> (so the backing vector stays
     // easy to grow, erase, and assign), but exposed through the iterators below as
     // the const-key value_type.
-    using Storage = std::vector<std::pair<K, V>>;
+    // Inline (small-vector) backing so the small Tables this type backs -- per-node runtime-arg
+    // values, tensor-arg bindings, and runtime-varargs, all rebuilt every dispatch -- build with no
+    // heap allocation; in the migrated ops they hold <=8 entries. A Table that exceeds the inline
+    // capacity spills to heap (LLVM SmallVector), so correctness never depends on the bound.
+    using Storage = ttsl::SmallVector<std::pair<K, V>, 8>;
 
 public:
     // Wraps a backing iterator and re-presents the stored pair it points at as the

--- a/tt_metal/impl/metal2_host_api/program_run_args.cpp
+++ b/tt_metal/impl/metal2_host_api/program_run_args.cpp
@@ -206,7 +206,7 @@ void ValidateProgramRunArgs(const Program& program, const ProgramRunArgs& params
 
         // Validate named RTAs: every declared name set per-node, no extras, no duplicate node entries.
         const auto& named_rta_names = schema->runtime_arg_names;
-        const std::unordered_set<std::string> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
+        const std::unordered_set<RtaName> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
 
         std::unordered_set<NodeCoord> nodes_with_named_params;
         for (const auto& [node, args] : kernel_params.runtime_arg_values) {
@@ -602,7 +602,7 @@ void SetProgramRunArgs(Program& program, const ProgramRunArgs& params, bool skip
             // before allocating. Build the node->values lookups and walk the kernel's logical cores
             // (the node coverage validation has confirmed) to assemble each combined buffer. This
             // runs once; every subsequent call takes the fast path above.
-            std::unordered_map<NodeCoord, const Table<std::string, uint32_t>*> named_rtas_by_node;
+            std::unordered_map<NodeCoord, const Table<RtaName, uint32_t>*> named_rtas_by_node;
             named_rtas_by_node.reserve(kernel_params.runtime_arg_values.size());
             for (const auto& [node, args] : kernel_params.runtime_arg_values) {
                 named_rtas_by_node[node] = &args;
@@ -925,7 +925,7 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
         // --- Named RTAs: supplied names must be declared (no extras); every non-invariant name
         //     must be supplied for every node; invariant names may be omitted. ---
         const auto& named_rta_names = schema->runtime_arg_names;
-        const std::unordered_set<std::string> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
+        const std::unordered_set<RtaName> named_rta_name_set(named_rta_names.begin(), named_rta_names.end());
         std::vector<std::string> regular_rta_names;
         for (const auto& n : named_rta_names) {
             if (!schema->enqueue_invariant_runtime_arg_names.contains(n)) {
@@ -976,7 +976,7 @@ void ValidateUpdateProgramRunArgs(const Program& program, const ProgramRunArgs& 
 
         // --- Named CRTAs: regular ones must be supplied; invariant may be omitted; no extras. ---
         const auto& named_crta_names = schema->common_runtime_arg_names;
-        const std::unordered_set<std::string> named_crta_name_set(named_crta_names.begin(), named_crta_names.end());
+        const std::unordered_set<RtaName> named_crta_name_set(named_crta_names.begin(), named_crta_names.end());
         for (const auto& [name, _value] : kernel_params.common_runtime_arg_values) {
             (void)_value;
             TT_FATAL(

--- a/tt_metal/impl/program/program_impl.hpp
+++ b/tt_metal/impl/program/program_impl.hpp
@@ -18,6 +18,7 @@
 #include "impl/buffers/semaphore.hpp"
 #include "tt-metalium/sub_device_types.hpp"
 #include "tt-metalium/experimental/tensor/spec/tensor_spec.hpp"  // Metal 2.0 TensorParameter registry
+#include "tt-metalium/experimental/metal2_host_api/runtime_arg_name.hpp"  // RtaName (RTA slot-map key)
 #include "tt_metal/impl/dataflow_buffer/dataflow_buffer_impl.hpp"
 
 #include <umd/device/types/core_coordinates.hpp>        // CoreType
@@ -385,8 +386,10 @@ public:
         // hot UpdateProgramRunArgs path does O(1) lookups instead of rebuilding a map per call —
         // that path is not bypassable via skip_validation, so per-call construction would be pure
         // host overhead on the inner re-enqueue loop.
-        std::unordered_map<std::string, size_t> runtime_arg_name_to_slot;
-        std::unordered_map<std::string, size_t> common_runtime_arg_name_to_slot;
+        // Keyed by RtaName (heap-free inline key) to match RuntimeArgValues' key type, so the hot
+        // apply-path lookup (slot_of.find(name)) is a memcmp, not a std::string hash+compare.
+        std::unordered_map<experimental::RtaName, size_t> runtime_arg_name_to_slot;
+        std::unordered_map<experimental::RtaName, size_t> common_runtime_arg_name_to_slot;
 
         // Vararg counts. RTA vararg count is per-node (stored post-expansion from the
         // user-facing schema, which groups nodes that share a count); CRTA vararg is a single


### PR DESCRIPTION
## What this PR does

Performance optimization for the Metal 2.0 `metal2_host_api` run-args framework. **Internal representation only — the op-facing API is unchanged** (ops still write `{{"name", value}}`).

- **`RtaName`** — a heap-free, inline, fixed-capacity (32-char) key that replaces `std::string` as the `RuntimeArgValues` key. The per-node run-args `Table` is rebuilt on every dispatch, so `std::string` keys heap-allocate for any name past the SSO threshold (longest name in use is 28 chars). `RtaName` stores the name inline and is a trivially-copyable POD, so the backing small-vector relocates by `memcpy` and comparison is a length-gated `memcmp`. Over-long names fail loud (never silently truncate).
- **`Table` backed by `ttsl::SmallVector<,8>`** — the small run-arg / tensor-binding / vararg `Table`s (≤8 entries in practice) build with no heap allocation; larger `Table`s spill to heap (LLVM SmallVector), semantics unchanged.
- **`program_impl` RTA name→slot maps keyed on `RtaName`** to match the run-args key type.

## Stack

Lowest PR in a 3-PR stack: **metal (this)** → ttnn spec-as-key → transpose op.

## Testing

- Builds clean (`build_metal.sh`).
- `metal2_host_api` unit tests + `ttsl::SmallVector` tests (see CI / below).

### CI Status
_Auto-generated on every push. Badges update live. Click a badge to filter runs by this branch._

- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml/badge.svg?branch=dgomez/metal2-runargs-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/sanity-tests.yaml?query=branch:dgomez/metal2-runargs-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml/badge.svg?branch=dgomez/metal2-runargs-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/runtime-sanity-tests.yaml?query=branch:dgomez/metal2-runargs-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml/badge.svg?branch=dgomez/metal2-runargs-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/blackhole-post-commit.yaml?query=branch:dgomez/metal2-runargs-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml/badge.svg?branch=dgomez/metal2-runargs-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/tt-metal-l2-nightly.yaml?query=branch:dgomez/metal2-runargs-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml/badge.svg?branch=dgomez/metal2-runargs-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/all-model-tests.yaml?query=branch:dgomez/metal2-runargs-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml/badge.svg?branch=dgomez/metal2-runargs-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select.yaml?query=branch:dgomez/metal2-runargs-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml/badge.svg?branch=dgomez/metal2-runargs-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-t3k.yaml?query=branch:dgomez/metal2-runargs-perf)
- [![](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml/badge.svg?branch=dgomez/metal2-runargs-perf)](https://github.com/tenstorrent/tt-metal/actions/workflows/pipeline-select-galaxy.yaml?query=branch:dgomez/metal2-runargs-perf)